### PR TITLE
Improve ImplicitTriangulation requests on the link

### DIFF
--- a/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -42,10 +42,11 @@ namespace ttk{
         const int segmentGeometry):
       isValid_{isValid},
       source_{saddle},
-      destination_{extremum},
-      isReversed_{isSegmentReversed},
-      geometry_{segmentGeometry}
-    {}
+      destination_{extremum}
+    {
+      isReversed_.push_back(isSegmentReversed);
+      geometry_.push_back(segmentGeometry);
+    }
 
     // for multiple segments :
     Separatrix(const bool isValid,

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1450,30 +1450,36 @@ int ImplicitTriangulation::getEdgeLink(const int &edgeId, const int &localLinkId
 
   linkId=-1;
 
-  int starId;
-  getEdgeStar(edgeId, localLinkId, starId);
-
-  int v0;
-  int v1;
-  getEdgeVertex(edgeId, 0, v0);
-  getEdgeVertex(edgeId, 1, v1);
-
   if(dimensionality_==3){
-    for(int i=0; i<4; ++i){
-      int anotherEdgeId;
-      getTetrahedronEdge(starId, i, anotherEdgeId);
+    int p[3];
 
-      if(anotherEdgeId==edgeId) continue;
-
-      int w0;
-      int w1;
-      getEdgeVertex(anotherEdgeId, 0, w0);
-      getEdgeVertex(anotherEdgeId, 1, w1);
-
-      if(w0!=v0 and w0!=v1 and w1!=v0 and w1!=v1){
-        linkId=anotherEdgeId;
-        break;
-      }
+    if(edgeId<esetshift_[0]){
+      edgeToPosition(edgeId,0,p);
+      linkId=getEdgeLinkL(p,localLinkId);//L
+    }
+    else if(edgeId<esetshift_[1]){
+      edgeToPosition(edgeId,1,p);
+      linkId=getEdgeLinkH(p,localLinkId);//H
+    }
+    else if(edgeId<esetshift_[2]){
+      edgeToPosition(edgeId,2,p);
+      linkId=getEdgeLinkP(p,localLinkId);//P
+    }
+    else if(edgeId<esetshift_[3]){
+      edgeToPosition(edgeId,3,p);
+      linkId=getEdgeLinkD1(p,localLinkId);//D1
+    }
+    else if(edgeId<esetshift_[4]){
+      edgeToPosition(edgeId,4,p);
+      linkId=getEdgeLinkD2(p,localLinkId);//D2
+    }
+    else if(edgeId<esetshift_[5]){
+      edgeToPosition(edgeId,5,p);
+      linkId=getEdgeLinkD3(p,localLinkId);//D3
+    }
+    else if(edgeId<esetshift_[6]){
+      edgeToPosition(edgeId,6,p);
+      linkId=getEdgeLinkD4(p,localLinkId);//D4
     }
   }
   else if(dimensionality_==2){

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1483,22 +1483,22 @@ int ImplicitTriangulation::getEdgeLink(const int &edgeId, const int &localLinkId
     }
   }
   else if(dimensionality_==2){
-    int starId;
-    getEdgeStar(edgeId, localLinkId, starId);
+    int p[2];
 
-    int v0;
-    int v1;
-    getEdgeVertex(edgeId, 0, v0);
-    getEdgeVertex(edgeId, 1, v1);
-
-    for(int i=0; i<3; ++i){
-      int vertexId;
-      getTriangleVertex(starId, i, vertexId);
-
-      if(vertexId!=v0 and vertexId!=v1){
-        linkId=vertexId;
-        break;
-      }
+    //L
+    if(edgeId<esetshift_[0]){
+      edgeToPosition2d(edgeId,0,p);
+      linkId=getEdgeLink2dL(p,localLinkId);
+    }
+    //H
+    else if(edgeId<esetshift_[1]){
+      edgeToPosition2d(edgeId,1,p);
+      linkId=getEdgeLink2dH(p,localLinkId);
+    }
+    //D1
+    else if(edgeId<esetshift_[2]){
+      edgeToPosition2d(edgeId,2,p);
+      linkId=getEdgeLink2dD1(p,localLinkId);
     }
   }
 

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1483,6 +1483,14 @@ int ImplicitTriangulation::getEdgeLink(const int &edgeId, const int &localLinkId
     }
   }
   else if(dimensionality_==2){
+    int starId;
+    getEdgeStar(edgeId, localLinkId, starId);
+
+    int v0;
+    int v1;
+    getEdgeVertex(edgeId, 0, v0);
+    getEdgeVertex(edgeId, 1, v1);
+
     for(int i=0; i<3; ++i){
       int vertexId;
       getTriangleVertex(starId, i, vertexId);

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -942,14 +942,34 @@ inline int ImplicitTriangulation::getEdgeTriangleD1_xy(const int p[3], const int
 }
 
 inline int ImplicitTriangulation::getEdgeLink2dL(const int p[2], const int id) const{
+  if(p[1]>0 and p[1]<nbvoxels_[Dj_]){
+    switch(id){
+      case 0: return p[0]+(p[1]+1)*vshift_[0];
+      case 1: return p[0]+(p[1]-1)*vshift_[0]+1;
+    }
+  }
+  else if(p[1]==0) return p[0]+vshift_[0];
+  else return p[0]+(p[1]-1)*vshift_[0]+1;
   return -1;
 }
 
 inline int ImplicitTriangulation::getEdgeLink2dH(const int p[2], const int id) const{
+  if(p[0]>0 and p[0]<nbvoxels_[Di_]){
+    switch(id){
+      case 0: return p[0]+p[1]*vshift_[0]+1;
+      case 1: return p[0]+(p[1]+1)*vshift_[0]-1;
+    }
+  }
+  else if(p[0]==0) return p[1]*vshift_[0]+1;
+  else return p[0]+(p[1]+1)*vshift_[0]-1;
   return -1;
 }
 
 inline int ImplicitTriangulation::getEdgeLink2dD1(const int p[2], const int id) const{
+  switch(id){
+    case 0: return p[0]+p[1]*vshift_[0];
+    case 1: return p[0]+(p[1]+1)*vshift_[0]+1;
+  }
   return -1;
 }
 

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -291,6 +291,10 @@ namespace ttk{
       int getEdgeTriangleH_Ny(const int p[3], const int localTriangleId) const;
       int getEdgeTriangleD1_xy(const int p[3], const int localTriangleId) const;
 
+      int getEdgeLink2dL(const int p[2], const int id) const;
+      int getEdgeLink2dH(const int p[2], const int id) const;
+      int getEdgeLink2dD1(const int p[2], const int id) const;
+
       int getEdgeStar2dL(const int p[2], const int id) const;
       int getEdgeStar2dH(const int p[2], const int id) const;
 
@@ -934,6 +938,18 @@ inline int ImplicitTriangulation::getEdgeTriangleD1_xy(const int p[3], const int
     case 0: return p[Di_]*2+p[Dj_]*tshift_[0];
     case 1: return p[Di_]*2+p[Dj_]*tshift_[0]+1;
   }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLink2dL(const int p[2], const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLink2dH(const int p[2], const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLink2dD1(const int p[2], const int id) const{
   return -1;
 }
 

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -19,7 +19,6 @@ namespace ttk{
   class ImplicitTriangulation : public AbstractTriangulation{
 
     public:
-
       ImplicitTriangulation();
       ~ImplicitTriangulation();
 
@@ -456,6 +455,14 @@ namespace ttk{
       int getEdgeTriangleD3_xNz(const int p[3], const int localTriangleId) const;
 
       int getEdgeTriangleD4_xyz(const int p[3], const int localTriangleId) const;
+
+      int getEdgeLinkL(const int p[3], const int id) const;
+      int getEdgeLinkH(const int p[3], const int id) const;
+      int getEdgeLinkP(const int p[3], const int id) const;
+      int getEdgeLinkD1(const int p[3], const int id) const;
+      int getEdgeLinkD2(const int p[3], const int id) const;
+      int getEdgeLinkD3(const int p[3], const int id) const;
+      int getEdgeLinkD4(const int p[3], const int id) const;
 
       int getEdgeStarL(const int p[3], const int id) const;
       int getEdgeStarH(const int p[3], const int id) const;
@@ -2745,6 +2752,258 @@ inline int ImplicitTriangulation::getEdgeTriangleD4_xyz(const int p[3], const in
     case 3: return tsetshift_[3]+p[0]*2+p[1]*tshift_[8]+p[2]*tshift_[9]+1;
     case 4: return tsetshift_[4]+p[0]*2+p[1]*tshift_[10]+p[2]*tshift_[11];
     case 5: return tsetshift_[4]+p[0]*2+p[1]*tshift_[10]+p[2]*tshift_[11]+1;
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkL(const int p[3], const int id) const{
+  if(p[2]==0 and p[1]==0){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+eshift_[4]; //CG
+      case 1: return esetshift_[0]+p[0]+eshift_[3]; //EG
+    }
+  }
+  else if(p[2]==0 and p[1]==nbvoxels_[1]) return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]; //BG
+  else if(p[2]==nbvoxels_[2] and p[1]==0) return esetshift_[5]+p[0]+(p[2]-1)*eshift_[13]; //BG
+  else if(p[2]==nbvoxels_[2] and p[1]==nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]-1)*eshift_[4]+(p[2]-1)*eshift_[5]+1; //BF
+      case 1: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+(p[2]-1)*eshift_[3]+1; //BD
+    }
+  }
+  else if(p[2]==0 and p[1]>0 and p[1]<nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]+1)*eshift_[4]; //CG
+      case 1: return esetshift_[0]+p[0]+p[1]*eshift_[2]+eshift_[3]; //EG
+      case 2: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]; //BG
+    }
+  }
+  else if(p[2]==nbvoxels_[2] and p[1]>0 and p[1]<nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]-1)*eshift_[4]+(p[2]-1)*eshift_[5]+1; //BF
+      case 1: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+(p[2]-1)*eshift_[3]+1; //BD
+      case 2: return esetshift_[5]+p[0]+p[1]*eshift_[12]+(p[2]-1)*eshift_[13]; //BG
+   }
+  }
+  else if(p[2]>0 and p[2]<nbvoxels_[2] and p[1]==0){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+p[2]*eshift_[5]+eshift_[4]; //CG
+      case 1: return esetshift_[0]+p[0]+(p[2]+1)*eshift_[3]; //EG
+      case 2: return esetshift_[5]+p[0]+(p[2]-1)*eshift_[13]; //BG
+    }
+  }
+  else if(p[2]>0 and p[2]<nbvoxels_[2] and p[1]==nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]-1)*eshift_[4]+(p[2]-1)*eshift_[5]+1; //BF
+      case 1: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+(p[2]-1)*eshift_[3]+1; //BD
+      case 2: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]+p[2]*eshift_[13]; //BG
+    }
+  }
+  else{
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]+1)*eshift_[4]+p[2]*eshift_[5]; //CG
+      case 1: return esetshift_[0]+p[0]+p[1]*eshift_[2]+(p[2]+1)*eshift_[3]; //EG
+      case 2: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]+p[2]*eshift_[13];
+      case 3: return esetshift_[1]+p[0]+1+(p[1]-1)*eshift_[4]+(p[2]-1)*eshift_[5]; //CG
+      case 4: return esetshift_[0]+p[0]+1+(p[1]-1)*eshift_[2]+(p[2]-1)*eshift_[3]; //EG
+      case 5: return esetshift_[5]+p[0]+p[1]*eshift_[12]+(p[2]-1)*eshift_[13];
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkH(const int p[3], const int id) const{
+  if(p[0]==0 and p[2]==0) return esetshift_[5]+p[1]*eshift_[12];
+  else if(p[0]==nbvoxels_[0] and p[2]==0){
+    switch(id){
+      case 0: return esetshift_[1]+p[0]+(p[1]+1)*eshift_[4]-1;
+      case 1: return p[0]+(p[1]+1)*eshift_[0]+eshift_[1]-1;
+    }
+  }
+  else if(p[0]==0 and p[2]==nbvoxels_[2]){
+    switch(id){
+      case 0: return p[1]*eshift_[0]+(p[2]-1)*eshift_[1];
+      case 1: return esetshift_[1]+p[1]*eshift_[4]+(p[2]-1)*eshift_[5]+1;
+    }
+  }
+  else if(p[0]==nbvoxels_[0] and p[2]==nbvoxels_[2]) return esetshift_[5]+p[0]-1+p[1]*eshift_[12]+(p[2]-1)*eshift_[13];
+  else if(p[0]>0 and p[0]<nbvoxels_[0] and p[2]==0){
+    switch(id){
+      case 0: return p[0]-1+(p[1]+1)*eshift_[0]+eshift_[1];
+      case 1: return esetshift_[1]+p[0]-1+(p[1]+1)*eshift_[4];
+      case 2: return esetshift_[5]+p[0]+p[1]*eshift_[12];
+    }
+  }
+  else if(p[0]>0 and p[0]<nbvoxels_[0] and p[2]==nbvoxels_[2]){
+    switch(id){
+      case 0: return esetshift_[5]+p[0]-1+p[1]*eshift_[12]+(p[2]-1)*eshift_[13];
+      case 1: return p[0]+p[1]*eshift_[0]+(p[2]-1)*eshift_[1];
+      case 2: return esetshift_[1]+p[0]+1+p[1]*eshift_[4]+(p[2]-1)*eshift_[5];
+    }
+  }
+  else if(p[0]==0 and p[2]>0 and p[2]<nbvoxels_[2]){
+    switch(id){
+      case 0: return esetshift_[1]+p[1]*eshift_[4]+(p[2]-1)*eshift_[5]+1;
+      case 1: return esetshift_[5]+p[1]*eshift_[12]+p[2]*eshift_[13];
+      case 2: return p[1]*eshift_[0]+(p[2]-1)*eshift_[1];
+    }
+  }
+  else if(p[0]==nbvoxels_[0] and p[2]>0 and p[2]<nbvoxels_[2]){
+    switch(id){
+      case 0: return esetshift_[5]+p[0]-1+p[1]*eshift_[12]+(p[2]-1)*eshift_[13];
+      case 1: return esetshift_[1]+p[0]-1+(p[1]+1)*eshift_[4]+p[2]*eshift_[5];
+      case 2: return p[0]-1+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1];
+    }
+  }
+  else{
+    switch(id){
+      case 0: return p[0]+p[1]*eshift_[0]+(p[2]-1)*eshift_[1];
+      case 1: return p[0]+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1]-1;
+      case 2: return esetshift_[1]+p[0]-1+(p[1]+1)*eshift_[4]+p[2]*eshift_[5];
+      case 3: return esetshift_[1]+p[0]+1+p[1]*eshift_[4]+(p[2]-1)*eshift_[5];
+      case 4: return esetshift_[5]+(p[0]-1)+p[1]*eshift_[12]+(p[2]-1)*eshift_[13];
+      case 5: return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13];
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkP(const int p[3], const int id) const{
+  if(p[0]==0 and p[1]==0) return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13];
+  else if(p[0]==0 and p[1]==nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+p[2]*eshift_[3]+1;
+      case 1: return p[0]+(p[1]-1)*eshift_[0]+p[2]*eshift_[1];
+    }
+  }
+  else if(p[0]==nbvoxels_[0] and p[1]==0){
+    switch(id){
+      case 0: return esetshift_[0]+p[0]+p[1]*eshift_[2]+(p[2]+1)*eshift_[3]-1;
+      case 1: return p[0]+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1]-1;
+    }
+  }
+  else if(p[0]==nbvoxels_[0] and p[1]==nbvoxels_[1]) return esetshift_[5]+p[0]-1+(p[1]-1)*eshift_[12]+p[2]*eshift_[13];
+  else if(p[0]>0 and p[0]<nbvoxels_[0] and p[1]==0){
+    switch(id){
+      case 0: return p[0]+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1]-1;
+      case 1: return esetshift_[0]+p[0]+p[1]*eshift_[2]+(p[2]+1)*eshift_[3]-1;
+      case 2: return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13];
+    }
+  }
+  else if(p[0]>0 and p[0]<nbvoxels_[0] and p[1]==nbvoxels_[1]){
+    switch(id){
+      case 0: return p[0]+(p[1]-1)*eshift_[0]+p[2]*eshift_[1];
+      case 1: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+p[2]*eshift_[3]+1;
+      case 2: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]+p[2]*eshift_[13]-1;
+    }
+  }
+  else if(p[0]==0 and p[1]>0 and p[1]<nbvoxels_[1]){
+    switch(id){
+      case 0: return p[0]+(p[1]-1)*eshift_[0]+p[2]*eshift_[1];
+      case 1: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+p[2]*eshift_[3]+1;
+      case 2: return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13];
+    }
+  }
+  else if(p[0]==nbvoxels_[0] and p[1]>0 and p[1]<nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]+p[2]*eshift_[13]-1;
+      case 1: return esetshift_[0]+p[0]+p[1]*eshift_[2]+(p[2]+1)*eshift_[3]-1;
+      case 2: return p[0]+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1]-1;
+    }
+  }
+  else{
+    switch(id){
+      case 0: return p[0]+(p[1]-1)*eshift_[0]+p[2]*eshift_[1];
+      case 1: return p[0]+(p[1]+1)*eshift_[0]+(p[2]+1)*eshift_[1]-1;
+      case 2: return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13];
+      case 3: return esetshift_[5]+p[0]+(p[1]-1)*eshift_[12]+p[2]*eshift_[13]-1;
+      case 4: return esetshift_[0]+p[0]+p[1]*eshift_[2]+(p[2]+1)*eshift_[3]-1;
+      case 5: return esetshift_[0]+p[0]+(p[1]-1)*eshift_[2]+p[2]*eshift_[3]+1;
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkD1(const int p[3], const int id) const{
+  if(p[2]>0 and p[2]<nbvoxels_[2]){
+    switch(id){
+      case 0: return esetshift_[4]+p[0]+p[1]*eshift_[10]+(p[2]-1)*eshift_[11];
+      case 1: return esetshift_[4]+p[0]+(p[1]+1)*eshift_[10]+p[2]*eshift_[11];
+      case 2: return esetshift_[3]+p[0]+p[1]*eshift_[8]+p[2]*eshift_[9];
+      case 3: return esetshift_[3]+p[0]+p[1]*eshift_[8]+(p[2]-1)*eshift_[9]+1;
+    }
+  }
+  else if(p[2]==0){
+    switch(id){
+      case 0: return esetshift_[3]+p[0]+p[1]*eshift_[8]+p[2]*eshift_[9];
+      case 1: return esetshift_[4]+p[0]+(p[1]+1)*eshift_[10]+p[2]*eshift_[11];
+    }
+  }
+  else{
+    switch(id){
+      case 0: return esetshift_[3]+p[0]+p[1]*eshift_[8]+(p[2]-1)*eshift_[9]+1;
+      case 1: return esetshift_[4]+p[0]+p[1]*eshift_[10]+(p[2]-1)*eshift_[11];
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkD2(const int p[3], const int id) const{
+  if(p[0]>0 and p[0]<nbvoxels_[0]){
+    switch(id){
+      case 0: return esetshift_[4]+p[0]+p[1]*eshift_[10]+p[2]*eshift_[11];
+      case 1: return esetshift_[4]+p[0]+(p[1]+1)*eshift_[10]+p[2]*eshift_[11]-1;
+      case 2: return esetshift_[2]+p[0]+p[1]*eshift_[6]+p[2]*eshift_[7];
+      case 3: return esetshift_[2]+p[0]+p[1]*eshift_[6]+(p[2]+1)*eshift_[7]-1;
+    }
+  }
+  else if(p[0]==0){
+    switch(id){
+      case 0: return esetshift_[2]+p[0]+p[1]*eshift_[6]+p[2]*eshift_[7];
+      case 1: return esetshift_[4]+p[0]+p[1]*eshift_[10]+p[2]*eshift_[11];
+    }
+  }
+  else{
+    switch(id){
+      case 0: return esetshift_[2]+p[0]+p[1]*eshift_[6]+(p[2]+1)*eshift_[7]-1;
+      case 1: return esetshift_[4]+p[0]+(p[1]+1)*eshift_[10]+p[2]*eshift_[11]-1;
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkD3(const int p[3], const int id) const{
+  if(p[1]>0 and p[1]<nbvoxels_[1]){
+    switch(id){
+      case 0: return esetshift_[2]+p[0]+(p[1]-1)*eshift_[6]+p[2]*eshift_[7];
+      case 1: return esetshift_[2]+p[0]+p[1]*eshift_[6]+(p[2]+1)*eshift_[7];
+      case 2: return esetshift_[3]+p[0]+p[1]*eshift_[8]+p[2]*eshift_[9];
+      case 3: return esetshift_[3]+p[0]+(p[1]-1)*eshift_[8]+p[2]*eshift_[9]+1;
+    }
+  }
+  else if(p[1]==0){
+    switch(id){
+      case 0: return esetshift_[2]+p[0]+p[1]*eshift_[6]+(p[2]+1)*eshift_[7];
+      case 1: return esetshift_[3]+p[0]+p[1]*eshift_[8]+p[2]*eshift_[9];
+    }
+  }
+  else{
+    switch(id){
+      case 0: return esetshift_[2]+p[0]+(p[1]-1)*eshift_[6]+p[2]*eshift_[7];
+      case 1: return esetshift_[3]+p[0]+(p[1]-1)*eshift_[8]+p[2]*eshift_[9]+1;
+    }
+  }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getEdgeLinkD4(const int p[3], const int id) const{
+  switch(id){
+    case 0: return p[0]+(p[1]+1)*eshift_[0]+p[2]*eshift_[1];
+    case 1: return p[0]+p[1]*eshift_[0]+(p[2]+1)*eshift_[1];
+    case 2: return esetshift_[1]+p[0]+p[1]*eshift_[4]+p[2]*eshift_[5];
+    case 3: return esetshift_[1]+p[0]+1+(p[1]+1)*eshift_[4]+p[2]*eshift_[5];
+    case 4: return esetshift_[0]+p[0]+p[1]*eshift_[2]+p[2]*eshift_[3];
+    case 5: return esetshift_[0]+p[0]+1+p[1]*eshift_[2]+(p[2]+1)*eshift_[3];
   }
   return -1;
 }


### PR DESCRIPTION
Dear Julien, I improved the efficiency of the requests on the link of an edge or a triangle in the ttk::ImplicitTriangulation module.

I also fixed a minor compilation warning in ttk::AbstractMorseSmaleComplex module.