### PR TITLE
ImplicitTriangulation - new getVertexTriangle*() requests

### DIFF
--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -624,6 +624,53 @@ const vector<vector<int>>* ImplicitTriangulation::getVertexEdges(){
   return &vertexEdgeList_;
 }
 
+inline int ImplicitTriangulation::getVertexTriangleNumber(const int &vertexId) const{
+#ifndef withKamikaze
+  if(vertexId<0 or vertexId>=vertexNumber_) return -1;
+#endif
+
+  if(dimensionality_==3){
+  }
+
+  return 0;
+}
+
+int ImplicitTriangulation::getVertexTriangle(const int &vertexId, const int &localTriangleId, int &triangleId) const{
+#ifndef withKamikaze
+  if(localTriangleId<0 or localTriangleId>=getVertexTriangleNumber(vertexId)) return -1;
+#endif
+  triangleId=-1;
+
+  if(dimensionality_==3){
+  }
+
+  return 0;
+}
+
+const vector<vector<int>>* ImplicitTriangulation::getVertexTriangles(){
+  if(!vertexTriangleList_.size()){
+    Timer t;
+
+    vertexTriangleList_.resize(vertexNumber_);
+    for(int i=0; i<vertexNumber_; ++i){
+      vertexTriangleList_[i].resize(getVertexTriangleNumber(i));
+      for(unsigned int j=0; j<vertexTriangleList_[i].size(); ++j)
+        getVertexTriangle(i,j,vertexTriangleList_[i][j]);
+    }
+
+    {
+      stringstream msg;
+      msg << "[ImplicitTriangulation] Vertex triangles built in "
+        << t.getElapsedTime() << " s. (" << 1
+        << " thread(s))."
+        << endl;
+      dMsg(cout, msg.str(), timeMsg);
+    }
+  }
+
+  return &vertexTriangleList_;
+}
+
 int ImplicitTriangulation::getVertexLinkNumber(const int& vertexId) const{
   return getVertexStarNumber(vertexId);
 }

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -635,49 +635,49 @@ inline int ImplicitTriangulation::getVertexTriangleNumber(const int &vertexId) c
 
     if(0<p[0] and p[0]<nbvoxels_[0]){
       if(0<p[1] and p[1]<nbvoxels_[1]){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//abcdefgh
-        else return 0;//abdc ou efhg
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 36;//abcdefgh
+        else return 21;//abdc ou efhg
       }
       else if(p[1]==0){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//aefb
-        else if(p[2]==0) return 0;//ab
-        else return 0;//ef
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 21;//aefb
+        else if(p[2]==0) return 15;//ab
+        else return 9;//ef
       }
       else{
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//ghdc
-        else if(p[2]==0) return 0;//cd
-        else return 0;//gh
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 21;//ghdc
+        else if(p[2]==0) return 9;//cd
+        else return 15;//gh
       }
     }
     else if(p[0]==0){
       if(0<p[1] and p[1]<nbvoxels_[1]){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//aegc
-        else if(p[2]==0) return 0;//ac
-        else return 0;//eg
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 21;//aegc
+        else if(p[2]==0) return 9;//ac
+        else return 15;//eg
       }
       else if(p[1]==0){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//ae
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 9;//ae
         else return 5;//a ou e
       }
       else{
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//cg
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 15;//cg
         else if(p[2]==0) return 5;//c
         else return 12;//g
       }
     }
     else{
       if(0<p[1] and p[1]<nbvoxels_[1]){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//bfhd
-        else if(p[2]==0) return 0;//bd
-        else return 0;//fh
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 21;//bfhd
+        else if(p[2]==0) return 15;//bd
+        else return 9;//fh
       }
       else if(p[1]==0){
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//bf
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 15;//bf
         else if(p[2]==0) return 12;//b
         else return 5;//f
       }
       else{
-        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//dh
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 9;//dh
         else return 5;//d ou h
       }
     }

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.cpp
@@ -630,6 +630,57 @@ inline int ImplicitTriangulation::getVertexTriangleNumber(const int &vertexId) c
 #endif
 
   if(dimensionality_==3){
+    int p[3];
+    vertexToPosition(vertexId,p);
+
+    if(0<p[0] and p[0]<nbvoxels_[0]){
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//abcdefgh
+        else return 0;//abdc ou efhg
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//aefb
+        else if(p[2]==0) return 0;//ab
+        else return 0;//ef
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//ghdc
+        else if(p[2]==0) return 0;//cd
+        else return 0;//gh
+      }
+    }
+    else if(p[0]==0){
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//aegc
+        else if(p[2]==0) return 0;//ac
+        else return 0;//eg
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//ae
+        else return 5;//a ou e
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//cg
+        else if(p[2]==0) return 5;//c
+        else return 12;//g
+      }
+    }
+    else{
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//bfhd
+        else if(p[2]==0) return 0;//bd
+        else return 0;//fh
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//bf
+        else if(p[2]==0) return 12;//b
+        else return 5;//f
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) return 0;//dh
+        else return 5;//d ou h
+      }
+    }
   }
 
   return 0;
@@ -642,6 +693,60 @@ int ImplicitTriangulation::getVertexTriangle(const int &vertexId, const int &loc
   triangleId=-1;
 
   if(dimensionality_==3){
+    int p[3];
+    vertexToPosition(vertexId,p);
+
+    if(0<p[0] and p[0]<nbvoxels_[0]){
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleABCDEFGH(p,localTriangleId);//abcdefgh
+        else if(p[2]==0) triangleId=getVertexTriangleABDC(p,localTriangleId);//abdc
+        else triangleId=getVertexTriangleEFHG(p,localTriangleId);//efhg
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleAEFB(p,localTriangleId);//aefb
+        else if(p[2]==0) triangleId=getVertexTriangleAB(p,localTriangleId);//ab
+        else triangleId=getVertexTriangleEF(p,localTriangleId);//ef
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleGHDC(p,localTriangleId);//ghdc
+        else if(p[2]==0) triangleId=getVertexTriangleCD(p,localTriangleId);//cd
+        else triangleId=getVertexTriangleGH(p,localTriangleId);//gh
+      }
+    }
+    else if(p[0]==0){
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleAEGC(p,localTriangleId);//aegc
+        else if(p[2]==0) triangleId=getVertexTriangleAC(p,localTriangleId);//ac
+        else triangleId=getVertexTriangleEG(p,localTriangleId);//eg
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleAE(p,localTriangleId);//ae
+        else if(p[2]==0) triangleId=getVertexTriangleA(p,localTriangleId);//a
+        else triangleId=getVertexTriangleE(p,localTriangleId);//e
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleCG(p,localTriangleId);//cg
+        else if(p[2]==0) triangleId=getVertexTriangleC(p,localTriangleId);//c
+        else triangleId=getVertexTriangleG(p,localTriangleId);//g
+      }
+    }
+    else{
+      if(0<p[1] and p[1]<nbvoxels_[1]){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleBFHD(p,localTriangleId);//bfhd
+        else if(p[2]==0) triangleId=getVertexTriangleBD(p,localTriangleId);//bd
+        else triangleId=getVertexTriangleFH(p,localTriangleId);//fh
+      }
+      else if(p[1]==0){
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleBF(p,localTriangleId);//bf
+        else if(p[2]==0) triangleId=getVertexTriangleB(p,localTriangleId);//b
+        else triangleId=getVertexTriangleF(p,localTriangleId);//f
+      }
+      else{
+        if(0<p[2] and p[2]<nbvoxels_[2]) triangleId=getVertexTriangleDH(p,localTriangleId);//dh
+        else if(p[2]==0) triangleId=getVertexTriangleD(p,localTriangleId);//d
+        else triangleId=getVertexTriangleH(p,localTriangleId);//h
+      }
+    }
   }
 
   return 0;

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -2231,6 +2231,7 @@ inline int ImplicitTriangulation::getVertexTriangleBFHD(const int p[3],const int
     case 15: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
     case 16: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
     case 17: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 18: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
     case 19: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+(p[2]-1)*tshift_[11]+1;
     case 20: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
   }

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -156,32 +156,11 @@ namespace ttk{
 
       const vector<vector<int>>* getVertexStars();
 
-      int getVertexTriangle(const int &vertexId, const int &localTriangleId, int &triangleId) const{
+      int getVertexTriangle(const int &vertexId, const int &localTriangleId, int &triangleId) const;
 
-        stringstream msg;
-        msg << "[ImplicitTriangulation] NOT IMPLEMENTED! TODO!" << endl;
-        dMsg(cerr, msg.str(), 0);
+      int getVertexTriangleNumber(const int &vertexId) const;
 
-        return -1;
-      }
-
-      int getVertexTriangleNumber(const int &vertexId) const{
-
-        stringstream msg;
-        msg << "[ImplicitTriangulation] NOT IMPLEMENTED! TODO!" << endl;
-        dMsg(cerr, msg.str(), 0);
-
-        return -1;
-      }
-
-      const vector<vector<int>>* getVertexTriangles(){
-
-        stringstream msg;
-        msg << "[ImplicitTriangulation] NOT IMPLEMENTED! TODO!" << endl;
-        dMsg(cerr, msg.str(), 0);
-
-        return NULL;
-      }
+      const vector<vector<int>>* getVertexTriangles();
 
       bool isEdgeOnBoundary(const int &edgeId) const;
 

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -339,6 +339,34 @@ namespace ttk{
       int getVertexEdgeGHDC(const int p[3],const int id) const;
       int getVertexEdgeABCDEFGH(const int p[3],const int id) const;
 
+      int getVertexTriangleA(const int p[3],const int id) const;
+      int getVertexTriangleB(const int p[3],const int id) const;
+      int getVertexTriangleC(const int p[3],const int id) const;
+      int getVertexTriangleD(const int p[3],const int id) const;
+      int getVertexTriangleE(const int p[3],const int id) const;
+      int getVertexTriangleF(const int p[3],const int id) const;
+      int getVertexTriangleG(const int p[3],const int id) const;
+      int getVertexTriangleH(const int p[3],const int id) const;
+      int getVertexTriangleAB(const int p[3],const int id) const;
+      int getVertexTriangleCD(const int p[3],const int id) const;
+      int getVertexTriangleEF(const int p[3],const int id) const;
+      int getVertexTriangleGH(const int p[3],const int id) const;
+      int getVertexTriangleAC(const int p[3],const int id) const;
+      int getVertexTriangleBD(const int p[3],const int id) const;
+      int getVertexTriangleEG(const int p[3],const int id) const;
+      int getVertexTriangleFH(const int p[3],const int id) const;
+      int getVertexTriangleAE(const int p[3],const int id) const;
+      int getVertexTriangleBF(const int p[3],const int id) const;
+      int getVertexTriangleCG(const int p[3],const int id) const;
+      int getVertexTriangleDH(const int p[3],const int id) const;
+      int getVertexTriangleABDC(const int p[3],const int id) const;
+      int getVertexTriangleEFHG(const int p[3],const int id) const;
+      int getVertexTriangleAEGC(const int p[3],const int id) const;
+      int getVertexTriangleBFHD(const int p[3],const int id) const;
+      int getVertexTriangleAEFB(const int p[3],const int id) const;
+      int getVertexTriangleGHDC(const int p[3],const int id) const;
+      int getVertexTriangleABCDEFGH(const int p[3],const int id) const;
+
       int getVertexLinkA(const int p[3],const int id) const;
       int getVertexLinkB(const int p[3],const int id) const;
       int getVertexLinkC(const int p[3],const int id) const;
@@ -1781,6 +1809,114 @@ inline int ImplicitTriangulation::getVertexEdgeABCDEFGH(const int p[3],const int
     case 12: return esetshift_[5]+p[0]+p[1]*eshift_[12]+p[2]*eshift_[13]-1;//bg-D4
     case 13: return esetshift_[3]+p[0]+p[1]*eshift_[8]+p[2]*eshift_[9];//bh-D2
   }
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleA(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleB(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleC(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleD(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleE(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleF(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleG(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleH(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleAB(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleCD(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleEF(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleGH(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleAC(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleBD(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleEG(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleFH(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleAE(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleBF(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleCG(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleDH(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleABDC(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleEFHG(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleAEGC(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleBFHD(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleAEFB(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleGHDC(const int p[3],const int id) const{
+  return -1;
+}
+
+inline int ImplicitTriangulation::getVertexTriangleABCDEFGH(const int p[3],const int id) const{
   return -1;
 }
 

--- a/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/baseCode/implicitTriangulation/ImplicitTriangulation.h
@@ -1813,110 +1813,523 @@ inline int ImplicitTriangulation::getVertexEdgeABCDEFGH(const int p[3],const int
 }
 
 inline int ImplicitTriangulation::getVertexTriangleA(const int p[3],const int id) const{
+  switch(id){
+    case 0: return 0;
+    case 1: return tsetshift_[0];
+    case 2: return tsetshift_[1];
+    case 3: return tsetshift_[3];
+    case 4: return tsetshift_[1]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleB(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2;
+    case 2: return tsetshift_[2]+(p[0]-1)*2;
+    case 3: return tsetshift_[3]+(p[0]-1)*2+1;
+    case 4: return tsetshift_[1]+p[0]*2;
+    case 5: return tsetshift_[1]+p[0]*2+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2;
+    case 10: return tsetshift_[0]+(p[0]-1)*2;
+    case 11: return (p[0]-1)*2;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleC(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[1]-1)*tshift_[0];
+    case 1: return (p[1]-1)*tshift_[0]+1;
+    case 2: return tsetshift_[4]+(p[1]-1)*tshift_[10];
+    case 3: return tsetshift_[0]+p[1]*tshift_[2];
+    case 4: return tsetshift_[1]+(p[1]-1)*tshift_[4];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleD(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+1;
+    case 1: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6];
+    case 2: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4];
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleE(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[0]+(p[2]-1)*tshift_[3];
+    case 1: return tsetshift_[2]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[2]-1)*tshift_[5]+1;
+    case 3: return p[2]*tshift_[1];
+    case 4: return tsetshift_[0]+(p[2]-1)*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleF(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[0]+(p[0]-1)*2+(p[2]-1)*tshift_[3]+1;
+    case 1: return (p[0]-1)*2+p[2]*tshift_[1];
+    case 2: return (p[0]-1)*2+p[2]*tshift_[1]+1;
+    case 3: return tsetshift_[4]+(p[0]-1)*2+(p[2]-1)*tshift_[11]+1;
+    case 4: return tsetshift_[1]+p[0]*2+(p[2]-1)*tshift_[5]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleG(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleH(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 1: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 2: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleAB(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2;
+    case 2: return tsetshift_[2]+(p[0]-1)*2;
+    case 3: return tsetshift_[3]+(p[0]-1)*2+1;
+    case 4: return tsetshift_[1]+p[0]*2;
+    case 5: return tsetshift_[1]+p[0]*2+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2;
+    case 10: return tsetshift_[0]+(p[0]-1)*2;
+    case 11: return (p[0]-1)*2;
+    case 12: return p[0]*2;
+    case 13: return tsetshift_[0]+p[0]*2;
+    case 14: return tsetshift_[3]+p[0]*2;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleCD(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+1;
+    case 1: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6];
+    case 2: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4];
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+1;
+    case 5: return p[0]*2+(p[1]-1)*tshift_[0];
+    case 6: return p[0]*2+(p[1]-1)*tshift_[0]+1;
+    case 7: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10];
+    case 8: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleEF(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[0]+(p[0]-1)*2+(p[2]-1)*tshift_[3]+1;
+    case 1: return (p[0]-1)*2+p[2]*tshift_[1];
+    case 2: return (p[0]-1)*2+p[2]*tshift_[1]+1;
+    case 3: return tsetshift_[4]+(p[0]-1)*2+(p[2]-1)*tshift_[11]+1;
+    case 4: return tsetshift_[1]+p[0]*2+(p[2]-1)*tshift_[5]+1;
+    case 5: return p[0]*2+tsetshift_[0]+(p[2]-1)*tshift_[3];
+    case 6: return p[0]*2+tsetshift_[2]+(p[2]-1)*tshift_[7]+1;
+    case 7: return p[0]*2+p[2]*tshift_[1];
+    case 8: return p[0]*2+tsetshift_[0]+(p[2]-1)*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleGH(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 1: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 2: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 5: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 6: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 7: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 8: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 9: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 10: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 11: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 12: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 13: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 14: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleAC(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[1]-1)*tshift_[0];
+    case 1: return (p[1]-1)*tshift_[0]+1;
+    case 2: return tsetshift_[4]+(p[1]-1)*tshift_[10];
+    case 3: return tsetshift_[0]+p[1]*tshift_[2];
+    case 4: return tsetshift_[1]+(p[1]-1)*tshift_[4];
+    case 5: return p[1]*tshift_[0];
+    case 6: return tsetshift_[1]+p[1]*tshift_[4];
+    case 7: return tsetshift_[3]+p[1]*tshift_[8];
+    case 8: return tsetshift_[1]+p[1]*tshift_[4]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleBD(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+1;
+    case 1: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6];
+    case 2: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4];
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+1;
+    case 5: return (p[0]-1)*2+p[1]*tshift_[0]+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10];
+    case 7: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6];
+    case 8: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+1;
+    case 9: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4];
+    case 10: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+1;
+    case 11: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+1;
+    case 12: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+1;
+    case 13: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8];
+    case 14: return (p[0]-1)*2+p[1]*tshift_[0];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleEG(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 12: return tsetshift_[2]+p[1]*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 13: return tsetshift_[1]+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 14: return p[1]*tshift_[0]+p[2]*tshift_[1];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleFH(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 1: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 2: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 5: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 6: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1]+1;
+    case 7: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleAE(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[0]+(p[2]-1)*tshift_[3];
+    case 1: return tsetshift_[2]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[2]-1)*tshift_[5]+1;
+    case 3: return p[2]*tshift_[1];
+    case 4: return tsetshift_[0]+(p[2]-1)*tshift_[3]+1;
+    case 5: return tsetshift_[0]+p[2]*tshift_[3];
+    case 6: return tsetshift_[1]+p[2]*tshift_[5];
+    case 7: return tsetshift_[3]+p[2]*tshift_[9];
+    case 8: return tsetshift_[1]+p[2]*tshift_[5]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleBF(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[0]+(p[0]-1)*2+(p[2]-1)*tshift_[3]+1;
+    case 1: return (p[0]-1)*2+p[2]*tshift_[1];
+    case 2: return (p[0]-1)*2+p[2]*tshift_[1]+1;
+    case 3: return tsetshift_[4]+(p[0]-1)*2+(p[2]-1)*tshift_[11]+1;
+    case 4: return tsetshift_[1]+p[0]*2+(p[2]-1)*tshift_[5]+1;
+    case 5: return tsetshift_[4]+(p[0]-1)*2+p[2]*tshift_[11];
+    case 6: return tsetshift_[2]+(p[0]-1)*2+p[2]*tshift_[7];
+    case 7: return tsetshift_[3]+(p[0]-1)*2+p[2]*tshift_[9]+1;
+    case 8: return tsetshift_[1]+p[0]*2+p[2]*tshift_[5];
+    case 9: return tsetshift_[1]+p[0]*2+p[2]*tshift_[5]+1;
+    case 10: return tsetshift_[4]+(p[0]-1)*2+p[2]*tshift_[11]+1;
+    case 11: return tsetshift_[0]+(p[0]-1)*2+p[2]*tshift_[3]+1;
+    case 12: return tsetshift_[2]+(p[0]-1)*2+p[2]*tshift_[7]+1;
+    case 13: return tsetshift_[3]+(p[0]-1)*2+p[2]*tshift_[9];
+    case 14: return tsetshift_[0]+(p[0]-1)*2+p[2]*tshift_[3];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleCG(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 12: return tsetshift_[4]+(p[1]-1)*tshift_[10]+p[2]*tshift_[11];
+    case 13: return tsetshift_[0]+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 14: return tsetshift_[1]+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleDH(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 1: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 2: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 5: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6]+p[2]*tshift_[7];
+    case 6: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 7: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+    case 8: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleABDC(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+p[1]*tshift_[0]+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10];
+    case 2: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6];
+    case 3: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+1;
+    case 4: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4];
+    case 5: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8];
+    case 10: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2];
+    case 11: return (p[0]-1)*2+p[1]*tshift_[0];
+    case 12: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+1;
+    case 13: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6];
+    case 14: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4];
+    case 15: return p[0]*2+(p[1]-1)*tshift_[0];
+    case 16: return p[0]*2+(p[1]-1)*tshift_[0]+1;
+    case 17: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10];
+    case 18: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2];
+    case 19: return p[0]*2+p[1]*tshift_[0];
+    case 20: return p[0]*2+tsetshift_[3]+p[1]*tshift_[8];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleEFHG(const int p[3],const int id) const{
+  switch(id){
+    case 0: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 12: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 13: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 14: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 15: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 16: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1]+1;
+    case 17: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 18: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 19: return p[0]*2+tsetshift_[2]+p[1]*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 20: return p[0]*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleAEGC(const int p[3],const int id) const{
+  switch(id){
+    case 0: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return (p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 12: return tsetshift_[2]+p[1]*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 13: return tsetshift_[1]+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 14: return p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 15: return tsetshift_[0]+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 16: return tsetshift_[1]+p[1]*tshift_[4]+p[2]*tshift_[5];
+    case 17: return tsetshift_[3]+p[1]*tshift_[8]+p[2]*tshift_[9];
+    case 18: return tsetshift_[1]+p[1]*tshift_[4]+p[2]*tshift_[5]+1;
+    case 19: return tsetshift_[4]+(p[1]-1)*tshift_[10]+p[2]*tshift_[11];
+    case 20: return tsetshift_[1]+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleBFHD(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1]+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+p[2]*tshift_[11];
+    case 2: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+p[2]*tshift_[7];
+    case 3: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+p[2]*tshift_[9]+1;
+    case 4: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+p[2]*tshift_[5];
+    case 5: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+p[2]*tshift_[5]+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+p[2]*tshift_[11]+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3]+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+p[2]*tshift_[7]+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+p[2]*tshift_[9];
+    case 10: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 11: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 12: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 13: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6]+p[2]*tshift_[7];
+    case 14: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+    case 15: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 16: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 17: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 19: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 20: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleAEFB(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+p[2]*tshift_[1]+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2+p[2]*tshift_[11];
+    case 2: return tsetshift_[2]+(p[0]-1)*2+p[2]*tshift_[7];
+    case 3: return tsetshift_[3]+(p[0]-1)*2+p[2]*tshift_[9]+1;
+    case 4: return tsetshift_[1]+p[0]*2+p[2]*tshift_[5];
+    case 5: return tsetshift_[1]+p[0]*2+p[2]*tshift_[5]+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+p[2]*tshift_[11]+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+p[2]*tshift_[3]+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+p[2]*tshift_[7]+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2+p[2]*tshift_[9];
+    case 10: return tsetshift_[0]+(p[0]-1)*2+p[2]*tshift_[3];
+    case 11: return (p[0]-1)*2+p[2]*tshift_[1];
+    case 12: return tsetshift_[0]+(p[0]-1)*2+(p[2]-1)*tshift_[3]+1;
+    case 13: return tsetshift_[4]+(p[0]-1)*2+(p[2]-1)*tshift_[11]+1;
+    case 14: return tsetshift_[1]+p[0]*2+(p[2]-1)*tshift_[5]+1;
+    case 15: return p[0]*2+tsetshift_[0]+(p[2]-1)*tshift_[3];
+    case 16: return p[0]*2+tsetshift_[2]+(p[2]-1)*tshift_[7]+1;
+    case 17: return p[0]*2+p[2]*tshift_[1];
+    case 18: return p[0]*2+tsetshift_[0]+(p[2]-1)*tshift_[3]+1;
+    case 19: return p[0]*2+tsetshift_[0]+p[2]*tshift_[3];
+    case 20: return p[0]*2+tsetshift_[3]+p[2]*tshift_[9];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleGHDC(const int p[3],const int id) const{
+  switch(id){
+    case 0: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 1: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 2: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 3: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 4: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 5: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 6: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 7: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 8: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 9: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 10: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 11: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 12: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 13: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 14: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 15: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6]+p[2]*tshift_[7];
+    case 16: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 17: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+    case 18: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3]+1;
+    case 19: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+p[2]*tshift_[11];
+    case 20: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+p[2]*tshift_[3];
+  }
   return -1;
 }
 
 inline int ImplicitTriangulation::getVertexTriangleABCDEFGH(const int p[3],const int id) const{
+  switch(id){
+    case 0: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1]+1;
+    case 1: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+p[2]*tshift_[11];
+    case 2: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+p[2]*tshift_[7];
+    case 3: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+p[2]*tshift_[9]+1;
+    case 4: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+p[2]*tshift_[5];
+    case 5: return tsetshift_[1]+p[0]*2+p[1]*tshift_[4]+p[2]*tshift_[5]+1;
+    case 6: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+p[2]*tshift_[11]+1;
+    case 7: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3]+1;
+    case 8: return tsetshift_[2]+(p[0]-1)*2+p[1]*tshift_[6]+p[2]*tshift_[7]+1;
+    case 9: return tsetshift_[3]+(p[0]-1)*2+p[1]*tshift_[8]+p[2]*tshift_[9];
+    case 10: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 11: return (p[0]-1)*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 12: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7];
+    case 13: return p[0]*2+tsetshift_[2]+(p[1]-1)*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 14: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5];
+    case 15: return p[0]*2+tsetshift_[1]+(p[1]-1)*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 16: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9];
+    case 17: return p[0]*2+tsetshift_[3]+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 18: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11];
+    case 19: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 20: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1];
+    case 21: return p[0]*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 22: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3];
+    case 23: return p[0]*2+tsetshift_[0]+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 24: return (p[0]-1)*2+(p[1]-1)*tshift_[0]+p[2]*tshift_[1]+1;
+    case 25: return tsetshift_[2]+(p[0]-1)*2+(p[1]-1)*tshift_[6]+p[2]*tshift_[7];
+    case 26: return tsetshift_[1]+p[0]*2+(p[1]-1)*tshift_[4]+p[2]*tshift_[5];
+    case 27: return p[0]*2+tsetshift_[2]+p[1]*tshift_[6]+(p[2]-1)*tshift_[7]+1;
+    case 28: return p[0]*2+tsetshift_[1]+p[1]*tshift_[4]+(p[2]-1)*tshift_[5]+1;
+    case 29: return p[0]*2+p[1]*tshift_[0]+p[2]*tshift_[1];
+    case 30: return tsetshift_[3]+(p[0]-1)*2+(p[1]-1)*tshift_[8]+(p[2]-1)*tshift_[9]+1;
+    case 31: return tsetshift_[0]+(p[0]-1)*2+p[1]*tshift_[2]+(p[2]-1)*tshift_[3]+1;
+    case 32: return tsetshift_[0]+p[0]*2+p[1]*tshift_[2]+p[2]*tshift_[3];
+    case 33: return tsetshift_[3]+p[0]*2+p[1]*tshift_[8]+p[2]*tshift_[9];
+    case 34: return tsetshift_[4]+(p[0]-1)*2+p[1]*tshift_[10]+(p[2]-1)*tshift_[11]+1;
+    case 35: return p[0]*2+tsetshift_[4]+(p[1]-1)*tshift_[10]+p[2]*tshift_[11];
+  }
   return -1;
 }
 


### PR DESCRIPTION
Dear Julien,

I have implemented the missing queries in the ImplicitTriangulation baseCode module concerning the triangles connected to a given vertex in a 3D regular grid.