### PR TITLE
TopologicalSimplification - bugfix

### DIFF
--- a/core/baseCode/topologicalSimplification/TopologicalSimplification.h
+++ b/core/baseCode/topologicalSimplification/TopologicalSimplification.h
@@ -293,7 +293,14 @@ int TopologicalSimplification::execute() const{
 
   // get the user extremum list
   vector<bool> extrema(vertexNumber_, false);
-  for(int k=0; k<constraintNumber_; ++k) extrema[identifiers[k]]=true;
+  for(int k=0; k<constraintNumber_; ++k){
+    const int identifierId=identifiers[k];
+
+#ifndef withKamikaze
+    if(identifierId>=0 and identifierId<vertexNumber_)
+#endif
+      extrema[identifierId]=true;
+  }
 
   vector<int> authorizedMinima;
   vector<int> authorizedMaxima;

--- a/core/vtkWrappers/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtkWrappers/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -254,9 +254,16 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
   }
 #endif
 
-  topologicalSimplification_.setVertexNumber(domain->GetNumberOfPoints());
-  topologicalSimplification_.setConstraintNumber(
-    constraints->GetNumberOfPoints());
+  const int numberOfConstraints=constraints->GetNumberOfPoints();
+#ifndef withKamikaze
+  if(numberOfConstraints<=0){
+    cerr << "[ttkTopologicalSimplification] Error : input has no constraints." << endl;
+    return -10;
+  }
+#endif
+
+  topologicalSimplification_.setVertexNumber(numberOfVertices);
+  topologicalSimplification_.setConstraintNumber(numberOfConstraints);
   topologicalSimplification_.setInputScalarFieldPointer(
     inputScalars_->GetVoidPointer(0));
   topologicalSimplification_.setVertexIdentifierScalarFieldPointer(
@@ -281,7 +288,7 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
   // something wrong in baseCode
   if(ret){
     cerr << "[ttkTopologicalSimplification] TopologicalSimplification.execute() error code : " << ret << endl;
-    return -10;
+    return -11;
   }
 #endif
 


### PR DESCRIPTION
Dear Julien,

I fixed a bug in TopologicalSimplification that occurs when no constraint is given by the user and added range checking to constraints' vertex identifiers.