### PR TITLE
Mask array in Smoothing

### DIFF
--- a/core/baseCode/scalarFieldSmoother/ScalarFieldSmoother.cpp
+++ b/core/baseCode/scalarFieldSmoother/ScalarFieldSmoother.cpp
@@ -1,15 +1,14 @@
-#include                  <ScalarFieldSmoother.h>
+#include <ScalarFieldSmoother.h>
 
 ScalarFieldSmoother::ScalarFieldSmoother(){
-
-  inputData_ = NULL;
-  outputData_ = NULL;
-  dimensionNumber_ = 1;
-  triangulation_ = NULL;
+   inputData_       = nullptr;
+   outputData_      = nullptr;
+   dimensionNumber_ = 1;
+   mask_            = nullptr;
+   triangulation_   = nullptr;
 }
 
 ScalarFieldSmoother::~ScalarFieldSmoother(){
-  
 }
 
 

--- a/core/baseCode/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/baseCode/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -109,8 +109,6 @@ template <class dataType> int ScalarFieldSmoother::smooth(
     }
   }
 
-  cout << "Mask: " << (mask_ == nullptr) << endl;
- 
   for(int it = 0; it < numberOfIterations; it++){
 #ifdef withOpenMP
     omp_lock_t writeLock;

--- a/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -1,11 +1,17 @@
 #include                  <ttkGeometrySmoother.h>
 
+#include <vtkPointData.h>
+#include <vtkCharArray.h>
+
 vtkStandardNewMacro(ttkGeometrySmoother)
 
 ttkGeometrySmoother::ttkGeometrySmoother(){
 
   // init
   NumberOfIterations = 1;
+  MaskIdentifier = 0;
+  UseInputMask = false;
+  InputMask = "";
 }
 
 ttkGeometrySmoother::~ttkGeometrySmoother(){
@@ -29,11 +35,32 @@ int ttkGeometrySmoother::doIt(vector<vtkDataSet *> &inputs,
   smoother_.setupTriangulation(triangulation);
   smoother_.setWrapper(this);
   
+  vtkCharArray *inputMaskField = NULL;
+
+  if(UseInputMask){
+      if(InputMask.length()){
+          inputMaskField = vtkCharArray::SafeDownCast(input->GetPointData()->GetArray(InputMask.data()));
+      } else {
+          inputMaskField = vtkCharArray::SafeDownCast(input->GetPointData()->GetArray(MaskIdentifier));
+      }
+
+      if(inputMaskField->GetName())
+          InputMask = inputMaskField->GetName();
+
+      {
+          stringstream msg;
+          msg << "[ScalarFieldSmoother] Using mask `"
+              << inputMaskField->GetName() << "'..." << endl;
+          dMsg(cout, msg.str(), infoMsg);
+      }
+  }
+
   // This filter copies the input into a new data-set (smoothed)
   // let's use shallow copies, in order to only duplicate point positions 
   // (before and after). the rest is not changed, pointers are sufficient.
   output->DeepCopy(input);
 
+  void* inputMaskPtr = (inputMaskField)?inputMaskField->GetVoidPointer(0):nullptr;
   // calling the smoothing package
   vtkPoints *inputPointSet = (vtkPointSet::SafeDownCast(input))->GetPoints();
   vtkPoints *outputPointSet = (vtkPointSet::SafeDownCast(output))->GetPoints();
@@ -44,6 +71,7 @@ int ttkGeometrySmoother::doIt(vector<vtkDataSet *> &inputs,
         smoother_.setDimensionNumber(3);
         smoother_.setInputDataPointer(inputPointSet->GetVoidPointer(0));
         smoother_.setOutputDataPointer(outputPointSet->GetVoidPointer(0));
+        smoother_.setMaskDataPointer(inputMaskPtr);
         smoother_.smooth<VTK_TT>(NumberOfIterations);
       }
     ));

--- a/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -64,6 +64,11 @@ class VTKFILTERSCORE_EXPORT ttkGeometrySmoother
     vtkSetMacro(NumberOfIterations, int);
     vtkGetMacro(NumberOfIterations, int);
     
+    vtkSetMacro(UseInputMask, bool);
+    vtkGetMacro(UseInputMask, bool);
+    
+    vtkSetMacro(InputMask, string);
+    vtkGetMacro(InputMask, string);
     
   protected:
     
@@ -77,6 +82,9 @@ class VTKFILTERSCORE_EXPORT ttkGeometrySmoother
   private:
     
     int                   NumberOfIterations;
+    int                   MaskIdentifier;
+    bool                  UseInputMask;
+    string                InputMask;
     
     ScalarFieldSmoother   smoother_;
   

--- a/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtkWrappers/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -64,6 +64,9 @@ class VTKFILTERSCORE_EXPORT ttkGeometrySmoother
     vtkSetMacro(NumberOfIterations, int);
     vtkGetMacro(NumberOfIterations, int);
     
+    vtkSetMacro(MaskIdentifier, int);
+    vtkGetMacro(MaskIdentifier, int);
+
     vtkSetMacro(UseInputMask, bool);
     vtkGetMacro(UseInputMask, bool);
     

--- a/core/vtkWrappers/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
+++ b/core/vtkWrappers/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
@@ -67,12 +67,22 @@ class VTKFILTERSCORE_EXPORT ttkScalarFieldSmoother
     vtkSetMacro(NumberOfIterations, int);
     vtkGetMacro(NumberOfIterations, int);
     
-    vtkSetMacro(ScalarField, string);
-    vtkGetMacro(ScalarField, string);
-
     vtkSetMacro(ScalarFieldIdentifier, int);
     vtkGetMacro(ScalarFieldIdentifier, int);
 
+    vtkSetMacro(MaskIdentifier, int);
+    vtkGetMacro(MaskIdentifier, int);
+
+    vtkSetMacro(UseInputMask, bool);
+    vtkGetMacro(UseInputMask, bool);
+    
+    vtkSetMacro(ScalarField, string);
+    vtkGetMacro(ScalarField, string);
+
+    vtkSetMacro(InputMask, string);
+    vtkGetMacro(InputMask, string);
+
+    
     
   protected:
     
@@ -87,7 +97,10 @@ class VTKFILTERSCORE_EXPORT ttkScalarFieldSmoother
     
     int                   NumberOfIterations;
     int                   ScalarFieldIdentifier;
+    int                   MaskIdentifier;
+    bool                  UseInputMask;
     string                ScalarField;
+    string                InputMask;
     vtkDataArray          *outputScalarField_;
     ScalarFieldSmoother   smoother_;
     

--- a/core/vtkWrappers/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtkWrappers/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -69,6 +69,7 @@ ttkUserInterfaceBase::ttkUserInterfaceBase() {
   isUp_ = false;
   repeat_ = false;
   transparency_ = false;
+  fullscreen_ = false;
   
   customInteractor_ = vtkSmartPointer<ttkCustomInteractor>::New();
   pngReader_ = vtkSmartPointer<vtkPNGReader>::New();
@@ -107,6 +108,7 @@ int ttkUserInterfaceBase::init(int &argc, char **argv){
 
   parser_.setOption("R", 
     &repeat_, "Repeat the program when hitting `Return'");
+  parser_.setOption("fullscreen", &fullscreen_, "Maximize the window at launch");
   
   return ProgramBase::init(argc, argv);
 }
@@ -198,7 +200,11 @@ int ttkUserInterfaceBase::run(){
   }
   
   renderWindow_->AddRenderer(renderer_);
-  renderWindow_->SetFullScreen(true);
+  if (fullscreen_) {
+     renderWindow_->SetFullScreen(fullscreen_);
+  } else {
+     renderWindow_->SetSize(1920,1080);
+  }
   renderWindow_->SetWindowName("TTK - The Topology ToolKit");
   
   interactor_->SetRenderWindow(renderWindow_);

--- a/core/vtkWrappers/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtkWrappers/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -102,7 +102,7 @@ class ttkUserInterfaceBase : public ttkProgramBase{
 
   protected:
     
-    bool                          hasTexture_, isUp_, repeat_, transparency_;
+    bool                          hasTexture_, isUp_, repeat_, transparency_, fullscreen_;
     vector<bool>                  visibleOutputs_;
     vector<int>                   hiddenOutputs_;
     ttkKeyHandler                 *keyHandler_;

--- a/paraview/GeometrySmoother/GeometrySmoother.xml
+++ b/paraview/GeometrySmoother/GeometrySmoother.xml
@@ -33,6 +33,41 @@ vertex.
       </InputProperty>
 
       <IntVectorProperty
+        name="UseInputMask"
+        command="SetUseInputMask"
+        label="Use Input Mask Field"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box if an input scalar field should be considered as
+          vertex mask (used to mark vertices to smooth).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+        name="InputMask"
+        command="SetInputMask"
+        label="Input Mask Field"
+        default_values="MaskField"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        animateable="0">
+        <ArrayListDomain
+          name="array_list"
+          default_values="0"
+          data_type="VTK_CHAR">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Input mask field (used to mark vertices to smooth).
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
          name="NumberOfIterations"
          label="Iteration Number"
          command="SetNumberOfIterations"
@@ -81,6 +116,9 @@ vertex.
       </IntVectorProperty>
       
       <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="Input" />
+        <Property name="UseInputMask" />
+        <Property name="InputMask" />
         <Property name="NumberOfIterations" />
       </PropertyGroup>
       

--- a/paraview/ScalarFieldSmoother/ScalarFieldSmoother.xml
+++ b/paraview/ScalarFieldSmoother/ScalarFieldSmoother.xml
@@ -28,7 +28,7 @@ See also GeometrySmoother.
         <DataTypeDomain name="input_type">
           <DataType value="vtkDataSet"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
+        <InputArrayDomain name="input_scalars" number_of_components="1" attribute_type="point">
           <Property name="Input" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>
@@ -55,6 +55,41 @@ See also GeometrySmoother.
         </Documentation>
       </StringVectorProperty>
       
+      <IntVectorProperty
+        name="UseInputMask"
+        command="SetUseInputMask"
+        label="Use Input Mask Field"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box if an input scalar field should be considered as
+          vertex mask (used to mark vertices to smooth).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+        name="InputMask"
+        command="SetInputMask"
+        label="Input Mask Field"
+        default_values="MaskField"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        animateable="0">
+        <ArrayListDomain
+          name="array_list"
+          default_values="0"
+          data_type="VTK_CHAR">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Input mask field (used to mark vertices to smooth).
+        </Documentation>
+      </StringVectorProperty>
+
       <IntVectorProperty
          name="NumberOfIterations"
          label="Iteration Number"
@@ -106,6 +141,8 @@ See also GeometrySmoother.
       
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="Scalar Field" />
+        <Property name="UseInputMask" />
+        <Property name="InputMask" />
         <Property name="NumberOfIterations" />
       </PropertyGroup>
       

--- a/standalone/GeometrySmoother/gui/main.cpp
+++ b/standalone/GeometrySmoother/gui/main.cpp
@@ -12,10 +12,12 @@ vtkUserInterface<ttkGeometrySmoother> program;
 int main(int argc, char **argv) {
   
   // specify local parameters to the TTK module with default values.
-  int iterationNumber = 1;
+  int iterationNumber = 1, maskId = -1;
 
   program.parser_.setArgument("I", &iterationNumber,
     "Number of smoothing iterations", true);
+  program.parser_.setArgument("M", &maskId,
+    "Mask field identifier", true);
   
   int ret = program.init(argc, argv);
  
@@ -23,6 +25,10 @@ int main(int argc, char **argv) {
     return ret;
 
   program.ttkObject_->SetNumberOfIterations(iterationNumber);
+  if (maskId != -1) {
+     program.ttkObject_->SetUseInputMask(true);
+     program.ttkObject_->SetMaskIdentifier(maskId);
+  }
   
   program.run();
   

--- a/standalone/ScalarFieldSmoother/cmd/main.cpp
+++ b/standalone/ScalarFieldSmoother/cmd/main.cpp
@@ -12,13 +12,15 @@ int main(int argc, char **argv) {
   vtkProgram<ttkScalarFieldSmoother> program;
   
   // specify local parameters to the TTK module with default values.
-  int iterationNumber = 1, scalarFieldId = 0;
+  int iterationNumber = 1, scalarFieldId = 0,  maskId = -1;
 
   // register these arguments to the command line parser
   program.parser_.setArgument("I", &iterationNumber,
     "Iteration number", true);
   program.parser_.setArgument("F", &scalarFieldId,
     "Scalar field identifier", true);
+  program.parser_.setArgument("M", &maskId,
+    "Mask field identifier", true);
   
   int ret = program.init(argc, argv);
  
@@ -29,6 +31,10 @@ int main(int argc, char **argv) {
   // to execution.
   program.ttkObject_->SetNumberOfIterations(iterationNumber);
   program.ttkObject_->SetScalarFieldIdentifier(scalarFieldId);
+  if (maskId != -1) {
+     program.ttkObject_->SetUseInputMask(true);
+     program.ttkObject_->SetMaskIdentifier(maskId);
+  }
   
   // execute data processing
   ret = program.run();


### PR DESCRIPTION
Dear Julien,

This patch is aimed to bring the ability to deal with a Mask array to the Geometry and ScalarField Smoother. When used, all the vertices with a 0ed value in the mask array will not be impacted by the filter.

Charles