### PR TITLE
MorseSmaleComplex - smoothing on 1-separatrices

### DIFF
--- a/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
+++ b/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
@@ -25,6 +25,7 @@ AbstractMorseSmaleComplex::AbstractMorseSmaleComplex():
 
   outputSeparatrices1_numberOfPoints_{},
   outputSeparatrices1_points_{},
+  outputSeparatrices1_points_smoothingMask_{},
   outputSeparatrices1_points_cellDimensions_{},
   outputSeparatrices1_points_cellIds_{},
   outputSeparatrices1_numberOfCells_{},

--- a/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -194,6 +194,7 @@ namespace ttk{
 
       inline int setOutputSeparatrices1(int* const separatrices1_numberOfPoints,
           vector<float>* const separatrices1_points,
+          vector<char>* const separatrices1_points_smoothingMask,
           vector<int>* const separatrices1_points_cellDimensions,
           vector<int>* const separatrices1_points_cellIds,
           int* const separatrices1_numberOfCells,
@@ -208,6 +209,7 @@ namespace ttk{
           vector<char>* const separatrices1_cells_isOnBoundary){
         outputSeparatrices1_numberOfPoints_=separatrices1_numberOfPoints;
         outputSeparatrices1_points_=separatrices1_points;
+        outputSeparatrices1_points_smoothingMask_=separatrices1_points_smoothingMask;
         outputSeparatrices1_points_cellDimensions_=separatrices1_points_cellDimensions;
         outputSeparatrices1_points_cellIds_=separatrices1_points_cellIds;
         outputSeparatrices1_numberOfCells_=separatrices1_numberOfCells;
@@ -285,6 +287,7 @@ namespace ttk{
 
       int* outputSeparatrices1_numberOfPoints_;
       vector<float>* outputSeparatrices1_points_;
+      vector<char>* outputSeparatrices1_points_smoothingMask_;
       vector<int>* outputSeparatrices1_points_cellDimensions_;
       vector<int>* outputSeparatrices1_points_cellIds_;
       int* outputSeparatrices1_numberOfCells_;

--- a/core/baseCode/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/baseCode/morseSmaleComplex/MorseSmaleComplex.h
@@ -155,6 +155,7 @@ namespace ttk{
 
       inline int setOutputSeparatrices1(int* const separatrices1_numberOfPoints,
           vector<float>* const separatrices1_points,
+          vector<char>* const separatrices1_points_smoothingMask,
           vector<int>* const separatrices1_points_cellDimensions,
           vector<int>* const separatrices1_points_cellIds,
           int* const separatrices1_numberOfCells,
@@ -169,6 +170,7 @@ namespace ttk{
           vector<char>* const separatrices1_cells_isOnBoundary){
         morseSmaleComplex2D_.setOutputSeparatrices1(separatrices1_numberOfPoints,
             separatrices1_points,
+            separatrices1_points_smoothingMask,
             separatrices1_points_cellDimensions,
             separatrices1_points_cellIds,
             separatrices1_numberOfCells,
@@ -183,6 +185,7 @@ namespace ttk{
             separatrices1_cells_isOnBoundary);
         morseSmaleComplex3D_.setOutputSeparatrices1(separatrices1_numberOfPoints,
             separatrices1_points,
+            separatrices1_points_smoothingMask,
             separatrices1_points_cellDimensions,
             separatrices1_points_cellIds,
             separatrices1_numberOfCells,

--- a/core/baseCode/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/baseCode/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -94,7 +94,9 @@ int MorseSmaleComplex2D::setSeparatrices(const vector<Separatrix>& separatrices,
 
       for(const int geometryId : separatrix.geometry_){
         int oldPointId=-1;
-        for(const Cell& cell : separatricesGeometry[geometryId]){
+        for(auto cellIte=separatricesGeometry[geometryId].begin(); cellIte!=separatricesGeometry[geometryId].end(); ++cellIte){
+          const Cell& cell=*cellIte;
+
           float point[3];
           discreteGradient_.getCellIncenter(cell, point);
 
@@ -102,6 +104,11 @@ int MorseSmaleComplex2D::setSeparatrices(const vector<Separatrix>& separatrices,
           outputSeparatrices1_points_->push_back(point[1]);
           outputSeparatrices1_points_->push_back(point[2]);
 
+          if(cellIte==separatricesGeometry[geometryId].begin() or
+              cellIte==separatricesGeometry[geometryId].end()-1)
+            outputSeparatrices1_points_smoothingMask_->push_back(0);
+          else
+            outputSeparatrices1_points_smoothingMask_->push_back(1);
           outputSeparatrices1_points_cellDimensions_->push_back(cell.dim_);
           outputSeparatrices1_points_cellIds_->push_back(cell.id_);
 

--- a/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -124,7 +124,9 @@ int MorseSmaleComplex3D::setSeparatrices1(const vector<Separatrix>& separatrices
 
       for(const int geometryId : separatrix.geometry_){
         int oldPointId=-1;
-        for(const Cell& cell : separatricesGeometry[geometryId]){
+        for(auto cellIte=separatricesGeometry[geometryId].begin(); cellIte!=separatricesGeometry[geometryId].end(); ++cellIte){
+          const Cell& cell=*cellIte;
+
           float point[3];
           discreteGradient_.getCellIncenter(cell, point);
 
@@ -132,6 +134,11 @@ int MorseSmaleComplex3D::setSeparatrices1(const vector<Separatrix>& separatrices
           outputSeparatrices1_points_->push_back(point[1]);
           outputSeparatrices1_points_->push_back(point[2]);
 
+          if(cellIte==separatricesGeometry[geometryId].begin() or
+              cellIte==separatricesGeometry[geometryId].end()-1)
+            outputSeparatrices1_points_smoothingMask_->push_back(0);
+          else
+            outputSeparatrices1_points_smoothingMask_->push_back(1);
           outputSeparatrices1_points_cellDimensions_->push_back(cell.dim_);
           outputSeparatrices1_points_cellIds_->push_back(cell.id_);
 

--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -519,7 +519,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!cellDimensions){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation "
                 << "problem." << endl;
-              return -16;
+              return -17;
             }
 #endif
             cellDimensions->SetNumberOfComponents(1);
@@ -531,7 +531,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!cellIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation "
                 << "problem." << endl;
-              return -17;
+              return -18;
             }
 #endif
             cellIds->SetNumberOfComponents(1);
@@ -543,7 +543,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!sourceIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation "
                 << "problem." << endl;
-              return -18;
+              return -19;
             }
 #endif
             sourceIds->SetNumberOfComponents(1);
@@ -555,7 +555,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!destinationIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation "
                 << "problem." << endl;
-              return -19;
+              return -20;
             }
 #endif
             destinationIds->SetNumberOfComponents(1);
@@ -567,7 +567,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation "
                 << "problem." << endl;
-              return -20;
+              return -21;
             }
 #endif
             separatrixIds->SetNumberOfComponents(1);
@@ -579,7 +579,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixTypes){
               cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
                 << "problem." << endl;
-              return -21;
+              return -22;
             }
 #endif
             separatrixTypes->SetNumberOfComponents(1);
@@ -590,7 +590,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionMaxima){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -22;
+              return -23;
             }
 #endif
             separatrixFunctionMaxima->SetNumberOfComponents(1);
@@ -601,7 +601,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionMinima){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -23;
+              return -24;
             }
 #endif
             separatrixFunctionMinima->SetNumberOfComponents(1);
@@ -612,7 +612,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionDiffs){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -24;
+              return -25;
             }
 #endif
             separatrixFunctionDiffs->SetNumberOfComponents(1);
@@ -624,7 +624,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!isOnBoundary){
               cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
                 << "problem." << endl;
-              return -25;
+              return -26;
             }
 #endif
             isOnBoundary->SetNumberOfComponents(1);
@@ -677,7 +677,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!pointData){
               cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
                 << "no point data." << endl;
-              return -26;
+              return -27;
             }
 #endif
 
@@ -690,7 +690,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!cellData){
               cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
                 << "no cell data." << endl;
-              return -27;
+              return -28;
             }
 #endif
 
@@ -711,7 +711,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!points){
               cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation problem." 
                 << endl;
-              return -28;
+              return -29;
             }
 #endif
 
@@ -720,7 +720,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!sourceIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation problem." 
                 << endl;
-              return -29;
+              return -30;
             }
 #endif
             sourceIds->SetNumberOfComponents(1);
@@ -731,7 +731,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixIds){
               cerr << "[ttkMorseSmaleComplex] Error : vtkIntArray allocation problem." 
                 << endl;
-              return -30;
+              return -31;
             }
 #endif
             separatrixIds->SetNumberOfComponents(1);
@@ -742,7 +742,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixTypes){
               cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation problem." 
                 << endl;
-              return -31;
+              return -32;
             }
 #endif
             separatrixTypes->SetNumberOfComponents(1);
@@ -753,7 +753,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionMaxima){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -32;
+              return -33;
             }
 #endif
             separatrixFunctionMaxima->SetNumberOfComponents(1);
@@ -764,7 +764,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionMinima){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -33;
+              return -34;
             }
 #endif
             separatrixFunctionMinima->SetNumberOfComponents(1);
@@ -775,7 +775,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!separatrixFunctionDiffs){
               cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
                 << "problem." << endl;
-              return -34;
+              return -35;
             }
 #endif
             separatrixFunctionDiffs->SetNumberOfComponents(1);
@@ -786,7 +786,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!isOnBoundary){
               cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation problem." 
                 << endl;
-              return -35;
+              return -36;
             }
 #endif
             isOnBoundary->SetNumberOfComponents(1);
@@ -841,7 +841,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             if(!cellData){
               cerr << "[ttkMorseSmaleComplex] Error : "
                 << "outputSeparatrices2 has no cell data." << endl;
-              return -36;
+              return -37;
             }
 #endif
 
@@ -865,7 +865,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
       cerr 
         << "[ttkMorseSmaleComplex] Error : outputMorseComplexes has no point "
         << "data." << endl;
-      return -37;
+      return -38;
     }
 #endif
     pointData->AddArray(descendingManifold);

--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -228,6 +228,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
   // 1-separatrices
   int separatrices1_numberOfPoints{};
   vector<float> separatrices1_points;
+  vector<char> separatrices1_points_smoothingMask;
   vector<int> separatrices1_points_cellDimensions;
   vector<int> separatrices1_points_cellIds;
   int separatrices1_numberOfCells{};
@@ -361,6 +362,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
           morseSmaleComplex_.setOutputSeparatrices1(
               &separatrices1_numberOfPoints,
               &separatrices1_points,
+              &separatrices1_points_smoothingMask,
               &separatrices1_points_cellDimensions,
               &separatrices1_points_cellIds,
               &separatrices1_numberOfCells,
@@ -499,6 +501,17 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
               return -15;
             }
 #endif
+            vtkSmartPointer<vtkCharArray>
+              smoothingMask=vtkSmartPointer<vtkCharArray>::New();
+#ifndef withKamikaze
+            if(!smoothingMask){
+              cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+                << "problem." << endl;
+              return -16;
+            }
+#endif
+            smoothingMask->SetNumberOfComponents(1);
+            smoothingMask->SetName("SmoothingMask");
 
             vtkSmartPointer<vtkIntArray> 
               cellDimensions=vtkSmartPointer<vtkIntArray>::New();
@@ -622,7 +635,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
                   separatrices1_points[3*i+1],
                   separatrices1_points[3*i+2]);
 
-
+              smoothingMask->InsertNextTuple1(separatrices1_points_smoothingMask[i]);
               cellDimensions->InsertNextTuple1(separatrices1_points_cellDimensions[i]);
               cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
             }
@@ -668,6 +681,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             }
 #endif
 
+            pointData->AddArray(smoothingMask);
             pointData->AddArray(cellDimensions);
             pointData->AddArray(cellIds);
 
@@ -865,9 +879,6 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
       << " MB." << endl;
     dMsg(cout, msg.str(), memoryMsg);
   }
-
-  // debug
-  //exit(0);
 
   return 0;
 }


### PR DESCRIPTION
Dear Julien,

I added a SmoothingMask scalar field on the points of the 1-separatrices of the MorseSmaleComplex so that it can be smoothed by the GeometrySmoother module.

I also ran all the ttk-data tests and everything works fine. 