### PR TITLE
Rename a scalar field of the MorseSmaleComplex module

### DIFF
--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -472,7 +472,7 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
             }
 #endif
             PLVertexIdentifiers->SetNumberOfComponents(1);
-            PLVertexIdentifiers->SetName("PLVertexIdentifier");
+            PLVertexIdentifiers->SetName("VertexIdentifier");
 
             vtkSmartPointer<vtkIntArray> manifoldSizeScalars=vtkSmartPointer<vtkIntArray>::New();
 #ifndef withKamikaze


### PR DESCRIPTION
Dear Julien,

I changed the name of the scalar field on the critical points of the MorseSmaleComplex module so that it will be compliant to PersistenceDiagram.