### PR TITLE
Remove bad references to Contour Forests

### DIFF
--- a/core/baseCode/bottleneckDistance/DataTypes.h
+++ b/core/baseCode/bottleneckDistance/DataTypes.h
@@ -3,22 +3,21 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date June 2016.
 ///
-///\brief TTK processing package that efficiently computes the contour tree of
-/// scalar data and more (data segmentation, topological simplification,
-/// persistence diagrams, persistence curves, etc.).
+///\brief Define usefull type for TTK (vertices, edges, cells)
+//and their null values.
 ///
 ///\param dataType Data type of the input scalar field (char, float,
 /// etc.).
-///
-/// \b Related \b publication \n
-/// "Contour Forests: Fast Multi-threaded Augmented Contour Trees" \n
-/// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
-/// Proc. of IEEE LDAV 2016.
-///
-/// \sa vtkContourForests.cpp %for a usage example.
 
 #ifndef DATATYPES_H
 #define DATATYPES_H
+
+// TODO:---------------------------------------------------------------------------
+// This file is the same and have the same sentinel that the ContourForests one
+// This is an undesirable situation that can leads to bug if one of this file
+// is modified and not the other.
+// FIX: We could try to instore a global Type Management file.
+// --------------------------------------------------------------------------------
 
 #include <tuple>
 #include <limits>

--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -69,7 +69,7 @@ int ttkMorseSmaleComplex::setupTriangulation(vtkDataSet* input){
   triangulation_=ttkTriangulation::getTriangulation(input);
 #ifndef withKamikaze
   if(!triangulation_){
-    cerr << "[vtkContourForests] Error : ttkTriangulation::getTriangulation() is null." << endl;
+    cerr << "[ttkMorseSmaleComplex] Error : ttkTriangulation::getTriangulation() is null." << endl;
     return -1;
   }
 #endif


### PR DESCRIPTION
Dear Julien,

These two files contained unwanted references to the ContourForests plugin that needed to be removed.

### BUG:

The *core/baseCode/bottleneckDistance/DataTypes.h* file is a copy of the *core/baseCode/contourForestsTree/DataType.h* with the same sentinels. This can leads to annoying bugs as described on the former file.