### PR TITLE
MorseSmaleComplex2D - bugfix

### DIFF
--- a/core/baseCode/morseSmaleComplex2D/MorseSmaleComplex2D.cpp
+++ b/core/baseCode/morseSmaleComplex2D/MorseSmaleComplex2D.cpp
@@ -37,7 +37,8 @@ int MorseSmaleComplex2D::getSeparatrices(const vector<Cell>& criticalPoints,
 
     // add ascending vpaths
     if(ComputeAscendingSeparatrices1){
-      for(int j=0; j<2; ++j){
+      const int starNumber=inputTriangulation_->getEdgeStarNumber(saddle.id_);
+      for(int j=0; j<starNumber; ++j){
         const int shift=j;
 
         int triangleId;


### PR DESCRIPTION
Dear Julien,

I fixed a bug in the MorseSmaleComplex2D baseCode module that causes some 1-separatrices created from 1-saddles on the boundary to be inconsistent.