### PR TITLE
fix(Cmake): for version btwn 2.8 and 3.1

### DIFF
--- a/core/baseCode/baseCode.cmake
+++ b/core/baseCode/baseCode.cmake
@@ -11,7 +11,9 @@
     cmake_policy(SET CMP0012 NEW)
     cmake_policy(SET CMP0023 OLD)
     cmake_policy(SET CMP0028 OLD)
-    cmake_policy(SET CMP0054 NEW)
+    if(POLICY CMP0054)
+       cmake_policy(SET CMP0054 NEW)
+    endif(POLICY CMP0054)
   endif(COMMAND cmake_policy)
   
   # kamikaze code compilation mode


### PR DESCRIPTION
Dear TTK Team,
this pull request is a fix for CMake.

On the "_CMakeLists.txt_", the **cmake\_minimum\_required** is set to 2.8,
but the "_baseCode.cmake_" uses the policy [CMP0054](https://cmake.org/cmake/help/v3.1/policy/CMP0054.html) introduced in cmake v3.1.
Here is a check to avoid using this policy for earlier version of CMake.

NOTE: as this policy is set to **NEW**, undefined behavior may appear for cmake < 3.1 if
this policy is indeed used.

Charles