### PR TITLE
Handle NaN in FTM Tree

### DIFF
--- a/core/baseCode/ftmtree/FTMTree_Template.h
+++ b/core/baseCode/ftmtree/FTMTree_Template.h
@@ -49,10 +49,12 @@ void ftm::FTMTree::build(void)
    // Recall: Equals values are distinguished using Simulation of Simplicity in the FTM tree
    // computation
    // Note: Can we detect NaN using vtk ?
+   if (std::numeric_limits<scalarType>::has_quiet_NaN) {
 #pragma omp parallel for
-   for (idVertex i = 0; i < scalars_->size; i++) {
-      if (isnan(((scalarType*)scalars_->values)[i])) {
-         ((scalarType*)scalars_->values)[i] = 0;
+      for (idVertex i = 0; i < scalars_->size; i++) {
+         if (isnan(((scalarType*)scalars_->values)[i])) {
+            ((scalarType*)scalars_->values)[i] = 0;
+         }
       }
    }
 

--- a/core/baseCode/ftmtree/FTMTree_Template.h
+++ b/core/baseCode/ftmtree/FTMTree_Template.h
@@ -43,6 +43,19 @@ void ftm::FTMTree::build(void)
    setDebugLevel(debugLevel_);
    initNbScalars();
 
+   // This section is aimed to prevent un-deterministic results if the data-set
+   // have NaN values in it.
+   // In this loop, we replace every NaN by a 0 value.
+   // Recall: Equals values are distinguished using Simulation of Simplicity in the FTM tree
+   // computation
+   // Note: Can we detect NaN using vtk ?
+#pragma omp parallel for
+   for (idVertex i = 0; i < scalars_->size; i++) {
+      if (isnan(((scalarType*)scalars_->values)[i])) {
+         ((scalarType*)scalars_->values)[i] = 0;
+      }
+   }
+
    // Alloc / reserve
    DebugTimer initTime;
    switch (params_->treeType) {


### PR DESCRIPTION
Dear Julien,

FTM is now able to deal with NaN values on data set where the scalar type can represent such a value.
In that case, a parallel pass in done in the base code to replace all NaN by a 0 value, as Paraview does in the GUI.