### PR TITLE
Filter saddle-connectors in the Morse-Smale Complex module

### DIFF
--- a/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/baseCode/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -156,6 +156,16 @@ namespace ttk{
         return 0;
       }
 
+      int setReturnSaddleConnectors(const bool state){
+        ReturnSaddleConnectors=state;
+        return 0;
+      }
+
+      int setSaddleConnectorsPersistenceThreshold(const double threshold){
+        SaddleConnectorsPersistenceThreshold=threshold;
+        return 0;
+      }
+
       inline int setupTriangulation(Triangulation* const data){
         inputTriangulation_=data;
         discreteGradient_.setupTriangulation(inputTriangulation_);
@@ -275,6 +285,8 @@ namespace ttk{
       bool ComputeAscendingSegmentation;
       bool ComputeDescendingSegmentation;
       bool ComputeFinalSegmentation;
+      bool ReturnSaddleConnectors;
+      double SaddleConnectorsPersistenceThreshold;
 
       DiscreteGradient discreteGradient_;
 

--- a/core/baseCode/discreteGradient/DiscreteGradient.cpp
+++ b/core/baseCode/discreteGradient/DiscreteGradient.cpp
@@ -2,9 +2,11 @@
 
 DiscreteGradient::DiscreteGradient():
   IterationThreshold{-1},
-  ReverseSaddleMaximumConnection{},
-  ReverseSaddleSaddleConnection{},
-  CollectPersistencePairs{},
+  ReverseSaddleMaximumConnection{false},
+  ReverseSaddleSaddleConnection{false},
+  CollectPersistencePairs{false},
+  ReturnSaddleConnectors{false},
+  SaddleConnectorsPersistenceThreshold{0},
 
   dimensionality_{-1},
   gradient_{},

--- a/core/baseCode/discreteGradient/discreteGradient.cmake
+++ b/core/baseCode/discreteGradient/discreteGradient.cmake
@@ -1,6 +1,7 @@
 ttk_add_baseCode_package(triangulation)
 ttk_add_baseCode_package(geometry)
 ttk_add_baseCode_package(scalarFieldCriticalPoints)
+ttk_add_baseCode_package(ftmtree)
 
 # if the package is a pure template class, comment the following line
 ttk_wrapup_library(libDiscreteGradient "DiscreteGradient.cpp")

--- a/core/baseCode/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/baseCode/morseSmaleComplex/MorseSmaleComplex.h
@@ -76,6 +76,14 @@ namespace ttk{
         return abstractMorseSmaleComplex_->setComputeFinalSegmentation(state);
       }
 
+      int setReturnSaddleConnectors(const bool state){
+        return abstractMorseSmaleComplex_->setReturnSaddleConnectors(state);
+      }
+
+      int setSaddleConnectorsPersistenceThreshold(const double threshold){
+        return abstractMorseSmaleComplex_->setSaddleConnectorsPersistenceThreshold(threshold);
+      }
+
       int setupTriangulation(Triangulation* const data){
         inputTriangulation_=data;
         const int dimensionality=inputTriangulation_->getCellVertexNumber(0)-1;

--- a/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -476,6 +476,9 @@ int MorseSmaleComplex3D::execute(){
   discreteGradient_.setDebugLevel(debugLevel_);
   discreteGradient_.setThreadNumber(threadNumber_);
   discreteGradient_.setCollectPersistencePairs(false);
+  discreteGradient_.setReturnSaddleConnectors(ReturnSaddleConnectors);
+  discreteGradient_.setSaddleConnectorsPersistenceThreshold(
+      SaddleConnectorsPersistenceThreshold);
   discreteGradient_.buildGradient<dataType>();
   discreteGradient_.buildGradient2<dataType>();
   discreteGradient_.buildGradient3<dataType>();

--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -19,6 +19,8 @@ vtkStandardNewMacro(ttkMorseSmaleComplex)
     ComputeFinalSegmentation{true},
     ScalarFieldId{},
     OffsetFieldId{-1},
+    ReturnSaddleConnectors{false},
+    SaddleConnectorsPersistenceThreshold{0},
 
     triangulation_{},
     defaultOffsets_{},
@@ -328,6 +330,11 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
   morseSmaleComplex_.setComputeDescendingSegmentation(
       ComputeDescendingSegmentation);
   morseSmaleComplex_.setComputeFinalSegmentation(ComputeFinalSegmentation);
+
+  morseSmaleComplex_.setReturnSaddleConnectors(
+      ReturnSaddleConnectors);
+  morseSmaleComplex_.setSaddleConnectorsPersistenceThreshold(
+      SaddleConnectorsPersistenceThreshold);
 
   morseSmaleComplex_.setInputScalarField(inputScalars->GetVoidPointer(0));
   morseSmaleComplex_.setInputOffsets(inputOffsets->GetVoidPointer(0));

--- a/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtkWrappers/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -126,6 +126,12 @@ class VTKFILTERSCORE_EXPORT ttkMorseSmaleComplex
     vtkSetMacro(ComputeFinalSegmentation, int);
     vtkGetMacro(ComputeFinalSegmentation, int);
 
+    vtkSetMacro(ReturnSaddleConnectors, int);
+    vtkGetMacro(ReturnSaddleConnectors, int);
+
+    vtkSetMacro(SaddleConnectorsPersistenceThreshold, double);
+    vtkGetMacro(SaddleConnectorsPersistenceThreshold, double);
+
     int setupTriangulation(vtkDataSet* input);
     vtkDataArray* getScalars(vtkDataSet* input);
     vtkDataArray* getOffsets(vtkDataSet* input);
@@ -157,6 +163,8 @@ class VTKFILTERSCORE_EXPORT ttkMorseSmaleComplex
     bool ComputeFinalSegmentation;
     int ScalarFieldId;
     int OffsetFieldId;
+    int ReturnSaddleConnectors;
+    double SaddleConnectorsPersistenceThreshold;
 
     MorseSmaleComplex morseSmaleComplex_;
     Triangulation *triangulation_;

--- a/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
+++ b/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
@@ -213,6 +213,30 @@ Computer Graphics Forum, 2012.
          </Documentation>
        </IntVectorProperty>
 
+       <IntVectorProperty name="ReturnSaddleConnectors"
+         label="Return Saddle Connectors"
+         command="SetReturnSaddleConnectors"
+         number_of_elements="1"
+         default_values="0"
+         panel_visibility="advanced">
+         <BooleanDomain name="bool"/>
+         <Documentation>
+           Return the saddle connectors.
+         </Documentation>
+       </IntVectorProperty>
+
+       <DoubleVectorProperty name="SaddleConnectorsPersistenceThreshold"
+         label="Saddle Connectors Persistence Threshold"
+         command="SetSaddleConnectorsPersistenceThreshold"
+         number_of_elements="1"
+         default_values="0"
+         panel_visibility="advanced">
+         <DoubleRangeDomain name="range" min="0.0" max="100.0" />
+         <Documentation>
+           Saddle Connectors Persistence Threshold.
+         </Documentation>
+       </DoubleVectorProperty>
+
       <IntVectorProperty
         name="UseAllCores"
         label="Use All Cores"
@@ -279,6 +303,8 @@ Computer Graphics Forum, 2012.
         <Property name="ComputeAscendingSegmentation"/>
         <Property name="ComputeDescendingSegmentation"/>
         <Property name="ComputeFinalSegmentation"/>
+        <Property name="ReturnSaddleConnectors"/>
+        <Property name="SaddleConnectorsPersistenceThreshold"/>
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Testing">


### PR DESCRIPTION
Dear Julien,

I added a way to apply a threshold on the saddle-connectors by their persistence values as a post-process pass on the gradient.