### PR TITLE
Fix the smoothingMask values of the saddle-connectors

### DIFF
--- a/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/baseCode/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -220,7 +220,8 @@ int MorseSmaleComplex3D::setSaddleConnectors(const vector<Separatrix>& separatri
 
       for(const int geometryId : separatrix.geometry_){
         int oldPointId=-1;
-        for(const Cell& cell : separatricesGeometry[geometryId]){
+        for(auto cellIte=separatricesGeometry[geometryId].begin(); cellIte!=separatricesGeometry[geometryId].end(); ++cellIte){
+          const Cell& cell=*cellIte;
           float point[3];
           discreteGradient_.getCellIncenter(cell, point);
 
@@ -228,6 +229,11 @@ int MorseSmaleComplex3D::setSaddleConnectors(const vector<Separatrix>& separatri
           outputSeparatrices1_points_->push_back(point[1]);
           outputSeparatrices1_points_->push_back(point[2]);
 
+          if(cellIte==separatricesGeometry[geometryId].begin() or
+              cellIte==separatricesGeometry[geometryId].end()-1)
+            outputSeparatrices1_points_smoothingMask_->push_back(0);
+          else
+            outputSeparatrices1_points_smoothingMask_->push_back(1);
           outputSeparatrices1_points_cellDimensions_->push_back(cell.dim_);
           outputSeparatrices1_points_cellIds_->push_back(cell.id_);
 


### PR DESCRIPTION
Dear Julien,

I fixed the values of the smoothingMask scalar field on the saddle-connectors of the MorseSmaleComplex module.