### PR TITLE
Fix Warning on ICC : const on return type

### DIFF
--- a/core/baseCode/common/Os.h
+++ b/core/baseCode/common/Os.h
@@ -376,7 +376,7 @@ namespace ttk{
       
     protected:
       
-      inline const double getTimeStamp(){
+      inline double getTimeStamp(){
         return OsCall::getTimeStamp();
       };
       

--- a/core/baseCode/contourForests/ContourForests.h
+++ b/core/baseCode/contourForests/ContourForests.h
@@ -59,12 +59,12 @@ namespace ttk
       {
          return lowerOverlap_;
       }
-      inline const idVertex getNbUpper(void) const
+      inline idVertex getNbUpper(void) const
       {
          return upperOverlap_.size();
       }
 
-      inline const idVertex getNbLower(void) const
+      inline idVertex getNbLower(void) const
       {
          return lowerOverlap_.size();
       }

--- a/core/baseCode/contourForestsTree/MergeTree.cpp
+++ b/core/baseCode/contourForestsTree/MergeTree.cpp
@@ -564,7 +564,7 @@ void MergeTree::closeSuperArc(const idSuperArc &superArcId, const idNode &upNode
    }
 }
 
-const idVertex MergeTree::insertNodeAboveSeed(const idSuperArc &arc,
+idVertex MergeTree::insertNodeAboveSeed(const idSuperArc &arc,
                                               const pair<idVertex, bool> &seed)
 {
    auto isLowerComp = [&](const pair<idVertex, bool> &a, const pair<idVertex, bool> &b) {
@@ -607,7 +607,7 @@ const idVertex MergeTree::insertNodeAboveSeed(const idSuperArc &arc,
    return stitchVert;
 }
 
-const idVertex MergeTree::getVertBelowSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed,
+idVertex MergeTree::getVertBelowSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed,
                                            const vector<idCorresp> &vert2treeOther)
 {
    auto isLowerComp = [&](const pair<idVertex, bool> &a, const pair<idVertex, bool> &b) {
@@ -733,7 +733,7 @@ idSuperArc MergeTree::getNumberOfExternalDownArcs(const idNode &n)
     return res;
 }
 
-const bool MergeTree::alreadyExtLinked(const idNode &node, const idPartition &tree, const idNode &treeNode)
+bool MergeTree::alreadyExtLinked(const idNode &node, const idPartition &tree, const idNode &treeNode)
 {
     Node* n = getNode(node);
 
@@ -938,7 +938,7 @@ void MergeTree::delNode(const idNode &node, const pair<idVertex, bool> *markVert
 //  |   * <- newNodeId
 //  |   |   <- currentSA
 //  - - -
-const idSuperArc MergeTree::insertNode(Node *node, const bool segment)
+idSuperArc MergeTree::insertNode(Node *node, const bool segment)
 {
    // already present
    if (isCorrespondingNode(node->getVertexId())) {
@@ -1011,7 +1011,7 @@ const idSuperArc MergeTree::insertNode(Node *node, const bool segment)
 //  |   * <- newNodeId
 //  | / |   <- newSA
 //  - - -
-const idSuperArc MergeTree::reverseInsertNode(Node *node, const bool segment)
+idSuperArc MergeTree::reverseInsertNode(Node *node, const bool segment)
 {
    // already present
    if (isCorrespondingNode(node->getVertexId())) {
@@ -1095,7 +1095,7 @@ idNode MergeTree::getParent(const idNode &n)
 }
 
 // Here the return of the vector use the move constructor
-const vector<idNode> MergeTree::getNodeNeighbors(const idNode &n)
+vector<idNode> MergeTree::getNodeNeighbors(const idNode &n)
 {
    Node *node   = getNode(n);
    auto  nbUp   = node->getNumberOfUpSuperArcs();
@@ -1122,7 +1122,7 @@ const vector<idNode> MergeTree::getNodeNeighbors(const idNode &n)
    return res;
 }
 
-const vector<idNode> MergeTree::getNodeUpNeighbors(const idNode &n)
+vector<idNode> MergeTree::getNodeUpNeighbors(const idNode &n)
 {
    Node *node   = getNode(n);
    auto  nbUp   = node->getNumberOfUpSuperArcs();
@@ -1139,7 +1139,7 @@ const vector<idNode> MergeTree::getNodeUpNeighbors(const idNode &n)
    return res;
 }
 
-const vector<idNode> MergeTree::getNodeDownNeighbors(const idNode &n)
+vector<idNode> MergeTree::getNodeDownNeighbors(const idNode &n)
 {
    Node *node   = getNode(n);
    auto  nbDown   = node->getNumberOfDownSuperArcs();
@@ -1368,7 +1368,7 @@ void MergeTree::markThisArc(vector<ExtendedUnionFind *> &ufArray, const idNode &
    ufArray[parentNodeId]->find()->setData(-((ufDataType)parentNodeId) - 1);
 }
 
-const idSuperArc MergeTree::newUpArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray)
+idSuperArc MergeTree::newUpArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray)
 {
 
     idSuperArc keepArc = nullSuperArc;
@@ -1390,7 +1390,7 @@ const idSuperArc MergeTree::newUpArc(const idNode &curNodeId, vector<ExtendedUni
     return keepArc;
 }
 
-const idSuperArc MergeTree::newDownArc(const idNode &               curNodeId,
+idSuperArc MergeTree::newDownArc(const idNode &               curNodeId,
                                        vector<ExtendedUnionFind *> &ufArray)
 {
 
@@ -1413,7 +1413,7 @@ const idSuperArc MergeTree::newDownArc(const idNode &               curNodeId,
     return keepArc;
 }
 
-const tuple<idNode, idNode, idVertex> MergeTree::createReceptArc(
+tuple<idNode, idNode, idVertex> MergeTree::createReceptArc(
     const idNode &root, const idSuperArc &receptacleArcId, vector<ExtendedUnionFind *> &ufArray,
     const vector<pair<idSuperArc, idSuperArc>> &valenceOffsets)
 {

--- a/core/baseCode/contourForestsTree/MergeTree.h
+++ b/core/baseCode/contourForestsTree/MergeTree.h
@@ -168,7 +168,7 @@ namespace ttk
       // partition
       // .....................{
 
-      inline const idPartition getPartition(void) const
+      inline idPartition getPartition(void) const
       {
          return treeData_.partition;
       }
@@ -202,12 +202,12 @@ namespace ttk
       // arcs
       // .....................{
 
-      inline const idSuperArc getNumberOfSuperArcs(void) const
+      inline idSuperArc getNumberOfSuperArcs(void) const
       {
          return treeData_.superArcs.size();
       }
 
-      inline const idSuperArc getNumberOfVisibleArcs(void) const
+      inline idSuperArc getNumberOfVisibleArcs(void) const
       {
          // Costly ! for dedbug only
          idSuperArc visibleArc = 0;
@@ -261,7 +261,7 @@ namespace ttk
       // nodes
       // .....................{
 
-      inline const idNode getNumberOfNodes(void) const
+      inline idNode getNumberOfNodes(void) const
       {
          return treeData_.nodes.size();
       }
@@ -281,7 +281,7 @@ namespace ttk
       // leaves / root
       // .....................{
 
-      inline const idVertex getNumberOfLeaves(void) const
+      inline idVertex getNumberOfLeaves(void) const
       {
          return treeData_.leaves.size();
       }
@@ -331,17 +331,17 @@ namespace ttk
       // test vertex correpondance
       // ...........................{
 
-      inline const bool isCorrespondingArc(const idVertex &val) const
+      inline bool isCorrespondingArc(const idVertex &val) const
       {
          return !isCorrespondingNull(val) && treeData_.vert2tree[val] >= 0;
       }
 
-      inline const bool isCorrespondingNode(const idVertex &val) const
+      inline bool isCorrespondingNode(const idVertex &val) const
       {
          return treeData_.vert2tree[val] < 0;
       }
 
-      inline const bool isCorrespondingNull(const idVertex &val) const
+      inline bool isCorrespondingNull(const idVertex &val) const
       {
          return treeData_.vert2tree[val] == nullCorresp;
       }
@@ -350,7 +350,7 @@ namespace ttk
       // Get vertex info
       // ...........................{
 
-      inline const idNode getCorrespondingNodeId(const idVertex &val) const
+      inline idNode getCorrespondingNodeId(const idVertex &val) const
       {
 #ifndef withKamikaze
          if (!isCorrespondingNode(val)) {
@@ -364,7 +364,7 @@ namespace ttk
          return corr2idNode(val);
       }
 
-      inline const idSuperArc getCorrespondingSuperArcId(const idVertex &val) const
+      inline idSuperArc getCorrespondingSuperArcId(const idVertex &val) const
       {
 #ifndef withKamikaze
          if (!isCorrespondingArc(val)) {
@@ -406,13 +406,13 @@ namespace ttk
          treeData_.vert2tree[vert] = idNode2corr(val);
       }
 
-      inline const idCorresp idNode2corr(const idNode &id) const
+      inline idCorresp idNode2corr(const idNode &id) const
       {
          // transform idNode to special value for the array : -idNode -1
          return -(idCorresp)(id + 1);
       }
 
-      inline const idNode corr2idNode(const idCorresp &corr) const
+      inline idNode corr2idNode(const idCorresp &corr) const
       {
           return -(idNode)(treeData_.vert2tree[corr]+1);
       }
@@ -501,14 +501,13 @@ namespace ttk
       void mergeArc(const idSuperArc &sa, const idSuperArc &recept,
                     const bool changeConnectivity = true);
 
-      const idVertex insertNodeAboveSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed);
+      idVertex insertNodeAboveSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed);
 
-      const idVertex getVertBelowSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed,
-                                      const vector<idCorresp> &vert2treeOther);
+      idVertex getVertBelowSeed(const idSuperArc &arc, const pair<idVertex, bool> &seed,
+                                const vector<idCorresp> &vert2treeOther);
 
       // is there an external arc linkind node with treeNode in tree
-      const bool alreadyExtLinked(const idNode &node, const idPartition &tree,
-                                  const idNode &treeNode);
+      bool alreadyExtLinked(const idNode &node, const idPartition &tree, const idNode &treeNode);
 
       idSuperArc getNumberOfExternalDownArcs(const idNode &node);
 
@@ -531,9 +530,9 @@ namespace ttk
 
       idNode makeNode(const Node *const n, const idVertex &linked = nullVertex);
 
-      const idSuperArc insertNode(Node *node, const bool segment);
+      idSuperArc insertNode(Node *node, const bool segment);
 
-      const idSuperArc reverseInsertNode(Node *node, const bool segment);
+      idSuperArc reverseInsertNode(Node *node, const bool segment);
 
       inline Node *getDownNode(const SuperArc *a);
 
@@ -548,11 +547,11 @@ namespace ttk
 
       // For persistance pair on CT
       // these function allow to make a JT / ST od the CT
-      const vector<idNode> getNodeNeighbors(const idNode &node);
+      vector<idNode> getNodeNeighbors(const idNode &node);
 
-      const vector<idNode> getNodeUpNeighbors(const idNode &n);
+      vector<idNode> getNodeUpNeighbors(const idNode &n);
 
-      const vector<idNode> getNodeDownNeighbors(const idNode &n);
+      vector<idNode> getNodeDownNeighbors(const idNode &n);
 
       // Remove part not in partition
 
@@ -651,24 +650,24 @@ namespace ttk
 
       // Strict
 
-      inline const bool isLower(const idVertex &a, const idVertex &b) const
+      inline bool isLower(const idVertex &a, const idVertex &b) const
       {
          return scalars_->mirrorVertices[a] < scalars_->mirrorVertices[b];
       }
 
-      inline const bool isHigher(const idVertex &a, const idVertex &b) const
+      inline bool isHigher(const idVertex &a, const idVertex &b) const
       {
          return scalars_->mirrorVertices[a] > scalars_->mirrorVertices[b];
       }
 
       // Large
 
-      inline const bool isEqLower(const idVertex &a, const idVertex &b) const
+      inline bool isEqLower(const idVertex &a, const idVertex &b) const
       {
          return scalars_->mirrorVertices[a] <= scalars_->mirrorVertices[b];
       }
 
-      inline const bool isEqHigher(const idVertex &a, const idVertex &b) const
+      inline bool isEqHigher(const idVertex &a, const idVertex &b) const
       {
          return scalars_->mirrorVertices[a] >= scalars_->mirrorVertices[b];
       }
@@ -684,7 +683,7 @@ namespace ttk
       // Compare using the scalar array : only for sort step
 
       template <typename scalarType>
-      inline const bool isLower(const idVertex &a, const idVertex &b) const
+      inline bool isLower(const idVertex &a, const idVertex &b) const
       {
          return ((scalarType *)scalars_->values)[a] < ((scalarType *)scalars_->values)[b] ||
                 (((scalarType *)scalars_->values)[a] == ((scalarType *)scalars_->values)[b] &&
@@ -692,7 +691,7 @@ namespace ttk
       }
 
       template <typename scalarType>
-      inline const bool isHigher(const idVertex &a, const idVertex &b) const
+      inline bool isHigher(const idVertex &a, const idVertex &b) const
       {
          return ((scalarType *)scalars_->values)[a] > ((scalarType *)scalars_->values)[b] ||
                 (((scalarType *)scalars_->values)[a] == ((scalarType *)scalars_->values)[b] &&
@@ -700,7 +699,7 @@ namespace ttk
       }
 
       template <typename scalarType>
-      inline const bool isEqLower(const idVertex &a, const idVertex &b) const
+      inline bool isEqLower(const idVertex &a, const idVertex &b) const
       {
          return ((scalarType *)scalars_->values)[a] < ((scalarType *)scalars_->values)[b] ||
                 (((scalarType *)scalars_->values)[a] == ((scalarType *)scalars_->values)[b] &&
@@ -708,7 +707,7 @@ namespace ttk
       }
 
       template <typename scalarType>
-      inline const bool isEqHigher(const idVertex &a, const idVertex &b) const
+      inline bool isEqHigher(const idVertex &a, const idVertex &b) const
       {
          return ((scalarType *)scalars_->values)[a] > ((scalarType *)scalars_->values)[b] ||
                 (((scalarType *)scalars_->values)[a] == ((scalarType *)scalars_->values)[b] &&
@@ -726,14 +725,14 @@ namespace ttk
                         const bool preserveDownNode = false);
 
       // Use BFS from root to find down and up of the receptarc (maintaining segmentation information)
-      const tuple<idNode, idNode, idVertex> createReceptArc(
+      tuple<idNode, idNode, idVertex> createReceptArc(
           const idNode &root, const idSuperArc &receptArcId, vector<ExtendedUnionFind *> &arrayUF,
           const vector<pair<idSuperArc, idSuperArc>> &valenceOffsets);
 
       // during this BFS nodes should have only one arc up/down : find it :
-      const idSuperArc newUpArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray);
+      idSuperArc newUpArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray);
 
-      const idSuperArc newDownArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray);
+      idSuperArc newDownArc(const idNode &curNodeId, vector<ExtendedUnionFind *> &ufArray);
 
       // }
       // --------------

--- a/core/baseCode/contourForestsTree/Node.h
+++ b/core/baseCode/contourForestsTree/Node.h
@@ -265,17 +265,17 @@ namespace ttk
       // Valence
       // .......................................... {
 
-      inline const idSuperArc getUpValence(void) const
+      inline idSuperArc getUpValence(void) const
       {
         return std::get<1>(valence_);
       }
 
-      inline const idSuperArc getDownValence(void) const
+      inline idSuperArc getDownValence(void) const
       {
         return std::get<0>(valence_);
       }
 
-      inline const idSuperArc getValence(void) const
+      inline idSuperArc getValence(void) const
       {
         return std::get<0>(valence_) + std::get<1>(valence_);
       }

--- a/core/baseCode/contourForestsTree/SuperArc.h
+++ b/core/baseCode/contourForestsTree/SuperArc.h
@@ -136,12 +136,12 @@ namespace ttk
       // .................................{
       //
       // idPartition u_char so lighter than a ref
-      inline const idPartition getDownCT(void) const
+      inline idPartition getDownCT(void) const
       {
          return downCT_;
       }
 
-      inline const idPartition getUpCT(void) const
+      inline idPartition getUpCT(void) const
       {
          return upCT_;
       }
@@ -155,17 +155,17 @@ namespace ttk
       // overlap
       // .................................{
 
-      inline const bool getOverlapAbove(void) const
+      inline bool getOverlapAbove(void) const
       {
          return overlapAbove_;
       }
 
-      inline const bool getOverlapBelow(void) const
+      inline bool getOverlapBelow(void) const
       {
          return overlapBelow_;
       }
 
-      inline const bool isCrossing(void) const
+      inline bool isCrossing(void) const
       {
           return overlapBelow_ || overlapAbove_;
       }
@@ -245,7 +245,7 @@ namespace ttk
          return replacantId_;
       }
 
-      inline const idPartition getReplacantCT(void) const
+      inline idPartition getReplacantCT(void) const
       {
          return replacantCT_;
       }
@@ -264,14 +264,14 @@ namespace ttk
          return getVertList()[idx].first;
       }
 
-      inline const bool isMasqued(const idVertex &v) const
+      inline bool isMasqued(const idVertex &v) const
       {
          return vertList_[v].second;
       }
 
       // The vector
 
-      inline const idVertex getSegmentationSize(void) const
+      inline idVertex getSegmentationSize(void) const
       {
          return vertices_.size();
       }

--- a/core/baseCode/contourTree/ContourTree.cpp
+++ b/core/baseCode/contourTree/ContourTree.cpp
@@ -1798,7 +1798,7 @@ int SubLevelSetTree::openSuperArc(const int &nodeId){
   return (int)superArcList_.size() - 1;
 }
 
-const bool SubLevelSetTree::isSosHigherThan(const int &vertexId0, 
+bool SubLevelSetTree::isSosHigherThan(const int &vertexId0, 
 					    const int &vertexId1) const{
 
   return (((*vertexScalars_)[vertexId0] > (*vertexScalars_)[vertexId1])
@@ -1806,7 +1806,7 @@ const bool SubLevelSetTree::isSosHigherThan(const int &vertexId0,
 	     &&((*vertexSoSoffsets_)[vertexId0] > (*vertexSoSoffsets_)[vertexId1])));
 }
 
-const bool SubLevelSetTree::isSosLowerThan(const int &vertexId0, 
+bool SubLevelSetTree::isSosLowerThan(const int &vertexId0, 
 					   const int &vertexId1) const{
     
   return (((*vertexScalars_)[vertexId0] < (*vertexScalars_)[vertexId1])

--- a/core/baseCode/contourTree/ContourTree.h
+++ b/core/baseCode/contourTree/ContourTree.h
@@ -318,7 +318,7 @@ namespace ttk{
 			 arcList_[nodeList_[nodeId].getUpArcId(neighborId)].getUpNodeId()]);
     };
       
-    inline const double getNodeScalar(const int &nodeId) const {
+    inline double getNodeScalar(const int &nodeId) const {
       if(!vertexScalars_)
 	return -DBL_MAX;
       if((nodeId < 0)||(nodeId >= (int) nodeList_.size()))
@@ -372,7 +372,7 @@ namespace ttk{
         
       return &(superArcList_[vertex2superArc_[vertexId]]);}; 
 
-    inline const int getVertexSuperArcId(const int &vertexId) const {
+    inline int getVertexSuperArcId(const int &vertexId) const {
       if((vertexId < 0)||(vertexId >= vertexNumber_)) return -1;
       return vertex2superArc_[vertexId];
     };
@@ -383,25 +383,25 @@ namespace ttk{
 	return &(nodeList_[vertex2node_[vertexId]]);
       return NULL;};
         
-    inline const int getVertexNodeId(const int &vertexId) const{
+    inline int getVertexNodeId(const int &vertexId) const{
       if((vertexId < 0)||(vertexId >= vertexNumber_)) return -1;
       return vertex2node_[vertexId];
     };
 
-    const bool isJoinTree() const{
+    bool isJoinTree() const{
       return 
         ((maximumList_ == NULL)||((maximumList_)&&(maximumList_->empty())));
     }
     
-    const bool isSplitTree() const{
+    bool isSplitTree() const{
       return 
         ((minimumList_ == NULL)||((minimumList_)&&(minimumList_->empty())));
     }
     
-    const bool isSosLowerThan(const int &vertexId0, 
+    bool isSosLowerThan(const int &vertexId0, 
 			      const int &vertexId1) const;
 
-    const bool isSosHigherThan(const int &vertexId0, 
+    bool isSosHigherThan(const int &vertexId0, 
 			       const int &vertexId1) const;
       
     virtual inline int maintainRegularVertices(const bool &onOff){

--- a/core/baseCode/reebSpace/ReebSpace.h
+++ b/core/baseCode/reebSpace/ReebSpace.h
@@ -192,7 +192,7 @@ namespace ttk{
         return jacobi2edges_[jacobiEdgeId];
       }
       
-      inline const int getNumberOf2sheets() const {
+      inline int getNumberOf2sheets() const {
         return currentData_.sheet2List_.size();
       }
      


### PR DESCRIPTION
Dear Julien,
This pull request is aimed to fix an intrusive compile time warning when using ICC.
Several function on the platform had a const qualifier on a primitive
or return-by-copy return type. This is not needed as the returned variable is
only a temporary value.

I have also noticed a little problem in ttkMeshSubdivision.cpp, line 60 and 65 thier is two for loop enclosed in a larger one (l.45) that use the same index name "i".
Do you want me to change these in this pull request ?

Charles