### PR TITLE
Compile on macOS with minimalistic setup

### DIFF
--- a/core/base/ftmtree/AtomicVector.h
+++ b/core/base/ftmtree/AtomicVector.h
@@ -8,7 +8,9 @@
 #ifndef ATOMICVECTOR_H
 #define ATOMICVECTOR_H
 
+#ifdef TTK_ENABLE_OPENMP
 #include <omp.h>
+#endif // TTK_ENABLE_OPENMP
 #include <iterator>
 #include <vector>
 

--- a/core/base/ftmtree/CMakeLists.txt
+++ b/core/base/ftmtree/CMakeLists.txt
@@ -6,7 +6,7 @@ ttk_add_base_library(ftmTree
 		FTMTree_MT.h FTMTree_MT_Template.h FTMTree_Template.h Node.h
 		Segmentation.h Structures.h SuperArc.h
 	LINK triangulation geometry)
-target_include_directories(ftmTree PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(ftmTree PUBLIC ${Boost_INCLUDE_DIR})
 
 option(TTK_ENABLE_FTM_TREE_PROCESS_SPEED "Enable FTM tree process speed" OFF)
 

--- a/core/base/ftmtree/CMakeLists.txt
+++ b/core/base/ftmtree/CMakeLists.txt
@@ -6,7 +6,7 @@ ttk_add_base_library(ftmTree
 		FTMTree_MT.h FTMTree_MT_Template.h FTMTree_Template.h Node.h
 		Segmentation.h Structures.h SuperArc.h
 	LINK triangulation geometry)
-target_include_directories(ftmTree PUBLIC ${BOOST_INCLUDE_DIRS})
+target_include_directories(ftmTree PUBLIC ${Boost_INCLUDE_DIRS})
 
 option(TTK_ENABLE_FTM_TREE_PROCESS_SPEED "Enable FTM tree process speed" OFF)
 


### PR DESCRIPTION
For a macOS compile TTK without VTK wrappers, without Paraview plugins, without OpenMP, and without standalone apps.