### PR TITLE
Allow const for copy constructor of Separatrix

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -61,7 +61,7 @@ namespace ttk{
       geometry_{geometry}
     {}
 
-    Separatrix(Separatrix& separatrix):
+    Separatrix(const Separatrix& separatrix):
       isValid_{separatrix.isValid_},
       source_{separatrix.source_},
       destination_{separatrix.destination_},


### PR DESCRIPTION
Dear Julien,

Some collaborator using a Mac needed this fix to compile TTK successfully.

Sincerely,
Daisuke