### PR TITLE
Avoid false negative on tree verification

### DIFF
--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -915,7 +915,7 @@ void FTMTree_MT::normalizeIds(void)
    }
 
 #ifndef TTK_ENABLE_KAMIKAZE
-   if (nIdMin + 1 != nIdMax) {
+   if (std::abs((long)nIdMax - (long)nIdMin) > 1) {
       cout << "[FTM] error during normalize, tree compromized: " << nIdMin << " " << nIdMax << endl;
    }
 #endif


### PR DESCRIPTION
Dear Julien,
I have recently added a new check on the tree structure after the Unification of the ids.
Their is some valid tree that could trigger this check and raise a warning even on a valid tree configuration. This commit fix this issue.

Charles