### PR TITLE
ttkFieldSelector - select scalar fields

### DIFF
--- a/core/vtk/ttkFieldSelector/CMakeLists.txt
+++ b/core/vtk/ttkFieldSelector/CMakeLists.txt
@@ -1,0 +1,4 @@
+ttk_add_vtk_library(ttkFieldSelector
+	SOURCES ttkFieldSelector.cpp
+	HEADERS ttkFieldSelector.h
+	LINK common)

--- a/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
+++ b/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
@@ -43,8 +43,10 @@ int ttkFieldSelector::doIt(vtkDataSet* input, vtkDataSet* output){
 #endif
 
   for(auto& scalar : ScalarFields){
-    vtkDataArray* arr=inputPointData->GetArray(scalar.data());
-    if(arr) outputPointData->AddArray(arr);
+    if(scalar.length()>0){
+      vtkDataArray* arr=inputPointData->GetArray(scalar.data());
+      if(arr) outputPointData->AddArray(arr);
+    }
   }
 
   if(ScalarFields.size())

--- a/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
+++ b/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
@@ -34,20 +34,19 @@ int ttkFieldSelector::doIt(vtkDataSet* input, vtkDataSet* output){
   }
 #endif
 
-  vtkPointData* outputPointData=output->GetPointData();
+  vtkSmartPointer<vtkPointData> outputPointData=vtkSmartPointer<vtkPointData>::New();
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!outputPointData){
-    cerr << "[ttkFieldSelector] Error: output has no point data." << endl;
+    cerr << "[ttkFieldSelector] Error: vtkPointData memory allocation problem." << endl;
     return -1;
   }
 #endif
 
-  const int numberOfArrays=outputPointData->GetNumberOfArrays();
-  for(int i=0; i<numberOfArrays; ++i)
-    outputPointData->RemoveArray(0);
-
   for(auto& scalar : ScalarFields)
     outputPointData->AddArray(inputPointData->GetArray(scalar.data()));
+
+  if(ScalarFields.size())
+    output->GetPointData()->ShallowCopy(outputPointData);
 
   ScalarFields.clear();
 

--- a/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
+++ b/core/vtk/ttkFieldSelector/ttkFieldSelector.cpp
@@ -42,8 +42,10 @@ int ttkFieldSelector::doIt(vtkDataSet* input, vtkDataSet* output){
   }
 #endif
 
-  for(auto& scalar : ScalarFields)
-    outputPointData->AddArray(inputPointData->GetArray(scalar.data()));
+  for(auto& scalar : ScalarFields){
+    vtkDataArray* arr=inputPointData->GetArray(scalar.data());
+    if(arr) outputPointData->AddArray(arr);
+  }
 
   if(ScalarFields.size())
     output->GetPointData()->ShallowCopy(outputPointData);

--- a/core/vtk/ttkFieldSelector/ttkFieldSelector.h
+++ b/core/vtk/ttkFieldSelector/ttkFieldSelector.h
@@ -1,0 +1,119 @@
+/// \ingroup vtk
+/// \class ttkFieldSelector
+/// \author Guillaume Favelier <guillaume.favelier@lip6.fr>
+/// \date December 2017
+///
+/// \brief TTK VTK-filter that selects scalar fields on input with shallow copy.
+/// 
+/// \param Input Input scalar field (vtkDataSet)
+/// \param Output Output scalar field (vtkDataSet)
+///
+/// This filter can be used as any other VTK filter (for instance, by using the 
+/// sequence of calls SetInputData(), Update(), GetOutput()).
+///
+/// See the related ParaView example state files for usage examples within a 
+/// VTK pipeline.
+#pragma once
+
+// ttk code includes
+#include<Wrapper.h>
+
+// VTK includes
+#include<vtkCharArray.h>
+#include<vtkDataArray.h>
+#include<vtkDataSet.h>
+#include<vtkDataSetAlgorithm.h>
+#include<vtkDoubleArray.h>
+#include<vtkFiltersCoreModule.h>
+#include<vtkFloatArray.h>
+#include<vtkInformation.h>
+#include<vtkIntArray.h>
+#include<vtkObjectFactory.h>
+#include<vtkPointData.h>
+#include<vtkSmartPointer.h>
+
+class VTKFILTERSCORE_EXPORT ttkFieldSelector 
+: public vtkDataSetAlgorithm, public Wrapper{
+
+  public:
+
+    static ttkFieldSelector* New();
+    vtkTypeMacro(ttkFieldSelector, vtkDataSetAlgorithm)
+
+      // default ttk setters
+      vtkSetMacro(debugLevel_, int);
+
+    void SetThreads(){
+      if(!UseAllCores)
+        threadNumber_ = ThreadNumber;
+      else{
+        threadNumber_ = OsCall::getNumberOfCores();
+      }
+      Modified();
+    }
+
+    void SetThreadNumber(int threadNumber){\
+      ThreadNumber = threadNumber;\
+        SetThreads();\
+    }\
+    void SetUseAllCores(bool onOff){
+      UseAllCores = onOff;
+      SetThreads();
+    }
+    // end of default ttk setters
+
+    void SetScalarFields(string s){
+      ScalarFields.push_back(s);
+      Modified();
+    }
+
+    int FillInputPortInformation(int port, vtkInformation *info){
+      switch(port){
+        case 0:
+          info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
+          break;
+        default:
+          break;
+      }
+
+      return 1;
+    }
+
+    int FillOutputPortInformation(int port, vtkInformation *info){
+
+      switch(port){
+        case 0:
+          info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
+          break;
+        default:
+          break;
+      }
+
+      return 1;
+    }
+
+  protected:
+
+    ttkFieldSelector(){
+      UseAllCores = false;
+
+      SetNumberOfInputPorts(1);
+      SetNumberOfOutputPorts(1);
+    }
+
+    ~ttkFieldSelector(){};
+
+    int RequestData(vtkInformation *request,
+        vtkInformationVector **inputVector,
+        vtkInformationVector *outputVector);
+
+  private:
+
+    bool UseAllCores;
+    int ThreadNumber;
+    vector<string> ScalarFields;
+
+    int doIt(vtkDataSet *input, vtkDataSet *output);
+    bool needsToAbort();
+    int updateProgress(const float &progress);
+};

--- a/paraview/FieldSelector/CMakeLists.txt
+++ b/paraview/FieldSelector/CMakeLists.txt
@@ -1,0 +1,6 @@
+ttk_add_paraview_plugin(ttkFieldSelector
+	SOURCES ${VTKWRAPPER_DIR}/ttkFieldSelector/ttkFieldSelector.cpp
+	PLUGIN_VERSION 1.0
+	PLUGIN_XML FieldSelector.xml
+	LINK common)
+

--- a/paraview/FieldSelector/FieldSelector.xml
+++ b/paraview/FieldSelector/FieldSelector.xml
@@ -1,0 +1,110 @@
+
+<ServerManagerConfiguration>
+  <!-- This is the server manager configuration XML. It defines the interface to
+       our new filter. As a rule of thumb, try to locate the configuration for
+       a filter already in ParaView (in Servers/ServerManager/Resources/*.xml)
+       that matches your filter and then model your xml on it -->
+  <ProxyGroup name="filters">
+    <SourceProxy 
+      name="FieldSelector" 
+      class="ttkFieldSelector" 
+      label="TTK FieldSelector">
+      <Documentation
+        long_help="TTK fieldSelector plugin."
+        short_help="TTK fieldSelector plugin.">
+        TTK fieldSelector plugin documentation.
+      </Documentation>
+      <InputProperty
+        name="Input"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+        </Documentation>
+      </InputProperty>
+
+      <IntVectorProperty
+        name="UseAllCores"
+        label="Use All Cores"
+        command="SetUseAllCores"
+        number_of_elements="1"
+        default_values="1" panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Use all available cores.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+        name="ThreadNumber"
+        label="Thread Number"
+        command="SetThreadNumber"
+        number_of_elements="1"
+        default_values="1" panel_visibility="advanced">
+        <IntRangeDomain name="range" min="1" max="100" />
+        <Documentation>
+          Thread number.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+        name="DebugLevel"
+        label="Debug Level"
+        command="SetdebugLevel_"
+        number_of_elements="1"
+        default_values="3" panel_visibility="advanced">
+        <IntRangeDomain name="range" min="0" max="100" />
+        <Documentation>
+          Debug level.
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty command="SetScalarFields"
+        label="Scalar Fields"
+        name="ScalarFields"
+        number_of_elements="0"
+        default_values="0"
+        number_of_elements_per_command="1"
+        repeat_command="1">
+        <ArrayListDomain name="array_list"
+          attribute_type="Scalars"
+          default_values="0"
+          input_domain_name="inputs_array">
+          <RequiredProperties>
+            <Property name="Input"
+              function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <NoDefault />
+        </Hints>
+        <Documentation>
+          Select the scalar fields to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="ScalarFields" />
+      </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Testing">
+        <Property name="UseAllCores" />
+        <Property name="ThreadNumber" />
+        <Property name="DebugLevel" />
+      </PropertyGroup>
+
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
Dear Julien,

I think that it would be great if we could be able to select the scalar fields we are interested in and exclude the rest inside ParaView with simple checkboxes not only during data loading but anywhere in the pipeline. Of course, this solution should use shallow copy of the selected data only and avoid unnecessary operations.