### PR TITLE
Improve TTK Field/Cell Selector using regexp

### DIFF
--- a/core/vtk/ttkCellDataSelector/ttkCellDataSelector.cpp
+++ b/core/vtk/ttkCellDataSelector/ttkCellDataSelector.cpp
@@ -1,4 +1,5 @@
 #include <ttkCellDataSelector.h>
+#include <regex>
 
 vtkStandardNewMacro(ttkCellDataSelector)
 
@@ -42,11 +43,15 @@ int ttkCellDataSelector::doIt(vtkDataSet* input, vtkDataSet* output){
   }
 #endif
 
-  for(auto& scalar : ScalarFields){
-    if(scalar.length()>0){
-      vtkDataArray* arr=inputCellData->GetArray(scalar.data());
-      if(arr) outputCellData->AddArray(arr);
-    }
+  try {
+     for (auto &scalar : ScalarFields) {
+        if (scalar.length() > 0 && regex_match(scalar, regex(RegexpString))) {
+           vtkDataArray *arr = inputCellData->GetArray(scalar.data());
+           if (arr) outputCellData->AddArray(arr);
+        }
+     }
+  } catch (std::regex_error) {
+     vtkWarningMacro("[ttkCellDataSelector]: Bad regexp.");
   }
 
   output->GetCellData()->ShallowCopy(outputCellData);

--- a/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
+++ b/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
@@ -46,6 +46,7 @@ class ttkCellDataSelector
 
       // default ttk setters
       vtkSetMacro(debugLevel_, int);
+      vtkSetMacro(RegexpString, string);
 
     void SetThreads(){
       if(!UseAllCores)
@@ -121,6 +122,7 @@ class ttkCellDataSelector
     bool UseAllCores;
     int ThreadNumber;
     vector<string> ScalarFields;
+    string RegexpString;
 
     int doIt(vtkDataSet *input, vtkDataSet *output);
     bool needsToAbort();

--- a/core/vtk/ttkPointDataSelector/ttkPointDataSelector.cpp
+++ b/core/vtk/ttkPointDataSelector/ttkPointDataSelector.cpp
@@ -1,4 +1,5 @@
 #include <ttkPointDataSelector.h>
+#include <regex>
 
 vtkStandardNewMacro(ttkPointDataSelector)
 
@@ -42,11 +43,15 @@ int ttkPointDataSelector::doIt(vtkDataSet* input, vtkDataSet* output){
   }
 #endif
 
-  for(auto& scalar : ScalarFields){
-    if(scalar.length()>0){
-      vtkDataArray* arr=inputPointData->GetArray(scalar.data());
-      if(arr) outputPointData->AddArray(arr);
-    }
+  try {
+     for(auto& scalar : ScalarFields){
+        if(scalar.length()>0 && regex_match(scalar, regex(RegexpString))){
+           vtkDataArray* arr=inputPointData->GetArray(scalar.data());
+           if(arr) outputPointData->AddArray(arr);
+        }
+     }
+  } catch (std::regex_error) {
+     vtkWarningMacro("[ttkPointDataSelector]: Bad regexp.");
   }
 
   output->GetPointData()->ShallowCopy(outputPointData);

--- a/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
+++ b/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
@@ -46,6 +46,7 @@ class ttkPointDataSelector
 
       // default ttk setters
       vtkSetMacro(debugLevel_, int);
+      vtkSetMacro(RegexpString, string);
 
     void SetThreads(){
       if(!UseAllCores)
@@ -121,6 +122,7 @@ class ttkPointDataSelector
     bool UseAllCores;
     int ThreadNumber;
     vector<string> ScalarFields;
+    string RegexpString;
 
     int doIt(vtkDataSet *input, vtkDataSet *output);
     bool needsToAbort();

--- a/paraview/CellDataSelector/CellDataSelector.xml
+++ b/paraview/CellDataSelector/CellDataSelector.xml
@@ -56,6 +56,16 @@
         </Documentation>
       </StringVectorProperty>
 
+      <StringVectorProperty
+         name="Filter"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*" panel_visibility="advanced">
+         <Documentation>
+            This regexp will be used to filter the chosen fields. Only matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
       <IntVectorProperty
         name="UseAllCores"
         label="Use All Cores"
@@ -94,6 +104,7 @@
 
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="ScalarFields" />
+        <Property name="Filter" />
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Testing">

--- a/paraview/PointDataSelector/PointDataSelector.xml
+++ b/paraview/PointDataSelector/PointDataSelector.xml
@@ -56,6 +56,16 @@
         </Documentation>
       </StringVectorProperty>
 
+      <StringVectorProperty
+         name="Filter"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*" panel_visibility="advanced">
+         <Documentation>
+            This regexp will be used to filter the chosen fields. Only matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
       <IntVectorProperty
         name="UseAllCores"
         label="Use All Cores"
@@ -94,6 +104,7 @@
 
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="ScalarFields" />
+        <Property name="Filter" />
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Testing">


### PR DESCRIPTION
Dear Julien,

this little pull request add a new feature to the Point/Cell data selector filters.
A string property is now available in advanced mode, corresponding to a regexp. Only the fields matching this regexp are selected by the filter. (The default value of this string is ".*")

This is useful on data set having a huge number of scalars, to select only a part of them quickly.

Charles