### PR TITLE
FTM: improve performances for GCC without openmp

### DIFF
--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -22,6 +22,10 @@
 #define HIGHER
 #endif
 
+#ifndef TTK_ENABLE_OPENMP
+#define HIGHER
+#endif
+
 using namespace ftm;
 
 DebugTimer _launchGlobalTime;


### PR DESCRIPTION
Dear Julien,
I have improved the FTM Tree performances when there is no openmp on GCC.

Our tasks for the arc growth step needs to be launched starting at the deepest leaves for best performances.
As GCC uses an (annoying) stack to store tasks, we need to sort the leaves in the reverse order for him in order to achieve the best schedule. But when openmp is disabled, such inversion should not occur.
This is what this pull request fix.

Charles 