### PR TITLE
Fix CRLF on paraview patch

### DIFF
--- a/paraview/patch/patch-paraview-msvc-x86.cmd
+++ b/paraview/patch/patch-paraview-msvc-x86.cmd
@@ -13,7 +13,7 @@ goto exit
 :patch
 %~d1
 cd %paraviewsrc%
-git apply %cdir%/ADF_internals.c.patch
+git apply --ignore-whitespace %cdir%/ADF_internals.c.patch
 cd %cdir%
 echo Finished patching.
 

--- a/paraview/patch/patch-paraview-msvc.cmd
+++ b/paraview/patch/patch-paraview-msvc.cmd
@@ -9,7 +9,7 @@ if not exist %paraviewsrc% goto error
 %~d1
 cd %paraviewsrc%
 
-git apply %cdir%/paraview-msvc-CMakeLists.txt.patch
+git apply --ignore-whitespace %cdir%/paraview-msvc-CMakeLists.txt.patch
 
 cd %cdir%
 echo Finished patching.


### PR DESCRIPTION
Dear julien,

During the paraview patch procedure on windows, some conflict may appear between the patch files generated on Windows and the Paraview files on linux.
This is the everlasting problem of the CRLF VS LF.
This patch allows to ignore these end of line symbols when patching files on Windows, thus avoiding the problem.

Charles 