### PR TITLE
Improve CMake build type option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ project(ttk VERSION 0.9.4 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 
+# Set a predefined build type
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+   message(STATUS "Setting build type to 'Release'.")
+   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
+endif()
+
 option(TTK_ENABLE_KAMIKAZE "Enable Kamikaze compilation mode" OFF)
 option(TTK_ENABLE_CPU_OPTIMIZATION "Enable native CPU optimizations" ON)
 


### PR DESCRIPTION
Dear Julien,

This pull request set the default build type of TTK to Release.
Moreover, we can now switch between Release and Debug mode by pressing enter on gui / ccmake.
This change is a piece of code coming from the Paraview CMakeLists.txt.

Charles