### PR TITLE
Allow build directory to be separated from source directory

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -65,11 +65,11 @@ if(TTK_BUILD_DOCUMENTATION)
 			${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/ttk.doxygen
 			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 			COMMENT "Generating API documentation with Doxygen" VERBATIM)
-		install(DIRECTORY 
-			${CMAKE_CURRENT_BINARY_DIR}/../../doc/html DESTINATION 
+		install(DIRECTORY
+			${CMAKE_CURRENT_BINARY_DIR}/doc/html DESTINATION
 			${CMAKE_INSTALL_PREFIX}/share/doc/ttk)
 		install(DIRECTORY
-			${CMAKE_CURRENT_BINARY_DIR}/../../doc/img DESTINATION
+          ${CMAKE_SOURCE_DIR}/doc/img DESTINATION
 			${CMAKE_INSTALL_PREFIX}/share/doc/ttk)
 	endif()
 endif()

--- a/core/ttk.doxygen
+++ b/core/ttk.doxygen
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @ttk_SOURCE_DIR@/doc/
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc/
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and


### PR DESCRIPTION
Dear Julien,

I am well aware that in the [standard TTK installation procedure](https://topology-tool-kit.github.io/installation.html), the build directory is to be in the source directory but personally I'm used to separate those directories from each other and in my case, building TTK somewhere else works just fine except for one little thing, the documentation. 

This patch address an issue occuring when one generates the TTK documentation with the build's directory outside the source directory.

I thought that it would be great to share it.