### PR TITLE
Fix support for glibc version 2.27

### DIFF
--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -36,7 +36,6 @@
   #define               round(x) OsCall::roundToNearestInt(x)
 #endif
   #define               srand48(seed) srand(seed)
-  #define               pow10(x) pow(10, x)
 #endif
 
 #ifdef __unix__
@@ -60,8 +59,9 @@
 #include                <sys/time.h>
 #include                <sys/types.h>
 #include                <unistd.h>
-#define                 pow10(x) pow(10, x)
 #endif
+
+#define               pow10(x) pow(10, x)
 
 //#define SINGLE_PRECISION  
 


### PR DESCRIPTION
Dear Julien,

As stated by Dmitry V. Levin talking about the changes of the new [version 2.27](https://sourceware.org/ml/libc-announce/2018/msg00000.html) of `glibc`:

> The libm functions pow10, pow10f and pow10l are no longer supported for
> new programs.  Programs should use the standard names exp10, exp10f and
> exp10l for these functions instead.

So I modified the code so that a macro for the `pow10()` function is used instead.

For compatibility reason, it's still using `pow()` internally because at the moment I have not evaluated
the level of support of the `exp10()` function on all the different architectures using TTK.
