### PR TITLE
Various fixes for Clang and Windows

### DIFF
--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -43,7 +43,7 @@
 #include                <climits>
 #include                <dirent.h>
 #include                <iomanip>
-#include                <math.h>
+#include                <cmath>
 #include                <sys/stat.h>
 #include                <sys/time.h>
 #include                <sys/types.h>

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -30,7 +30,12 @@
 #  include <algorithm>
 #  include <numeric>
 # else
-#  include <parallel/algorithm>
+#  ifdef __clang__
+#   include <algorithm>
+#   include <numeric>
+#  else
+#   include <parallel/algorithm>
+#  endif
 # endif
 #endif
 

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -41,7 +41,12 @@ void MergeTree::sortInput(void)
       iota(sortedVect.begin(), sortedVect.end(), 0);
 
 #ifdef TTK_ENABLE_OPENMP
+# ifdef _GLIBCXX_PARALLEL_FEATURES_H
+      // ensure this namespace exists
       __gnu_parallel::sort(sortedVect.begin(), sortedVect.end(), indirect_sort);
+# else
+      sort(sortedVect.begin(), sortedVect.end(), indirect_sort);
+# endif
 #else
       sort(sortedVect.begin(), sortedVect.end(), indirect_sort);
 #endif
@@ -133,7 +138,11 @@ idEdge MergeTree::globalSimplify(const idVertex posSeed0, const idVertex posSeed
 // Sort nodes by vertex scalar
 //{
 #ifdef TTK_ENABLE_OPENMP
+# ifdef _GLIBCXX_PARALLEL_FEATURES_H
     __gnu_parallel::sort(sortedNodes.begin(), sortedNodes.end(), isLowerComp);
+#else
+    sort(sortedNodes.begin(), sortedNodes.end(), isLowerComp);
+#endif
 #else
     sort(sortedNodes.begin(), sortedNodes.end(), isLowerComp);
 #endif
@@ -176,7 +185,11 @@ idEdge MergeTree::globalSimplify(const idVertex posSeed0, const idVertex posSeed
     // IS SET STILL BETTER ? (parallel sort) TODO
 
 #ifdef TTK_ENABLE_OPENMP
+# ifdef _GLIBCXX_PARALLEL_FEATURES_H
         __gnu_parallel::sort(sortedPairs.begin(), sortedPairs.end(), pairComp);
+# else
+        sort(sortedPairs.begin(), sortedPairs.end(), pairComp);
+# endif
 #else
         sort(sortedPairs.begin(), sortedPairs.end(), pairComp);
 #endif

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -30,14 +30,20 @@
 
 // standard includes
 #ifdef __APPLE__
-#include <algorithm>
+# include <algorithm>
 #else
-#ifdef _WIN32
-#include <algorithm>
-#else
-#include <parallel/algorithm>
+# ifdef _WIN32
+#  include <algorithm>
+# else
+#  ifdef __clang__
+#   include <algorithm>
+#   include <numeric>
+#  else
+#   include <parallel/algorithm>
+#  endif
+# endif
 #endif
-#endif
+
 #include                  <queue>
 
 // base code includes
@@ -1667,7 +1673,7 @@ template <class dataTypeU, class dataTypeV>
   }
 #endif
    
-  finalize<dataTypeU, dataTypeV>(pointSnapping_, NULL, NULL, NULL);
+  finalize<dataTypeU, dataTypeV>(pointSnapping_, false, false, false);
     
   {
     stringstream msg;

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -18,6 +18,11 @@
 
 #include "FTMTree.h"
 
+// for std::isnan
+#include <cmath>
+// for std::numeric_limits
+#include <limits>
+
 // -------
 // PROCESS
 // -------
@@ -49,12 +54,12 @@ void ftm::FTMTree::build(void)
    // Recall: Equals values are distinguished using Simulation of Simplicity in the FTM tree
    // computation
    // Note: Can we detect NaN using vtk ?
-   if (std::numeric_limits<scalarType>::has_quiet_NaN) {
+   if (::std::numeric_limits<scalarType>::has_quiet_NaN) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for
 #endif
       for (idVertex i = 0; i < scalars_->size; i++) {
-         if (std::isnan((double) ((scalarType*)scalars_->values)[i])) {
+         if (::std::isnan((double)(((scalarType*)scalars_->values)[i])) {
             ((scalarType*)scalars_->values)[i] = 0;
          }
       }

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -59,7 +59,7 @@ void ftm::FTMTree::build(void)
 #pragma omp parallel for
 #endif
       for (idVertex i = 0; i < scalars_->size; i++) {
-         if (::std::isnan((double)(((scalarType*)scalars_->values)[i])) {
+         if (::std::isnan((double)(((scalarType*)scalars_->values)[i]))) {
             ((scalarType*)scalars_->values)[i] = 0;
          }
       }

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -140,7 +140,7 @@ void ftm::FTMTreePP::computePairs(ftm::FTMTree_MT* tree,
       return tree->getSuperArc(parentArc)->getUpNodeId();
    };
 
-   std::queue<idNode> toSee;
+   ::std::queue<idNode> toSee;
 
    // start at the leaves
    auto& vectLeaves = tree->getLeaves();

--- a/core/vtk/ttkBlank/ttkBlank.h
+++ b/core/vtk/ttkBlank/ttkBlank.h
@@ -56,10 +56,10 @@ class ttkBlank
     // default ttk setters
     vtkSetMacro(debugLevel_, int);
     
-    void SetThreadNumber(int threadNumber){\
-      ThreadNumber = threadNumber;\
-      SetThreads();\
-    }\
+    void SetThreadNumber(int threadNumber){
+      ThreadNumber = threadNumber;
+      SetThreads();
+    }
     void SetUseAllCores(bool onOff){
       UseAllCores = onOff;
       SetThreads();
@@ -91,7 +91,7 @@ class ttkBlank
     // Here, you can re-define the input types, on a per input basis.
     // In this example, the first input type is forced to vtkUnstructuredGrid.
     // The second input type is forced to vtkImageData.
-//     int FillInputPortInformation(int port, vtkInformation *info){
+//     int FillInputPortInformation(int port, vtkInformation *info) override {
 //       
 //       switch(port){
 //         case 0:
@@ -114,7 +114,7 @@ class ttkBlank
     // Here, you can re-define the output types, on a per output basis.
     // In this example, the first output type is forced to vtkUnstructuredGrid.
     // The second output type is forced to vtkImageData.
-//     int FillOutputPortInformation(int port, vtkInformation *info){
+//     int FillOutputPortInformation(int port, vtkInformation *info) override {
 //       
 //       switch(port){
 //         case 0:

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -366,7 +366,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
               pointCount++;
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -400,7 +400,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
               pointCount++;
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -433,7 +433,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
               pointCount++;
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -464,7 +464,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
               pointCount++;
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -497,7 +497,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
               pointCount++;
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -199,7 +199,7 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
               scalarArray->SetTuple(j, value);
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -218,7 +218,7 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
               scalarArray->SetTuple(j, value);
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -237,7 +237,7 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
               scalarArray->SetTuple(j, value);
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           
@@ -256,7 +256,7 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
               scalarArray->SetTuple(j, value);
             }
             output->GetPointData()->AddArray(scalarArray);
-            delete value;
+            delete[] value;
           }
           break;
           

--- a/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.cpp
+++ b/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.cpp
@@ -148,7 +148,7 @@ int ttkTextureMapFromField::doIt(vtkDataSet *input, vtkDataSet *output){
   for(int i = 0; i < threadNumber_; i++){
     delete coordinates[i];
   }
-  delete coordinates;
+  delete[] coordinates;
 
   {
     stringstream msg;

--- a/core/vtk/ttkTriangulation/ttkWrapper.h
+++ b/core/vtk/ttkTriangulation/ttkWrapper.h
@@ -61,7 +61,7 @@
 #define TTK_OUTPUT_MANAGEMENT() \
   protected: \
     int RequestDataObject(vtkInformation *request, \
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector){\
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override {\
       \
       vtkDataSetAlgorithm::RequestDataObject(\
         request, inputVector, outputVector);\
@@ -93,7 +93,7 @@
       vector<vtkSmartPointer<ttkTriangulationFilter> > inputTriangulations_;\
       int RequestData(vtkInformation *request, \
         vtkInformationVector **inputVector, \
-        vtkInformationVector *outputVector){\
+        vtkInformationVector *outputVector) override {\
         \
         if((int) inputTriangulations_.size() != GetNumberOfInputPorts()){\
           inputTriangulations_.resize(GetNumberOfInputPorts());\
@@ -143,9 +143,9 @@
     private:\
       int doIt(vector<vtkDataSet *> &inputs, vector<vtkDataSet *> &outputs);\
       \
-      bool needsToAbort(){ return GetAbortExecute();};\
+      bool needsToAbort() override { return GetAbortExecute();};\
       \
-      int updateProgress(const float &progress) { \
+      int updateProgress(const float &progress) override { \
         UpdateProgress(progress);\
         return 0;\
       };\
@@ -172,16 +172,16 @@ class ttkTriangulationFilter
     ~ttkTriangulationFilter(){};
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
    
     int RequestDataObject(vtkInformation *request,
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
   private:
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
@@ -303,7 +303,7 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *request,
 
   doIt(input, boundFields, probability, mean, numInputs);
 
-  delete input;
+  delete[] input;
 
   {
     stringstream msg;

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -1,6 +1,8 @@
 // local includes
 #include                  <ttkUserInterfaceBase.h>
 
+#include <vtkTexture.h>
+
 vtkStandardNewMacro(ttkCustomInteractor);
 
 

--- a/standalone/UncertainDataEstimator/cmd/Editor.cpp
+++ b/standalone/UncertainDataEstimator/cmd/Editor.cpp
@@ -257,9 +257,6 @@ int Editor::init(int &argc, char **argv){
   } else if(inputFormat_ == "vti") {
     outputBounds_ = vtkImageData::New();
     outputHistograms_ = vtkImageData::New();
-  } else if(inputFormat_ == "vto") {
-    outputBounds_ = vtkHyperOctree::New();
-    outputHistograms_ = vtkHyperOctree::New();
   }
 
   if(debugLevel_ > infoMsg) {
@@ -378,12 +375,6 @@ int Editor::loadData(const string &fileName) {
         input_ = NULL;
       }
       input_ = readXMLFile<vtkXMLImageDataReader>(fileName);
-    } else if (inputFormat_ == "vto") {
-      if(input_) {
-        input_->Delete();
-        input_ = NULL;
-      }
-      input_ = readXMLFile<vtkXMLHyperOctreeReader>(fileName);
     } else {
       stringstream msg;
       msg << "[Editor] File format " << inputFormat_ << " not supported" << endl;

--- a/standalone/UncertainDataEstimator/cmd/Editor.h
+++ b/standalone/UncertainDataEstimator/cmd/Editor.h
@@ -18,7 +18,6 @@
 #include <vtkStructuredGrid.h>
 #include <vtkRectilinearGrid.h>
 #include <vtkImageData.h>
-#include <vtkHyperOctree.h>
 #include <vtkDataSet.h>
 // Readers
 #include <vtkImageReader2.h>
@@ -27,7 +26,6 @@
 #include <vtkXMLStructuredGridReader.h>
 #include <vtkXMLRectilinearGridReader.h>
 #include <vtkXMLImageDataReader.h>
-#include <vtkXMLHyperOctreeReader.h>
 #include <vtkDataSetReader.h>
 // Writers
 #include <vtkXMLUnstructuredGridWriter.h>
@@ -35,7 +33,6 @@
 #include <vtkXMLStructuredGridWriter.h>
 #include <vtkXMLRectilinearGridWriter.h>
 #include <vtkXMLImageDataWriter.h>
-#include <vtkXMLHyperOctreeWriter.h>
 #include <vtkDataSetWriter.h>
 // Array types
 #include <vtkFloatArray.h>


### PR DESCRIPTION
Dear Julien,

This pull request fixes various little things in TTK including:
* Compilation issue on the latest VTK for windows: 
    * the file *vtkHyperOctree.h* has been removed. This drop the support for".vto" files (UncertainDataEstimator)
    * include *vtkTexture.h* in *ttkUserInterfaceBase.h* is now required
* Better clang support (include files, global namespace)
* fix memory leaks caused by some `delete` instead of `delete[]`
* add `override` keyword on some core functions
* ...

I have built it successfully on Windows (msvc 15 2017) and Linux (gcc 7.3.1, clang 6.0.0)

Charles