### PR TITLE
MSVC fix when UNICODE is defined

### DIFF
--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 ttk_add_base_library(common
-	SOURCES Debug.cpp
+	SOURCES Debug.cpp Os.cpp
 	HEADERS CommandLineParser.h Debug.h
 			Os.h ProgramBase.h Wrapper.h)
 

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -1,0 +1,244 @@
+#include <Os.h>
+#include <Debug.h>
+
+#ifdef _WIN32
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <ciso646>
+#include <cwchar>
+#include <direct.h>
+#include <stdint.h>
+#include <time.h>
+
+#elif defined(__unix__) || defined(__APPLE__)
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+#include <iostream>
+#include <algorithm>
+#include <sstream>
+
+namespace ttk {
+
+int OsCall::getCurrentDirectory(std::string &directoryPath) {
+#ifdef _WIN32
+    directoryPath = _getcwd(NULL, 0);
+#else
+    directoryPath = getcwd(NULL, PATH_MAX);
+#endif
+    directoryPath += "/";
+
+    return 0;
+}
+
+float OsCall::getMemoryInstantUsage() {
+#ifdef __linux__
+    // horrible hack since getrusage() doesn't seem to work well under
+    // linux
+    std::stringstream procFileName;
+    procFileName << "/proc/" << getpid() << "/statm";
+
+    std::ifstream procFile(procFileName.str().data(), std::ios::in);
+    if (procFile) {
+        float memoryUsage;
+        procFile >> memoryUsage;
+        procFile.close();
+        return memoryUsage / 1024.0;
+    }
+#endif
+    return 0;
+}
+
+int OsCall::getNumberOfCores() {
+#ifdef TTK_ENABLE_OPENMP
+    return omp_get_num_procs();
+#endif
+    return 1;
+}
+
+double OsCall::getTimeStamp() {
+#ifdef _WIN32
+    LARGE_INTEGER frequency;
+    QueryPerformanceFrequency(&frequency);
+
+    LARGE_INTEGER temp;
+    QueryPerformanceCounter(&temp);
+
+    return (double)temp.QuadPart / frequency.QuadPart;
+#endif
+
+#ifdef __APPLE__
+    struct timeval stamp;
+    gettimeofday(&stamp, NULL);
+    return (stamp.tv_sec * 1000000 + stamp.tv_usec) / 1000000.0;
+#endif
+
+#ifdef __unix__
+    struct timeval stamp;
+    gettimeofday(&stamp, NULL);
+    return (stamp.tv_sec * 1000000 + stamp.tv_usec) / 1000000.0;
+#endif
+}
+
+std::vector<std::string> OsCall::listFilesInDirectory(const std::string &directoryName,
+                                                      const std::string &extension) {
+
+    std::vector<std::string> filesInDir;
+
+#ifdef _WIN32
+
+#ifdef UNICODE
+    auto toWString = [](const std::string &str) {
+        if (str.empty()) return std::wstring();
+        int wcharCount = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+        std::wstring wstr;
+        wstr.resize(wcharCount);
+        MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], wcharCount);
+        return wstr;
+    };
+    auto toString = [](const WCHAR wstr[]) {
+        int charCount = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
+        std::string str;
+        str.resize(charCount);
+        WideCharToMultiByte(CP_UTF8, 0, wstr, -1, &str[0], charCount, nullptr, nullptr);
+        return str;
+    };
+#else
+    auto toWString = [](const std::string &str) { return str; };
+    auto toString = [](const char *c) { return std::string(c); };
+#endif
+
+    WIN32_FIND_DATA FindFileData;
+    char *buffer;
+    buffer = _getcwd(NULL, 0);
+    if ((buffer = _getcwd(NULL, 0)) == NULL)
+        perror("_getcwd error");
+    else {
+        free(buffer);
+    }
+
+    HANDLE hFind = FindFirstFile(toWString(directoryName).c_str(), &FindFileData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        std::stringstream msg;
+        msg << "[Os] Could not open directory `" << directoryName << "'. Error: " << GetLastError()
+            << std::endl;
+        Debug d;
+        d.dMsg(std::cerr, msg.str(), 0);
+    } else {
+        const std::string filename = toString(FindFileData.cFileName);
+
+        std::string entryExtension(filename);
+        entryExtension = entryExtension.substr(entryExtension.find_last_of('.') + 1);
+
+        if (entryExtension == extension) filesInDir.push_back(filename);
+        std::string dir = directoryName;
+        dir.resize(dir.size() - 1);
+        while (FindNextFile(hFind, &FindFileData)) {
+            if (extension.size()) {
+                std::string entryExtension(filename);
+                entryExtension = entryExtension.substr(entryExtension.find_last_of('.') + 1);
+                if (entryExtension == extension) filesInDir.push_back(dir + filename);
+            } else {
+                if ((filename != ".") && (filename != "..")) {
+                    filesInDir.push_back(directoryName + "/" + filename);
+                }
+            }
+        }
+    }
+    FindClose(hFind);
+#else
+    DIR *d = opendir((directoryName + "/").data());
+    if (!d) {
+        std::stringstream msg;
+        msg << "[Os] Could not open directory `" << directoryName << "'..." << std::endl;
+        Debug d;
+        d.dMsg(std::cerr, msg.str(), 0);
+    } else {
+        struct dirent *dirEntry;
+        while ((dirEntry = readdir(d)) != NULL) {
+            if (extension.size()) {
+                std::string entryExtension(dirEntry->d_name);
+                entryExtension = entryExtension.substr(entryExtension.find_last_of('.') + 1);
+                if (entryExtension == extension)
+                    filesInDir.push_back(directoryName + "/" + std::string(dirEntry->d_name));
+            } else {
+                if ((std::string(dirEntry->d_name) != ".") &&
+                    (std::string(dirEntry->d_name) != ".."))
+                    filesInDir.push_back(directoryName + "/" + std::string(dirEntry->d_name));
+            }
+        }
+    }
+    closedir(d);
+#endif
+
+    std::sort(filesInDir.begin(), filesInDir.end());
+
+    return filesInDir;
+}
+
+int OsCall::mkDir(const std::string &directoryName) {
+
+#ifdef _WIN32
+    return _mkdir(directoryName.data());
+#else
+    return mkdir(directoryName.data(), 0777);
+#endif
+}
+
+int OsCall::nearbyint(const double &x) {
+    const double upperBound = ceil(x);
+    const double lowerBound = floor(x);
+
+    if (upperBound - x <= x - lowerBound)
+        return (int)upperBound;
+    else
+        return (int)lowerBound;
+}
+
+int OsCall::rmDir(const std::string &directoryName) {
+
+#ifdef _WIN32
+    // NOTE:
+    // the directory will be deleted with this call
+    // only if it's empty...
+    return _rmdir(directoryName.data());
+#else
+    std::stringstream cmd;
+    cmd << "rm -R " << directoryName << " 2> /dev/null";
+    return system(cmd.str().data());
+#endif
+}
+
+int OsCall::rmFile(const std::string &fileName) {
+
+    std::stringstream cmd;
+
+#ifdef _WIN32
+    cmd << "del";
+#else
+    cmd << "rm";
+#endif
+
+    cmd << " " << fileName;
+
+#ifndef _WIN32
+    cmd << " 2> /dev/null";
+#endif
+
+    return system(cmd.str().data());
+}
+
+}  // namespace ttk

--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -8,58 +8,26 @@
 #ifndef                 _OS_H
 #define                 _OS_H
 
-#include                <stdlib.h>
-
-#include                <algorithm>
-#include                <sstream>
-
-#include                <Debug.h>
-
-
 #ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
 #endif
-  #include              <ciso646>
-  #include              <cwchar>
-  #include              <direct.h>
-  #include              <float.h>
-  #include              <iomanip>
-  #include              <math.h>
-  #include              <stdint.h>
-  #include              <time.h>
-  #include              <windows.h>
 
-  #define               drand48() (double(rand()) / RAND_MAX)
+#define               drand48() (double(rand()) / RAND_MAX)
 //  #define               isnan(x)      _isnan(x)
 #ifndef _MSC_VER
-  #define               round(x) OsCall::roundToNearestInt(x)
+#define               round(x) OsCall::roundToNearestInt(x)
 #endif
-  #define               srand48(seed) srand(seed)
-#endif
+#define               srand48(seed) srand(seed)
+#endif // _WIN32
 
-#ifdef __unix__
-#include                <cfloat>
+#include                <vector>
+#include                <string>
 #include                <climits>
-#include                <dirent.h>
+#include                <cstdlib>
+#include                <cfloat>
 #include                <iomanip>
 #include                <cmath>
-#include                <sys/stat.h>
-#include                <sys/time.h>
-#include                <sys/types.h>
-#include                <unistd.h>
-#endif
-
-#ifdef __APPLE__
-#include                <climits>
-#include                <cfloat>
-#include                <dirent.h>
-#include                <math.h>
-#include                <sys/stat.h>
-#include                <sys/time.h>
-#include                <sys/types.h>
-#include                <unistd.h>
-#endif
 
 #define               pow10(x) pow(10, x)
 
@@ -91,236 +59,45 @@
 namespace ttk{
  
 #ifdef SINGLE_PRECISION
-	typedef float real;
+    typedef float real;
 #else
-	typedef double real;
+    typedef double real;
 #endif
  
-  class OsCall{
-    
-    
-    public:
+  class OsCall{    
+    public:      
+      static int getCurrentDirectory(std::string &directoryPath);
       
-      inline static int getCurrentDirectory(std::string &directoryPath){
-        #ifdef _WIN32
-          directoryPath = _getcwd(NULL, 0);
-        #else
-          directoryPath = getcwd(NULL, PATH_MAX);
-        #endif
-        directoryPath += "/";
-        
-        return 0;
-      }
-      
-      inline static float getMemoryInstantUsage(){
-        #ifdef __linux__
-          // horrible hack since getrusage() doesn't seem to work well under 
-          // linux
-          std::stringstream procFileName;
-          procFileName << "/proc/" << getpid() << "/statm";
-          
-          std::ifstream procFile(procFileName.str().data(), std::ios::in);
-          if(procFile){
-            float memoryUsage;
-            procFile >> memoryUsage;
-            procFile.close();
-            return memoryUsage/1024.0;
-          }
-        #endif
-        return 0;
-      };
+      static float getMemoryInstantUsage();
      
-      inline static int getNumberOfCores(){
-        #ifdef TTK_ENABLE_OPENMP
-          return omp_get_num_procs();
-        #endif
-        return 1;
-      }
+      static int getNumberOfCores();
       
-      inline static double getTimeStamp(){
-        #ifdef _WIN32
-          LARGE_INTEGER frequency;
-          QueryPerformanceFrequency(&frequency);
-          
-          LARGE_INTEGER temp;
-          QueryPerformanceCounter(&temp);
-          
-          return (double) temp.QuadPart/frequency.QuadPart;
-        #endif
-          
-        #ifdef __APPLE__
-          struct timeval stamp;
-          gettimeofday(&stamp, NULL);
-          return (stamp.tv_sec*1000000 + stamp.tv_usec)/1000000.0;
-        #endif
-          
-        #ifdef __unix__
-          struct timeval stamp;
-          gettimeofday(&stamp, NULL);
-          return (stamp.tv_sec*1000000 + stamp.tv_usec)/1000000.0;
-        #endif
-      };
+      static double getTimeStamp();
       
-      inline static std::vector<std::string> listFilesInDirectory(
-        const std::string &directoryName, const std::string &extension){
-        
-        std::vector<std::string> filesInDir;
-        #ifdef _WIN32
-          WIN32_FIND_DATA FindFileData;
-          char* buffer;
-          buffer = _getcwd( NULL, 0 );
-          if((buffer = _getcwd( NULL, 0 )) == NULL)
-            perror( "_getcwd error" );
-          else{
-            free(buffer);
-          }
-          
-          HANDLE hFind = FindFirstFile(directoryName.data(), &FindFileData);
-          if(hFind == INVALID_HANDLE_VALUE){
-            std::stringstream msg;
-            msg << "[Os] Could not open directory `" 
-              << directoryName << "'. Error: "<< GetLastError() << std::endl;
-            Debug d;
-            d.dMsg(std::cerr, msg.str(), 0);
-          } 
-          else{
-            std::string entryExtension(FindFileData.cFileName);
-            entryExtension = 
-              entryExtension.substr(entryExtension.find_last_of('.') + 1);
-            
-            if(entryExtension == extension)
-              filesInDir.push_back(std::string(FindFileData.cFileName));
-            std::string dir = directoryName;
-            dir.resize(dir.size()-1);
-            while(FindNextFile(hFind, &FindFileData)){
-              if(extension.size()){
-                std::string entryExtension(FindFileData.cFileName);
-                entryExtension = entryExtension.substr(
-                  entryExtension.find_last_of('.') + 1);
-                if(entryExtension == extension)
-                  filesInDir.push_back(dir 
-                    + std::string(FindFileData.cFileName));
-              }
-              else{
-                if((std::string(FindFileData.cFileName) != ".")
-                  &&(std::string(FindFileData.cFileName) != "..")){
-                  filesInDir.push_back(directoryName
-                    + "/"
-                    + std::string(FindFileData.cFileName));  
-                }
-              }
-            }
-          }
-          FindClose(hFind);
-        #else 
-          DIR *d = opendir((directoryName + "/").data());
-          if(!d){
-            std::stringstream msg;
-            msg 
-              << "[Os] Could not open directory `" 
-              << directoryName << "'..." << std::endl;
-            Debug d;
-            d.dMsg(std::cerr, msg.str(), 0);
-          } 
-          else{
-            struct dirent *dirEntry;
-            while((dirEntry = readdir(d)) != NULL){
-              if(extension.size()){
-                std::string entryExtension(dirEntry->d_name);
-                entryExtension = 
-                  entryExtension.substr(entryExtension.find_last_of('.') + 1);
-                if(entryExtension == extension)
-                  filesInDir.push_back(directoryName 
-                    + "/" 
-                    + std::string(dirEntry->d_name));
-              }
-              else{
-                if((std::string(dirEntry->d_name) != ".")
-                  &&(std::string(dirEntry->d_name) != ".."))
-                  filesInDir.push_back(directoryName 
-                    + "/"
-                    + std::string(dirEntry->d_name));
-              }
-            }
-          }
-          closedir(d);
-        #endif
-          
-        sort(filesInDir.begin(), filesInDir.end());
-        
-        return filesInDir;
-      }
+      static std::vector<std::string> listFilesInDirectory(
+        const std::string &directoryName, const std::string &extension);
      
-      inline static int mkDir(const std::string &directoryName){ 
-        #ifdef _WIN32
-          return _mkdir(directoryName.data()); 
-        #else 
-          return mkdir(directoryName.data(), 0777); 
-        #endif
-      }
+      static int mkDir(const std::string &directoryName);
      
-      inline static int nearbyint(const double &x){
-        const double upperBound = ceil( x );
-        const double lowerBound = floor( x );
-        
-        if( upperBound-x <= x-lowerBound )
-            return (int)upperBound;
-        else
-            return (int)lowerBound;
-      };
+      static int nearbyint(const double &x);
      
-      inline static int rmDir(const std::string &directoryName){ 
-        #ifdef _WIN32
-          // NOTE:
-          // the directory will be deleted with this call
-          // only if it's empty...
-          return _rmdir(directoryName.data()); 
-        #else 
-          std::stringstream cmd;
-          cmd << "rm -R " << directoryName << " 2> /dev/null";
-          return system(cmd.str().data()); 
-        #endif
-      }
+      static int rmDir(const std::string &directoryName);
       
-      inline static int rmFile(const std::string &fileName){
-        
-        std::stringstream cmd;
-        
-        #ifdef _WIN32
-          cmd << "del";
-        #else
-          cmd << "rm";
-        #endif
-          
-        cmd << " " << fileName;
-        
-        #ifndef _WIN32
-          cmd << " 2> /dev/null";
-        #endif
-          
-        return system(cmd.str().data());
-      }
+      static int rmFile(const std::string &fileName);
       
-      int static roundToNearestInt(const double &val){
-        
-        const double upperBound = ceil(val);
-        const double lowerBound = floor(val);
-          
-        if(upperBound - val <= val - lowerBound){
-          return (int)upperBound;
-        }
-        else{
-          return (int)lowerBound;
-        }
-      }
-      
-      
-    protected:
-      
-      
-    private:
-      
+      int static roundToNearestInt(const double &val);
   };
+
+  inline int OsCall::roundToNearestInt(const double &val) {
+      const double upperBound = ceil(val);
+      const double lowerBound = floor(val);
+
+      if (upperBound - val <= val - lowerBound) {
+          return (int)upperBound;
+      } else {
+          return (int)lowerBound;
+      }
+  }
 
   class Memory{
     
@@ -330,15 +107,15 @@ namespace ttk{
       
       inline float getInitialMemoryUsage(){
         return initialMemory_;
-      };
+      }
       
       inline float getInstantUsage(){
         return OsCall::getMemoryInstantUsage();
-      };
+      }
       
       inline float getElapsedUsage(){
         return OsCall::getMemoryInstantUsage() - initialMemory_;
-      };
+      }
       
     protected:
       
@@ -365,18 +142,17 @@ namespace ttk{
       
       inline double getStartTime(){ 
         return start_;
-      };
+      }
       
       inline void reStart(){ 
         start_ = getTimeStamp();
-      };
-      
-      
+      }
+            
     protected:
       
       inline double getTimeStamp(){
         return OsCall::getTimeStamp();
-      };
+      }
       
       double          start_;
   };

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -7,6 +7,8 @@
 
 #include "DeprecatedSegmentation.h"
 
+#include <algorithm>
+
 using namespace std;
 using namespace ttk;
 

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -1,5 +1,7 @@
 #include                <Geometry.h>
 
+#include <algorithm>
+
 // TODO:
 // for faster computations, remove all pow10
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -14,6 +14,10 @@
 // base code includes
 #include                  <AbstractTriangulation.h>
 
+#ifdef _WIN32
+#include <ciso646>
+#endif
+
 namespace ttk{
 
   class ImplicitTriangulation : public AbstractTriangulation{


### PR DESCRIPTION
Hi,
here is a small fix for builds on Windows. This will fix an issue in `OsCall::listFilesInDirectory()` when `UNICODE` is defined and `windows.h` is included since this will use wchar instead of char.
Furthermore, I move the implementations to `Os.cpp` to reduce the number of include files in the header.

Martin