### PR TITLE
Morse-Smale complex - new feature

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
@@ -14,6 +14,8 @@ AbstractMorseSmaleComplex::AbstractMorseSmaleComplex():
   ComputeAscendingSegmentation{true},
   ComputeDescendingSegmentation{true},
   ComputeFinalSegmentation{true},
+  ReturnSaddleConnectors{false},
+  PrioritizeSpeedOverMemory{false},
 
   inputScalarField_{},
   inputTriangulation_{},

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -243,12 +243,23 @@ namespace ttk{
         return 0;
       }
 
-      /** Set the threshold value for post-processing of
+      /**
+       * Set the threshold value for post-processing of
        * (saddle,...,saddle) vpaths gradient reversal
        * (default value us 0.0).
        */
       int setSaddleConnectorsPersistenceThreshold(const double threshold){
         SaddleConnectorsPersistenceThreshold=threshold;
+        return 0;
+      }
+
+      /**
+       * Enable/Disable compromise on memory allowing
+       * computation the geometry of the 2-separatrices
+       * in parallel.
+       */
+      int setPrioritizeSpeedOverMemory(const bool state){
+        PrioritizeSpeedOverMemory=state;
         return 0;
       }
 
@@ -436,6 +447,7 @@ namespace ttk{
       bool ComputeFinalSegmentation;
       bool ReturnSaddleConnectors;
       double SaddleConnectorsPersistenceThreshold;
+      bool PrioritizeSpeedOverMemory;
 
       DiscreteGradient discreteGradient_;
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -303,6 +303,15 @@ namespace ttk{
         return abstractMorseSmaleComplex_->setSaddleConnectorsPersistenceThreshold(threshold);
       }
 
+      int setPrioritizeSpeedOverMemory(const bool state){
+#ifdef TTK_ENABLE_KAMIKAZE
+        if(!abstractMorseSmaleComplex_){
+          return -1;
+        }
+#endif
+        return abstractMorseSmaleComplex_->setPrioritizeSpeedOverMemory(state);
+      }
+
       int setupTriangulation(Triangulation* const data){
         dimensionality_=data->getCellVertexNumber(0)-1;
 

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -65,21 +65,41 @@ int ttk::MorseSmaleComplex2D::execute(){
 
   // 1-separatrices
   if(ComputeDescendingSeparatrices1){
+    Timer tmp;
     std::vector<Separatrix> separatrices;
     std::vector<std::vector<Cell>> separatricesGeometry;
     getDescendingSeparatrices1(criticalPoints, separatrices, separatricesGeometry);
     setSeparatrices1<dataType>(separatrices, separatricesGeometry);
+
+    {
+      std::stringstream msg;
+      msg << "[MorseSmaleComplex3D] Descending 1-separatrices computed in "
+        << tmp.getElapsedTime() << " s."
+        << std::endl;
+      dMsg(std::cout, msg.str(), timeMsg);
+    }
   }
 
   if(ComputeAscendingSeparatrices1){
+    Timer tmp;
     std::vector<Separatrix> separatrices;
     std::vector<std::vector<Cell>> separatricesGeometry;
     getAscendingSeparatrices1(criticalPoints, separatrices, separatricesGeometry);
     setSeparatrices1<dataType>(separatrices, separatricesGeometry);
+
+    {
+      std::stringstream msg;
+      msg << "[MorseSmaleComplex3D] Ascending 1-separatrices computed in "
+        << tmp.getElapsedTime() << " s."
+        << std::endl;
+      dMsg(std::cout, msg.str(), timeMsg);
+    }
   }
 
   std::vector<int> maxSeeds;
   {
+    Timer tmp;
+
     int numberOfMaxima{};
     int numberOfMinima{};
 
@@ -91,6 +111,14 @@ int ttk::MorseSmaleComplex2D::execute(){
 
     if(ComputeAscendingSegmentation and ComputeDescendingSegmentation and ComputeFinalSegmentation)
       setFinalSegmentation(numberOfMaxima, numberOfMinima, ascendingManifold, descendingManifold, morseSmaleManifold);
+
+    {
+      std::stringstream msg;
+      msg << "[MorseSmaleComplex3D] Segmentation computed in "
+        << tmp.getElapsedTime() << " s."
+        << std::endl;
+      dMsg(std::cout, msg.str(), timeMsg);
+    }
   }
 
   if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.cpp
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.cpp
@@ -131,9 +131,6 @@ int MorseSmaleComplex3D::getAscendingSeparatrices2(const vector<Cell>& criticalP
   vector<wallId_t> isVisited(numberOfEdges, 0);
 
   // apriori: by default construction, the separatrices are not valid
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
   for(int i=0; i<numberOfSaddles; ++i){
     const int saddleIndex=saddleIndexes[i];
     const Cell& saddle1=criticalPoints[saddleIndex];
@@ -174,9 +171,6 @@ int MorseSmaleComplex3D::getDescendingSeparatrices2(const vector<Cell>& critical
   vector<wallId_t> isVisited(numberOfTriangles, 0);
 
   // apriori: by default construction, the separatrices are not valid
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
   for(int i=0; i<numberOfSaddles; ++i){
     const int saddleIndex=saddleIndexes[i];
     const Cell& saddle2=criticalPoints[saddleIndex];

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -221,6 +221,7 @@ template<typename dataType>
 int ttk::MorseSmaleComplex3D::omp_setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
    const std::vector<std::vector<Cell>>& separatricesGeometry,
    const std::vector<std::set<int>>& separatricesSaddles) const{
+
   const dataType* const scalars=static_cast<dataType*>(inputScalarField_);
   std::vector<dataType>* outputSeparatrices2_cells_separatrixFunctionMaxima=
     static_cast<std::vector<dataType>*>(outputSeparatrices2_cells_separatrixFunctionMaxima_);
@@ -371,7 +372,7 @@ int ttk::MorseSmaleComplex3D::omp_setAscendingSeparatrices2(const std::vector<Se
     outputSeparatrices2_cells_separatrixFunctionMinima->resize(oldFieldSize+totalNumberOfCells);
     outputSeparatrices2_cells_separatrixFunctionDiffs->resize(oldFieldSize+totalNumberOfCells);
     outputSeparatrices2_cells_isOnBoundary_->resize(oldFieldSize+totalNumberOfCells);
-// #pragma omp parallel for num_threads(threadNumber_)
+#pragma omp parallel for num_threads(threadNumber_)
     for(int i=0; i<threadNumber_; ++i){
       // reduce: points
       const int tmp_npoints=separatrices2_points[i].size();
@@ -422,6 +423,7 @@ template<typename dataType>
 int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
    const std::vector<std::vector<Cell>>& separatricesGeometry,
    const std::vector<std::set<int>>& separatricesSaddles) const{
+
   const dataType* const scalars=static_cast<dataType*>(inputScalarField_);
   std::vector<dataType>* outputSeparatrices2_cells_separatrixFunctionMaxima=
     static_cast<std::vector<dataType>*>(outputSeparatrices2_cells_separatrixFunctionMaxima_);

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -901,7 +901,12 @@ int ttk::MorseSmaleComplex3D::execute(){
     std::vector<std::vector<Cell>> separatricesGeometry;
     std::vector<std::set<int>> separatricesSaddles;
     getDescendingSeparatrices2(criticalPoints, separatrices, separatricesGeometry, separatricesSaddles);
-    omp_setDescendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
+#ifdef TTK_ENABLE_OPENMP
+    if(PrioritizeSpeedOverMemory)
+      omp_setDescendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
+    else
+#endif
+    setDescendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
 
     {
       std::stringstream msg;
@@ -918,7 +923,12 @@ int ttk::MorseSmaleComplex3D::execute(){
     std::vector<std::vector<Cell>> separatricesGeometry;
     std::vector<std::set<int>> separatricesSaddles;
     getAscendingSeparatrices2(criticalPoints, separatrices, separatricesGeometry, separatricesSaddles);
-    omp_setAscendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
+#ifdef TTK_ENABLE_OPENMP
+    if(PrioritizeSpeedOverMemory)
+      omp_setAscendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
+    else
+#endif
+    setAscendingSeparatrices2<dataType>(separatrices, separatricesGeometry, separatricesSaddles);
 
     {
       std::stringstream msg;
@@ -945,7 +955,7 @@ int ttk::MorseSmaleComplex3D::execute(){
     if(ComputeAscendingSegmentation and ComputeDescendingSegmentation and ComputeFinalSegmentation)
       setFinalSegmentation(numberOfMaxima, numberOfMinima, ascendingManifold, descendingManifold, morseSmaleManifold);
 
-    {
+    if(ComputeAscendingSegmentation or ComputeDescendingSegmentation or ComputeFinalSegmentation){
       std::stringstream msg;
       msg << "[MorseSmaleComplex3D] Segmentation computed in "
         << tmp.getElapsedTime() << " s."

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -340,6 +340,9 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
   morseSmaleComplex_.setSaddleConnectorsPersistenceThreshold(
       SaddleConnectorsPersistenceThreshold);
 
+  morseSmaleComplex_.setPrioritizeSpeedOverMemory(
+      PrioritizeSpeedOverMemory);
+
   morseSmaleComplex_.setInputScalarField(inputScalars->GetVoidPointer(0));
   morseSmaleComplex_.setInputOffsets(inputOffsets->GetVoidPointer(0));
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -136,6 +136,9 @@ class ttkMorseSmaleComplex
     vtkSetMacro(SaddleConnectorsPersistenceThreshold, double);
     vtkGetMacro(SaddleConnectorsPersistenceThreshold, double);
 
+    vtkSetMacro(PrioritizeSpeedOverMemory, int);
+    vtkGetMacro(PrioritizeSpeedOverMemory, int);
+
     int setupTriangulation(vtkDataSet* input);
     vtkDataArray* getScalars(vtkDataSet* input);
     vtkDataArray* getOffsets(vtkDataSet* input);
@@ -169,6 +172,7 @@ class ttkMorseSmaleComplex
     int OffsetFieldId;
     int ReturnSaddleConnectors;
     double SaddleConnectorsPersistenceThreshold;
+    bool PrioritizeSpeedOverMemory;
 
     ttk::MorseSmaleComplex morseSmaleComplex_;
     ttk::Triangulation *triangulation_;

--- a/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
+++ b/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
@@ -237,6 +237,18 @@ Computer Graphics Forum, 2012.
          </Documentation>
        </DoubleVectorProperty>
 
+       <IntVectorProperty name="PrioritizeSpeedOverMemory"
+         label="Prioritize Speed Over Memory"
+         command="SetPrioritizeSpeedOverMemory"
+         number_of_elements="1"
+         default_values="0"
+         panel_visibility="advanced">
+         <BooleanDomain name="bool"/>
+         <Documentation>
+           Prioritize speed over memory.
+         </Documentation>
+       </IntVectorProperty>
+
       <IntVectorProperty
         name="UseAllCores"
         label="Use All Cores"
@@ -311,6 +323,7 @@ Computer Graphics Forum, 2012.
         <Property name="UseAllCores" />
         <Property name="ThreadNumber" />
         <Property name="DebugLevel" />
+        <Property name="PrioritizeSpeedOverMemory" />
 <!--        <Property name="IterationThreshold"/>-->
       </PropertyGroup>
 


### PR DESCRIPTION
Dear Julien,

I added a new advanced option in the Morse-Smale complex module allowing, with some compromises on memory, the computation of the geometry of the 2-separatrices more efficiently if OpenMP acceleration is available. In ParaView's GUI, it's name is "_Prioritize Speed Over Memory_".