### PR TITLE
Updating to link with OpenMP libraries

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -22,7 +22,7 @@ function(ttk_set_compile_options library)
 	if (TTK_ENABLE_OPENMP)
 		target_compile_definitions(${library} PUBLIC TTK_ENABLE_OPENMP)
 		target_compile_options(${library} PUBLIC ${OpenMP_CXX_FLAGS})
-		target_link_libraries(${library} PUBLIC ${OpenMP_CXX_FLAGS})
+		target_link_libraries(${library} PUBLIC ${OpenMP_CXX_LIBRARIES})
 	endif()
 
 	if (TTK_ENABLE_MPI)

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -91,10 +91,12 @@ namespace ttk{
       int setDescendingSeparatrices2(const std::vector<Separatrix>& separatrices,
           const std::vector<std::vector<Cell>>& separatricesGeometry,
           const std::vector<std::set<int>>& separatricesSaddles) const;
+#ifdef TTK_ENABLE_OPENMP      
       template<typename dataType>
         int omp_setDescendingSeparatrices2(const std::vector<Separatrix>& separatrices,
             const std::vector<std::vector<Cell>>& separatricesGeometry,
             const std::vector<std::set<int>>& separatricesSaddles) const;
+#endif
 
       int getDualPolygon(const int edgeId, std::vector<int>& polygon) const;
 
@@ -117,10 +119,13 @@ namespace ttk{
       int setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
           const std::vector<std::vector<Cell>>& separatricesGeometry,
           const std::vector<std::set<int>>& separatricesSaddles) const;
+
+#ifdef TTK_ENABLE_OPENMP      
       template<typename dataType>
         int omp_setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
             const std::vector<std::vector<Cell>>& separatricesGeometry,
             const std::vector<std::set<int>>& separatricesSaddles) const;
+#endif      
   };
 }
 
@@ -217,6 +222,7 @@ std::vector<Separatrix>& separatrices,
   return 0;
 }
 
+#ifdef TTK_ENABLE_OPENMP      
 template<typename dataType>
 int ttk::MorseSmaleComplex3D::omp_setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
    const std::vector<std::vector<Cell>>& separatricesGeometry,
@@ -418,6 +424,7 @@ int ttk::MorseSmaleComplex3D::omp_setAscendingSeparatrices2(const std::vector<Se
 
   return 0;
 }
+#endif
 
 template<typename dataType>
 int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(const std::vector<Separatrix>& separatrices,
@@ -534,6 +541,7 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(const std::vector<Separa
   return 0;
 }
 
+#ifdef TTK_ENABLE_OPENMP      
 template<typename dataType>
 int ttk::MorseSmaleComplex3D::omp_setDescendingSeparatrices2(const std::vector<Separatrix>& separatrices,
     const std::vector<std::vector<Cell>>& separatricesGeometry,
@@ -725,6 +733,7 @@ int ttk::MorseSmaleComplex3D::omp_setDescendingSeparatrices2(const std::vector<S
 
   return 0;
 }
+#endif
 
 template<typename dataType>
 int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(const std::vector<Separatrix>& separatrices,


### PR DESCRIPTION
OpenMP_CXX_FLAGS now only has the compiler, not the linking flags

This change is consistent with FindOpenMP.cmake as of CMake 3.9.1:

https://github.com/Kitware/CMake/blob/v3.9.1/Modules/FindOpenMP.cmake
https://cmake.org/cmake/help/v3.9/module/FindOpenMP.html