### PR TITLE
Improve Debug mode compile flags

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,10 @@ function(ttk_set_compile_options library)
     endif()
   endif()
 
+  if (uppercase_CMAKE_BUILD_TYPE MATCHES DEBUG)
+     target_compile_options(${library} PRIVATE -O0 -g -pg)
+  endif()
+
 	if (TTK_ENABLE_OPENMP)
 		target_compile_definitions(${library} PUBLIC TTK_ENABLE_OPENMP)
 		target_compile_options(${library} PUBLIC ${OpenMP_CXX_FLAGS})


### PR DESCRIPTION
Dear Julien,

I added some flags for the Debug mode compilation of TTK, completely preventing every optimizations and enabling every code annotations. This allows a complete evaluation of the code by tools like GDB, even when templates are used.

Note, we could use -g3 for more expressiveness but I am not sure this would be compliant with other tools than GDB. 

Charles