### PR TITLE
Use generic syntax in CMake as advised

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,17 +11,11 @@ function(ttk_set_compile_options library)
 		target_compile_definitions(${library} PUBLIC TTK_ENABLE_KAMIKAZE)
 	endif()
 
+   if (TTK_ENABLE_CPU_OPTIMIZATION)
+      target_compile_options(${library} PRIVATE $<$<CONFIG:Release>:-march=native -O3 -Wfatal-errors>)
+   endif()
 
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-  if (uppercase_CMAKE_BUILD_TYPE MATCHES RELEASE)
-    if (TTK_ENABLE_CPU_OPTIMIZATION)
-      target_compile_options(${library} PRIVATE -march=native -O3)
-    endif()
-  endif()
-
-  if (uppercase_CMAKE_BUILD_TYPE MATCHES DEBUG)
-     target_compile_options(${library} PRIVATE -O0 -g -pg)
-  endif()
+  target_compile_options(${library} PRIVATE $<$<CONFIG:Debug>:-O0 -g -pg>)
 
 	if (TTK_ENABLE_OPENMP)
 		target_compile_definitions(${library} PUBLIC TTK_ENABLE_OPENMP)


### PR DESCRIPTION
Dear julien,

This is a fix concerning the @petersteneteg comments on #114 for the CMake options.
The behavior should be the same for single-configurations generators but also suitable for multi-configurations generator.

Charles