### PR TITLE
examples - bugfix

### DIFF
--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -16,6 +16,7 @@ vtkStandardNewMacro(ttkIntegralLines)
   triangulation_ = NULL;
   
   OffsetScalarFieldName = "OutputOffsetScalarField";
+  UseOffsetScalarField = false;
 }
 
 ttkIntegralLines::~ttkIntegralLines(){

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -24,6 +24,7 @@ vtkStandardNewMacro(ttkPersistenceCurve)
   triangulation_ = NULL;
   ScalarFieldId = 0;
   InputOffsetScalarFieldName = "OutputOffsetScalarField";
+  UseInputOffsetScalarField = false;
 
   inputTriangulation_ = vtkSmartPointer<ttkTriangulationFilter>::New();
 }

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -20,6 +20,7 @@ vtkStandardNewMacro(ttkPersistenceDiagram)
   OffsetFieldId = -1;
   ComputeSaddleConnectors = false;
   InputOffsetScalarFieldName = "OutputOffsetScalarField";
+  UseInputOffsetScalarField = false;
   ShowInsideDomain = false;
   computeDiagram_= true;
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -16,6 +16,8 @@ vtkStandardNewMacro(ttkTopologicalSimplification)
   triangulation_ = NULL;
 
   ScalarFieldId = 0;
+  UseInputOffsetScalarField = false;
+  AddPerturbation = false;
   OutputOffsetScalarFieldName = "OutputOffsetScalarField";
   VertexIdentifierScalarField = "VertexIdentifier";
   ConsiderIdentifierAsBlackList = false;


### PR DESCRIPTION
Dear Julien,

I fixed a bug causing inconsistency in the TTK examples. In some cases, uninitialized variables forced the modules to load an input offset scalar field even if it was not provided and then displayed an error message.