### PR TITLE
Morse-Smale complex - number of threads

### DIFF
--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -56,6 +56,8 @@ int ttk::MorseSmaleComplex2D::execute(){
   int* descendingManifold=static_cast<int*>(outputDescendingManifold_);
   int* morseSmaleManifold=static_cast<int*>(outputMorseSmaleManifold_);
 
+  discreteGradient_.setThreadNumber(threadNumber_);
+  discreteGradient_.setDebugLevel(debugLevel_);
   discreteGradient_.buildGradient<dataType>();
   discreteGradient_.buildGradient2<dataType>();
   discreteGradient_.reverseGradient<dataType>();

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -847,6 +847,8 @@ int ttk::MorseSmaleComplex3D::execute(){
   int* descendingManifold=static_cast<int*>(outputDescendingManifold_);
   int* morseSmaleManifold=static_cast<int*>(outputMorseSmaleManifold_);
 
+  discreteGradient_.setThreadNumber(threadNumber_);
+  discreteGradient_.setDebugLevel(debugLevel_);
   discreteGradient_.buildGradient<dataType>();
   discreteGradient_.buildGradient2<dataType>();
   discreteGradient_.buildGradient3<dataType>();


### PR DESCRIPTION
Dear Julien,

I fixed a broken link between `DiscreteGradient` and `MorseSmaleComplex` which set the number of threads to be used for the computation.