### PR TITLE
LowestCommonAncestor - bugfix

### DIFF
--- a/core/base/lowestCommonAncestor/LowestCommonAncestor.h
+++ b/core/base/lowestCommonAncestor/LowestCommonAncestor.h
@@ -92,11 +92,9 @@ namespace ttk {
     /// Get the id of the lowest common ancestor of i and j.
     /// \pre preprocess() must have been called after the last change in the tree.
     inline int query(int i, int j) const {
-      #ifndef TTK_ENABLE_KAMIKAZE
       if(nodeFirstAppearence_[i]>nodeFirstAppearence_[j]) {
         std::swap(i,j);
       }
-      #endif
       return
         nodeOrder_[RMQuery(nodeFirstAppearence_[i], nodeFirstAppearence_[j])];
     }


### PR DESCRIPTION
Dear Julien,

I fixed a minor bug occuring when the flag `TTK_ENABLE_KAMIKAZE` is enabled in the `LowestCommonAncestor` module preventing the [tests](https://github.com/topology-tool-kit/ttk-data) to run successfully.