### PR TITLE
Minor include in FTM

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -2,6 +2,8 @@
 #define TTKFTMSTRUCTURES_H
 
 #include <FTMTree.h>
+#include <ttkWrapper.h>
+
 #include <vtkCellData.h>
 #include <vtkDataArray.h>
 #include <vtkPointData.h>


### PR DESCRIPTION
Dear Julien,

I have added a missing include in the FTM Wrapper. This include is required for the new ttkIdType system. The missing include was reported by Clang linter but did not prevent compilation in my experiments.

Charles