### PR TITLE
PersistenceCurve - SafeDownCast

### DIFF
--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -66,6 +66,16 @@ int ttkPersistenceCurve::updateProgress(const float &progress){
   return 0;
 }
 
+vtkTable* ttkPersistenceCurve::GetOutput()
+{
+  return this->GetOutput(0);
+}
+
+vtkTable* ttkPersistenceCurve::GetOutput(int port)
+{
+  return vtkTable::SafeDownCast(this->GetOutputDataObject(port));
+}
+
 int ttkPersistenceCurve::FillOutputPortInformation(int port, vtkInformation* info){
   switch (port) {
     case 0:

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -99,6 +99,9 @@ class ttkPersistenceCurve
     vtkSetMacro(ComputeSaddleConnectors, int);
     vtkGetMacro(ComputeSaddleConnectors, int);
 
+    vtkTable* GetOutput();
+    vtkTable* GetOutput(int);
+
     int getScalars(vtkDataSet* input);
     int getTriangulation(vtkDataSet* input);
     int getOffsets(vtkDataSet* input);


### PR DESCRIPTION
Dear Julien,

I implemented the feature requested in #147 so now the outputs of the ttkPersistenceCurve filter are valid vtkTable objects.