### PR TITLE
Improved i/o in ttkUncertainDataEstimator

### DIFF
--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
@@ -64,22 +64,29 @@ int ttkUncertainDataEstimator::updateProgress(const float &progress){
 
 int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundFields, vtkDataSet *outputProbability, vtkDataSet *outputMean, int numInputs){
 
-
   // Use a pointer-base copy for the input data
   outputBoundFields->ShallowCopy(input[0]);
   outputProbability->ShallowCopy(input[0]);
   outputMean->ShallowCopy(input[0]);
-
   // Get arrays from input datas
   //vtkDataArray* inputScalarField[numInputs] = { NULL };
-  vector<vtkDataArray*> inputScalarField(numInputs);
-  for(int i=0 ; i<numInputs ; i++){
-    if(ScalarField.length()){
-      inputScalarField[i] = input[i]->GetPointData()->GetArray(ScalarField.data());
+  int numFields=0;
+  int numArrays=0;
+
+  vector<vtkDataArray*> inputScalarField;
+
+  for(int i=0; i<numInputs; i++){
+    numArrays = input[i]->GetPointData()->GetNumberOfArrays();
+    numFields+=numArrays;
+    for(int iarray=0; iarray<numArrays; iarray++){
+      inputScalarField.push_back( input[i]->GetPointData()->GetArray(iarray) );
     }
-    else{
-      inputScalarField[i] = input[i]->GetPointData()->GetArray(0);
-    }
+  }
+
+  std::cout << "[ttkUncertainDataEstimator] Number of Fields: " <<numFields<< '\n';
+
+  for(int i=0 ; i<numFields ; i++){
+
     // Check if inputs have the same data type and the same number of points
     if(inputScalarField[i]->GetDataType() != inputScalarField[0]->GetDataType()){
       stringstream msg;
@@ -97,7 +104,6 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
     if(!inputScalarField[i])
       return -1;
   }
-
   // Allocate the memory for the output bound scalar fields
   if(!outputLowerBoundScalarField_
      && !outputUpperBoundScalarField_){
@@ -151,10 +157,8 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
   outputProbabilityScalarField_ = (vtkDoubleArray **) malloc(binCount_*sizeof(vtkDoubleArray *));
   allocatedBinCount_ = binCount_;
   // Delete the pointer to the input field
-  if(ScalarField.length()){
-    outputProbability->GetPointData()->RemoveArray(ScalarField.data());
-  }
-  else{
+  int numberOfArrays = outputProbability->GetPointData()->GetNumberOfArrays();
+  for(int i=0 ; i<numberOfArrays ; i++) {
     outputProbability->GetPointData()->RemoveArray(0);
   }
   // Create DoubleArray objects and link them to the data set
@@ -168,9 +172,9 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
 
   // Mean field data set
   // Remove Arrays
-  int numberOfArrays = outputMean->GetPointData()->GetNumberOfArrays();
+  numberOfArrays = outputMean->GetPointData()->GetNumberOfArrays();
   for(int i=0 ; i<numberOfArrays ; i++) {
-    outputMean->GetPointData()->RemoveArray(outputMean->GetPointData()->GetArrayName(i));
+    outputMean->GetPointData()->RemoveArray(0);
   }
   // Allocate new array
   if(!outputMeanField_) {
@@ -183,10 +187,8 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
 
 
   // On the output, replace the field array by a pointer to its processed version
-  if(ScalarField.length()){
-    outputBoundFields->GetPointData()->RemoveArray(ScalarField.data());
-  }
-  else{
+  numberOfArrays = outputBoundFields->GetPointData()->GetNumberOfArrays();
+  for(int i=0 ; i<numberOfArrays ; i++) {
     outputBoundFields->GetPointData()->RemoveArray(0);
   }
 
@@ -209,50 +211,52 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
 
 
   // Calling the executing package
-  switch(inputScalarField[0]->GetDataType()){
+  if(numFields>0){
+    switch(inputScalarField[0]->GetDataType()){
 
-    vtkTemplateMacro(
-    {
-      UncertainDataEstimator uncertainDataEstimator;
-      uncertainDataEstimator.setWrapper(this);
- 
-      uncertainDataEstimator.setVertexNumber(
-        outputBoundFields->GetNumberOfPoints());
+      vtkTemplateMacro(
+      {
+        UncertainDataEstimator uncertainDataEstimator;
+        uncertainDataEstimator.setWrapper(this);
 
-      uncertainDataEstimator.setNumberOfInputs(numInputs);
-      for (int i = 0; i<numInputs; i++) {
-        uncertainDataEstimator.setInputDataPointer(i, 
-        inputScalarField[i]->GetVoidPointer(0));
+        uncertainDataEstimator.setVertexNumber(
+          outputBoundFields->GetNumberOfPoints());
+
+        uncertainDataEstimator.setNumberOfInputs(numFields);
+        for (int i = 0; i<numFields; i++) {
+          uncertainDataEstimator.setInputDataPointer(i,
+          inputScalarField[i]->GetVoidPointer(0));
+        }
+
+        uncertainDataEstimator.setComputeLowerBound(computeLowerBound_);
+        uncertainDataEstimator.setComputeUpperBound(computeUpperBound_);
+
+
+        uncertainDataEstimator.setOutputLowerBoundField(
+          outputLowerBoundScalarField_->GetVoidPointer(0));
+
+        uncertainDataEstimator.setOutputUpperBoundField(
+          outputUpperBoundScalarField_->GetVoidPointer(0));
+
+        uncertainDataEstimator.setOutputMeanField(
+          outputMeanField_->GetVoidPointer(0));
+
+        uncertainDataEstimator.setBinCount(binCount_);
+        for (int b = 0; b<binCount_; b++) {
+          uncertainDataEstimator.setOutputProbability(b,
+            outputProbabilityScalarField_[b]->GetVoidPointer(0));
+        }
+
+        uncertainDataEstimator.execute<VTK_TT>();
+
+        for (int b = 0; b<binCount_; b++) {
+          stringstream name;
+          name << setprecision(8) << uncertainDataEstimator.getBinValue(b);
+          outputProbabilityScalarField_[b]->SetName(name.str().c_str());
+        }
       }
-
-      uncertainDataEstimator.setComputeLowerBound(computeLowerBound_);
-      uncertainDataEstimator.setComputeUpperBound(computeUpperBound_);
-
-    
-      uncertainDataEstimator.setOutputLowerBoundField(
-        outputLowerBoundScalarField_->GetVoidPointer(0));
-        
-      uncertainDataEstimator.setOutputUpperBoundField(
-        outputUpperBoundScalarField_->GetVoidPointer(0));
-
-      uncertainDataEstimator.setOutputMeanField(
-        outputMeanField_->GetVoidPointer(0));
-
-      uncertainDataEstimator.setBinCount(binCount_);
-      for (int b = 0; b<binCount_; b++) {
-        uncertainDataEstimator.setOutputProbability(b, 
-          outputProbabilityScalarField_[b]->GetVoidPointer(0));
-      }
-
-      uncertainDataEstimator.execute<VTK_TT>();
-
-      for (int b = 0; b<binCount_; b++) {
-        stringstream name;
-        name << setprecision(8) << uncertainDataEstimator.getBinValue(b);
-        outputProbabilityScalarField_[b]->SetName(name.str().c_str());
-      }
+      );
     }
-    );
   }
 
   return 0;
@@ -296,8 +300,6 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *request,
   // Mean field
   outInfo = outputVector->GetInformationObject(2);
   vtkDataSet *mean = vtkDataSet::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
-
-
   // Number of input files
   int numInputs = inputVector[0]->GetNumberOfInformationObjects();
   {
@@ -305,16 +307,13 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *request,
     msg << "[ttkUncertainDataEstimator] Number of inputs: " << numInputs << endl;
     dMsg(cout, msg.str(), infoMsg);
   }
-
   // Get input datas
   vtkDataSet* *input = new vtkDataSet*[numInputs];
   for(int i=0 ; i<numInputs ; i++)
   {
     input[i] = vtkDataSet::GetData(inputVector[0], i);
   }
-
   doIt(input, boundFields, probability, mean, numInputs);
-
   delete[] input;
 
   {
@@ -323,6 +322,5 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *request,
       << " MB." << endl;
     dMsg(cout, msg.str(), memoryMsg);
   }
-
   return 1;
 }

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
@@ -3,23 +3,23 @@
 /// \author Michael Michaux <michauxmichael89@gmail.com>
 /// \date August 2016.
 ///
-/// \brief TTK VTK-filter that takes an input ensemble data set 
-/// (represented by a list of scalar fields) and which computes various 
+/// \brief TTK VTK-filter that takes an input ensemble data set
+/// (represented by a list of scalar fields) and which computes various
 /// vertexwise statistics (PDF estimation, bounds, moments, etc.)
 ///
-/// \param Input0 Input ensemble scalar field #0 (vtkDataSet) 
-/// \param Input1 Input ensemble scalar field #1 (vtkDataSet)\n 
+/// \param Input0 Input ensemble scalar field #0 (vtkDataSet)
+/// \param Input1 Input ensemble scalar field #1 (vtkDataSet)\n
 /// ...\n
 /// \param InputN Input ensemble scalar field #N (vtkDataSet)
 /// \param Output0 Lower and upper bound fields (vtkDataSet)
-/// \param Output1 Histogram estimations of the vertex probability density 
+/// \param Output1 Histogram estimations of the vertex probability density
 /// functions (vtkDataSet)
 /// \param Output2 Mean field (vtkDataSet)
 ///
-/// This filter can be used as any other VTK filter (for instance, by using the 
+/// This filter can be used as any other VTK filter (for instance, by using the
 /// sequence of calls SetInputData(), Update(), GetOutput()).
 ///
-/// See the corresponding ParaView state file example for a usage example 
+/// See the corresponding ParaView state file example for a usage example
 /// within a VTK pipeline.
 ///
 /// \sa vtkMandatoryCriticalPoints
@@ -122,8 +122,7 @@ class ttkUncertainDataEstimator
       Modified();
     }
 
-    vtkSetMacro(ScalarField, std::string);
-    vtkGetMacro(ScalarField, std::string);
+
 
 
   protected:
@@ -143,7 +142,6 @@ class ttkUncertainDataEstimator
 
     bool                  UseAllCores;
     ttk::ThreadId                   ThreadNumber;
-    std::string                ScalarField;
     bool                  computeLowerBound_;
     bool                  computeUpperBound_;
     int                   binCount_;

--- a/paraview/UncertainDataEstimator/UncertainDataEstimator.xml
+++ b/paraview/UncertainDataEstimator/UncertainDataEstimator.xml
@@ -10,15 +10,15 @@
      class="ttkUncertainDataEstimator"
      label="TTK UncertainDataEstimator">
      <Documentation
-        long_help="TTK plugin that takes an input ensemble data set (represented 
-by a list of scalar fields) and which computes various vertexwise statistics 
+        long_help="TTK plugin that takes an input ensemble data set (represented
+by a list of scalar fields) and which computes various vertexwise statistics
 (PDF estimation, bounds, moments, etc.)."
-        short_help="TTK plugin that takes an input ensemble data set 
-(represented 
-by a list of scalar fields) and which computes various vertexwise statistics 
+        short_help="TTK plugin that takes an input ensemble data set
+(represented
+by a list of scalar fields) and which computes various vertexwise statistics
 (PDF estimation, bounds, moments, etc.).">
-          TTK plugin that takes an input ensemble data set (represented 
-by a list of scalar fields) and which computes various vertexwise statistics 
+          TTK plugin that takes an input ensemble data set (represented
+by a list of scalar fields) and which computes various vertexwise statistics
 (PDF estimation, bounds, moments, etc.).
 
 See also MandatoryCriticalPoints.
@@ -42,24 +42,6 @@ See also MandatoryCriticalPoints.
         </Documentation>
       </InputProperty>
 
-      <StringVectorProperty
-        name="Scalar Field"
-        command="SetScalarField"
-        number_of_elements="1"
-        animateable="0"
-        label="Scalar Field"
-        >
-        <ArrayListDomain
-          name="array_list"
-          default_values="0">
-          <RequiredProperties>
-            <Property name="Input" function="Input" />
-          </RequiredProperties>
-        </ArrayListDomain>
-        <Documentation>
-          Select the scalar field to process.
-        </Documentation>
-      </StringVectorProperty>
 
 
       <IntVectorProperty name="Bound to Compute" command="BoundToCompute"
@@ -140,10 +122,9 @@ See also MandatoryCriticalPoints.
       </IntVectorProperty>
 
       <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="Scalar Field" />
         <Property name="Bound to Compute" />
       </PropertyGroup>
-      
+
       <PropertyGroup panel_widget="Line" label="Testing">
         <Property name="UseAllCores" />
         <Property name="ThreadNumber" />


### PR DESCRIPTION
Hello Julien, 

As we discussed I modified the UncertainDataEstimator plugin to enforce the following properties :
- The plugin can take one or several inputs
- All the fields of each input are included in the computation
(the plugin is meant to be used with PointDataSelector to clean the inputs of unwanted fields beforehand)
- The names of the input fields can be different (thus I removed the corresponding property in the paraview gui)
- The only outputs are the resulting fields : lower/upper bounds, probabilities and mean of the ensemble data

see you soon,

Jules
 