### PR TITLE
WIP: Have TTK's CMake config files find dependencies

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -182,10 +182,7 @@ if(TTK_BUILD_DOCUMENTATION)
     endif()
 endif()
 
-find_package(Boost COMPONENTS system)
-if(NOT Boost_FOUND)
-  find_package(Boost REQUIRED)
-endif()
+find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(ZLIB)
 if(NOT ZLIB_INCLUDE_DIR)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,8 +8,7 @@ function(ttk_set_compile_options library)
     target_compile_options(${library} PRIVATE -Wall)
 
     if(Boost_FOUND)
-    target_include_directories(${library} PUBLIC ${Boost_INCLUDE_DIR})
-    target_link_libraries(${library} PUBLIC ${Boost_LIBRARIES})
+		target_link_libraries(${library} PUBLIC Boost::boost Boost::system)
     endif()
 
     if (TTK_ENABLE_KAMIKAZE)
@@ -196,6 +195,7 @@ else()
   option(TTK_ENABLE_ZLIB "Enable Zlib support" ON)
 endif()
 
+# TODO: This should be in its own findpackage.cmake file!
 # START_FINDSQLITE3
 find_path(SQLITE3_INCLUDE_DIR sqlite3.h
     PATHS
@@ -231,6 +231,7 @@ else()
   message(STATUS "SQLITE3 not found, disabling SQLITE3 support in TTK.")
 endif()
 
+# Same here, should be its own findpackage file!
 # START_FINDZFP
 find_path(ZFP_INCLUDE_DIR zfp.h
     PATHS

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -60,8 +60,7 @@ function(ttk_add_base_template_library library)
 		$<INSTALL_INTERFACE:include/ttk/base>)
 
   if(Boost_FOUND)
-    target_include_directories(${library} INTERFACE ${Boost_INCLUDE_DIR})
-    target_link_libraries(${library} INTERFACE ${Boost_LIBRARIES})
+    target_link_libraries(${library} INTERFACE Boost::boost)
   endif()
 
 	if (TTK_ENABLE_KAMIKAZE)

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -30,7 +30,7 @@ function(ttk_add_base_library library)
 	ttk_set_compile_options(${library})
 
 	install(TARGETS ${library}
-		EXPORT TTKBaseConfig
+		EXPORT TTKBaseTargets
 		RUNTIME DESTINATION bin/ttk
 		ARCHIVE DESTINATION lib/ttk
 		LIBRARY DESTINATION lib/ttk)
@@ -112,7 +112,7 @@ function(ttk_add_base_template_library library)
 	endif()
 
 	install(TARGETS ${library}
-		EXPORT TTKBaseConfig
+		EXPORT TTKBaseTargets
 		RUNTIME DESTINATION bin/ttk
 		ARCHIVE DESTINATION lib/ttk
 		LIBRARY DESTINATION lib/ttk)
@@ -133,11 +133,16 @@ add_library(baseAll INTERFACE)
 target_link_libraries(baseAll INTERFACE ${LIB_LIST})
 
 install(TARGETS baseAll
-	EXPORT TTKBaseConfig
+	EXPORT TTKBaseTargets
 	RUNTIME DESTINATION bin/ttk
 	ARCHIVE DESTINATION lib/ttk
 	LIBRARY DESTINATION lib/ttk)
 
-install(EXPORT TTKBaseConfig
+install(EXPORT TTKBaseTargets
 	NAMESPACE ttk::base::
 	DESTINATION lib/cmake/ttk)
+
+configure_file(TTKBaseConfig.cmake.in TTKBaseConfig.cmake @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/TTKBaseConfig.cmake"
+	DESTINATION lib/cmake/ttk)
+

--- a/core/base/TTKBaseConfig.cmake.in
+++ b/core/base/TTKBaseConfig.cmake.in
@@ -1,0 +1,21 @@
+include(CMakeFindDependencyMacro)
+
+# Boost is a required dependency
+find_dependency(Boost REQUIRED COMPONENTS system)
+
+# Was TTK built with zlib?
+if (@TTK_ENABLE_ZLIB@)
+	find_dependency(ZLIB REQUIRED)
+endif()
+
+if (@TTK_ENABLE_OPENMP@)
+	find_dependency(OpenMP REQUIRED)
+endif()
+
+if (@TTK_ENABLE_MPI@)
+    find_package(MPI REQUIRED)
+endif()
+
+# Include the actual targets for TTK Base
+include("${CMAKE_CURRENT_LIST_DIR}/TTKBaseTargets.cmake")
+

--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -36,7 +36,7 @@ function(ttk_add_vtk_library library)
 	endif()
 
 	install(TARGETS ${library}
-		EXPORT TTKVTKConfig
+		EXPORT TTKVTKTargets
 		RUNTIME DESTINATION bin/ttk
 		ARCHIVE DESTINATION lib/ttk
 		LIBRARY DESTINATION lib/ttk)
@@ -64,12 +64,16 @@ add_library(ttkAll INTERFACE)
 target_link_libraries(ttkAll INTERFACE ${VTKWRAPPER_LIB_LIST})
 
 install(TARGETS ttkAll
-	EXPORT TTKVTKConfig
+	EXPORT TTKVTKTargets
 	RUNTIME DESTINATION bin/ttk
 	ARCHIVE DESTINATION lib/ttk
 	LIBRARY DESTINATION lib/ttk)
 
-install(EXPORT TTKVTKConfig
+install(EXPORT TTKVTKTargets
 	NAMESPACE ttk::vtk::
+	DESTINATION lib/cmake/ttk)
+
+configure_file(TTKVTKConfig.cmake.in TTKVTKConfig.cmake @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/TTKVTKConfig.cmake"
 	DESTINATION lib/cmake/ttk)
 

--- a/core/vtk/TTKVTKConfig.cmake.in
+++ b/core/vtk/TTKVTKConfig.cmake.in
@@ -1,0 +1,18 @@
+include(CMakeFindDependencyMacro)
+
+if (@TTK_BUILD_PARAVIEW_PLUGINS@)
+	find_package(ParaView REQUIRED)
+	include(${PARAVIEW_USE_FILE})
+	include_directories(${PARAVIEW_INCLUDE_DIRS})
+else()
+	find_dependency(VTK REQUIRED)
+	include(${VTK_USE_FILE})
+	include_directories(${VTK_INCLUDE_DIRS})
+endif()
+
+# Include the actual config for TTK Base
+include("${CMAKE_CURRENT_LIST_DIR}/TTKBaseConfig.cmake")
+# And the actual targets for TTK VTK
+include("${CMAKE_CURRENT_LIST_DIR}/TTKVTKTargets.cmake")
+
+


### PR DESCRIPTION
Hey Julien, I later found https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html which I think is the cleanest way to have the the config files we make for TTK's packages find their corresponding dependencies. This also lets us find other dependencies for the user depending on the build configuration (e.g., OpenMP, MPI, VTK, etc.). We can also have the TTKVTK CMake file automatically import the TTKBase config, so that people using TTKVTK don't need to also search for TTKBase, we just handle it for them.

This is still a bit of a work in progress, I haven't tested if this has any effect on the ParaView plugin side of things or how things work with the VTK wrappers when building just VTK, or with ParaView for the dependent applications. But this is probably the path to go for resolving #170 . Feel free to edit this as well