### PR TITLE
Discrete gradient - memory

### DIFF
--- a/core/base/discreteGradient/CMakeLists.txt
+++ b/core/base/discreteGradient/CMakeLists.txt
@@ -3,10 +3,10 @@ ttk_add_base_library(discreteGradient
 	HEADERS DiscreteGradient.h DiscreteGradient_Template.h
 	LINK triangulation geometry scalarFieldCriticalPoints ftmTree)
 
-  option(TTK_ENABLE_DG_OPTIMIZE_MEMORY "Enable Discrete Gradient memory optimization" OFF)
-mark_as_advanced(TTK_ENABLE_DG_OPTIMIZE_MEMORY)
+  option(TTK_ENABLE_DCG_OPTIMIZE_MEMORY "Enable Discrete Gradient memory optimization" OFF)
+mark_as_advanced(TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
 
-if (TTK_ENABLE_DG_OPTIMIZE_MEMORY)
-  target_compile_definitions(discreteGradient PUBLIC TTK_ENABLE_DG_OPTIMIZE_MEMORY)
+if (TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
+  target_compile_definitions(discreteGradient PUBLIC TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
 endif()
 

--- a/core/base/discreteGradient/CMakeLists.txt
+++ b/core/base/discreteGradient/CMakeLists.txt
@@ -3,3 +3,10 @@ ttk_add_base_library(discreteGradient
 	HEADERS DiscreteGradient.h DiscreteGradient_Template.h
 	LINK triangulation geometry scalarFieldCriticalPoints ftmTree)
 
+  option(TTK_ENABLE_DG_OPTIMIZE_MEMORY "Enable Discrete Gradient memory optimization" OFF)
+mark_as_advanced(TTK_ENABLE_DG_OPTIMIZE_MEMORY)
+
+if (TTK_ENABLE_DG_OPTIMIZE_MEMORY)
+  target_compile_definitions(discreteGradient PUBLIC TTK_ENABLE_DG_OPTIMIZE_MEMORY)
+endif()
+

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -209,49 +209,65 @@ bool DiscreteGradient::isBoundary(const Cell& cell) const{
   return false;
 }
 
-int DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) const{
+SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) const{
+  SimplexId id{-1};
   if(dimensionality_==2){
     switch(cell.dim_){
       case 0:
-        return gradient_[0][0][cell.id_];
+        inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
+        return id;
         break;
 
       case 1:
-        if(isReverse)
-          return gradient_[0][1][cell.id_];
+        if(isReverse){
+          inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
+          return id;
+        }
 
-        return gradient_[1][1][cell.id_];
+        inputTriangulation_->getEdgeStar(cell.id_, gradient_[1][1][cell.id_], id);
+        return id;
         break;
 
       case 2:
-        if(isReverse)
-          return gradient_[1][2][cell.id_];
+        if(isReverse){
+          inputTriangulation_->getCellEdge(cell.id_, gradient_[1][2][cell.id_], id);
+          return id;
+        }
         break;
     }
   }
   else if(dimensionality_==3){
     switch(cell.dim_){
       case 0:
-        return gradient_[0][0][cell.id_];
+        inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
+        return id;
         break;
 
       case 1:
-        if(isReverse)
-          return gradient_[0][1][cell.id_];
+        if(isReverse){
+          inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
+          return id;
+        }
 
-        return gradient_[1][1][cell.id_];
+        inputTriangulation_->getEdgeTriangle(cell.id_, gradient_[1][1][cell.id_], id);
+        return id;
         break;
 
       case 2:
-        if(isReverse)
-          return gradient_[1][2][cell.id_];
+        if(isReverse){
+          inputTriangulation_->getTriangleEdge(cell.id_, gradient_[1][2][cell.id_], id);
+          return id;
+        }
 
-        return gradient_[2][2][cell.id_];
+        inputTriangulation_->getTriangleStar(cell.id_, gradient_[2][2][cell.id_], id);
+        return id;
         break;
 
       case 3:
-        if(isReverse)
-          return gradient_[2][3][cell.id_];
+        if(isReverse){
+          inputTriangulation_->getCellTriangle(cell.id_, gradient_[2][3][cell.id_], id);
+          return id;
+        }
         break;
     }
   }
@@ -730,8 +746,22 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
-      gradient_[1][2][triangleId]=edgeId;
-      gradient_[1][1][edgeId]=triangleId;
+      for(int k=0; k<3; ++k){
+        SimplexId tmp;
+        inputTriangulation_->getCellEdge(triangleId, k, tmp);
+        if(tmp == edgeId){
+          gradient_[1][2][triangleId]=k;
+          break;
+        }
+      }
+      for(int k=0; k<inputTriangulation_->getEdgeStarNumber(edgeId); ++k){
+        SimplexId tmp;
+        inputTriangulation_->getEdgeStar(edgeId, k, tmp);
+        if(tmp == triangleId){
+          gradient_[1][1][edgeId]=k;
+          break;
+        }
+      }
     }
   }
   else if(dimensionality_==3){
@@ -741,8 +771,22 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId tetraId=vpath[i+1].id_;
 
-      gradient_[2][3][tetraId]=triangleId;
-      gradient_[2][2][triangleId]=tetraId;
+      for(int k=0; k<4; ++k){
+        SimplexId tmp;
+        inputTriangulation_->getCellTriangle(tetraId, k, tmp);
+        if(tmp == triangleId){
+          gradient_[2][3][tetraId]=k;
+          break;
+        }
+      }
+      for(int k=0; k<inputTriangulation_->getTriangleStarNumber(triangleId); ++k){
+        SimplexId tmp;
+        inputTriangulation_->getTriangleStar(triangleId, k, tmp);
+        if(tmp == tetraId){
+          gradient_[2][2][triangleId]=k;
+          break;
+        }
+      }
     }
   }
 
@@ -757,8 +801,22 @@ int DiscreteGradient::reverseAscendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
-      gradient_[1][2][triangleId]=edgeId;
-      gradient_[1][1][edgeId]=triangleId;
+      for(int k=0; k<3; ++k){
+        SimplexId tmp;
+        inputTriangulation_->getTriangleEdge(triangleId, k, tmp);
+        if(tmp == edgeId){
+          gradient_[1][2][triangleId]=k;
+          break;
+        }
+      }
+      for(int k=0; k<inputTriangulation_->getEdgeTriangleNumber(edgeId); ++k){
+        SimplexId tmp;
+        inputTriangulation_->getEdgeTriangle(edgeId, k, tmp);
+        if(tmp == triangleId){
+          gradient_[1][1][edgeId]=k;
+          break;
+        }
+      }
     }
   }
 
@@ -773,8 +831,22 @@ int DiscreteGradient::reverseDescendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId edgeId=vpath[i+1].id_;
 
-      gradient_[1][1][edgeId]=triangleId;
-      gradient_[1][2][triangleId]=edgeId;
+      for(int k=0; k<3; ++k){
+        SimplexId tmp;
+        inputTriangulation_->getTriangleEdge(triangleId, k, tmp);
+        if(tmp == edgeId){
+          gradient_[1][2][triangleId]=k;
+          break;
+        }
+      }
+      for(int k=0; k<inputTriangulation_->getEdgeTriangleNumber(edgeId); ++k){
+        SimplexId tmp;
+        inputTriangulation_->getEdgeTriangle(edgeId, k, tmp);
+        if(tmp == triangleId){
+          gradient_[1][1][edgeId]=k;
+          break;
+        }
+      }
     }
   }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -214,24 +214,38 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
   if(dimensionality_==2){
     switch(cell.dim_){
       case 0:
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
-        return id;
+#else
+        return gradient_[0][0][cell.id_];
+#endif
         break;
 
       case 1:
         if(isReverse){
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
           return id;
+#else
+          return gradient_[0][1][cell.id_];
+#endif
         }
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         inputTriangulation_->getEdgeStar(cell.id_, gradient_[1][1][cell.id_], id);
-        return id;
+#else
+        return gradient_[1][1][cell.id_];
+#endif
         break;
 
       case 2:
         if(isReverse){
-          inputTriangulation_->getCellEdge(cell.id_, gradient_[1][2][cell.id_], id);
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+          inputTriangulation_->getCellEdge(cell.id_, gradient_[2][2][cell.id_], id);
           return id;
+#else
+          return gradient_[1][2][cell.id_];
+#endif
         }
         break;
     }
@@ -239,40 +253,61 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
   else if(dimensionality_==3){
     switch(cell.dim_){
       case 0:
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
-        return id;
+#else
+        return gradient_[0][0][cell.id_];
+#endif
         break;
 
       case 1:
         if(isReverse){
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
           return id;
+#else
+          return gradient_[0][1][cell.id_];
+#endif
         }
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         inputTriangulation_->getEdgeTriangle(cell.id_, gradient_[1][1][cell.id_], id);
-        return id;
+#else
+        return gradient_[1][1][cell.id_];
+#endif
         break;
 
       case 2:
         if(isReverse){
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           inputTriangulation_->getTriangleEdge(cell.id_, gradient_[1][2][cell.id_], id);
           return id;
+#else
+          return gradient_[1][2][cell.id_];
+#endif
         }
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         inputTriangulation_->getTriangleStar(cell.id_, gradient_[2][2][cell.id_], id);
-        return id;
+#else
+        return gradient_[2][2][cell.id_];
+#endif
         break;
 
       case 3:
         if(isReverse){
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           inputTriangulation_->getCellTriangle(cell.id_, gradient_[2][3][cell.id_], id);
           return id;
+#else
+          return gradient_[2][3][cell.id_];
+#endif
         }
         break;
     }
   }
 
-  return -1;
+  return id;
 }
 
 int DiscreteGradient::getCriticalPoints(vector<Cell>& criticalPoints) const{
@@ -746,6 +781,7 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getCellEdge(triangleId, k, tmp);
@@ -762,6 +798,10 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
           break;
         }
       }
+#else
+      gradient_[1][2][triangleId]=edgeId;
+      gradient_[1][1][edgeId]=triangleId;
+#endif
     }
   }
   else if(dimensionality_==3){
@@ -771,6 +811,7 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId tetraId=vpath[i+1].id_;
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
       for(int k=0; k<4; ++k){
         SimplexId tmp;
         inputTriangulation_->getCellTriangle(tetraId, k, tmp);
@@ -787,6 +828,10 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
           break;
         }
       }
+#else
+      gradient_[2][3][tetraId]=triangleId;
+      gradient_[2][2][triangleId]=tetraId;
+#endif
     }
   }
 
@@ -801,6 +846,7 @@ int DiscreteGradient::reverseAscendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getTriangleEdge(triangleId, k, tmp);
@@ -817,6 +863,10 @@ int DiscreteGradient::reverseAscendingPathOnWall(const vector<Cell>& vpath){
           break;
         }
       }
+#else
+      gradient_[1][2][triangleId]=edgeId;
+      gradient_[1][1][edgeId]=triangleId;
+#endif
     }
   }
 
@@ -831,6 +881,7 @@ int DiscreteGradient::reverseDescendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId edgeId=vpath[i+1].id_;
 
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getTriangleEdge(triangleId, k, tmp);
@@ -847,6 +898,10 @@ int DiscreteGradient::reverseDescendingPathOnWall(const vector<Cell>& vpath){
           break;
         }
       }
+#else
+      gradient_[1][1][edgeId]=triangleId;
+      gradient_[1][2][triangleId]=edgeId;
+#endif
     }
   }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -241,7 +241,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
       case 2:
         if(isReverse){
 #ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
-          inputTriangulation_->getCellEdge(cell.id_, gradient_[2][2][cell.id_], id);
+          inputTriangulation_->getCellEdge(cell.id_, gradient_[1][2][cell.id_], id);
           return id;
 #else
           return gradient_[1][2][cell.id_];

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -214,7 +214,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
   if(dimensionality_==2){
     switch(cell.dim_){
       case 0:
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
 #else
         return gradient_[0][0][cell.id_];
@@ -223,7 +223,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 
       case 1:
         if(isReverse){
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
           return id;
 #else
@@ -231,7 +231,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 #endif
         }
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         inputTriangulation_->getEdgeStar(cell.id_, gradient_[1][1][cell.id_], id);
 #else
         return gradient_[1][1][cell.id_];
@@ -240,7 +240,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 
       case 2:
         if(isReverse){
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           inputTriangulation_->getCellEdge(cell.id_, gradient_[1][2][cell.id_], id);
           return id;
 #else
@@ -253,7 +253,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
   else if(dimensionality_==3){
     switch(cell.dim_){
       case 0:
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         inputTriangulation_->getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
 #else
         return gradient_[0][0][cell.id_];
@@ -262,7 +262,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 
       case 1:
         if(isReverse){
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           inputTriangulation_->getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
           return id;
 #else
@@ -270,7 +270,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 #endif
         }
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         inputTriangulation_->getEdgeTriangle(cell.id_, gradient_[1][1][cell.id_], id);
 #else
         return gradient_[1][1][cell.id_];
@@ -279,7 +279,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 
       case 2:
         if(isReverse){
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           inputTriangulation_->getTriangleEdge(cell.id_, gradient_[1][2][cell.id_], id);
           return id;
 #else
@@ -287,7 +287,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 #endif
         }
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         inputTriangulation_->getTriangleStar(cell.id_, gradient_[2][2][cell.id_], id);
 #else
         return gradient_[2][2][cell.id_];
@@ -296,7 +296,7 @@ SimplexId DiscreteGradient::getPairedCell(const Cell& cell, bool isReverse) cons
 
       case 3:
         if(isReverse){
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           inputTriangulation_->getCellTriangle(cell.id_, gradient_[2][3][cell.id_], id);
           return id;
 #else
@@ -781,7 +781,7 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getCellEdge(triangleId, k, tmp);
@@ -811,7 +811,7 @@ int DiscreteGradient::reverseAscendingPath(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId tetraId=vpath[i+1].id_;
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       for(int k=0; k<4; ++k){
         SimplexId tmp;
         inputTriangulation_->getCellTriangle(tetraId, k, tmp);
@@ -846,7 +846,7 @@ int DiscreteGradient::reverseAscendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId edgeId=vpath[i].id_;
       const SimplexId triangleId=vpath[i+1].id_;
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getTriangleEdge(triangleId, k, tmp);
@@ -881,7 +881,7 @@ int DiscreteGradient::reverseDescendingPathOnWall(const vector<Cell>& vpath){
       const SimplexId triangleId=vpath[i].id_;
       const SimplexId edgeId=vpath[i+1].id_;
 
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       for(int k=0; k<3; ++k){
         SimplexId tmp;
         inputTriangulation_->getTriangleEdge(triangleId, k, tmp);

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -452,7 +452,7 @@ given dimension.
       int assignGradient(const int alphaDim,
                          const dataType *const scalars,
                          const idType *const offsets,
-                         std::vector<std::vector<SimplexId>> &gradient) const;
+                         std::vector<std::vector<char>> &gradient) const;
 
       /**
        * Body of AssignGradient2 algorithm from "Parallel Computation of 3D 
@@ -465,7 +465,7 @@ unpaired cells.
       int assignGradient2(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-                          std::vector<std::vector<SimplexId>> &gradient) const;
+                          std::vector<std::vector<char>> &gradient) const;
 
       /**
        * Brand new pass on the discrete gradient designed specifically for this 
@@ -477,7 +477,7 @@ triangulation only).
       int assignGradient3(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-                          std::vector<std::vector<SimplexId>> &gradient) const;
+                          std::vector<std::vector<char>> &gradient) const;
 
       /**
        * Compute the initial gradient field of the input scalar function on the 
@@ -891,7 +891,7 @@ discrete gradient, false otherwise.
        * Return the identifier of the cell paired to the cell given by the user 
 in the gradient.
        */
-      int getPairedCell(const Cell &cell, bool isReverse = false) const;
+      SimplexId getPairedCell(const Cell &cell, bool isReverse = false) const;
 
       /**
        * Get the output critical points as a STL vector of cells.
@@ -1034,7 +1034,7 @@ tetra identifier.
 
       int dimensionality_;
       SimplexId numberOfVertices_;
-      std::vector<std::vector<std::vector<SimplexId>>> gradient_;
+      std::vector<std::vector<std::vector<char>>> gradient_;
       std::vector<SimplexId> dmtMax2PL_;
       std::vector<SimplexId> dmt1Saddle2PL_;
       std::vector<SimplexId> dmt2Saddle2PL_;

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -452,7 +452,7 @@ given dimension.
       int assignGradient(const int alphaDim,
                          const dataType *const scalars,
                          const idType *const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                          std::vector<std::vector<char>> &gradient) const;
 #else
                          std::vector<std::vector<SimplexId>> &gradient) const;
@@ -469,7 +469,7 @@ unpaired cells.
       int assignGradient2(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                          std::vector<std::vector<char>> &gradient) const;
 #else
                          std::vector<std::vector<SimplexId>> &gradient) const;
@@ -485,7 +485,7 @@ triangulation only).
       int assignGradient3(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                          std::vector<std::vector<char>> &gradient) const;
 #else
                          std::vector<std::vector<SimplexId>> &gradient) const;
@@ -1046,7 +1046,7 @@ tetra identifier.
 
       int dimensionality_;
       SimplexId numberOfVertices_;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       std::vector<std::vector<std::vector<char>>> gradient_;
 #else
       std::vector<std::vector<std::vector<SimplexId>>> gradient_;

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -452,7 +452,11 @@ given dimension.
       int assignGradient(const int alphaDim,
                          const dataType *const scalars,
                          const idType *const offsets,
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                          std::vector<std::vector<char>> &gradient) const;
+#else
+                         std::vector<std::vector<SimplexId>> &gradient) const;
+#endif
 
       /**
        * Body of AssignGradient2 algorithm from "Parallel Computation of 3D 
@@ -465,7 +469,11 @@ unpaired cells.
       int assignGradient2(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-                          std::vector<std::vector<char>> &gradient) const;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+                         std::vector<std::vector<char>> &gradient) const;
+#else
+                         std::vector<std::vector<SimplexId>> &gradient) const;
+#endif
 
       /**
        * Brand new pass on the discrete gradient designed specifically for this 
@@ -477,7 +485,11 @@ triangulation only).
       int assignGradient3(const int alphaDim,
                           const dataType *const scalars,
                           const idType *const offsets,
-                          std::vector<std::vector<char>> &gradient) const;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+                         std::vector<std::vector<char>> &gradient) const;
+#else
+                         std::vector<std::vector<SimplexId>> &gradient) const;
+#endif
 
       /**
        * Compute the initial gradient field of the input scalar function on the 
@@ -1034,7 +1046,11 @@ tetra identifier.
 
       int dimensionality_;
       SimplexId numberOfVertices_;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
       std::vector<std::vector<std::vector<char>>> gradient_;
+#else
+      std::vector<std::vector<std::vector<SimplexId>>> gradient_;
+#endif
       std::vector<SimplexId> dmtMax2PL_;
       std::vector<SimplexId> dmt1Saddle2PL_;
       std::vector<SimplexId> dmt2Saddle2PL_;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -182,7 +182,7 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
 #else
     std::vector<std::vector<SimplexId>>& gradient) const{
@@ -202,7 +202,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
     for(SimplexId alpha=0; alpha<alphaNumber; ++alpha){
       if (alphaDim == 0) {
         SimplexId minEdgeId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minEdgeLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -219,14 +219,14 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if(sosLowerThan(vertexId, alpha)){
             if(minVertexId==-1){
               minEdgeId = edgeId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
 #endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minEdgeId = edgeId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
 #endif
               minVertexId = vertexId;
@@ -234,7 +234,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
         }
         if (minEdgeId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minEdgeLocalId;
 
           char minAlphaLocalId{-1};
@@ -260,7 +260,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minStarId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -279,14 +279,14 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if (sosLowerThan(vertexId,v0) and sosLowerThan(vertexId,v1)){
             if (minVertexId == -1) {
               minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minStarLocalId = k;
 #endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minStarLocalId = k;
 #endif
               minVertexId = vertexId;
@@ -294,7 +294,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
         }
         if (minStarId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -323,7 +323,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
     for (SimplexId alpha = 0; alpha < alphaNumber; ++alpha) {
       if (alphaDim == 0) {
         SimplexId minEdgeId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minEdgeLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -340,14 +340,14 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if (sosLowerThan(vertexId, alpha)) {
             if(minVertexId==-1){
               minEdgeId = edgeId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
 #endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minEdgeId = edgeId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
 #endif
               minVertexId = vertexId;
@@ -355,7 +355,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
         }
         if (minEdgeId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minEdgeLocalId;
 
           char minAlphaLocalId{-1};
@@ -381,7 +381,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minTriangleId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minTriangleLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -401,14 +401,14 @@ int DiscreteGradient::assignGradient(const int alphaDim,
               sosLowerThan(vertexId,v1)) {
             if (minVertexId == -1) {
               minTriangleId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minTriangleLocalId = k;
 #endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minTriangleId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minTriangleLocalId = k;
 #endif
               minVertexId = vertexId;
@@ -416,7 +416,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
         }
         if (minTriangleId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minTriangleLocalId;
 
           char minAlphaLocalId{-1};
@@ -444,7 +444,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getTriangleVertex(alpha, 2, v2);
 
         SimplexId minStarId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -467,14 +467,14 @@ int DiscreteGradient::assignGradient(const int alphaDim,
               sosLowerThan(vertexId,v2)) {
             if (minVertexId == -1) {
               minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minStarLocalId = k;
 #endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
               minStarLocalId = k;
 #endif
               minVertexId = vertexId;
@@ -482,7 +482,7 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
         }
         if (minStarId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -512,7 +512,7 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient2(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
 #else
     std::vector<std::vector<SimplexId>>& gradient) const{
@@ -538,7 +538,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minStarId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -560,14 +560,14 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
                 (sosLowerThan(vertexId,v1) and sosLowerThan(v0, vertexId))){
               if (minVertexId == -1) {
                 minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
 #endif
                 minVertexId = vertexId;
               }
               else if(sosLowerThan(vertexId,minVertexId)){
                 minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
 #endif
                 minVertexId = vertexId;
@@ -576,7 +576,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
           }
         }
         if (minStarId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -611,7 +611,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
           inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
           SimplexId minTriangleId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           char minTriangleLocalId{-1};
 #endif
           SimplexId minVertexId{-1};
@@ -633,14 +633,14 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
                   (sosLowerThan(vertexId,v1) and sosLowerThan(v0, vertexId))){
                 if (minVertexId == -1) {
                   minTriangleId = triangleId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                   minTriangleLocalId = k;
 #endif
                   minVertexId = vertexId;
                 }
                 else if(sosLowerThan(vertexId,minVertexId)){
                   minTriangleId = triangleId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                   minTriangleLocalId = k;
 #endif
                   minVertexId = vertexId;
@@ -649,7 +649,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             }
           }
           if (minTriangleId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
             gradient[alphaDim][alpha] = minTriangleLocalId;
 
             char minAlphaLocalId{-1};
@@ -692,7 +692,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             vb=v2;
 
           SimplexId minStarId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           char minStarLocalId{-1};
 #endif
           SimplexId minVertexId{-1};
@@ -714,14 +714,14 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
               if(sosLowerThan(vertexId, vb)){
                 if (minVertexId == -1) {
                   minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                   minStarLocalId = k;
 #endif
                   minVertexId = vertexId;
                 }
                 else if(sosLowerThan(vertexId,minVertexId)){
                   minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                   minStarLocalId = k;
 #endif
                   minVertexId = vertexId;
@@ -730,7 +730,7 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             }
           }
           if (minStarId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
             gradient[alphaDim][alpha] = minStarLocalId;
 
             char minAlphaLocalId{-1};
@@ -761,7 +761,7 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient3(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
 #else
     std::vector<std::vector<SimplexId>>& gradient) const{
@@ -798,7 +798,7 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
           vmax=v2;
 
         SimplexId minStarId{-1};
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
 #endif
         SimplexId minVertexId{-1};
@@ -820,14 +820,14 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
             if(sosLowerThan(vertexId,vmax)) {
               if (minVertexId == -1) {
                 minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
 #endif
                 minVertexId = vertexId;
               }
               else if(sosLowerThan(vertexId,minVertexId)){
                 minStarId = starId;
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
 #endif
                 minVertexId = vertexId;
@@ -836,7 +836,7 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
           }
         }
         if (minStarId != -1) {
-#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -182,7 +182,11 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
+#else
+    std::vector<std::vector<SimplexId>>& gradient) const{
+#endif
   const int betaDim=alphaDim+1;
   const SimplexId alphaNumber=gradient[alphaDim].size();
 
@@ -198,7 +202,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
     for(SimplexId alpha=0; alpha<alphaNumber; ++alpha){
       if (alphaDim == 0) {
         SimplexId minEdgeId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minEdgeLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId edgeNumber = inputTriangulation_->getVertexEdgeNumber(alpha);
         for (SimplexId k=0; k<edgeNumber; ++k) {
@@ -213,17 +219,22 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if(sosLowerThan(vertexId, alpha)){
             if(minVertexId==-1){
               minEdgeId = edgeId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
+#endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minEdgeId = edgeId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
+#endif
               minVertexId = vertexId;
             }
           }
         }
         if (minEdgeId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minEdgeLocalId;
 
           char minAlphaLocalId{-1};
@@ -237,6 +248,10 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
 
           gradient[betaDim][minEdgeId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minEdgeId;
+          gradient[betaDim][minEdgeId] = alpha;
+#endif
         }
       } else if (alphaDim == 1) {
         SimplexId v0;
@@ -245,7 +260,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minStarId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId starNumber = inputTriangulation_->getEdgeStarNumber(alpha);
         for (SimplexId k = 0; k < starNumber; ++k) {
@@ -262,17 +279,22 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if (sosLowerThan(vertexId,v0) and sosLowerThan(vertexId,v1)){
             if (minVertexId == -1) {
               minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minStarLocalId = k;
+#endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minStarLocalId = k;
+#endif
               minVertexId = vertexId;
             }
           }
         }
         if (minStarId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -286,6 +308,10 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
 
           gradient[betaDim][minStarId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minStarId;
+          gradient[betaDim][minStarId] = alpha;
+#endif
         }
       }
     }
@@ -297,7 +323,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
     for (SimplexId alpha = 0; alpha < alphaNumber; ++alpha) {
       if (alphaDim == 0) {
         SimplexId minEdgeId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minEdgeLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId edgeNumber = inputTriangulation_->getVertexEdgeNumber(alpha);
         for (SimplexId k = 0; k < edgeNumber; ++k) {
@@ -312,17 +340,22 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           if (sosLowerThan(vertexId, alpha)) {
             if(minVertexId==-1){
               minEdgeId = edgeId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
+#endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minEdgeId = edgeId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minEdgeLocalId = k;
+#endif
               minVertexId = vertexId;
             }
           }
         }
         if (minEdgeId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minEdgeLocalId;
 
           char minAlphaLocalId{-1};
@@ -336,6 +369,10 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
 
           gradient[betaDim][minEdgeId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minEdgeId;
+          gradient[betaDim][minEdgeId] = alpha;
+#endif
         }
       } else if (alphaDim == 1) {
         SimplexId v0;
@@ -344,7 +381,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minTriangleId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minTriangleLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId triangleNumber = inputTriangulation_->getEdgeTriangleNumber(alpha);
         for (SimplexId k = 0; k < triangleNumber; ++k) {
@@ -362,17 +401,22 @@ int DiscreteGradient::assignGradient(const int alphaDim,
               sosLowerThan(vertexId,v1)) {
             if (minVertexId == -1) {
               minTriangleId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minTriangleLocalId = k;
+#endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minTriangleId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minTriangleLocalId = k;
+#endif
               minVertexId = vertexId;
             }
           }
         }
         if (minTriangleId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minTriangleLocalId;
 
           char minAlphaLocalId{-1};
@@ -386,6 +430,10 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
 
           gradient[betaDim][minTriangleId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minTriangleId;
+          gradient[betaDim][minTriangleId] = alpha;
+#endif
         }
       } else if (alphaDim == 2) {
         SimplexId v0;
@@ -396,7 +444,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
         inputTriangulation_->getTriangleVertex(alpha, 2, v2);
 
         SimplexId minStarId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId starNumber = inputTriangulation_->getTriangleStarNumber(alpha);
         for (SimplexId k = 0; k < starNumber; ++k) {
@@ -417,17 +467,22 @@ int DiscreteGradient::assignGradient(const int alphaDim,
               sosLowerThan(vertexId,v2)) {
             if (minVertexId == -1) {
               minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minStarLocalId = k;
+#endif
               minVertexId = vertexId;
             }
             else if(sosLowerThan(vertexId,minVertexId)){
               minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
               minStarLocalId = k;
+#endif
               minVertexId = vertexId;
             }
           }
         }
         if (minStarId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -441,6 +496,10 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           }
 
           gradient[betaDim][minStarId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minStarId;
+          gradient[betaDim][minStarId] = alpha;
+#endif
         }
       }
     }
@@ -453,7 +512,11 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient2(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
+#else
+    std::vector<std::vector<SimplexId>>& gradient) const{
+#endif
   if(alphaDim>0){
     const int betaDim=alphaDim+1;
     const SimplexId alphaNumber=gradient[alphaDim].size();
@@ -475,7 +538,9 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
         inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
         SimplexId minStarId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId starNumber=inputTriangulation_->getEdgeStarNumber(alpha);
         for(SimplexId k=0; k<starNumber; ++k){
@@ -495,18 +560,23 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
                 (sosLowerThan(vertexId,v1) and sosLowerThan(v0, vertexId))){
               if (minVertexId == -1) {
                 minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
+#endif
                 minVertexId = vertexId;
               }
               else if(sosLowerThan(vertexId,minVertexId)){
                 minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
+#endif
                 minVertexId = vertexId;
               }
             }
           }
         }
         if (minStarId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -520,6 +590,10 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
           }
 
           gradient[betaDim][minStarId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minStarId;
+          gradient[betaDim][minStarId] = alpha;
+#endif
         }
       }
     }
@@ -537,7 +611,9 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
           inputTriangulation_->getEdgeVertex(alpha, 1, v1);
 
           SimplexId minTriangleId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           char minTriangleLocalId{-1};
+#endif
           SimplexId minVertexId{-1};
           const SimplexId triangleNumber=inputTriangulation_->getEdgeTriangleNumber(alpha);
           for(SimplexId k=0; k<triangleNumber; ++k){
@@ -557,18 +633,23 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
                   (sosLowerThan(vertexId,v1) and sosLowerThan(v0, vertexId))){
                 if (minVertexId == -1) {
                   minTriangleId = triangleId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                   minTriangleLocalId = k;
+#endif
                   minVertexId = vertexId;
                 }
                 else if(sosLowerThan(vertexId,minVertexId)){
                   minTriangleId = triangleId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                   minTriangleLocalId = k;
+#endif
                   minVertexId = vertexId;
                 }
               }
             }
           }
           if (minTriangleId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
             gradient[alphaDim][alpha] = minTriangleLocalId;
 
             char minAlphaLocalId{-1};
@@ -582,6 +663,10 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             }
 
             gradient[betaDim][minTriangleId] = minAlphaLocalId;
+#else
+            gradient[alphaDim][alpha] = minTriangleId;
+            gradient[betaDim][minTriangleId] = alpha;
+#endif
           }
         }
         else if(alphaDim==2){
@@ -607,7 +692,9 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             vb=v2;
 
           SimplexId minStarId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           char minStarLocalId{-1};
+#endif
           SimplexId minVertexId{-1};
           const SimplexId starNumber=inputTriangulation_->getTriangleStarNumber(alpha);
           for(SimplexId k=0; k<starNumber; ++k){
@@ -627,18 +714,23 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
               if(sosLowerThan(vertexId, vb)){
                 if (minVertexId == -1) {
                   minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                   minStarLocalId = k;
+#endif
                   minVertexId = vertexId;
                 }
                 else if(sosLowerThan(vertexId,minVertexId)){
                   minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                   minStarLocalId = k;
+#endif
                   minVertexId = vertexId;
                 }
               }
             }
           }
           if (minStarId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
             gradient[alphaDim][alpha] = minStarLocalId;
 
             char minAlphaLocalId{-1};
@@ -652,6 +744,10 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             }
 
             gradient[betaDim][minStarId] = minAlphaLocalId;
+#else
+            gradient[alphaDim][alpha] = minStarId;
+            gradient[betaDim][minStarId] = alpha;
+#endif
           }
         }
       }
@@ -665,7 +761,11 @@ template <typename dataType, typename idType>
 int DiscreteGradient::assignGradient3(const int alphaDim,
     const dataType* const scalars,
     const idType* const offsets,
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
     std::vector<std::vector<char>>& gradient) const{
+#else
+    std::vector<std::vector<SimplexId>>& gradient) const{
+#endif
   if(alphaDim>0){
     const int betaDim=alphaDim+1;
     const SimplexId alphaNumber=gradient[alphaDim].size();
@@ -698,7 +798,9 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
           vmax=v2;
 
         SimplexId minStarId{-1};
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
         char minStarLocalId{-1};
+#endif
         SimplexId minVertexId{-1};
         const SimplexId starNumber=inputTriangulation_->getTriangleStarNumber(alpha);
         for(SimplexId k=0; k<starNumber; ++k){
@@ -718,18 +820,23 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
             if(sosLowerThan(vertexId,vmax)) {
               if (minVertexId == -1) {
                 minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
+#endif
                 minVertexId = vertexId;
               }
               else if(sosLowerThan(vertexId,minVertexId)){
                 minStarId = starId;
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
                 minStarLocalId = k;
+#endif
                 minVertexId = vertexId;
               }
             }
           }
         }
         if (minStarId != -1) {
+#ifdef TTK_ENABLE_DG_OPTIMIZE_MEMORY
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
@@ -743,6 +850,10 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
           }
 
           gradient[betaDim][minStarId] = minAlphaLocalId;
+#else
+          gradient[alphaDim][alpha] = minStarId;
+          gradient[betaDim][minStarId] = alpha;
+#endif
         }
       }
     }

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -431,9 +431,9 @@ int DiscreteGradient::assignGradient(const int alphaDim,
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
-          for(SimplexId k=0; k<3; ++k){
+          for(SimplexId k=0; k<4; ++k){
             SimplexId tmp;
-            inputTriangulation_->getTriangleEdge(minStarId, k, tmp);
+            inputTriangulation_->getCellTriangle(minStarId, k, tmp);
             if(tmp == alpha){
               minAlphaLocalId = k;
               break;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -642,9 +642,9 @@ int DiscreteGradient::assignGradient2(const int alphaDim,
             gradient[alphaDim][alpha] = minStarLocalId;
 
             char minAlphaLocalId{-1};
-            for(SimplexId k=0; k<3; ++k){
+            for(SimplexId k=0; k<4; ++k){
               SimplexId tmp;
-              inputTriangulation_->getTriangleEdge(minStarId, k, tmp);
+              inputTriangulation_->getCellTriangle(minStarId, k, tmp);
               if(tmp == alpha){
                 minAlphaLocalId = k;
                 break;
@@ -733,9 +733,9 @@ int DiscreteGradient::assignGradient3(const int alphaDim,
           gradient[alphaDim][alpha] = minStarLocalId;
 
           char minAlphaLocalId{-1};
-          for(SimplexId k=0; k<3; ++k){
+          for(SimplexId k=0; k<4; ++k){
             SimplexId tmp;
-            inputTriangulation_->getTriangleEdge(minStarId, k, tmp);
+            inputTriangulation_->getCellTriangle(minStarId, k, tmp);
             if(tmp == alpha){
               minAlphaLocalId = k;
               break;

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -188,7 +188,7 @@ int ttkDiscreteGradient::doIt(vector<vtkDataSet *> &inputs,
     return -1;
   }
 
-  if(input->GetNumberOfPoints()){
+  if(!input->GetNumberOfPoints()){
     cerr << "[ttkDiscreteGradient] Error: input has no point." << endl;
     return -1;
   }


### PR DESCRIPTION
Dear Julien,

I fixed some bugs in DiscreteGradient and integrated a new CMake cache variable called `TTK_ENABLE_DCG_OPTIMIZE_MEMORY` to enable some optimization concerning the memory consumption.