### PR TITLE
Fix for mandatory critical points

### DIFF
--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -12,6 +12,7 @@
 
 using namespace std;
 using namespace ttk;
+using namespace cf;
 
 Interface::Interface(const SimplexId &seed) : seed_(seed)
 {

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -26,6 +26,8 @@
 
 namespace ttk
 {
+namespace cf
+{
    // Classes Interface
    //         ContourForests
 
@@ -276,7 +278,8 @@ parallelParams_.nbInterfaces)
       // }
    };
 
-#include <ContourForestsTemplate.h>
 }
+}
+#include <ContourForestsTemplate.h>
 
 #endif

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -22,8 +22,10 @@
 
 #include "ContourForests.h"
 
-// TODO
-// Template wrapper
+namespace ttk
+{
+namespace cf
+{
 
 // ------------------- Contour Forests
 
@@ -525,5 +527,8 @@ speedProcess.cend());
 }
 
 //}
+
+}
+}
 
 #endif /* end of include guard: _CONTOURFORESTSTEMPLATE_H */

--- a/core/base/contourForestsTree/ContourForestsTree.cpp
+++ b/core/base/contourForestsTree/ContourForestsTree.cpp
@@ -12,6 +12,7 @@
 
 using namespace std;
 using namespace ttk;
+using namespace cf;
 
 ContourForestsTree::ContourForestsTree(
   Params *const params, Triangulation *mesh,

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -34,6 +34,8 @@
 
 namespace ttk
 {
+namespace cf
+{
    class ContourForestsTree : public MergeTree
    {
       friend class ContourForests;
@@ -120,6 +122,7 @@ namespace ttk
 
       // }
    };
+}
 }
 
 #endif  // CONTOURTREE_H

--- a/core/base/contourForestsTree/DeprecatedDataTypes.h
+++ b/core/base/contourForestsTree/DeprecatedDataTypes.h
@@ -26,6 +26,8 @@
 
 namespace ttk
 {
+namespace cf
+{
 
    // Types
    // --------
@@ -58,7 +60,7 @@ namespace ttk
    // QUESTION impact on performance using max (0 would be faster alloacted)
    static const idSuperArc     nullSuperArc       = std::numeric_limits<idSuperArc>::max();
    static const idNode         nullNodes          = std::numeric_limits<idNode>::max();
-   static const SimplexId       nullVertex         = std::numeric_limits<SimplexId>::max();
+   static const SimplexId      nullVertex         = std::numeric_limits<SimplexId>::max();
    static const idCorresp      nullCorresp        = std::numeric_limits<idCorresp>::max();
    static const idSegment      nullSegment        = std::numeric_limits<idSegment>::max();
    static const idInterface    nullInterface      = std::numeric_limits<idInterface>::max();
@@ -78,6 +80,7 @@ namespace ttk
    enum class TreeComponent { Arc = -1, Local_minimum, Saddle1, Saddle2, Local_maximum };
 
    enum class ArcType { Min_arc = 0, Max_arc, Saddle1_arc, Saddle2_arc, Saddle1_saddle2_arc };
+}
 }
 
 #endif /* end of include guard: DATATYPES_H */

--- a/core/base/contourForestsTree/DeprecatedNode.h
+++ b/core/base/contourForestsTree/DeprecatedNode.h
@@ -27,6 +27,8 @@
 
 namespace ttk
 {
+namespace cf
+{
 
    class Node
    {
@@ -317,6 +319,7 @@ namespace ttk
    };
 
 
+}
 }
 #endif /* end of include guard: NODE_H */
 

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -11,6 +11,7 @@
 
 using namespace std;
 using namespace ttk;
+using namespace cf;
 
 // -------
 // Segment

--- a/core/base/contourForestsTree/DeprecatedSegmentation.h
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.h
@@ -26,6 +26,8 @@
 
 namespace ttk
 {
+namespace cf
+{
 
   // one segment: like a std::vector<vertex>
   class Segment
@@ -87,6 +89,7 @@ namespace ttk
      // when and how to compact ?
      std::vector<vertex> segmentation_;  // SimplexId only ?
   };
+}
 }
 
 #endif /* end of include guard: SEGMENTATION_H_ */

--- a/core/base/contourForestsTree/DeprecatedStructures.h
+++ b/core/base/contourForestsTree/DeprecatedStructures.h
@@ -23,6 +23,8 @@
 
 namespace ttk
 {
+namespace cf
+{
    // Compute parameters (global)
    struct Params {
       int           debugLevel;
@@ -134,6 +136,7 @@ forward_(false)
           return sorted_iterator(segmentRevIterator(segmentBegin));
       }
    };
+}
 }
 
 #endif /* end of include guard: STRUCTURES_H */

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -29,6 +29,8 @@
 
 namespace ttk
 {
+namespace cf
+{
 
    class SuperArc
    {
@@ -449,6 +451,7 @@ make_move_iterator(b));
 
       //}
     };
+}
 }
 
 #endif /* end of include guard: SUPERARC_H */

--- a/core/base/contourForestsTree/ExtendedUF.h
+++ b/core/base/contourForestsTree/ExtendedUF.h
@@ -26,6 +26,8 @@
 
 namespace ttk
 {
+namespace cf
+{
    class ExtendedUnionFind
    {
      private:
@@ -146,6 +148,7 @@ namespace ttk
       };
 
    };
+}
 }
 
 #endif /* end of include guard: EXTENDEDUF_H */

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -9,6 +9,7 @@
 
 using namespace std;
 using namespace ttk;
+using namespace cf;
 
 // Constructors & destructors
 
@@ -1734,13 +1735,13 @@ bool MergeTree::verifyTree(void)
 
 // Operators
 
-ostream &ttk::operator<<(ostream &o, SuperArc const &a)
+ostream &ttk::cf::operator<<(ostream &o, SuperArc const &a)
 {
    o << a.getDownNodeId() << " <>> " << a.getUpNodeId();
    return o;
 }
 
-ostream &ttk::operator<<(ostream &o, Node const &n)
+ostream &ttk::cf::operator<<(ostream &o, Node const &n)
 {
    o << n.getNumberOfDownSuperArcs() << " .-. " << n.getNumberOfUpSuperArcs();
    return o;

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -51,6 +51,8 @@
 
 namespace ttk
 {
+namespace cf
+{
    class MergeTree : virtual public Debug
    {
       friend class ContourForests;
@@ -824,7 +826,9 @@ bool>> &pairs, const SimplexId &orig,
    std::ostream &operator<<(std::ostream &o, Node const &n);
    std::ostream &operator<<(std::ostream &o, SuperArc const &a);
 
-#include <MergeTreeTemplate.h>
 }
+}
+
+#include <MergeTreeTemplate.h>
 
 #endif /* end of include guard: MERGETREE_H */

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -23,6 +23,10 @@
 
 #include "MergeTree.h"
 
+namespace ttk
+{
+namespace cf
+{
 // Init
 // {
 
@@ -844,6 +848,8 @@ getValue<scalarType>(term)));
 }
 
 // }
+}
+}
 
 #endif /* end of include guard: MERGETREETEMPLATE_H */
 

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -2,6 +2,7 @@
 
 using namespace std;
 using namespace ttk;
+using namespace cf;
 
 vtkStandardNewMacro(ttkContourForests);
 

--- a/core/vtk/ttkContourForests/ttkContourForests.h
+++ b/core/vtk/ttkContourForests/ttkContourForests.h
@@ -32,7 +32,7 @@
 /// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
 /// Proc. of IEEE LDAV 2016.
 ///
-/// \sa ttk::ContourForests
+/// \sa ttk::cf::ContourForests
 
 #ifndef _TTK_CONTOURTREE_H
 #define _TTK_CONTOURTREE_H
@@ -142,7 +142,7 @@ class ttkContourForests
     void getTree();
     void updateTree();
     ttk::CriticalType getNodeType(ttk::SimplexId id);
-    ttk::CriticalType getNodeType(ttk::SimplexId id, ttk::TreeType type, ttk::MergeTree* tree);
+    ttk::CriticalType getNodeType(ttk::SimplexId id, ttk::cf::TreeType type, ttk::cf::MergeTree* tree);
     void getCriticalPoints();
     void clearTree();
 
@@ -186,8 +186,8 @@ class ttkContourForests
     std::string inputOffsetScalarFieldName_;
     bool isLoaded_;
     bool lessPartition_;
-    ttk::MergeTree* tree_;
-    ttk::ContourForests* contourTree_;
+    ttk::cf::MergeTree* tree_;
+    ttk::cf::ContourForests* contourTree_;
     vtkPolyData* skeletonNodes_;
     vtkPolyData* skeletonArcs_;
     vtkDataSet* segmentation_;
@@ -200,7 +200,7 @@ class ttkContourForests
     bool useInputOffsetScalarField_;
     bool varyingMesh_;
     bool varyingDataValues_;
-    ttk::TreeType treeType_;
+    ttk::cf::TreeType treeType_;
     std::string scalarField_;
     bool showMin_;
     bool showMax_;


### PR DESCRIPTION
Dear Julien,

The last commit (b19fb5b9d6ec4fd69274693a7bf30a1dcb5f80f0) introduced a bug in the mandatory critical point filter. This bug was due to a conflict between the classe `Node` in ***ContourTree.h*** and the class `Node` in ***ContourForestsTree.h*** (idem for the class `SuperArc`).
I have put ContourForests in its own namespace, as I did for FTM, and the issue is fixed.

Idea, could we add a namespace in the blank example so new filter could easily live in their own namespaces ?

Charles