### PR TITLE
FTM Tree minor fix for scalar arrays

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -467,7 +467,8 @@ struct VertData: public WrapperData {
       if (!params.segm)
          return;
 
-      pointData->SetScalars(ids);
+      pointData->AddArray(ids);
+      pointData->SetActiveScalars(ids->GetName());
 
       if (params.advStats) {
          pointData->AddArray(sizeRegion);


### PR DESCRIPTION
Dear Julien,

The use of SetScalars to set the active scalar array for the segmentation output implied the last active scalar was removed from the output data set. I have replaced it by an AddArray + SetActiveScalar to avoid this drawback.

Charles