### PR TITLE
core/base: Add missing OpenMP guards

### DIFF
--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -104,7 +104,9 @@ int ttk::TrackingFromFields::performDiagramComputation(
   const ttk::Wrapper *wrapper)
 {
 
-  #pragma omp parallel for num_threads(threadNumber_)
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
   for (int i = 0; i < fieldNumber; ++i)
   {
     ttk::PersistenceDiagram persistenceDiagram_;

--- a/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
+++ b/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
@@ -172,7 +172,9 @@ int ttk::TrackingFromPersistenceDiagrams::performMatchings(
   const ttk::Wrapper *wrapper)
 {
 
-  #pragma omp parallel for num_threads(threadNumber_)
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
   for (int i = 0; i < numInputs - 1; ++i)
   {
     performSingleMatching<dataType>(


### PR DESCRIPTION
Fix two compiler warnings appearing when compiling TTK with OpenMP
support disabled (TTK_ENABLE_OPENMP=OFF)

My first GitHub pull request :)