### PR TITLE
core/CMakeLists: Force generation of a compilation database

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,6 +9,9 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()
 
+# Generate a compilation database
+SET(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 option(TTK_ENABLE_64BIT_IDS "Enable processing on large datasets" OFF)
 mark_as_advanced(TTK_ENABLE_64BIT_IDS)
 


### PR DESCRIPTION
A compilation database is a small file usually called
compile_commands.json, located at the root of the build directory.

It contains compilation rules for every source file, including
definitions as passed by CMake, those being specific to the current
build directory.

Once generated, this file can be used by third-party tools like
clang-tidy [1] (a C/C++ code linter which detects code defects) or
language servers [2], such as RTags (for Emacs) and
clangd/cquery/ccls. Those can be used by code editors to provide them
IDE-like features (improved code completion, better warnings,
goto-definition).

[1] https://clang.llvm.org/extra/clang-tidy/
[2] https://langserver.org/