### PR TITLE
base/DimensionReduction.cpp: Fix type conversion compiler warning

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -109,7 +109,7 @@ int DimensionReduction::execute() const{
    string modulePath;
 
   if(PyArray_API==NULL){
-    import_array();
+    import_array1(-1);
   }
 
   // convert the input matrix into a NumPy array.


### PR DESCRIPTION
The Numpy import_array() macro executes a ```return NULL;``` statement when failing, thus forcing the caller ```int DimensionReduction::execute()``` to return a void pointer, that can be interpreted by its own caller as an 'return without error' signal.

The alternative macro import_array1() allows the user to set an integer return value, which matches better with the error code semantics used in TTK.

This alternative macro is available in Numpy since 2006 (v.1.0b3, c.f. https://scipy.github.io/old-wiki/pages/ReleaseNotes/NumPy_1.html).