### PR TITLE
Geometry: Template functions to extract a float version

### DIFF
--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -23,15 +23,18 @@ bool Geometry::areVectorsColinear(const T *vA0, const T *vA1, const T *vB0,
   vector<T> a(3), b(3);
   for (int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
-    if (fabs(a[i]) < pow10(-FLT_DIG))
+    if (fabs(a[i]) < pow10(-FLT_DIG)) {
       aNullComponents++;
+    }
     b[i] = vB1[i] - vB0[i];
-    if (fabs(b[i]) < pow10(-FLT_DIG))
+    if (fabs(b[i]) < pow10(-FLT_DIG)) {
       bNullComponents++;
+    }
   }
 
-  if ((aNullComponents == 3) || (bNullComponents == 3))
+  if ((aNullComponents == 3) || (bNullComponents == 3)) {
     return true;
+  }
 
   // check for axis aligned vectors
   if ((aNullComponents > 1) || (bNullComponents > 1)) {
@@ -84,8 +87,9 @@ bool Geometry::areVectorsColinear(const T *vA0, const T *vA1, const T *vB0,
   T colinearityThreshold;
 
   colinearityThreshold = pow10(-FLT_DIG);
-  if (tolerance)
+  if (tolerance) {
     colinearityThreshold = *tolerance;
+  }
 
   if (coefficients) {
     (*coefficients) = k;
@@ -101,8 +105,9 @@ bool Geometry::areVectorsColinear(const T *vA0, const T *vA1, const T *vB0,
     }
   } else {
     if (fabs(1 - fabs(k[(isNan + 1) % 3] / k[(isNan + 2) % 3])) <
-        colinearityThreshold)
+        colinearityThreshold) {
       return true;
+    }
   }
 
   k[0] = k[1] = k[2] = 0;
@@ -141,13 +146,15 @@ int Geometry::computeBarycentricCoordinates(const T *p0, const T *p1,
 
   // check if the point lies in the edge
   vector<T> test(dimension);
-  for (int i = 0; i < dimension; i++)
+  for (int i = 0; i < dimension; i++) {
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
+  }
 
   if ((!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG + 1)) &&
          (fabs(test[1] - p[1]) < pow(10, -FLT_DIG + 1))))) {
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < 2; i++) {
       baryCentrics[i] = -baryCentrics[i];
+    }
   }
 
   return 0;
@@ -174,8 +181,9 @@ int Geometry::computeBarycentricCoordinates(const T *p0, const T *p1,
 
       T denominator = fabs(baryCentrics[0]);
 
-      if (fabs(baryCentrics[1]) < denominator)
+      if (fabs(baryCentrics[1]) < denominator) {
         denominator = fabs(baryCentrics[1]);
+      }
 
       if ((i == 0) && (j == 1)) {
         maxDenominator = denominator;
@@ -208,15 +216,17 @@ int Geometry::computeBarycentricCoordinates(const T *p0, const T *p1,
 
   // check if the point lies in the triangle
   vector<T> test(3);
-  for (int i = 0; i < 3; i++)
+  for (int i = 0; i < 3; i++) {
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i] +
               baryCentrics[2] * p2[i];
+  }
 
   if (!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG)) &&
         (fabs(test[1] - p[1]) < pow(10, -FLT_DIG)) &&
         (fabs(test[2] - p[2]) < pow(10, -FLT_DIG)))) {
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 3; i++) {
       baryCentrics[i] = -1 - baryCentrics[i];
+    }
   }
 
   return 0;
@@ -230,20 +240,23 @@ bool Geometry::computeSegmentIntersection(const T &xA, const T &yA, const T &xB,
 
   T d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
 
-  if (fabs(d) < pow(10, -DBL_DIG))
+  if (fabs(d) < pow(10, -DBL_DIG)) {
     return false;
+  }
 
   x = ((xC - xD) * (xA * yB - yA * xB) - (xA - xB) * (xC * yD - yC * xD)) / d;
 
   y = ((yC - yD) * (xA * yB - yA * xB) - (yA - yB) * (xC * yD - yC * xD)) / d;
 
   if ((x < std::min(xA, xB) - pow10(-FLT_DIG)) ||
-      (x > std::max(xA, xB) + pow10(-FLT_DIG)))
+      (x > std::max(xA, xB) + pow10(-FLT_DIG))) {
     return false;
+  }
 
   if ((x < std::min(xC, xD) - pow10(-FLT_DIG)) ||
-      (x > std::max(xC, xD) + pow10(-FLT_DIG)))
+      (x > std::max(xC, xD) + pow10(-FLT_DIG))) {
     return false;
+  }
 
   return true;
 }
@@ -319,8 +332,9 @@ template <typename T>
 T Geometry::dotProduct(const T *vA0, const T *vA1, const T *vB0, const T *vB1) {
 
   T dotProduct = 0;
-  for (int i = 0; i < 3; i++)
+  for (int i = 0; i < 3; i++) {
     dotProduct += (vA1[i] - vA0[i]) * (vB1[i] - vB0[i]);
+  }
 
   return dotProduct;
 }
@@ -333,16 +347,17 @@ template <typename T>
 int Geometry::getBoundingBox(const vector<vector<float>> &points,
                              vector<pair<T, T>> &bBox) {
 
-  if (!points.size())
+  if (points.empty()) {
     return -1;
+  }
 
   int dimension = points[0].size();
 
   bBox.resize(dimension);
 
-  for (SimplexId i = 0; i < (SimplexId)points.size(); i++) {
+  for (SimplexId i = 0; i < static_cast<SimplexId>(points.size()); i++) {
 
-    if (!i) {
+    if (i == 0) {
       for (int j = 0; j < dimension; j++) {
         bBox[j].first = points[i][j];
         bBox[j].second = points[i][j];
@@ -370,11 +385,13 @@ bool Geometry::isPointInTriangle(const T *p0, const T *p1, const T *p2,
 
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
 
-  for (int i = 0; i < (int)barycentrics.size(); i++) {
-    if (barycentrics[i] < -pow10(-DBL_DIG))
+  for (int i = 0; i < static_cast<int>(barycentrics.size()); i++) {
+    if (barycentrics[i] < -pow10(-DBL_DIG)) {
       return false;
-    if (barycentrics[i] > 1 + pow10(-DBL_DIG))
+    }
+    if (barycentrics[i] > 1 + pow10(-DBL_DIG)) {
       return false;
+    }
   }
 
   return true;

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -8,10 +8,6 @@
 using namespace std;
 using namespace ttk;
 
-Geometry::Geometry() {}
-
-Geometry::~Geometry() {}
-
 double Geometry::angle(const double *vA0, const double *vA1, const double *vB0,
                        const double *vB1) {
 

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -8,20 +8,19 @@
 using namespace std;
 using namespace ttk;
 
-double Geometry::angle(const double *vA0, const double *vA1, const double *vB0,
-                       const double *vB1) {
-
+template <typename T>
+T Geometry::angle(const T *vA0, const T *vA1, const T *vB0, const T *vB1) {
   return M_PI - acos(dotProduct(vA0, vA1, vB0, vB1) /
                      (magnitude(vA0, vA1) * magnitude(vB0, vB1)));
 }
 
-bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
-                                  const double *vB0, const double *vB1,
-                                  vector<double> *coefficients,
-                                  const double *tolerance) {
+template <typename T>
+bool Geometry::areVectorsColinear(const T *vA0, const T *vA1, const T *vB0,
+                                  const T *vB1, vector<T> *coefficients,
+                                  const T *tolerance) {
 
   int aNullComponents = 0, bNullComponents = 0;
-  vector<double> a(3), b(3);
+  vector<T> a(3), b(3);
   for (int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
     if (fabs(a[i]) < pow10(-FLT_DIG))
@@ -43,7 +42,7 @@ bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
   }
 
   bool useDenominatorA = false;
-  double sumA = 0, sumB = 0;
+  T sumA = 0, sumB = 0;
   for (int i = 0; i < 3; i++) {
     sumA += fabs(a[i]);
     sumB += fabs(b[i]);
@@ -52,9 +51,9 @@ bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
     useDenominatorA = true;
   }
 
-  vector<double> k(3, 0);
+  vector<T> k(3, 0);
 
-  double maxDenominator = 0;
+  T maxDenominator = 0;
   int isNan = -1, maximizer = 0;
   for (int i = 0; i < 3; i++) {
     if (useDenominatorA) {
@@ -82,7 +81,7 @@ bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
     }
   }
 
-  double colinearityThreshold;
+  T colinearityThreshold;
 
   colinearityThreshold = pow10(-FLT_DIG);
   if (tolerance)
@@ -111,19 +110,19 @@ bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
   return false;
 }
 
-int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
-                                            const double *p,
-                                            vector<double> &baryCentrics,
+template <typename T>
+int Geometry::computeBarycentricCoordinates(const T *p0, const T *p1,
+                                            const T *p, vector<T> &baryCentrics,
                                             const int &dimension) {
 
   baryCentrics.resize(2);
 
   int bestI = 0;
-  double maxDenominator = 0;
+  T maxDenominator = 0;
 
   for (int i = 0; i < dimension; i++) {
 
-    double denominator = fabs(p0[i] - p1[i]);
+    T denominator = fabs(p0[i] - p1[i]);
     if (!i) {
       maxDenominator = denominator;
       bestI = i;
@@ -141,7 +140,7 @@ int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
   baryCentrics[1] = 1 - baryCentrics[0];
 
   // check if the point lies in the edge
-  vector<float> test(dimension);
+  vector<T> test(dimension);
   for (int i = 0; i < dimension; i++)
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
 
@@ -153,17 +152,17 @@ int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
 
   return 0;
 }
-
-int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
-                                            const double *p2, const double *p,
-                                            vector<double> &baryCentrics) {
+template <typename T>
+int Geometry::computeBarycentricCoordinates(const T *p0, const T *p1,
+                                            const T *p2, const T *p,
+                                            vector<T> &baryCentrics) {
 
   baryCentrics.resize(3);
 
   // find the pair of coordinates that maximize the sum of the denominators
   // (more stable computations)
   int bestI = 0, bestJ = 1;
-  double maxDenominator = 0;
+  T maxDenominator = 0;
 
   for (int i = 0; i < 2; i++) {
     for (int j = i + 1; j < 3; j++) {
@@ -173,7 +172,7 @@ int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
       baryCentrics[1] =
           (p1[j] - p2[j]) * (p0[i] - p2[i]) + (p2[i] - p1[i]) * (p0[j] - p2[j]);
 
-      double denominator = fabs(baryCentrics[0]);
+      T denominator = fabs(baryCentrics[0]);
 
       if (fabs(baryCentrics[1]) < denominator)
         denominator = fabs(baryCentrics[1]);
@@ -208,7 +207,7 @@ int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
   baryCentrics[2] = 1 - baryCentrics[0] - baryCentrics[1];
 
   // check if the point lies in the triangle
-  vector<float> test(3);
+  vector<T> test(3);
   for (int i = 0; i < 3; i++)
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i] +
               baryCentrics[2] * p2[i];
@@ -223,30 +222,13 @@ int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
   return 0;
 }
 
-int Geometry::computeBarycentricCoordinates(const float *p0, const float *p1,
-                                            const float *p2, const float *p,
-                                            vector<double> &baryCentrics) {
+template <typename T>
+bool Geometry::computeSegmentIntersection(const T &xA, const T &yA, const T &xB,
+                                          const T &yB, const T &xC, const T &yC,
+                                          const T &xD, const T &yD, T &x,
+                                          T &y) {
 
-  vector<double> P0(3), P1(3), P2(3), P(3);
-
-  for (int i = 0; i < 3; i++) {
-    P0[i] = p0[i];
-    P1[i] = p1[i];
-    P2[i] = p2[i];
-    P[i] = p[i];
-  }
-
-  return computeBarycentricCoordinates(P0.data(), P1.data(), P2.data(),
-                                       P.data(), baryCentrics);
-}
-
-bool Geometry::computeSegmentIntersection(const double &xA, const double &yA,
-                                          const double &xB, const double &yB,
-                                          const double &xC, const double &yC,
-                                          const double &xD, const double &yD,
-                                          double &x, double &y) {
-
-  double d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
+  T d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
 
   if (fabs(d) < pow(10, -DBL_DIG))
     return false;
@@ -266,10 +248,11 @@ bool Geometry::computeSegmentIntersection(const double &xA, const double &yA,
   return true;
 }
 
-int Geometry::computeTriangleArea(const double *p0, const double *p1,
-                                  const double *p2, double &area) {
+template <typename T>
+int Geometry::computeTriangleArea(const T *p0, const T *p1, const T *p2,
+                                  T &area) {
 
-  vector<double> cross;
+  vector<T> cross;
 
   crossProduct(p0, p1, p1, p2, cross);
 
@@ -278,8 +261,9 @@ int Geometry::computeTriangleArea(const double *p0, const double *p1,
   return 0;
 }
 
-int Geometry::computeTriangleAngles(const double *p0, const double *p1,
-                                    const double *p2, vector<double> &angles) {
+template <typename T>
+int Geometry::computeTriangleAngles(const T *p0, const T *p1, const T *p2,
+                                    vector<T> &angles) {
 
   angles.resize(3);
 
@@ -290,13 +274,13 @@ int Geometry::computeTriangleAngles(const double *p0, const double *p1,
   return 0;
 }
 
-int Geometry::crossProduct(const double *vA0, const double *vA1,
-                           const double *vB0, const double *vB1,
-                           vector<double> &crossProduct) {
+template <typename T>
+int Geometry::crossProduct(const T *vA0, const T *vA1, const T *vB0,
+                           const T *vB1, vector<T> &crossProduct) {
 
   crossProduct.resize(3);
 
-  vector<double> a(3), b(3);
+  vector<T> a(3), b(3);
 
   for (int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
@@ -311,30 +295,18 @@ int Geometry::crossProduct(const double *vA0, const double *vA1,
   return 0;
 }
 
-int Geometry::crossProduct(const double *vA, const double *vB,
-                           double *crossProduct) {
+template <typename T>
+int Geometry::crossProduct(const T *vA, const T *vB, T *crossProduct) {
   crossProduct[0] = vA[1] * vB[2] - vA[2] * vB[1];
   crossProduct[1] = vA[2] * vB[0] - vA[0] * vB[2];
   crossProduct[2] = vA[0] * vB[1] - vA[1] * vB[0];
   return 0;
 }
 
-double Geometry::distance(const double *p0, const double *p1,
-                          const int &dimension) {
+template <typename T>
+T Geometry::distance(const T *p0, const T *p1, const int &dimension) {
 
-  double distance = 0;
-
-  for (int i = 0; i < dimension; i++) {
-    distance += (p0[i] - p1[i]) * (p0[i] - p1[i]);
-  }
-
-  return sqrt(distance);
-}
-
-double Geometry::distance(const float *p0, const float *p1,
-                          const int &dimension) {
-
-  double distance = 0;
+  T distance = 0;
 
   for (int i = 0; i < dimension; i++) {
     distance += (p0[i] - p1[i]) * (p0[i] - p1[i]);
@@ -343,22 +315,23 @@ double Geometry::distance(const float *p0, const float *p1,
   return sqrt(distance);
 }
 
-double Geometry::dotProduct(const double *vA0, const double *vA1,
-                            const double *vB0, const double *vB1) {
+template <typename T>
+T Geometry::dotProduct(const T *vA0, const T *vA1, const T *vB0, const T *vB1) {
 
-  double dotProduct = 0;
+  T dotProduct = 0;
   for (int i = 0; i < 3; i++)
     dotProduct += (vA1[i] - vA0[i]) * (vB1[i] - vB0[i]);
 
   return dotProduct;
 }
 
-double Geometry::dotProduct(const double *vA, const double *vB) {
+template <typename T> T Geometry::dotProduct(const T *vA, const T *vB) {
   return vA[0] * vB[0] + vA[1] * vB[1] + vA[2] * vB[2];
 }
 
+template <typename T>
 int Geometry::getBoundingBox(const vector<vector<float>> &points,
-                             vector<pair<double, double>> &bBox) {
+                             vector<pair<T, T>> &bBox) {
 
   if (!points.size())
     return -1;
@@ -389,10 +362,11 @@ int Geometry::getBoundingBox(const vector<vector<float>> &points,
   return 0;
 }
 
-bool Geometry::isPointInTriangle(const double *p0, const double *p1,
-                                 const double *p2, const double *p) {
+template <typename T>
+bool Geometry::isPointInTriangle(const T *p0, const T *p1, const T *p2,
+                                 const T *p) {
 
-  vector<double> barycentrics;
+  vector<T> barycentrics;
 
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
 
@@ -406,28 +380,11 @@ bool Geometry::isPointInTriangle(const double *p0, const double *p1,
   return true;
 }
 
-bool Geometry::isPointInTriangle(const float *p0, const float *p1,
-                                 const float *p2, const float *p) {
+template <typename T>
+bool Geometry::isPointOnSegment(const T &x, const T &y, const T &xA,
+                                const T &yA, const T &xB, const T &yB) {
 
-  vector<double> barycentrics;
-
-  Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
-
-  for (int i = 0; i < (int)barycentrics.size(); i++) {
-    if (barycentrics[i] < -pow10(-FLT_DIG))
-      return false;
-    if (barycentrics[i] > 1 + pow10(-FLT_DIG))
-      return false;
-  }
-
-  return true;
-}
-
-bool Geometry::isPointOnSegment(const double &x, const double &y,
-                                const double &xA, const double &yA,
-                                const double &xB, const double &yB) {
-
-  vector<double> pA(2), pB(2), p(2);
+  vector<T> pA(2), pB(2), p(2);
 
   pA[0] = xA;
   pA[1] = yA;
@@ -441,10 +398,11 @@ bool Geometry::isPointOnSegment(const double &x, const double &y,
   return Geometry::isPointOnSegment(p.data(), pA.data(), pB.data(), 2);
 }
 
-bool Geometry::isPointOnSegment(const double *p, const double *pA,
-                                const double *pB, const int &dimension) {
+template <typename T>
+bool Geometry::isPointOnSegment(const T *p, const T *pA, const T *pB,
+                                const int &dimension) {
 
-  vector<double> baryCentrics;
+  vector<T> baryCentrics;
 
   Geometry::computeBarycentricCoordinates(pA, pB, p, baryCentrics, dimension);
 
@@ -454,12 +412,13 @@ bool Geometry::isPointOnSegment(const double *p, const double *pA,
            (baryCentrics[1] < 1 + pow10(-DBL_DIG))));
 }
 
-bool Geometry::isTriangleColinear(const double *p0, const double *p1,
-                                  const double *p2, const double *tolerance) {
+template <typename T>
+bool Geometry::isTriangleColinear(const T *p0, const T *p1, const T *p2,
+                                  const T *tolerance) {
 
   bool maxDecision = false;
-  double maxCoefficient = 0;
-  vector<double> coefficients(3);
+  T maxCoefficient = 0;
+  vector<T> coefficients(3);
 
   bool decision = areVectorsColinear(p0, p1, p1, p2, &coefficients, tolerance);
   maxDecision = decision;
@@ -494,9 +453,9 @@ bool Geometry::isTriangleColinear(const double *p0, const double *p1,
   return maxDecision;
 }
 
-double Geometry::magnitude(const double *v) {
+template <typename T> T Geometry::magnitude(const T *v) {
 
-  double mag = 0;
+  T mag = 0;
 
   for (int i = 0; i < 3; i++) {
     mag += v[i] * v[i];
@@ -505,9 +464,9 @@ double Geometry::magnitude(const double *v) {
   return sqrt(mag);
 }
 
-double Geometry::magnitude(const double *o, const double *d) {
+template <typename T> T Geometry::magnitude(const T *o, const T *d) {
 
-  double mag = 0;
+  T mag = 0;
 
   for (int i = 0; i < 3; i++) {
     mag += (o[i] - d[i]) * (o[i] - d[i]);
@@ -515,3 +474,114 @@ double Geometry::magnitude(const double *o, const double *d) {
 
   return sqrt(mag);
 }
+
+// explicit instantiations for double
+
+template double Geometry::angle<double>(double const *, double const *,
+                                        double const *, double const *);
+template bool
+Geometry::areVectorsColinear<double>(double const *, double const *,
+                                     double const *, double const *,
+                                     std::vector<double> *, double const *);
+template int Geometry::computeBarycentricCoordinates<double>(
+    double const *, double const *, double const *, std::vector<double> &,
+    int const &);
+// template int Geometry::computeBarycentricCoordinates<double>(
+//     double const &, double const &, double const &, double const &,
+//     double const &, double const &, std::vector<double> &);
+template int
+Geometry::computeBarycentricCoordinates<double>(double const *, double const *,
+                                                double const *, double const *,
+                                                std::vector<double> &);
+template bool Geometry::computeSegmentIntersection<double>(
+    double const &, double const &, double const &, double const &,
+    double const &, double const &, double const &, double const &, double &,
+    double &);
+template int Geometry::computeTriangleAngles<double>(double const *,
+                                                     double const *,
+                                                     double const *,
+                                                     std::vector<double> &);
+template int Geometry::computeTriangleArea<double>(double const *,
+                                                   double const *,
+                                                   double const *, double &);
+template int Geometry::crossProduct<double>(double const *, double const *,
+                                            double const *, double const *,
+                                            std::vector<double> &);
+template int Geometry::crossProduct<double>(double const *, double const *,
+                                            double *);
+template double Geometry::distance<double>(double const *, double const *,
+                                           int const &);
+template double Geometry::dotProduct<double>(double const *, double const *,
+                                             double const *, double const *);
+template double Geometry::dotProduct<double>(double const *, double const *);
+template int
+Geometry::getBoundingBox<double>(std::vector<std::vector<float>> const &,
+                                 std::vector<std::pair<double, double>> &);
+template bool Geometry::isPointInTriangle<double>(double const *,
+                                                  double const *,
+                                                  double const *,
+                                                  double const *);
+template bool Geometry::isPointOnSegment<double>(double const &, double const &,
+                                                 double const &, double const &,
+                                                 double const &,
+                                                 double const &);
+template bool Geometry::isPointOnSegment<double>(double const *, double const *,
+                                                 double const *, int const &);
+template bool Geometry::isTriangleColinear<double>(double const *,
+                                                   double const *,
+                                                   double const *,
+                                                   double const *);
+template double Geometry::magnitude<double>(double const *);
+template double Geometry::magnitude<double>(double const *, double const *);
+
+// explicit instantiations for float
+
+template float Geometry::angle<float>(float const *, float const *,
+                                      float const *, float const *);
+template bool Geometry::areVectorsColinear<float>(float const *, float const *,
+                                                  float const *, float const *,
+                                                  std::vector<float> *,
+                                                  float const *);
+template int Geometry::computeBarycentricCoordinates<float>(
+    float const *, float const *, float const *, std::vector<float> &,
+    int const &);
+// template int Geometry::computeBarycentricCoordinates<float>(
+//     float const &, float const &, float const &, float const &,
+//     float const &, float const &, std::vector<float> &);
+template int
+Geometry::computeBarycentricCoordinates<float>(float const *, float const *,
+                                               float const *, float const *,
+                                               std::vector<float> &);
+template bool Geometry::computeSegmentIntersection<float>(
+    float const &, float const &, float const &, float const &, float const &,
+    float const &, float const &, float const &, float &, float &);
+template int Geometry::computeTriangleAngles<float>(float const *,
+                                                    float const *,
+                                                    float const *,
+                                                    std::vector<float> &);
+template int Geometry::computeTriangleArea<float>(float const *, float const *,
+                                                  float const *, float &);
+template int Geometry::crossProduct<float>(float const *, float const *,
+                                           float const *, float const *,
+                                           std::vector<float> &);
+template int Geometry::crossProduct<float>(float const *, float const *,
+                                           float *);
+template float Geometry::distance<float>(float const *, float const *,
+                                         int const &);
+template float Geometry::dotProduct<float>(float const *, float const *,
+                                           float const *, float const *);
+template float Geometry::dotProduct<float>(float const *, float const *);
+template int
+Geometry::getBoundingBox<float>(std::vector<std::vector<float>> const &,
+                                std::vector<std::pair<float, float>> &);
+template bool Geometry::isPointInTriangle<float>(float const *, float const *,
+                                                 float const *, float const *);
+template bool Geometry::isPointOnSegment<float>(float const &, float const &,
+                                                float const &, float const &,
+                                                float const &, float const &);
+template bool Geometry::isPointOnSegment<float>(float const *, float const *,
+                                                float const *, int const &);
+template bool Geometry::isTriangleColinear<float>(float const *, float const *,
+                                                  float const *, float const *);
+template float Geometry::magnitude<float>(float const *);
+template float Geometry::magnitude<float>(float const *, float const *);

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -1,4 +1,4 @@
-#include                <Geometry.h>
+#include <Geometry.h>
 
 #include <algorithm>
 
@@ -8,196 +8,184 @@
 using namespace std;
 using namespace ttk;
 
-Geometry::Geometry(){ 
-  
+Geometry::Geometry() {}
+
+Geometry::~Geometry() {}
+
+double Geometry::angle(const double *vA0, const double *vA1, const double *vB0,
+                       const double *vB1) {
+
+  return M_PI - acos(dotProduct(vA0, vA1, vB0, vB1) /
+                     (magnitude(vA0, vA1) * magnitude(vB0, vB1)));
 }
 
-Geometry::~Geometry(){
-}
-
-double Geometry::angle(
-  const double *vA0, const double *vA1, 
-  const double *vB0, const double *vB1){
-
-  return M_PI - acos(
-    dotProduct(vA0, vA1, vB0, vB1)/
-    (magnitude(vA0, vA1)*magnitude(vB0, vB1)));
-}
-
-bool Geometry::areVectorsColinear(const double *vA0, const double *vA1, 
-  const double *vB0, const double *vB1, 
-  vector<double> *coefficients,
-  const double *tolerance){
+bool Geometry::areVectorsColinear(const double *vA0, const double *vA1,
+                                  const double *vB0, const double *vB1,
+                                  vector<double> *coefficients,
+                                  const double *tolerance) {
 
   int aNullComponents = 0, bNullComponents = 0;
   vector<double> a(3), b(3);
-  for(int i = 0; i < 3; i++){
+  for (int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
-    if(fabs(a[i]) < pow10(-FLT_DIG))
-      aNullComponents ++;
+    if (fabs(a[i]) < pow10(-FLT_DIG))
+      aNullComponents++;
     b[i] = vB1[i] - vB0[i];
-    if(fabs(b[i]) < pow10(-FLT_DIG))
-      bNullComponents ++;
+    if (fabs(b[i]) < pow10(-FLT_DIG))
+      bNullComponents++;
   }
-  
-  if((aNullComponents == 3)||(bNullComponents == 3))
+
+  if ((aNullComponents == 3) || (bNullComponents == 3))
     return true;
-  
+
   // check for axis aligned vectors
-  if((aNullComponents > 1)||(bNullComponents > 1)){
-    if(aNullComponents == bNullComponents){
+  if ((aNullComponents > 1) || (bNullComponents > 1)) {
+    if (aNullComponents == bNullComponents) {
       // only one non-null component for both vectors
       return true;
     }
   }
- 
+
   bool useDenominatorA = false;
   double sumA = 0, sumB = 0;
-  for(int i = 0; i < 3; i++){
+  for (int i = 0; i < 3; i++) {
     sumA += fabs(a[i]);
     sumB += fabs(b[i]);
   }
-  if(sumA > sumB){
+  if (sumA > sumB) {
     useDenominatorA = true;
   }
-  
+
   vector<double> k(3, 0);
- 
+
   double maxDenominator = 0;
   int isNan = -1, maximizer = 0;
-  for(int i = 0; i < 3; i++){
-    if(useDenominatorA){
-      if(fabs(a[i]) > pow10(-FLT_DIG)){
-        k[i] = b[i]/a[i];
-      }
-      else{
+  for (int i = 0; i < 3; i++) {
+    if (useDenominatorA) {
+      if (fabs(a[i]) > pow10(-FLT_DIG)) {
+        k[i] = b[i] / a[i];
+      } else {
         isNan = i;
-      } 
-    }
-    else{
-      if(fabs(b[i]) > pow10(-FLT_DIG)){
-        k[i] = a[i]/b[i];
       }
-      else{
+    } else {
+      if (fabs(b[i]) > pow10(-FLT_DIG)) {
+        k[i] = a[i] / b[i];
+      } else {
         isNan = i;
       }
     }
-    
-    if(!i){
+
+    if (!i) {
       maxDenominator = fabs(k[i]);
       maximizer = i;
-    }
-    else{
-      if(fabs(k[i]) > maxDenominator){
+    } else {
+      if (fabs(k[i]) > maxDenominator) {
         maxDenominator = fabs(k[i]);
         maximizer = i;
       }
     }
   }
-  
+
   double colinearityThreshold;
-  
+
   colinearityThreshold = pow10(-FLT_DIG);
-  if(tolerance)
+  if (tolerance)
     colinearityThreshold = *tolerance;
-  
-  if(coefficients){
+
+  if (coefficients) {
     (*coefficients) = k;
   }
-  
-  if(isNan == -1){
-   
-    if((fabs(1 - fabs(k[(maximizer+1)%3]/k[maximizer])) < colinearityThreshold)
-      &&(fabs(1 - fabs(k[(maximizer+2)%3]/k[maximizer])) 
-        < colinearityThreshold)){
+
+  if (isNan == -1) {
+
+    if ((fabs(1 - fabs(k[(maximizer + 1) % 3] / k[maximizer])) <
+         colinearityThreshold) &&
+        (fabs(1 - fabs(k[(maximizer + 2) % 3] / k[maximizer])) <
+         colinearityThreshold)) {
       return true;
     }
-  }
-  else{
-    if(fabs(1 - fabs(k[(isNan+1)%3]/k[(isNan+2)%3])) < colinearityThreshold)
+  } else {
+    if (fabs(1 - fabs(k[(isNan + 1) % 3] / k[(isNan + 2) % 3])) <
+        colinearityThreshold)
       return true;
   }
 
   k[0] = k[1] = k[2] = 0;
-  
+
   return false;
 }
 
-int Geometry::computeBarycentricCoordinates(
-  const double *p0, const double *p1, const double *p, 
-  vector<double> &baryCentrics, const int &dimension){
+int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
+                                            const double *p,
+                                            vector<double> &baryCentrics,
+                                            const int &dimension) {
 
   baryCentrics.resize(2);
-  
+
   int bestI = 0;
   double maxDenominator = 0;
-  
-  for(int i = 0; i < dimension; i++){
-    
+
+  for (int i = 0; i < dimension; i++) {
+
     double denominator = fabs(p0[i] - p1[i]);
-    if(!i){
+    if (!i) {
       maxDenominator = denominator;
       bestI = i;
-    }
-    else{
-      if(denominator > maxDenominator){
+    } else {
+      if (denominator > maxDenominator) {
         maxDenominator = denominator;
         bestI = i;
       }
     }
   }
-  
+
   baryCentrics[0] = p0[bestI] - p1[bestI];
-  baryCentrics[0] = (p[bestI] - p1[bestI])/baryCentrics[0];
-  
+  baryCentrics[0] = (p[bestI] - p1[bestI]) / baryCentrics[0];
+
   baryCentrics[1] = 1 - baryCentrics[0];
-  
-  
+
   // check if the point lies in the edge
   vector<float> test(dimension);
-  for(int i = 0; i < dimension; i++)
-    test[i] = 
-      baryCentrics[0]*p0[i] + baryCentrics[1]*p1[i];
-     
-  if((!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG+1))
-    &&(fabs(test[1] - p[1]) < pow(10, -FLT_DIG+1))))
-    ){
-    for(int i = 0; i < 2; i++) baryCentrics[i] = -baryCentrics[i];
+  for (int i = 0; i < dimension; i++)
+    test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
+
+  if ((!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG + 1)) &&
+         (fabs(test[1] - p[1]) < pow(10, -FLT_DIG + 1))))) {
+    for (int i = 0; i < 2; i++)
+      baryCentrics[i] = -baryCentrics[i];
   }
-  
+
   return 0;
 }
 
-
-int Geometry::computeBarycentricCoordinates(
-  const double *p0, const double *p1, const double *p2, const double *p, 
-  vector<double> &baryCentrics){
+int Geometry::computeBarycentricCoordinates(const double *p0, const double *p1,
+                                            const double *p2, const double *p,
+                                            vector<double> &baryCentrics) {
 
   baryCentrics.resize(3);
- 
+
   // find the pair of coordinates that maximize the sum of the denominators
   // (more stable computations)
   int bestI = 0, bestJ = 1;
   double maxDenominator = 0;
-  
-  for(int i = 0; i < 2; i++){
-    for(int j = i + 1; j < 3; j++){
-      
-      baryCentrics[0] = (p1[j] - p2[j])*(p0[i] - p2[i])
-        + (p2[i] - p1[i])*(p0[j] - p2[j]);
-      baryCentrics[1] = (p1[j] - p2[j])*(p0[i] - p2[i])
-        + (p2[i] - p1[i])*(p0[j] - p2[j]);
-        
+
+  for (int i = 0; i < 2; i++) {
+    for (int j = i + 1; j < 3; j++) {
+
+      baryCentrics[0] =
+          (p1[j] - p2[j]) * (p0[i] - p2[i]) + (p2[i] - p1[i]) * (p0[j] - p2[j]);
+      baryCentrics[1] =
+          (p1[j] - p2[j]) * (p0[i] - p2[i]) + (p2[i] - p1[i]) * (p0[j] - p2[j]);
+
       double denominator = fabs(baryCentrics[0]);
-      
-      if(fabs(baryCentrics[1]) < denominator)
+
+      if (fabs(baryCentrics[1]) < denominator)
         denominator = fabs(baryCentrics[1]);
-        
-      if((i == 0)&&(j == 1)){
+
+      if ((i == 0) && (j == 1)) {
         maxDenominator = denominator;
-      }
-      else{
-        if(denominator > maxDenominator){
+      } else {
+        if (denominator > maxDenominator) {
           maxDenominator = denominator;
           bestI = i;
           bestJ = j;
@@ -205,352 +193,329 @@ int Geometry::computeBarycentricCoordinates(
       }
     }
   }
-  
-  baryCentrics[0] = (p1[bestJ] - p2[bestJ])*(p0[bestI] - p2[bestI])
-    + (p2[bestI] - p1[bestI])*(p0[bestJ] - p2[bestJ]);
+
+  baryCentrics[0] = (p1[bestJ] - p2[bestJ]) * (p0[bestI] - p2[bestI]) +
+                    (p2[bestI] - p1[bestI]) * (p0[bestJ] - p2[bestJ]);
   // (y1 - y2)*(x - x2) + (x2 - x1)*(y - y2)
-  baryCentrics[0] = ((p1[bestJ] - p2[bestJ])*(p[bestI] - p2[bestI]) 
-    + (p2[bestI] - p1[bestI])*(p[bestJ] - p2[bestJ]))/baryCentrics[0];
-  
+  baryCentrics[0] = ((p1[bestJ] - p2[bestJ]) * (p[bestI] - p2[bestI]) +
+                     (p2[bestI] - p1[bestI]) * (p[bestJ] - p2[bestJ])) /
+                    baryCentrics[0];
+
   // (y1 - y2)*(x0 - x2) + (x2 - x1)*(y0 - y2)
-  baryCentrics[1] = (p1[bestJ] - p2[bestJ])*(p0[bestI] - p2[bestI])
-    + (p2[bestI] - p1[bestI])*(p0[bestJ] - p2[bestJ]);
+  baryCentrics[1] = (p1[bestJ] - p2[bestJ]) * (p0[bestI] - p2[bestI]) +
+                    (p2[bestI] - p1[bestI]) * (p0[bestJ] - p2[bestJ]);
   // (y2 - y0)*(x - x2) + (x0 - x2)*(y - y2)
-  baryCentrics[1] = ((p2[bestJ] - p0[bestJ])*(p[bestI] - p2[bestI])
-    + (p0[bestI] - p2[bestI])*(p[bestJ] - p2[bestJ]))/baryCentrics[1];
-    
+  baryCentrics[1] = ((p2[bestJ] - p0[bestJ]) * (p[bestI] - p2[bestI]) +
+                     (p0[bestI] - p2[bestI]) * (p[bestJ] - p2[bestJ])) /
+                    baryCentrics[1];
+
   baryCentrics[2] = 1 - baryCentrics[0] - baryCentrics[1];
-  
+
   // check if the point lies in the triangle
   vector<float> test(3);
-  for(int i = 0; i < 3; i++)
-    test[i] = 
-      baryCentrics[0]*p0[i] + baryCentrics[1]*p1[i] + baryCentrics[2]*p2[i];
-     
-  if(!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG))
-    &&(fabs(test[1] - p[1]) < pow(10  , -FLT_DIG))
-    &&(fabs(test[2] - p[2]) < pow(10, -FLT_DIG)))){
-    for(int i = 0; i < 3; i++) baryCentrics[i] = -1 - baryCentrics[i];
+  for (int i = 0; i < 3; i++)
+    test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i] +
+              baryCentrics[2] * p2[i];
+
+  if (!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG)) &&
+        (fabs(test[1] - p[1]) < pow(10, -FLT_DIG)) &&
+        (fabs(test[2] - p[2]) < pow(10, -FLT_DIG)))) {
+    for (int i = 0; i < 3; i++)
+      baryCentrics[i] = -1 - baryCentrics[i];
   }
-  
+
   return 0;
 }
 
-int Geometry::computeBarycentricCoordinates(
-  const float *p0, const float *p1, const float *p2, const float *p, 
-  vector<double> &baryCentrics){
+int Geometry::computeBarycentricCoordinates(const float *p0, const float *p1,
+                                            const float *p2, const float *p,
+                                            vector<double> &baryCentrics) {
 
   vector<double> P0(3), P1(3), P2(3), P(3);
-  
-  for(int i = 0; i < 3; i++){
+
+  for (int i = 0; i < 3; i++) {
     P0[i] = p0[i];
     P1[i] = p1[i];
     P2[i] = p2[i];
     P[i] = p[i];
   }
-  
-  return computeBarycentricCoordinates(
-    P0.data(), P1.data(), P2.data(), P.data(), baryCentrics);
+
+  return computeBarycentricCoordinates(P0.data(), P1.data(), P2.data(),
+                                       P.data(), baryCentrics);
 }
 
-bool Geometry::computeSegmentIntersection(
-  const double &xA, const double &yA, const double &xB, const double &yB,
-  const double &xC, const double &yC, const double &xD, const double &yD,
-  double &x, double &y){
+bool Geometry::computeSegmentIntersection(const double &xA, const double &yA,
+                                          const double &xB, const double &yB,
+                                          const double &xC, const double &yC,
+                                          const double &xD, const double &yD,
+                                          double &x, double &y) {
 
-  double d = (xA - xB)
-    *(yC - yD) 
-    - 
-    (yA - yB)
-    *(xC- xD);
- 
-  if(fabs(d) < pow(10, -DBL_DIG))
+  double d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
+
+  if (fabs(d) < pow(10, -DBL_DIG))
     return false;
-  
-  x = 
-    ((xC - xD)
-      *(xA*yB 
-        - yA*xB)
-      - (xA - xB)
-        *(xC*yD 
-          - yC*xD))/d;
-          
-  y = 
-    ((yC - yD)
-      *(xA*yB
-        - yA*xB)
-      - (yA - yB)
-        *(xC*yD
-          - yC*xD))/d;
-  
-  if((x < std::min(xA, xB) - pow10(-FLT_DIG))
-    ||(x > std::max(xA, xB) + pow10(-FLT_DIG)))
+
+  x = ((xC - xD) * (xA * yB - yA * xB) - (xA - xB) * (xC * yD - yC * xD)) / d;
+
+  y = ((yC - yD) * (xA * yB - yA * xB) - (yA - yB) * (xC * yD - yC * xD)) / d;
+
+  if ((x < std::min(xA, xB) - pow10(-FLT_DIG)) ||
+      (x > std::max(xA, xB) + pow10(-FLT_DIG)))
     return false;
-          
-  if((x < std::min(xC, xD) - pow10(-FLT_DIG))
-    ||(x > std::max(xC, xD) + pow10(-FLT_DIG)))
+
+  if ((x < std::min(xC, xD) - pow10(-FLT_DIG)) ||
+      (x > std::max(xC, xD) + pow10(-FLT_DIG)))
     return false;
-    
+
   return true;
 }
 
-int Geometry::computeTriangleArea(
-  const double *p0, const double *p1, const double *p2, 
-  double &area){
-  
+int Geometry::computeTriangleArea(const double *p0, const double *p1,
+                                  const double *p2, double &area) {
+
   vector<double> cross;
-  
+
   crossProduct(p0, p1, p1, p2, cross);
-  
-  area = 0.5*magnitude(cross.data());
-  
+
+  area = 0.5 * magnitude(cross.data());
+
   return 0;
 }
 
-int Geometry::computeTriangleAngles(
-  const double *p0, const double *p1, const double *p2, 
-  vector<double> &angles){
+int Geometry::computeTriangleAngles(const double *p0, const double *p1,
+                                    const double *p2, vector<double> &angles) {
 
   angles.resize(3);
- 
+
   angles[0] = angle(p0, p1, p1, p2);
   angles[1] = angle(p1, p2, p2, p0);
   angles[2] = angle(p2, p0, p0, p1);
-  
+
   return 0;
 }
 
 int Geometry::crossProduct(const double *vA0, const double *vA1,
-  const double *vB0, const double *vB1,
-  vector<double> &crossProduct){
-  
+                           const double *vB0, const double *vB1,
+                           vector<double> &crossProduct) {
+
   crossProduct.resize(3);
- 
+
   vector<double> a(3), b(3);
-  
-  for(int i = 0; i < 3; i++){
+
+  for (int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
     b[i] = vB1[i] - vB0[i];
   }
-  
-  for(int i = 0; i < 3; i++){
-    crossProduct[i] = 
-      a[(i+1)%3]*b[(i+2)%3] - a[(i+2)%3]*b[(i+1)%3];
+
+  for (int i = 0; i < 3; i++) {
+    crossProduct[i] =
+        a[(i + 1) % 3] * b[(i + 2) % 3] - a[(i + 2) % 3] * b[(i + 1) % 3];
   }
-  
+
   return 0;
 }
 
 int Geometry::crossProduct(const double *vA, const double *vB,
-		double *crossProduct){
-	crossProduct[0]=vA[1]*vB[2]-vA[2]*vB[1];
-	crossProduct[1]=vA[2]*vB[0]-vA[0]*vB[2];
-	crossProduct[2]=vA[0]*vB[1]-vA[1]*vB[0];
-	return 0;
+                           double *crossProduct) {
+  crossProduct[0] = vA[1] * vB[2] - vA[2] * vB[1];
+  crossProduct[1] = vA[2] * vB[0] - vA[0] * vB[2];
+  crossProduct[2] = vA[0] * vB[1] - vA[1] * vB[0];
+  return 0;
 }
 
-double Geometry::distance(const double *p0, const double *p1, 
-  const int &dimension){
+double Geometry::distance(const double *p0, const double *p1,
+                          const int &dimension) {
 
   double distance = 0;
-  
-  for(int i = 0; i < dimension; i++){
-    distance += (p0[i] - p1[i])*(p0[i] - p1[i]);
+
+  for (int i = 0; i < dimension; i++) {
+    distance += (p0[i] - p1[i]) * (p0[i] - p1[i]);
   }
-  
+
   return sqrt(distance);
 }
 
-double Geometry::distance(const float *p0, const float *p1, 
-  const int &dimension){
+double Geometry::distance(const float *p0, const float *p1,
+                          const int &dimension) {
 
   double distance = 0;
-  
-  for(int i = 0; i < dimension; i++){
-    distance += (p0[i] - p1[i])*(p0[i] - p1[i]);
+
+  for (int i = 0; i < dimension; i++) {
+    distance += (p0[i] - p1[i]) * (p0[i] - p1[i]);
   }
-  
+
   return sqrt(distance);
 }
 
-double Geometry::dotProduct(
-  const double *vA0, const double *vA1, 
-  const double *vB0, const double *vB1){
+double Geometry::dotProduct(const double *vA0, const double *vA1,
+                            const double *vB0, const double *vB1) {
 
   double dotProduct = 0;
-  for(int i = 0; i < 3; i++)
-    dotProduct += (vA1[i] - vA0[i])*(vB1[i] - vB0[i]);
-    
+  for (int i = 0; i < 3; i++)
+    dotProduct += (vA1[i] - vA0[i]) * (vB1[i] - vB0[i]);
+
   return dotProduct;
 }
 
-double Geometry::dotProduct(const double *vA,
-		const double *vB){
-		return vA[0]*vB[0]+vA[1]*vB[1]+vA[2]*vB[2];
+double Geometry::dotProduct(const double *vA, const double *vB) {
+  return vA[0] * vB[0] + vA[1] * vB[1] + vA[2] * vB[2];
 }
 
-int Geometry::getBoundingBox(const vector<vector<float> > &points, 
-  vector<pair<double, double>> &bBox){
+int Geometry::getBoundingBox(const vector<vector<float>> &points,
+                             vector<pair<double, double>> &bBox) {
 
-  if(!points.size())
+  if (!points.size())
     return -1;
-  
+
   int dimension = points[0].size();
-  
+
   bBox.resize(dimension);
-  
-  for(SimplexId i = 0; i < (SimplexId) points.size(); i++){
-      
-    if(!i){
-      for(int j = 0; j < dimension; j++){
+
+  for (SimplexId i = 0; i < (SimplexId)points.size(); i++) {
+
+    if (!i) {
+      for (int j = 0; j < dimension; j++) {
         bBox[j].first = points[i][j];
         bBox[j].second = points[i][j];
       }
-    }
-    else{
-      for(int j = 0; j < dimension; j++){
-        if(points[i][j] < bBox[j].first){
+    } else {
+      for (int j = 0; j < dimension; j++) {
+        if (points[i][j] < bBox[j].first) {
           bBox[j].first = points[i][j];
         }
-        if(points[i][j] > bBox[j].second){
+        if (points[i][j] > bBox[j].second) {
           bBox[j].second = points[i][j];
         }
       }
     }
   }
-  
+
   return 0;
 }
 
-bool Geometry::isPointInTriangle(const double *p0, 
-  const double *p1, const double *p2, const double *p){
+bool Geometry::isPointInTriangle(const double *p0, const double *p1,
+                                 const double *p2, const double *p) {
 
   vector<double> barycentrics;
-  
+
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
-  
-  for(int i = 0; i < (int) barycentrics.size(); i++){
-    if(barycentrics[i] < -pow10(-DBL_DIG))
+
+  for (int i = 0; i < (int)barycentrics.size(); i++) {
+    if (barycentrics[i] < -pow10(-DBL_DIG))
       return false;
-    if(barycentrics[i] > 1 + pow10(-DBL_DIG))
+    if (barycentrics[i] > 1 + pow10(-DBL_DIG))
       return false;
   }
-    
+
   return true;
 }
 
-bool Geometry::isPointInTriangle(const float *p0, 
-  const float *p1, const float *p2, const float *p){
+bool Geometry::isPointInTriangle(const float *p0, const float *p1,
+                                 const float *p2, const float *p) {
 
   vector<double> barycentrics;
-  
+
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
-  
-  for(int i = 0; i < (int) barycentrics.size(); i++){
-    if(barycentrics[i] < -pow10(-FLT_DIG))
+
+  for (int i = 0; i < (int)barycentrics.size(); i++) {
+    if (barycentrics[i] < -pow10(-FLT_DIG))
       return false;
-    if(barycentrics[i] > 1 + pow10(-FLT_DIG))
+    if (barycentrics[i] > 1 + pow10(-FLT_DIG))
       return false;
   }
-    
+
   return true;
 }
 
 bool Geometry::isPointOnSegment(const double &x, const double &y,
-  const double &xA, const double &yA, const double &xB, const double &yB){
-    
-  
+                                const double &xA, const double &yA,
+                                const double &xB, const double &yB) {
+
   vector<double> pA(2), pB(2), p(2);
-  
+
   pA[0] = xA;
   pA[1] = yA;
-  
+
   pB[0] = xB;
   pB[1] = yB;
-  
+
   p[0] = x;
   p[1] = y;
-  
-  
+
   return Geometry::isPointOnSegment(p.data(), pA.data(), pB.data(), 2);
 }
 
-bool Geometry::isPointOnSegment(const double *p, 
-  const double *pA, const double *pB, const int &dimension){
+bool Geometry::isPointOnSegment(const double *p, const double *pA,
+                                const double *pB, const int &dimension) {
 
   vector<double> baryCentrics;
-  
-  Geometry::computeBarycentricCoordinates(pA, pB, p,
-    baryCentrics, dimension);
-  
-  return (((baryCentrics[0] > -pow10(-DBL_DIG))
-    &&(baryCentrics[0] < 1 + pow10(-DBL_DIG)))
-    &&
-    ((baryCentrics[1] > -pow10(-DBL_DIG))
-    &&(baryCentrics[1] < 1 + pow10(-DBL_DIG))));
+
+  Geometry::computeBarycentricCoordinates(pA, pB, p, baryCentrics, dimension);
+
+  return (((baryCentrics[0] > -pow10(-DBL_DIG)) &&
+           (baryCentrics[0] < 1 + pow10(-DBL_DIG))) &&
+          ((baryCentrics[1] > -pow10(-DBL_DIG)) &&
+           (baryCentrics[1] < 1 + pow10(-DBL_DIG))));
 }
 
+bool Geometry::isTriangleColinear(const double *p0, const double *p1,
+                                  const double *p2, const double *tolerance) {
 
-bool Geometry::isTriangleColinear(
-  const double *p0, const double *p1, const double *p2, 
-  const double *tolerance){
- 
   bool maxDecision = false;
   double maxCoefficient = 0;
   vector<double> coefficients(3);
-  
+
   bool decision = areVectorsColinear(p0, p1, p1, p2, &coefficients, tolerance);
   maxDecision = decision;
-  for(int i = 0; i < 3; i++){
-    if(!i){
+  for (int i = 0; i < 3; i++) {
+    if (!i) {
       maxCoefficient = fabs(coefficients[i]);
       maxDecision = decision;
-    }
-    else{
-      if(fabs(coefficients[i]) > maxCoefficient){
+    } else {
+      if (fabs(coefficients[i]) > maxCoefficient) {
         maxCoefficient = fabs(coefficients[i]);
         maxDecision = decision;
       }
     }
   }
-  
+
   decision = areVectorsColinear(p0, p2, p2, p1, &coefficients, tolerance);
-  for(int i = 0; i < 3; i++){
-    if(fabs(coefficients[i]) > maxCoefficient){
+  for (int i = 0; i < 3; i++) {
+    if (fabs(coefficients[i]) > maxCoefficient) {
       maxCoefficient = fabs(coefficients[i]);
       maxDecision = decision;
     }
   }
-  
+
   decision = areVectorsColinear(p1, p0, p0, p2, &coefficients, tolerance);
-  for(int i = 0; i < 3; i++){
-    if(fabs(coefficients[i]) > maxCoefficient){
+  for (int i = 0; i < 3; i++) {
+    if (fabs(coefficients[i]) > maxCoefficient) {
       maxCoefficient = fabs(coefficients[i]);
       maxDecision = decision;
     }
   }
-  
+
   return maxDecision;
 }
 
-double Geometry::magnitude(const double *v){
-  
+double Geometry::magnitude(const double *v) {
+
   double mag = 0;
-  
-  for(int i = 0; i < 3; i++){
-    mag += v[i]*v[i];
+
+  for (int i = 0; i < 3; i++) {
+    mag += v[i] * v[i];
   }
-  
+
   return sqrt(mag);
 }
 
-double Geometry::magnitude(const double *o, const double *d){
+double Geometry::magnitude(const double *o, const double *d) {
 
   double mag = 0;
-  
-  for(int i = 0; i < 3; i++){
-    mag += (o[i] - d[i])*(o[i] - d[i]);
+
+  for (int i = 0; i < 3; i++) {
+    mag += (o[i] - d[i]) * (o[i] - d[i]);
   }
-  
+
   return sqrt(mag);
 }

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -2,272 +2,264 @@
 /// \class ttk::Geometry
 /// \author Julien Tierny <julien.tierny@lip6.fr>
 /// \date February 2016.
-/// 
-/// \brief Minimalist class that handles simple geometric computations 
+///
+/// \brief Minimalist class that handles simple geometric computations
 /// (operations on std::vectors, barycentric coordinates, etc.).
 ///
-#ifndef                 _GEOMETRY_H
-#define                 _GEOMETRY_H
+#ifndef _GEOMETRY_H
+#define _GEOMETRY_H
 
-#include                <Debug.h>
+#include <Debug.h>
 
-namespace ttk{
+namespace ttk {
 
-  class Geometry : public Debug{
-    
-    public:
-      
-      // 1) constructors, destructors, operators, etc.
-      Geometry();
-      
-      virtual ~Geometry();
-     
-      /// Compute the angle between two std::vectors
-      /// \param vA0 xyz coordinates of vA's origin
-      /// \param vA1 xyz coordinates of vA's destination
-      /// \param vB0 xyz coordinates of vB's origin
-      /// \param vB1 xyz coordinates of vB's destination
-      static double angle(
-        const double *vA0, const double *vA1, 
-        const double *vB0, const double *vB1);
-      
-      /// Check if two 3D std::vectors vA and vB are colinear.
-      /// \param vA0 xyz coordinates of vA's origin
-      /// \param vA1 xyz coordinates of vA's destination
-      /// \param vB0 xyz coordinates of vB's origin
-      /// \param vB1 xyz coordinates of vB's destination
-      /// \param coefficients Optional output std::vector of colinearity 
-      /// coefficients.
-      /// \returns Returns true if the std::vectors are colinear, false 
-      /// otherwise.
-      static bool areVectorsColinear(const double *vA0, const double *vA1,
-        const double *vB0, const double *vB1, 
-        std::vector<double> *coefficients = NULL, 
-        const double *tolerance = NULL);
-      
-      /// Compute the barycentric coordinates of point \p p with regard to the 
-      /// edge defined by the 3D points \p p0 and \p p1.
-      /// \param p0 xyz coordinates of the first vertex of the edge 
-      /// \param p1 xyz coordinates of the second vertex of the edge
-      /// \param p xyz coordinates of the queried point
-      /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-      /// \p p belongs to the edge).
-      /// \param dimension Optional parameter that specifies the dimension of 
-      /// the point set (by default 3).
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int computeBarycentricCoordinates(
-        const double *p0, const double *p1, const double *p,
-        std::vector<double> &baryCentrics, const int &dimension = 3);
-      
-      /// Compute the barycentric coordinates of point \p xyz with regard to
-      /// the edge defined by the points \p xy0 and \p xy1.
-      /// \param x0 x coordinate of the first vertex of the edge 
-      /// \param y0 y coordinate of the first vertex of the edge
-      /// \param x1 x coordinate of the second vertex of the edge
-      /// \param y1 y coordinate of the second vertex of the edge
-      /// \param x x coordinate of the queried point
-      /// \param y y coordinate of the queried point
-      /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-      /// \p p belongs to the edge).
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int computeBarycentricCoordinates(
-        const double &x0, const double &y0,
-        const double &x1, const double &y1,
-        const double &x, const double &y,
-        std::vector<double> &baryCentrics);
-      
-      /// Compute the barycentric coordinates of point \p p with regard to the 
-      /// triangle defined by the 3D points \p p0, \p p1, and \p p2.
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param p xyz coordinates of the queried point
-      /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-      /// \p p belongs to the triangle).
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int computeBarycentricCoordinates(
-        const double *p0, const double *p1, const double *p2,
-        const double *p,
-        std::vector<double> &baryCentrics);
-      
-      /// Compute the barycentric coordinates of point \p p with regard to the 
-      /// triangle defined by the points \p p0, \p p1, and \p p2.
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param p xyz coordinates of the queried point
-      /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-      /// \p p belongs to the triangle).
-      /// \return Returns 0 upon success, negative values otherwise.
-      /// \note Backward compatibility.
-      static int computeBarycentricCoordinates(
-        const float *p0, const float *p1, const float *p2,
-        const float *p,
-        std::vector<double> &baryCentrics);
-      
-      /// Compute the intersection between two 2D segments AB and CD.
-      /// \param xA x coordinate of the first vertex of the first segment (AB)
-      /// \param yA y coordinate of the first vertex of the first segment (AB)
-      /// \param xB x coordinate of the second vertex of the first segment (AB)
-      /// \param yB y coordinate of the second vertex of the first segment (AB)
-      /// \param xC x coordinate of the first vertex of the second segment (CD)
-      /// \param yC y coordinate of the first vertex of the second segment (CD)
-      /// \param xD x coordinate of the second vertex of the second segment (CD)
-      /// \param yD y coordinate of the second vertex of the second segment (CD)
-      /// \param x x coordinate of the output intersection (if any).
-      /// \param y y coordinate of the output intersection (if any).
-      /// \return Returns true if the segments intersect (false otherwise).
-      static bool computeSegmentIntersection(
-        const double &xA, const double &yA, const double &xB, const double &yB,
-        const double &xC, const double &yC, const double &xD, const double &yD,
-        double &x, double &y);
-     
-      /// Compute the angles of a triangle
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param angles Angles (p0p1, p1p2) (p1p2, p2p0) (p2p0, p0p1)
-      static int computeTriangleAngles(
-        const double *p0, const double *p1, const double *p2,
-        std::vector<double> &angles);
-      
-      /// Compute the area of a 3D triangle.
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param area Output area.
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int computeTriangleArea(
-        const double *p0, const double *p1, const double *p2,
-        double &area);
-      
-      /// Compute the cross product of two 3D std::vectors
-      /// \param vA0 xyz coordinates of vA's origin
-      /// \param vA1 xyz coordinates of vA's destination
-      /// \param vB0 xyz coordinates of vB's origin
-      /// \param vB1 xyz coordinates of vB's destination
-      /// \param crossProduct Output cross product.
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int crossProduct(
-        const double *vA0, const double *vA1, 
-        const double *vB0, const double *vB1,
-        std::vector<double> &crossProduct);
+class Geometry : public Debug {
 
-			/// Compute the cross product of two 3D std::vectors
-      /// \param vA xyz coordinates of vA std::vector
-      /// \param vB xyz coordinates of vB std::vector
-      /// \param vC Output cross product.
-      /// \return Returns 0 upon success, negative values otherwise.
-			static int crossProduct(const double *vA, const double *vB,
-					double *vC);
-  
-      /// Compute the Euclidean distance between two points
-      /// \param p0 xyz coordinates of the first input point.
-      /// \param p1 xyz coordinates of the second input point.
-      /// \param dimension Optional parameter that specifies the dimension of 
-      /// the point set (by default 3).
-      static double distance(const double *p0, const double *p1,
-        const int &dimension = 3);
-      
-      /// Compute the Euclidean distance between two points
-      /// \param p0 xyz coordinates of the first input point.
-      /// \param p1 xyz coordinates of the second input point.
-      /// \param dimension Optional parameter that specifies the dimension of 
-      /// the point set (by default 3).
-      static double distance(const float *p0, const float *p1,
-        const int &dimension = 3);
-      
-      /// Compute the dot product of two 3D std::vectors
-      /// \param vA0 xyz coordinates of vA's origin
-      /// \param vA1 xyz coordinates of vA's destination
-      /// \param vB0 xyz coordinates of vB's origin
-      /// \param vB1 xyz coordinates of vB's destination
-      /// \return Returns Output dot product
-      static double dotProduct(
-        const double *vA0, const double *vA1, 
-        const double *vB0, const double *vB1);
+public:
+  // 1) constructors, destructors, operators, etc.
+  Geometry();
 
-			/// Compute the dot product of two 3D std::vectors
-      /// \param vA0 xyz coordinates of vA std::vector
-      /// \param vB0 xyz coordinates of vB std::vector
-      /// \return Returns Output dot product
-			static double dotProduct(const double *vA,
-					const double *vB);
-    
-      /// Compute the bounding box of a point set.
-      /// \param points Vector of points. Each entry is a std::vector whose size 
-      /// is 
-      /// equal to the dimension of the space embedding the points.
-      /// \param bBox Output bounding box. The number of entries in this 
-      /// std::vector
-      /// is equal to the dimension of the space embedding the points.
-      /// \return Returns 0 upon success, negative values otherwise.
-      static int getBoundingBox(const std::vector<std::vector<float> > &points,
-        std::vector<std::pair<double, double>> &bBox);
-      
-      /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param p xyz coordinates of the queried point
-      /// \return Returns true if \p p is in the triangle, false otherwise.
-      static bool isPointInTriangle(const double *p0, const double *p1,
-        const double *p2, const double *p);
-      
-      /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
-      /// \param p0 xyz coordinates of the first vertex of the triangle 
-      /// \param p1 xyz coordinates of the second vertex of the triangle
-      /// \param p2 xyz coordinates of the third vertex of the triangle
-      /// \param p xyz coordinates of the queried point
-      /// \return Returns true if \p p is in the triangle, false otherwise.
-      static bool isPointInTriangle(const float *p0, const float *p1,
-        const float *p2, const float *p);
-      
-      /// Check if a 2D point \p xy lies on a 2D segment \p AB.
-      /// \param x x coordinate of the input point.
-      /// \param y y coordinate of the input point.
-      /// \param xA x coordinate of the first vertex of the segment [AB]
-      /// \param yA y coordinate of the first vertex of the segment [AB]
-      /// \param xB x coordinate of the second vertex of the segment [AB]
-      /// \param yB y coordinate of the second vertex of the segment [AB]
-      /// \return Returns true if the point lies on the segment, false 
-      /// otherwise.
-      static bool isPointOnSegment(const double &x, const double &y,
-        const double &xA, const double &yA, const double &xB, const double &yB);
-      
-      /// Check if a point \p p lies on a segment \p AB.
-      /// \param p xyz coordinates of the input point.
-      /// \param pA xyz coordinates of the first vertex of the segment [AB]
-      /// \param pB xyz coordinate of the second vertex of the segment [AB]
-      /// \param dimension Optional parameter that specifies the dimension of 
-      /// the point set (by default 3).
-      /// \return Returns true if the point lies on the segment, false 
-      /// otherwise.
-      static bool isPointOnSegment(const double *p,
-        const double *pA, const double *pB, const int &dimension = 3);
-      
-      /// Check if all the edges of a triangle are colinear.
-      /// \param p0 xyz coordinates of the first vertex of the triangle.
-      /// \param p1 xyz coordinates of the second vertex of the triangle.
-      /// \param p2 xyz coordinates of the third vertex of the triangle.
-      /// \return Returns true if all the edges are colinear (false otherwise).
-      static bool isTriangleColinear(
-        const double *p0, const double *p1, const double *p2, 
-        const double *tolerance = NULL);
-      
-      /// Compute the magnitude of a 3D std::vector \p v.
-      /// \param v xyz coordinates of the input std::vector.
-      /// \return Returns the magnitude upon success, negative values otherwise.
-      static double magnitude(const double *v);
-      
-      /// Compute the magnitude of a 3D std::vector.
-      /// \param o xyz coordinates of the std::vector's origin
-      /// \param d xyz coordinates of the std::vector's destination
-      static double magnitude(const double *o, const double *d);
-      
-    protected:
-      
-  };
-}
+  virtual ~Geometry();
+
+  /// Compute the angle between two std::vectors
+  /// \param vA0 xyz coordinates of vA's origin
+  /// \param vA1 xyz coordinates of vA's destination
+  /// \param vB0 xyz coordinates of vB's origin
+  /// \param vB1 xyz coordinates of vB's destination
+  static double angle(const double *vA0, const double *vA1, const double *vB0,
+                      const double *vB1);
+
+  /// Check if two 3D std::vectors vA and vB are colinear.
+  /// \param vA0 xyz coordinates of vA's origin
+  /// \param vA1 xyz coordinates of vA's destination
+  /// \param vB0 xyz coordinates of vB's origin
+  /// \param vB1 xyz coordinates of vB's destination
+  /// \param coefficients Optional output std::vector of colinearity
+  /// coefficients.
+  /// \returns Returns true if the std::vectors are colinear, false
+  /// otherwise.
+  static bool areVectorsColinear(const double *vA0, const double *vA1,
+                                 const double *vB0, const double *vB1,
+                                 std::vector<double> *coefficients = NULL,
+                                 const double *tolerance = NULL);
+
+  /// Compute the barycentric coordinates of point \p p with regard to the
+  /// edge defined by the 3D points \p p0 and \p p1.
+  /// \param p0 xyz coordinates of the first vertex of the edge
+  /// \param p1 xyz coordinates of the second vertex of the edge
+  /// \param p xyz coordinates of the queried point
+  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+  /// \p p belongs to the edge).
+  /// \param dimension Optional parameter that specifies the dimension of
+  /// the point set (by default 3).
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int computeBarycentricCoordinates(const double *p0, const double *p1,
+                                           const double *p,
+                                           std::vector<double> &baryCentrics,
+                                           const int &dimension = 3);
+
+  /// Compute the barycentric coordinates of point \p xyz with regard to
+  /// the edge defined by the points \p xy0 and \p xy1.
+  /// \param x0 x coordinate of the first vertex of the edge
+  /// \param y0 y coordinate of the first vertex of the edge
+  /// \param x1 x coordinate of the second vertex of the edge
+  /// \param y1 y coordinate of the second vertex of the edge
+  /// \param x x coordinate of the queried point
+  /// \param y y coordinate of the queried point
+  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+  /// \p p belongs to the edge).
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int computeBarycentricCoordinates(const double &x0, const double &y0,
+                                           const double &x1, const double &y1,
+                                           const double &x, const double &y,
+                                           std::vector<double> &baryCentrics);
+
+  /// Compute the barycentric coordinates of point \p p with regard to the
+  /// triangle defined by the 3D points \p p0, \p p1, and \p p2.
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param p xyz coordinates of the queried point
+  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+  /// \p p belongs to the triangle).
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int computeBarycentricCoordinates(const double *p0, const double *p1,
+                                           const double *p2, const double *p,
+                                           std::vector<double> &baryCentrics);
+
+  /// Compute the barycentric coordinates of point \p p with regard to the
+  /// triangle defined by the points \p p0, \p p1, and \p p2.
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param p xyz coordinates of the queried point
+  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+  /// \p p belongs to the triangle).
+  /// \return Returns 0 upon success, negative values otherwise.
+  /// \note Backward compatibility.
+  static int computeBarycentricCoordinates(const float *p0, const float *p1,
+                                           const float *p2, const float *p,
+                                           std::vector<double> &baryCentrics);
+
+  /// Compute the intersection between two 2D segments AB and CD.
+  /// \param xA x coordinate of the first vertex of the first segment (AB)
+  /// \param yA y coordinate of the first vertex of the first segment (AB)
+  /// \param xB x coordinate of the second vertex of the first segment (AB)
+  /// \param yB y coordinate of the second vertex of the first segment (AB)
+  /// \param xC x coordinate of the first vertex of the second segment (CD)
+  /// \param yC y coordinate of the first vertex of the second segment (CD)
+  /// \param xD x coordinate of the second vertex of the second segment (CD)
+  /// \param yD y coordinate of the second vertex of the second segment (CD)
+  /// \param x x coordinate of the output intersection (if any).
+  /// \param y y coordinate of the output intersection (if any).
+  /// \return Returns true if the segments intersect (false otherwise).
+  static bool computeSegmentIntersection(const double &xA, const double &yA,
+                                         const double &xB, const double &yB,
+                                         const double &xC, const double &yC,
+                                         const double &xD, const double &yD,
+                                         double &x, double &y);
+
+  /// Compute the angles of a triangle
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param angles Angles (p0p1, p1p2) (p1p2, p2p0) (p2p0, p0p1)
+  static int computeTriangleAngles(const double *p0, const double *p1,
+                                   const double *p2,
+                                   std::vector<double> &angles);
+
+  /// Compute the area of a 3D triangle.
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param area Output area.
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int computeTriangleArea(const double *p0, const double *p1,
+                                 const double *p2, double &area);
+
+  /// Compute the cross product of two 3D std::vectors
+  /// \param vA0 xyz coordinates of vA's origin
+  /// \param vA1 xyz coordinates of vA's destination
+  /// \param vB0 xyz coordinates of vB's origin
+  /// \param vB1 xyz coordinates of vB's destination
+  /// \param crossProduct Output cross product.
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int crossProduct(const double *vA0, const double *vA1,
+                          const double *vB0, const double *vB1,
+                          std::vector<double> &crossProduct);
+
+  /// Compute the cross product of two 3D std::vectors
+  /// \param vA xyz coordinates of vA std::vector
+  /// \param vB xyz coordinates of vB std::vector
+  /// \param vC Output cross product.
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int crossProduct(const double *vA, const double *vB, double *vC);
+
+  /// Compute the Euclidean distance between two points
+  /// \param p0 xyz coordinates of the first input point.
+  /// \param p1 xyz coordinates of the second input point.
+  /// \param dimension Optional parameter that specifies the dimension of
+  /// the point set (by default 3).
+  static double distance(const double *p0, const double *p1,
+                         const int &dimension = 3);
+
+  /// Compute the Euclidean distance between two points
+  /// \param p0 xyz coordinates of the first input point.
+  /// \param p1 xyz coordinates of the second input point.
+  /// \param dimension Optional parameter that specifies the dimension of
+  /// the point set (by default 3).
+  static double distance(const float *p0, const float *p1,
+                         const int &dimension = 3);
+
+  /// Compute the dot product of two 3D std::vectors
+  /// \param vA0 xyz coordinates of vA's origin
+  /// \param vA1 xyz coordinates of vA's destination
+  /// \param vB0 xyz coordinates of vB's origin
+  /// \param vB1 xyz coordinates of vB's destination
+  /// \return Returns Output dot product
+  static double dotProduct(const double *vA0, const double *vA1,
+                           const double *vB0, const double *vB1);
+
+  /// Compute the dot product of two 3D std::vectors
+  /// \param vA0 xyz coordinates of vA std::vector
+  /// \param vB0 xyz coordinates of vB std::vector
+  /// \return Returns Output dot product
+  static double dotProduct(const double *vA, const double *vB);
+
+  /// Compute the bounding box of a point set.
+  /// \param points Vector of points. Each entry is a std::vector whose size
+  /// is
+  /// equal to the dimension of the space embedding the points.
+  /// \param bBox Output bounding box. The number of entries in this
+  /// std::vector
+  /// is equal to the dimension of the space embedding the points.
+  /// \return Returns 0 upon success, negative values otherwise.
+  static int getBoundingBox(const std::vector<std::vector<float>> &points,
+                            std::vector<std::pair<double, double>> &bBox);
+
+  /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param p xyz coordinates of the queried point
+  /// \return Returns true if \p p is in the triangle, false otherwise.
+  static bool isPointInTriangle(const double *p0, const double *p1,
+                                const double *p2, const double *p);
+
+  /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
+  /// \param p0 xyz coordinates of the first vertex of the triangle
+  /// \param p1 xyz coordinates of the second vertex of the triangle
+  /// \param p2 xyz coordinates of the third vertex of the triangle
+  /// \param p xyz coordinates of the queried point
+  /// \return Returns true if \p p is in the triangle, false otherwise.
+  static bool isPointInTriangle(const float *p0, const float *p1,
+                                const float *p2, const float *p);
+
+  /// Check if a 2D point \p xy lies on a 2D segment \p AB.
+  /// \param x x coordinate of the input point.
+  /// \param y y coordinate of the input point.
+  /// \param xA x coordinate of the first vertex of the segment [AB]
+  /// \param yA y coordinate of the first vertex of the segment [AB]
+  /// \param xB x coordinate of the second vertex of the segment [AB]
+  /// \param yB y coordinate of the second vertex of the segment [AB]
+  /// \return Returns true if the point lies on the segment, false
+  /// otherwise.
+  static bool isPointOnSegment(const double &x, const double &y,
+                               const double &xA, const double &yA,
+                               const double &xB, const double &yB);
+
+  /// Check if a point \p p lies on a segment \p AB.
+  /// \param p xyz coordinates of the input point.
+  /// \param pA xyz coordinates of the first vertex of the segment [AB]
+  /// \param pB xyz coordinate of the second vertex of the segment [AB]
+  /// \param dimension Optional parameter that specifies the dimension of
+  /// the point set (by default 3).
+  /// \return Returns true if the point lies on the segment, false
+  /// otherwise.
+  static bool isPointOnSegment(const double *p, const double *pA,
+                               const double *pB, const int &dimension = 3);
+
+  /// Check if all the edges of a triangle are colinear.
+  /// \param p0 xyz coordinates of the first vertex of the triangle.
+  /// \param p1 xyz coordinates of the second vertex of the triangle.
+  /// \param p2 xyz coordinates of the third vertex of the triangle.
+  /// \return Returns true if all the edges are colinear (false otherwise).
+  static bool isTriangleColinear(const double *p0, const double *p1,
+                                 const double *p2,
+                                 const double *tolerance = NULL);
+
+  /// Compute the magnitude of a 3D std::vector \p v.
+  /// \param v xyz coordinates of the input std::vector.
+  /// \return Returns the magnitude upon success, negative values otherwise.
+  static double magnitude(const double *v);
+
+  /// Compute the magnitude of a 3D std::vector.
+  /// \param o xyz coordinates of the std::vector's origin
+  /// \param d xyz coordinates of the std::vector's destination
+  static double magnitude(const double *o, const double *d);
+
+protected:
+};
+} // namespace ttk
 
 #endif

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -130,9 +130,10 @@ int crossProduct(const T *vA0, const T *vA1, const T *vB0, const T *vB1,
 /// Compute the cross product of two 3D std::vectors
 /// \param vA xyz coordinates of vA std::vector
 /// \param vB xyz coordinates of vB std::vector
-/// \param vC Output cross product.
+/// \param crossProduct Output cross product.
 /// \return Returns 0 upon success, negative values otherwise.
-template <typename T> int crossProduct(const T *vA, const T *vB, T *vC);
+template <typename T>
+int crossProduct(const T *vA, const T *vB, T *crossProduct);
 
 /// Compute the Euclidean distance between two points
 /// \param p0 xyz coordinates of the first input point.

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -13,253 +13,240 @@
 
 namespace ttk {
 
-class Geometry : public Debug {
+namespace Geometry {
 
-public:
-  // 1) constructors, destructors, operators, etc.
-  Geometry();
+/// Compute the angle between two std::vectors
+/// \param vA0 xyz coordinates of vA's origin
+/// \param vA1 xyz coordinates of vA's destination
+/// \param vB0 xyz coordinates of vB's origin
+/// \param vB1 xyz coordinates of vB's destination
+double angle(const double *vA0, const double *vA1, const double *vB0,
+             const double *vB1);
 
-  virtual ~Geometry();
+/// Check if two 3D std::vectors vA and vB are colinear.
+/// \param vA0 xyz coordinates of vA's origin
+/// \param vA1 xyz coordinates of vA's destination
+/// \param vB0 xyz coordinates of vB's origin
+/// \param vB1 xyz coordinates of vB's destination
+/// \param coefficients Optional output std::vector of colinearity
+/// coefficients.
+/// \returns Returns true if the std::vectors are colinear, false
+/// otherwise.
+bool areVectorsColinear(const double *vA0, const double *vA1, const double *vB0,
+                        const double *vB1,
+                        std::vector<double> *coefficients = NULL,
+                        const double *tolerance = NULL);
 
-  /// Compute the angle between two std::vectors
-  /// \param vA0 xyz coordinates of vA's origin
-  /// \param vA1 xyz coordinates of vA's destination
-  /// \param vB0 xyz coordinates of vB's origin
-  /// \param vB1 xyz coordinates of vB's destination
-  static double angle(const double *vA0, const double *vA1, const double *vB0,
-                      const double *vB1);
+/// Compute the barycentric coordinates of point \p p with regard to the
+/// edge defined by the 3D points \p p0 and \p p1.
+/// \param p0 xyz coordinates of the first vertex of the edge
+/// \param p1 xyz coordinates of the second vertex of the edge
+/// \param p xyz coordinates of the queried point
+/// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+/// \p p belongs to the edge).
+/// \param dimension Optional parameter that specifies the dimension of
+/// the point set (by default 3).
+/// \return Returns 0 upon success, negative values otherwise.
+int computeBarycentricCoordinates(const double *p0, const double *p1,
+                                  const double *p,
+                                  std::vector<double> &baryCentrics,
+                                  const int &dimension = 3);
 
-  /// Check if two 3D std::vectors vA and vB are colinear.
-  /// \param vA0 xyz coordinates of vA's origin
-  /// \param vA1 xyz coordinates of vA's destination
-  /// \param vB0 xyz coordinates of vB's origin
-  /// \param vB1 xyz coordinates of vB's destination
-  /// \param coefficients Optional output std::vector of colinearity
-  /// coefficients.
-  /// \returns Returns true if the std::vectors are colinear, false
-  /// otherwise.
-  static bool areVectorsColinear(const double *vA0, const double *vA1,
-                                 const double *vB0, const double *vB1,
-                                 std::vector<double> *coefficients = NULL,
-                                 const double *tolerance = NULL);
+/// Compute the barycentric coordinates of point \p xyz with regard to
+/// the edge defined by the points \p xy0 and \p xy1.
+/// \param x0 x coordinate of the first vertex of the edge
+/// \param y0 y coordinate of the first vertex of the edge
+/// \param x1 x coordinate of the second vertex of the edge
+/// \param y1 y coordinate of the second vertex of the edge
+/// \param x x coordinate of the queried point
+/// \param y y coordinate of the queried point
+/// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+/// \p p belongs to the edge).
+/// \return Returns 0 upon success, negative values otherwise.
+int computeBarycentricCoordinates(const double &x0, const double &y0,
+                                  const double &x1, const double &y1,
+                                  const double &x, const double &y,
+                                  std::vector<double> &baryCentrics);
 
-  /// Compute the barycentric coordinates of point \p p with regard to the
-  /// edge defined by the 3D points \p p0 and \p p1.
-  /// \param p0 xyz coordinates of the first vertex of the edge
-  /// \param p1 xyz coordinates of the second vertex of the edge
-  /// \param p xyz coordinates of the queried point
-  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-  /// \p p belongs to the edge).
-  /// \param dimension Optional parameter that specifies the dimension of
-  /// the point set (by default 3).
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int computeBarycentricCoordinates(const double *p0, const double *p1,
-                                           const double *p,
-                                           std::vector<double> &baryCentrics,
-                                           const int &dimension = 3);
+/// Compute the barycentric coordinates of point \p p with regard to the
+/// triangle defined by the 3D points \p p0, \p p1, and \p p2.
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param p xyz coordinates of the queried point
+/// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+/// \p p belongs to the triangle).
+/// \return Returns 0 upon success, negative values otherwise.
+int computeBarycentricCoordinates(const double *p0, const double *p1,
+                                  const double *p2, const double *p,
+                                  std::vector<double> &baryCentrics);
 
-  /// Compute the barycentric coordinates of point \p xyz with regard to
-  /// the edge defined by the points \p xy0 and \p xy1.
-  /// \param x0 x coordinate of the first vertex of the edge
-  /// \param y0 y coordinate of the first vertex of the edge
-  /// \param x1 x coordinate of the second vertex of the edge
-  /// \param y1 y coordinate of the second vertex of the edge
-  /// \param x x coordinate of the queried point
-  /// \param y y coordinate of the queried point
-  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-  /// \p p belongs to the edge).
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int computeBarycentricCoordinates(const double &x0, const double &y0,
-                                           const double &x1, const double &y1,
-                                           const double &x, const double &y,
-                                           std::vector<double> &baryCentrics);
+/// Compute the barycentric coordinates of point \p p with regard to the
+/// triangle defined by the points \p p0, \p p1, and \p p2.
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param p xyz coordinates of the queried point
+/// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
+/// \p p belongs to the triangle).
+/// \return Returns 0 upon success, negative values otherwise.
+/// \note Backward compatibility.
+int computeBarycentricCoordinates(const float *p0, const float *p1,
+                                  const float *p2, const float *p,
+                                  std::vector<double> &baryCentrics);
 
-  /// Compute the barycentric coordinates of point \p p with regard to the
-  /// triangle defined by the 3D points \p p0, \p p1, and \p p2.
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param p xyz coordinates of the queried point
-  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-  /// \p p belongs to the triangle).
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int computeBarycentricCoordinates(const double *p0, const double *p1,
-                                           const double *p2, const double *p,
-                                           std::vector<double> &baryCentrics);
+/// Compute the intersection between two 2D segments AB and CD.
+/// \param xA x coordinate of the first vertex of the first segment (AB)
+/// \param yA y coordinate of the first vertex of the first segment (AB)
+/// \param xB x coordinate of the second vertex of the first segment (AB)
+/// \param yB y coordinate of the second vertex of the first segment (AB)
+/// \param xC x coordinate of the first vertex of the second segment (CD)
+/// \param yC y coordinate of the first vertex of the second segment (CD)
+/// \param xD x coordinate of the second vertex of the second segment (CD)
+/// \param yD y coordinate of the second vertex of the second segment (CD)
+/// \param x x coordinate of the output intersection (if any).
+/// \param y y coordinate of the output intersection (if any).
+/// \return Returns true if the segments intersect (false otherwise).
+bool computeSegmentIntersection(const double &xA, const double &yA,
+                                const double &xB, const double &yB,
+                                const double &xC, const double &yC,
+                                const double &xD, const double &yD, double &x,
+                                double &y);
 
-  /// Compute the barycentric coordinates of point \p p with regard to the
-  /// triangle defined by the points \p p0, \p p1, and \p p2.
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param p xyz coordinates of the queried point
-  /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-  /// \p p belongs to the triangle).
-  /// \return Returns 0 upon success, negative values otherwise.
-  /// \note Backward compatibility.
-  static int computeBarycentricCoordinates(const float *p0, const float *p1,
-                                           const float *p2, const float *p,
-                                           std::vector<double> &baryCentrics);
+/// Compute the angles of a triangle
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param angles Angles (p0p1, p1p2) (p1p2, p2p0) (p2p0, p0p1)
+int computeTriangleAngles(const double *p0, const double *p1, const double *p2,
+                          std::vector<double> &angles);
 
-  /// Compute the intersection between two 2D segments AB and CD.
-  /// \param xA x coordinate of the first vertex of the first segment (AB)
-  /// \param yA y coordinate of the first vertex of the first segment (AB)
-  /// \param xB x coordinate of the second vertex of the first segment (AB)
-  /// \param yB y coordinate of the second vertex of the first segment (AB)
-  /// \param xC x coordinate of the first vertex of the second segment (CD)
-  /// \param yC y coordinate of the first vertex of the second segment (CD)
-  /// \param xD x coordinate of the second vertex of the second segment (CD)
-  /// \param yD y coordinate of the second vertex of the second segment (CD)
-  /// \param x x coordinate of the output intersection (if any).
-  /// \param y y coordinate of the output intersection (if any).
-  /// \return Returns true if the segments intersect (false otherwise).
-  static bool computeSegmentIntersection(const double &xA, const double &yA,
-                                         const double &xB, const double &yB,
-                                         const double &xC, const double &yC,
-                                         const double &xD, const double &yD,
-                                         double &x, double &y);
+/// Compute the area of a 3D triangle.
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param area Output area.
+/// \return Returns 0 upon success, negative values otherwise.
+int computeTriangleArea(const double *p0, const double *p1, const double *p2,
+                        double &area);
 
-  /// Compute the angles of a triangle
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param angles Angles (p0p1, p1p2) (p1p2, p2p0) (p2p0, p0p1)
-  static int computeTriangleAngles(const double *p0, const double *p1,
-                                   const double *p2,
-                                   std::vector<double> &angles);
+/// Compute the cross product of two 3D std::vectors
+/// \param vA0 xyz coordinates of vA's origin
+/// \param vA1 xyz coordinates of vA's destination
+/// \param vB0 xyz coordinates of vB's origin
+/// \param vB1 xyz coordinates of vB's destination
+/// \param crossProduct Output cross product.
+/// \return Returns 0 upon success, negative values otherwise.
+int crossProduct(const double *vA0, const double *vA1, const double *vB0,
+                 const double *vB1, std::vector<double> &crossProduct);
 
-  /// Compute the area of a 3D triangle.
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param area Output area.
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int computeTriangleArea(const double *p0, const double *p1,
-                                 const double *p2, double &area);
+/// Compute the cross product of two 3D std::vectors
+/// \param vA xyz coordinates of vA std::vector
+/// \param vB xyz coordinates of vB std::vector
+/// \param vC Output cross product.
+/// \return Returns 0 upon success, negative values otherwise.
+int crossProduct(const double *vA, const double *vB, double *vC);
 
-  /// Compute the cross product of two 3D std::vectors
-  /// \param vA0 xyz coordinates of vA's origin
-  /// \param vA1 xyz coordinates of vA's destination
-  /// \param vB0 xyz coordinates of vB's origin
-  /// \param vB1 xyz coordinates of vB's destination
-  /// \param crossProduct Output cross product.
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int crossProduct(const double *vA0, const double *vA1,
-                          const double *vB0, const double *vB1,
-                          std::vector<double> &crossProduct);
+/// Compute the Euclidean distance between two points
+/// \param p0 xyz coordinates of the first input point.
+/// \param p1 xyz coordinates of the second input point.
+/// \param dimension Optional parameter that specifies the dimension of
+/// the point set (by default 3).
+double distance(const double *p0, const double *p1, const int &dimension = 3);
 
-  /// Compute the cross product of two 3D std::vectors
-  /// \param vA xyz coordinates of vA std::vector
-  /// \param vB xyz coordinates of vB std::vector
-  /// \param vC Output cross product.
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int crossProduct(const double *vA, const double *vB, double *vC);
+/// Compute the Euclidean distance between two points
+/// \param p0 xyz coordinates of the first input point.
+/// \param p1 xyz coordinates of the second input point.
+/// \param dimension Optional parameter that specifies the dimension of
+/// the point set (by default 3).
+double distance(const float *p0, const float *p1, const int &dimension = 3);
 
-  /// Compute the Euclidean distance between two points
-  /// \param p0 xyz coordinates of the first input point.
-  /// \param p1 xyz coordinates of the second input point.
-  /// \param dimension Optional parameter that specifies the dimension of
-  /// the point set (by default 3).
-  static double distance(const double *p0, const double *p1,
-                         const int &dimension = 3);
+/// Compute the dot product of two 3D std::vectors
+/// \param vA0 xyz coordinates of vA's origin
+/// \param vA1 xyz coordinates of vA's destination
+/// \param vB0 xyz coordinates of vB's origin
+/// \param vB1 xyz coordinates of vB's destination
+/// \return Returns Output dot product
+double dotProduct(const double *vA0, const double *vA1, const double *vB0,
+                  const double *vB1);
 
-  /// Compute the Euclidean distance between two points
-  /// \param p0 xyz coordinates of the first input point.
-  /// \param p1 xyz coordinates of the second input point.
-  /// \param dimension Optional parameter that specifies the dimension of
-  /// the point set (by default 3).
-  static double distance(const float *p0, const float *p1,
-                         const int &dimension = 3);
+/// Compute the dot product of two 3D std::vectors
+/// \param vA0 xyz coordinates of vA std::vector
+/// \param vB0 xyz coordinates of vB std::vector
+/// \return Returns Output dot product
+double dotProduct(const double *vA, const double *vB);
 
-  /// Compute the dot product of two 3D std::vectors
-  /// \param vA0 xyz coordinates of vA's origin
-  /// \param vA1 xyz coordinates of vA's destination
-  /// \param vB0 xyz coordinates of vB's origin
-  /// \param vB1 xyz coordinates of vB's destination
-  /// \return Returns Output dot product
-  static double dotProduct(const double *vA0, const double *vA1,
-                           const double *vB0, const double *vB1);
+/// Compute the bounding box of a point set.
+/// \param points Vector of points. Each entry is a std::vector whose size
+/// is
+/// equal to the dimension of the space embedding the points.
+/// \param bBox Output bounding box. The number of entries in this
+/// std::vector
+/// is equal to the dimension of the space embedding the points.
+/// \return Returns 0 upon success, negative values otherwise.
+int getBoundingBox(const std::vector<std::vector<float>> &points,
+                   std::vector<std::pair<double, double>> &bBox);
 
-  /// Compute the dot product of two 3D std::vectors
-  /// \param vA0 xyz coordinates of vA std::vector
-  /// \param vB0 xyz coordinates of vB std::vector
-  /// \return Returns Output dot product
-  static double dotProduct(const double *vA, const double *vB);
+/// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param p xyz coordinates of the queried point
+/// \return Returns true if \p p is in the triangle, false otherwise.
+bool isPointInTriangle(const double *p0, const double *p1, const double *p2,
+                       const double *p);
 
-  /// Compute the bounding box of a point set.
-  /// \param points Vector of points. Each entry is a std::vector whose size
-  /// is
-  /// equal to the dimension of the space embedding the points.
-  /// \param bBox Output bounding box. The number of entries in this
-  /// std::vector
-  /// is equal to the dimension of the space embedding the points.
-  /// \return Returns 0 upon success, negative values otherwise.
-  static int getBoundingBox(const std::vector<std::vector<float>> &points,
-                            std::vector<std::pair<double, double>> &bBox);
+/// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
+/// \param p0 xyz coordinates of the first vertex of the triangle
+/// \param p1 xyz coordinates of the second vertex of the triangle
+/// \param p2 xyz coordinates of the third vertex of the triangle
+/// \param p xyz coordinates of the queried point
+/// \return Returns true if \p p is in the triangle, false otherwise.
+bool isPointInTriangle(const float *p0, const float *p1, const float *p2,
+                       const float *p);
 
-  /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param p xyz coordinates of the queried point
-  /// \return Returns true if \p p is in the triangle, false otherwise.
-  static bool isPointInTriangle(const double *p0, const double *p1,
-                                const double *p2, const double *p);
+/// Check if a 2D point \p xy lies on a 2D segment \p AB.
+/// \param x x coordinate of the input point.
+/// \param y y coordinate of the input point.
+/// \param xA x coordinate of the first vertex of the segment [AB]
+/// \param yA y coordinate of the first vertex of the segment [AB]
+/// \param xB x coordinate of the second vertex of the segment [AB]
+/// \param yB y coordinate of the second vertex of the segment [AB]
+/// \return Returns true if the point lies on the segment, false
+/// otherwise.
+bool isPointOnSegment(const double &x, const double &y, const double &xA,
+                      const double &yA, const double &xB, const double &yB);
 
-  /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
-  /// \param p0 xyz coordinates of the first vertex of the triangle
-  /// \param p1 xyz coordinates of the second vertex of the triangle
-  /// \param p2 xyz coordinates of the third vertex of the triangle
-  /// \param p xyz coordinates of the queried point
-  /// \return Returns true if \p p is in the triangle, false otherwise.
-  static bool isPointInTriangle(const float *p0, const float *p1,
-                                const float *p2, const float *p);
+/// Check if a point \p p lies on a segment \p AB.
+/// \param p xyz coordinates of the input point.
+/// \param pA xyz coordinates of the first vertex of the segment [AB]
+/// \param pB xyz coordinate of the second vertex of the segment [AB]
+/// \param dimension Optional parameter that specifies the dimension of
+/// the point set (by default 3).
+/// \return Returns true if the point lies on the segment, false
+/// otherwise.
+bool isPointOnSegment(const double *p, const double *pA, const double *pB,
+                      const int &dimension = 3);
 
-  /// Check if a 2D point \p xy lies on a 2D segment \p AB.
-  /// \param x x coordinate of the input point.
-  /// \param y y coordinate of the input point.
-  /// \param xA x coordinate of the first vertex of the segment [AB]
-  /// \param yA y coordinate of the first vertex of the segment [AB]
-  /// \param xB x coordinate of the second vertex of the segment [AB]
-  /// \param yB y coordinate of the second vertex of the segment [AB]
-  /// \return Returns true if the point lies on the segment, false
-  /// otherwise.
-  static bool isPointOnSegment(const double &x, const double &y,
-                               const double &xA, const double &yA,
-                               const double &xB, const double &yB);
+/// Check if all the edges of a triangle are colinear.
+/// \param p0 xyz coordinates of the first vertex of the triangle.
+/// \param p1 xyz coordinates of the second vertex of the triangle.
+/// \param p2 xyz coordinates of the third vertex of the triangle.
+/// \return Returns true if all the edges are colinear (false otherwise).
+bool isTriangleColinear(const double *p0, const double *p1, const double *p2,
+                        const double *tolerance = NULL);
 
-  /// Check if a point \p p lies on a segment \p AB.
-  /// \param p xyz coordinates of the input point.
-  /// \param pA xyz coordinates of the first vertex of the segment [AB]
-  /// \param pB xyz coordinate of the second vertex of the segment [AB]
-  /// \param dimension Optional parameter that specifies the dimension of
-  /// the point set (by default 3).
-  /// \return Returns true if the point lies on the segment, false
-  /// otherwise.
-  static bool isPointOnSegment(const double *p, const double *pA,
-                               const double *pB, const int &dimension = 3);
+/// Compute the magnitude of a 3D std::vector \p v.
+/// \param v xyz coordinates of the input std::vector.
+/// \return Returns the magnitude upon success, negative values otherwise.
+double magnitude(const double *v);
 
-  /// Check if all the edges of a triangle are colinear.
-  /// \param p0 xyz coordinates of the first vertex of the triangle.
-  /// \param p1 xyz coordinates of the second vertex of the triangle.
-  /// \param p2 xyz coordinates of the third vertex of the triangle.
-  /// \return Returns true if all the edges are colinear (false otherwise).
-  static bool isTriangleColinear(const double *p0, const double *p1,
-                                 const double *p2,
-                                 const double *tolerance = NULL);
+/// Compute the magnitude of a 3D std::vector.
+/// \param o xyz coordinates of the std::vector's origin
+/// \param d xyz coordinates of the std::vector's destination
+double magnitude(const double *o, const double *d);
 
-  /// Compute the magnitude of a 3D std::vector \p v.
-  /// \param v xyz coordinates of the input std::vector.
-  /// \return Returns the magnitude upon success, negative values otherwise.
-  static double magnitude(const double *v);
-
-  /// Compute the magnitude of a 3D std::vector.
-  /// \param o xyz coordinates of the std::vector's origin
-  /// \param d xyz coordinates of the std::vector's destination
-  static double magnitude(const double *o, const double *d);
-
-protected:
-};
+} // namespace Geometry
 } // namespace ttk
 
 #endif

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -20,8 +20,8 @@ namespace Geometry {
 /// \param vA1 xyz coordinates of vA's destination
 /// \param vB0 xyz coordinates of vB's origin
 /// \param vB1 xyz coordinates of vB's destination
-double angle(const double *vA0, const double *vA1, const double *vB0,
-             const double *vB1);
+template <typename T>
+T angle(const T *vA0, const T *vA1, const T *vB0, const T *vB1);
 
 /// Check if two 3D std::vectors vA and vB are colinear.
 /// \param vA0 xyz coordinates of vA's origin
@@ -32,10 +32,10 @@ double angle(const double *vA0, const double *vA1, const double *vB0,
 /// coefficients.
 /// \returns Returns true if the std::vectors are colinear, false
 /// otherwise.
-bool areVectorsColinear(const double *vA0, const double *vA1, const double *vB0,
-                        const double *vB1,
-                        std::vector<double> *coefficients = NULL,
-                        const double *tolerance = NULL);
+template <typename T>
+bool areVectorsColinear(const T *vA0, const T *vA1, const T *vB0, const T *vB1,
+                        std::vector<T> *coefficients = NULL,
+                        const T *tolerance = NULL);
 
 /// Compute the barycentric coordinates of point \p p with regard to the
 /// edge defined by the 3D points \p p0 and \p p1.
@@ -47,9 +47,9 @@ bool areVectorsColinear(const double *vA0, const double *vA1, const double *vB0,
 /// \param dimension Optional parameter that specifies the dimension of
 /// the point set (by default 3).
 /// \return Returns 0 upon success, negative values otherwise.
-int computeBarycentricCoordinates(const double *p0, const double *p1,
-                                  const double *p,
-                                  std::vector<double> &baryCentrics,
+template <typename T>
+int computeBarycentricCoordinates(const T *p0, const T *p1, const T *p,
+                                  std::vector<T> &baryCentrics,
                                   const int &dimension = 3);
 
 /// Compute the barycentric coordinates of point \p xyz with regard to
@@ -63,10 +63,10 @@ int computeBarycentricCoordinates(const double *p0, const double *p1,
 /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
 /// \p p belongs to the edge).
 /// \return Returns 0 upon success, negative values otherwise.
-int computeBarycentricCoordinates(const double &x0, const double &y0,
-                                  const double &x1, const double &y1,
-                                  const double &x, const double &y,
-                                  std::vector<double> &baryCentrics);
+template <typename T>
+int computeBarycentricCoordinates(const T &x0, const T &y0, const T &x1,
+                                  const T &y1, const T &x, const T &y,
+                                  std::vector<T> &baryCentrics);
 
 /// Compute the barycentric coordinates of point \p p with regard to the
 /// triangle defined by the 3D points \p p0, \p p1, and \p p2.
@@ -77,23 +77,9 @@ int computeBarycentricCoordinates(const double &x0, const double &y0,
 /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
 /// \p p belongs to the triangle).
 /// \return Returns 0 upon success, negative values otherwise.
-int computeBarycentricCoordinates(const double *p0, const double *p1,
-                                  const double *p2, const double *p,
-                                  std::vector<double> &baryCentrics);
-
-/// Compute the barycentric coordinates of point \p p with regard to the
-/// triangle defined by the points \p p0, \p p1, and \p p2.
-/// \param p0 xyz coordinates of the first vertex of the triangle
-/// \param p1 xyz coordinates of the second vertex of the triangle
-/// \param p2 xyz coordinates of the third vertex of the triangle
-/// \param p xyz coordinates of the queried point
-/// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-/// \p p belongs to the triangle).
-/// \return Returns 0 upon success, negative values otherwise.
-/// \note Backward compatibility.
-int computeBarycentricCoordinates(const float *p0, const float *p1,
-                                  const float *p2, const float *p,
-                                  std::vector<double> &baryCentrics);
+template <typename T>
+int computeBarycentricCoordinates(const T *p0, const T *p1, const T *p2,
+                                  const T *p, std::vector<T> &baryCentrics);
 
 /// Compute the intersection between two 2D segments AB and CD.
 /// \param xA x coordinate of the first vertex of the first segment (AB)
@@ -107,19 +93,19 @@ int computeBarycentricCoordinates(const float *p0, const float *p1,
 /// \param x x coordinate of the output intersection (if any).
 /// \param y y coordinate of the output intersection (if any).
 /// \return Returns true if the segments intersect (false otherwise).
-bool computeSegmentIntersection(const double &xA, const double &yA,
-                                const double &xB, const double &yB,
-                                const double &xC, const double &yC,
-                                const double &xD, const double &yD, double &x,
-                                double &y);
+template <typename T>
+bool computeSegmentIntersection(const T &xA, const T &yA, const T &xB,
+                                const T &yB, const T &xC, const T &yC,
+                                const T &xD, const T &yD, T &x, T &y);
 
 /// Compute the angles of a triangle
 /// \param p0 xyz coordinates of the first vertex of the triangle
 /// \param p1 xyz coordinates of the second vertex of the triangle
 /// \param p2 xyz coordinates of the third vertex of the triangle
 /// \param angles Angles (p0p1, p1p2) (p1p2, p2p0) (p2p0, p0p1)
-int computeTriangleAngles(const double *p0, const double *p1, const double *p2,
-                          std::vector<double> &angles);
+template <typename T>
+int computeTriangleAngles(const T *p0, const T *p1, const T *p2,
+                          std::vector<T> &angles);
 
 /// Compute the area of a 3D triangle.
 /// \param p0 xyz coordinates of the first vertex of the triangle
@@ -127,8 +113,8 @@ int computeTriangleAngles(const double *p0, const double *p1, const double *p2,
 /// \param p2 xyz coordinates of the third vertex of the triangle
 /// \param area Output area.
 /// \return Returns 0 upon success, negative values otherwise.
-int computeTriangleArea(const double *p0, const double *p1, const double *p2,
-                        double &area);
+template <typename T>
+int computeTriangleArea(const T *p0, const T *p1, const T *p2, T &area);
 
 /// Compute the cross product of two 3D std::vectors
 /// \param vA0 xyz coordinates of vA's origin
@@ -137,29 +123,24 @@ int computeTriangleArea(const double *p0, const double *p1, const double *p2,
 /// \param vB1 xyz coordinates of vB's destination
 /// \param crossProduct Output cross product.
 /// \return Returns 0 upon success, negative values otherwise.
-int crossProduct(const double *vA0, const double *vA1, const double *vB0,
-                 const double *vB1, std::vector<double> &crossProduct);
+template <typename T>
+int crossProduct(const T *vA0, const T *vA1, const T *vB0, const T *vB1,
+                 std::vector<T> &crossProduct);
 
 /// Compute the cross product of two 3D std::vectors
 /// \param vA xyz coordinates of vA std::vector
 /// \param vB xyz coordinates of vB std::vector
 /// \param vC Output cross product.
 /// \return Returns 0 upon success, negative values otherwise.
-int crossProduct(const double *vA, const double *vB, double *vC);
+template <typename T> int crossProduct(const T *vA, const T *vB, T *vC);
 
 /// Compute the Euclidean distance between two points
 /// \param p0 xyz coordinates of the first input point.
 /// \param p1 xyz coordinates of the second input point.
 /// \param dimension Optional parameter that specifies the dimension of
 /// the point set (by default 3).
-double distance(const double *p0, const double *p1, const int &dimension = 3);
-
-/// Compute the Euclidean distance between two points
-/// \param p0 xyz coordinates of the first input point.
-/// \param p1 xyz coordinates of the second input point.
-/// \param dimension Optional parameter that specifies the dimension of
-/// the point set (by default 3).
-double distance(const float *p0, const float *p1, const int &dimension = 3);
+template <typename T>
+T distance(const T *p0, const T *p1, const int &dimension = 3);
 
 /// Compute the dot product of two 3D std::vectors
 /// \param vA0 xyz coordinates of vA's origin
@@ -167,14 +148,14 @@ double distance(const float *p0, const float *p1, const int &dimension = 3);
 /// \param vB0 xyz coordinates of vB's origin
 /// \param vB1 xyz coordinates of vB's destination
 /// \return Returns Output dot product
-double dotProduct(const double *vA0, const double *vA1, const double *vB0,
-                  const double *vB1);
+template <typename T>
+T dotProduct(const T *vA0, const T *vA1, const T *vB0, const T *vB1);
 
 /// Compute the dot product of two 3D std::vectors
 /// \param vA0 xyz coordinates of vA std::vector
 /// \param vB0 xyz coordinates of vB std::vector
 /// \return Returns Output dot product
-double dotProduct(const double *vA, const double *vB);
+template <typename T> T dotProduct(const T *vA, const T *vB);
 
 /// Compute the bounding box of a point set.
 /// \param points Vector of points. Each entry is a std::vector whose size
@@ -184,8 +165,9 @@ double dotProduct(const double *vA, const double *vB);
 /// std::vector
 /// is equal to the dimension of the space embedding the points.
 /// \return Returns 0 upon success, negative values otherwise.
+template <typename T>
 int getBoundingBox(const std::vector<std::vector<float>> &points,
-                   std::vector<std::pair<double, double>> &bBox);
+                   std::vector<std::pair<T, T>> &bBox);
 
 /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
 /// \param p0 xyz coordinates of the first vertex of the triangle
@@ -193,17 +175,8 @@ int getBoundingBox(const std::vector<std::vector<float>> &points,
 /// \param p2 xyz coordinates of the third vertex of the triangle
 /// \param p xyz coordinates of the queried point
 /// \return Returns true if \p p is in the triangle, false otherwise.
-bool isPointInTriangle(const double *p0, const double *p1, const double *p2,
-                       const double *p);
-
-/// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
-/// \param p0 xyz coordinates of the first vertex of the triangle
-/// \param p1 xyz coordinates of the second vertex of the triangle
-/// \param p2 xyz coordinates of the third vertex of the triangle
-/// \param p xyz coordinates of the queried point
-/// \return Returns true if \p p is in the triangle, false otherwise.
-bool isPointInTriangle(const float *p0, const float *p1, const float *p2,
-                       const float *p);
+template <typename T>
+bool isPointInTriangle(const T *p0, const T *p1, const T *p2, const T *p);
 
 /// Check if a 2D point \p xy lies on a 2D segment \p AB.
 /// \param x x coordinate of the input point.
@@ -214,8 +187,9 @@ bool isPointInTriangle(const float *p0, const float *p1, const float *p2,
 /// \param yB y coordinate of the second vertex of the segment [AB]
 /// \return Returns true if the point lies on the segment, false
 /// otherwise.
-bool isPointOnSegment(const double &x, const double &y, const double &xA,
-                      const double &yA, const double &xB, const double &yB);
+template <typename T>
+bool isPointOnSegment(const T &x, const T &y, const T &xA, const T &yA,
+                      const T &xB, const T &yB);
 
 /// Check if a point \p p lies on a segment \p AB.
 /// \param p xyz coordinates of the input point.
@@ -225,7 +199,8 @@ bool isPointOnSegment(const double &x, const double &y, const double &xA,
 /// the point set (by default 3).
 /// \return Returns true if the point lies on the segment, false
 /// otherwise.
-bool isPointOnSegment(const double *p, const double *pA, const double *pB,
+template <typename T>
+bool isPointOnSegment(const T *p, const T *pA, const T *pB,
                       const int &dimension = 3);
 
 /// Check if all the edges of a triangle are colinear.
@@ -233,18 +208,19 @@ bool isPointOnSegment(const double *p, const double *pA, const double *pB,
 /// \param p1 xyz coordinates of the second vertex of the triangle.
 /// \param p2 xyz coordinates of the third vertex of the triangle.
 /// \return Returns true if all the edges are colinear (false otherwise).
-bool isTriangleColinear(const double *p0, const double *p1, const double *p2,
-                        const double *tolerance = NULL);
+template <typename T>
+bool isTriangleColinear(const T *p0, const T *p1, const T *p2,
+                        const T *tolerance = NULL);
 
 /// Compute the magnitude of a 3D std::vector \p v.
 /// \param v xyz coordinates of the input std::vector.
 /// \return Returns the magnitude upon success, negative values otherwise.
-double magnitude(const double *v);
+template <typename T> T magnitude(const T *v);
 
 /// Compute the magnitude of a 3D std::vector.
 /// \param o xyz coordinates of the std::vector's origin
 /// \param d xyz coordinates of the std::vector's destination
-double magnitude(const double *o, const double *d);
+template <typename T> T magnitude(const T *o, const T *d);
 
 } // namespace Geometry
 } // namespace ttk


### PR DESCRIPTION
The Geometry library contains functions whose parameters are only doubles. This conflicts with the Triangulation class, which operates on float values.

The current branch aims to solve this issue by providing a template version of the Geometry library, with template instantiations for double and float types. No direct user of the library should be impacted by this change; the function call syntax is the same.

Also in the same branch, two *slightly controversial* changes:
1. I have applied clang-format onto Geometry.h and Geometry.cpp prior to working on those files to improve their readability on my editor (using default formatting, waiting on #190 to provide specific options)
2. I have switched out the Geometry class in favor of a Geometry namespace, since all methods were static and no state was used. That change should be easy to revert.