### PR TITLE
Replace omp_lock_t usage with critical sections

### DIFF
--- a/core/base/jacobiSet/JacobiSet.inl
+++ b/core/base/jacobiSet/JacobiSet.inl
@@ -89,8 +89,6 @@ template <class dataTypeU, class dataTypeV>
   }
   
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_) 
 #endif
   for(SimplexId i = 0; i < (SimplexId) edgeList_->size(); i++){
@@ -154,26 +152,19 @@ template <class dataTypeU, class dataTypeV>
       // update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if((wrapper_)
-          &&(!(count % ((vertexNumber_)/10)))){
-          wrapper_->updateProgress((count + 1.0)
-            /vertexNumber_);
-        }
+        {
+          if ((wrapper_) && (!(count % ((vertexNumber_) / 10)))) {
+            wrapper_->updateProgress((count + 1.0) / vertexNumber_);
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   }
    
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
-  
   {
     std::stringstream msg;
     msg << "[JacobiSet] Edge-fans computed in "
@@ -370,8 +361,6 @@ template <class dataTypeU, class dataTypeV>
   std::vector<std::vector<std::pair<SimplexId, char> > > threadedCriticalTypes(threadNumber_);
 
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_) 
 #endif
   for(SimplexId i = 0; i < (SimplexId) edgeList_->size(); i++){
@@ -444,18 +433,15 @@ template <class dataTypeU, class dataTypeV>
       // update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if((wrapper_)
-          &&(!(count % ((vertexNumber_)/10)))){
-          wrapper_->updateProgress((count + 1.0)
-            /vertexNumber_);
-        }
+        {
+          if ((wrapper_) && (!(count % ((vertexNumber_) / 10)))) {
+            wrapper_->updateProgress((count + 1.0) / vertexNumber_);
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   }
@@ -467,10 +453,6 @@ template <class dataTypeU, class dataTypeV>
     }
   }
   
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
- 
   if(debugLevel_ >= Debug::infoMsg){
     SimplexId minimumNumber = 0, saddleNumber = 0, maximumNumber = 0, 
       monkeySaddleNumber = 0;

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -451,8 +451,6 @@ int TwoSkeleton::buildTriangleList(const SimplexId &vertexNumber,
     // the following open-mp processing is only relevant for embarassingly 
     // parallel algorithms (such as smoothing) -- to adapt
 #ifdef TTK_ENABLE_OPENMP
-    omp_lock_t writeLock;
-    omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_) 
 #endif
     for(SimplexId i = 0; i < (SimplexId) cellNumber; i++){
@@ -514,26 +512,19 @@ int TwoSkeleton::buildTriangleList(const SimplexId &vertexNumber,
         // update the progress bar of the wrapping code -- to adapt
         if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-          omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-          if((wrapper_)
-            &&(!(count % ((cellNumber)/10)))){
-            wrapper_->updateProgress((count + 1.0)
-              /cellNumber);
-          }
+          {
+            if ((wrapper_) && (!(count % ((cellNumber) / 10)))) {
+              wrapper_->updateProgress((count + 1.0) / cellNumber);
+            }
 
-          count++;
-#ifdef TTK_ENABLE_OPENMP
-          omp_unset_lock(&writeLock);
-#endif
+            count++;
+          }
         }
       }
     }
     
-#ifdef TTK_ENABLE_OPENMP
-    omp_destroy_lock(&writeLock);
-#endif
-  
     Timer mergeTimer;
     // now merge the lists
     vector<vector<pair<vector<SimplexId>, SimplexId > > > mainTriangleTable(vertexNumber);

--- a/core/base/uncertainDataEstimator/UncertainDataEstimator.h
+++ b/core/base/uncertainDataEstimator/UncertainDataEstimator.h
@@ -439,8 +439,6 @@ template <class dataType> int ttk::UncertainDataEstimator::execute() const{
 
 
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
 
@@ -478,18 +476,15 @@ template <class dataType> int ttk::UncertainDataEstimator::execute() const{
       // Update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if((wrapper_)
-          &&(!(count % ((vertexNumber_)/10)))){
-          wrapper_->updateProgress((count + 1.0)
-            /vertexNumber_);
-        }
+        {
+          if ((wrapper_) && (!(count % ((vertexNumber_) / 10)))) {
+            wrapper_->updateProgress((count + 1.0) / vertexNumber_);
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   }
@@ -539,12 +534,6 @@ template <class dataType> int ttk::UncertainDataEstimator::execute() const{
     }
     outputMeanField[v] = sum / static_cast<double>(numberOfInputs_);
   }
-
-
-
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
 
   {
     std::stringstream msg;

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
@@ -71,8 +71,6 @@ int ttkIdentifiers::doIt(vtkDataSet *input, vtkDataSet *output){
 //   }
   
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_) 
 #endif
   for(SimplexId i = 0; i < vertexNumber; i++){
@@ -84,18 +82,15 @@ int ttkIdentifiers::doIt(vtkDataSet *input, vtkDataSet *output){
       // update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if((wrapper_)
-          &&(!(count % ((vertexNumber)/10)))){
-          wrapper_->updateProgress((count + 1.0)
-            /(2*vertexNumber));
-        }
+        {
+          if ((wrapper_) && (!(count % ((vertexNumber) / 10)))) {
+            wrapper_->updateProgress((count + 1.0) / (2 * vertexNumber));
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   } 
@@ -112,26 +107,19 @@ int ttkIdentifiers::doIt(vtkDataSet *input, vtkDataSet *output){
       // update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if((wrapper_)
-          &&(!(count % ((cellNumber)/10)))){
-          wrapper_->updateProgress(1 + (count + 1.0) 
-            /(2*cellNumber));
-        }
+        {
+          if ((wrapper_) && (!(count % ((cellNumber) / 10)))) {
+            wrapper_->updateProgress(1 + (count + 1.0) / (2 * cellNumber));
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   }
   
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
- 
   output->GetPointData()->AddArray(vertexIdentifiers);
   output->GetCellData()->AddArray(cellIdentifiers);
   

--- a/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.cpp
+++ b/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.cpp
@@ -122,8 +122,6 @@ int ttkSphereFromPoint::doIt(vtkDataSet *input, vtkPolyData *output){
   SimplexId count = 0;
   
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
   for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++){
@@ -273,16 +271,15 @@ int ttkSphereFromPoint::doIt(vtkDataSet *input, vtkPolyData *output){
  
       if(debugLevel_ > 3){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
-#endif   
-        if(!(count % (input->GetNumberOfPoints()/10))){
-          updateProgress((count + 1.0)/input->GetNumberOfPoints());
-        }
-
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
+#pragma omp critical
 #endif
+        {
+          if (!(count % (input->GetNumberOfPoints() / 10))) {
+            updateProgress((count + 1.0) / input->GetNumberOfPoints());
+          }
+
+          count++;
+        }
       }
     }
   }
@@ -293,10 +290,6 @@ int ttkSphereFromPoint::doIt(vtkDataSet *input, vtkPolyData *output){
         appenderList_[i]->GetOutputPort());
   }
   masterAppender_->Update();
-  
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
   
   output->ShallowCopy(masterAppender_->GetOutput());
 

--- a/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.cpp
+++ b/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.cpp
@@ -94,8 +94,6 @@ int ttkTextureMapFromField::doIt(vtkDataSet *input, vtkDataSet *output){
   SimplexId count = 0;
   
 #ifdef TTK_ENABLE_OPENMP
-  omp_lock_t writeLock;
-  omp_init_lock(&writeLock);
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
   for(SimplexId i = 0; i < output->GetNumberOfPoints(); i++){
@@ -130,23 +128,18 @@ int ttkTextureMapFromField::doIt(vtkDataSet *input, vtkDataSet *output){
     
       if(debugLevel_ > 3){
 #ifdef TTK_ENABLE_OPENMP
-        omp_set_lock(&writeLock);
+#pragma omp critical
 #endif
-        if(!(count % (output->GetNumberOfPoints()/10))){
-          updateProgress((count + 1.0)/output->GetNumberOfPoints());
-        }
+        {
+          if (!(count % (output->GetNumberOfPoints() / 10))) {
+            updateProgress((count + 1.0) / output->GetNumberOfPoints());
+          }
 
-        count++;
-#ifdef TTK_ENABLE_OPENMP
-        omp_unset_lock(&writeLock);
-#endif
+          count++;
+        }
       }
     }
   }
-  
-#ifdef TTK_ENABLE_OPENMP
-  omp_destroy_lock(&writeLock);
-#endif
   
   output->GetPointData()->SetTCoords(textureCoordinates_);
  


### PR DESCRIPTION
An OpenMP critical section is executed by only one thread at a given
time.

Since this is apparently the intended usage of those omp_lock_t
variables, using critical sections improves code readability and lets
the OpenMP run-time handle the low-level
bits (c.f. https://stackoverflow.com/questions/29587124/openmp-critical-section-vs-locks).