### PR TITLE
Minor fix: Unused variable with GCC on FTR

### DIFF
--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -912,6 +912,9 @@ namespace ttk {
         }
       }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+
       valence oldVal = 0;
       if(localProp->goUp()) {
         // for gcc 4.8 and old openMP
@@ -961,6 +964,8 @@ namespace ttk {
         }
         oldVal = decr + newVal + (totalVal + 1);
       }
+
+#pragma GCC diagnostic pop
 
       return oldVal == decr;
     }

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1476,9 +1476,11 @@ int ttkContourForests::doIt(vector<vtkDataSet *> &inputs,
   vector<vtkDataSet *> &outputs){
 
   if(debugLevel_){
-    vtkWarningMacro("[ttkContourForests]: DEPRECATED This plugin will be removed in a futur elease, please use FTM instead");
+    vtkWarningMacro("[ttkContourForests]: DEPRECATED This plugin will be "
+                    "removed in a futur elease, please use FTM instead for "
+                    "contour trees and FTR for Reeb graphs.");
   }
-  
+
   Memory m;
 
 #ifndef TTK_ENABLE_KAMIKAZE


### PR DESCRIPTION
Dear Julien,

This PR remove a warning when compiling FTR with GCC.
Also, I have updated the warning message on Contour Forests to also mention FTR.

Charles