### PR TITLE
Minor fix for FTR: rename executable

### DIFF
--- a/standalone/FTRGraph/cmd/CMakeLists.txt
+++ b/standalone/FTRGraph/cmd/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(FTRGraphCmd)
+project(ttkFTRGraphCmd)
 
 set(CMAKE_SKIP_BUILD_RPATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/ttk/")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-add_executable(FTRGraphCmd main.cpp)
-target_link_libraries(FTRGraphCmd ${VTK_LIBRARIES}
+add_executable(ttkFTRGraphCmd main.cpp)
+target_link_libraries(ttkFTRGraphCmd ${VTK_LIBRARIES}
 	ttkFTRGraph ttkProgramBase)
 
-install(TARGETS FTRGraphCmd RUNTIME DESTINATION ${TTK_INSTALL_BINARY_DIR})
+install(TARGETS ttkFTRGraphCmd RUNTIME DESTINATION ${TTK_INSTALL_BINARY_DIR})

--- a/standalone/FTRGraph/gui/CMakeLists.txt
+++ b/standalone/FTRGraph/gui/CMakeLists.txt
@@ -1,16 +1,16 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(FTRGraphGui)
+project(ttkFTRGraphGui)
 
 set(CMAKE_SKIP_BUILD_RPATH TRUE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE) 
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib/ttk/")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-add_executable(FTRGraphGui main.cpp)
-target_link_libraries(FTRGraphGui ${VTK_LIBRARIES}
+add_executable(ttkFTRGraphGui main.cpp)
+target_link_libraries(ttkFTRGraphGui ${VTK_LIBRARIES}
 	ttkFTRGraph ttkProgramBase ttkUserInterfaceBase)
 
-install(TARGETS FTRGraphGui RUNTIME DESTINATION ${TTK_INSTALL_BINARY_DIR})
+install(TARGETS ttkFTRGraphGui RUNTIME DESTINATION ${TTK_INSTALL_BINARY_DIR})
 install(DIRECTORY textures DESTINATION ${TTK_INSTALL_BINARY_DIR})
 


### PR DESCRIPTION
Dear Julien,

I have renamed the standalone executable of FTR so that it is prefixed with 'ttk' accordingly to other fillers.

Charles 