### PR TITLE
FTR: Improve warning for openmp max task priority

### DIFF
--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -58,10 +58,9 @@ namespace ttk {
       omp_set_nested(1);
 #ifdef TTK_ENABLE_FTR_PRIORITY
       if(omp_get_max_task_priority() < PriorityLevel::Max) {
-        std::cout << "[FTR]: Max priority is " << omp_get_max_task_priority();
-        std::cout << ", you need to set it to at last : " << PriorityLevel::Max
-                  << std::endl;
-        std::cout << "  you can use $OMP_MAX_TASK_PRIORITY" << std::endl;
+        std::cout << "[FTR Graph]: Warning, OpenMP max priority is lower than 5"
+                  << endl;
+        // std::cout << "  you can use $OMP_MAX_TASK_PRIORITY" << std::endl;
       }
 #endif
 #endif


### PR DESCRIPTION
Dear Julien,

When `$OMP_MAX_TASK_PRIORITY` is lower than 5, the use of task priority is not optimal.
The warning raised by FTR in this situation has been improved.

Charles