### PR TITLE
FTR: SoS offsets use SimplexId type

### DIFF
--- a/core/base/ftrGraph/Scalars.h
+++ b/core/base/ftrGraph/Scalars.h
@@ -28,7 +28,7 @@ namespace ttk {
       idVertex size_;
 
       ScalarType *values_;
-      idVertex *offsets_;
+      SimplexId *offsets_;
 
       bool externalOffsets_;
 
@@ -74,14 +74,14 @@ namespace ttk {
         values_ = values;
       }
 
-      void setOffsets(idVertex *sos) {
+      void setOffsets(SimplexId *sos) {
         externalOffsets_ = sos;
         offsets_ = sos;
       }
 
       void alloc() {
         if(!externalOffsets_) {
-          offsets_ = new idVertex[size_];
+          offsets_ = new SimplexId[size_];
         }
         vertices_.resize(size_);
         mirror_.resize(size_);
@@ -93,7 +93,7 @@ namespace ttk {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(static, size_ / threadNumber_)
 #endif
-          for(idVertex i = 0; i < size_; i++) {
+          for(SimplexId i = 0; i < size_; i++) {
             offsets_[i] = i;
           }
         }


### PR DESCRIPTION
Dear Julien,

the SoS array in FTR is now in SimplexId type instead of vertexId (both are the same under the hood, this is a semantic improvment).
Should this type be changed in favor of a template ?

Charles