### PR TITLE
FTR fix empty nodes output

### DIFF
--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -508,6 +508,8 @@ int ttkFTRGraph::getSkeletonNodes(const Graph &graph,
   nodes->SetPoints(points);
   nodeData.addArrays(nodes->GetPointData(), params_);
 
+  outputSkeletonNodes->ShallowCopy(nodes);
+
   return 0;
 }
 


### PR DESCRIPTION
Dear Julien,

It seems I forgot the shallowCopy on the getSkeletonNode function... This is fixed here!

Charles