### PR TITLE
FTR: Fix wrapper for data sets with multiple CC

### DIFF
--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -442,6 +442,8 @@ int ttkFTRGraph::getSegmentation(const ttk::ftr::Graph &graph,
 int ttkFTRGraph::getSkeletonArcs(const ttk::ftr::Graph &graph,
                                  vtkUnstructuredGrid *outputSkeletonArcs) {
   const idSuperArc nbArcs = graph.getNumberOfArcs();
+  const idNode nbNodes = graph.getNumberOfNodes();
+
   idSuperArc nbFinArc = 0;
   switch(params_.samplingLvl) {
     case -1:
@@ -456,7 +458,7 @@ int ttkFTRGraph::getSkeletonArcs(const ttk::ftr::Graph &graph,
       break;
   }
 
-  ttk::ftr::ArcData arcData(nbFinArc);
+  ttk::ftr::ArcData arcData(nbFinArc, nbNodes);
   vtkSmartPointer<vtkUnstructuredGrid> arcs
     = vtkSmartPointer<vtkUnstructuredGrid>::New();
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();

--- a/core/vtk/ttkFTRGraph/ttkFTRGraphStructures.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraphStructures.h
@@ -73,10 +73,9 @@ namespace ttk {
 #endif
       std::map<ttk::ftr::idVertex, vtkIdType> points;
 
-      explicit ArcData(const ttk::ftr::idSuperArc nbArcs) {
+      ArcData(const ttk::ftr::idSuperArc nbArcs, const ttk::ftr::idNode nbNodes) {
         ids = allocArray<vtkIntArray>("ArcId", nbArcs);
-        reg = allocArray<vtkCharArray>(ttk::MaskScalarFieldName,
-          nbArcs + 1);
+        reg = allocArray<vtkCharArray>(ttk::MaskScalarFieldName, nbNodes);
 #ifndef NDEBUG
         fromUp = allocArray<vtkUnsignedCharArray>("growUp", nbArcs);
 #endif


### PR DESCRIPTION
Dear Julien,

This is a fix for FTR, where the number of nodes in the arc structure was wrongly deduced from the number of arcs. This could lead to memory corruption on data sets with several connected components.

Charles