### PR TITLE
Refix for FTR: the number of node in the arc when sampling

### DIFF
--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -442,7 +442,6 @@ int ttkFTRGraph::getSegmentation(const ttk::ftr::Graph &graph,
 int ttkFTRGraph::getSkeletonArcs(const ttk::ftr::Graph &graph,
                                  vtkUnstructuredGrid *outputSkeletonArcs) {
   const idSuperArc nbArcs = graph.getNumberOfArcs();
-  const idNode nbNodes = graph.getNumberOfNodes();
 
   idSuperArc nbFinArc = 0;
   switch(params_.samplingLvl) {
@@ -458,7 +457,7 @@ int ttkFTRGraph::getSkeletonArcs(const ttk::ftr::Graph &graph,
       break;
   }
 
-  ttk::ftr::ArcData arcData(nbFinArc, nbNodes);
+  ttk::ftr::ArcData arcData(nbFinArc);
   vtkSmartPointer<vtkUnstructuredGrid> arcs
     = vtkSmartPointer<vtkUnstructuredGrid>::New();
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();

--- a/core/vtk/ttkFTRGraph/ttkFTRGraphStructures.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraphStructures.h
@@ -73,9 +73,9 @@ namespace ttk {
 #endif
       std::map<ttk::ftr::idVertex, vtkIdType> points;
 
-      ArcData(const ttk::ftr::idSuperArc nbArcs, const ttk::ftr::idNode nbNodes) {
+      ArcData(const ttk::ftr::idSuperArc nbArcs) {
         ids = allocArray<vtkIntArray>("ArcId", nbArcs);
-        reg = allocArray<vtkCharArray>(ttk::MaskScalarFieldName, nbNodes);
+        reg = allocArray<vtkCharArray>(ttk::MaskScalarFieldName, nbArcs * 2);
 #ifndef NDEBUG
         fromUp = allocArray<vtkUnsignedCharArray>("growUp", nbArcs);
 #endif


### PR DESCRIPTION
Dear Julien,

The last fix for the reserve on the number of nodes on the arc skeleton was not enough as this number can be higher than the number of node in the RG if sampling is used. A pessimistic reserve is now used, where the number of nodes is twice the number of arcs.

Charles