### PR TITLE
Standalone textures: Manage install path in executables

### DIFF
--- a/core/vtk/ttkUserInterfaceBase/CMakeLists.txt
+++ b/core/vtk/ttkUserInterfaceBase/CMakeLists.txt
@@ -2,3 +2,8 @@ ttk_add_vtk_library(ttkUserInterfaceBase
 	SOURCES ttkUserInterfaceBase.cpp
 	HEADERS ttkUserInterfaceBase.h
 	LINK ttkProgramBase ttkTextureMapFromField)
+
+target_compile_definitions(
+  ttkUserInterfaceBase
+  PRIVATE TTK_INSTALL_ASSETS_DIR="${CMAKE_INSTALL_PREFIX}/share/ttk"
+  )

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -3,6 +3,10 @@
 
 #include <vtkTexture.h>
 
+#ifndef TTK_INSTALL_ASSETS_DIR
+#define TTK_INSTALL_ASSETS_DIR "."
+#endif // TTK_INSTALL_ASSETS_DIR
+
 using namespace std;
 using namespace ttk;
 
@@ -84,7 +88,7 @@ ttkUserInterfaceBase::ttkUserInterfaceBase() {
   texture_ = vtkSmartPointer<vtkTexture>::New();
 
   pngReader_->SetFileName(
-    "textures/png/scalarFieldTexturePaleInterleavedRules.png");
+    TTK_INSTALL_ASSETS_DIR "/textures/png/scalarFieldTexturePaleInterleavedRules.png");
   pngReader_->Update();
   hasTexture_ = 
     !((pngReader_->GetOutput()->GetNumberOfPoints() == 1)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -22,4 +22,4 @@ foreach(STANDALONE ${STANDALONE_DIRS})
 	endif()
 endforeach()
 
-install(DIRECTORY textures DESTINATION ${TTK_INSTALL_BINARY_DIR})
+install(DIRECTORY textures DESTINATION share/ttk)


### PR DESCRIPTION
The GUI executables in the ```standalone``` folders were searching PNG textures into their local directory.
The current set of commits make them look for textures into the installation directory when built by CMake, or locally otherwise.

The textures installation directory, since containing no executable files, was also changed from ```$prefix/bin``` to ```$prefix/share/ttk```, to be more consistent with the standard filesystem hierarchy.