### PR TITLE
FTR: Great performance improvement

### DIFF
--- a/core/base/ftrGraph/CMakeLists.txt
+++ b/core/base/ftrGraph/CMakeLists.txt
@@ -34,7 +34,7 @@ ttk_add_base_library(ftrGraph
    HEADERS AtomicVector.h FTRGraph.h FTRGraph_Template.h
            FTRGraphPrint_Template.h FTRGraphPrivate_Template.h DynamicGraph.h
            Lazy.h Mesh.h Propagation.h Propagations.h Scalars.h Segmentation.h
-           LINK triangulation ${profiler_lib})
+           LINK triangulation scalarFieldCriticalPoints ${profiler_lib})
 
 target_include_directories(ftrGraph PUBLIC ${Boost_INCLUDE_DIR})
 

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -17,6 +17,7 @@
 #include "FTRCommon.h"
 
 #include <vector>
+#include <set>
 
 namespace ttk {
   namespace ftr {
@@ -133,16 +134,13 @@ namespace ttk {
 
       /// \brief findRoot but using ids of the nodes in a vector
       template <typename type>
-      std::vector<DynGraphNode<Type> *>
+      std::set<DynGraphNode<Type> *>
         findRoot(const std::vector<type> &nodesIds) {
-        std::vector<DynGraphNode<Type> *> roots;
-        roots.reserve(nodesIds.size());
+
+        std::set<DynGraphNode<Type> *> roots;
         for(auto n : nodesIds) {
-          roots.emplace_back(findRoot(n));
+          roots.emplace(findRoot(n));
         }
-        std::sort(roots.begin(), roots.end());
-        const auto it = std::unique(roots.begin(), roots.end());
-        roots.erase(it, roots.end());
         return roots;
       }
 

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -20,6 +20,7 @@
 
 namespace ttk {
   namespace ftr {
+
     template <typename Type>
     struct DynGraphNode;
 

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -172,6 +172,7 @@ namespace ttk {
     template <typename Type>
     std::tuple<DynGraphNode<Type> *, DynGraphNode<Type> *>
       DynGraphNode<Type>::findMinWeightRoot() const {
+
       DynGraphNode *minNode = const_cast<DynGraphNode<Type> *>(this);
       auto minW = minNode->weight_;
       DynGraphNode *curNode = minNode->parent_;

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -58,7 +58,7 @@ namespace ttk {
     };
 
     struct Comp {
-      std::vector<DynGraphNode<idVertex> *> lower, upper;
+      std::set<DynGraphNode<idVertex> *> lower, upper;
     };
 
     template <typename ScalarType>
@@ -283,13 +283,13 @@ namespace ttk {
       /// and find their corresponding components in the current
       /// preimage graph, each representing a component.
       /// \ret the set of uniques representing components
-      std::vector<DynGraphNode<idVertex> *>
+      std::set<DynGraphNode<idVertex> *>
         lowerComps(const std::vector<idEdge> &finishingEdges,
                    const Propagation *const localProp);
 
       /// Symetric to lowerComps
       /// \ref lowerComps
-      std::vector<DynGraphNode<idVertex> *>
+      std::set<DynGraphNode<idVertex> *>
         upperComps(const std::vector<idEdge> &startingEdges,
                    const Propagation *const localProp);
 
@@ -400,20 +400,20 @@ namespace ttk {
       idSuperArc
         mergeAtSaddle(const idNode saddleId,
                       Propagation *localProp,
-                      const std::vector<DynGraphNode<idVertex> *> &lowerComp);
+                      const std::set<DynGraphNode<idVertex> *> &lowerComp);
 
       // At a join saddle, close onped arcs only
       // do not touch local propagations
       // return the number of visible arcs merging
       idSuperArc
         mergeAtSaddle(const idNode saddleId,
-                      const std::vector<DynGraphNode<idVertex> *> &lowerComp);
+                      const std::set<DynGraphNode<idVertex> *> &lowerComp);
 
       // At a split saddle, assign new arcs at each CC in the DynGraph,
       // and launch a new propagation taking care of these arcs simultaneously
       // if hidden is true, new arcs are created hidden
       void splitAtSaddle(Propagation *const localProp,
-                         const std::vector<DynGraphNode<idVertex> *> &upperComp,
+                         const std::set<DynGraphNode<idVertex> *> &upperComp,
                          const bool hidden = false);
 
       // Retrun one triangle by upper CC of the vertex v

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -28,6 +28,9 @@
 #include "Propagations.h"
 #include "Scalars.h"
 
+// other baseCode
+#include "ScalarFieldCriticalPoints.h"
+
 #ifndef TTK_DISABLE_FTR_LAZY
 #include "Lazy.h"
 #endif
@@ -78,11 +81,6 @@ namespace ttk {
 #ifndef TTK_DISABLE_FTR_LAZY
       Lazy lazy_;
 #endif
-
-      // BFS history arrays
-      std::vector<idCell> bfsCells_;
-      std::vector<idEdge> bfsEdges_;
-      std::vector<idVertex> bfsVerts_;
 
 #ifdef TTK_ENABLE_FTR_TASK_STATS
       // Stats
@@ -190,7 +188,7 @@ namespace ttk {
       /// them in a morse discret geometry compliant way.
       /// This is explained in the TTK report.
       /// Set the array to use here
-      void setVertexSoSoffsets(idVertex *sos) {
+      void setVertexSoSoffsets(std::vector<SimplexId> *sos) {
         scalars_->setOffsets(sos);
       }
 
@@ -220,9 +218,6 @@ namespace ttk {
 
     protected:
       // Build functions
-
-      /// Find the extrema from which the local propagations will start
-      void leafSearch();
 
       // classify critical points, marks saddle in join/split vectors
       // and add min/max or both as leaves.

--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -829,28 +829,10 @@ namespace ttk {
     template <typename ScalarType>
     void FTRGraph<ScalarType>::lazyApply(Propagation *const localProp,
                                          const idSuperArc a) {
-      auto comp = [localProp](const idVertex a, const idVertex b) {
-        return localProp->compare(a, b);
-      };
-
       auto add = lazy_.addGetNext(a);
-      auto del = lazy_.delGetNext(a);
-      while(add != nullLink || del != nullLink) {
-        if(del == nullLink) {
-          updateLazyAdd(localProp, add, a);
-          add = lazy_.addGetNext(a);
-        } else if(add == nullLink || mesh_.compareLinks(del, add, comp)) {
-          updateLazyDel(localProp, del, a);
-          del = lazy_.delGetNext(a);
-        } else if(mesh_.compareLinks(add, del, comp)) {
-          updateLazyAdd(localProp, add, a);
-          add = lazy_.addGetNext(a);
-        } else {
-          // same arc in both list, should be added and removed so we jus ignore
-          // it (add and del cant be null both of them at the same time)
-          add = lazy_.addGetNext(a);
-          del = lazy_.delGetNext(a);
-        }
+      while(add != nullLink) {
+        updateLazyAdd(localProp, add, a);
+        add = lazy_.addGetNext(a);
       }
     }
 

--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -161,7 +161,7 @@ namespace ttk {
             break;
           } else {
             if(comp.lower.size()) {
-              currentArc = comp.lower[0]->getCorArc();
+              currentArc = (*comp.lower.begin())->getCorArc();
               if(currentArc == nullSuperArc) {
                 PRINT("n--" << curVert);
                 continue;
@@ -459,7 +459,7 @@ namespace ttk {
           bool isJoin = false;
           comp.lower = lowerComps(star.lower, localProp);
           if(comp.lower.size() == 1) { // regular
-            currentArc = comp.lower[0]->getCorArc();
+            currentArc = (*comp.lower.begin())->getCorArc();
           } else if(comp.lower.size() > 1) { // join saddle
             const idNode sadNode = graph_.makeNode(curVert);
             currentArc = graph_.openArc(sadNode, localProp);
@@ -520,16 +520,16 @@ namespace ttk {
     }
 
     template <typename ScalarType>
-    std::vector<DynGraphNode<idVertex> *> FTRGraph<ScalarType>::lowerComps(
+    std::set<DynGraphNode<idVertex> *> FTRGraph<ScalarType>::lowerComps(
       const std::vector<idEdge> &finishingEdges,
       const Propagation *const localProp) {
       return dynGraph(localProp).findRoot(finishingEdges);
     }
 
     template <typename ScalarType>
-    std::vector<DynGraphNode<idVertex> *>
-      FTRGraph<ScalarType>::upperComps(const std::vector<idEdge> &startingEdges,
-                                       const Propagation *const localProp) {
+    std::set<DynGraphNode<idVertex> *> FTRGraph<ScalarType>::upperComps(
+        const std::vector<idEdge> &startingEdges,
+        const Propagation *const localProp) {
       return dynGraph(localProp).findRoot(startingEdges);
     }
 
@@ -956,7 +956,7 @@ namespace ttk {
     idSuperArc FTRGraph<ScalarType>::mergeAtSaddle(
       const idNode saddleId,
       Propagation *localProp,
-      const std::vector<DynGraphNode<idVertex> *> &compVect) {
+      const std::set<DynGraphNode<idVertex> *> &compVect) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(compVect.size() < 2) {
@@ -983,7 +983,7 @@ namespace ttk {
     template <typename ScalarType>
     idSuperArc FTRGraph<ScalarType>::mergeAtSaddle(
       const idNode saddleId,
-      const std::vector<DynGraphNode<idVertex> *> &compVect) {
+      const std::set<DynGraphNode<idVertex> *> &compVect) {
       // version for the sequential arc growth, do not merge the propagations
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -1008,7 +1008,7 @@ namespace ttk {
     template <typename ScalarType>
     void FTRGraph<ScalarType>::splitAtSaddle(
       Propagation *const localProp,
-      const std::vector<DynGraphNode<idVertex> *> &compVect,
+      const std::set<DynGraphNode<idVertex> *> &compVect,
       const bool hidden) {
       const idVertex curVert = localProp->getCurVertex();
       const idNode curNode = graph_.getNodeId(curVert);

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -145,7 +145,14 @@ namespace ttk {
       graph_.arcs2nodes<ScalarType>(scalars_);
       printTime(postProcTime, "[FTR Graph]: postProcess: ", advancedInfoMsg);
 
+      // std::cout << "nb verts: " << mesh_.getNumberOfVertices() << std::endl;
+      // std::cout << "nb triangle: " << mesh_.getNumberOfVertices() << std::endl;
+      // std::cout << "nb nodes: " << graph_.getNumberOfNodes() << std::endl;
+      // std::cout << "nb leaves: " << graph_.getNumberOfLeaves() << std::endl;
+      // std::cout << "nb  arcs: " << graph_.getNumberOfVisibleArcs() << std::endl;
+
       printTime(finTime, "[FTR Graph]: *TOTAL* time: ", timeMsg);
+
 #ifdef GPROFILE
       ProfilerStop();
 #endif

--- a/core/base/ftrGraph/Lazy.h
+++ b/core/base/ftrGraph/Lazy.h
@@ -19,13 +19,14 @@
 
 // c++ includes
 #include <deque>
+#include <set>
 #include <vector>
 
 namespace ttk {
   namespace ftr {
     class Lazy : public Allocable {
     private:
-      std::vector<std::deque<linkEdge>> lazyAdd_, lazyDel_;
+      std::vector<std::set<linkEdge>> lazyAdd_;
 
     public:
       Lazy() {
@@ -33,7 +34,6 @@ namespace ttk {
 
       void alloc() override {
         lazyAdd_.resize(nbElmt_);
-        lazyDel_.resize(nbElmt_);
       }
 
       void init() override {
@@ -41,12 +41,15 @@ namespace ttk {
       }
 
       void addEmplace(const idEdge e0, const idEdge e1, const idSuperArc a) {
-        lazyAdd_[a].emplace_back(std::make_pair(e0, e1));
+        lazyAdd_[a].emplace(std::make_pair(e0, e1));
       }
 
       void delEmplace(const idEdge e0, const idEdge e1, const idSuperArc a) {
-        // here the arc would be a non sense.
-        lazyDel_[a].emplace_back(std::make_pair(e0, e1));
+        const auto p = std::make_pair(e0, e1);
+        auto it = lazyAdd_[a].find(p);
+        if (it != lazyAdd_[a].end()) {
+          lazyAdd_[a].erase(it);
+        }
       }
 
       // return the head of lazyAdd / lazyDel (or a null link if empty)
@@ -55,24 +58,14 @@ namespace ttk {
         if(lazyAdd_[a].empty()) {
           return nullLink;
         } else {
-          linkEdge add = lazyAdd_[a].front();
-          lazyAdd_[a].pop_front();
+          linkEdge add = *lazyAdd_[a].begin();
+          lazyAdd_[a].erase(lazyAdd_[a].begin());
           return add;
         }
       }
 
-      linkEdge delGetNext(const idSuperArc a) {
-        if(lazyDel_[a].empty()) {
-          return nullLink;
-        } else {
-          linkEdge del = lazyDel_[a].front();
-          lazyDel_[a].pop_front();
-          return del;
-        }
-      }
-
       bool isEmpty(const idSuperArc a) {
-        return lazyAdd_[a].empty() && (lazyDel_[a].empty());
+        return lazyAdd_[a].empty();
       }
 
       // const decltype(lazyAdd_)& addEach() const

--- a/core/base/ftrGraph/Lazy.h
+++ b/core/base/ftrGraph/Lazy.h
@@ -18,7 +18,6 @@
 #include "FTRCommon.h"
 
 // c++ includes
-#include <deque>
 #include <set>
 #include <vector>
 

--- a/core/base/ftrGraph/Mesh.h
+++ b/core/base/ftrGraph/Mesh.h
@@ -79,6 +79,10 @@ namespace ttk {
         tri_ = tri;
       }
 
+      Triangulation* getTriangulation() {
+        return tri_;
+      }
+
       void alloc(void) override {
         edgesSortId_.resize(nbEdges_);
         trianglesSortId_.resize(nbTriangles_);
@@ -91,9 +95,8 @@ namespace ttk {
         tri_->preprocessVertexNeighbors();
         tri_->preprocessVertexEdges();
         tri_->preprocessVertexTriangles();
+        tri_->preprocessVertexStars();
         tri_->preprocessTriangleEdges();
-        tri_->preprocessEdgeTriangles();
-        tri_->preprocessTriangles();
 
         nbVerts_ = tri_->getNumberOfVertices();
         nbEdges_ = tri_->getNumberOfEdges();
@@ -101,6 +104,10 @@ namespace ttk {
       }
 
       // Facade Triangulation
+
+      inline SimplexId getDimensionality(void) const {
+        return tri_->getDimensionality();
+      }
 
       inline idVertex getNumberOfVertices(void) const {
         return nbVerts_;

--- a/core/base/ftrGraph/Scalars.h
+++ b/core/base/ftrGraph/Scalars.h
@@ -28,6 +28,7 @@ namespace ttk {
       idVertex size_;
 
       ScalarType *values_;
+      std::vector<SimplexId> *vOffsets_;
       SimplexId *offsets_;
 
       bool externalOffsets_;
@@ -37,8 +38,8 @@ namespace ttk {
 
     public:
       Scalars()
-        : size_(nullVertex), values_(nullptr), offsets_(nullptr),
-          externalOffsets_(false), vertices_(), mirror_() {
+        : size_(nullVertex), values_(nullptr), vOffsets_(nullptr),
+          offsets_(nullptr), externalOffsets_(false), vertices_(), mirror_() {
       }
 
       // Heavy, prevent using it
@@ -48,6 +49,18 @@ namespace ttk {
         if(!externalOffsets_) {
           delete[] offsets_;
         }
+      }
+
+      ScalarType* getScalars() {
+        return values_;
+      }
+
+      std::vector<SimplexId> *getVOffsets() {
+        return vOffsets_;
+      }
+
+      SimplexId* getOffsets() {
+        return offsets_;
       }
 
       idVertex getSize(void) const {
@@ -74,9 +87,12 @@ namespace ttk {
         values_ = values;
       }
 
-      void setOffsets(SimplexId *sos) {
+      void setOffsets(std::vector<SimplexId> *sos) {
         externalOffsets_ = sos;
-        offsets_ = sos;
+        vOffsets_ = sos;
+        if(vOffsets_) {
+          offsets_ = vOffsets_->data();
+        }
       }
 
       void alloc() {

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -1,15 +1,15 @@
 /// \ingroup base
-/// \class ttk::ScalarFieldCriticalPoints 
+/// \class ttk::ScalarFieldCriticalPoints
 /// \author Julien Tierny <julien.tierny@lip6.fr>
 /// \date June 2015.
 ///
 /// \brief TTK processing package for the computation of critical points in PL
 /// scalar fields defined on PL manifolds.
 ///
-/// This class computes the list of critical points of the input scalar field 
+/// This class computes the list of critical points of the input scalar field
 /// and classify them according to their type.
 ///
-/// \param dataType Data type of the input scalar field (char, float, 
+/// \param dataType Data type of the input scalar field (char, float,
 /// etc.).
 ///
 /// \b Related \b publication \n
@@ -22,124 +22,138 @@
 #ifndef _SCALARFIELDCRITICALPOINTS_H
 #define _SCALARFIELDCRITICALPOINTS_H
 
-#include                  <map>
+#include <map>
 
 // base code includes
-#include                  <Triangulation.h>
-#include                  <UnionFind.h>
-#include                  <Wrapper.h>
+#include <Triangulation.h>
+#include <UnionFind.h>
+#include <Wrapper.h>
 
+namespace ttk {
 
-namespace ttk{
+  template <class dataType>
+  class ScalarFieldCriticalPoints : public Debug {
 
-  template <class dataType> class ScalarFieldCriticalPoints : public Debug{
+  public:
+    ScalarFieldCriticalPoints();
 
-    public:
-        
-      ScalarFieldCriticalPoints();
-      
-      ~ScalarFieldCriticalPoints();
+    ~ScalarFieldCriticalPoints();
 
-      /// Execute the package.
-      /// \param argment Dummy integer argument.
-      /// \return Returns 0 upon success, negative values otherwise.
-      int execute();
-      
-      char getCriticalType(const SimplexId &vertexId) const{
-        
-        return getCriticalType(vertexId, triangulation_);
+    /// Execute the package.
+    /// \param argment Dummy integer argument.
+    /// \return Returns 0 upon success, negative values otherwise.
+    int execute();
+
+    std::pair<SimplexId, SimplexId>
+      getNumberOfLowerUpperComponents(const SimplexId vertexId,
+                                      Triangulation *triangulation) const;
+
+    char getCriticalType(const SimplexId &vertexId) const {
+
+      return getCriticalType(vertexId, triangulation_);
+    }
+
+    char getCriticalType(const SimplexId &vertexId,
+                         Triangulation *triangulation) const;
+
+    char getCriticalType(const SimplexId &vertexId,
+                         const std::vector<std::pair<SimplexId, SimplexId>>
+                           &vertexLinkEdgeList) const;
+
+    static bool isSosHigherThan(const SimplexId &offset0,
+                                const dataType &value0,
+                                const SimplexId &offset1,
+                                const dataType &value1) {
+
+      return ((value0 > value1) || ((value0 == value1) && (offset0 > offset1)));
+    }
+
+    static bool isSosLowerThan(const SimplexId &offset0,
+                               const dataType &value0,
+                               const SimplexId &offset1,
+                               const dataType &value1) {
+
+      return ((value0 < value1) || ((value0 == value1) && (offset0 < offset1)));
+    }
+
+    int setDomainDimension(const int &dimension) {
+
+      dimension_ = dimension;
+
+      return 0;
+    }
+
+    int setOutput(std::vector<std::pair<SimplexId, char>> *criticalPoints) {
+
+      criticalPoints_ = criticalPoints;
+
+      return 0;
+    }
+
+    int setupTriangulation(Triangulation *triangulation) {
+
+      triangulation_ = triangulation;
+
+      // pre-condition functions
+      if(triangulation_) {
+        triangulation_->preprocessVertexNeighbors();
+        triangulation_->preprocessVertexStars();
       }
 
-      char getCriticalType(const SimplexId &vertexId,
-        Triangulation *triangulation) const;
-      
-      char getCriticalType(const SimplexId &vertexId,
-        const std::vector<std::pair<SimplexId, SimplexId> > &vertexLinkEdgeList) const;
-      
-      static bool isSosHigherThan(const SimplexId &offset0, const dataType &value0,
-        const SimplexId &offset1, const dataType &value1){
-        
-        return ((value0 > value1)||((value0 == value1)&&(offset0 > offset1)));
-      }
-      
-      static bool isSosLowerThan(const SimplexId &offset0, const dataType &value0,
-        const SimplexId &offset1, const dataType &value1){
-        
-        return ((value0 < value1)||((value0 == value1)&&(offset0 < offset1)));
-      }
-    
-      int setDomainDimension(const int &dimension){
-        
-        dimension_ = dimension;
-        
-        return 0;
-      }
-      
-      int setOutput(std::vector<std::pair<SimplexId, char> > *criticalPoints){
-        
-        criticalPoints_ = criticalPoints;
-        
-        return 0;
-      }
-      
-      int setupTriangulation(Triangulation *triangulation){
-        
-        triangulation_ = triangulation;
-        
-        // pre-condition functions
-        if(triangulation_){
-          triangulation_->preprocessVertexNeighbors();
-          triangulation_->preprocessVertexStars();
-        }
-        
-        return 0;
-      }
-      
-      int setScalarValues(const void *data){
-        
-        scalarValues_ = (const dataType *) data;
-        
-        return 0;
-      }
-      
-      int setSosOffsets(std::vector<SimplexId> *offsets){
-        
-        sosOffsets_ = offsets;
-        
-        return 0;
-      }
-      
-      int setVertexLinkEdgeLists(
-        const std::vector<std::vector<std::pair<SimplexId, SimplexId> > > *edgeList){
-        
-        vertexLinkEdgeLists_ = edgeList;
-        
-        return 0;
-      }
-      
-      /// Set the number of vertices in the scalar field.
-      /// \param vertexNumber Number of vertices in the data-set.
-      /// \return Returns 0 upon success, negative values otherwise. 
-      int setVertexNumber(const SimplexId &vertexNumber){
-        vertexNumber_ = vertexNumber;
-        return 0;
-      }
-      
-      
-    protected:
-      
-      int                   dimension_;
-      SimplexId             vertexNumber_;
-      const dataType        *scalarValues_;
-      const std::vector<std::vector<std::pair<SimplexId, SimplexId> > > *vertexLinkEdgeLists_;
-      std::vector<std::pair<SimplexId, char> > *criticalPoints_;
-      std::vector<SimplexId>           *sosOffsets_;
-      std::vector<SimplexId>           localSosOffSets_;
-      Triangulation         *triangulation_;
+      return 0;
+    }
+
+    int setScalarValues(const void *data) {
+
+      scalarValues_ = (const dataType *)data;
+
+      return 0;
+    }
+
+    int setSosOffsets(std::vector<SimplexId> *offsets) {
+
+      sosOffsets_ = offsets;
+
+      return 0;
+    }
+
+    int setVertexLinkEdgeLists(
+      const std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
+        *edgeList) {
+
+      vertexLinkEdgeLists_ = edgeList;
+
+      return 0;
+    }
+
+    /// Set the number of vertices in the scalar field.
+    /// \param vertexNumber Number of vertices in the data-set.
+    /// \return Returns 0 upon success, negative values otherwise.
+    int setVertexNumber(const SimplexId &vertexNumber) {
+      vertexNumber_ = vertexNumber;
+      return 0;
+    }
+
+    void setNonManifold(const bool b) {
+      forceNonManifoldCheck = b;
+    }
+
+  protected:
+    int dimension_;
+    SimplexId vertexNumber_;
+    const dataType *scalarValues_;
+    const std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
+      *vertexLinkEdgeLists_;
+    std::vector<std::pair<SimplexId, char>> *criticalPoints_;
+    std::vector<SimplexId> *sosOffsets_;
+    std::vector<SimplexId> localSosOffSets_;
+    Triangulation *triangulation_;
+
+    bool forceNonManifoldCheck;
   };
-}
+} // namespace ttk
 
 // if the package is not a template, comment the following line
-#include                  <ScalarFieldCriticalPoints.inl>
+#include <ScalarFieldCriticalPoints.inl>
 
 #endif // SCALARFIELDCRITICALPOINTS_H

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -1,12 +1,11 @@
 #ifndef SCALARFIELDCRITICALPOINTS_INL
 #define SCALARFIELDCRITICALPOINTS_INL
 
-#include                  <ScalarFieldCriticalPoints.h>
+#include <ScalarFieldCriticalPoints.h>
 
-template <class dataType> 
-  ttk::ScalarFieldCriticalPoints<dataType>::ScalarFieldCriticalPoints(){
+template <class dataType>
+ttk::ScalarFieldCriticalPoints<dataType>::ScalarFieldCriticalPoints() {
 
-  
   dimension_ = 0;
   vertexNumber_ = 0;
   scalarValues_ = NULL;
@@ -14,93 +13,93 @@ template <class dataType>
   criticalPoints_ = NULL;
   sosOffsets_ = NULL;
   triangulation_ = NULL;
-  
-//   threadNumber_ = 1;
+
+  forceNonManifoldCheck = false;
+
+  //   threadNumber_ = 1;
 }
 
-template <class dataType> 
-  ttk::ScalarFieldCriticalPoints<dataType>::~ScalarFieldCriticalPoints(){
-  
+template <class dataType>
+ttk::ScalarFieldCriticalPoints<dataType>::~ScalarFieldCriticalPoints() {
 }
 
-template <class dataType> int 
-ttk::ScalarFieldCriticalPoints<dataType>::execute(){
+template <class dataType>
+int ttk::ScalarFieldCriticalPoints<dataType>::execute() {
 
   // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
-  if((!dimension_)&&((!triangulation_)||(triangulation_->isEmpty())))
+  if((!dimension_) && ((!triangulation_) || (triangulation_->isEmpty())))
     return -1;
-  if((!vertexNumber_)&&((!triangulation_)||(triangulation_->isEmpty())))
+  if((!vertexNumber_) && ((!triangulation_) || (triangulation_->isEmpty())))
     return -2;
   if(!scalarValues_)
     return -3;
-  if((!vertexLinkEdgeLists_)&&((!triangulation_)||(triangulation_->isEmpty())))
+  if((!vertexLinkEdgeLists_)
+     && ((!triangulation_) || (triangulation_->isEmpty())))
     return -4;
   if(!criticalPoints_)
     return -5;
 #endif
 
-  if(triangulation_){
+  if(triangulation_) {
     vertexNumber_ = triangulation_->getNumberOfVertices();
     dimension_ = triangulation_->getCellVertexNumber(0) - 1;
   }
-  
-  if(!sosOffsets_){
+
+  if(!sosOffsets_) {
     // let's use our own local copy
     sosOffsets_ = &localSosOffSets_;
   }
-  if((SimplexId) sosOffsets_->size() != vertexNumber_){
+  if((SimplexId)sosOffsets_->size() != vertexNumber_) {
     Timer preProcess;
     sosOffsets_->resize(vertexNumber_);
     for(SimplexId i = 0; i < vertexNumber_; i++)
       (*sosOffsets_)[i] = i;
-      
+
     {
       std::stringstream msg;
-      msg << 
-        "[ScalarFieldCriticalPoints] Offset pre-processing done in "
-        << preProcess.getElapsedTime() << " s. Go!" << std::endl;
+      msg << "[ScalarFieldCriticalPoints] Offset pre-processing done in "
+          << preProcess.getElapsedTime() << " s. Go!" << std::endl;
       dMsg(std::cout, msg.str(), timeMsg);
     }
   }
-  
+
   Timer t;
-  
+
   std::vector<char> vertexTypes(vertexNumber_);
- 
-  if(triangulation_){
+
+  if(triangulation_) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) 
+#pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId) vertexNumber_; i++){
-    
+    for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
+
       vertexTypes[i] = getCriticalType(i, triangulation_);
     }
-  }
-  else if(vertexLinkEdgeLists_){
+  } else if(vertexLinkEdgeLists_) {
     // legacy implementation
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) 
+#pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId) vertexNumber_; i++){
-    
+    for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
+
       vertexTypes[i] = getCriticalType(i, (*vertexLinkEdgeLists_)[i]);
     }
   }
-   
+
   SimplexId minimumNumber = 0, maximumNumber = 0, saddleNumber = 0,
-    oneSaddleNumber = 0, twoSaddleNumber = 0, monkeySaddleNumber = 0;
- 
+            oneSaddleNumber = 0, twoSaddleNumber = 0, monkeySaddleNumber = 0;
+
   // debug msg
-  if(debugLevel_ >= Debug::infoMsg){
-    if(dimension_ == 3){
-      for(SimplexId i = 0; i < vertexNumber_; i++){
-        switch(vertexTypes[i]){
+  if(debugLevel_ >= Debug::infoMsg) {
+    if(dimension_ == 3) {
+      for(SimplexId i = 0; i < vertexNumber_; i++) {
+        switch(vertexTypes[i]) {
 
           case static_cast<char>(CriticalType::Local_minimum):
             minimumNumber++;
             break;
-            
+
           case static_cast<char>(CriticalType::Saddle1):
             oneSaddleNumber++;
             break;
@@ -108,202 +107,199 @@ ttk::ScalarFieldCriticalPoints<dataType>::execute(){
           case static_cast<char>(CriticalType::Saddle2):
             twoSaddleNumber++;
             break;
-            
+
           case static_cast<char>(CriticalType::Local_maximum):
             maximumNumber++;
             break;
-          
+
           case static_cast<char>(CriticalType::Degenerate):
             monkeySaddleNumber++;
             break;
         }
       }
-    }
-    else if(dimension_ == 2){
-      for(SimplexId i = 0; i < vertexNumber_; i++){
-        switch(vertexTypes[i]){
-          
+    } else if(dimension_ == 2) {
+      for(SimplexId i = 0; i < vertexNumber_; i++) {
+        switch(vertexTypes[i]) {
+
           case static_cast<char>(CriticalType::Local_minimum):
             minimumNumber++;
             break;
-            
+
           case static_cast<char>(CriticalType::Saddle1):
             saddleNumber++;
             break;
-            
+
           case static_cast<char>(CriticalType::Local_maximum):
             maximumNumber++;
             break;
-          
+
           case static_cast<char>(CriticalType::Degenerate):
             monkeySaddleNumber++;
             break;
         }
       }
     }
-    
+
     {
       std::stringstream msg;
       msg << "[ScalarFieldCriticalPoints] " << minimumNumber << " minima."
-        << std::endl;
-      if(dimension_ == 3){
+          << std::endl;
+      if(dimension_ == 3) {
         msg << "[ScalarFieldCriticalPoints] " << oneSaddleNumber
-          << " 1-saddle(s)." << std::endl;
+            << " 1-saddle(s)." << std::endl;
         msg << "[ScalarFieldCriticalPoints] " << twoSaddleNumber
-          << " 2-saddle(s)." << std::endl;
+            << " 2-saddle(s)." << std::endl;
       }
-      if(dimension_ == 2){
-        msg << "[ScalarFieldCriticalPoints] " << saddleNumber
-          << " saddle(s)." << std::endl;
+      if(dimension_ == 2) {
+        msg << "[ScalarFieldCriticalPoints] " << saddleNumber << " saddle(s)."
+            << std::endl;
       }
       msg << "[ScalarFieldCriticalPoints] " << monkeySaddleNumber
-        << " multi-saddle(s)." << std::endl;
-      msg << "[ScalarFieldCriticalPoints] " << maximumNumber
-        << " maxima." << std::endl;
-        
-//       msg << "[ScalarFieldCriticalPoints] Euler characteristic 
-// approximation:";
-//       if(monkeySaddleNumber){
-//         msg << " approximation";
-//       }
-//       msg << ": ";
-//       if(dimension_ == 3){
-//         msg 
-//           << minimumNumber - oneSaddleNumber + twoSaddleNumber - 
-// maximumNumber;
-//       }
-//       if(dimension_ == 2){
-//         msg << minimumNumber - saddleNumber + maximumNumber;
-//       }
-//       msg << std::endl;
+          << " multi-saddle(s)." << std::endl;
+      msg << "[ScalarFieldCriticalPoints] " << maximumNumber << " maxima."
+          << std::endl;
+
+      //       msg << "[ScalarFieldCriticalPoints] Euler characteristic
+      // approximation:";
+      //       if(monkeySaddleNumber){
+      //         msg << " approximation";
+      //       }
+      //       msg << ": ";
+      //       if(dimension_ == 3){
+      //         msg
+      //           << minimumNumber - oneSaddleNumber + twoSaddleNumber -
+      // maximumNumber;
+      //       }
+      //       if(dimension_ == 2){
+      //         msg << minimumNumber - saddleNumber + maximumNumber;
+      //       }
+      //       msg << std::endl;
       dMsg(std::cout, msg.str(), Debug::infoMsg);
     }
   }
-  
+
   // prepare the output
   criticalPoints_->clear();
   criticalPoints_->reserve(vertexNumber_);
-  for(SimplexId i = 0; i < vertexNumber_; i++){
-    if(vertexTypes[i] != static_cast<char>(CriticalType::Regular)){
+  for(SimplexId i = 0; i < vertexNumber_; i++) {
+    if(vertexTypes[i] != static_cast<char>(CriticalType::Regular)) {
       criticalPoints_->emplace_back(i, vertexTypes[i]);
     }
   }
-  
+
   {
     std::stringstream msg;
     msg << "[ScalarFieldCriticalPoints] Data-set (" << vertexNumber_
-      << " vertices) processed in "
-      << t.getElapsedTime() << " s. (" << threadNumber_
-      << " thread(s))."
-      << std::endl;
+        << " vertices) processed in " << t.getElapsedTime() << " s. ("
+        << threadNumber_ << " thread(s))." << std::endl;
     dMsg(std::cout, msg.str(), 2);
   }
-  
+
   return 0;
 }
 
-template <class dataType> char ttk::ScalarFieldCriticalPoints<dataType>
-  ::getCriticalType(const SimplexId &vertexId,
-    Triangulation *triangulation) const{
-     
+template <class dataType>
+std::pair<ttk::SimplexId, ttk::SimplexId>
+  ttk::ScalarFieldCriticalPoints<dataType>::getNumberOfLowerUpperComponents(
+    const SimplexId vertexId, Triangulation *triangulation) const {
+
   SimplexId neighborNumber = triangulation->getVertexNeighborNumber(vertexId);
   std::vector<SimplexId> lowerNeighbors, upperNeighbors;
-  
-  for(SimplexId i = 0; i < neighborNumber; i++){
+
+  for(SimplexId i = 0; i < neighborNumber; i++) {
     SimplexId neighborId = 0;
     triangulation->getVertexNeighbor(vertexId, i, neighborId);
-    
-    if(isSosLowerThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
- 
+
+    if(isSosLowerThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                      (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       lowerNeighbors.push_back(neighborId);
     }
-    
+
     // upper link
-    if(isSosHigherThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
-      
+    if(isSosHigherThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                       (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       upperNeighbors.push_back(neighborId);
     }
   }
-  
-  if(lowerNeighbors.empty()){
+
+  // shortcut, if min or max do not construct the complete star
+  if(!forceNonManifoldCheck && lowerNeighbors.empty()) {
     // minimum
-    return static_cast<char>(CriticalType::Local_minimum);
+    return std::make_pair(0,1);
   }
-  
-  if(upperNeighbors.empty()){
+
+  if(!forceNonManifoldCheck && upperNeighbors.empty()) {
     // maximum
-    return static_cast<char>(CriticalType::Local_maximum);
+    return std::make_pair(1,0);
   }
-  
+
   // now do the actual work
   std::vector<UnionFind> lowerSeeds(lowerNeighbors.size());
   std::vector<UnionFind *> lowerList(lowerNeighbors.size());
   std::vector<UnionFind> upperSeeds(upperNeighbors.size());
   std::vector<UnionFind *> upperList(upperNeighbors.size());
-  
-  for(SimplexId i = 0; i < (SimplexId) lowerSeeds.size(); i++){
+
+  for(SimplexId i = 0; i < (SimplexId)lowerSeeds.size(); i++) {
     lowerList[i] = &(lowerSeeds[i]);
   }
-  for(SimplexId i = 0; i < (SimplexId) upperSeeds.size(); i++){
+  for(SimplexId i = 0; i < (SimplexId)upperSeeds.size(); i++) {
     upperList[i] = &(upperSeeds[i]);
   }
-  
+
   SimplexId vertexStarSize = triangulation->getVertexStarNumber(vertexId);
-  
-  for(SimplexId i = 0; i < vertexStarSize; i++){
+
+  for(SimplexId i = 0; i < vertexStarSize; i++) {
     SimplexId cellId = 0;
     triangulation->getVertexStar(vertexId, i, cellId);
-    
+
     SimplexId cellSize = triangulation->getCellVertexNumber(cellId);
-    for(SimplexId j = 0; j < cellSize; j++){
+    for(SimplexId j = 0; j < cellSize; j++) {
       SimplexId neighborId0 = -1;
       triangulation->getCellVertex(cellId, j, neighborId0);
-      
-      if(neighborId0 != vertexId){
-        // we are on the link 
-        
+
+      if(neighborId0 != vertexId) {
+        // we are on the link
+
         bool lower0 = isSosLowerThan(
           (*sosOffsets_)[neighborId0], scalarValues_[neighborId0],
           (*sosOffsets_)[vertexId], scalarValues_[vertexId]);
-        
+
         // connect it to everybody except himself and vertexId
-        for(SimplexId k = j + 1; k < cellSize; k++){
-         
+        for(SimplexId k = j + 1; k < cellSize; k++) {
+
           SimplexId neighborId1 = -1;
           triangulation->getCellVertex(cellId, k, neighborId1);
-          
-          if((neighborId1 != neighborId0)&&(neighborId1 != vertexId)){
-            
+
+          if((neighborId1 != neighborId0) && (neighborId1 != vertexId)) {
+
             bool lower1 = isSosLowerThan(
               (*sosOffsets_)[neighborId1], scalarValues_[neighborId1],
               (*sosOffsets_)[vertexId], scalarValues_[vertexId]);
-            
-            std::vector<SimplexId > *neighbors = &lowerNeighbors;
+
+            std::vector<SimplexId> *neighbors = &lowerNeighbors;
             std::vector<UnionFind *> *seeds = &lowerList;
-            
-            if(!lower0){
+
+            if(!lower0) {
               neighbors = &upperNeighbors;
               seeds = &upperList;
             }
-            
-            if(lower0 == lower1){
+
+            if(lower0 == lower1) {
               // connect their union-find sets!
               SimplexId lowerId0 = -1, lowerId1 = -1;
-              for(SimplexId l = 0; l < (SimplexId) neighbors->size(); l++){
-                if((*neighbors)[l] == neighborId0){
+              for(SimplexId l = 0; l < (SimplexId)neighbors->size(); l++) {
+                if((*neighbors)[l] == neighborId0) {
                   lowerId0 = l;
                 }
-                if((*neighbors)[l] == neighborId1){
+                if((*neighbors)[l] == neighborId1) {
                   lowerId1 = l;
                 }
               }
-              if((lowerId0 != -1)&&(lowerId1 != -1)){
-                (*seeds)[lowerId0] = 
-                  makeUnion((*seeds)[lowerId0], (*seeds)[lowerId1]);
+              if((lowerId0 != -1) && (lowerId1 != -1)) {
+                (*seeds)[lowerId0]
+                  = makeUnion((*seeds)[lowerId0], (*seeds)[lowerId1]);
                 (*seeds)[lowerId1] = (*seeds)[lowerId0];
               }
             }
@@ -312,163 +308,168 @@ template <class dataType> char ttk::ScalarFieldCriticalPoints<dataType>
       }
     }
   }
-    
+
   // let's remove duplicates now
-  
+
   // update the UF if necessary
-  for(SimplexId i = 0; i < (SimplexId) lowerList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
     lowerList[i] = lowerList[i]->find();
-  for(SimplexId i = 0; i < (SimplexId) upperList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
     upperList[i] = upperList[i]->find();
-  
+
   std::vector<UnionFind *>::iterator it;
   sort(lowerList.begin(), lowerList.end());
   it = unique(lowerList.begin(), lowerList.end());
   lowerList.resize(distance(lowerList.begin(), it));
-  
+
   sort(upperList.begin(), upperList.end());
   it = unique(upperList.begin(), upperList.end());
   upperList.resize(distance(upperList.begin(), it));
-  
-  if(debugLevel_ >= Debug::advancedInfoMsg){
+
+  if(debugLevel_ >= Debug::advancedInfoMsg) {
     std::stringstream msg;
     msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId
-      << ": lowerLink-#CC=" << lowerList.size() 
-      << " upperLink-#CC=" << upperList.size() << std::endl;
-      
+        << ": lowerLink-#CC=" << lowerList.size()
+        << " upperLink-#CC=" << upperList.size() << std::endl;
+
     dMsg(std::cout, msg.str(), Debug::advancedInfoMsg);
   }
-  
-  if((lowerList.size() == 1)&&(upperList.size() == 1))
+
+  return std::make_pair(lowerList.size(), upperList.size());
+}
+
+template <class dataType>
+char ttk::ScalarFieldCriticalPoints<dataType>::getCriticalType(
+  const SimplexId &vertexId, Triangulation *triangulation) const {
+
+  SimplexId downValence, upValence;
+  std::tie(downValence, upValence)
+    = getNumberOfLowerUpperComponents(vertexId, triangulation);
+
+  if((downValence == 1) && (upValence == 1))
     // regular point
     return static_cast<char>(CriticalType::Regular);
-  else{
+  else {
     // saddles
-    if(dimension_ == 2){
-      if((lowerList.size() > 2)||(upperList.size() > 2)){
+    if(dimension_ == 2) {
+      if((downValence > 2) || (upValence > 2)) {
         // monkey saddle
         return static_cast<char>(CriticalType::Degenerate);
-      }
-      else{
+      } else {
         // regular saddle
         return static_cast<char>(CriticalType::Saddle1);
-        // NOTE: you may have multi-saddles on the boundary in that 
+        // NOTE: you may have multi-saddles on the boundary in that
         // configuration
         // to make this computation 100% correct, one would need to disambiguate
         // boundary from interior vertices
       }
-    }
-    else if(dimension_ == 3){
-      if((lowerList.size() == 2)&&(upperList.size() == 1)){
+    } else if(dimension_ == 3) {
+      if((downValence == 2) && (upValence == 1)) {
         return static_cast<char>(CriticalType::Saddle1);
-      }
-      else if((lowerList.size() == 1)&&(upperList.size() == 2)){
+      } else if((downValence == 1) && (upValence == 2)) {
         return static_cast<char>(CriticalType::Saddle2);
-      }
-      else{
+      } else {
         // monkey saddle
         return static_cast<char>(CriticalType::Degenerate);
         // NOTE: we may have a similar effect in 3D (TODO)
       }
     }
   }
-  
+
   // -2: regular points
   return static_cast<char>(CriticalType::Regular);
 }
 
-template <class dataType> char ttk::ScalarFieldCriticalPoints<dataType>
-  ::getCriticalType(const SimplexId &vertexId,
-    const std::vector<std::pair<SimplexId, SimplexId> > &vertexLink) const{
+template <class dataType>
+char ttk::ScalarFieldCriticalPoints<dataType>::getCriticalType(
+  const SimplexId &vertexId,
+  const std::vector<std::pair<SimplexId, SimplexId>> &vertexLink) const {
 
   std::map<SimplexId, SimplexId> global2LowerLink, global2UpperLink;
   std::map<SimplexId, SimplexId>::iterator neighborIt;
-  
+
   SimplexId lowerCount = 0, upperCount = 0;
-  
-  for(SimplexId i = 0; i < (SimplexId) vertexLink.size(); i++){
-    
+
+  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
+
     SimplexId neighborId = vertexLink[i].first;
-   
+
     // first vertex
     // lower link search
-    if(isSosLowerThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
-      
+    if(isSosLowerThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                      (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       neighborIt = global2LowerLink.find(neighborId);
-      if(neighborIt == global2LowerLink.end()){
+      if(neighborIt == global2LowerLink.end()) {
         // not in there, add it
         global2LowerLink[neighborId] = lowerCount;
         lowerCount++;
       }
     }
-    
+
     // upper link
-    if(isSosHigherThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
-      
+    if(isSosHigherThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                       (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       neighborIt = global2UpperLink.find(neighborId);
-      if(neighborIt == global2UpperLink.end()){
+      if(neighborIt == global2UpperLink.end()) {
         // not in there, add it
         global2UpperLink[neighborId] = upperCount;
         upperCount++;
       }
     }
-    
+
     // second vertex
     neighborId = vertexLink[i].second;
-    
+
     // lower link search
-    if(isSosLowerThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
-      
+    if(isSosLowerThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                      (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       neighborIt = global2LowerLink.find(neighborId);
-      if(neighborIt == global2LowerLink.end()){
+      if(neighborIt == global2LowerLink.end()) {
         // not in there, add it
         global2LowerLink[neighborId] = lowerCount;
         lowerCount++;
       }
     }
-    
+
     // upper link
-    if(isSosHigherThan(
-      (*sosOffsets_)[neighborId], scalarValues_[neighborId],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId])){
-      
+    if(isSosHigherThan((*sosOffsets_)[neighborId], scalarValues_[neighborId],
+                       (*sosOffsets_)[vertexId], scalarValues_[vertexId])) {
+
       neighborIt = global2UpperLink.find(neighborId);
-      if(neighborIt == global2UpperLink.end()){
+      if(neighborIt == global2UpperLink.end()) {
         // not in there, add it
         global2UpperLink[neighborId] = upperCount;
         upperCount++;
       }
     }
   }
-  
-  if(debugLevel_ >= Debug::advancedInfoMsg){
+
+  if(debugLevel_ >= Debug::advancedInfoMsg) {
     std::stringstream msg;
-    msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId 
-      << " lower link (" << lowerCount << " vertices)" << std::endl;;
-    
-    msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId 
-      << " upper link (" << upperCount << " vertices)" << std::endl;
-    
+    msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId << " lower link ("
+        << lowerCount << " vertices)" << std::endl;
+    ;
+
+    msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId << " upper link ("
+        << upperCount << " vertices)" << std::endl;
+
     dMsg(std::cout, msg.str(), Debug::advancedInfoMsg);
   }
-  
-  if(!lowerCount){
+
+  if(!lowerCount) {
     // minimum
     return static_cast<char>(CriticalType::Local_minimum);
   }
-  if(!upperCount){
+  if(!upperCount) {
     // maximum
     return static_cast<char>(CriticalType::Local_maximum);
   }
-  
+
   // so far 40% of the computation, that's ok.
- 
+
   // now enumerate the connected components of the lower and upper links
   // NOTE: a breadth first search might be faster than a UF
   // if so, one would need the one-skeleton data structure, not the edge list
@@ -476,108 +477,108 @@ template <class dataType> char ttk::ScalarFieldCriticalPoints<dataType>
   std::vector<UnionFind> upperSeeds(upperCount);
   std::vector<UnionFind *> lowerList(lowerCount);
   std::vector<UnionFind *> upperList(upperCount);
-  for(SimplexId i = 0; i < (SimplexId) lowerList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
     lowerList[i] = &(lowerSeeds[i]);
-  for(SimplexId i = 0; i < (SimplexId) upperList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
     upperList[i] = &(upperSeeds[i]);
-  
-  for(SimplexId i = 0; i < (SimplexId) vertexLink.size(); i++){
-    
+
+  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
+
     SimplexId neighborId0 = vertexLink[i].first;
     SimplexId neighborId1 = vertexLink[i].second;
-    
+
     // process the lower link
     if((isSosLowerThan((*sosOffsets_)[neighborId0], scalarValues_[neighborId0],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId]))
-      &&
-      (isSosLowerThan((*sosOffsets_)[neighborId1], scalarValues_[neighborId1],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId]))){
-      
+                       (*sosOffsets_)[vertexId], scalarValues_[vertexId]))
+       && (isSosLowerThan((*sosOffsets_)[neighborId1],
+                          scalarValues_[neighborId1], (*sosOffsets_)[vertexId],
+                          scalarValues_[vertexId]))) {
+
       // both vertices are lower, let's add that edge and update the UF
-      std::map<SimplexId, SimplexId>::iterator n0It = global2LowerLink.find(neighborId0);
-      std::map<SimplexId, SimplexId>::iterator n1It = global2LowerLink.find(neighborId1);
-    
-      lowerList[n0It->second] = 
-        makeUnion(lowerList[n0It->second], lowerList[n1It->second]);
+      std::map<SimplexId, SimplexId>::iterator n0It
+        = global2LowerLink.find(neighborId0);
+      std::map<SimplexId, SimplexId>::iterator n1It
+        = global2LowerLink.find(neighborId1);
+
+      lowerList[n0It->second]
+        = makeUnion(lowerList[n0It->second], lowerList[n1It->second]);
       lowerList[n1It->second] = lowerList[n0It->second];
     }
-    
+
     // process the upper link
     if((isSosHigherThan((*sosOffsets_)[neighborId0], scalarValues_[neighborId0],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId]))
-      &&
-      (isSosHigherThan((*sosOffsets_)[neighborId1], scalarValues_[neighborId1],
-      (*sosOffsets_)[vertexId], scalarValues_[vertexId]))){
-      
+                        (*sosOffsets_)[vertexId], scalarValues_[vertexId]))
+       && (isSosHigherThan((*sosOffsets_)[neighborId1],
+                           scalarValues_[neighborId1], (*sosOffsets_)[vertexId],
+                           scalarValues_[vertexId]))) {
+
       // both vertices are lower, let's add that edge and update the UF
-      std::map<SimplexId, SimplexId>::iterator n0It = global2UpperLink.find(neighborId0);
-      std::map<SimplexId, SimplexId>::iterator n1It = global2UpperLink.find(neighborId1);
-    
-      upperList[n0It->second] = 
-        makeUnion(upperList[n0It->second], upperList[n1It->second]);
+      std::map<SimplexId, SimplexId>::iterator n0It
+        = global2UpperLink.find(neighborId0);
+      std::map<SimplexId, SimplexId>::iterator n1It
+        = global2UpperLink.find(neighborId1);
+
+      upperList[n0It->second]
+        = makeUnion(upperList[n0It->second], upperList[n1It->second]);
       upperList[n1It->second] = upperList[n0It->second];
     }
   }
-  
+
   // let's remove duplicates
   std::vector<UnionFind *>::iterator it;
   // update the UFs if necessary
-  for(SimplexId i = 0; i < (SimplexId) lowerList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
     lowerList[i] = lowerList[i]->find();
-  for(SimplexId i = 0; i < (SimplexId) upperList.size(); i++)
+  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
     upperList[i] = upperList[i]->find();
-  
+
   sort(lowerList.begin(), lowerList.end());
   it = unique(lowerList.begin(), lowerList.end());
   lowerList.resize(distance(lowerList.begin(), it));
-  
+
   sort(upperList.begin(), upperList.end());
   it = unique(upperList.begin(), upperList.end());
   upperList.resize(distance(upperList.begin(), it));
-  
-  if(debugLevel_ >= Debug::advancedInfoMsg){
+
+  if(debugLevel_ >= Debug::advancedInfoMsg) {
     std::stringstream msg;
     msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId
-      << ": lowerLink-#CC=" << lowerList.size() 
-      << " upperLink-#CC=" << upperList.size() << std::endl;
-      
+        << ": lowerLink-#CC=" << lowerList.size()
+        << " upperLink-#CC=" << upperList.size() << std::endl;
+
     dMsg(std::cout, msg.str(), Debug::advancedInfoMsg);
   }
-  
-  if((lowerList.size() == 1)&&(upperList.size() == 1))
+
+  if((lowerList.size() == 1) && (upperList.size() == 1))
     // regular point
     return static_cast<char>(CriticalType::Regular);
-  else{
+  else {
     // saddles
-    if(dimension_ == 2){
-      if((lowerList.size() > 2)||(upperList.size() > 2)){
+    if(dimension_ == 2) {
+      if((lowerList.size() > 2) || (upperList.size() > 2)) {
         // monkey saddle
         return static_cast<char>(CriticalType::Degenerate);
-      }
-      else{
+      } else {
         // regular saddle
         return static_cast<char>(CriticalType::Saddle1);
-        // NOTE: you may have multi-saddles on the boundary in that 
+        // NOTE: you may have multi-saddles on the boundary in that
         // configuration
         // to make this computation 100% correct, one would need to disambiguate
         // boundary from interior vertices
       }
-    }
-    else if(dimension_ == 3){
-      if((lowerList.size() == 2)&&(upperList.size() == 1)){
+    } else if(dimension_ == 3) {
+      if((lowerList.size() == 2) && (upperList.size() == 1)) {
         return static_cast<char>(CriticalType::Saddle1);
-      }
-      else if((lowerList.size() == 1)&&(upperList.size() == 2)){
+      } else if((lowerList.size() == 1) && (upperList.size() == 2)) {
         return static_cast<char>(CriticalType::Saddle2);
-      }
-      else{
+      } else {
         // monkey saddle
         return static_cast<char>(CriticalType::Degenerate);
         // NOTE: we may have a similar effect in 3D (TODO)
       }
     }
   }
-  
+
   // -2: regular points
   return static_cast<char>(CriticalType::Regular);
 }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -346,30 +346,35 @@ char ttk::ScalarFieldCriticalPoints<dataType>::getCriticalType(
   std::tie(downValence, upValence)
     = getNumberOfLowerUpperComponents(vertexId, triangulation);
 
-  if((downValence == 1) && (upValence == 1))
+  if(downValence == 0 && upValence == 1) {
+    return static_cast<char>(CriticalType::Local_minimum);
+  } else if (downValence == 1 && upValence == 0) {
+    return static_cast<char>(CriticalType::Local_maximum);
+  } else if(downValence == 1 && upValence == 1) {
     // regular point
     return static_cast<char>(CriticalType::Regular);
-  else {
+  } else {
     // saddles
     if(dimension_ == 2) {
-      if((downValence > 2) || (upValence > 2)) {
-        // monkey saddle
-        return static_cast<char>(CriticalType::Degenerate);
-      } else {
+      if((downValence == 2 && upValence == 1)
+         || (downValence == 1 && upValence == 2)) {
         // regular saddle
         return static_cast<char>(CriticalType::Saddle1);
+      } else {
+        // monkey saddle, saddle + extremum
+        return static_cast<char>(CriticalType::Degenerate);
         // NOTE: you may have multi-saddles on the boundary in that
         // configuration
-        // to make this computation 100% correct, one would need to disambiguate
-        // boundary from interior vertices
+        // to make this computation 100% correct, one would need to
+        // disambiguate boundary from interior vertices
       }
     } else if(dimension_ == 3) {
-      if((downValence == 2) && (upValence == 1)) {
+      if(downValence == 2 && upValence == 1) {
         return static_cast<char>(CriticalType::Saddle1);
-      } else if((downValence == 1) && (upValence == 2)) {
+      } else if(downValence == 1 && upValence == 2) {
         return static_cast<char>(CriticalType::Saddle2);
       } else {
-        // monkey saddle
+        // monkey saddle, saddle + extremum
         return static_cast<char>(CriticalType::Degenerate);
         // NOTE: we may have a similar effect in 3D (TODO)
       }

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -300,7 +300,7 @@ int ttkFTRGraph::doIt(std::vector<vtkDataSet *> &inputs,
       ftrGraph_.setParams(params_);
       // reeb graph parameters
       ftrGraph_.setScalars(inputScalars_->GetVoidPointer(0));
-      ftrGraph_.setVertexSoSoffsets(offsets_.data());
+      ftrGraph_.setVertexSoSoffsets(&offsets_);
       // build
       ftrGraph_.build();
       // get output

--- a/standalone/FTRGraph/cmd/main.cpp
+++ b/standalone/FTRGraph/cmd/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
    if (ret != 0)
       return ret;
 
-   ret = program.save();
+   // ret = program.save();
 
    return ret;
 }

--- a/standalone/FTRGraph/cmd/main.cpp
+++ b/standalone/FTRGraph/cmd/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
    if (ret != 0)
       return ret;
 
-   // ret = program.save();
+   ret = program.save();
 
    return ret;
 }


### PR DESCRIPTION
Dear Julien,

This PR brings new performance improvements to FTR throughout two main contributions:

* Improve the laziness mechanism so a single list of operation is used, on which deletion are directly applied.
* Use the scalarFieldCritical point filter to extract critical points before the sweep. 

For this second contribution, the scalarFieldCriticalPoint filter has been refactored a bit:
The API now expose the getNumberOfLowerUpperComponent function, wich return a pair with the number of CC in the lower / upper star of a vertex.
Also, the shortcut for extrema avoiding the computation of the lower/upper star can be discarded if the mesh is not manifold
Finally, the filter has been re-indented with the new clang-format style

Charles