### PR TITLE
Fix for ScalarField critial points: Monkey Saddle

### DIFF
--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -357,7 +357,8 @@ char ttk::ScalarFieldCriticalPoints<dataType>::getCriticalType(
     // saddles
     if(dimension_ == 2) {
       if((downValence == 2 && upValence == 1)
-         || (downValence == 1 && upValence == 2)) {
+         || (downValence == 1 && upValence == 2)
+         || (downValence == 2 && upValence == 2)) {
         // regular saddle
         return static_cast<char>(CriticalType::Saddle1);
       } else {


### PR DESCRIPTION
Dear Julien,

In the last P-R, monkey saddles in 2D have been classified as degenerate saddles. This was wrong so this pull request re-classify them as normal saddles.

Charles