### PR TITLE
Clang warnings

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.cpp
@@ -115,7 +115,7 @@ int AbstractMorseSmaleComplex::getDescendingSeparatrices1(const vector<Cell>& cr
           const SimplexId separatrixIndex=4*i+shift;
 
           separatricesGeometry[separatrixIndex]=std::move(vpath);
-          separatrices[separatrixIndex]=std::move(Separatrix(true,saddle,lastCell,false,separatrixIndex));
+          separatrices[separatrixIndex] = Separatrix(true,saddle,lastCell,false,separatrixIndex);
         }
       }
     }

--- a/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
@@ -41,10 +41,6 @@ int BottleneckDistance::computeBottleneck(
   const int wasserstein = (wasserstein_ == "inf") ? -1 : stoi(wasserstein_);
   if (wasserstein < 0 && wasserstein != -1) return -4;
 
-  // Needed for distance computation.
-  const double maxDistance =
-      this->computeGeometricalRange<dataType>(CTDiagram1, CTDiagram2, d1Size, d2Size);
-
   // Needed to limit computation time.
   const dataType zeroThresh =
       this->computeMinimumRelevantPersistence<dataType>(CTDiagram1, CTDiagram2, d1Size, d2Size);
@@ -95,7 +91,7 @@ int BottleneckDistance::computeBottleneck(
 
   std::function<dataType (const diagramTuple, const diagramTuple)>
       distanceFunction =
-      [maxDistance, wasserstein, px, py, pz, pe, ps]
+      [wasserstein, px, py, pz, pe, ps]
           (const diagramTuple a, const diagramTuple b) -> dataType
       {
         BNodeType ta1 = std::get<1>(a);

--- a/core/base/bottleneckDistance/Munkres.h
+++ b/core/base/bottleneckDistance/Munkres.h
@@ -95,7 +95,7 @@ namespace ttk {
       for (int c = 0; c < colSize; ++c) {
         msg << colCover[c] << "  ";
       }
-      msg << std::endl << "   | ";;
+      msg << std::endl << "   | ";
       for (int c = 0; c < colSize; ++c) {
         msg << "---";
       }

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -180,8 +180,8 @@ std::vector<std::string> OsCall::listFilesInDirectory(const std::string &directo
                     filesInDir.push_back(directoryName + "/" + std::string(dirEntry->d_name));
             }
         }
+        closedir(d);
     }
-    closedir(d);
 #endif
 
     std::sort(filesInDir.begin(), filesInDir.end());

--- a/core/base/common/ProgramBase.h
+++ b/core/base/common/ProgramBase.h
@@ -69,11 +69,6 @@ namespace ttk{
       /// Save the output(s) of the TTK module.
       virtual int save() const = 0;
       
-      virtual int setTTKmodule(Debug *ttkModule){
-        ttkModule_ = ttkModule;
-        return -1;
-      }
-     
       CommandLineParser             parser_;
       
       

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -117,12 +117,12 @@ const Segment& Segments::operator[](size_t idx) const
 
 ArcRegion::ArcRegion(const segmentIterator& s)
 {
-    segmentsIn_.emplace_front(Region{s, s});
+    segmentsIn_.emplace_front(Region{s, s, bool()});
 }
 
 void ArcRegion::addSegment(const segmentIterator& begin, const segmentIterator& end)
 {
-    segmentsIn_.emplace_front(Region{begin, end});
+    segmentsIn_.emplace_front(Region{begin, end, bool()});
 }
 
 void ArcRegion::createSegmentation(const idSuperArc& thisArc)

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -143,7 +143,6 @@ void ArcRegion::createSegmentation(const idSuperArc& thisArc)
 
     while(added){
        added = false;
-       segmentIterator addVert;
        for (unsigned i = 0; i < nbSegments; i++) {
            auto&& head = heads[i];
            auto&& end  = ends[i];

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -1587,7 +1587,7 @@ bool MergeTree::verifyTree(void)
             ++nbArcsVisibles;
             const idNode &up  = arc.getUpNodeId();
             const idNode &down  = arc.getDownNodeId();
-            if(up == nullSuperArc || down == nullSuperArc){
+            if(up == nullNodes || down == nullNodes){
                 res = false;
                 cout << "[Verif]: arc id : " << aid << "have a null boundary :";
                 cout << " down :" << down << " up:" << up << endl;
@@ -1645,7 +1645,7 @@ bool MergeTree::verifyTree(void)
                    res = false;
                    const idNode upnode = arc.getUpNodeId();
                    const idNode downnode = arc.getDownNodeId();
-                   if(upnode == nullSuperArc || downnode == nullSuperArc){
+                   if(upnode == nullNodes || downnode == nullNodes){
                       cout << "[Verif]: arc id : " << node.getUpSuperArcId(ua);
                       cout << "have a null boundary :";
                       cout << " down :" << downnode << " up:" << upnode << endl;
@@ -1666,7 +1666,7 @@ bool MergeTree::verifyTree(void)
                    res = false;
                    const idNode upnode = arc.getUpNodeId();
                    const idNode downnode = arc.getDownNodeId();
-                   if(upnode == nullSuperArc || downnode == nullSuperArc){
+                   if(upnode == nullNodes || downnode == nullNodes){
                       cout << "[Verif]: arc id : " << node.getDownSuperArcId(da);
                       cout << "have a null boundary :";
                       cout << " down :" << downnode << " up:" << upnode << endl;

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -1956,14 +1956,13 @@ int SubLevelSetTree::simplify(const double &simplificationThreshold,
   
   //   if((simplificationThreshold < 0)||(simplificationThreshold > 1))
   //     return -1;
-  
-  bool defaultMetric = false;
-  
-  if(!metric){
-    metric = new PersistenceMetric;
-    defaultMetric = true;
+
+  PersistenceMetric defaultMetric;
+
+  if(metric == nullptr) {
+    metric = &defaultMetric;
   }
- 
+
   metric->tree_ = this;
  
   //   double unNormalizedThreshold = simplificationThreshold
@@ -2189,9 +2188,6 @@ int SubLevelSetTree::simplify(const double &simplificationThreshold,
 	<< endl;
     dMsg(cout, msg.str(), 3);
   }
-  
-  if(defaultMetric)
-    delete metric;
   
   return 0;
 }

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -1354,7 +1354,10 @@ int SubLevelSetTree::getPersistenceDiagram(vector<pair<double, double> > &diagra
   return 0;
 }
 
-int SubLevelSetTree::getPersistencePairs(vector<pair<pair<int,int>,double>> &pairs) const{
+int SubLevelSetTree::getPersistencePairs(
+    vector<pair<pair<int, int>, double>> &pairs,
+    std::vector<std::pair<std::pair<int, int>, double>> *mergePairs,
+    std::vector<std::pair<std::pair<int, int>, double>> *splitPairs) const {
 
   Timer t;
   
@@ -2904,10 +2907,10 @@ int ContourTree::clearSkeleton(){
   return 0;
 }
 
-int ContourTree::getPersistencePairs(vector<pair<pair<int,int>,double>>* pairs,
+int ContourTree::getPersistencePairs(vector<pair<pair<int,int>,double>>& pairs,
 				     vector<pair<pair<int,int>,double>>* mergePairs,
 				     vector<pair<pair<int,int>,double>>* splitPairs) const{
-  if(pairs->size())
+  if(pairs.size())
     return 0;
   
   bool isLocalMerge=false;
@@ -2945,16 +2948,16 @@ int ContourTree::getPersistencePairs(vector<pair<pair<int,int>,double>>* pairs,
     }
   }
 
-  pairs->resize(mergePairs->size() + splitPairs->size());
+  pairs.resize(mergePairs->size() + splitPairs->size());
 
   for(unsigned int i=0; i<mergePairs->size(); ++i)
-    (*pairs)[i]=(*mergePairs)[i];
+    pairs[i]=(*mergePairs)[i];
 
   unsigned int shift=mergePairs->size();
   for(unsigned int i=0; i<splitPairs->size(); ++i)
-    (*pairs)[shift+i]=(*splitPairs)[i];
+    pairs[shift+i]=(*splitPairs)[i];
   
-  std::sort(pairs->begin(), pairs->end(), _pCmp);
+  std::sort(pairs.begin(), pairs.end(), _pCmp);
 
   if(isLocalMerge)
     delete mergePairs;
@@ -2975,7 +2978,7 @@ int ContourTree::getPersistencePlot(vector<pair<double,int>>& plot,
   }
 
   if(!pairs->size())
-    getPersistencePairs(pairs,mergePairs,splitPairs);
+    getPersistencePairs(*pairs,mergePairs,splitPairs);
   
   plot.resize(pairs->size());
   
@@ -3005,7 +3008,7 @@ int ContourTree::getPersistenceDiagram(vector<pair<double, double> > &diagram,
   }
 
   if(!pairs->size())
-    getPersistencePairs(pairs,mergePairs,splitPairs);
+    getPersistencePairs(*pairs,mergePairs,splitPairs);
   
   // fast fix :(
   diagram.resize(pairs->size());

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -346,10 +346,13 @@ const;
     //   - extremum vertex Id (first.first)
     //   - std::paired saddle Id (first.second)
     // - persistence (second)
-    virtual int 
-      getPersistencePairs(
-        std::vector<std::pair<std::pair<int,int>,double>>& pairs) const;
-      
+    virtual int getPersistencePairs(
+        std::vector<std::pair<std::pair<int, int>, double>> &pairs,
+        std::vector<std::pair<std::pair<int, int>, double>> *mergePairs =
+            nullptr,
+        std::vector<std::pair<std::pair<int, int>, double>> *splitPairs =
+            nullptr) const;
+
     int getPersistencePlot(std::vector<std::pair<double,int>> &plot,
 			   std::vector<std::pair<std::pair<int,int>,double>>* 
 persistencePairs=nullptr) const;
@@ -521,8 +524,7 @@ persistencePairs=nullptr) const;
     inline const SubLevelSetTree* getMergeTree() const{
       return &mergeTree_;};
     
-    int getPersistencePairs(std::vector<std::pair<std::pair<int,int>,double>>* 
-pairs,
+    int getPersistencePairs(std::vector<std::pair<std::pair<int,int>,double>>& pairs,
 			    std::vector<std::pair<std::pair<int,int>,double>>* mergePairs=nullptr,
 			    std::vector<std::pair<std::pair<int,int>,double>>* splitPairs=nullptr) 
 const;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -3329,7 +3329,7 @@ int DiscreteGradient::filterSaddleConnectors(const bool allowBoundary){
 
   // get the node type of a contour tree node (for compatibility with
   // ScalarFieldCriticalPoints)
-  auto getNodeType=[&](const ftm::FTMTree_MT* tree, const ftm::Node* node){
+  auto getNodeType=[&](const ftm::Node* node) {
     const int upDegree   = node->getNumberOfUpSuperArcs();
     const int downDegree = node->getNumberOfDownSuperArcs();
     const int degree = upDegree + downDegree;
@@ -3373,7 +3373,7 @@ int DiscreteGradient::filterSaddleConnectors(const bool allowBoundary){
     const ftm::Node* node = tree->getNode(nodeId);
     const SimplexId vertexId = node->getVertexId();
 
-    cpset.push_back(std::make_pair(vertexId, getNodeType(tree,node)));
+    cpset.push_back(std::make_pair(vertexId, getNodeType(node)));
   }
 
   std::vector<char> isPL;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -29,7 +29,7 @@ const scalars) const{
 
       case 1:
         for(int i=0; i<2; ++i){
-          SimplexId vertexId;
+          SimplexId vertexId = -1;
           inputTriangulation_->getEdgeVertex(cell.id_,i,vertexId);
           const dataType vertexScalar=scalars[vertexId];
 
@@ -40,7 +40,7 @@ const scalars) const{
 
       case 2:
         for(int i=0; i<3; ++i){
-          SimplexId vertexId;
+          SimplexId vertexId = -1;
           inputTriangulation_->getCellVertex(cell.id_,i,vertexId);
           const dataType vertexScalar=scalars[vertexId];
 
@@ -58,7 +58,7 @@ const scalars) const{
 
       case 1:
         for(int i=0; i<2; ++i){
-          SimplexId vertexId;
+          SimplexId vertexId = -1;
           inputTriangulation_->getEdgeVertex(cell.id_,i,vertexId);
           const dataType vertexScalar=scalars[vertexId];
 
@@ -69,7 +69,7 @@ const scalars) const{
 
       case 2:
         for(int i=0; i<3; ++i){
-          SimplexId vertexId;
+          SimplexId vertexId = -1;
           inputTriangulation_->getTriangleVertex(cell.id_,i,vertexId);
           const dataType vertexScalar=scalars[vertexId];
 
@@ -80,7 +80,7 @@ const scalars) const{
 
       case 3:
         for(int i=0; i<4; ++i){
-          SimplexId vertexId;
+          SimplexId vertexId = -1;
           inputTriangulation_->getCellVertex(cell.id_,i,vertexId);
           const dataType vertexScalar=scalars[vertexId];
 

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1048,9 +1048,9 @@ criticalPoints) const{
         vertexId=dmt2Saddle2PL_[cellId];
 
         if(vertexId==-1){
-          SimplexId v0;
-          SimplexId v1;
-          SimplexId v2;
+          SimplexId v0 = 0;
+          SimplexId v1 = 0;
+          SimplexId v2 = 0;
           if(dimensionality_==2){
             inputTriangulation_->getCellVertex(cellId, 0, v0);
             inputTriangulation_->getCellVertex(cellId, 1, v1);
@@ -1171,9 +1171,9 @@ int DiscreteGradient::setAugmentedCriticalPoints(const std::vector<Cell>& critic
         vertexId=dmt2Saddle2PL_[cellId];
 
         if(vertexId==-1){
-          SimplexId v0;
-          SimplexId v1;
-          SimplexId v2;
+          SimplexId v0 = 0;
+          SimplexId v1 = 0;
+          SimplexId v2 = 0;
           if(dimensionality_==2){
             inputTriangulation_->getCellVertex(cellId, 0, v0);
             inputTriangulation_->getCellVertex(cellId, 1, v1);

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -85,7 +85,7 @@ namespace ftm
          st_->setupTriangulation(m, false);
       }
 
-      inline int setDebugLevel(const int d)
+      inline int setDebugLevel(const int &d)
       {
          Debug::setDebugLevel(d);
          jt_->setDebugLevel(d);

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.cpp
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.cpp
@@ -57,7 +57,7 @@ int MorseSmaleComplex2D::getAscendingSeparatrices1(const vector<Cell>& criticalP
           const SimplexId separatrixIndex=4*i+shift;
 
           separatricesGeometry[separatrixIndex]=std::move(vpath);
-          separatrices[separatrixIndex]=std::move(Separatrix(true,saddle,lastCell,false,separatrixIndex));
+          separatrices[separatrixIndex] = Separatrix(true,saddle,lastCell,false,separatrixIndex);
         }
       }
     }

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.cpp
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.cpp
@@ -58,7 +58,7 @@ int MorseSmaleComplex3D::getAscendingSeparatrices1(const vector<Cell>& criticalP
           const SimplexId separatrixIndex=4*i+shift;
 
           separatricesGeometry[separatrixIndex]=std::move(vpath);
-          separatrices[separatrixIndex]=std::move(Separatrix(true,saddle,lastCell,false,separatrixIndex));
+          separatrices[separatrixIndex] = Separatrix(true,saddle,lastCell,false,separatrixIndex);
         }
       }
     }
@@ -97,7 +97,7 @@ int MorseSmaleComplex3D::getSaddleConnectors(const vector<Cell>& criticalPoints,
         if(!isMultiConnected and lastCell.dim_==saddle2.dim_ and lastCell.id_==saddle2.id_){
           const SimplexId separatrixIndex=separatrices.size();
           separatricesGeometry.push_back(std::move(vpath));
-          separatrices.push_back(std::move(Separatrix(true,saddle1,saddle2,false,separatrixIndex)));
+          separatrices.push_back(Separatrix(true,saddle1,saddle2,false,separatrixIndex));
         }
       }
     }
@@ -140,7 +140,7 @@ int MorseSmaleComplex3D::getAscendingSeparatrices2(const vector<Cell>& criticalP
     discreteGradient_.getAscendingWall(saddle1.id_, saddle1, isVisited, &wall, &separatricesSaddles[i]);
 
     separatricesGeometry[i]=std::move(wall);
-    separatrices[i]=std::move(Separatrix(true,saddle1,emptyCell,false,i));
+    separatrices[i] = Separatrix(true,saddle1,emptyCell,false,i);
   }
 
   return 0;
@@ -180,7 +180,7 @@ int MorseSmaleComplex3D::getDescendingSeparatrices2(const vector<Cell>& critical
     discreteGradient_.getDescendingWall(saddle2.id_, saddle2, isVisited, &wall, &separatricesSaddles[i]);
 
     separatricesGeometry[i]=std::move(wall);
-    separatrices[i]=std::move(Separatrix(true,saddle2,emptyCell,false,i));
+    separatrices[i] = Separatrix(true,saddle2,emptyCell,false,i);
   }
 
   return 0;

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -457,7 +457,6 @@ char ttk::ScalarFieldCriticalPoints<dataType>::getCriticalType(
     std::stringstream msg;
     msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId << " lower link ("
         << lowerCount << " vertices)" << std::endl;
-    ;
 
     msg << "[ScalarFieldCriticalPoints] Vertex #" << vertexId << " upper link ("
         << upperCount << " vertices)" << std::endl;

--- a/core/base/uncertainDataEstimator/UncertainDataEstimator.h
+++ b/core/base/uncertainDataEstimator/UncertainDataEstimator.h
@@ -38,8 +38,7 @@ namespace ttk{
       #endif
       const dataType *inputData =
         reinterpret_cast<const dataType*>(voidPointer);
-      SimplexId numberOfVertices =
-        static_cast<SimplexId>(numberOfVertices_);
+      auto numberOfVertices = static_cast<size_t>(numberOfVertices_);
       /* Initialize if first call since a change */
       if (!(upperBound_.size()==numberOfVertices) || !(lowerBound_.size()==numberOfVertices)) {
         upperBound_.resize(numberOfVertices);
@@ -162,7 +161,7 @@ namespace ttk{
         /* Initialize */
         probability_.resize(numberOfBins_);
         double dx = (rangeMax_-rangeMin_) / static_cast<double>(numberOfBins_);
-        for (size_t i=0 ; i < numberOfBins_ ; i++) {
+        for (size_t i=0 ; i < static_cast<size_t>(numberOfBins_) ; i++) {
           probability_[i].resize(numberOfVertices_);
           binValue_[i] = rangeMin_+(dx/2.0)+(static_cast<double>(i)*dx);
         }

--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
@@ -120,7 +120,7 @@ public:
   vtkGetMacro(result, double);
 
   // Override input types.
-  int FillInputPortInformation(int port, vtkInformation *info) {
+  int FillInputPortInformation(int port, vtkInformation *info) override {
     switch (port) {
       case 0:
         info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
@@ -135,7 +135,7 @@ public:
   }
 
   // Override output types.
-  int FillOutputPortInformation(int port, vtkInformation *info) {
+  int FillOutputPortInformation(int port, vtkInformation *info) override {
     switch (port) {
       case 0:
         info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");

--- a/core/vtk/ttkCellDataConverter/ttkCellDataConverter.h
+++ b/core/vtk/ttkCellDataConverter/ttkCellDataConverter.h
@@ -105,8 +105,8 @@ Double=0,
     ttkCellDataConverter();    
     ~ttkCellDataConverter();
 
-    int RequestData(vtkInformation *request, 
-		      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+    int RequestData(vtkInformation *request, vtkInformationVector **inputVector,
+                    vtkInformationVector *outputVector) override;
 
     template<typename A, typename B, typename C>
       int convert(vtkDataArray* inputData, vtkDataSet* output);
@@ -120,8 +120,8 @@ Double=0,
     
     // base code features
     int doIt(vtkDataSet *input, vtkDataSet *output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);   
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };
 
 #endif // _TTK_CELLDATACONVERTER_H

--- a/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
+++ b/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
@@ -85,7 +85,7 @@ class ttkCellDataSelector
       Modified();
     }
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
       switch(port){
         case 0:
           info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
@@ -97,7 +97,7 @@ class ttkCellDataSelector
       return 1;
     }
 
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:
@@ -132,7 +132,7 @@ class ttkCellDataSelector
 
     int RequestData(vtkInformation *request,
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -145,6 +145,6 @@ class ttkCellDataSelector
     vtkDataArray             *localFieldCopy_;
 
     int doIt(vtkDataSet *input, vtkDataSet *output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkCinemaLayout/ttkCinemaLayout.h
+++ b/core/vtk/ttkCinemaLayout/ttkCinemaLayout.h
@@ -105,9 +105,11 @@ class ttkCinemaLayout
         bool UseAllCores;
         int ThreadNumber;
 
-        int RequestData(vtkInformation *request, vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+        int RequestData(vtkInformation *request,
+                        vtkInformationVector **inputVector,
+                        vtkInformationVector *outputVector) override;
 
-    private:
+      private:
 
         bool needsToAbort() override { return GetAbortExecute();};
         int updateProgress(const float &progress) override {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -39,7 +39,7 @@ int ttkCinemaWriter::RequestData (
         msg<<"[ttkCinemaWriter] RequestData"<<endl;
         msg<<"[ttkCinemaWriter]     Path: "<<this->DatabasePath<<endl;
         msg<<"[ttkCinemaWriter] Override: "<<(this->OverrideDatabase?"yes":"no")<<endl;
-        msg<<"[ttkCinemaWriter] C. Level: "<<this->GetCompressionLevel()<<endl;
+        msg<<"[ttkCinemaWriter] C. Level: "<<this->GetCompressLevel()<<endl;
         msg<<"[ttkCinemaWriter] --------------------------------------------------------------"<<endl;
         dMsg(cout, msg.str(), infoMsg);
     }
@@ -133,7 +133,7 @@ int ttkCinemaWriter::RequestData (
     mbWriter->SetDataModeToAppended();
     mbWriter->SetCompressorTypeToZLib();
     vtkZLibDataCompressor::SafeDownCast( mbWriter->GetCompressor() )->SetCompressionLevel(
-        this->GetCompressionLevel()
+        this->GetCompressLevel()
     );
     mbWriter->SetInputData( inputMB );
     mbWriter->Write();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -88,9 +88,11 @@ class ttkCinemaWriter
         bool UseAllCores;
         int ThreadNumber;
 
-        int RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector);
+        int RequestData(vtkInformation *request,
+                        vtkInformationVector **inputVector,
+                        vtkInformationVector *outputVector) override;
 
-    private:
+      private:
 
         std::string DatabasePath;
         bool OverrideDatabase;

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -36,8 +36,8 @@ class ttkCinemaWriter
         vtkSetMacro(OverrideDatabase, bool);
         vtkGetMacro(OverrideDatabase, bool);
 
-        vtkSetMacro(CompressionLevel, int);
-        vtkGetMacro(CompressionLevel, int);
+        vtkSetMacro(CompressLevel, int);
+        vtkGetMacro(CompressLevel, int);
 
         // default ttk setters
         vtkSetMacro(debugLevel_, int);
@@ -76,7 +76,7 @@ class ttkCinemaWriter
         ttkCinemaWriter(){
             SetDatabasePath("");
             SetOverrideDatabase(true);
-            SetCompressionLevel(9);
+            SetCompressLevel(9);
 
             UseAllCores = false;
 
@@ -96,7 +96,7 @@ class ttkCinemaWriter
 
         std::string DatabasePath;
         bool OverrideDatabase;
-        int CompressionLevel;
+        int CompressLevel;
 
         bool needsToAbort() override { return GetAbortExecute(); };
         int updateProgress(const float &progress) override {

--- a/core/vtk/ttkComponentSize/ttkComponentSize.h
+++ b/core/vtk/ttkComponentSize/ttkComponentSize.h
@@ -81,7 +81,7 @@ class ttkComponentSize
     
     /// Over-ride the input data type to vtkDataSet.
     int FillOutputPortInformation(int port,
-      vtkInformation *info){
+      vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
       return 1;
     }
@@ -94,7 +94,7 @@ class ttkComponentSize
     ~ttkComponentSize();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -110,9 +110,9 @@ class ttkComponentSize
     // base code features
     int doIt(vtkPointSet *input, vtkUnstructuredGrid *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
@@ -122,8 +122,8 @@ class ttkContinuousScatterPlot
     
     TTK_SETUP();
 
-    int FillInputPortInformation(int port, vtkInformation* info);
-    int FillOutputPortInformation(int port, vtkInformation* info);
+    int FillInputPortInformation(int port, vtkInformation* info) override;
+    int FillOutputPortInformation(int port, vtkInformation* info) override;
     
     
   private:

--- a/core/vtk/ttkContourForests/ttkContourForests.h
+++ b/core/vtk/ttkContourForests/ttkContourForests.h
@@ -226,7 +226,6 @@ class ttkContourForests
     double deltaScalar_;
     ttk::SimplexId numberOfVertices_;
     ttk::Triangulation *triangulation_;
-    std::vector<std::vector<ttk::SimplexId>>* vertexNeighbors_;
     std::vector<ttk::SimplexId>* vertexSoSoffsets_;
     std::vector<ttk::SimplexId>* criticalPoints_;
     std::vector<double>* vertexScalars_;

--- a/core/vtk/ttkContourForests/ttkContourForests.h
+++ b/core/vtk/ttkContourForests/ttkContourForests.h
@@ -130,8 +130,8 @@ class ttkContourForests
     ~ttkContourForests();
     
     // VTK Interface //
-    virtual int FillInputPortInformation(int port, vtkInformation* info);
-    virtual int FillOutputPortInformation(int port, vtkInformation* info);
+    virtual int FillInputPortInformation(int port, vtkInformation* info) override;
+    virtual int FillOutputPortInformation(int port, vtkInformation* info) override;
 
     // Base //
     int vtkDataSetToStdVector(vtkDataSet* input);
@@ -172,9 +172,9 @@ class ttkContourForests
     
     int doIt(std::vector<vtkDataSet *> &inputs, std::vector<vtkDataSet *> &outputs);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
       
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
     
   private:

--- a/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
+++ b/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
@@ -84,7 +84,7 @@ class ttkDataSetInterpolator
 
     int RequestData(vtkInformation *request, 
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -92,6 +92,6 @@ class ttkDataSetInterpolator
     int                   ThreadNumber;
 
     int doIt(vtkDataSet* source, vtkDataSet* target, vtkDataSet* output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
@@ -76,7 +76,7 @@ class ttkDataSetToTable
     vtkSetMacro(DataAssociation, int);
     vtkGetMacro(DataAssociation, int);
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
       switch(port){
         case 0:
           info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
@@ -88,7 +88,7 @@ class ttkDataSetToTable
       return 1;
     }
 
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:
@@ -114,7 +114,7 @@ class ttkDataSetToTable
 
     int RequestData(vtkInformation *request,
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -123,6 +123,6 @@ class ttkDataSetToTable
     int DataAssociation;
 
     int doIt(vtkDataSet* input, vtkTable* output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -316,13 +316,13 @@ class ttkDimensionReduction
     };
 
     int RequestData(vtkInformation *request,
-        vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+        vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
 
   private:
 
     int doIt(vtkTable* input, vtkTable* output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 
     // default
     int NumberOfComponents;

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -112,8 +112,8 @@ class ttkDiscreteGradient
 
     TTK_SETUP();
 
-    int FillInputPortInformation(int port, vtkInformation* info);
-    int FillOutputPortInformation(int port, vtkInformation* info);
+    int FillInputPortInformation(int port, vtkInformation* info) override;
+    int FillOutputPortInformation(int port, vtkInformation* info) override;
 
   private:
 

--- a/core/vtk/ttkDistanceField/ttkDistanceField.h
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.h
@@ -101,7 +101,7 @@ class ttkDistanceField
     
     TTK_SETUP();
 
-    int FillInputPortInformation(int port, vtkInformation* info);
+    int FillInputPortInformation(int port, vtkInformation* info) override;
 
     
   private:

--- a/core/vtk/ttkFiber/ttkFiber.h
+++ b/core/vtk/ttkFiber/ttkFiber.h
@@ -91,7 +91,7 @@ class ttkFiber
     vtkGetMacro(Vvalue, double);
     vtkSetMacro(Vvalue, double);
     
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData"); 
       return 1;
     }
@@ -103,7 +103,7 @@ class ttkFiber
     ~ttkFiber();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -117,9 +117,9 @@ class ttkFiber
     // base code features
     int doIt(vtkDataSet *input, vtkPolyData *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.h
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.h
@@ -122,7 +122,7 @@ class ttkFiberSurface
     vtkGetMacro(PointMergeDistanceThreshold, double);
     vtkSetMacro(PointMergeDistanceThreshold, double);
    
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
 
       switch (port) {
         case 0:
@@ -138,7 +138,7 @@ class ttkFiberSurface
       return 0;  
     }
     
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData"); 
       return 1;
     }

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.h
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.h
@@ -91,7 +91,7 @@ class ttkIdentifiers
     ~ttkIdentifiers();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -103,9 +103,9 @@ class ttkIdentifiers
     // base code features
     int doIt(vtkDataSet *input, vtkDataSet *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
@@ -81,7 +81,7 @@ class ttkImportEmbeddingFromTable
     vtkSetMacro(Embedding2D, bool);
     vtkGetMacro(Embedding2D, bool);
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
       if(port == 0)
         info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPointSet");
       if(port == 1)
@@ -102,7 +102,7 @@ class ttkImportEmbeddingFromTable
 
     int RequestData(vtkInformation *request,
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -115,6 +115,6 @@ class ttkImportEmbeddingFromTable
     int ThreadNumber;
 
     int doIt(vtkPointSet* inputDataSet, vtkTable* inputTable,  vtkPointSet* output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.h
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.h
@@ -108,8 +108,8 @@ class ttkIntegralLines
     
     TTK_SETUP();
 
-    int FillInputPortInformation(int port, vtkInformation* info);
-    int FillOutputPortInformation(int port, vtkInformation* info);
+    int FillInputPortInformation(int port, vtkInformation* info) override;
+    int FillOutputPortInformation(int port, vtkInformation* info) override;
 
   private:
 

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.h
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.h
@@ -120,7 +120,7 @@ class ttkJacobiSet
     vtkSetMacro(VertexScalars, bool);
     vtkGetMacro(VertexScalars, bool);
     
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid"); 
       return 1;
     }

--- a/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.h
+++ b/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.h
@@ -214,8 +214,8 @@ class ttkMandatoryCriticalPoints
 
     ~ttkMandatoryCriticalPoints();
 
-    int FillInputPortInformation(int port, vtkInformation *info);
-    int FillOutputPortInformation(int port, vtkInformation *info);
+    int FillInputPortInformation(int port, vtkInformation *info) override;
+    int FillOutputPortInformation(int port, vtkInformation *info) override;
 
     TTK_PIPELINE_REQUEST();
     TTK_OUTPUT_MANAGEMENT();
@@ -279,9 +279,9 @@ class ttkMandatoryCriticalPoints
     // base code features
     int doIt(std::vector<vtkDataSet *> &inputs, std::vector<vtkDataSet *> &outputs);
 
-    bool needsToAbort();
+    bool needsToAbort() override;
 
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
 
 };
 

--- a/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.h
+++ b/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.h
@@ -105,7 +105,7 @@ class ttkMeshSubdivision
     ~ttkMeshSubdivision();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -117,9 +117,9 @@ class ttkMeshSubdivision
     // base code features
     int doIt(vtkUnstructuredGrid *input, vtkUnstructuredGrid *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -153,8 +153,8 @@ class ttkMorseSmaleComplex
 
     TTK_SETUP();
 
-    virtual int FillInputPortInformation(int port, vtkInformation* info);
-    virtual int FillOutputPortInformation(int port, vtkInformation* info);
+    virtual int FillInputPortInformation(int port, vtkInformation* info) override;
+    virtual int FillOutputPortInformation(int port, vtkInformation* info) override;
 
   private:
     std::string ScalarField;

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
@@ -27,7 +27,7 @@ void ttkOBJWriter::PrintSelf(ostream &os, vtkIndent indent){
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "File Name: " 
-    << (this->FileName ? this->FileName : "(none)") << endl;
+    << (this->Filename ? this->Filename : "(none)") << endl;
 }
 
 // }}}
@@ -35,19 +35,19 @@ void ttkOBJWriter::PrintSelf(ostream &os, vtkIndent indent){
 // {{{
 
 ttkOBJWriter::ttkOBJWriter(){
-  FileName = NULL;
+  Filename = NULL;
   Stream = NULL;
 }
 
 ttkOBJWriter::~ttkOBJWriter(){
-  SetFileName(NULL);
+  SetFilename(NULL);
   if(Stream)
     delete Stream;
 }
 
 int ttkOBJWriter::OpenFile(){
 
-  ofstream *f = new ofstream(FileName, ios::out);
+  ofstream *f = new ofstream(Filename, ios::out);
   
   if(!f->fail()){
     Stream = f;
@@ -70,7 +70,7 @@ void ttkOBJWriter::WriteData(){
   
   if(this->OpenFile()){
     cerr << "[ttkOBJWriter] Could not open file `"
-      << FileName << "' :(" << endl; 
+      << Filename << "' :(" << endl;
     return;
   }
   

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.h
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.h
@@ -31,8 +31,8 @@ class ttkOBJWriter
 
     // Description:
     // Specify file name of the .abc file.
-    vtkSetStringMacro(FileName);
-    vtkGetStringMacro(FileName);
+    vtkSetStringMacro(Filename);
+    vtkGetStringMacro(Filename);
 
   protected:
     ttkOBJWriter();
@@ -41,7 +41,7 @@ class ttkOBJWriter
     int OpenFile();
     virtual void WriteData() override;
     
-    char *FileName;
+    char *Filename;
     ofstream *Stream;
     
   private:

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
@@ -27,7 +27,7 @@ void ttkOFFWriter::PrintSelf(ostream &os, vtkIndent indent){
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "File Name: " 
-    << (this->FileName ? this->FileName : "(none)") << endl;
+    << (this->Filename ? this->Filename : "(none)") << endl;
 }
 
 // }}}
@@ -35,19 +35,19 @@ void ttkOFFWriter::PrintSelf(ostream &os, vtkIndent indent){
 // {{{
 
 ttkOFFWriter::ttkOFFWriter(){
-  FileName = NULL;
+  Filename = NULL;
   Stream = NULL;
 }
 
 ttkOFFWriter::~ttkOFFWriter(){
-  SetFileName(NULL);
+  SetFilename(NULL);
   if(Stream)
     delete Stream;
 }
 
 int ttkOFFWriter::OpenFile(){
 
-  ofstream *f = new ofstream(FileName, ios::out);
+  ofstream *f = new ofstream(Filename, ios::out);
   
   if(!f->fail()){
     Stream = f;

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.h
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.h
@@ -31,8 +31,8 @@ class ttkOFFWriter
 
     // Description:
     // Specify file name of the .abc file.
-    vtkSetStringMacro(FileName);
-    vtkGetStringMacro(FileName);
+    vtkSetStringMacro(Filename);
+    vtkGetStringMacro(Filename);
 
   protected:
     ttkOFFWriter();
@@ -41,7 +41,7 @@ class ttkOFFWriter
     int OpenFile();
     virtual void WriteData() override;
     
-    char *FileName;
+    char *Filename;
     ofstream *Stream;
     
   private:

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -112,9 +112,9 @@ class ttkPersistenceCurve
     ~ttkPersistenceCurve();
 
     int RequestData(vtkInformation *request,
-        vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+        vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
 
-    int FillOutputPortInformation(int port, vtkInformation* info);
+    int FillOutputPortInformation(int port, vtkInformation* info) override;
 
     template <typename vtkArrayType, typename scalarType>
       int getPersistenceCurve(ttk::ftm::TreeType treeType, 
@@ -153,8 +153,8 @@ class ttkPersistenceCurve
         vtkTable* outputMSCPersistenceCurve,
         vtkTable* outputSTPersistenceCurve,
         vtkTable* outputCTPersistenceCurve);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };
 
 template <typename vtkArrayType, typename scalarType>

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -183,7 +183,7 @@ class ttkPersistenceDiagram
     ttkPersistenceDiagram();
     ~ttkPersistenceDiagram();
 
-    int FillOutputPortInformation(int port, vtkInformation* info);
+    int FillOutputPortInformation(int port, vtkInformation* info) override;
 
     TTK_SETUP();
 

--- a/core/vtk/ttkPointDataConverter/ttkPointDataConverter.h
+++ b/core/vtk/ttkPointDataConverter/ttkPointDataConverter.h
@@ -106,8 +106,8 @@ Double=0,
     ttkPointDataConverter();    
     ~ttkPointDataConverter();
 
-    int RequestData(vtkInformation *request, 
-		      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+    int RequestData(vtkInformation *request, vtkInformationVector **inputVector,
+                    vtkInformationVector *outputVector) override;
 
     template<typename A, typename B, typename C>
       int convert(vtkDataArray* inputData, vtkDataSet* output);
@@ -121,8 +121,8 @@ Double=0,
     
     // base code features
     int doIt(vtkDataSet *input, vtkDataSet *output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);   
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };
 
 #endif // _TTK_POINTDATACONVERTER_H

--- a/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
+++ b/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
@@ -85,7 +85,7 @@ class ttkPointDataSelector
       Modified();
     }
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
       switch(port){
         case 0:
           info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
@@ -97,7 +97,7 @@ class ttkPointDataSelector
       return 1;
     }
 
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:
@@ -131,7 +131,7 @@ class ttkPointDataSelector
 
     int RequestData(vtkInformation *request,
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -144,6 +144,6 @@ class ttkPointDataSelector
     vtkDataArray             *localFieldCopy_;
 
     int doIt(vtkDataSet *input, vtkDataSet *output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -88,7 +88,7 @@ class ttkProjectionFromField
     ~ttkProjectionFromField();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -102,9 +102,9 @@ class ttkProjectionFromField
     // base code features
     int doIt(vtkPointSet *input, vtkPointSet *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.h
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.h
@@ -100,7 +100,7 @@ class ttkRangePolygon
     vtkGetMacro(NumberOfIterations, int);
     vtkSetMacro(NumberOfIterations, int);
     
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid"); 
       return 1;
     }

--- a/core/vtk/ttkReebSpace/ttkReebSpace.h
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.h
@@ -205,7 +205,7 @@ class ttkReebSpace
     
     ~ttkReebSpace();
     
-    virtual int FillOutputPortInformation(int port, vtkInformation *info){
+    virtual int FillOutputPortInformation(int port, vtkInformation *info) override {
       
       if(port == 0){
         // 0-sheets, corners of jacobi set segments

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -103,7 +103,7 @@ class ttkScalarFieldCriticalPoints
     vtkGetMacro(OffsetField, std::string);
     vtkSetMacro(OffsetField, std::string);
     
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid"); 
       return 1;
     }

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
@@ -91,11 +91,10 @@ class ttkScalarFieldNormalizer
     ~ttkScalarFieldNormalizer();
     
     int normalize(vtkDataArray *input, vtkDataArray *output) const;
-    
-    int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
-    
-    
+
+    int RequestData(vtkInformation *request, vtkInformationVector **inputVector,
+                    vtkInformationVector *outputVector) override;
+
   private:
     
     bool                  UseAllCores;
@@ -106,9 +105,9 @@ class ttkScalarFieldNormalizer
     // base code features
     int doIt(vtkDataSet *input, vtkDataSet *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
+++ b/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
@@ -90,7 +90,7 @@ class ttkSphereFromPoint
     
     /// Over-ride the input data type to vtkDataSet.
     int FillOutputPortInformation(int port,
-      vtkInformation *info){
+      vtkInformation *info) override {
       info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
       return 1;
     }
@@ -102,7 +102,7 @@ class ttkSphereFromPoint
     ~ttkSphereFromPoint();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -124,9 +124,9 @@ class ttkSphereFromPoint
     // base code features
     int doIt(vtkDataSet *input, vtkPolyData *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
+++ b/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
@@ -79,7 +79,7 @@ class ttkTableDataSelector
       Modified();
     }
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
       switch(port){
         case 0:
           info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
@@ -91,7 +91,7 @@ class ttkTableDataSelector
       return 1;
     }
 
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:
@@ -117,7 +117,7 @@ class ttkTableDataSelector
 
     int RequestData(vtkInformation *request,
         vtkInformationVector **inputVector,
-        vtkInformationVector *outputVector);
+        vtkInformationVector *outputVector) override;
 
   private:
 
@@ -126,6 +126,6 @@ class ttkTableDataSelector
     std::vector<std::string> ScalarFields;
 
     int doIt(vtkTable *input, vtkTable *output);
-    bool needsToAbort();
-    int updateProgress(const float &progress);
+    bool needsToAbort() override;
+    int updateProgress(const float &progress) override;
 };

--- a/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.h
+++ b/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.h
@@ -101,7 +101,7 @@ class ttkTextureMapFromField
     ~ttkTextureMapFromField();
     
     int RequestData(vtkInformation *request, 
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
     
     
   private:
@@ -116,9 +116,9 @@ class ttkTextureMapFromField
     // base code features
     int doIt(vtkDataSet *input, vtkDataSet *output);
     
-    bool needsToAbort();
+    bool needsToAbort() override;
     
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
    
 };
 

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -90,7 +90,6 @@ class ttkTopologicalCompressionReader
     int                              DataExtent[6];
     double                           DataSpacing[3];
     double                           DataOrigin[3];
-    double                           Tolerance;
     bool                             ZFPOnly;
     int                              SQMethod;
 

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -74,7 +74,7 @@ class ttkTopologicalCompressionReader
     virtual int RequestInformation(
       vtkInformation *request,
       vtkInformationVector **inputVector,
-      vtkInformationVector *outputVector);
+      vtkInformationVector *outputVector) override;
 
     // TTK management.
     void BuildMesh();

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -157,7 +157,7 @@ void ttkTopologicalCompressionWriter::WriteData()
     return;
   }
 
-  int dt = vti->GetPointData()->GetArray(inputScalarField->GetName())->GetDataType();;
+  int dt = vti->GetPointData()->GetArray(inputScalarField->GetName())->GetDataType();
   double *vp = (double*) vti->GetPointData()->GetArray(inputScalarField->GetName())->GetVoidPointer(0);
 
   topologicalCompression.setFileName(FileName);

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -127,8 +127,8 @@ class ttkTopologicalCompressionWriter
     // Regular writer management.
     ttkTopologicalCompressionWriter();
     ~ttkTopologicalCompressionWriter();
-    virtual int FillInputPortInformation(int port, vtkInformation *info);
-    void WriteData();
+    virtual int FillInputPortInformation(int port, vtkInformation *info) override;
+    void WriteData() override;
 
     // TTK management.
     vtkDataArray* GetInputScalarField(vtkImageData *vti);

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -135,7 +135,7 @@ class ttkTopologicalSimplification
     
     TTK_SETUP();
 
-    int FillInputPortInformation(int port, vtkInformation* info);
+    int FillInputPortInformation(int port, vtkInformation* info) override;
 
     
   private:

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
@@ -147,7 +147,7 @@ class ttkTrackingFromFields
 
     TTK_SETUP();
 
-    virtual int FillOutputPortInformation(int port, vtkInformation* info);
+    virtual int FillOutputPortInformation(int port, vtkInformation* info) override;
 
   private:
 

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.cpp
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.cpp
@@ -88,15 +88,13 @@ int ttkTrackingFromPersistenceDiagrams::RequestData(vtkInformation *request,
   }
 
   // Get input data
-  auto input = new vtkDataSet*[numInputs];
+  std::vector<vtkDataSet*> input(numInputs);
   for (int i = 0; i < numInputs; i++)
   {
     input[i] = vtkDataSet::GetData(inputVector[0], i);
   }
 
   doIt<double>(input, mesh, numInputs);
-
-  delete input;
 
   {
     std::stringstream msg;

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
@@ -175,7 +175,7 @@ class ttkTrackingFromPersistenceDiagrams
     vtkUnstructuredGrid   *outputMesh_;
 
     template <typename dataType>
-    int doIt(vtkDataSet **input,
+      int doIt(std::vector<vtkDataSet *> &input,
              vtkUnstructuredGrid *outputMean,
              int numInputs);
 
@@ -188,7 +188,7 @@ class ttkTrackingFromPersistenceDiagrams
 
 template <typename dataType>
 int ttkTrackingFromPersistenceDiagrams::doIt(
-  vtkDataSet **input,
+  std::vector<vtkDataSet *> &input,
   vtkUnstructuredGrid *mesh,
   int numInputs)
 {

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
@@ -128,11 +128,11 @@ class ttkTrackingFromPersistenceDiagrams
 
     ~ttkTrackingFromPersistenceDiagrams();
 
-    int FillInputPortInformation(int port, vtkInformation *info);
-    int FillOutputPortInformation(int port, vtkInformation *info);
+    int FillInputPortInformation(int port, vtkInformation *info) override;
+    int FillOutputPortInformation(int port, vtkInformation *info) override;
 
     int RequestData(vtkInformation *request,
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
 
 	// Warn: this is a duplicate from ttkBottleneckDistance.h
 	template <typename dataType>
@@ -179,9 +179,9 @@ class ttkTrackingFromPersistenceDiagrams
              vtkUnstructuredGrid *outputMean,
              int numInputs);
 
-    bool needsToAbort();
+    bool needsToAbort() override;
 
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
 
     ttk::TrackingFromPersistenceDiagrams tracking_;
 };

--- a/core/vtk/ttkTriangulation/ttkWrapper.h
+++ b/core/vtk/ttkTriangulation/ttkWrapper.h
@@ -61,8 +61,8 @@
 #endif
 
 #ifndef _MSC_VER 
-#define ttkTemplateMacro(s) vtkTemplateMacro((s));
-#define ttkTemplate2Macro(s) vtkTemplate2Macro((s));
+#define ttkTemplateMacro(s) vtkTemplateMacro((s))
+#define ttkTemplate2Macro(s) vtkTemplate2Macro((s))
 #else
 #define ttkTemplateMacro(s) vtkTemplateMacro(s);
 #define ttkTemplate2Macro(s) vtkTemplate2Macro(s);

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -90,7 +90,7 @@ class ttkTriangulationRequest
     vtkSetMacro(KeepAllDataArrays, bool);
     vtkGetMacro(KeepAllDataArrays, bool);
 
-    int FillInputPortInformation(int port, vtkInformation *info){
+    int FillInputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:
@@ -104,7 +104,7 @@ class ttkTriangulationRequest
       return 1;
     }
 
-    int FillOutputPortInformation(int port, vtkInformation *info){
+    int FillOutputPortInformation(int port, vtkInformation *info) override {
 
       switch(port){
         case 0:

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
@@ -131,11 +131,11 @@ class ttkUncertainDataEstimator
 
     ~ttkUncertainDataEstimator();
 
-    int FillInputPortInformation(int port, vtkInformation *info);
-    int FillOutputPortInformation(int port, vtkInformation *info);
+    int FillInputPortInformation(int port, vtkInformation *info) override;
+    int FillOutputPortInformation(int port, vtkInformation *info) override;
 
     int RequestData(vtkInformation *request,
-      vtkInformationVector **inputVector, vtkInformationVector *outputVector);
+      vtkInformationVector **inputVector, vtkInformationVector *outputVector) override;
 
 
   private:
@@ -158,9 +158,9 @@ class ttkUncertainDataEstimator
              vtkDataSet *outputMean,
              int numInputs);
 
-    bool needsToAbort();
+    bool needsToAbort() override;
 
-    int updateProgress(const float &progress);
+    int updateProgress(const float &progress) override;
 
 };
 

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -36,7 +36,7 @@ class ttkCustomInteractor : public vtkInteractorStyleTrackballCamera{
     
     vtkTypeMacro(ttkCustomInteractor, vtkInteractorStyleTrackballCamera);
     
-    virtual void OnKeyPress();
+    virtual void OnKeyPress() override;
     
     inline int setUserInterface(ttkUserInterfaceBase *userInterface){
       

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -26,7 +26,7 @@
                 <BooleanDomain name="bool" />
                 <Documentation>Determines if the filter replaces (true) or appends (false) database content.</Documentation>
             </IntVectorProperty>
-            <IntVectorProperty name="CompressionLevel" label="Compression Level" command="SetCompressionLevel" number_of_elements="1" default_values="9">
+            <IntVectorProperty name="CompressionLevel" label="Compression Level" command="SetCompressLevel" number_of_elements="1" default_values="9">
                 <IntRangeDomain name="range" min="0" max="9" />
                 <Documentation>Determines the compression level form 0 (fast + large files) to 9 (slow + small files).</Documentation>
             </IntVectorProperty>

--- a/paraview/OBJWriter/OBJWriter.xml
+++ b/paraview/OBJWriter/OBJWriter.xml
@@ -18,7 +18,7 @@
         </InputProperty>
         <StringVectorProperty
           name="FileName"
-          command="SetFileName"
+          command="SetFilename"
           number_of_elements="1">
           <FileListDomain name="files"/>
           <Documentation>

--- a/paraview/OFFWriter/OFFWriter.xml
+++ b/paraview/OFFWriter/OFFWriter.xml
@@ -18,7 +18,7 @@
         </InputProperty>
         <StringVectorProperty
           name="FileName"
-          command="SetFileName"
+          command="SetFilename"
           number_of_elements="1">
           <FileListDomain name="files"/>
           <Documentation>


### PR DESCRIPTION
This branch contains some quick fixes that silence compilation warnings using Clang (the default compiler on MacOS?).

Removing these warnings improve code quality and helps developers concentrate on the warnings they produce.

This pull-request can be divided into three subsets:
* the first fixes all default Clang warnings with the ```-Wall``` flag (set by default in TTK). Most of the work consisted in adding missing ```override``` keywords.
* a second subset focuses on fixing 3 defects reported by ```scan-build```, a front-end of the Clang Static Analyzer
* the third portion also fixes some low-hanging ```-Wextra``` and ```-pedantic``` warnings.