### PR TITLE
Fix HarmonicField behavior

### DIFF
--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -51,15 +51,6 @@ int ttk::HarmonicField::execute() const {
     dMsg(cout, msg.str(), advancedInfoMsg);
   }
 
-  // get unique constraint vertices
-  std::set<SimplexId> identifiersSet;
-  for(SimplexId i = 0; i < constraintNumber_; ++i) {
-    identifiersSet.insert(identifiers[i]);
-  }
-  // contains vertices with constraints
-  std::vector<SimplexId> identifiersVec(
-    identifiersSet.begin(), identifiersSet.end());
-
   // graph laplacian of current mesh
   SpMat lap;
   if(useCotanWeights_) {
@@ -71,9 +62,9 @@ int ttk::HarmonicField::execute() const {
 
   // constraints vector
   SpVec constraints(vertexNumber_);
-  for(size_t i = 0; i < identifiersVec.size(); i++) {
+  for(SimplexId i = 0; i < constraintNumber_; i++) {
     // put constraint at identifier index
-    constraints.coeffRef(identifiersVec[i]) = sf[i];
+    constraints.coeffRef(identifiers[i]) = sf[i];
   }
 
   auto sm = ttk::SolvingMethodType::Cholesky;
@@ -96,9 +87,9 @@ int ttk::HarmonicField::execute() const {
   const scalarFieldType alpha = pow10(logAlpha_);
 
   std::vector<TripletType> triplets;
-  triplets.reserve(identifiersVec.size());
-  for(auto i : identifiersVec) {
-    triplets.emplace_back(TripletType(i, i, alpha));
+  triplets.reserve(constraintNumber_);
+  for(SimplexId i = 0; i < constraintNumber_; ++i) {
+    triplets.emplace_back(TripletType(identifiers[i], identifiers[i], alpha));
   }
   penalty.setFromTriplets(triplets.begin(), triplets.end());
 

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -100,6 +100,14 @@ int ttkHarmonicField::getConstraints(vtkPointSet *input) {
   }
 #endif
 
+  if(constraints_->IsA("vtkDoubleArray")) {
+    OutputScalarFieldType = HarmonicFieldType::Double;
+  } else if(constraints_->IsA("vtkFloatArray")) {
+    OutputScalarFieldType = HarmonicFieldType::Float;
+  } else {
+    return -2;
+  }
+
   return 0;
 }
 

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -84,11 +84,12 @@ int ttkHarmonicField::getIdentifiers(vtkPointSet *input) {
 
 int ttkHarmonicField::getConstraints(vtkPointSet *input) {
   auto osfn = static_cast<const char *>(ttk::OffsetScalarFieldName);
+  auto pointData = input->GetPointData();
 
   if(InputScalarFieldName.length() != 0) {
-    constraints_ = input->GetPointData()->GetArray(InputScalarFieldName.data());
-  } else if(input->GetPointData()->GetArray(osfn) != nullptr) {
-    constraints_ = input->GetPointData()->GetArray(osfn);
+    constraints_ = pointData->GetArray(InputScalarFieldName.data());
+  } else if(pointData->GetArray(osfn) != nullptr) {
+    constraints_ = pointData->GetArray(osfn);
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.h
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.h
@@ -91,9 +91,6 @@ public:
   vtkSetMacro(OutputScalarFieldName, std::string);
   vtkGetMacro(OutputScalarFieldName, std::string);
 
-  vtkSetMacro(OutputScalarFieldType, int);
-  vtkGetMacro(OutputScalarFieldType, int);
-
   vtkSetMacro(ForceConstraintIdentifiers, bool);
   vtkGetMacro(ForceConstraintIdentifiers, bool);
 

--- a/paraview/HarmonicField/HarmonicField.xml
+++ b/paraview/HarmonicField/HarmonicField.xml
@@ -169,24 +169,6 @@
         </Documentation>
       </DoubleVectorProperty>
 
-      
-
-      <IntVectorProperty
-        name="OutputScalarFieldType"
-        label="Output Field Type"
-        command="SetOutputScalarFieldType"
-        number_of_elements="1"
-        default_values="0" 
-        panel_visibility="advanced">
-        <EnumerationDomain name="enum">
-          <Entry value="0" text="Float" />
-          <Entry value="1" text="Double" />
-        </EnumerationDomain>
-        <Documentation>
-          Select the type of the output scalar field.
-        </Documentation>
-      </IntVectorProperty>
-
       <StringVectorProperty
         name="OutputScalarFieldName"
         command="SetOutputScalarFieldName"
@@ -260,7 +242,6 @@
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">
-        <Property name="OutputScalarFieldType"/>
         <Property name="OutputScalarFieldName"/>
       </PropertyGroup>
 


### PR DESCRIPTION
There were (at least) two bugs in my HarmonicField filter:
* a pre-processing of the constraints TTK identifiers that caused wrong constraint values on identifiers
* the filter was not reacting to the input constraints type.

This pull request fixes those two behaviors by:
* removing the pre-processing of the constraints identifiers
* linking the computation to the constraints input type
* removing the setting of the filter output type