### PR TITLE
Remove absolute boost

### DIFF
--- a/core/base/ftrGraph/CMakeLists.txt
+++ b/core/base/ftrGraph/CMakeLists.txt
@@ -53,8 +53,6 @@ ttk_add_base_library(ftrGraph
     ${profiler_lib}
     )
 
-target_include_directories(ftrGraph PUBLIC ${Boost_INCLUDE_DIR})
-
 # target definitions
 
 if(ENABLE_PROFILING)

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -153,7 +153,7 @@ namespace ttk {
   schedule(static, size_ / threadNumber_)
 #endif
           for(idVertex i = 0; i < size_; i++) {
-            if(::std::isnan(values_[i])) {
+            if(::std::isnan((double) values_[i])) {
               values_[i] = 0;
             }
           }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -318,11 +318,11 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
     upperList[i] = upperList[i]->find();
 
   std::vector<UnionFind *>::iterator it;
-  sort(lowerList.begin(), lowerList.end());
+  std::sort(lowerList.begin(), lowerList.end());
   it = unique(lowerList.begin(), lowerList.end());
   lowerList.resize(distance(lowerList.begin(), it));
 
-  sort(upperList.begin(), upperList.end());
+  std::sort(upperList.begin(), upperList.end());
   it = unique(upperList.begin(), upperList.end());
   upperList.resize(distance(upperList.begin(), it));
 


### PR DESCRIPTION
Current Version will generate 

```
set_target_properties(ttk::base::ftrGraph PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "TTK_ENABLE_EIGEN;TTK_ENABLE_64BIT_IDS"
  INTERFACE_COMPILE_OPTIONS "/bigobj;/wd4005;/wd4061;/wd4100;/wd4146;/wd4221;/wd4242;/wd4244;/wd4245;/wd4263;/wd4264;/wd4267;/wd4273;/wd4275;/wd4296;/wd4305;/wd4365;/wd4371;/wd4435;/wd4456;/wd4457;/wd4514;/wd4619;/wd4625;/wd4626;/wd4628;/wd4668;/wd4701;/wd4702;/wd4710;/wd4800;/wd4820;/wd4996;/wd5027;/wd5029;/wd5031"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/ttk/base;C:/dev/libraries/boost_1_68_0"
  INTERFACE_LINK_LIBRARIES "ttk::base::triangulation;ttk::base::scalarFieldCriticalPoints;Boost::boost;Boost::system;Eigen3::Eigen"
)

```

* "C:/dev/libraries/boost_1_68_0" path is hardcoded inside the cmake config 

>  INTERFACE_LINK_LIBRARIES "ttk::base::triangulation;ttk::base::scalarFieldCriticalPoints;Boost::boost;Boost::system;Eigen3::Eigen"

* Boost was already linked using interface, therefore we can remove "target_include_directories"

