### PR TITLE
OpenMP Priority improvements

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -190,7 +190,24 @@ option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 
 if (TTK_ENABLE_OPENMP)
   find_package(OpenMP REQUIRED)
+  if(OPENMP_FOUND)
+    option(TTK_ENABLE_OMP_PRIORITY "Gives tasks priority, high perf improvement" OFF)
+
+    if (OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 4 AND OpenMP_CXX_VERSION_MINOR GREATER_EQUAL 5)
+      set(TTK_ENABLE_OMP_PRIORITY ON CACHE BOOL "Enable priorities on opnemp tasks" FORCE)
+    endif()
+
+    mark_as_advanced(TTK_ENABLE_OMP_PRIORITY)
+
+  endif()
+else()
+  if(TTK_ENABLE_OMP_PRIORITY)
+    # priorities are only meaningful when openmp is on
+    set(TTK_ENABLE_OMP_PRIORITY OFF CACHE BOOL "Enable priorities on opnemp tasks" FORCE)
+  endif()
 endif()
+
+
 
 if (TTK_ENABLE_MPI)
   find_package(MPI REQUIRED)

--- a/core/base/ftmTree/FTMTree.cpp
+++ b/core/base/ftmTree/FTMTree.cpp
@@ -1,5 +1,5 @@
-/// \ingroup base
 /// \class ttk:FTMTree
+/// \ingroup base
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date Dec 2016.
 ///

--- a/core/base/ftmTree/FTMTree_CT.cpp
+++ b/core/base/ftmTree/FTMTree_CT.cpp
@@ -66,6 +66,16 @@ void FTMTree_CT::build(TreeType tt)
       printTime(precomputeTime, "leafSearch", -1, 3);
    }
 
+#ifdef TTK_ENABLE_OMP_PRIORITY
+   {
+     // Set priority
+     if (st_->getNumberOfLeaves() < jt_->getNumberOfLeaves())
+       st_->setPrior();
+     else
+       jt_->setPrior();
+   }
+#endif
+
    // JT & ST
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel num_threads(threadNumber_)
@@ -76,9 +86,15 @@ void FTMTree_CT::build(TreeType tt)
 #endif
        {
           if (tt == TreeType::Join || bothMT) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task untied if (threadNumber_ > 1)
+#endif
              jt_->build(tt == TreeType::Contour);
           }
           if (tt == TreeType::Split || bothMT) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task untied if (threadNumber_ > 1)
+#endif
              st_->build(tt == TreeType::Contour);
           }
        }

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -83,16 +83,22 @@ namespace ftm
       // opened nodes
       std::vector<char> *openedNodes;
 
-#ifdef TTK_ENABLE_FTM_TREE_STATS_TIME
-      std::vector<ActiveTask> *activeTasksStats;
-#endif
-
       // current nb of tasks
       idNode activeTasks;
 
       // Segmentation, stay empty for Contour tree as
       // they are created by Merge Tree
       Segments segments_;
+
+#ifdef TTK_ENABLE_FTM_TREE_STATS_TIME
+      std::vector<ActiveTask> *activeTasksStats;
+#endif
+
+#ifdef TTK_ENABLE_OMP_PRIORITY
+      // Is this MT to be computed with greater task priority than others
+      bool prior;
+#endif
+
    };
 
    class FTMTree_MT : virtual public Debug
@@ -339,6 +345,18 @@ namespace ftm
       {
           params_->normalize = normalize;
       }
+
+#ifdef TTK_ENABLE_OMP_PRIORITY
+      inline void setPrior(void)
+      {
+         mt_data_.prior = true;
+      }
+
+      inline bool isPrior(void) const
+      {
+         return mt_data_.prior;
+      }
+#endif
 
       // scalar
 

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -39,6 +39,14 @@ void ttk::ftm::FTMTree::build(void)
 #ifdef TTK_ENABLE_OPENMP
    omp_set_num_threads(threadNumber_);
    omp_set_nested(1);
+#ifdef TTK_ENABLE_OMP_PRIORITY
+      if(omp_get_max_task_priority() < 5) {
+        std::stringstream msg;
+        msg << "[FTM Graph]: Warning, OpenMP max priority is lower than 5"
+            << std::endl;
+        dMsg(std::cerr, msg.str(), infoMsg);
+      }
+#endif
 #endif
 
    // ----

--- a/core/base/ftrGraph/CMakeLists.txt
+++ b/core/base/ftrGraph/CMakeLists.txt
@@ -8,16 +8,6 @@ if(ENABLE_PROFILING)
   set(profiler_lib profiler)
 endif()
 
-if(OPENMP_FOUND)
-  option(TTK_ENABLE_FTR_PRIORITY "Gives tasks priority, high perf improvement" OFF)
-
-  if (OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 4 AND OpenMP_CXX_VERSION_MINOR GREATER_EQUAL 5)
-    set(TTK_ENABLE_FTR_PRIORITY ON CACHE BOOL "Enable priorities on opnemp tasks" FORCE)
-  endif()
-
-  mark_as_advanced(TTK_ENABLE_FTR_PRIORITY)
-endif()
-
 # option (TTK_DISABLE_FTR_LAZY "Disable the lazyness optimization" OFF)
 # mark_as_advanced(TTK_DISABLE_FTR_LAZY)
 
@@ -57,10 +47,6 @@ ttk_add_base_library(ftrGraph
 
 if(ENABLE_PROFILING)
   target_compile_definitions(ftrGraph PUBLIC GPROFILE=1)
-endif()
-
-if (TTK_ENABLE_FTR_PRIORITY)
-  target_compile_definitions(ftrGraph PUBLIC TTK_ENABLE_FTR_PRIORITY)
 endif()
 
 # if(TTK_DISABLE_FTR_LAZY)

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -12,7 +12,7 @@
 #include <iterator>
 #endif
 
-#ifdef TTK_ENABLE_FTR_PRIORITY
+#ifdef TTK_ENABLE_OMP_PRIORITY
 #define OPTIONAL_PRIORITY(value) priority(value)
 #else
 #define OPTIONAL_PRIORITY(value)
@@ -56,7 +56,7 @@ namespace ttk {
 #ifdef TTK_ENABLE_OPENMP
       omp_set_num_threads(params_.threadNumber);
       omp_set_nested(1);
-#ifdef TTK_ENABLE_FTR_PRIORITY
+#ifdef TTK_ENABLE_OMP_PRIORITY
       if(omp_get_max_task_priority() < PriorityLevel::Max) {
         std::stringstream msg;
         msg << "[FTR Graph]: Warning, OpenMP max priority is lower than 5"

--- a/core/functions.cmake
+++ b/core/functions.cmake
@@ -36,6 +36,10 @@ function(ttk_set_compile_options library)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_OPENMP)
     target_compile_options(${library} PUBLIC ${OpenMP_CXX_FLAGS})
     target_link_libraries(${library} PUBLIC ${OpenMP_CXX_LIBRARIES})
+
+    if (TTK_ENABLE_OMP_PRIORITY)
+      target_compile_definitions(${library} PUBLIC TTK_ENABLE_OMP_PRIORITY)
+    endif()
   endif()
 
   if (TTK_ENABLE_MPI)


### PR DESCRIPTION
Dear Julien,

This PR unifies OpenMP priority handling between FTM and FTR. It also improves FTM by computing JT and ST simultaneously when the output is a contour tree.

Charles