### PR TITLE
Quick fixes after playing with MSVC

### DIFF
--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -894,8 +894,10 @@ namespace ttk {
         }
       }
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-value"
+#endif // __GNUC__
 
       valence oldVal = 0;
       if(localProp->goUp()) {
@@ -947,7 +949,9 @@ namespace ttk {
         oldVal = decr + newVal + (totalVal + 1);
       }
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif // __GNUC__
 
       return oldVal == decr;
     }

--- a/core/functions.cmake
+++ b/core/functions.cmake
@@ -5,7 +5,15 @@
 # ttk_set_compile_options(<library_name>)
 #
 function(ttk_set_compile_options library)
-  target_compile_options(${library} PRIVATE -Wall)
+
+  # compilation flags
+  if (NOT MSVC)
+    # GCC and Clang
+    target_compile_options(${library} PRIVATE -Wall)
+  else()
+    # MSVC
+    target_compile_options(${library} PRIVATE /W4)
+  endif()
 
   if(Boost_FOUND)
     target_link_libraries(${library} PUBLIC Boost::boost)

--- a/core/vtk/ttkEigenField/ttkEigenField.h
+++ b/core/vtk/ttkEigenField/ttkEigenField.h
@@ -89,10 +89,6 @@ public:
 
   // get mesh from VTK
   int getTriangulation(vtkDataSet *input);
-  // get array of identifiers on the mesh
-  int getIdentifiers(vtkPointSet *input);
-  // get constraint values on identifiers
-  int getConstraints(vtkPointSet *input);
 
   // default copy constructor
   ttkEigenField(const ttkEigenField &) = delete;


### PR DESCRIPTION
The current pull-request has small build fixes for MSVC compatibility:

1. Separating compilation flags between GCC/Clang and MSVC and reducing warning level from /Wall to /W4;
2. Fixing a link error in my new EigenField filter concerning some unimplemented methods;
3. Adding some missing pre-processor guards around compiler specific pragmas in the FTRGraph filter that caused a MSVC warning.