### PR TITLE
Fix warnings found by the Clang Static Analyzer

### DIFF
--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -564,7 +564,6 @@ void ContourForests::unifyTree(const char treetype)
 
       for (idSuperArc upArcPos = 0; upArcPos < nbUpArc; upArcPos++) {
           // reset partition / node and tree
-         currentPartition = refPartition;
          currentTree      = getTreePart(refPartition);
          currentNodeId    = refNodeId;
          currentNode      = currentTree->getNode(currentNodeId);

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -319,6 +319,11 @@ void MergeTree::processVertex(const SimplexId &             currentVertex,
       }
 
    } else {
+#ifndef TTK_ENABLE_KAMIKAZE
+     if (seed == nullptr) {
+         return;
+      }
+#endif //TTK_ENABLE_KAMIKAZE
       // regular node
       currentArc = (idSuperArc)seed->find()->getData();
       updateCorrespondingArc(currentVertex, currentArc);

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -2006,7 +2006,7 @@ int SubLevelSetTree::simplify(const double &simplificationThreshold,
   vector<pair<real,int> > regularNodeList;
   
   int arcToSimplify = -1;
-  double currentScore = 0, minScore = maxScalar_ - minScalar_;
+  double currentScore = 0, minScore;
   
   do{
    
@@ -2541,14 +2541,12 @@ int ContourTree::combineTrees(){
 
     for(int i = 0; i < mergeTree_.getNumberOfNodes(); i++){
       mergeNode = mergeTree_.getNode(i);
-      splitNode = splitTree_.getVertexNode(mergeNode->getVertexId());
       if(isNodeEligible(mergeNode)){
         nodeQueue.push(mergeNode);
       }
     }
     for(int i = 0; i < splitTree_.getNumberOfNodes(); i++){
       splitNode = splitTree_.getNode(i);
-      mergeNode = mergeTree_.getVertexNode(splitNode->getVertexId());
       if(isNodeEligible(splitNode)){
         nodeQueue.push(splitNode);
       }

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -2562,6 +2562,12 @@ int ContourTree::combineTrees(){
       n0 = nodeQueue.front();
       nodeQueue.pop();
 
+#ifndef TTK_ENABLE_KAMIKAZE
+      if (n0 == nullptr) {
+        continue;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+
       if((mergeTree_.getNode(n0 - mergeTree_.getNode(0)) == n0)
 	 &&(isNodeEligible(n0))){
         // merge node
@@ -2775,6 +2781,12 @@ int ContourTree::finalizeSuperArc(const int &nodeId, const int &arcId){
 }
 
 bool ContourTree::isNodeEligible(const Node *n) const{
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if (n == nullptr) {
+    return false;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
 
   const Node *merge = NULL, *split = NULL;
 

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -414,7 +414,6 @@ int FiberSurface::computeTriangleIntersection(const SimplexId &tetId,
     p0a.data(), p1a.data())){
     if(!foundA){
       pA = p1b;
-      foundA = true;
     }
     else if(!foundB){
       // check it's far enough from pA
@@ -422,7 +421,6 @@ int FiberSurface::computeTriangleIntersection(const SimplexId &tetId,
         ||(fabs(pA[1] - p1b[1]) > pow10(-DBL_DIG+4))
         ||(fabs(pA[2] - p1b[2]) > pow10(-DBL_DIG+4))){
         pB = p1b;
-        foundB = true;
       }
     }
   }

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -1116,13 +1116,13 @@ void FTMTree_MT::printParams(void) const
 
 int FTMTree_MT::printTime(DebugTimer &t, const string &s, SimplexId nbScalars, const int debugLevel) const
 {
-   if (nbScalars == -1) {
-      nbScalars = scalars_->size;
-   }
 
    if (debugLevel_ >= debugLevel) {
       stringstream st;
 #ifdef TTK_ENABLE_FTM_TREE_PROCESS_SPEED
+      if (nbScalars == -1) {
+         nbScalars = scalars_->size;
+      }
       int          speed = nbScalars / t.getElapsedTime();
 #endif
       for (int i = 3; i < debugLevel; i++)

--- a/core/base/planarGraphLayout/PlanarGraphLayout.h
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.h
@@ -336,6 +336,12 @@ template <typename topoType, typename idType> int ttk::PlanarGraphLayout::comput
     float* layout
 ) const{
 
+#ifndef TTK_ENABLE_KAMIKAZE
+    if (sizes == nullptr || levels == nullptr) {
+        return -1;
+    }
+#endif // TTK_ENABLE_KAMIKAZE
+
     // Comparator that sorts children based on layout.y
     struct ChildrenComparator {
         const float* layout;

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -176,7 +176,6 @@ int ZeroSkeleton::buildVertexLink(const SimplexId &vertexId, const SimplexId &ce
           for(SimplexId n = 0; n < (SimplexId) faceIds.size(); n++){
             vertexLink[i*(verticesPerCell) + n] = faceIds[n];
           }
-          hasPivotVertex = true;
           break;
         }
       }

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -151,12 +151,12 @@ void ttk::TopologicalCompression::CompressWithZlib(
 
 #endif
 
-int ttk::TopologicalCompression::log2(
+unsigned int ttk::TopologicalCompression::log2(
     int val)
 {
   if (val == 0) return UINT_MAX;
   if (val == 1) return 0;
-  int ret = 0;
+  unsigned int ret = 0;
   while (val > 1) {
     val >>= 1;
     ret++;
@@ -312,7 +312,14 @@ int ttk::TopologicalCompression::ReadCompactSegmentation(
   numberOfBytesRead += sizeof(int);
   numberOfSegments = ReadInt(fm);
 
-  int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
+  unsigned int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  // avoid left shift with negative operand
+  if (numberOfBitsPerSegment == 0) {
+    return -2;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
 
   // [MEDIUM] TODO: support long int
   if (numberOfBitsPerSegment > 32) return -3;
@@ -408,7 +415,7 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
 
   // Compute number of bits per segment
   // (can be deduced at read-time from numberOfSegments)
-  int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
+  unsigned int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
 
   // [MEDIUM] TODO: support long int
   if (numberOfBitsPerSegment > 32) return -3;

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -212,7 +212,7 @@ class TopologicalCompression : public Debug
     }
 
     // IO management.
-    static int log2(int val);
+    static unsigned int log2(int val);
     inline static bool cmp(
         const std::tuple<double, int> &a,
         const std::tuple<double, int> &b)

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -97,6 +97,9 @@ namespace ttk{
         const int &localEdgeId, SimplexId &edgeId) const{
          
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        edgeId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -245,6 +248,9 @@ namespace ttk{
         const int &localNeighborId, SimplexId &neighborId) const{
          
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        neighborId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -370,6 +376,9 @@ namespace ttk{
         const int &localTriangleId, SimplexId &triangleId) const{
          
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        triangleId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -523,6 +532,9 @@ namespace ttk{
         const int &localVertexId, SimplexId &vertexId) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        vertexId = -1;
+
         if(isEmptyCheck())
           return -1;
 #endif
@@ -626,6 +638,9 @@ namespace ttk{
       inline int getEdgeLink(const SimplexId &edgeId, 
         const int &localLinkId, SimplexId &linkId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        linkId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -756,6 +771,9 @@ namespace ttk{
       inline int getEdgeStar(const SimplexId &edgeId,
         const int &localStarId, SimplexId &starId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        starId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -892,6 +910,9 @@ namespace ttk{
         const int &localTriangleId, SimplexId &triangleId) const{
          
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        triangleId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -1043,6 +1064,9 @@ namespace ttk{
       inline int getEdgeVertex(const SimplexId &edgeId, 
         const int &localVertexId, SimplexId &vertexId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        vertexId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -1259,6 +1283,9 @@ namespace ttk{
       inline int getTriangleEdge(const SimplexId &triangleId, 
         const int &localEdgeId, SimplexId &edgeId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        edgeId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -1410,6 +1437,9 @@ namespace ttk{
       inline int getTriangleLink(const SimplexId &triangleId, 
         const int &localLinkId, SimplexId &linkId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        linkId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -1540,6 +1570,9 @@ namespace ttk{
       inline int getTriangleStar(const SimplexId &triangleId,
         const int &localStarId, SimplexId &starId) const{
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        starId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -1668,6 +1701,9 @@ namespace ttk{
         const int &localVertexId, SimplexId &vertexId) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        vertexId = -1;
+
         if(isEmptyCheck())
           return -1;
         
@@ -1719,6 +1755,9 @@ namespace ttk{
         const int &localEdgeId, SimplexId &edgeId) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        edgeId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -1863,6 +1902,9 @@ namespace ttk{
         const int &localLinkId, SimplexId &linkId) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        linkId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -1982,6 +2024,9 @@ namespace ttk{
         const int &localNeighborId, SimplexId &neighborId) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        neighborId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -2086,6 +2131,11 @@ namespace ttk{
         float &x, float &y, float &z) const{
           
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variables before early return
+        x = NAN;
+        y = NAN;
+        z = NAN;
+
         if(isEmptyCheck())
           return -1;
 #endif
@@ -2116,6 +2166,9 @@ namespace ttk{
         const int &localStarId, SimplexId &starId) const{
         
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        starId = -1;
+
         if(isEmptyCheck())
           return -1;
           
@@ -2238,6 +2291,9 @@ namespace ttk{
         const int &localTriangleId, SimplexId &triangleId) const{
          
 #ifndef TTK_ENABLE_KAMIKAZE
+        // initialize output variable before early return
+        triangleId = -1;
+
         if(isEmptyCheck())
           return -1;
           

--- a/core/vtk/ttkBlank/ttkBlank.cpp
+++ b/core/vtk/ttkBlank/ttkBlank.cpp
@@ -66,9 +66,11 @@ int ttkBlank::doIt(vector<vtkDataSet *> &inputs, vector<vtkDataSet *> &outputs){
         outputScalarField_ = vtkIdTypeArray::New();
         break;
         
+    default:
       stringstream msg;
       msg << "[ttkBlank] Unsupported data type :(" << endl;
       dMsg(cerr, msg.str(), fatalMsg);
+      return -3;
     }
   }
   outputScalarField_->SetNumberOfTuples(input->GetNumberOfPoints());

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1547,6 +1547,12 @@ int ttkContourForests::doIt(vector<vtkDataSet *> &inputs,
 
   // Skeleton //
   if (varyingMesh_ || varyingDataValues_ || toComputeSkeleton_) {
+#ifndef TTK_ENABLE_KAMIKAZE
+    if (tree_ == nullptr) {
+      cerr << "[ttkContourForests] Error: MergeTree pointer is NULL." << endl;
+      return -2;
+    }
+#endif // TTK_ENABLE_KAMIKAZE
     clearSkeleton();
     getSkeleton();
   }

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -220,9 +220,11 @@ int ttkScalarFieldNormalizer::doIt(vtkDataSet *input, vtkDataSet *output){
         outputScalarField_ = vtkIdTypeArray::New();
         break;
         
+    default:
       stringstream msg;
       msg << "[ttkScalarFieldNormalizer] Unsupported data type :(" << endl;
       dMsg(cerr, msg.str(), fatalMsg);
+      return -2;
     }
     outputScalarField_->SetNumberOfTuples(input->GetNumberOfPoints());
     outputScalarField_->SetName(inputScalarField->GetName());

--- a/core/vtk/ttkTriangulation/ttkTriangulation.cpp
+++ b/core/vtk/ttkTriangulation/ttkTriangulation.cpp
@@ -42,6 +42,8 @@ int ttkTriangulation::deepCopy(vtkDataObject *other){
     // the other object has already been enhanced 
     // copy the triangulation object from the other
     (*triangulation_) = *(otherTriangulation->triangulation_);
+  } else {
+    triangulation_ = nullptr;
   }
   
   // populate the data-structure

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
@@ -132,9 +132,11 @@ int ttkUncertainDataEstimator::doIt(vtkDataSet **input, vtkDataSet *outputBoundF
         outputUpperBoundScalarField_ = vtkIdTypeArray::New();
         break;
 
+    default:
       stringstream msg;
       msg << "[ttkUncertainDataEstimator] Unsupported data type :(" << endl;
       dMsg(cerr, msg.str(), fatalMsg);
+      return -2;
     }
     outputLowerBoundScalarField_->SetName("lowerBoundField");
     outputUpperBoundScalarField_->SetName("upperBoundField");

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -221,7 +221,6 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
 
       if (!pointDataWritten) {
           this->WritePointData(points, NULL, NULL, colors, fp);
-          pointDataWritten = 1;
       }
       else {
           fprintf(fp, "            coord  USE VTKcoordinates\n");

--- a/standalone/BottleneckDistance/gui/main.cpp
+++ b/standalone/BottleneckDistance/gui/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
   string wasserstein;
   double alpha = 1.0;
   double spacing = 5.0;
-  bool useMatchingMesh;
+  bool useMatchingMesh = false;
 
   bool persistence = false;
 


### PR DESCRIPTION
Static Analysis is a methodology for finding potential software bugs without executing the program. It is currently a research subject in computer science (c.f. the LIP6 [MOPSA Project](http://mopsa.lip6.fr/)). Static Analysis tools detect, in C or C++, bugs around memory use, such as:

- garbage or undefined values,
- uninitialized variables,
- NULL pointer de-references,
- memory leaks,
- dead stores (writes into variables that are never read).

Some static analyzers have reached maturity and can be easily used on a given codebase. One of them is the [Clang Static Analyser](https://clang.llvm.org/docs/ClangStaticAnalyzer.html) which is part of the Clang/LLVM tool suite (in the `clang-tools` package on Ubuntu). The Clang Static Analyzer can be invoked on a source file using the `clang-tidy` front-end or on the whole project with the `scan-build` front-end (in conjunction with CMake) with the following commands:

```sh
# go to the project sources and create a build directory
mkdir build && cd build
# set the configuration options
scan-build ccmake ..
# analyze the project according to the current configuration
scan-build make # -j$(nproc) to speed up the process
```
The output of the previous set of commands is a navigable HTML document that lists all detected defects, and for every one of them, the path (annotated source code) that lead to this bug.

Applied on TTK (on the default configuration), the Clang Static Analyzer raise ~100 warnings, a few of them (~5) coming from external libraries (Boost, Eigen). This pull request aims at fixing all the other ones, mostly by providing additional (guarded) null checks, variable initializations and removing dead stores.