### PR TITLE
Adding #include<array> to fix a compilation bug on line 128

### DIFF
--- a/core/base/laplacian/Laplacian.cpp
+++ b/core/base/laplacian/Laplacian.cpp
@@ -4,6 +4,8 @@
 #ifdef TTK_ENABLE_EIGEN
 #include <Eigen/Sparse>
 
+#include <array>
+
 template <typename T, typename SparseMatrixType = Eigen::SparseMatrix<T>>
 int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
                                       const Triangulation &triangulation) {


### PR DESCRIPTION
On MacOS the line:

std::array<float, 9> coords{};

Leads to the compiler complaining with:

/Users/josh/git/github/ttk/core/base/laplacian/Laplacian.cpp:128:28: fatal error: implicit instantiation of undefined template
      'std::__1::array<float, 9>'
      std::array<float, 9> coords{};

Which is fixed by #include<array>