### PR TITLE
Outline vtkTemplateMacro arguments into functions

### DIFF
--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -117,7 +117,7 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     outputScalarField->SetName(inputScalarField->GetName());
     output->GetPointData()->AddArray(outputScalarField);
     switch(inputScalarField->GetDataType()) {
-      ttkTemplateMacro(baseWorker_.interpolateCellDataField<VTK_TT>(
+      vtkTemplateMacro(baseWorker_.interpolateCellDataField<VTK_TT>(
         static_cast<VTK_TT *>(inputScalarField->GetVoidPointer(0)),
         static_cast<VTK_TT *>(outputScalarField->GetVoidPointer(0))));
     }

--- a/core/vtk/ttkBlank/ttkBlank.cpp
+++ b/core/vtk/ttkBlank/ttkBlank.cpp
@@ -101,7 +101,7 @@ vtkStandardNewMacro(ttkBlank)
   blank_.setInputDataPointer(inputScalarField->GetVoidPointer(0));
   blank_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
   switch(inputScalarField->GetDataType()) {
-    ttkTemplateMacro(blank_.execute<VTK_TT>(SomeIntegerArgument));
+    vtkTemplateMacro(blank_.execute<VTK_TT>(SomeIntegerArgument));
   }
 
   {

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
@@ -202,8 +202,7 @@ int ttkContinuousScatterPlot::doIt(vector<vtkDataSet *> &inputs,
   continuousScatterPlot.setOutputMask(&validPointMask_);
   switch(vtkTemplate2PackMacro(
     inputScalars1_->GetDataType(), inputScalars2_->GetDataType())) {
-    ttkTemplate2Macro(
-      ret = continuousScatterPlot.execute<VTK_T1 TTK_COMMA VTK_T2>());
+    ttkTemplate2Macro((ret = continuousScatterPlot.execute<VTK_T1, VTK_T2>()));
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
@@ -202,7 +202,7 @@ int ttkContinuousScatterPlot::doIt(vector<vtkDataSet *> &inputs,
   continuousScatterPlot.setOutputMask(&validPointMask_);
   switch(vtkTemplate2PackMacro(
     inputScalars1_->GetDataType(), inputScalars2_->GetDataType())) {
-    ttkTemplate2Macro((ret = continuousScatterPlot.execute<VTK_T1, VTK_T2>()));
+    vtkTemplate2Macro((ret = continuousScatterPlot.execute<VTK_T1, VTK_T2>()));
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -212,7 +212,7 @@ bool ttkContourAroundPoint::process() {
   _wrappedModule.setWrapper(this);
   int errorCode = 0; // In TTK, negative is bad.
   switch(_scalarTypeCode) {
-    ttkTemplateMacro((errorCode = _wrappedModule.execute<VTK_TT>()));
+    vtkTemplateMacro((errorCode = _wrappedModule.execute<VTK_TT>()));
   }
   if(errorCode < 0) {
     vtkErrorMacro("_wrappedModule.execute failed with code "

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -84,20 +84,17 @@ vtkStandardNewMacro(ttkDepthImageBasedGeometryApproximation)
 
     // Approximate geometry
     switch(depthValues->GetDataType()) {
-      vtkTemplateMacro({
-        depthImageBasedGeometryApproximation_.execute<VTK_TT>(
-          // Input
-          (VTK_TT *)depthValues->GetVoidPointer(0),
-          (double *)camPosition->GetVoidPointer(0),
-          (double *)camDirection->GetVoidPointer(0),
-          (double *)camUp->GetVoidPointer(0),
-          (double *)camRes->GetVoidPointer(0),
-          (double *)camNearFar->GetVoidPointer(0),
-          (double *)camHeight->GetVoidPointer(0), this->GetSubsampling(),
+      vtkTemplateMacro(depthImageBasedGeometryApproximation_.execute<VTK_TT>(
+        // Input
+        (VTK_TT *)depthValues->GetVoidPointer(0),
+        (double *)camPosition->GetVoidPointer(0),
+        (double *)camDirection->GetVoidPointer(0),
+        (double *)camUp->GetVoidPointer(0), (double *)camRes->GetVoidPointer(0),
+        (double *)camNearFar->GetVoidPointer(0),
+        (double *)camHeight->GetVoidPointer(0), this->GetSubsampling(),
 
-          // Output
-          indicies, vertices, triangles, triangleDistortions);
-      });
+        // Output
+        indicies, vertices, triangles, triangleDistortions));
     }
 
     // Represent approximated geometry via VTK

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -155,6 +155,194 @@ int ttkDiscreteGradient::getOffsets(vtkDataSet *input) {
   return 0;
 }
 
+template <typename VTK_TT>
+int ttkDiscreteGradient::dispatch(
+  vtkUnstructuredGrid *outputCriticalPoints,
+  SimplexId criticalPoints_numberOfPoints,
+  vector<float> criticalPoints_points,
+  vector<char> criticalPoints_points_cellDimensions,
+  vector<SimplexId> criticalPoints_points_cellIds,
+  vector<char> criticalPoints_points_isOnBoundary,
+  vector<SimplexId> criticalPoints_points_PLVertexIdentifiers,
+  vector<SimplexId> criticalPoints_points_manifoldSize) {
+
+  int ret = 0;
+  vector<VTK_TT> criticalPoints_points_cellScalars;
+  const int dimensionality = triangulation_->getDimensionality();
+
+  discreteGradient_.setOutputCriticalPoints(
+    &criticalPoints_numberOfPoints, &criticalPoints_points,
+    &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
+    &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
+    &criticalPoints_points_PLVertexIdentifiers,
+    &criticalPoints_points_manifoldSize);
+
+  if(inputOffsets_->GetDataType() == VTK_INT)
+    ret = discreteGradient_.buildGradient<VTK_TT, int>();
+  if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+    ret = discreteGradient_.buildGradient<VTK_TT, vtkIdType>();
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkDiscreteGradient] Error : DiscreteGradient.buildGradient() "
+            "error code : "
+         << ret << endl;
+    return -1;
+  }
+#endif
+
+  if(AllowSecondPass) {
+    if(inputOffsets_->GetDataType() == VTK_INT)
+      ret = discreteGradient_.buildGradient2<VTK_TT, int>();
+    if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+      ret = discreteGradient_.buildGradient2<VTK_TT, vtkIdType>();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(ret) {
+      cerr << "[ttkDiscreteGradient] Error : DiscreteGradient.buildGradient2() "
+              "error code : "
+           << ret << endl;
+      return -1;
+    }
+#endif
+  }
+
+  if(dimensionality == 3 and AllowThirdPass) {
+    if(inputOffsets_->GetDataType() == VTK_INT)
+      ret = discreteGradient_.buildGradient3<VTK_TT, int>();
+    if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+      ret = discreteGradient_.buildGradient3<VTK_TT, vtkIdType>();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(ret) {
+      cerr << "[ttkDiscreteGradient] Error : DiscreteGradient.buildGradient2() "
+              "error code : "
+           << ret << endl;
+      return -1;
+    }
+#endif
+  }
+
+  if(inputOffsets_->GetDataType() == VTK_INT)
+    ret = discreteGradient_.reverseGradient<VTK_TT, int>();
+  if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+    ret = discreteGradient_.reverseGradient<VTK_TT, vtkIdType>();
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkDiscreteGradient] Error : DiscreteGradient.reverseGradient() "
+            "error code : "
+         << ret << endl;
+    return -1;
+  }
+#endif
+
+  // critical points
+  {
+    if(inputOffsets_->GetDataType() == VTK_INT)
+      discreteGradient_.setCriticalPoints<VTK_TT, int>();
+    if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+      discreteGradient_.setCriticalPoints<VTK_TT, vtkIdType>();
+
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!points) {
+      cerr << "[ttkDiscreteGradient] Error : vtkPoints allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+
+    vtkSmartPointer<vtkCharArray> cellDimensions
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellDimensions) {
+      cerr << "[ttkDiscreteGradient] Error : vtkCharArray allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+    cellDimensions->SetNumberOfComponents(1);
+    cellDimensions->SetName("CellDimension");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellIds) {
+      cerr << "[ttkDiscreteGradient] Error : ttkSimplexIdTypeArray allocation "
+              "problem."
+           << endl;
+      return -1;
+    }
+#endif
+    cellIds->SetNumberOfComponents(1);
+    cellIds->SetName("CellId");
+
+    vtkDataArray *cellScalars = inputScalars_->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellScalars) {
+      cerr << "[ttkDiscreteGradient] Error : vtkDataArray allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+    cellScalars->SetNumberOfComponents(1);
+    cellScalars->SetName(ScalarField.data());
+
+    vtkSmartPointer<vtkCharArray> isOnBoundary
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!isOnBoundary) {
+      cerr << "[vtkMorseSmaleComplex] Error : vtkCharArray allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+    isOnBoundary->SetNumberOfComponents(1);
+    isOnBoundary->SetName("IsOnBoundary");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!PLVertexIdentifiers) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    PLVertexIdentifiers->SetNumberOfComponents(1);
+    PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
+
+    for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
+      points->InsertNextPoint(criticalPoints_points[3 * i],
+                              criticalPoints_points[3 * i + 1],
+                              criticalPoints_points[3 * i + 2]);
+
+      cellDimensions->InsertNextTuple1(criticalPoints_points_cellDimensions[i]);
+      cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
+      cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
+      isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
+      PLVertexIdentifiers->InsertNextTuple1(
+        criticalPoints_points_PLVertexIdentifiers[i]);
+    }
+    outputCriticalPoints->SetPoints(points);
+
+    vtkPointData *pointData = outputCriticalPoints->GetPointData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!pointData) {
+      cerr << "[ttkDiscreteGradient] Error : outputCriticalPoints has no point "
+              "data."
+           << endl;
+      return -1;
+    }
+#endif
+
+    pointData->AddArray(cellDimensions);
+    pointData->AddArray(cellIds);
+    pointData->AddArray(cellScalars);
+    pointData->AddArray(isOnBoundary);
+    pointData->AddArray(PLVertexIdentifiers);
+  }
+
+  return ret;
+}
+
 int ttkDiscreteGradient::doIt(vector<vtkDataSet *> &inputs,
                               vector<vtkDataSet *> &outputs) {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -255,441 +443,21 @@ int ttkDiscreteGradient::doIt(vector<vtkDataSet *> &inputs,
     &gradientGlyphs_points_pairOrigins, &gradientGlyphs_numberOfCells,
     &gradientGlyphs_cells, &gradientGlyphs_cells_pairTypes);
 
-  const int dimensionality = triangulation_->getDimensionality();
-
   switch(inputScalars_->GetDataType()) {
-#ifndef _MSC_VER
-    vtkTemplateMacro(({
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      discreteGradient_.setOutputCriticalPoints(
-        &criticalPoints_numberOfPoints, &criticalPoints_points,
-        &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-        &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
-        &criticalPoints_points_PLVertexIdentifiers,
-        &criticalPoints_points_manifoldSize);
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = discreteGradient_.buildGradient<VTK_TT, int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = discreteGradient_.buildGradient<VTK_TT, vtkIdType>();
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkDiscreteGradient] Error : "
-                "DiscreteGradient.buildGradient() error code : "
-             << ret << endl;
-        return -1;
-      }
-#endif
-
-      if(AllowSecondPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient2<VTK_TT, int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient2<VTK_TT, vtkIdType>();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(ret) {
-          cerr << "[ttkDiscreteGradient] Error : "
-                  "DiscreteGradient.buildGradient2() error code : "
-               << ret << endl;
-          return -1;
-        }
-#endif
-      }
-
-      if(dimensionality == 3 and AllowThirdPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient3<VTK_TT, int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient3<VTK_TT, vtkIdType>();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(ret) {
-          cerr << "[ttkDiscreteGradient] Error : "
-                  "DiscreteGradient.buildGradient2() error code : "
-               << ret << endl;
-          return -1;
-        }
-#endif
-      }
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = discreteGradient_.reverseGradient<VTK_TT, int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = discreteGradient_.reverseGradient<VTK_TT, vtkIdType>();
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkDiscreteGradient] Error : "
-                "DiscreteGradient.reverseGradient() error code : "
-             << ret << endl;
-        return -1;
-      }
-#endif
-
-      // critical points
-      {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          discreteGradient_.setCriticalPoints<VTK_TT, int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          discreteGradient_.setCriticalPoints<VTK_TT, vtkIdType>();
-
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!points) {
-          cerr << "[ttkDiscreteGradient] Error : vtkPoints allocation problem."
-               << endl;
-          return -1;
-        }
-#endif
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellDimensions) {
-          cerr
-            << "[ttkDiscreteGradient] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-#endif
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellIds) {
-          cerr << "[ttkDiscreteGradient] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-#endif
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars_->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellScalars) {
-          cerr
-            << "[ttkDiscreteGradient] Error : vtkDataArray allocation problem."
-            << endl;
-          return -1;
-        }
-#endif
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!isOnBoundary) {
-          cerr
-            << "[vtkMorseSmaleComplex] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-#endif
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!PLVertexIdentifiers) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!pointData) {
-          cerr << "[ttkDiscreteGradient] Error : outputCriticalPoints has no "
-                  "point data."
-               << endl;
-          return -1;
-        }
-#endif
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-      }
-    }));
-#else
-#ifndef TTK_ENABLE_KAMIKAZE
-    vtkTemplateMacro({
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      discreteGradient_.setOutputCriticalPoints(
-        &criticalPoints_numberOfPoints, &criticalPoints_points,
-        &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-        &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
-        &criticalPoints_points_PLVertexIdentifiers,
-        &criticalPoints_points_manifoldSize);
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = discreteGradient_.buildGradient<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = discreteGradient_.buildGradient<VTK_TT TTK_COMMA vtkIdType>();
-      if(ret) {
-        cerr << "[ttkDiscreteGradient] Error : "
-                "DiscreteGradient.buildGradient() error code : "
-             << ret << endl;
-        return -1;
-      }
-
-      if(AllowSecondPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient2<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient2<VTK_TT TTK_COMMA vtkIdType>();
-        if(ret) {
-          cerr << "[ttkDiscreteGradient] Error : "
-                  "DiscreteGradient.buildGradient2() error code : "
-               << ret << endl;
-          return -1;
-        }
-      }
-
-      if(dimensionality == 3 and AllowThirdPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient3<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient3<VTK_TT TTK_COMMA vtkIdType>();
-        if(ret) {
-          cerr << "[ttkDiscreteGradient] Error : "
-                  "DiscreteGradient.buildGradient2() error code : "
-               << ret << endl;
-          return -1;
-        }
-      }
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = discreteGradient_.reverseGradient<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = discreteGradient_.reverseGradient<VTK_TT TTK_COMMA vtkIdType>();
-      if(ret) {
-        cerr << "[ttkDiscreteGradient] Error : "
-                "DiscreteGradient.reverseGradient() error code : "
-             << ret << endl;
-        return -1;
-      }
-
-      // critical points
-      {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          discreteGradient_.setCriticalPoints<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          discreteGradient_.setCriticalPoints<VTK_TT TTK_COMMA vtkIdType>();
-
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-        if(!points) {
-          cerr << "[ttkDiscreteGradient] Error : vtkPoints allocation problem."
-               << endl;
-          return -1;
-        }
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!cellDimensions) {
-          cerr
-            << "[ttkDiscreteGradient] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!cellIds) {
-          cerr << "[ttkDiscreteGradient] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars_->NewInstance();
-        if(!cellScalars) {
-          cerr
-            << "[ttkDiscreteGradient] Error : vtkDataArray allocation problem."
-            << endl;
-          return -1;
-        }
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!isOnBoundary) {
-          cerr
-            << "[vtkMorseSmaleComplex] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!PLVertexIdentifiers) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-        if(!pointData) {
-          cerr << "[ttkDiscreteGradient] Error : outputCriticalPoints has no "
-                  "point data."
-               << endl;
-          return -1;
-        }
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-      }
-    });
-#else
-    vtkTemplateMacro({
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      discreteGradient_.setOutputCriticalPoints(
-        &criticalPoints_numberOfPoints, &criticalPoints_points,
-        &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-        &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
-        &criticalPoints_points_PLVertexIdentifiers,
-        &criticalPoints_points_manifoldSize);
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = discreteGradient_.buildGradient<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = discreteGradient_.buildGradient<VTK_TT TTK_COMMA vtkIdType>();
-
-      if(AllowSecondPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient2<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient2<VTK_TT TTK_COMMA vtkIdType>();
-      }
-
-      if(dimensionality == 3 and AllowThirdPass) {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          ret = discreteGradient_.buildGradient3<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-          ret = discreteGradient_.buildGradient3<VTK_TT TTK_COMMA vtkIdType>();
-      }
-
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        discreteGradient_.reverseGradient<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        discreteGradient_.reverseGradient<VTK_TT TTK_COMMA vtkIdType>();
-
-      // critical points
-      {
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          discreteGradient_.setCriticalPoints<VTK_TT TTK_COMMA int>();
-        if(inputOffsets_->GetDataType() == VTK_INT)
-          discreteGradient_.setCriticalPoints<VTK_TT TTK_COMMA vtkIdType>();
-
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars_->NewInstance();
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-      }
-    });
-#endif
-#endif
+    vtkTemplateMacro(
+      ret = dispatch<VTK_TT>(
+        outputCriticalPoints, criticalPoints_numberOfPoints,
+        criticalPoints_points, criticalPoints_points_cellDimensions,
+        criticalPoints_points_cellIds, criticalPoints_points_isOnBoundary,
+        criticalPoints_points_PLVertexIdentifiers,
+        criticalPoints_points_manifoldSize));
   }
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret != 0) {
+    return -1;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
 
   // gradient glyphs
   if(ComputeGradientGlyphs) {

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -115,6 +115,17 @@ protected:
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
 private:
+  template <typename T>
+  int dispatch(
+    vtkUnstructuredGrid *outputCriticalPoints,
+    ttk::SimplexId criticalPoints_numberOfPoints,
+    std::vector<float> criticalPoints_points,
+    std::vector<char> criticalPoints_points_cellDimensions,
+    std::vector<ttk::SimplexId> criticalPoints_points_cellIds,
+    std::vector<char> criticalPoints_points_isOnBoundary,
+    std::vector<ttk::SimplexId> criticalPoints_points_PLVertexIdentifiers,
+    std::vector<ttk::SimplexId> criticalPoints_points_manifoldSize);
+
   std::string ScalarField;
   std::string InputOffsetScalarFieldName;
   bool ForceInputOffsetScalarField;

--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -272,8 +272,8 @@ namespace ttk {
         const SimplexId g_vertexId = idMapper->GetTuple1(l_vertexId);
         float cellScalar = 0;
         switch(scalarType) {
-          vtkTemplateMacro(
-            { cellScalar = (float)tree->getValue<VTK_TT>(l_vertexId); });
+          vtkTemplateMacro(cellScalar
+                           = (float)tree->getValue<VTK_TT>(l_vertexId));
         }
 
         ids->SetTuple1(arrIdx, idOffset + nodeId);

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -376,7 +376,7 @@ int ttkFTMTree::doIt(vector<vtkDataSet *> &inputs,
     ftmTree_[cc].tree.setNormalizeIds(GetWithNormalize());
 
     switch(inputScalars_[cc]->GetDataType()) {
-      ttkTemplateMacro(ftmTree_[cc].tree.build<VTK_TT TTK_COMMA SimplexId>());
+      ttkTemplateMacro((ftmTree_[cc].tree.build<VTK_TT, SimplexId>()));
     }
 
     ftmTree_[cc].offset = acc_nbNodes;

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -376,7 +376,7 @@ int ttkFTMTree::doIt(vector<vtkDataSet *> &inputs,
     ftmTree_[cc].tree.setNormalizeIds(GetWithNormalize());
 
     switch(inputScalars_[cc]->GetDataType()) {
-      ttkTemplateMacro((ftmTree_[cc].tree.build<VTK_TT, SimplexId>()));
+      vtkTemplateMacro((ftmTree_[cc].tree.build<VTK_TT, SimplexId>()));
     }
 
     ftmTree_[cc].offset = acc_nbNodes;

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -175,6 +175,9 @@ public:
   int getSegmentation(const ttk::ftr::Graph &graph,
                       vtkDataSet *outputSegmentation);
 
+  template <typename VTK_TT>
+  int dispatch(ttk::ftr::Graph &graph);
+
 protected:
   ttkFTRGraph();
   ~ttkFTRGraph();

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
@@ -20,6 +20,18 @@ vtkStandardNewMacro(ttkFiberSurface)
 
 ttkFiberSurface::~ttkFiberSurface() {
 }
+
+template <typename VTK_T1, typename VTK_T2>
+int ttkFiberSurface::dispatch() {
+#ifdef TTK_ENABLE_FIBER_SURFACE_WITH_RANGE_OCTREE
+  if(RangeOctree) {
+    fiberSurface_.buildOctree<VTK_T1, VTK_T2>();
+  }
+#endif // TTK_ENABLE_FIBER_SURFACE_WITH_RANGE_OCTREE
+  fiberSurface_.computeSurface<VTK_T1, VTK_T2>();
+  return 0;
+}
+
 int ttkFiberSurface::doIt(vector<vtkDataSet *> &inputs,
                           vector<vtkDataSet *> &outputs) {
 
@@ -169,21 +181,10 @@ int ttkFiberSurface::doIt(vector<vtkDataSet *> &inputs,
     fiberSurface_.setVertexList(i, &(threadedVertexList_[i]));
   }
 
-#ifdef TTK_ENABLE_FIBER_SURFACE_WITH_RANGE_OCTREE
   switch(vtkTemplate2PackMacro(
     dataUfield->GetDataType(), dataVfield->GetDataType())) {
-    ttkTemplate2Macro({
-      if(RangeOctree)
-        fiberSurface_.buildOctree<VTK_T1 TTK_COMMA VTK_T2>();
-      fiberSurface_.computeSurface<VTK_T1 TTK_COMMA VTK_T2>();
-    });
+    ttkTemplate2Macro((dispatch<VTK_T1, VTK_T2>()));
   }
-#else
-  switch(vtkTemplate2PackMacro(
-    dataUfield->GetDataType(), dataVfield->GetDataType())) {
-    ttkTemplate2Macro(fiberSurface_.computeSurface<VTK_T1 TTK_COMMA VTK_T2>());
-  }
-#endif
 
   // prepare the VTK output
   // NOTE: right now, there is a copy of the output data. this is no good.

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
@@ -183,7 +183,7 @@ int ttkFiberSurface::doIt(vector<vtkDataSet *> &inputs,
 
   switch(vtkTemplate2PackMacro(
     dataUfield->GetDataType(), dataVfield->GetDataType())) {
-    ttkTemplate2Macro((dispatch<VTK_T1, VTK_T2>()));
+    vtkTemplate2Macro((dispatch<VTK_T1, VTK_T2>()));
   }
 
   // prepare the VTK output

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.h
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.h
@@ -142,6 +142,9 @@ public:
     return 1;
   }
 
+  template <typename VTK_T1, typename VTK_T2>
+  int dispatch();
+
 protected:
   ttkFiberSurface();
 

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -74,15 +74,14 @@ int ttkGeometrySmoother::doIt(vector<vtkDataSet *> &inputs,
   // calling the smoothing package
   vtkPoints *inputPointSet = (vtkPointSet::SafeDownCast(input))->GetPoints();
   vtkPoints *outputPointSet = (vtkPointSet::SafeDownCast(output))->GetPoints();
-  switch(outputPointSet->GetDataType()) {
 
-    vtkTemplateMacro({
-      smoother_.setDimensionNumber(3);
-      smoother_.setInputDataPointer(inputPointSet->GetVoidPointer(0));
-      smoother_.setOutputDataPointer(outputPointSet->GetVoidPointer(0));
-      smoother_.setMaskDataPointer(inputMaskPtr);
-      smoother_.smooth<VTK_TT>(NumberOfIterations);
-    });
+  smoother_.setDimensionNumber(3);
+  smoother_.setInputDataPointer(inputPointSet->GetVoidPointer(0));
+  smoother_.setOutputDataPointer(outputPointSet->GetVoidPointer(0));
+  smoother_.setMaskDataPointer(inputMaskPtr);
+
+  switch(outputPointSet->GetDataType()) {
+    vtkTemplateMacro(smoother_.smooth<VTK_TT>(NumberOfIterations));
   }
 
   {

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
@@ -43,6 +43,22 @@ vtkStandardNewMacro(ttkIdentifyByScalarField)
   return 0;
 }
 
+template <typename VTK_TT>
+int ttkIdentifyByScalarField::dispatch(vector<SimplexId> &inputIds) {
+  VTK_TT *arr = static_cast<VTK_TT *>(inputScalars_->GetVoidPointer(0));
+
+  auto greater_cmp = [=](int a, int b) { return arr[a] > arr[b]; };
+  auto lower_cmp = [=](int a, int b) { return arr[a] < arr[b]; };
+
+  if(IncreasingOrder) {
+    std::sort(inputIds.begin(), inputIds.end(), lower_cmp);
+  } else {
+    std::sort(inputIds.begin(), inputIds.end(), greater_cmp);
+  }
+
+  return 0;
+}
+
 int ttkIdentifyByScalarField::doIt(vector<vtkDataSet *> &inputs,
                                    vector<vtkDataSet *> &outputs) {
   Memory m;
@@ -86,18 +102,7 @@ int ttkIdentifyByScalarField::doIt(vector<vtkDataSet *> &inputs,
   vector<SimplexId> inputIds(numberOfCells);
   std::iota(inputIds.begin(), inputIds.end(), 0);
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro({
-      VTK_TT *arr = static_cast<VTK_TT *>(inputScalars_->GetVoidPointer(0));
-
-      auto greater_cmp = [arr](int a, int b) { return arr[a] > arr[b]; };
-
-      auto lower_cmp = [arr](int a, int b) { return arr[a] < arr[b]; };
-
-      if(IncreasingOrder)
-        std::sort(inputIds.begin(), inputIds.end(), lower_cmp);
-      else
-        std::sort(inputIds.begin(), inputIds.end(), greater_cmp);
-    });
+    ttkTemplateMacro(dispatch<VTK_TT>(inputIds));
   }
 
   vtkSmartPointer<ttkSimplexIdTypeArray> ids

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
@@ -102,7 +102,7 @@ int ttkIdentifyByScalarField::doIt(vector<vtkDataSet *> &inputs,
   vector<SimplexId> inputIds(numberOfCells);
   std::iota(inputIds.begin(), inputIds.end(), 0);
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro(dispatch<VTK_TT>(inputIds));
+    vtkTemplateMacro(dispatch<VTK_TT>(inputIds));
   }
 
   vtkSmartPointer<ttkSimplexIdTypeArray> ids

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
@@ -97,6 +97,9 @@ public:
 
   int getScalars(vtkDataSet *input);
 
+  template <typename VTK_TT>
+  int dispatch(std::vector<ttk::SimplexId> &inputIds);
+
 protected:
   ttkIdentifyByScalarField() {
     UseAllCores = true;

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
@@ -26,6 +26,21 @@ int ttkImportEmbeddingFromTable::updateProgress(const float &progress) {
   return 0;
 }
 
+template <typename VTK_TT>
+inline void setPointFromData(vtkSmartPointer<vtkPoints> points,
+                             VTK_TT *xdata,
+                             VTK_TT *ydata,
+                             VTK_TT *zdata,
+                             const bool Embedding2D) {
+  for(SimplexId i = 0; i < points->GetNumberOfPoints(); ++i) {
+    double p[3];
+    p[0] = xdata[i];
+    p[1] = ydata[i];
+    p[2] = Embedding2D ? 0 : zdata[i];
+    points->SetPoint(i, p);
+  }
+}
+
 int ttkImportEmbeddingFromTable::doIt(vtkPointSet *inputDataSet,
                                       vtkTable *inputTable,
                                       vtkPointSet *output) {
@@ -73,19 +88,10 @@ int ttkImportEmbeddingFromTable::doIt(vtkPointSet *inputDataSet,
   points->SetNumberOfPoints(numberOfPoints);
 
   switch(xarr->GetDataType()) {
-    vtkTemplateMacro({
-      VTK_TT *xdata = static_cast<VTK_TT *>(xarr->GetVoidPointer(0));
-      VTK_TT *ydata = static_cast<VTK_TT *>(yarr->GetVoidPointer(0));
-      VTK_TT *zdata = static_cast<VTK_TT *>(zarr->GetVoidPointer(0));
-
-      for(SimplexId i = 0; i < numberOfPoints; ++i) {
-        double p[3];
-        p[0] = xdata[i];
-        p[1] = ydata[i];
-        p[2] = Embedding2D ? 0 : zdata[i];
-        points->SetPoint(i, p);
-      }
-    });
+    vtkTemplateMacro(setPointFromData(
+      points, static_cast<VTK_TT *>(xarr->GetVoidPointer(0)),
+      static_cast<VTK_TT *>(yarr->GetVoidPointer(0)),
+      static_cast<VTK_TT *>(zarr->GetVoidPointer(0)), Embedding2D));
   }
 
   output->ShallowCopy(inputDataSet);

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -233,6 +233,18 @@ int ttkIntegralLines::getTrajectories(vtkDataSet *input,
   return 0;
 }
 
+template <typename VTK_TT>
+int ttkIntegralLines::dispatch() {
+  int ret = 0;
+  if(inputOffsets_->GetDataType() == VTK_INT) {
+    ret = integralLines_.execute<VTK_TT, int>();
+  }
+  if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
+    ret = integralLines_.execute<VTK_TT, vtkIdType>();
+  }
+  return ret;
+}
+
 int ttkIntegralLines::doIt(vector<vtkDataSet *> &inputs,
                            vector<vtkDataSet *> &outputs) {
   //                            vtkPointSet* seeds, vtkUnstructuredGrid*
@@ -320,12 +332,7 @@ int ttkIntegralLines::doIt(vector<vtkDataSet *> &inputs,
   integralLines_.setOutputTrajectories(&trajectories);
 
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro({
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = integralLines_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = integralLines_.execute<VTK_TT TTK_COMMA vtkIdType>();
-    });
+    ttkTemplateMacro(ret = dispatch<VTK_TT>());
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -332,7 +332,7 @@ int ttkIntegralLines::doIt(vector<vtkDataSet *> &inputs,
   integralLines_.setOutputTrajectories(&trajectories);
 
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro(ret = dispatch<VTK_TT>());
+    vtkTemplateMacro(ret = dispatch<VTK_TT>());
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.h
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.h
@@ -102,6 +102,9 @@ public:
                       std::vector<std::vector<ttk::SimplexId>> &trajectories,
                       vtkUnstructuredGrid *output);
 
+  template <typename VTK_TT>
+  int dispatch();
+
 protected:
   ttkIntegralLines();
   ~ttkIntegralLines();

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -165,7 +165,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
   // set the jacobi functor
   switch(vtkTemplate2PackMacro(
     uComponent->GetDataType(), vComponent->GetDataType())) {
-    ttkTemplate2Macro(
+    vtkTemplate2Macro(
       (baseCall<VTK_T1, VTK_T2>(input, uComponent, vComponent)));
   }
 

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -166,7 +166,7 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
   switch(vtkTemplate2PackMacro(
     uComponent->GetDataType(), vComponent->GetDataType())) {
     ttkTemplate2Macro(
-      baseCall<VTK_T1 TTK_COMMA VTK_T2>(input, uComponent, vComponent));
+      (baseCall<VTK_T1, VTK_T2>(input, uComponent, vComponent)));
   }
 
   vtkSmartPointer<vtkCharArray> edgeTypes

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -238,190 +238,53 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
     for(int i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {
 
       vtkDataArray *scalarField = input->GetPointData()->GetArray(i);
+      vtkSmartPointer<vtkDataArray> scalarArray;
 
       switch(scalarField->GetDataType()) {
-
-        case VTK_CHAR: {
-          vtkSmartPointer<vtkCharArray> scalarArray
-            = vtkSmartPointer<vtkCharArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_DOUBLE: {
-          vtkSmartPointer<vtkDoubleArray> scalarArray
-            = vtkSmartPointer<vtkDoubleArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_FLOAT: {
-          vtkSmartPointer<vtkFloatArray> scalarArray
-            = vtkSmartPointer<vtkFloatArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_INT: {
-          vtkSmartPointer<vtkIntArray> scalarArray
-            = vtkSmartPointer<vtkIntArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_ID_TYPE: {
-          vtkSmartPointer<vtkIdTypeArray> scalarArray
-            = vtkSmartPointer<vtkIdTypeArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_UNSIGNED_SHORT: {
-          vtkSmartPointer<vtkUnsignedShortArray> scalarArray
-            = vtkSmartPointer<vtkUnsignedShortArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-          scalarArray->SetName(scalarField->GetName());
-
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          pointCount = 0;
-          for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-            SimplexId edgeId = jacobiSet_[j].first;
-            SimplexId vertexId0 = -1, vertexId1 = -1;
-            triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-            triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-            scalarField->GetTuple(vertexId0, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-
-            scalarField->GetTuple(vertexId1, value);
-            scalarArray->SetTuple(pointCount, value);
-            pointCount++;
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
+        case VTK_CHAR:
+          scalarArray = vtkSmartPointer<vtkCharArray>::New();
+          break;
+        case VTK_DOUBLE:
+          scalarArray = vtkSmartPointer<vtkDoubleArray>::New();
+          break;
+        case VTK_FLOAT:
+          scalarArray = vtkSmartPointer<vtkFloatArray>::New();
+          break;
+        case VTK_INT:
+          scalarArray = vtkSmartPointer<vtkIntArray>::New();
+          break;
+        case VTK_ID_TYPE:
+          scalarArray = vtkSmartPointer<vtkIdTypeArray>::New();
+          break;
+        case VTK_UNSIGNED_SHORT:
+          scalarArray = vtkSmartPointer<vtkUnsignedShortArray>::New();
+          break;
         default: {
           stringstream msg;
           msg << "[ttkJacobiSet] Scalar attachment: "
               << "unsupported data type :(" << endl;
           dMsg(cerr, msg.str(), detailedInfoMsg);
-        } break;
+        }
+          return -4;
       }
+      scalarArray->SetNumberOfComponents(scalarField->GetNumberOfComponents());
+      scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
+      scalarArray->SetName(scalarField->GetName());
+      std::vector<double> value(scalarField->GetNumberOfComponents());
+      for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
+
+        SimplexId edgeId = jacobiSet_[j].first;
+        SimplexId vertexId0 = -1, vertexId1 = -1;
+        triangulation->getEdgeVertex(edgeId, 0, vertexId0);
+        triangulation->getEdgeVertex(edgeId, 1, vertexId1);
+
+        scalarField->GetTuple(vertexId0, value.data());
+        scalarArray->SetTuple(2 * j, value.data());
+
+        scalarField->GetTuple(vertexId1, value.data());
+        scalarArray->SetTuple(2 * j + 1, value.data());
+      }
+      output->GetPointData()->AddArray(scalarArray);
     }
   } else {
     for(int i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {

--- a/core/vtk/ttkLDistance/ttkLDistance.cpp
+++ b/core/vtk/ttkLDistance/ttkLDistance.cpp
@@ -110,14 +110,13 @@ vtkStandardNewMacro(ttkLDistance)
 
   output->GetPointData()->AddArray(outputScalarField_);
 
+  lDistance_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
+  lDistance_.setInputDataPointer1(inputScalarField1->GetVoidPointer(0));
+  lDistance_.setInputDataPointer2(inputScalarField2->GetVoidPointer(0));
+
   // Calling the executing package.
   switch(inputScalarField1->GetDataType()) {
-    vtkTemplateMacro({
-      lDistance_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
-      lDistance_.setInputDataPointer1(inputScalarField1->GetVoidPointer(0));
-      lDistance_.setInputDataPointer2(inputScalarField2->GetVoidPointer(0));
-      lDistance_.execute<VTK_TT>(DistanceType);
-    });
+    vtkTemplateMacro(lDistance_.execute<VTK_TT>(DistanceType));
   }
 
   result = lDistance_.getResult();

--- a/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.cpp
+++ b/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.cpp
@@ -690,7 +690,7 @@ int ttkMandatoryCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
 
   if((triangulation_->isEmpty())
      || (ttkTriangulation::hasChangedConnectivity(
-          triangulation_, input, this))) {
+       triangulation_, input, this))) {
     Modified();
     hasChangedConnectivity = true;
   }
@@ -726,56 +726,53 @@ int ttkMandatoryCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
   outputSplitSaddle->GetPointData()->AddArray(outputMandatorySplitSaddle_);
   outputMaximum->GetPointData()->AddArray(outputMandatoryMaximum_);
 
-  // Calling the executing package
-  switch(inputUpperBoundField->GetDataType()) {
+  // Reset the baseCode object
+  if((computeAll_) || (hasChangedConnectivity))
+    mandatoryCriticalPoints_.flush();
 
-    vtkTemplateMacro({
-      // Reset the baseCode object
-      if((computeAll_) || (hasChangedConnectivity))
-        mandatoryCriticalPoints_.flush();
+  // Wrapper
+  mandatoryCriticalPoints_.setWrapper(this);
+  // Set the number of vertex
+  mandatoryCriticalPoints_.setVertexNumber(input->GetNumberOfPoints());
+  // Set the coordinates of each vertex
+  double point[3];
+  for(int i = 0; i < input->GetNumberOfPoints(); i++) {
+    input->GetPoint(i, point);
+    mandatoryCriticalPoints_.setVertexPosition(i, point);
+  }
+  // Set the void pointers to the upper and lower bound fields
+  mandatoryCriticalPoints_.setLowerBoundFieldPointer(
+    inputLowerBoundField->GetVoidPointer(0));
+  mandatoryCriticalPoints_.setUpperBoundFieldPointer(
+    inputUpperBoundField->GetVoidPointer(0));
+  // Set the output data pointers
+  mandatoryCriticalPoints_.setOutputMinimumDataPointer(
+    outputMandatoryMinimum_->GetVoidPointer(0));
+  mandatoryCriticalPoints_.setOutputJoinSaddleDataPointer(
+    outputMandatoryJoinSaddle_->GetVoidPointer(0));
+  mandatoryCriticalPoints_.setOutputSplitSaddleDataPointer(
+    outputMandatorySplitSaddle_->GetVoidPointer(0));
+  mandatoryCriticalPoints_.setOutputMaximumDataPointer(
+    outputMandatoryMaximum_->GetVoidPointer(0));
+  // Set the triangulation object
+  // Set the offsets
+  mandatoryCriticalPoints_.setSoSoffsets();
+  // Simplification threshold
 
-      // Wrapper
-      mandatoryCriticalPoints_.setWrapper(this);
-      // Set the number of vertex
-      mandatoryCriticalPoints_.setVertexNumber(input->GetNumberOfPoints());
-      // Set the coordinates of each vertex
-      double point[3];
-      for(int i = 0; i < input->GetNumberOfPoints(); i++) {
-        input->GetPoint(i, point);
-        mandatoryCriticalPoints_.setVertexPosition(i, point);
-      }
-      // Set the void pointers to the upper and lower bound fields
-      mandatoryCriticalPoints_.setLowerBoundFieldPointer(
-        inputLowerBoundField->GetVoidPointer(0));
-      mandatoryCriticalPoints_.setUpperBoundFieldPointer(
-        inputUpperBoundField->GetVoidPointer(0));
-      // Set the output data pointers
-      mandatoryCriticalPoints_.setOutputMinimumDataPointer(
-        outputMandatoryMinimum_->GetVoidPointer(0));
-      mandatoryCriticalPoints_.setOutputJoinSaddleDataPointer(
-        outputMandatoryJoinSaddle_->GetVoidPointer(0));
-      mandatoryCriticalPoints_.setOutputSplitSaddleDataPointer(
-        outputMandatorySplitSaddle_->GetVoidPointer(0));
-      mandatoryCriticalPoints_.setOutputMaximumDataPointer(
-        outputMandatoryMaximum_->GetVoidPointer(0));
-      // Set the triangulation object
-      // Set the offsets
-      mandatoryCriticalPoints_.setSoSoffsets();
-      // Simplification threshold
+  mandatoryCriticalPoints_.setSimplificationThreshold(simplificationThreshold_);
 
-      mandatoryCriticalPoints_.setSimplificationThreshold(
-        simplificationThreshold_);
-      // Execute process
-      if(computeAll_) {
-        mandatoryCriticalPoints_.execute<VTK_TT>();
-        computeAll_ = false;
-        simplify_ = false;
-        computeMinimumOutput_ = true;
-        computeJoinSaddleOutput_ = true;
-        computeSplitSaddleOutput_ = true;
-        computeMaximumOutput_ = true;
-      }
-    });
+  // Execute process
+  if(computeAll_) {
+    // Calling the executing package
+    switch(inputUpperBoundField->GetDataType()) {
+      vtkTemplateMacro(mandatoryCriticalPoints_.execute<VTK_TT>());
+    }
+    computeAll_ = false;
+    simplify_ = false;
+    computeMinimumOutput_ = true;
+    computeJoinSaddleOutput_ = true;
+    computeSplitSaddleOutput_ = true;
+    computeMaximumOutput_ = true;
   }
 
   // Simplification

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
@@ -81,37 +81,37 @@ vtkStandardNewMacro(ttkMeshGraph)
   if(this->GetUseQuadraticCells()) {
     // Quadratic cells
     switch(sizeType) {
-      ttkTemplateMacro(status = meshGraph.execute<vtkIdType TTK_COMMA VTK_TT>(
-                         // Input
-                         (float *)input->GetPoints()->GetVoidPointer(0),
-                         inputCells->GetPointer(), nInputPoints, nInputCells,
+      ttkTemplateMacro(
+        (status = meshGraph.execute<vtkIdType, VTK_TT>(
+           // Input
+           (float *)input->GetPoints()->GetVoidPointer(0),
+           inputCells->GetPointer(), nInputPoints, nInputCells,
 
-                         this->GetUseVariableSize()
-                           ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
-                           : nullptr,
-                         this->GetSizeScale(), this->GetSizeAxis(),
+           this->GetUseVariableSize()
+             ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
+             : nullptr,
+           this->GetSizeScale(), this->GetSizeAxis(),
 
-                         // Output
-                         outputVertices,
-                         (vtkIdType *)outputCells->GetVoidPointer(0)));
+           // Output
+           outputVertices, (vtkIdType *)outputCells->GetVoidPointer(0))));
     }
   } else {
     // Linear Polygons
     switch(sizeType) {
-      ttkTemplateMacro(status = meshGraph.execute2<vtkIdType TTK_COMMA VTK_TT>(
-                         // Input
-                         (float *)input->GetPoints()->GetVoidPointer(0),
-                         inputCells->GetPointer(), nInputPoints, nInputCells,
-                         this->GetSubdivisions(),
+      ttkTemplateMacro(
+        (status = meshGraph.execute2<vtkIdType, VTK_TT>(
+           // Input
+           (float *)input->GetPoints()->GetVoidPointer(0),
+           inputCells->GetPointer(), nInputPoints, nInputCells,
+           this->GetSubdivisions(),
 
-                         this->GetUseVariableSize()
-                           ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
-                           : nullptr,
-                         this->GetSizeScale(), this->GetSizeAxis(),
+           this->GetUseVariableSize()
+             ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
+             : nullptr,
+           this->GetSizeScale(), this->GetSizeAxis(),
 
-                         // Output
-                         outputVertices,
-                         (vtkIdType *)outputCells->GetVoidPointer(0)));
+           // Output
+           outputVertices, (vtkIdType *)outputCells->GetVoidPointer(0))));
     }
   }
   if(status != 1)
@@ -148,15 +148,14 @@ vtkStandardNewMacro(ttkMeshGraph)
 
       switch(iArray->GetDataType()) {
         ttkTemplateMacro(
-          status
-          = meshGraph
-              .mapInputPointDataToOutputPointData<vtkIdType TTK_COMMA VTK_TT>(
-                inputCells->GetPointer(), nInputPoints, nInputCells,
+          (status
+           = meshGraph.mapInputPointDataToOutputPointData<vtkIdType, VTK_TT>(
+             inputCells->GetPointer(), nInputPoints, nInputCells,
 
-                (VTK_TT *)iArray->GetVoidPointer(0),
-                (VTK_TT *)oArray->GetVoidPointer(0),
+             (VTK_TT *)iArray->GetVoidPointer(0),
+             (VTK_TT *)oArray->GetVoidPointer(0),
 
-                this->GetUseQuadraticCells(), this->GetSubdivisions()));
+             this->GetUseQuadraticCells(), this->GetSubdivisions())));
       }
       if(status != 1)
         return 0;
@@ -182,15 +181,14 @@ vtkStandardNewMacro(ttkMeshGraph)
 
       switch(iArray->GetDataType()) {
         ttkTemplateMacro(
-          status
-          = meshGraph
-              .mapInputCellDataToOutputCellData<vtkIdType TTK_COMMA VTK_TT>(
-                nInputCells,
+          (status
+           = meshGraph.mapInputCellDataToOutputCellData<vtkIdType, VTK_TT>(
+             nInputCells,
 
-                (VTK_TT *)iArray->GetVoidPointer(0),
-                (VTK_TT *)oArray->GetVoidPointer(0),
+             (VTK_TT *)iArray->GetVoidPointer(0),
+             (VTK_TT *)oArray->GetVoidPointer(0),
 
-                this->GetUseQuadraticCells(), this->GetSubdivisions()));
+             this->GetUseQuadraticCells(), this->GetSubdivisions())));
       }
       if(status != 1)
         return 0;

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
@@ -81,7 +81,7 @@ vtkStandardNewMacro(ttkMeshGraph)
   if(this->GetUseQuadraticCells()) {
     // Quadratic cells
     switch(sizeType) {
-      ttkTemplateMacro(
+      vtkTemplateMacro(
         (status = meshGraph.execute<vtkIdType, VTK_TT>(
            // Input
            (float *)input->GetPoints()->GetVoidPointer(0),
@@ -98,7 +98,7 @@ vtkStandardNewMacro(ttkMeshGraph)
   } else {
     // Linear Polygons
     switch(sizeType) {
-      ttkTemplateMacro(
+      vtkTemplateMacro(
         (status = meshGraph.execute2<vtkIdType, VTK_TT>(
            // Input
            (float *)input->GetPoints()->GetVoidPointer(0),
@@ -147,7 +147,7 @@ vtkStandardNewMacro(ttkMeshGraph)
       oPointData->AddArray(oArray);
 
       switch(iArray->GetDataType()) {
-        ttkTemplateMacro(
+        vtkTemplateMacro(
           (status
            = meshGraph.mapInputPointDataToOutputPointData<vtkIdType, VTK_TT>(
              inputCells->GetPointer(), nInputPoints, nInputCells,
@@ -180,7 +180,7 @@ vtkStandardNewMacro(ttkMeshGraph)
       oCellData->AddArray(oArray);
 
       switch(iArray->GetDataType()) {
-        ttkTemplateMacro(
+        vtkTemplateMacro(
           (status
            = meshGraph.mapInputCellDataToOutputCellData<vtkIdType, VTK_TT>(
              nInputCells,

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
@@ -81,39 +81,37 @@ vtkStandardNewMacro(ttkMeshGraph)
   if(this->GetUseQuadraticCells()) {
     // Quadratic cells
     switch(sizeType) {
-      ttkTemplateMacro({
-        status = meshGraph.execute<vtkIdType TTK_COMMA VTK_TT>(
-          // Input
-          (float *)input->GetPoints()->GetVoidPointer(0),
-          inputCells->GetPointer(), nInputPoints, nInputCells,
+      ttkTemplateMacro(status = meshGraph.execute<vtkIdType TTK_COMMA VTK_TT>(
+                         // Input
+                         (float *)input->GetPoints()->GetVoidPointer(0),
+                         inputCells->GetPointer(), nInputPoints, nInputCells,
 
-          this->GetUseVariableSize()
-            ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
-            : nullptr,
-          this->GetSizeScale(), this->GetSizeAxis(),
+                         this->GetUseVariableSize()
+                           ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
+                           : nullptr,
+                         this->GetSizeScale(), this->GetSizeAxis(),
 
-          // Output
-          outputVertices, (vtkIdType *)outputCells->GetVoidPointer(0));
-      });
+                         // Output
+                         outputVertices,
+                         (vtkIdType *)outputCells->GetVoidPointer(0)));
     }
   } else {
     // Linear Polygons
     switch(sizeType) {
-      ttkTemplateMacro({
-        status = meshGraph.execute2<vtkIdType TTK_COMMA VTK_TT>(
-          // Input
-          (float *)input->GetPoints()->GetVoidPointer(0),
-          inputCells->GetPointer(), nInputPoints, nInputCells,
-          this->GetSubdivisions(),
+      ttkTemplateMacro(status = meshGraph.execute2<vtkIdType TTK_COMMA VTK_TT>(
+                         // Input
+                         (float *)input->GetPoints()->GetVoidPointer(0),
+                         inputCells->GetPointer(), nInputPoints, nInputCells,
+                         this->GetSubdivisions(),
 
-          this->GetUseVariableSize()
-            ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
-            : nullptr,
-          this->GetSizeScale(), this->GetSizeAxis(),
+                         this->GetUseVariableSize()
+                           ? (VTK_TT *)inputPointSizes->GetVoidPointer(0)
+                           : nullptr,
+                         this->GetSizeScale(), this->GetSizeAxis(),
 
-          // Output
-          outputVertices, (vtkIdType *)outputCells->GetVoidPointer(0));
-      });
+                         // Output
+                         outputVertices,
+                         (vtkIdType *)outputCells->GetVoidPointer(0)));
     }
   }
   if(status != 1)
@@ -149,20 +147,19 @@ vtkStandardNewMacro(ttkMeshGraph)
       oPointData->AddArray(oArray);
 
       switch(iArray->GetDataType()) {
-        ttkTemplateMacro({
+        ttkTemplateMacro(
           status
-            = meshGraph
-                .mapInputPointDataToOutputPointData<vtkIdType TTK_COMMA VTK_TT>(
-                  inputCells->GetPointer(), nInputPoints, nInputCells,
+          = meshGraph
+              .mapInputPointDataToOutputPointData<vtkIdType TTK_COMMA VTK_TT>(
+                inputCells->GetPointer(), nInputPoints, nInputCells,
 
-                  (VTK_TT *)iArray->GetVoidPointer(0),
-                  (VTK_TT *)oArray->GetVoidPointer(0),
+                (VTK_TT *)iArray->GetVoidPointer(0),
+                (VTK_TT *)oArray->GetVoidPointer(0),
 
-                  this->GetUseQuadraticCells(), this->GetSubdivisions());
-          if(status != 1)
-            return 0;
-        });
+                this->GetUseQuadraticCells(), this->GetSubdivisions()));
       }
+      if(status != 1)
+        return 0;
     }
   }
 
@@ -184,20 +181,19 @@ vtkStandardNewMacro(ttkMeshGraph)
       oCellData->AddArray(oArray);
 
       switch(iArray->GetDataType()) {
-        ttkTemplateMacro({
+        ttkTemplateMacro(
           status
-            = meshGraph
-                .mapInputCellDataToOutputCellData<vtkIdType TTK_COMMA VTK_TT>(
-                  nInputCells,
+          = meshGraph
+              .mapInputCellDataToOutputCellData<vtkIdType TTK_COMMA VTK_TT>(
+                nInputCells,
 
-                  (VTK_TT *)iArray->GetVoidPointer(0),
-                  (VTK_TT *)oArray->GetVoidPointer(0),
+                (VTK_TT *)iArray->GetVoidPointer(0),
+                (VTK_TT *)oArray->GetVoidPointer(0),
 
-                  this->GetUseQuadraticCells(), this->GetSubdivisions());
-          if(status != 1)
-            return 0;
-        });
+                this->GetUseQuadraticCells(), this->GetSubdivisions()));
       }
+      if(status != 1)
+        return 0;
     }
   }
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -306,7 +306,7 @@ int ttkMorseSmaleComplex::dispatch(
     cellIds->SetNumberOfComponents(1);
     cellIds->SetName("CellId");
 
-    vtkDataArray *cellScalars = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> cellScalars{inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!cellScalars) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -488,7 +488,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
 
-    vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionMaxima{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionMaxima) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -499,7 +500,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
 
-    vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionMinima{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionMinima) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -510,7 +512,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
 
-    vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionDiffs{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionDiffs) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -575,7 +578,7 @@ int ttkMorseSmaleComplex::dispatch(
       ptr += (separatrices1_cells[ptr] + 1);
     }
 
-    vtkPointData *pointData = outputSeparatrices1->GetPointData();
+    auto pointData = outputSeparatrices1->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!pointData) {
       cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
@@ -588,7 +591,7 @@ int ttkMorseSmaleComplex::dispatch(
     pointData->AddArray(cellDimensions);
     pointData->AddArray(cellIds);
 
-    vtkCellData *cellData = outputSeparatrices1->GetCellData();
+    auto cellData = outputSeparatrices1->GetCellData();
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!cellData) {
       cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
@@ -657,7 +660,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
 
-    vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionMaxima{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionMaxima) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -668,7 +672,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
 
-    vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionMinima{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionMinima) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -679,7 +684,8 @@ int ttkMorseSmaleComplex::dispatch(
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
 
-    vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
+    vtkSmartPointer<vtkDataArray> separatrixFunctionDiffs{
+      inputScalars->NewInstance()};
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!separatrixFunctionDiffs) {
       cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
@@ -747,7 +753,7 @@ int ttkMorseSmaleComplex::dispatch(
       ptr += (separatrices2_cells[ptr] + 1);
     }
 
-    vtkCellData *cellData = outputSeparatrices2->GetCellData();
+    auto cellData = outputSeparatrices2->GetCellData();
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!cellData) {
       cerr << "[ttkMorseSmaleComplex] Error : "

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -174,6 +174,600 @@ vtkDataArray *ttkMorseSmaleComplex::getOffsets(vtkDataSet *input) {
   return inputOffsets;
 }
 
+template <typename VTK_TT>
+int ttkMorseSmaleComplex::dispatch(
+  vtkDataArray *inputScalars,
+  vtkDataArray *inputOffsets,
+  vtkUnstructuredGrid *outputCriticalPoints,
+  vtkUnstructuredGrid *outputSeparatrices1,
+  vtkUnstructuredGrid *outputSeparatrices2,
+  SimplexId criticalPoints_numberOfPoints,
+  vector<float> &criticalPoints_points,
+  vector<char> &criticalPoints_points_cellDimensions,
+  vector<SimplexId> &criticalPoints_points_cellIds,
+  vector<char> &criticalPoints_points_isOnBoundary,
+  vector<SimplexId> &criticalPoints_points_PLVertexIdentifiers,
+  vector<SimplexId> &criticalPoints_points_manifoldSize,
+  SimplexId separatrices1_numberOfPoints,
+  vector<float> &separatrices1_points,
+  vector<char> &separatrices1_points_smoothingMask,
+  vector<char> &separatrices1_points_cellDimensions,
+  vector<SimplexId> separatrices1_points_cellIds,
+  SimplexId separatrices1_numberOfCells,
+  vector<SimplexId> &separatrices1_cells,
+  vector<SimplexId> &separatrices1_cells_sourceIds,
+  vector<SimplexId> &separatrices1_cells_destinationIds,
+  vector<SimplexId> &separatrices1_cells_separatrixIds,
+  vector<char> &separatrices1_cells_separatrixTypes,
+  vector<char> &separatrices1_cells_isOnBoundary,
+  SimplexId separatrices2_numberOfPoints,
+  vector<float> &separatrices2_points,
+  SimplexId separatrices2_numberOfCells,
+  vector<SimplexId> &separatrices2_cells,
+  vector<SimplexId> &separatrices2_cells_sourceIds,
+  vector<SimplexId> &separatrices2_cells_separatrixIds,
+  vector<char> &separatrices2_cells_separatrixTypes,
+  vector<char> &separatrices2_cells_isOnBoundary) {
+
+  const int dimensionality = triangulation_->getCellVertexNumber(0) - 1;
+
+  // critical points
+  vector<VTK_TT> criticalPoints_points_cellScalars;
+
+  // 1-separatrices
+  vector<VTK_TT> separatrices1_cells_separatrixFunctionMaxima;
+  vector<VTK_TT> separatrices1_cells_separatrixFunctionMinima;
+  vector<VTK_TT> separatrices1_cells_separatrixFunctionDiffs;
+
+  // 2-separatrices
+  vector<VTK_TT> separatrices2_cells_separatrixFunctionMaxima;
+  vector<VTK_TT> separatrices2_cells_separatrixFunctionMinima;
+  vector<VTK_TT> separatrices2_cells_separatrixFunctionDiffs;
+
+  if(ComputeCriticalPoints) {
+    morseSmaleComplex_.setOutputCriticalPoints(
+      &criticalPoints_numberOfPoints, &criticalPoints_points,
+      &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
+      &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
+      &criticalPoints_points_PLVertexIdentifiers,
+      &criticalPoints_points_manifoldSize);
+  } else {
+    morseSmaleComplex_.setOutputCriticalPoints(
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  }
+
+  morseSmaleComplex_.setOutputSeparatrices1(
+    &separatrices1_numberOfPoints, &separatrices1_points,
+    &separatrices1_points_smoothingMask, &separatrices1_points_cellDimensions,
+    &separatrices1_points_cellIds, &separatrices1_numberOfCells,
+    &separatrices1_cells, &separatrices1_cells_sourceIds,
+    &separatrices1_cells_destinationIds, &separatrices1_cells_separatrixIds,
+    &separatrices1_cells_separatrixTypes,
+    &separatrices1_cells_separatrixFunctionMaxima,
+    &separatrices1_cells_separatrixFunctionMinima,
+    &separatrices1_cells_separatrixFunctionDiffs,
+    &separatrices1_cells_isOnBoundary);
+
+  morseSmaleComplex_.setOutputSeparatrices2(
+    &separatrices2_numberOfPoints, &separatrices2_points,
+    &separatrices2_numberOfCells, &separatrices2_cells,
+    &separatrices2_cells_sourceIds, &separatrices2_cells_separatrixIds,
+    &separatrices2_cells_separatrixTypes,
+    &separatrices2_cells_separatrixFunctionMaxima,
+    &separatrices2_cells_separatrixFunctionMinima,
+    &separatrices2_cells_separatrixFunctionDiffs,
+    &separatrices2_cells_isOnBoundary);
+
+  int ret = 0;
+  if(inputOffsets->GetDataType() == VTK_INT)
+    ret = morseSmaleComplex_.execute<VTK_TT, int>();
+  if(inputOffsets->GetDataType() == VTK_ID_TYPE)
+    ret = morseSmaleComplex_.execute<VTK_TT, vtkIdType>();
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkMorseSmaleComplex] Error : MorseSmaleComplex.execute() "
+         << "error code : " << ret << endl;
+    return -1;
+  }
+#endif
+
+  // critical points
+  {
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!points) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+
+    vtkSmartPointer<vtkCharArray> cellDimensions
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellDimensions) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    cellDimensions->SetNumberOfComponents(1);
+    cellDimensions->SetName("CellDimension");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    cellIds->SetNumberOfComponents(1);
+    cellIds->SetName("CellId");
+
+    vtkDataArray *cellScalars = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellScalars) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    cellScalars->SetNumberOfComponents(1);
+    cellScalars->SetName(ScalarField.data());
+
+    vtkSmartPointer<vtkCharArray> isOnBoundary
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!isOnBoundary) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    isOnBoundary->SetNumberOfComponents(1);
+    isOnBoundary->SetName("IsOnBoundary");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!PLVertexIdentifiers) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    PLVertexIdentifiers->SetNumberOfComponents(1);
+    PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> manifoldSizeScalars
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!manifoldSizeScalars) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    manifoldSizeScalars->SetNumberOfComponents(1);
+    manifoldSizeScalars->SetName("ManifoldSize");
+
+    for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
+      points->InsertNextPoint(criticalPoints_points[3 * i],
+                              criticalPoints_points[3 * i + 1],
+                              criticalPoints_points[3 * i + 2]);
+
+      cellDimensions->InsertNextTuple1(criticalPoints_points_cellDimensions[i]);
+      cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
+
+      cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
+
+      isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
+
+      PLVertexIdentifiers->InsertNextTuple1(
+        criticalPoints_points_PLVertexIdentifiers[i]);
+
+      if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)
+        manifoldSizeScalars->InsertNextTuple1(
+          criticalPoints_points_manifoldSize[i]);
+      else
+        manifoldSizeScalars->InsertNextTuple1(-1);
+    }
+    outputCriticalPoints->SetPoints(points);
+
+    vtkPointData *pointData = outputCriticalPoints->GetPointData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!pointData) {
+      cerr << "[ttkMorseSmaleComplex] Error : outputCriticalPoints has "
+           << "no point data." << endl;
+      return -1;
+    }
+#endif
+
+    pointData->AddArray(cellDimensions);
+    pointData->AddArray(cellIds);
+    pointData->AddArray(cellScalars);
+    pointData->AddArray(isOnBoundary);
+    pointData->AddArray(PLVertexIdentifiers);
+    pointData->AddArray(manifoldSizeScalars);
+  }
+
+  // 1-separatrices
+  if(ComputeAscendingSeparatrices1 or ComputeDescendingSeparatrices1
+     or ComputeSaddleConnectors) {
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!points) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    vtkSmartPointer<vtkCharArray> smoothingMask
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!smoothingMask) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    smoothingMask->SetNumberOfComponents(1);
+    smoothingMask->SetName(ttk::MaskScalarFieldName);
+
+    vtkSmartPointer<vtkCharArray> cellDimensions
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellDimensions) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    cellDimensions->SetNumberOfComponents(1);
+    cellDimensions->SetName("CellDimension");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    cellIds->SetNumberOfComponents(1);
+    cellIds->SetName("CellId");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!sourceIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    sourceIds->SetNumberOfComponents(1);
+    sourceIds->SetName("SourceId");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> destinationIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!destinationIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    destinationIds->SetNumberOfComponents(1);
+    destinationIds->SetName("DestinationId");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixIds->SetNumberOfComponents(1);
+    separatrixIds->SetName("SeparatrixId");
+
+    vtkSmartPointer<vtkCharArray> separatrixTypes
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixTypes) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixTypes->SetNumberOfComponents(1);
+    separatrixTypes->SetName("SeparatrixType");
+
+    vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionMaxima) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionMaxima->SetNumberOfComponents(1);
+    separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
+
+    vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionMinima) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionMinima->SetNumberOfComponents(1);
+    separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
+
+    vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionDiffs) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionDiffs->SetNumberOfComponents(1);
+    separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
+
+    vtkSmartPointer<vtkCharArray> isOnBoundary
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!isOnBoundary) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    isOnBoundary->SetNumberOfComponents(1);
+    isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
+
+    for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
+      points->InsertNextPoint(separatrices1_points[3 * i],
+                              separatrices1_points[3 * i + 1],
+                              separatrices1_points[3 * i + 2]);
+
+      smoothingMask->InsertNextTuple1(separatrices1_points_smoothingMask[i]);
+      cellDimensions->InsertNextTuple1(separatrices1_points_cellDimensions[i]);
+      cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
+    }
+    outputSeparatrices1->SetPoints(points);
+
+    outputSeparatrices1->Allocate(separatrices1_numberOfCells);
+    SimplexId ptr{};
+    for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
+      vtkIdType line[2];
+      line[0] = separatrices1_cells[ptr + 1];
+      line[1] = separatrices1_cells[ptr + 2];
+
+      outputSeparatrices1->InsertNextCell(VTK_LINE, 2, line);
+
+      sourceIds->InsertNextTuple1(separatrices1_cells_sourceIds[i]);
+
+      destinationIds->InsertNextTuple1(separatrices1_cells_destinationIds[i]);
+
+      separatrixIds->InsertNextTuple1(separatrices1_cells_separatrixIds[i]);
+
+      separatrixTypes->InsertNextTuple1(separatrices1_cells_separatrixTypes[i]);
+
+      separatrixFunctionMaxima->InsertNextTuple1(
+        separatrices1_cells_separatrixFunctionMaxima[i]);
+
+      separatrixFunctionMinima->InsertNextTuple1(
+        separatrices1_cells_separatrixFunctionMinima[i]);
+
+      separatrixFunctionDiffs->InsertNextTuple1(
+        separatrices1_cells_separatrixFunctionDiffs[i]);
+
+      isOnBoundary->InsertNextTuple1(separatrices1_cells_isOnBoundary[i]);
+
+      ptr += (separatrices1_cells[ptr] + 1);
+    }
+
+    vtkPointData *pointData = outputSeparatrices1->GetPointData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!pointData) {
+      cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
+           << "no point data." << endl;
+      return -1;
+    }
+#endif
+
+    pointData->AddArray(smoothingMask);
+    pointData->AddArray(cellDimensions);
+    pointData->AddArray(cellIds);
+
+    vtkCellData *cellData = outputSeparatrices1->GetCellData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellData) {
+      cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
+           << "no cell data." << endl;
+      return -1;
+    }
+#endif
+
+    cellData->AddArray(sourceIds);
+    cellData->AddArray(destinationIds);
+    cellData->AddArray(separatrixIds);
+    cellData->AddArray(separatrixTypes);
+    cellData->AddArray(separatrixFunctionMaxima);
+    cellData->AddArray(separatrixFunctionMinima);
+    cellData->AddArray(separatrixFunctionDiffs);
+    cellData->AddArray(isOnBoundary);
+  }
+
+  // 2-separatrices
+  if(dimensionality == 3
+     and (ComputeAscendingSeparatrices2 or ComputeDescendingSeparatrices2)) {
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!points) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!sourceIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+              "problem."
+           << endl;
+      return -1;
+    }
+#endif
+    sourceIds->SetNumberOfComponents(1);
+    sourceIds->SetName("SourceId");
+
+    vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
+      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixIds) {
+      cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray allocation "
+              "problem."
+           << endl;
+      return -1;
+    }
+#endif
+    separatrixIds->SetNumberOfComponents(1);
+    separatrixIds->SetName("SeparatrixId");
+
+    vtkSmartPointer<vtkCharArray> separatrixTypes
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixTypes) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation  problem."
+           << endl;
+      return -1;
+    }
+#endif
+    separatrixTypes->SetNumberOfComponents(1);
+    separatrixTypes->SetName("SeparatrixType");
+
+    vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionMaxima) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionMaxima->SetNumberOfComponents(1);
+    separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
+
+    vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionMinima) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionMinima->SetNumberOfComponents(1);
+    separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
+
+    vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!separatrixFunctionDiffs) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
+           << "problem." << endl;
+      return -1;
+    }
+#endif
+    separatrixFunctionDiffs->SetNumberOfComponents(1);
+    separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
+
+    vtkSmartPointer<vtkCharArray> isOnBoundary
+      = vtkSmartPointer<vtkCharArray>::New();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!isOnBoundary) {
+      cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation problem."
+           << endl;
+      return -1;
+    }
+#endif
+    isOnBoundary->SetNumberOfComponents(1);
+    isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
+
+    for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
+      points->InsertNextPoint(separatrices2_points[3 * i],
+                              separatrices2_points[3 * i + 1],
+                              separatrices2_points[3 * i + 2]);
+    }
+    outputSeparatrices2->SetPoints(points);
+
+    outputSeparatrices2->Allocate(separatrices2_numberOfCells);
+    SimplexId ptr{};
+    for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
+      const int vertexNumber = separatrices2_cells[ptr];
+
+      if(vertexNumber == 3) {
+        vtkIdType triangle[3];
+        triangle[0] = separatrices2_cells[ptr + 1];
+        triangle[1] = separatrices2_cells[ptr + 2];
+        triangle[2] = separatrices2_cells[ptr + 3];
+
+        outputSeparatrices2->InsertNextCell(
+          VTK_TRIANGLE, vertexNumber, triangle);
+      } else {
+        vtkIdType ids[16];
+        for(int j = 1; j <= vertexNumber; ++j)
+          ids[j - 1] = separatrices2_cells[ptr + j];
+
+        outputSeparatrices2->InsertNextCell(VTK_POLYGON, vertexNumber, ids);
+      }
+
+      sourceIds->InsertNextTuple1(separatrices2_cells_sourceIds[i]);
+      separatrixIds->InsertNextTuple1(separatrices2_cells_separatrixIds[i]);
+
+      separatrixTypes->InsertNextTuple1(separatrices2_cells_separatrixTypes[i]);
+      separatrixFunctionMaxima->InsertNextTuple1(
+        separatrices2_cells_separatrixFunctionMaxima[i]);
+
+      separatrixFunctionMinima->InsertNextTuple1(
+        separatrices2_cells_separatrixFunctionMinima[i]);
+
+      separatrixFunctionDiffs->InsertNextTuple1(
+        separatrices2_cells_separatrixFunctionDiffs[i]);
+      isOnBoundary->InsertNextTuple1(separatrices2_cells_isOnBoundary[i]);
+
+      ptr += (separatrices2_cells[ptr] + 1);
+    }
+
+    vtkCellData *cellData = outputSeparatrices2->GetCellData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!cellData) {
+      cerr << "[ttkMorseSmaleComplex] Error : "
+           << "outputSeparatrices2 has no cell data." << endl;
+      return -1;
+    }
+#endif
+
+    cellData->AddArray(sourceIds);
+    cellData->AddArray(separatrixIds);
+    cellData->AddArray(separatrixTypes);
+    cellData->AddArray(separatrixFunctionMaxima);
+    cellData->AddArray(separatrixFunctionMinima);
+    cellData->AddArray(separatrixFunctionDiffs);
+    cellData->AddArray(isOnBoundary);
+  }
+
+  return ret;
+}
+
 int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
                                vector<vtkDataSet *> &outputs) {
   Memory m;
@@ -286,8 +880,6 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
   vector<char> separatrices2_cells_separatrixTypes;
   vector<char> separatrices2_cells_isOnBoundary;
 
-  const int dimensionality = triangulation_->getCellVertexNumber(0) - 1;
-
   // morse complexes
   const SimplexId numberOfVertices = triangulation_->getNumberOfVertices();
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -384,1459 +976,30 @@ int ttkMorseSmaleComplex::doIt(vector<vtkDataSet *> &inputs,
     ascendingManifoldPtr, descendingManifoldPtr, morseSmaleManifoldPtr);
 
   switch(inputScalars->GetDataType()) {
-#ifndef _MSC_VER
-    vtkTemplateMacro(({
-      // critical points
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      // 1-separatrices
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionDiffs;
-
-      // 2-separatrices
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionDiffs;
-
-      if(ComputeCriticalPoints) {
-        morseSmaleComplex_.setOutputCriticalPoints(
-          &criticalPoints_numberOfPoints, &criticalPoints_points,
-          &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-          &criticalPoints_points_cellScalars,
-          &criticalPoints_points_isOnBoundary,
-          &criticalPoints_points_PLVertexIdentifiers,
-          &criticalPoints_points_manifoldSize);
-      } else {
-        morseSmaleComplex_.setOutputCriticalPoints(nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr);
-      }
-
-      morseSmaleComplex_.setOutputSeparatrices1(
-        &separatrices1_numberOfPoints, &separatrices1_points,
-        &separatrices1_points_smoothingMask,
-        &separatrices1_points_cellDimensions, &separatrices1_points_cellIds,
-        &separatrices1_numberOfCells, &separatrices1_cells,
-        &separatrices1_cells_sourceIds, &separatrices1_cells_destinationIds,
-        &separatrices1_cells_separatrixIds,
-        &separatrices1_cells_separatrixTypes,
-        &separatrices1_cells_separatrixFunctionMaxima,
-        &separatrices1_cells_separatrixFunctionMinima,
-        &separatrices1_cells_separatrixFunctionDiffs,
-        &separatrices1_cells_isOnBoundary);
-
-      morseSmaleComplex_.setOutputSeparatrices2(
-        &separatrices2_numberOfPoints, &separatrices2_points,
-        &separatrices2_numberOfCells, &separatrices2_cells,
-        &separatrices2_cells_sourceIds, &separatrices2_cells_separatrixIds,
-        &separatrices2_cells_separatrixTypes,
-        &separatrices2_cells_separatrixFunctionMaxima,
-        &separatrices2_cells_separatrixFunctionMinima,
-        &separatrices2_cells_separatrixFunctionDiffs,
-        &separatrices2_cells_isOnBoundary);
-
-      if(inputOffsets->GetDataType() == VTK_INT)
-        ret = morseSmaleComplex_.execute<VTK_TT, int>();
-      if(inputOffsets->GetDataType() == VTK_ID_TYPE)
-        ret = morseSmaleComplex_.execute<VTK_TT, vtkIdType>();
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkMorseSmaleComplex] Error : MorseSmaleComplex.execute() "
-             << "error code : " << ret << endl;
-        return -1;
-      }
-#endif
-
-      // critical points
-      {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellDimensions) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellScalars) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!isOnBoundary) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!PLVertexIdentifiers) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> manifoldSizeScalars
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!manifoldSizeScalars) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        manifoldSizeScalars->SetNumberOfComponents(1);
-        manifoldSizeScalars->SetName("ManifoldSize");
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-
-          if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)
-            manifoldSizeScalars->InsertNextTuple1(
-              criticalPoints_points_manifoldSize[i]);
-          else
-            manifoldSizeScalars->InsertNextTuple1(-1);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!pointData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputCriticalPoints has "
-               << "no point data." << endl;
-          return -1;
-        }
-#endif
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-        pointData->AddArray(manifoldSizeScalars);
-      }
-
-      // 1-separatrices
-      if(ComputeAscendingSeparatrices1 or ComputeDescendingSeparatrices1
-         or ComputeSaddleConnectors) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        vtkSmartPointer<vtkCharArray> smoothingMask
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!smoothingMask) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        smoothingMask->SetNumberOfComponents(1);
-        smoothingMask->SetName(ttk::MaskScalarFieldName);
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellDimensions) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!sourceIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> destinationIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!destinationIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        destinationIds->SetNumberOfComponents(1);
-        destinationIds->SetName("DestinationId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixTypes) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionMaxima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionMinima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionDiffs) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!isOnBoundary) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices1_points[3 * i],
-                                  separatrices1_points[3 * i + 1],
-                                  separatrices1_points[3 * i + 2]);
-
-          smoothingMask->InsertNextTuple1(
-            separatrices1_points_smoothingMask[i]);
-          cellDimensions->InsertNextTuple1(
-            separatrices1_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
-        }
-        outputSeparatrices1->SetPoints(points);
-
-        outputSeparatrices1->Allocate(separatrices1_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
-          vtkIdType line[2];
-          line[0] = separatrices1_cells[ptr + 1];
-          line[1] = separatrices1_cells[ptr + 2];
-
-          outputSeparatrices1->InsertNextCell(VTK_LINE, 2, line);
-
-          sourceIds->InsertNextTuple1(separatrices1_cells_sourceIds[i]);
-
-          destinationIds->InsertNextTuple1(
-            separatrices1_cells_destinationIds[i]);
-
-          separatrixIds->InsertNextTuple1(separatrices1_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices1_cells_separatrixTypes[i]);
-
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionDiffs[i]);
-
-          isOnBoundary->InsertNextTuple1(separatrices1_cells_isOnBoundary[i]);
-
-          ptr += (separatrices1_cells[ptr] + 1);
-        }
-
-        vtkPointData *pointData = outputSeparatrices1->GetPointData();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!pointData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
-               << "no point data." << endl;
-          return -1;
-        }
-#endif
-
-        pointData->AddArray(smoothingMask);
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-
-        vtkCellData *cellData = outputSeparatrices1->GetCellData();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
-               << "no cell data." << endl;
-          return -1;
-        }
-#endif
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(destinationIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-
-      // 2-separatrices
-      if(dimensionality == 3
-         and (ComputeAscendingSeparatrices2
-              or ComputeDescendingSeparatrices2)) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation problem."
-               << endl;
-          return -1;
-        }
-#endif
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!sourceIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-#endif
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-#endif
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixTypes) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation  "
-                  "problem."
-               << endl;
-          return -1;
-        }
-#endif
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionMaxima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionMinima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!separatrixFunctionDiffs) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-#endif
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!isOnBoundary) {
-          cerr
-            << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-#endif
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices2_points[3 * i],
-                                  separatrices2_points[3 * i + 1],
-                                  separatrices2_points[3 * i + 2]);
-        }
-        outputSeparatrices2->SetPoints(points);
-
-        outputSeparatrices2->Allocate(separatrices2_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
-          const int vertexNumber = separatrices2_cells[ptr];
-
-          if(vertexNumber == 3) {
-            vtkIdType triangle[3];
-            triangle[0] = separatrices2_cells[ptr + 1];
-            triangle[1] = separatrices2_cells[ptr + 2];
-            triangle[2] = separatrices2_cells[ptr + 3];
-
-            outputSeparatrices2->InsertNextCell(
-              VTK_TRIANGLE, vertexNumber, triangle);
-          } else {
-            vtkIdType ids[16];
-            for(int j = 1; j <= vertexNumber; ++j)
-              ids[j - 1] = separatrices2_cells[ptr + j];
-
-            outputSeparatrices2->InsertNextCell(VTK_POLYGON, vertexNumber, ids);
-          }
-
-          sourceIds->InsertNextTuple1(separatrices2_cells_sourceIds[i]);
-          separatrixIds->InsertNextTuple1(separatrices2_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices2_cells_separatrixTypes[i]);
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionDiffs[i]);
-          isOnBoundary->InsertNextTuple1(separatrices2_cells_isOnBoundary[i]);
-
-          ptr += (separatrices2_cells[ptr] + 1);
-        }
-
-        vtkCellData *cellData = outputSeparatrices2->GetCellData();
-#ifndef TTK_ENABLE_KAMIKAZE
-        if(!cellData) {
-          cerr << "[ttkMorseSmaleComplex] Error : "
-               << "outputSeparatrices2 has no cell data." << endl;
-          return -1;
-        }
-#endif
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-    }));
-#else
-#ifndef TTK_ENABLE_KAMIKAZE
-    vtkTemplateMacro({
-      // critical points
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      // 1-separatrices
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionDiffs;
-
-      // 2-separatrices
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionDiffs;
-
-      if(ComputeCriticalPoints) {
-        morseSmaleComplex_.setOutputCriticalPoints(
-          &criticalPoints_numberOfPoints, &criticalPoints_points,
-          &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-          &criticalPoints_points_cellScalars,
-          &criticalPoints_points_isOnBoundary,
-          &criticalPoints_points_PLVertexIdentifiers,
-          &criticalPoints_points_manifoldSize);
-      } else {
-        morseSmaleComplex_.setOutputCriticalPoints(nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr);
-      }
-
-      morseSmaleComplex_.setOutputSeparatrices1(
-        &separatrices1_numberOfPoints, &separatrices1_points,
-        &separatrices1_points_smoothingMask,
-        &separatrices1_points_cellDimensions, &separatrices1_points_cellIds,
-        &separatrices1_numberOfCells, &separatrices1_cells,
-        &separatrices1_cells_sourceIds, &separatrices1_cells_destinationIds,
-        &separatrices1_cells_separatrixIds,
-        &separatrices1_cells_separatrixTypes,
-        &separatrices1_cells_separatrixFunctionMaxima,
-        &separatrices1_cells_separatrixFunctionMinima,
-        &separatrices1_cells_separatrixFunctionDiffs,
-        &separatrices1_cells_isOnBoundary);
-
-      morseSmaleComplex_.setOutputSeparatrices2(
-        &separatrices2_numberOfPoints, &separatrices2_points,
-        &separatrices2_numberOfCells, &separatrices2_cells,
-        &separatrices2_cells_sourceIds, &separatrices2_cells_separatrixIds,
-        &separatrices2_cells_separatrixTypes,
-        &separatrices2_cells_separatrixFunctionMaxima,
-        &separatrices2_cells_separatrixFunctionMinima,
-        &separatrices2_cells_separatrixFunctionDiffs,
-        &separatrices2_cells_isOnBoundary);
-
-      if(inputOffsets->GetDataType() == VTK_INT)
-        ret = morseSmaleComplex_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets->GetDataType() == VTK_ID_TYPE)
-        ret = morseSmaleComplex_.execute<VTK_TT TTK_COMMA vtkIdType>();
-      if(ret) {
-        cerr << "[ttkMorseSmaleComplex] Error : MorseSmaleComplex.execute() "
-             << "error code : " << ret << endl;
-        return -1;
-      }
-
-      // critical points
-      {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
-               << "problem." << endl;
-          return -1;
-        }
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!cellDimensions) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!cellIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars->NewInstance();
-        if(!cellScalars) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!isOnBoundary) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!PLVertexIdentifiers) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> manifoldSizeScalars
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!manifoldSizeScalars) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        manifoldSizeScalars->SetNumberOfComponents(1);
-        manifoldSizeScalars->SetName("ManifoldSize");
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-
-          if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)
-            manifoldSizeScalars->InsertNextTuple1(
-              criticalPoints_points_manifoldSize[i]);
-          else
-            manifoldSizeScalars->InsertNextTuple1(-1);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-        if(!pointData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputCriticalPoints has "
-               << "no point data." << endl;
-          return -1;
-        }
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-        pointData->AddArray(manifoldSizeScalars);
-      }
-
-      // 1-separatrices
-      if(ComputeAscendingSeparatrices1 or ComputeDescendingSeparatrices1
-         or ComputeSaddleConnectors) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        vtkSmartPointer<vtkCharArray> smoothingMask
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!smoothingMask) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        smoothingMask->SetNumberOfComponents(1);
-        smoothingMask->SetName(ttk::MaskScalarFieldName);
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!cellDimensions) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!cellIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!sourceIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> destinationIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!destinationIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        destinationIds->SetNumberOfComponents(1);
-        destinationIds->SetName("DestinationId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!separatrixIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!separatrixTypes) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-        if(!separatrixFunctionMaxima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-        if(!separatrixFunctionMinima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-        if(!separatrixFunctionDiffs) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!isOnBoundary) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices1_points[3 * i],
-                                  separatrices1_points[3 * i + 1],
-                                  separatrices1_points[3 * i + 2]);
-
-          smoothingMask->InsertNextTuple1(
-            separatrices1_points_smoothingMask[i]);
-          cellDimensions->InsertNextTuple1(
-            separatrices1_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
-        }
-        outputSeparatrices1->SetPoints(points);
-
-        outputSeparatrices1->Allocate(separatrices1_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
-          vtkIdType line[2];
-          line[0] = separatrices1_cells[ptr + 1];
-          line[1] = separatrices1_cells[ptr + 2];
-
-          outputSeparatrices1->InsertNextCell(VTK_LINE, 2, line);
-
-          sourceIds->InsertNextTuple1(separatrices1_cells_sourceIds[i]);
-
-          destinationIds->InsertNextTuple1(
-            separatrices1_cells_destinationIds[i]);
-
-          separatrixIds->InsertNextTuple1(separatrices1_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices1_cells_separatrixTypes[i]);
-
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionDiffs[i]);
-
-          isOnBoundary->InsertNextTuple1(separatrices1_cells_isOnBoundary[i]);
-
-          ptr += (separatrices1_cells[ptr] + 1);
-        }
-
-        vtkPointData *pointData = outputSeparatrices1->GetPointData();
-        if(!pointData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
-               << "no point data." << endl;
-          return -1;
-        }
-
-        pointData->AddArray(smoothingMask);
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-
-        vtkCellData *cellData = outputSeparatrices1->GetCellData();
-        if(!cellData) {
-          cerr << "[ttkMorseSmaleComplex] Error : outputSeparatrices1 has "
-               << "no cell data." << endl;
-          return -1;
-        }
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(destinationIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-
-      // 2-separatrices
-      if(dimensionality == 3
-         and (ComputeAscendingSeparatrices2
-              or ComputeDescendingSeparatrices2)) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-        if(!points) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkPoints allocation problem."
-               << endl;
-          return -1;
-        }
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!sourceIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        if(!separatrixIds) {
-          cerr << "[ttkMorseSmaleComplex] Error : ttkSimplexIdTypeArray "
-                  "allocation problem."
-               << endl;
-          return -1;
-        }
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!separatrixTypes) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation  "
-                  "problem."
-               << endl;
-          return -1;
-        }
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-        if(!separatrixFunctionMaxima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-        if(!separatrixFunctionMinima) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-        if(!separatrixFunctionDiffs) {
-          cerr << "[ttkMorseSmaleComplex] Error : vtkDataArray allocation "
-               << "problem." << endl;
-          return -1;
-        }
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-        if(!isOnBoundary) {
-          cerr
-            << "[ttkMorseSmaleComplex] Error : vtkCharArray allocation problem."
-            << endl;
-          return -1;
-        }
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices2_points[3 * i],
-                                  separatrices2_points[3 * i + 1],
-                                  separatrices2_points[3 * i + 2]);
-        }
-        outputSeparatrices2->SetPoints(points);
-
-        outputSeparatrices2->Allocate(separatrices2_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
-          const int vertexNumber = separatrices2_cells[ptr];
-
-          if(vertexNumber == 3) {
-            vtkIdType triangle[3];
-            triangle[0] = separatrices2_cells[ptr + 1];
-            triangle[1] = separatrices2_cells[ptr + 2];
-            triangle[2] = separatrices2_cells[ptr + 3];
-
-            outputSeparatrices2->InsertNextCell(
-              VTK_TRIANGLE, vertexNumber, triangle);
-          } else {
-            vtkIdType ids[16];
-            for(int j = 1; j <= vertexNumber; ++j)
-              ids[j - 1] = separatrices2_cells[ptr + j];
-
-            outputSeparatrices2->InsertNextCell(VTK_POLYGON, vertexNumber, ids);
-          }
-
-          sourceIds->InsertNextTuple1(separatrices2_cells_sourceIds[i]);
-          separatrixIds->InsertNextTuple1(separatrices2_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices2_cells_separatrixTypes[i]);
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionDiffs[i]);
-          isOnBoundary->InsertNextTuple1(separatrices2_cells_isOnBoundary[i]);
-
-          ptr += (separatrices2_cells[ptr] + 1);
-        }
-
-        vtkCellData *cellData = outputSeparatrices2->GetCellData();
-        if(!cellData) {
-          cerr << "[ttkMorseSmaleComplex] Error : "
-               << "outputSeparatrices2 has no cell data." << endl;
-          return -1;
-        }
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-    });
-#else
-    vtkTemplateMacro({
-      // critical points
-      vector<VTK_TT> criticalPoints_points_cellScalars;
-
-      // 1-separatrices
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices1_cells_separatrixFunctionDiffs;
-
-      // 2-separatrices
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMaxima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionMinima;
-      vector<VTK_TT> separatrices2_cells_separatrixFunctionDiffs;
-
-      if(ComputeCriticalPoints) {
-        morseSmaleComplex_.setOutputCriticalPoints(
-          &criticalPoints_numberOfPoints, &criticalPoints_points,
-          &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-          &criticalPoints_points_cellScalars,
-          &criticalPoints_points_isOnBoundary,
-          &criticalPoints_points_PLVertexIdentifiers,
-          &criticalPoints_points_manifoldSize);
-      } else {
-        morseSmaleComplex_.setOutputCriticalPoints(nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr);
-      }
-
-      morseSmaleComplex_.setOutputSeparatrices1(
-        &separatrices1_numberOfPoints, &separatrices1_points,
-        &separatrices1_points_smoothingMask,
-        &separatrices1_points_cellDimensions, &separatrices1_points_cellIds,
-        &separatrices1_numberOfCells, &separatrices1_cells,
-        &separatrices1_cells_sourceIds, &separatrices1_cells_destinationIds,
-        &separatrices1_cells_separatrixIds,
-        &separatrices1_cells_separatrixTypes,
-        &separatrices1_cells_separatrixFunctionMaxima,
-        &separatrices1_cells_separatrixFunctionMinima,
-        &separatrices1_cells_separatrixFunctionDiffs,
-        &separatrices1_cells_isOnBoundary);
-
-      morseSmaleComplex_.setOutputSeparatrices2(
-        &separatrices2_numberOfPoints, &separatrices2_points,
-        &separatrices2_numberOfCells, &separatrices2_cells,
-        &separatrices2_cells_sourceIds, &separatrices2_cells_separatrixIds,
-        &separatrices2_cells_separatrixTypes,
-        &separatrices2_cells_separatrixFunctionMaxima,
-        &separatrices2_cells_separatrixFunctionMinima,
-        &separatrices2_cells_separatrixFunctionDiffs,
-        &separatrices2_cells_isOnBoundary);
-
-      if(inputOffsets->GetDataType() == VTK_INT)
-        morseSmaleComplex_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets->GetDataType() == VTK_ID_TYPE)
-        morseSmaleComplex_.execute<VTK_TT TTK_COMMA vtkIdType>();
-
-      // critical points
-      {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkDataArray *cellScalars = inputScalars->NewInstance();
-
-        cellScalars->SetNumberOfComponents(1);
-        cellScalars->SetName(ScalarField.data());
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("IsOnBoundary");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> PLVertexIdentifiers
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        PLVertexIdentifiers->SetNumberOfComponents(1);
-        PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> manifoldSizeScalars
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        manifoldSizeScalars->SetNumberOfComponents(1);
-        manifoldSizeScalars->SetName("ManifoldSize");
-
-        for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-          points->InsertNextPoint(criticalPoints_points[3 * i],
-                                  criticalPoints_points[3 * i + 1],
-                                  criticalPoints_points[3 * i + 2]);
-
-          cellDimensions->InsertNextTuple1(
-            criticalPoints_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
-
-          cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-
-          isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-
-          PLVertexIdentifiers->InsertNextTuple1(
-            criticalPoints_points_PLVertexIdentifiers[i]);
-
-          if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)
-            manifoldSizeScalars->InsertNextTuple1(
-              criticalPoints_points_manifoldSize[i]);
-          else
-            manifoldSizeScalars->InsertNextTuple1(-1);
-        }
-        outputCriticalPoints->SetPoints(points);
-
-        vtkPointData *pointData = outputCriticalPoints->GetPointData();
-
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-        pointData->AddArray(cellScalars);
-        pointData->AddArray(isOnBoundary);
-        pointData->AddArray(PLVertexIdentifiers);
-        pointData->AddArray(manifoldSizeScalars);
-      }
-
-      // 1-separatrices
-      if(ComputeAscendingSeparatrices1 or ComputeDescendingSeparatrices1
-         or ComputeSaddleConnectors) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-
-        vtkSmartPointer<vtkCharArray> smoothingMask
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        smoothingMask->SetNumberOfComponents(1);
-        smoothingMask->SetName(ttk::MaskScalarFieldName);
-
-        vtkSmartPointer<vtkCharArray> cellDimensions
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        cellDimensions->SetNumberOfComponents(1);
-        cellDimensions->SetName("CellDimension");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> cellIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        cellIds->SetNumberOfComponents(1);
-        cellIds->SetName("CellId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> destinationIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        destinationIds->SetNumberOfComponents(1);
-        destinationIds->SetName("DestinationId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices1_points[3 * i],
-                                  separatrices1_points[3 * i + 1],
-                                  separatrices1_points[3 * i + 2]);
-
-          smoothingMask->InsertNextTuple1(
-            separatrices1_points_smoothingMask[i]);
-
-          cellDimensions->InsertNextTuple1(
-            separatrices1_points_cellDimensions[i]);
-          cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
-        }
-        outputSeparatrices1->SetPoints(points);
-
-        outputSeparatrices1->Allocate(separatrices1_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
-          vtkIdType line[2];
-          line[0] = separatrices1_cells[ptr + 1];
-          line[1] = separatrices1_cells[ptr + 2];
-
-          outputSeparatrices1->InsertNextCell(VTK_LINE, 2, line);
-
-          sourceIds->InsertNextTuple1(separatrices1_cells_sourceIds[i]);
-
-          destinationIds->InsertNextTuple1(
-            separatrices1_cells_destinationIds[i]);
-
-          separatrixIds->InsertNextTuple1(separatrices1_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices1_cells_separatrixTypes[i]);
-
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices1_cells_separatrixFunctionDiffs[i]);
-
-          isOnBoundary->InsertNextTuple1(separatrices1_cells_isOnBoundary[i]);
-
-          ptr += (separatrices1_cells[ptr] + 1);
-        }
-
-        vtkPointData *pointData = outputSeparatrices1->GetPointData();
-
-        pointData->AddArray(smoothingMask);
-        pointData->AddArray(cellDimensions);
-        pointData->AddArray(cellIds);
-
-        vtkCellData *cellData = outputSeparatrices1->GetCellData();
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(destinationIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-
-      // 2-separatrices
-      if(dimensionality == 3
-         and (ComputeAscendingSeparatrices2
-              or ComputeDescendingSeparatrices2)) {
-        vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> sourceIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        sourceIds->SetNumberOfComponents(1);
-        sourceIds->SetName("SourceId");
-
-        vtkSmartPointer<ttkSimplexIdTypeArray> separatrixIds
-          = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-
-        separatrixIds->SetNumberOfComponents(1);
-        separatrixIds->SetName("SeparatrixId");
-
-        vtkSmartPointer<vtkCharArray> separatrixTypes
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        separatrixTypes->SetNumberOfComponents(1);
-        separatrixTypes->SetName("SeparatrixType");
-
-        vtkDataArray *separatrixFunctionMaxima = inputScalars->NewInstance();
-
-        separatrixFunctionMaxima->SetNumberOfComponents(1);
-        separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-
-        vtkDataArray *separatrixFunctionMinima = inputScalars->NewInstance();
-
-        separatrixFunctionMinima->SetNumberOfComponents(1);
-        separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-
-        vtkDataArray *separatrixFunctionDiffs = inputScalars->NewInstance();
-
-        separatrixFunctionDiffs->SetNumberOfComponents(1);
-        separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-
-        vtkSmartPointer<vtkCharArray> isOnBoundary
-          = vtkSmartPointer<vtkCharArray>::New();
-
-        isOnBoundary->SetNumberOfComponents(1);
-        isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-        for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
-          points->InsertNextPoint(separatrices2_points[3 * i],
-                                  separatrices2_points[3 * i + 1],
-                                  separatrices2_points[3 * i + 2]);
-        }
-        outputSeparatrices2->SetPoints(points);
-
-        outputSeparatrices2->Allocate(separatrices2_numberOfCells);
-        SimplexId ptr{};
-        for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
-          const int vertexNumber = separatrices2_cells[ptr];
-
-          if(vertexNumber == 3) {
-            vtkIdType triangle[3];
-            triangle[0] = separatrices2_cells[ptr + 1];
-            triangle[1] = separatrices2_cells[ptr + 2];
-            triangle[2] = separatrices2_cells[ptr + 3];
-
-            outputSeparatrices2->InsertNextCell(
-              VTK_TRIANGLE, vertexNumber, triangle);
-          } else {
-            vtkIdType ids[16];
-            for(int j = 1; j <= vertexNumber; ++j)
-              ids[j - 1] = separatrices2_cells[ptr + j];
-
-            outputSeparatrices2->InsertNextCell(VTK_POLYGON, vertexNumber, ids);
-          }
-
-          sourceIds->InsertNextTuple1(separatrices2_cells_sourceIds[i]);
-          separatrixIds->InsertNextTuple1(separatrices2_cells_separatrixIds[i]);
-
-          separatrixTypes->InsertNextTuple1(
-            separatrices2_cells_separatrixTypes[i]);
-          separatrixFunctionMaxima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMaxima[i]);
-
-          separatrixFunctionMinima->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionMinima[i]);
-
-          separatrixFunctionDiffs->InsertNextTuple1(
-            separatrices2_cells_separatrixFunctionDiffs[i]);
-          isOnBoundary->InsertNextTuple1(separatrices2_cells_isOnBoundary[i]);
-
-          ptr += (separatrices2_cells[ptr] + 1);
-        }
-
-        vtkCellData *cellData = outputSeparatrices2->GetCellData();
-
-        cellData->AddArray(sourceIds);
-        cellData->AddArray(separatrixIds);
-        cellData->AddArray(separatrixTypes);
-        cellData->AddArray(separatrixFunctionMaxima);
-        cellData->AddArray(separatrixFunctionMinima);
-        cellData->AddArray(separatrixFunctionDiffs);
-        cellData->AddArray(isOnBoundary);
-      }
-    });
-#endif
-#endif
+    vtkTemplateMacro(
+      ret = dispatch<VTK_TT>(
+        inputScalars, inputOffsets, outputCriticalPoints, outputSeparatrices1,
+        outputSeparatrices2, criticalPoints_numberOfPoints,
+        criticalPoints_points, criticalPoints_points_cellDimensions,
+        criticalPoints_points_cellIds, criticalPoints_points_isOnBoundary,
+        criticalPoints_points_PLVertexIdentifiers,
+        criticalPoints_points_manifoldSize, separatrices1_numberOfPoints,
+        separatrices1_points, separatrices1_points_smoothingMask,
+        separatrices1_points_cellDimensions, separatrices1_points_cellIds,
+        separatrices1_numberOfCells, separatrices1_cells,
+        separatrices1_cells_sourceIds, separatrices1_cells_destinationIds,
+        separatrices1_cells_separatrixIds, separatrices1_cells_separatrixTypes,
+        separatrices1_cells_isOnBoundary, separatrices2_numberOfPoints,
+        separatrices2_points, separatrices2_numberOfCells, separatrices2_cells,
+        separatrices2_cells_sourceIds, separatrices2_cells_separatrixIds,
+        separatrices2_cells_separatrixTypes, separatrices2_cells_isOnBoundary));
   }
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret != 0) {
+    return -1;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
 
   outputMorseComplexes->ShallowCopy(input);
   // morse complexes

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -147,6 +147,41 @@ public:
   vtkDataArray *getOffsets(vtkDataSet *input);
 
 protected:
+  template <typename VTK_TT>
+  int dispatch(
+    vtkDataArray *inputScalars,
+    vtkDataArray *inputOffsets,
+    vtkUnstructuredGrid *outputCriticalPoints,
+    vtkUnstructuredGrid *outputSeparatrices1,
+    vtkUnstructuredGrid *outputSeparatrices2,
+    ttk::SimplexId criticalPoints_numberOfPoints,
+    std::vector<float> &criticalPoints_points,
+    std::vector<char> &criticalPoints_points_cellDimensions,
+    std::vector<ttk::SimplexId> &criticalPoints_points_cellIds,
+    std::vector<char> &criticalPoints_points_isOnBoundary,
+    std::vector<ttk::SimplexId> &criticalPoints_points_PLVertexIdentifiers,
+    std::vector<ttk::SimplexId> &criticalPoints_points_manifoldSize,
+    ttk::SimplexId separatrices1_numberOfPoints,
+    std::vector<float> &separatrices1_points,
+    std::vector<char> &separatrices1_points_smoothingMask,
+    std::vector<char> &separatrices1_points_cellDimensions,
+    std::vector<ttk::SimplexId> separatrices1_points_cellIds,
+    ttk::SimplexId separatrices1_numberOfCells,
+    std::vector<ttk::SimplexId> &separatrices1_cells,
+    std::vector<ttk::SimplexId> &separatrices1_cells_sourceIds,
+    std::vector<ttk::SimplexId> &separatrices1_cells_destinationIds,
+    std::vector<ttk::SimplexId> &separatrices1_cells_separatrixIds,
+    std::vector<char> &separatrices1_cells_separatrixTypes,
+    std::vector<char> &separatrices1_cells_isOnBoundary,
+    ttk::SimplexId separatrices2_numberOfPoints,
+    std::vector<float> &separatrices2_points,
+    ttk::SimplexId separatrices2_numberOfCells,
+    std::vector<ttk::SimplexId> &separatrices2_cells,
+    std::vector<ttk::SimplexId> &separatrices2_cells_sourceIds,
+    std::vector<ttk::SimplexId> &separatrices2_cells_separatrixIds,
+    std::vector<char> &separatrices2_cells_separatrixTypes,
+    std::vector<char> &separatrices2_cells_isOnBoundary);
+
   ttkMorseSmaleComplex();
   ~ttkMorseSmaleComplex();
 

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -187,6 +187,71 @@ int ttkPersistenceCurve::getOffsets(vtkDataSet *input) {
 
   return 0;
 }
+
+template <typename VTK_TT>
+int ttkPersistenceCurve::dispatch() {
+  int ret = 0;
+  vector<pair<VTK_TT, SimplexId>> JTPlot;
+  vector<pair<VTK_TT, SimplexId>> STPlot;
+  vector<pair<VTK_TT, SimplexId>> MSCPlot;
+  vector<pair<VTK_TT, SimplexId>> CTPlot;
+
+  persistenceCurve_.setOutputJTPlot(&JTPlot);
+  persistenceCurve_.setOutputMSCPlot(&MSCPlot);
+  persistenceCurve_.setOutputSTPlot(&STPlot);
+  persistenceCurve_.setOutputCTPlot(&CTPlot);
+  if(inputOffsets_->GetDataType() == VTK_INT)
+    ret = persistenceCurve_.execute<VTK_TT, int>();
+  if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
+    ret = persistenceCurve_.execute<VTK_TT, vtkIdType>();
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkPersistenceCurve] PersistenceCurve.execute() error code : "
+         << ret << endl;
+    return -1;
+  }
+#endif
+
+  ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(TreeType::Join, JTPlot);
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkPersistenceCurve] Error :"
+         << " build of join tree persistence curve has failed." << endl;
+    return -1;
+  }
+#endif
+
+  ret = getMSCPersistenceCurve<vtkDoubleArray, VTK_TT>(MSCPlot);
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkPersistenceCurve] Error : "
+         << "build of saddle-saddle persistence curve has failed." << endl;
+    return -1;
+  }
+#endif
+
+  ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(TreeType::Split, STPlot);
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkPersistenceCurve] Error : "
+         << "build of split tree persistence curve has failed." << endl;
+    return -1;
+  }
+#endif
+
+  ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(TreeType::Contour, CTPlot);
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret) {
+    cerr << "[ttkPersistenceCurve] Error : "
+         << "build of contour tree persistence curve has failed." << endl;
+    return -1;
+  }
+#endif
+
+  return ret;
+}
+
 int ttkPersistenceCurve::doIt(vtkDataSet *input,
                               vtkTable *outputJTPersistenceCurve,
                               vtkTable *outputMSCPersistenceCurve,
@@ -248,151 +313,7 @@ int ttkPersistenceCurve::doIt(vtkDataSet *input,
   persistenceCurve_.setInputOffsets(inputOffsets_->GetVoidPointer(0));
   persistenceCurve_.setComputeSaddleConnectors(ComputeSaddleConnectors);
   switch(inputScalars_->GetDataType()) {
-#ifndef _MSC_VER
-    vtkTemplateMacro(({
-      vector<pair<VTK_TT, SimplexId>> JTPlot;
-      vector<pair<VTK_TT, SimplexId>> STPlot;
-      vector<pair<VTK_TT, SimplexId>> MSCPlot;
-      vector<pair<VTK_TT, SimplexId>> CTPlot;
-
-      persistenceCurve_.setOutputJTPlot(&JTPlot);
-      persistenceCurve_.setOutputMSCPlot(&MSCPlot);
-      persistenceCurve_.setOutputSTPlot(&STPlot);
-      persistenceCurve_.setOutputCTPlot(&CTPlot);
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = persistenceCurve_.execute<VTK_TT, int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = persistenceCurve_.execute<VTK_TT, vtkIdType>();
-
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] PersistenceCurve.execute() error code : "
-             << ret << endl;
-        return -1;
-      }
-#endif
-
-      ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(TreeType::Join, JTPlot);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error :"
-             << " build of join tree persistence curve has failed." << endl;
-        return -1;
-      }
-#endif
-
-      ret = getMSCPersistenceCurve<vtkDoubleArray, VTK_TT>(MSCPlot);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of saddle-saddle persistence curve has failed." << endl;
-        return -1;
-      }
-#endif
-
-      ret
-        = getPersistenceCurve<vtkDoubleArray, VTK_TT>(TreeType::Split, STPlot);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of split tree persistence curve has failed." << endl;
-        return -1;
-      }
-#endif
-
-      ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(
-        TreeType::Contour, CTPlot);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of contour tree persistence curve has failed." << endl;
-        return -1;
-      }
-#endif
-    }));
-#else
-#ifndef TTK_ENABLE_KAMIKAZE
-    vtkTemplateMacro({
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> JTPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> STPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> MSCPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> CTPlot;
-
-      persistenceCurve_.setOutputJTPlot(&JTPlot);
-      persistenceCurve_.setOutputMSCPlot(&MSCPlot);
-      persistenceCurve_.setOutputSTPlot(&STPlot);
-      persistenceCurve_.setOutputCTPlot(&CTPlot);
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = persistenceCurve_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = persistenceCurve_.execute<VTK_TT TTK_COMMA vtkIdType>();
-
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] PersistenceCurve.execute() error code : "
-             << ret << endl;
-        return -1;
-      }
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Join, JTPlot);
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error :"
-             << " build of join tree persistence curve has failed." << endl;
-        return -1;
-      }
-
-      ret = getMSCPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(MSCPlot);
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of saddle-saddle persistence curve has failed." << endl;
-        return -1;
-      }
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Split, STPlot);
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of split tree persistence curve has failed." << endl;
-        return -1;
-      }
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Contour, CTPlot);
-      if(ret) {
-        cerr << "[ttkPersistenceCurve] Error : "
-             << "build of contour tree persistence curve has failed." << endl;
-        return -1;
-      }
-    });
-#else
-    vtkTemplateMacro({
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> JTPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> STPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> MSCPlot;
-      vector<pair<VTK_TT TTK_COMMA SimplexId>> CTPlot;
-
-      persistenceCurve_.setOutputJTPlot(&JTPlot);
-      persistenceCurve_.setOutputMSCPlot(&MSCPlot);
-      persistenceCurve_.setOutputSTPlot(&STPlot);
-      persistenceCurve_.setOutputCTPlot(&CTPlot);
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = persistenceCurve_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = persistenceCurve_.execute<VTK_TT TTK_COMMA vtkIdType>();
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Join, JTPlot);
-
-      ret = getMSCPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(MSCPlot);
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Split, STPlot);
-
-      ret = getPersistenceCurve<vtkDoubleArray TTK_COMMA VTK_TT>(
-        TreeType::Contour, CTPlot);
-    });
-#endif
-#endif
+    vtkTemplateMacro(ret = dispatch<VTK_TT>());
   }
 
   outputJTPersistenceCurve->ShallowCopy(JTPersistenceCurve_);

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -106,6 +106,9 @@ public:
   int getTriangulation(vtkDataSet *input);
   int getOffsets(vtkDataSet *input);
 
+  template <typename VTK_TT>
+  int dispatch();
+
 protected:
   ttkPersistenceCurve();
   ~ttkPersistenceCurve();

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -33,7 +33,11 @@ ttkPersistenceDiagram::~ttkPersistenceDiagram() {
   if(offsets_)
     offsets_->Delete();
 
-  deleteDiagram();
+  if(CTDiagram_ and inputScalars_) {
+    switch(inputScalars_->GetDataType()) {
+      ttkTemplateMacro(deleteDiagram<VTK_TT>());
+    }
+  }
 }
 
 int ttkPersistenceDiagram::FillOutputPortInformation(int port,
@@ -160,18 +164,12 @@ int ttkPersistenceDiagram::getOffsets(vtkDataSet *input) {
   return 0;
 }
 
+template <typename VTK_TT>
 int ttkPersistenceDiagram::deleteDiagram() {
-  if(CTDiagram_ and inputScalars_) {
-    switch(inputScalars_->GetDataType()) {
-      ttkTemplateMacro({
-        using tuple_t
-          = tuple<SimplexId TTK_COMMA CriticalType TTK_COMMA SimplexId TTK_COMMA
-                    CriticalType TTK_COMMA VTK_TT TTK_COMMA SimplexId>;
-        vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
-        delete CTDiagram;
-      });
-    }
-  }
+  using tuple_t = tuple<SimplexId, CriticalType, SimplexId, CriticalType,
+                        VTK_TT, SimplexId>;
+  vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
+  delete CTDiagram;
   return 0;
 }
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -35,7 +35,7 @@ ttkPersistenceDiagram::~ttkPersistenceDiagram() {
 
   if(CTDiagram_ and inputScalars_) {
     switch(inputScalars_->GetDataType()) {
-      ttkTemplateMacro(deleteDiagram<VTK_TT>());
+      vtkTemplateMacro(deleteDiagram<VTK_TT>());
     }
   }
 }

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -199,6 +199,9 @@ public:
   template <typename VTK_TT>
   int deleteDiagram();
 
+  template <typename VTK_TT>
+  int dispatch();
+
 protected:
   ttkPersistenceDiagram();
   ~ttkPersistenceDiagram();

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -196,6 +196,7 @@ public:
                                  scalarType,
                                  ttk::SimplexId>> &diagram);
 
+  template <typename VTK_TT>
   int deleteDiagram();
 
 protected:

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -113,18 +113,17 @@ vtkStandardNewMacro(ttkPlanarGraphLayout)
   // Compute layout with base code
   switch(vtkTemplate2PackMacro(branchType, sequenceType)) {
     ttkTemplate2Macro(
-      status
-      = planarGraphLayout.execute<vtkIdType TTK_COMMA VTK_T1 TTK_COMMA VTK_T2>(
-        // Input
-        !this->GetUseSequences() ? nullptr
-                                 : (VTK_T2 *)sequences->GetVoidPointer(0),
-        !this->GetUseSizes() ? nullptr : (float *)sizes->GetVoidPointer(0),
-        !this->GetUseBranches() ? nullptr
-                                : (VTK_T1 *)branches->GetVoidPointer(0),
-        !this->GetUseLevels() ? nullptr : (VTK_T1 *)levels->GetVoidPointer(0),
-        output->GetCells()->GetPointer(), nPoints, nEdges,
-        // Output
-        (float *)outputField->GetVoidPointer(0)));
+      (status = planarGraphLayout.execute<vtkIdType, VTK_T1, VTK_T2>(
+         // Input
+         !this->GetUseSequences() ? nullptr
+                                  : (VTK_T2 *)sequences->GetVoidPointer(0),
+         !this->GetUseSizes() ? nullptr : (float *)sizes->GetVoidPointer(0),
+         !this->GetUseBranches() ? nullptr
+                                 : (VTK_T1 *)branches->GetVoidPointer(0),
+         !this->GetUseLevels() ? nullptr : (VTK_T1 *)levels->GetVoidPointer(0),
+         output->GetCells()->GetPointer(), nPoints, nEdges,
+         // Output
+         (float *)outputField->GetVoidPointer(0))));
   }
   if(status != 1)
     return 0;

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -108,30 +108,26 @@ vtkStandardNewMacro(ttkPlanarGraphLayout)
     return 0;
   }
 
+  int status = 1;
+
   // Compute layout with base code
   switch(vtkTemplate2PackMacro(branchType, sequenceType)) {
-    ttkTemplate2Macro({
-      int status
-        = planarGraphLayout
-            .execute<vtkIdType TTK_COMMA VTK_T1 TTK_COMMA VTK_T2>(
-              // Input
-              !this->GetUseSequences() ? nullptr
-                                       : (VTK_T2 *)sequences->GetVoidPointer(0),
-              !this->GetUseSizes() ? nullptr
-                                   : (float *)sizes->GetVoidPointer(0),
-              !this->GetUseBranches() ? nullptr
-                                      : (VTK_T1 *)branches->GetVoidPointer(0),
-              !this->GetUseLevels() ? nullptr
-                                    : (VTK_T1 *)levels->GetVoidPointer(0),
-              output->GetCells()->GetPointer(), nPoints, nEdges,
-
-              // Output
-              (float *)outputField->GetVoidPointer(0));
-
-      if(status != 1)
-        return 0;
-    });
+    ttkTemplate2Macro(
+      status
+      = planarGraphLayout.execute<vtkIdType TTK_COMMA VTK_T1 TTK_COMMA VTK_T2>(
+        // Input
+        !this->GetUseSequences() ? nullptr
+                                 : (VTK_T2 *)sequences->GetVoidPointer(0),
+        !this->GetUseSizes() ? nullptr : (float *)sizes->GetVoidPointer(0),
+        !this->GetUseBranches() ? nullptr
+                                : (VTK_T1 *)branches->GetVoidPointer(0),
+        !this->GetUseLevels() ? nullptr : (VTK_T1 *)levels->GetVoidPointer(0),
+        output->GetCells()->GetPointer(), nPoints, nEdges,
+        // Output
+        (float *)outputField->GetVoidPointer(0)));
   }
+  if(status != 1)
+    return 0;
 
   // Add output field to output
   outputPointData->AddArray(outputField);

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -112,7 +112,7 @@ vtkStandardNewMacro(ttkPlanarGraphLayout)
 
   // Compute layout with base code
   switch(vtkTemplate2PackMacro(branchType, sequenceType)) {
-    ttkTemplate2Macro(
+    vtkTemplate2Macro(
       (status = planarGraphLayout.execute<vtkIdType, VTK_T1, VTK_T2>(
          // Input
          !this->GetUseSequences() ? nullptr

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
@@ -126,25 +126,23 @@ int ttkRangePolygon::processTriangles(vtkUnstructuredGrid *input,
     smoother.setupTriangulation(triangulation);
 
     switch(output->GetPoints()->GetDataType()) {
-      vtkTemplateMacro({ smoother.smooth<VTK_TT>(NumberOfIterations); });
+      vtkTemplateMacro(smoother.smooth<VTK_TT>(NumberOfIterations));
     }
 
     for(int i = 0; i < output->GetPointData()->GetNumberOfArrays(); i++) {
       vtkDataArray *field = output->GetPointData()->GetArray(i);
 
+      smoother.setWrapper(this);
+      smoother.setDebugLevel(0);
+
+      smoother.setDimensionNumber(field->GetNumberOfComponents());
+      smoother.setInputDataPointer(field->GetVoidPointer(0));
+
+      smoother.setOutputDataPointer(field->GetVoidPointer(0));
+      smoother.setupTriangulation(triangulation);
+
       switch(field->GetDataType()) {
-
-        vtkTemplateMacro({
-          smoother.setWrapper(this);
-          smoother.setDebugLevel(0);
-
-          smoother.setDimensionNumber(field->GetNumberOfComponents());
-          smoother.setInputDataPointer(field->GetVoidPointer(0));
-
-          smoother.setOutputDataPointer(field->GetVoidPointer(0));
-          smoother.setupTriangulation(triangulation);
-          smoother.smooth<VTK_TT>(NumberOfIterations);
-        });
+        vtkTemplateMacro(smoother.smooth<VTK_TT>(NumberOfIterations));
       }
     }
   }

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -230,8 +230,8 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
   // set the Reeb space functor
   switch(vtkTemplate2PackMacro(
     uComponent_->GetDataType(), vComponent_->GetDataType())) {
-    ttkTemplate2Macro(baseCall<VTK_T1 TTK_COMMA VTK_T2>(
-      input, uComponent_, offsetFieldU_, vComponent_, offsetFieldV_));
+    ttkTemplate2Macro((baseCall<VTK_T1, VTK_T2>(
+      input, uComponent_, offsetFieldU_, vComponent_, offsetFieldV_)));
   }
 
   // prepare the output

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -230,7 +230,7 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
   // set the Reeb space functor
   switch(vtkTemplate2PackMacro(
     uComponent_->GetDataType(), vComponent_->GetDataType())) {
-    ttkTemplate2Macro((baseCall<VTK_T1, VTK_T2>(
+    vtkTemplate2Macro((baseCall<VTK_T1, VTK_T2>(
       input, uComponent_, offsetFieldU_, vComponent_, offsetFieldV_)));
   }
 

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -214,96 +214,41 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
     for(SimplexId i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {
 
       vtkDataArray *scalarField = input->GetPointData()->GetArray(i);
+      vtkSmartPointer<vtkDataArray> scalarArray;
 
       switch(scalarField->GetDataType()) {
-
-        case VTK_CHAR: {
-          vtkSmartPointer<vtkCharArray> scalarArray
-            = vtkSmartPointer<vtkCharArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(criticalPoints_.size());
-          scalarArray->SetName(scalarField->GetName());
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-            scalarField->GetTuple(criticalPoints_[j].first, value);
-            scalarArray->SetTuple(j, value);
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_DOUBLE: {
-          vtkSmartPointer<vtkDoubleArray> scalarArray
-            = vtkSmartPointer<vtkDoubleArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(criticalPoints_.size());
-          scalarArray->SetName(scalarField->GetName());
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-            scalarField->GetTuple(criticalPoints_[j].first, value);
-            scalarArray->SetTuple(j, value);
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_FLOAT: {
-          vtkSmartPointer<vtkFloatArray> scalarArray
-            = vtkSmartPointer<vtkFloatArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(criticalPoints_.size());
-          scalarArray->SetName(scalarField->GetName());
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-            scalarField->GetTuple(criticalPoints_[j].first, value);
-            scalarArray->SetTuple(j, value);
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_INT: {
-          vtkSmartPointer<vtkIntArray> scalarArray
-            = vtkSmartPointer<vtkIntArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(criticalPoints_.size());
-          scalarArray->SetName(scalarField->GetName());
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-            scalarField->GetTuple(criticalPoints_[j].first, value);
-            scalarArray->SetTuple(j, value);
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
-        case VTK_ID_TYPE: {
-          vtkSmartPointer<vtkIdTypeArray> scalarArray
-            = vtkSmartPointer<vtkIdTypeArray>::New();
-          scalarArray->SetNumberOfComponents(
-            scalarField->GetNumberOfComponents());
-          scalarArray->SetNumberOfTuples(criticalPoints_.size());
-          scalarArray->SetName(scalarField->GetName());
-          double *value = new double[scalarField->GetNumberOfComponents()];
-          for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-            scalarField->GetTuple(criticalPoints_[j].first, value);
-            scalarArray->SetTuple(j, value);
-          }
-          output->GetPointData()->AddArray(scalarArray);
-          delete[] value;
-        } break;
-
+        case VTK_CHAR:
+          scalarArray = vtkSmartPointer<vtkCharArray>::New();
+          break;
+        case VTK_DOUBLE:
+          scalarArray = vtkSmartPointer<vtkDoubleArray>::New();
+          break;
+        case VTK_FLOAT:
+          scalarArray = vtkSmartPointer<vtkFloatArray>::New();
+          break;
+        case VTK_INT:
+          scalarArray = vtkSmartPointer<vtkIntArray>::New();
+          break;
+        case VTK_ID_TYPE:
+          scalarArray = vtkSmartPointer<vtkIdTypeArray>::New();
+          break;
         default: {
           stringstream msg;
           msg << "[ttkScalarFieldCriticalPoints] Scalar attachment: "
               << "unsupported data type :(" << endl;
           dMsg(cerr, msg.str(), detailedInfoMsg);
-        } break;
+        }
+          return -1;
       }
+      scalarArray->SetNumberOfComponents(scalarField->GetNumberOfComponents());
+      scalarArray->SetNumberOfTuples(criticalPoints_.size());
+      scalarArray->SetName(scalarField->GetName());
+      std::vector<double> value(scalarField->GetNumberOfComponents());
+      for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
+        scalarField->GetTuple(criticalPoints_[j].first, value.data());
+        scalarArray->SetTuple(j, value.data());
+      }
+      output->GetPointData()->AddArray(scalarArray);
     }
   } else {
     for(SimplexId i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -108,6 +108,11 @@ public:
     return 1;
   }
 
+  template <typename VTK_TT>
+  int dispatch(ttk::Triangulation *triangulation,
+               void *scalarValues,
+               const ttk::SimplexId vertexNumber);
+
 protected:
   ttkScalarFieldCriticalPoints();
 

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -192,16 +192,14 @@ int ttkScalarFieldSmoother::doIt(vector<vtkDataSet *> &inputs,
   void *inputMaskPtr
     = (inputMaskField) ? inputMaskField->GetVoidPointer(0) : nullptr;
 
+  smoother_.setDimensionNumber(inputScalarField->GetNumberOfComponents());
+  smoother_.setInputDataPointer(inputScalarField->GetVoidPointer(0));
+  smoother_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
+  smoother_.setMaskDataPointer(inputMaskPtr);
+
   // calling the smoothing package
   switch(inputScalarField->GetDataType()) {
-
-    vtkTemplateMacro({
-      smoother_.setDimensionNumber(inputScalarField->GetNumberOfComponents());
-      smoother_.setInputDataPointer(inputScalarField->GetVoidPointer(0));
-      smoother_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
-      smoother_.setMaskDataPointer(inputMaskPtr);
-      smoother_.smooth<VTK_TT>(NumberOfIterations);
-    });
+    vtkTemplateMacro(smoother_.smooth<VTK_TT>(NumberOfIterations));
   }
 
   {

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -178,6 +178,18 @@ int ttkTopologicalSimplification::getOffsets(vtkDataSet *input) {
   return 0;
 }
 
+template <typename VTK_TT>
+int ttkTopologicalSimplification::dispatch() {
+  int ret = 0;
+  if(inputOffsets_->GetDataType() == VTK_INT) {
+    ret = topologicalSimplification_.execute<VTK_TT, int>();
+  }
+  if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
+    ret = topologicalSimplification_.execute<VTK_TT, vtkIdType>();
+  }
+  return ret;
+}
+
 int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
                                        vector<vtkDataSet *> &outputs) {
 
@@ -351,12 +363,7 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
 #endif
 
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro({
-      if(inputOffsets_->GetDataType() == VTK_INT)
-        ret = topologicalSimplification_.execute<VTK_TT TTK_COMMA int>();
-      if(inputOffsets_->GetDataType() == VTK_ID_TYPE)
-        ret = topologicalSimplification_.execute<VTK_TT TTK_COMMA vtkIdType>();
-    });
+    ttkTemplateMacro(ret = dispatch<VTK_TT>());
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -363,7 +363,7 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
 #endif
 
   switch(inputScalars_->GetDataType()) {
-    ttkTemplateMacro(ret = dispatch<VTK_TT>());
+    vtkTemplateMacro(ret = dispatch<VTK_TT>());
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -125,6 +125,9 @@ public:
   int getIdentifiers(vtkPointSet *input);
   int getOffsets(vtkDataSet *input);
 
+  template <typename VTK_TT>
+  int dispatch();
+
 protected:
   ttkTopologicalSimplification();
 

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -235,11 +235,10 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
     cout, "[ttkTrackingFromOverlap] Meshing nested tracking graph\n", infoMsg);
 
   switch(this->LabelDataType) {
-    vtkTemplateMacro({
+    vtkTemplateMacro(
       finalize<VTK_TT>(this->levelTimeNodesMap, this->levelTimeEdgesTMap,
                        this->timeLevelEdgesNMap, this->LabelDataType,
-                       this->GetLabelFieldName(), trackingGraph);
-    });
+                       this->GetLabelFieldName(), trackingGraph));
   }
 
   stringstream msg;
@@ -516,12 +515,10 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
           continue;
 
         switch(this->LabelDataType) {
-          vtkTemplateMacro({
-            this->trackingFromOverlap.computeNodes<VTK_TT>(
-              (float *)pointSet->GetPoints()->GetVoidPointer(0),
-              (VTK_TT *)labels->GetVoidPointer(0), nPoints,
-              timeNodesMap[timeOffset + t]);
-          });
+          vtkTemplateMacro(this->trackingFromOverlap.computeNodes<VTK_TT>(
+            (float *)pointSet->GetPoints()->GetVoidPointer(0),
+            (VTK_TT *)labels->GetVoidPointer(0), nPoints,
+            timeNodesMap[timeOffset + t]));
         }
       }
     }
@@ -593,15 +590,12 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
         continue;
 
       switch(this->LabelDataType) {
-        vtkTemplateMacro({
-          this->trackingFromOverlap.computeOverlap<VTK_TT>(
-            (float *)pointSet0->GetPoints()->GetVoidPointer(0),
-            (float *)pointSet1->GetPoints()->GetVoidPointer(0),
-            (VTK_TT *)labels0->GetVoidPointer(0),
-            (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
-
-            timeEdgesTMap[timeOffset + t - 1]);
-        });
+        vtkTemplateMacro(this->trackingFromOverlap.computeOverlap<VTK_TT>(
+          (float *)pointSet0->GetPoints()->GetVoidPointer(0),
+          (float *)pointSet1->GetPoints()->GetVoidPointer(0),
+          (VTK_TT *)labels0->GetVoidPointer(0),
+          (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
+          timeEdgesTMap[timeOffset + t - 1]));
       }
     }
   }
@@ -670,15 +664,12 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
         continue;
 
       switch(this->LabelDataType) {
-        vtkTemplateMacro({
-          this->trackingFromOverlap.computeOverlap<VTK_TT>(
-            (float *)pointSet0->GetPoints()->GetVoidPointer(0),
-            (float *)pointSet1->GetPoints()->GetVoidPointer(0),
-            (VTK_TT *)labels0->GetVoidPointer(0),
-            (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
-
-            levelEdgesNMap[l - 1]);
-        });
+        vtkTemplateMacro(this->trackingFromOverlap.computeOverlap<VTK_TT>(
+          (float *)pointSet0->GetPoints()->GetVoidPointer(0),
+          (float *)pointSet1->GetPoints()->GetVoidPointer(0),
+          (VTK_TT *)labels0->GetVoidPointer(0),
+          (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
+          levelEdgesNMap[l - 1]));
       }
     }
   }

--- a/core/vtk/ttkTriangulation/ttkWrapper.h
+++ b/core/vtk/ttkTriangulation/ttkWrapper.h
@@ -66,9 +66,6 @@
 #endif
 #endif
 
-#define ttkTemplateMacro(s) vtkTemplateMacro(s)
-#define ttkTemplate2Macro(s) vtkTemplate2Macro(s)
-
 #ifdef TTK_ENABLE_64BIT_IDS
 using ttkSimplexIdTypeArray = vtkIdTypeArray;
 #else

--- a/core/vtk/ttkTriangulation/ttkWrapper.h
+++ b/core/vtk/ttkTriangulation/ttkWrapper.h
@@ -66,21 +66,14 @@
 #endif
 #endif
 
-#ifndef _MSC_VER
-#define ttkTemplateMacro(s) vtkTemplateMacro((s))
-#define ttkTemplate2Macro(s) vtkTemplate2Macro((s))
-#else
-#define ttkTemplateMacro(s) vtkTemplateMacro(s);
-#define ttkTemplate2Macro(s) vtkTemplate2Macro(s);
-#endif
+#define ttkTemplateMacro(s) vtkTemplateMacro(s)
+#define ttkTemplate2Macro(s) vtkTemplate2Macro(s)
 
 #ifdef TTK_ENABLE_64BIT_IDS
 using ttkSimplexIdTypeArray = vtkIdTypeArray;
 #else
 using ttkSimplexIdTypeArray = vtkIntArray;
 #endif
-
-#define TTK_COMMA ,
 
 // Macros for vtkWrappers
 #define TTK_POLY_DATA_NEW(i, ouputInformation, dataTYpe)           \

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
@@ -211,47 +211,44 @@ int ttkUncertainDataEstimator::doIt(const std::vector<vtkDataSet *> &input,
 
   // Calling the executing package
   if(numFields > 0) {
+    UncertainDataEstimator uncertainDataEstimator;
+    uncertainDataEstimator.setWrapper(this);
+
+    uncertainDataEstimator.setVertexNumber(
+      outputBoundFields->GetNumberOfPoints());
+
+    uncertainDataEstimator.setNumberOfInputs(numFields);
+    for(int i = 0; i < numFields; i++) {
+      uncertainDataEstimator.setInputDataPointer(
+        i, inputScalarField[i]->GetVoidPointer(0));
+    }
+
+    uncertainDataEstimator.setComputeLowerBound(computeLowerBound_);
+    uncertainDataEstimator.setComputeUpperBound(computeUpperBound_);
+
+    uncertainDataEstimator.setOutputLowerBoundField(
+      outputLowerBoundScalarField_->GetVoidPointer(0));
+
+    uncertainDataEstimator.setOutputUpperBoundField(
+      outputUpperBoundScalarField_->GetVoidPointer(0));
+
+    uncertainDataEstimator.setOutputMeanField(
+      outputMeanField_->GetVoidPointer(0));
+
+    uncertainDataEstimator.setBinCount(binCount_);
+    for(int b = 0; b < binCount_; b++) {
+      uncertainDataEstimator.setOutputProbability(
+        b, outputProbabilityScalarField_[b]->GetPointer(0));
+    }
+
     switch(inputScalarField[0]->GetDataType()) {
+      vtkTemplateMacro(uncertainDataEstimator.execute<VTK_TT>());
+    }
 
-      vtkTemplateMacro({
-        UncertainDataEstimator uncertainDataEstimator;
-        uncertainDataEstimator.setWrapper(this);
-
-        uncertainDataEstimator.setVertexNumber(
-          outputBoundFields->GetNumberOfPoints());
-
-        uncertainDataEstimator.setNumberOfInputs(numFields);
-        for(int i = 0; i < numFields; i++) {
-          uncertainDataEstimator.setInputDataPointer(
-            i, inputScalarField[i]->GetVoidPointer(0));
-        }
-
-        uncertainDataEstimator.setComputeLowerBound(computeLowerBound_);
-        uncertainDataEstimator.setComputeUpperBound(computeUpperBound_);
-
-        uncertainDataEstimator.setOutputLowerBoundField(
-          outputLowerBoundScalarField_->GetVoidPointer(0));
-
-        uncertainDataEstimator.setOutputUpperBoundField(
-          outputUpperBoundScalarField_->GetVoidPointer(0));
-
-        uncertainDataEstimator.setOutputMeanField(
-          outputMeanField_->GetVoidPointer(0));
-
-        uncertainDataEstimator.setBinCount(binCount_);
-        for(int b = 0; b < binCount_; b++) {
-          uncertainDataEstimator.setOutputProbability(
-            b, outputProbabilityScalarField_[b]->GetPointer(0));
-        }
-
-        uncertainDataEstimator.execute<VTK_TT>();
-
-        for(int b = 0; b < binCount_; b++) {
-          stringstream name;
-          name << setprecision(8) << uncertainDataEstimator.getBinValue(b);
-          outputProbabilityScalarField_[b]->SetName(name.str().c_str());
-        }
-      });
+    for(int b = 0; b < binCount_; b++) {
+      stringstream name;
+      name << setprecision(8) << uncertainDataEstimator.getBinValue(b);
+      outputProbabilityScalarField_[b]->SetName(name.str().c_str());
     }
   }
 


### PR DESCRIPTION
This PR aims at fixing some portability issues arising around `vtkTemplateMacro` calls by outlining the macro arguments into proper functions.

Using macro directives (`#ifdef`, `#define`…) inside macro calls is not portable although accepted by GCC and Clang (with a lot of -Wpedantic warning though).

On the contrary, MSVC seems not to support those kind of constructs. This case arises with the use of the `vtkTemplateMacro` macro and its derivatives throughout `core/vtk` in the TTK codebase. The previous workaround was to write three times the same macro argument, one for GCC and Clang, and two for MSVC, like the following example:
```c++
vtkTemplateMacro({
#ifndef _MSC_VER
  foo();
#ifdef TTK_ENABLE_KAMIKAZE
  bar();
#endif 
#else // _MSC_VER
#ifdef TTK_ENABLE_KAMIKAZE
  foo();
  bar();
#else 
  foo();
#endif 
#endif // _MSC_VER
});
```
Outlining the macro argument will reduce code duplication while increasing portability:

```c++
void baz() {
  foo();
#ifdef TTK_ENABLE_KAMIKAZE
  bar();
#endif 
}
...
vtkTemplateMacro(baz());
```

The proposed changes will also allow us to get rid of the `ttkTemplateMacro` and `TTK_COMMA` macros.