### PR TITLE
Fix -Wshadow warnings in TTK

### DIFF
--- a/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
@@ -271,9 +271,9 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
 
   int numberOfMismatches = 0;
   for(int m = 0, ms = (int)matchings.size(); m < ms; ++m) {
-    matchingTuple t = matchings[m];
-    int i = transposeOriginal ? std::get<1>(t) : std::get<0>(t);
-    int j = transposeOriginal ? std::get<0>(t) : std::get<1>(t);
+    matchingTuple mt = matchings[m];
+    int i = transposeOriginal ? std::get<1>(mt) : std::get<0>(mt);
+    int j = transposeOriginal ? std::get<0>(mt) : std::get<1>(mt);
     // dataType val = std::get<2>(t);
 
     diagramTuple t1 = CTDiagram1[i];
@@ -308,11 +308,11 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
   dataType affectationD = d;
   d = wasserstein > 0
         ? pow(
-            d + addedMaxPersistence + addedMinPersistence + addedSadPersistence,
-            (1.0 / (double)wasserstein))
+          d + addedMaxPersistence + addedMinPersistence + addedSadPersistence,
+          (1.0 / (double)wasserstein))
         : std::max(
-            d, std::max(addedMaxPersistence,
-                        std::max(addedMinPersistence, addedSadPersistence)));
+          d, std::max(addedMaxPersistence,
+                      std::max(addedMinPersistence, addedSadPersistence)));
 
   {
     std::stringstream msg;

--- a/core/base/bottleneckDistance/GabowTarjanImpl.h
+++ b/core/base/bottleneckDistance/GabowTarjanImpl.h
@@ -256,11 +256,11 @@ void GabowTarjan::printCurrentMatching() {
 template <typename dataType>
 int GabowTarjan::run(std::vector<matchingTuple> &matchings) {
   // Compute distance.
-  double d = Distance<dataType>(1);
+  double dist = Distance<dataType>(1);
   {
     std::stringstream msg;
     ttk::Debug m;
-    msg << "[Gabow-Tarjan] Computed distance " << d << std::endl;
+    msg << "[Gabow-Tarjan] Computed distance " << dist << std::endl;
     m.dMsg(std::cout, msg.str(), ttk::Debug::timeMsg);
   }
 

--- a/core/base/cinemaQuery/CinemaQuery.cpp
+++ b/core/base/cinemaQuery/CinemaQuery.cpp
@@ -5,7 +5,6 @@
 
 // Process a row of a query resultCSV and append it to a string
 static int processRow(void *data, int argc, char **argv, char **azColName) {
-  int i;
 
   // Get output string as reference
   string &resultCSV = *((string *)data);
@@ -18,7 +17,7 @@ static int processRow(void *data, int argc, char **argv, char **azColName) {
   }
 
   // Append row content to string
-  for(i = 0; i < argc; i++)
+  for(int i = 0; i < argc; i++)
     resultCSV += (i > 0 ? "," : "") + string(argv[i]);
   resultCSV += "\n";
 

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -175,8 +175,8 @@ namespace ttk {
       std::stringstream msg;
       msg << "[Os] Could not open directory `" << directoryName << "'..."
           << std::endl;
-      Debug d;
-      d.dMsg(std::cerr, msg.str(), 0);
+      Debug dbg;
+      dbg.dMsg(std::cerr, msg.str(), 0);
     } else {
       struct dirent *dirEntry;
       while((dirEntry = readdir(d)) != NULL) {

--- a/core/base/continuousScatterPlot/ContinuousScatterPlot.h
+++ b/core/base/continuousScatterPlot/ContinuousScatterPlot.h
@@ -426,13 +426,13 @@ int ttk::ContinuousScatterPlot::execute() const {
           const double o[3]{scalarMin_[0] + i * sampling[0],
                             scalarMin_[1] + j * sampling[1], 1};
           for(unsigned int k = 0; k < triangles.size(); ++k) {
-            const auto &triangle = triangles[k];
+            const auto &tr = triangles[k];
 
             // get triangle info
             double p0[3];
             if(isInTriangle) {
-              p0[0] = scalars1[triangle[0]];
-              p0[1] = scalars2[triangle[0]];
+              p0[0] = scalars1[tr[0]];
+              p0[1] = scalars2[tr[0]];
             } else {
               p0[0] = imaginaryPosition[0];
               p0[1] = imaginaryPosition[1];
@@ -440,9 +440,9 @@ int ttk::ContinuousScatterPlot::execute() const {
             p0[2] = 0;
 
             const double p1[3]{
-              (double)scalars1[triangle[1]], (double)scalars2[triangle[1]], 0};
+              (double)scalars1[tr[1]], (double)scalars2[tr[1]], 0};
             const double p2[3]{
-              (double)scalars1[triangle[2]], (double)scalars2[triangle[2]], 0};
+              (double)scalars1[tr[2]], (double)scalars2[tr[2]], 0};
             const double e1[3]{p1[0] - p0[0], p1[1] - p0[1], 0};
             const double e2[3]{p2[0] - p0[0], p2[1] - p0[1], 0};
 

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -176,8 +176,8 @@ namespace ttk {
       // .....................{
 
       template <typename scalarType>
-      inline const scalarType &getValue(const SimplexId &idNode) const {
-        return (((scalarType *)scalars_->values))[idNode];
+      inline const scalarType &getValue(const SimplexId &nodeId) const {
+        return (((scalarType *)scalars_->values))[nodeId];
       }
 
       template <typename scalarType>

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -349,8 +349,8 @@ namespace ttk {
       // scalar
 
       template <typename scalarType>
-      inline const scalarType &getValue(SimplexId idNode) const {
-        return (((scalarType *)scalars_->values))[idNode];
+      inline const scalarType &getValue(SimplexId nodeId) const {
+        return (((scalarType *)scalars_->values))[nodeId];
       }
 
       template <typename scalarType>

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
@@ -740,11 +740,11 @@ int MandatoryCriticalPoints::computePlanarLayout(const TreeType &treeType) {
     msg << endl;
     dMsg(cout, msg.str(), advancedInfoMsg);
     for(int i = 0; i < numberOfPoints; i++) {
-      stringstream msg;
-      msg << "  (" << i << ") :"
-          << "  x = " << (*xCoord)[i] << "  y = " << (*yCoord)[i];
-      msg << endl;
-      dMsg(cout, msg.str(), advancedInfoMsg);
+      stringstream msg2;
+      msg2 << "  (" << i << ") :"
+           << "  x = " << (*xCoord)[i] << "  y = " << (*yCoord)[i];
+      msg2 << endl;
+      dMsg(cout, msg2.str(), advancedInfoMsg);
     }
   }
 
@@ -944,21 +944,21 @@ int MandatoryCriticalPoints::enumerateMandatoryExtrema(
       queue<int> superArcQueue;
       superArcQueue.push(rootSuperArcId);
       while(isMandatory && (!superArcQueue.empty())) {
-        int superArcId = superArcQueue.front();
+        int spaId = superArcQueue.front();
         superArcQueue.pop();
-        if(isSuperArcAlreadyVisited[superArcId]) {
+        if(isSuperArcAlreadyVisited[spaId]) {
           isMandatory = false;
         } else {
-          int downNodeId = secondTree->getSuperArc(superArcId)->getDownNodeId();
+          int downNodeId = secondTree->getSuperArc(spaId)->getDownNodeId();
           int numberOfDownSuperArcs
             = secondTree->getNode(downNodeId)->getNumberOfDownSuperArcs();
           if(numberOfDownSuperArcs > 0) {
-            for(int i = 0; i < numberOfDownSuperArcs; i++) {
+            for(int j = 0; j < numberOfDownSuperArcs; j++) {
               superArcQueue.push(
-                secondTree->getNode(downNodeId)->getDownSuperArcId(i));
+                secondTree->getNode(downNodeId)->getDownSuperArcId(j));
             }
           }
-          subTreeSuperArcId.push_back(superArcId);
+          subTreeSuperArcId.push_back(spaId);
         }
       }
     }
@@ -988,11 +988,11 @@ int MandatoryCriticalPoints::enumerateMandatoryExtrema(
       }
       // Mark the super arc from the root of the sub tree to the global root
       int upNodeId = secondTree->getSuperArc(rootSuperArcId)->getUpNodeId();
-      int superArcId = secondTree->getNode(upNodeId)->getUpSuperArcId(0);
-      while((superArcId != -1) && !(isSuperArcAlreadyVisited[superArcId])) {
-        isSuperArcAlreadyVisited[superArcId] = true;
-        upNodeId = secondTree->getSuperArc(superArcId)->getUpNodeId();
-        superArcId = secondTree->getNode(upNodeId)->getUpSuperArcId(0);
+      int spaId = secondTree->getNode(upNodeId)->getUpSuperArcId(0);
+      while((spaId != -1) && !(isSuperArcAlreadyVisited[spaId])) {
+        isSuperArcAlreadyVisited[spaId] = true;
+        upNodeId = secondTree->getSuperArc(spaId)->getUpNodeId();
+        spaId = secondTree->getNode(upNodeId)->getUpSuperArcId(0);
       }
     }
 
@@ -1591,13 +1591,13 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
       = lowerTree->getNode(nodeId)->getVertexId();
     for(unsigned int j = 0; j < lowComponent[i].size(); j++) {
       // First saddle
-      int nodeId = lowerSaddleList[lowComponent[i][j]];
-      double nodeScalar = lowerTree->getNodeScalar(nodeId);
+      int nId = lowerSaddleList[lowComponent[i][j]];
+      double nodeScalar = lowerTree->getNodeScalar(nId);
       double refScalar = 0;
       lowerTree->getVertexScalar((*mandatorySaddleVertex)[i].first, refScalar);
       if(nodeScalar < refScalar) {
         (*mandatorySaddleVertex)[i].first
-          = lowerTree->getNode(nodeId)->getVertexId();
+          = lowerTree->getNode(nId)->getVertexId();
       }
     }
 
@@ -1615,13 +1615,13 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
       = upperTree->getNode(nodeId)->getVertexId();
     for(unsigned int j = 0; j < uppComponent[i].size(); j++) {
       // First saddle
-      int nodeId = upperSaddleList[uppComponent[i][j]];
-      double nodeScalar = upperTree->getNodeScalar(nodeId);
+      int nId = upperSaddleList[uppComponent[i][j]];
+      double nodeScalar = upperTree->getNodeScalar(nId);
       double refScalar = 0;
       upperTree->getVertexScalar((*mandatorySaddleVertex)[i].second, refScalar);
       if(nodeScalar > refScalar) {
         (*mandatorySaddleVertex)[i].second
-          = upperTree->getNode(nodeId)->getVertexId();
+          = upperTree->getNode(nId)->getVertexId();
       }
     }
   }
@@ -1697,20 +1697,20 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
   }
   if(debugLevel_ > advancedInfoMsg) {
     stringstream title;
-    stringstream pointType;
+    stringstream pointTypeMsg;
     title << "[MandatoryCriticalPoints] List of ";
     if(lowerTree->isJoinTree()) {
       title << "join saddles : ";
-      pointType << "Join Saddle";
+      pointTypeMsg << "Join Saddle";
     } else {
       title << "split saddles : ";
-      pointType << "Split Saddle";
+      pointTypeMsg << "Split Saddle";
     }
     title << endl;
     dMsg(cout, title.str(), advancedInfoMsg);
     for(int i = 0; i < (int)mandatorySaddleVertex->size(); i++) {
       stringstream msg;
-      msg << "  -> " << pointType.str() << " (";
+      msg << "  -> " << pointTypeMsg.str() << " (";
       msg << setw(3) << right << i << ")";
       msg << "  Vertices  <";
       msg << setw(9) << right << (*mandatorySaddleVertex)[i].first << " ; ";
@@ -1944,9 +1944,9 @@ int MandatoryCriticalPoints::simplify(const double &normalizedThreshold,
     dMsg(cout, msg.str(), advancedInfoMsg);
     for(size_t i = 0; i < extremumSimplified->size(); i++) {
       if((*extremumSimplified)[i]) {
-        stringstream msg;
-        msg << "    (" << i << ")" << endl;
-        dMsg(cout, msg.str(), advancedInfoMsg);
+        stringstream msg2;
+        msg2 << "    (" << i << ")" << endl;
+        dMsg(cout, msg2.str(), advancedInfoMsg);
       }
     }
   }
@@ -1973,9 +1973,9 @@ int MandatoryCriticalPoints::simplify(const double &normalizedThreshold,
     dMsg(cout, msg.str(), advancedInfoMsg);
     for(size_t i = 0; i < saddleSimplified->size(); i++) {
       if((*saddleSimplified)[i]) {
-        stringstream msg;
-        msg << "    (" << i << ")" << endl;
-        dMsg(cout, msg.str(), advancedInfoMsg);
+        stringstream msg2;
+        msg2 << "    (" << i << ")" << endl;
+        dMsg(cout, msg2.str(), advancedInfoMsg);
       }
     }
   }

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -732,8 +732,8 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
           outputSeparatrices2_cells_->push_back(vertexNumber);
 
           float point[3];
-          for(SimplexId i = 0; i < vertexNumber; ++i) {
-            const SimplexId tetraId = polygon[i];
+          for(SimplexId j = 0; j < vertexNumber; ++j) {
+            const SimplexId tetraId = polygon[j];
             discreteGradient_.getCellIncenter(dcg::Cell(3, tetraId), point);
 
             if(isVisited[tetraId] == -1) {

--- a/core/base/planarGraphLayout/PlanarGraphLayout.cpp
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.cpp
@@ -1,1 +1,65 @@
-// This file needs to exist for the Mac compiler
+#include <PlanarGraphLayout.h>
+
+#if TTK_ENABLE_GRAPHVIZ
+#include <graphviz/cgraph.h>
+#include <graphviz/gvc.h>
+#endif
+
+// Compute Dot Layout
+int ttk::PlanarGraphLayout::computeDotLayout(
+  // Input
+  const vector<size_t> &nodeIndicies,
+  const string &dotString,
+
+  // Output
+  float *layout) const {
+#if TTK_ENABLE_GRAPHVIZ
+  Timer t;
+
+  dMsg(cout, "[ttkPlanarGraphLayout] Computing layout ... ", timeMsg);
+
+  // ---------------------------------------------------------
+  // Init GraphViz
+  // ---------------------------------------------------------
+  Agraph_t *G = agmemread(dotString.data());
+  GVC_t *gvc = gvContext();
+  gvLayout(gvc, G, "dot");
+
+  // ---------------------------------------------------------
+  // Get layout data from GraphViz
+  // ---------------------------------------------------------
+  for(auto i : nodeIndicies) {
+    Agnode_t *n = agnode(G, const_cast<char *>(to_string(i).data()), 0);
+    if(n != nullptr) {
+      auto &coord = ND_coord(n);
+      size_t offset = i * 2;
+      layout[offset] = coord.x / 72; // points to inches
+      layout[offset + 1] = coord.y / 72; // points to inches
+    }
+  }
+
+  // ---------------------------------------------------------
+  // Free GraphViz memory
+  // ---------------------------------------------------------
+  gvFreeLayout(gvc, G);
+  agclose(G);
+  gvFreeContext(gvc);
+
+  // ---------------------------------------------------------
+  // Print status
+  // ---------------------------------------------------------
+  {
+    stringstream msg;
+    msg << "done (" << t.getElapsedTime() << " s)" << endl;
+    dMsg(cout, msg.str(), timeMsg);
+  }
+
+  return 1;
+#else
+  dMsg(cout,
+       "[ttkPlanarGraphLayout] ERROR: This filter requires GraphViz to compute "
+       "a layout.\n",
+       fatalMsg);
+  return 0;
+#endif
+}

--- a/core/base/reebSpace/ReebSpace.cpp
+++ b/core/base/reebSpace/ReebSpace.cpp
@@ -590,14 +590,14 @@ int ReebSpace::compute3sheets(vector<vector<vector<SimplexId>>> &tetTriangles) {
                     SimplexId y = tetTriangles[tetId][m][1];
                     SimplexId z = tetTriangles[tetId][m][2];
 
-                    FiberSurface::Triangle *t
+                    FiberSurface::Triangle *tr
                       = &(originalData_.sheet2List_[x].triangleList_[y][z]);
 
                     bool cuttingTriangle = false;
                     for(int n = 0; n < 3; n++) {
                       FiberSurface::Vertex *v
                         = &(originalData_.sheet2List_[x]
-                              .vertexList_[y][t->vertexIds_[n]]);
+                              .vertexList_[y][tr->vertexIds_[n]]);
 
                       if(((v->meshEdge_.first == vertexId)
                           && (v->meshEdge_.second == otherVertexId))
@@ -611,7 +611,7 @@ int ReebSpace::compute3sheets(vector<vector<vector<SimplexId>>> &tetTriangles) {
 
                     if(cuttingTriangle) {
 
-                      SimplexId polygonId = t->polygonEdgeId_;
+                      SimplexId polygonId = tr->polygonEdgeId_;
                       SimplexId edgeId = jacobi2edges_[polygonId];
                       if(originalData_.edgeTypes_[edgeId] == 1) {
                         // this is a saddle Jacobi edge

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -476,7 +476,7 @@ inline int ttk::ReebSpace::execute() {
   // post-process for further interaction
   if((totalArea_ == -1) || (totalVolume_ == -1) || (totalHyperVolume_ == -1)) {
 
-    Timer t;
+    Timer tm;
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
@@ -495,7 +495,7 @@ inline int ttk::ReebSpace::execute() {
     {
       std::stringstream msg;
       msg << "[ReebSpace] Geometrical measures computed in "
-          << t.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))"
+          << tm.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))"
           << std::endl;
       dMsg(std::cout, msg.str(), timeMsg);
     }

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -495,11 +495,10 @@ int ZeroSkeleton::buildVertexNeighbors(
   }
 
   if(!localEdgeList->size()) {
-    OneSkeleton oneSkeleton;
-    oneSkeleton.setDebugLevel(debugLevel_);
-    oneSkeleton.setThreadNumber(threadNumber_);
-    oneSkeleton.buildEdgeList(
-      vertexNumber, cellNumber, cellArray, *localEdgeList);
+    OneSkeleton osk;
+    osk.setDebugLevel(debugLevel_);
+    osk.setThreadNumber(threadNumber_);
+    osk.buildEdgeList(vertexNumber, cellNumber, cellArray, *localEdgeList);
   }
 
   for(SimplexId i = 0; i < (SimplexId)localEdgeList->size(); i++) {

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -204,9 +204,9 @@ double ttk::TopologicalCompression::ReadDouble(FILE *fm) {
   int ret = (int)std::fread(&d, sizeof(double), 1, fm);
   if(!ret) {
     std::stringstream msg;
-    ttk::Debug d;
+    ttk::Debug dbg;
     msg << "[TopologicalCompression] Error reading double!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
+    dbg.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
   }
   return d;
 }
@@ -215,9 +215,9 @@ void ttk::TopologicalCompression::WriteDouble(FILE *fm, double d) {
   int ret = (int)std::fwrite(&d, sizeof(double), 1, fm);
   if(!ret) {
     std::stringstream msg;
-    ttk::Debug d;
+    ttk::Debug dbg;
     msg << "[TopologicalCompression] Error writing double!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
+    dbg.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
   }
 }
 

--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -50,26 +50,17 @@ typedef boost::variant<double,
 typedef float sizeType;
 
 struct Node {
-  labelTypeVariant label;
-  sizeType size;
-  float x;
-  float y;
-  float z;
+  labelTypeVariant label{};
+  sizeType size{};
+  float x{};
+  float y{};
+  float z{};
 
-  idType branchID;
-  idType maxPredID;
-  idType maxSuccID;
+  idType branchID{-1};
+  idType maxPredID{-1};
+  idType maxSuccID{-1};
 
-  Node(sizeType size = 0,
-       float x = 0,
-       float y = 0,
-       float z = 0,
-       idType branchID = -1,
-       idType maxPredID = -1,
-       idType maxSuccID = -1)
-    : size(size), x(x), y(y), z(z), branchID(branchID), maxPredID(maxPredID),
-      maxSuccID(maxSuccID) {
-  }
+  Node() = default;
 };
 
 typedef vector<idType> Edges; // [index0, index1, overlap, branch,...]
@@ -78,7 +69,7 @@ typedef vector<Node> Nodes;
 struct CoordinateComparator {
   const float *coordinates;
 
-  CoordinateComparator(const float *coordinates) : coordinates(coordinates){};
+  CoordinateComparator(const float *coords) : coordinates(coords){};
 
   inline bool operator()(const size_t &i, const size_t &j) {
     size_t ic = i * 3;
@@ -120,7 +111,7 @@ namespace ttk {
     int computeBranches(vector<Edges> &timeEdgesMap,
                         vector<Nodes> &timeNodesMap) const {
       dMsg(cout, "[ttkTrackingFromOverlap] Computing branches  ... ", timeMsg);
-      Timer t;
+      Timer tm;
 
       size_t nT = timeNodesMap.size();
 
@@ -209,7 +200,7 @@ namespace ttk {
       }
 
       stringstream msg;
-      msg << "done (" << t.getElapsedTime() << " s)." << endl;
+      msg << "done (" << tm.getElapsedTime() << " s)." << endl;
       dMsg(cout, msg.str(), timeMsg);
 
       return 1;
@@ -347,8 +338,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
      >0: p0Coords < p1Coords
      <0: p0Coords > p1Coords
   */
-  auto compare = [](const float *pointCoordinates0,
-                    const float *pointCoordinates1, size_t p0, size_t p1) {
+  auto compare = [&](size_t p0, size_t p1) {
     size_t p0CoordIndex = p0 * 3;
     size_t p1CoordIndex = p1 * 3;
 
@@ -376,8 +366,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
     size_t pointIndex1 = sortedIndicies1[j];
 
     // Determine point configuration
-    int c
-      = compare(pointCoordinates0, pointCoordinates1, pointIndex0, pointIndex1);
+    int c = compare(pointIndex0, pointIndex1);
 
     if(c == 0) { // Points have same coordinates -> track
       labelType label0 = pointLabels0[pointIndex0];

--- a/core/functions.cmake
+++ b/core/functions.cmake
@@ -9,7 +9,7 @@ function(ttk_set_compile_options library)
   # compilation flags
   if (NOT MSVC)
     # GCC and Clang
-    target_compile_options(${library} PRIVATE -Wall)
+    target_compile_options(${library} PRIVATE -Wall -Wshadow)
   else()
     # MSVC
     target_compile_options(${library} PRIVATE /W4)

--- a/core/vtk/ttkAddFieldData/ttkAddFieldData.cpp
+++ b/core/vtk/ttkAddFieldData/ttkAddFieldData.cpp
@@ -178,22 +178,22 @@ int ttkAddFieldData::RequestData(vtkInformation *request,
       timeMsg);
 
     // Check if second input exists
-    auto inInfo = inputVector[1]->GetInformationObject(0);
-    if(inInfo) {
+    auto inInfoObj = inputVector[1]->GetInformationObject(0);
+    if(inInfoObj) {
       // Vector that stores all vtkFieldData sources
       vector<vtkFieldData *> candidates(3);
 
       // Get Second Input
-      auto input = inInfo->Get(vtkDataObject::DATA_OBJECT());
+      auto input2 = inInfoObj->Get(vtkDataObject::DATA_OBJECT());
 
       // If second input exists add its field data to candidates
-      if(input) {
-        candidates[2] = input->GetFieldData();
+      if(input2) {
+        candidates[2] = input2->GetFieldData();
 
         // If second input is a vtkDataSet then also add point/cell data to
         // candidates
-        if(input->IsA("vtkDataSet")) {
-          auto inputAsDataSet = vtkDataSet::SafeDownCast(input);
+        if(input2->IsA("vtkDataSet")) {
+          auto inputAsDataSet = vtkDataSet::SafeDownCast(input2);
           candidates[0] = (vtkFieldData *)inputAsDataSet->GetPointData();
           candidates[1] = (vtkFieldData *)inputAsDataSet->GetCellData();
         }

--- a/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
+++ b/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
@@ -49,8 +49,8 @@ int ttkBlockAggregator::RequestData(vtkInformation *request,
   }
 
   // Get Input
-  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
-  auto firstInput = inInfo->Get(vtkDataObject::DATA_OBJECT());
+  vtkInformation *inInfoObj = inputVector[0]->GetInformationObject(0);
+  auto firstInput = inInfoObj->Get(vtkDataObject::DATA_OBJECT());
 
   // Get iteration information
   auto iterationInformation = vtkDoubleArray::SafeDownCast(

--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
@@ -464,8 +464,8 @@ int ttkBottleneckDistance::augmentPersistenceDiagrams(
   const std::vector<diagramTuple> &diagram1,
   const std::vector<diagramTuple> &diagram2,
   const std::vector<matchingTuple> &matchings,
-  vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram1_,
-  vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram2_) {
+  vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram1,
+  vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram2) {
 
   auto diagramSize1 = (BIdVertex)diagram1.size();
   auto diagramSize2 = (BIdVertex)diagram2.size();
@@ -494,12 +494,12 @@ int ttkBottleneckDistance::augmentPersistenceDiagrams(
 
     // Last cell = junction
     if(diagramSize1
-       < CTPersistenceDiagram1_->GetCellData()->GetNumberOfTuples()) {
+       < CTPersistenceDiagram1->GetCellData()->GetNumberOfTuples()) {
       matchingIdentifiers1->InsertTuple1(diagramSize1, -1);
       matchingIdentifiers1->InsertTuple1(diagramSize1 + 1, -1);
     }
     if(diagramSize2
-       < CTPersistenceDiagram2_->GetCellData()->GetNumberOfTuples()) {
+       < CTPersistenceDiagram2->GetCellData()->GetNumberOfTuples()) {
       matchingIdentifiers2->InsertTuple1(diagramSize2, -1);
       matchingIdentifiers2->InsertTuple1(diagramSize2 + 1, -1);
     }
@@ -515,8 +515,8 @@ int ttkBottleneckDistance::augmentPersistenceDiagrams(
       pairingIndex++;
     }
 
-    CTPersistenceDiagram1_->GetCellData()->AddArray(matchingIdentifiers1);
-    CTPersistenceDiagram2_->GetCellData()->AddArray(matchingIdentifiers2);
+    CTPersistenceDiagram1->GetCellData()->AddArray(matchingIdentifiers1);
+    CTPersistenceDiagram2->GetCellData()->AddArray(matchingIdentifiers2);
   }
 
   return 0;

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -48,7 +48,7 @@ vtkStandardNewMacro(ttkCinemaImaging)
     dMsg(cout, msg.str(), infoMsg);
   }
 
-  Memory m;
+  Memory mem;
   Timer t;
   double t0 = 0;
 
@@ -143,11 +143,8 @@ vtkStandardNewMacro(ttkCinemaImaging)
     auto valuePassCollection = vtkSmartPointer<vtkRenderPassCollection>::New();
 
     // Lambda function that generates vtkValuePasses for Point or Cell Data
-    auto addValuePasses = [](
-                            vtkRenderPassCollection *valuePassCollection,
-                            vector<pair<vtkValuePass *, string>> &valuePassList,
-                            vtkFieldData *data,
-                            int pointDataFlag // 0: Point Data, 1: Cell Data
+    auto addValuePasses = [&](vtkFieldData *data,
+                              int pointDataFlag // 0: Point Data, 1: Cell Data
                           ) {
       double minmax[2];
       size_t n = data->GetNumberOfArrays();
@@ -176,10 +173,10 @@ vtkStandardNewMacro(ttkCinemaImaging)
     };
 
     // Add Point Data Passes
-    addValuePasses(valuePassCollection, valuePassList, poly->GetPointData(), 0);
+    addValuePasses(poly->GetPointData(), 0);
 
     // Add Cell Data Passes
-    addValuePasses(valuePassCollection, valuePassList, poly->GetCellData(), 1);
+    addValuePasses(poly->GetCellData(), 1);
 
     // Build Render Sequence
     {
@@ -366,7 +363,7 @@ vtkStandardNewMacro(ttkCinemaImaging)
     msg << "[ttkCinemaImaging] " << n << " Images rendered" << endl;
     msg << "[ttkCinemaImaging]   time: " << (t.getElapsedTime() - t0) << " s"
         << endl;
-    msg << "[ttkCinemaImaging] memory: " << m.getElapsedUsage() << " MB"
+    msg << "[ttkCinemaImaging] memory: " << mem.getElapsedUsage() << " MB"
         << endl;
     dMsg(cout, msg.str(), timeMsg);
   }

--- a/core/vtk/ttkCinemaLayout/ttkCinemaLayout.cpp
+++ b/core/vtk/ttkCinemaLayout/ttkCinemaLayout.cpp
@@ -47,8 +47,6 @@ vtkStandardNewMacro(ttkCinemaLayout)
   size_t nColumns = nRows == 0 ? ceil(sqrt(nBlocks))
                                : (nBlocks % nRows) == 0 ? nBlocks / nRows
                                                         : ceil(nBlocks / nRows);
-  size_t i = 0;
-  double y = 0;
 
   double width = 0;
   double height = 0;
@@ -72,6 +70,8 @@ vtkStandardNewMacro(ttkCinemaLayout)
   width += width * (this->GetColumnGap() / 100);
   height += height * (this->GetRowGap() / 100);
 
+  size_t i = 0;
+  double y = 0;
   while(i < nBlocks) {
     for(size_t x = 0; x < nColumns && i < nBlocks; x++) {
 

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -27,7 +27,7 @@ vtkStandardNewMacro(ttkCinemaProductReader)
   }
 
   Timer t;
-  Memory m;
+  Memory mem;
 
   // Prepare Input and Output
   vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
@@ -135,8 +135,8 @@ vtkStandardNewMacro(ttkCinemaProductReader)
         << endl;
     msg << "[ttkCinemaProductReader]   time: " << t.getElapsedTime() << " s."
         << endl;
-    msg << "[ttkCinemaProductReader] memory: " << m.getElapsedUsage() << " MB."
-        << endl;
+    msg << "[ttkCinemaProductReader] memory: " << mem.getElapsedUsage()
+        << " MB." << endl;
     dMsg(cout, msg.str(), timeMsg);
   }
 

--- a/core/vtk/ttkEndFor/ttkEndFor.cpp
+++ b/core/vtk/ttkEndFor/ttkEndFor.cpp
@@ -40,8 +40,8 @@ int ttkEndFor::RequestData(vtkInformation *request,
   dMsg(cout, divider + "\n", infoMsg);
 
   // Get Input
-  vtkInformation *inInfo = inputVector[1]->GetInformationObject(0);
-  auto inputFor = inInfo->Get(vtkDataObject::DATA_OBJECT());
+  vtkInformation *inInfo0 = inputVector[1]->GetInformationObject(0);
+  auto inputFor = inInfo0->Get(vtkDataObject::DATA_OBJECT());
 
   // Get iteration information
   auto iterationInformation = vtkDoubleArray::SafeDownCast(
@@ -64,8 +64,8 @@ int ttkEndFor::RequestData(vtkInformation *request,
     {
       stringstream msg;
       msg << "[ttkEndFor] Next Iteration: " << this->nextIndex << "   ";
-      size_t n = divider.length() - msg.str().length();
-      for(size_t i = 0; i < n; i++)
+      size_t padd = divider.length() - msg.str().length();
+      for(size_t i = 0; i < padd; i++)
         msg << "\\";
       msg << endl;
       dMsg(cout, msg.str(), infoMsg);
@@ -83,8 +83,8 @@ int ttkEndFor::RequestData(vtkInformation *request,
     }
 
     // Copy input to output
-    vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
-    auto input = inInfo->Get(vtkDataObject::DATA_OBJECT());
+    vtkInformation *inInfo1 = inputVector[0]->GetInformationObject(0);
+    auto input = inInfo1->Get(vtkDataObject::DATA_OBJECT());
 
     vtkInformation *outInfo = outputVector->GetInformationObject(0);
     auto output = outInfo->Get(vtkDataObject::DATA_OBJECT());

--- a/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
+++ b/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
@@ -68,11 +68,11 @@ vtkStandardNewMacro(ttkIcoSphere)
 
     size_t q = 0;
     for(size_t i = 0; i < triangles.size(); i++) {
-      auto &t = triangles[i];
+      auto &tr = triangles[i];
       cellIds[q++] = 3;
-      cellIds[q++] = (vtkIdType)get<0>(t);
-      cellIds[q++] = (vtkIdType)get<1>(t);
-      cellIds[q++] = (vtkIdType)get<2>(t);
+      cellIds[q++] = get<0>(tr);
+      cellIds[q++] = get<1>(tr);
+      cellIds[q++] = get<2>(tr);
     }
 
     auto cellArray = vtkSmartPointer<vtkCellArray>::New();

--- a/core/vtk/ttkManifoldCheck/ttkManifoldCheck.cpp
+++ b/core/vtk/ttkManifoldCheck/ttkManifoldCheck.cpp
@@ -8,7 +8,7 @@ vtkStandardNewMacro(ttkManifoldCheck)
   int ttkManifoldCheck::doIt(vector<vtkDataSet *> &inputs,
                              vector<vtkDataSet *> &outputs) {
 
-  Memory m;
+  Memory mem;
 
   vtkDataSet *input = inputs[0];
   vtkDataSet *output = outputs[0];
@@ -34,9 +34,11 @@ vtkStandardNewMacro(ttkManifoldCheck)
     &triangleLinkComponentNumber_);
   manifoldCheck_.execute();
 
-  stringstream msg;
-  msg << "[ttkManifoldCheck] Preparing VTK output..." << endl;
-  dMsg(cout, msg.str(), Debug::timeMsg);
+  {
+    stringstream msg;
+    msg << "[ttkManifoldCheck] Preparing VTK output..." << endl;
+    dMsg(cout, msg.str(), Debug::timeMsg);
+  }
 
   vtkSmartPointer<ttkSimplexIdTypeArray> vertexPointArray
     = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
@@ -260,8 +262,8 @@ vtkStandardNewMacro(ttkManifoldCheck)
 
   {
     stringstream msg;
-    msg << "[ttkManifoldCheck] Memory usage: " << m.getElapsedUsage() << " MB."
-        << endl;
+    msg << "[ttkManifoldCheck] Memory usage: " << mem.getElapsedUsage()
+        << " MB." << endl;
     dMsg(cout, msg.str(), memoryMsg);
   }
 

--- a/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.cpp
+++ b/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.cpp
@@ -60,14 +60,14 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
       = vtkSmartPointer<vtkGenericCell>::New();
     tmpGrid->GetCell(0, threadCell);
     double value = 0;
-    for(int i = 0; i < tmpGrid->GetPointData()->GetNumberOfArrays(); i++) {
-      if(tmpGrid->GetPointData()->GetArray(i)->GetNumberOfComponents() == 1) {
-        tmpGrid->GetPointData()->GetArray(i)->GetTuple(0, &value);
+    for(int j = 0; j < tmpGrid->GetPointData()->GetNumberOfArrays(); j++) {
+      if(tmpGrid->GetPointData()->GetArray(j)->GetNumberOfComponents() == 1) {
+        tmpGrid->GetPointData()->GetArray(j)->GetTuple(0, &value);
       }
     }
-    for(int i = 0; i < tmpGrid->GetCellData()->GetNumberOfArrays(); i++) {
-      if(tmpGrid->GetCellData()->GetArray(i)->GetNumberOfComponents() == 1) {
-        tmpGrid->GetCellData()->GetArray(i)->GetTuple(0, &value);
+    for(int j = 0; j < tmpGrid->GetCellData()->GetNumberOfArrays(); j++) {
+      if(tmpGrid->GetCellData()->GetArray(j)->GetNumberOfComponents() == 1) {
+        tmpGrid->GetCellData()->GetArray(j)->GetTuple(0, &value);
       }
     }
 
@@ -121,13 +121,13 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
           newPoints[j][pointCounter][l] = p[l];
 
         // copy the point data
-        double value;
+        double val;
         for(int l = 0; l < tmpGrid->GetPointData()->GetNumberOfArrays(); l++) {
           if(tmpGrid->GetPointData()->GetArray(l)->GetNumberOfComponents()
              == 1) {
             tmpGrid->GetPointData()->GetArray(l)->GetTuple(
-              cell->GetPointId(k), &value);
-            newPointData[j][pointCounter][l] = value;
+              cell->GetPointId(k), &val);
+            newPointData[j][pointCounter][l] = val;
           }
         }
 
@@ -138,7 +138,7 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
 
       vector<SimplexId> edgeMap(cell->GetNumberOfEdges());
       // 1) create the edge list and create one new vertex per edge
-      for(int k = 0; k < (int)cell->GetNumberOfEdges(); k++) {
+      for(int k = 0; k < cell->GetNumberOfEdges(); k++) {
 
         vtkCell *edge = cell->GetEdge(k);
         double p0[3], p1[3];
@@ -170,7 +170,7 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
 
       // 2) create the face list and create one new vertex per face
       vector<SimplexId> faceMap(cell->GetNumberOfFaces());
-      for(int k = 0; k < (int)cell->GetNumberOfFaces(); k++) {
+      for(int k = 0; k < cell->GetNumberOfFaces(); k++) {
 
         vtkCell *face = cell->GetFace(k);
         newPoints[j][pointCounter].resize(3, 0);
@@ -183,16 +183,16 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
           }
 
           // take care of the point data
-          double value = 0;
+          double val = 0;
           for(int m = 0; m < tmpGrid->GetPointData()->GetNumberOfArrays();
               m++) {
 
             if(tmpGrid->GetPointData()->GetArray(m)->GetNumberOfComponents()
                == 1) {
               tmpGrid->GetPointData()->GetArray(m)->GetTuple(
-                face->GetPointId(l), &value);
+                face->GetPointId(l), &val);
               newPointData[j][pointCounter][m]
-                += (1 / ((double)face->GetNumberOfPoints())) * value;
+                += (1 / ((double)face->GetNumberOfPoints())) * val;
             }
           }
         }
@@ -215,15 +215,15 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
           newPoints[j][pointCounter][l] += p[l];
 
         // take care of the point data
-        double value = 0;
+        double val = 0;
         for(int l = 0; l < tmpGrid->GetPointData()->GetNumberOfArrays(); l++) {
 
           if(tmpGrid->GetPointData()->GetArray(l)->GetNumberOfComponents()
              == 1) {
             tmpGrid->GetPointData()->GetArray(l)->GetTuple(
-              cell->GetPointId(k), &value);
+              cell->GetPointId(k), &val);
             newPointData[j][pointCounter][l]
-              += (1 / ((double)cell->GetNumberOfPoints())) * value;
+              += (1 / ((double)cell->GetNumberOfPoints())) * val;
           }
         }
       }
@@ -321,7 +321,6 @@ int ttkMeshSubdivision::doIt(vtkUnstructuredGrid *input,
               newCells[j][k]->InsertNextId(faceMap[l]);
 
               firstFace = l;
-              vtkCell *face = cell->GetFace(l);
               for(int n = 0; n < face->GetNumberOfPoints(); n++) {
                 firstFaceVertices.push_back(face->GetPointId(n));
               }

--- a/core/vtk/ttkProgramBase/ttkProgramBase.cpp
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.cpp
@@ -54,7 +54,7 @@ int ttkProgramBase::save() const {
   if(!vtkWrapper_)
     return -1;
 
-  for(int i = 0; i < (int)vtkWrapper_->GetNumberOfOutputPorts(); i++) {
+  for(int i = 0; i < vtkWrapper_->GetNumberOfOutputPorts(); i++) {
 
     if(vtkWrapper_->GetOutput(i)) {
 

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
@@ -129,7 +129,7 @@ int ttkRangePolygon::processTriangles(vtkUnstructuredGrid *input,
       vtkTemplateMacro({ smoother.smooth<VTK_TT>(NumberOfIterations); });
     }
 
-    for(int i = 0; i < (int)output->GetPointData()->GetNumberOfArrays(); i++) {
+    for(int i = 0; i < output->GetPointData()->GetNumberOfArrays(); i++) {
       vtkDataArray *field = output->GetPointData()->GetArray(i);
 
       switch(field->GetDataType()) {

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -338,9 +338,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
           vertexScalarsV->SetTuple1(vertexNumber, v);
         }
         if(ZeroSheetType) {
-          const ReebSpace::Sheet0 *sheet
+          const ReebSpace::Sheet0 *sht0
             = reebSpace_.get0sheet((*sheet0segmentation)[i]);
-          vertexTypes->SetTuple1(vertexNumber, sheet->type_);
+          vertexTypes->SetTuple1(vertexNumber, sht0->type_);
         }
 
         vertexNumber++;
@@ -617,16 +617,16 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     SimplexId triangleNumber = 0;
     idList->SetNumberOfIds(3);
     for(SimplexId i = 0; i < reebSpace_.getNumberOf2sheets(); i++) {
-      const ReebSpace::Sheet2 *sheet = reebSpace_.get2sheet(i);
+      const ReebSpace::Sheet2 *sht2 = reebSpace_.get2sheet(i);
 
-      if(!sheet->pruned_) {
-        for(SimplexId j = 0; j < (SimplexId)sheet->triangleList_.size(); j++) {
+      if(!sht2->pruned_) {
+        for(SimplexId j = 0; j < (SimplexId)sht2->triangleList_.size(); j++) {
 
-          for(SimplexId k = 0; k < (SimplexId)sheet->triangleList_[j].size();
+          for(SimplexId k = 0; k < (SimplexId)sht2->triangleList_[j].size();
               k++) {
 
             for(int l = 0; l < 3; l++) {
-              idList->SetId(l, sheet->triangleList_[j][k].vertexIds_[l]);
+              idList->SetId(l, sht2->triangleList_[j][k].vertexIds_[l]);
             }
 
             sheet2Triangles->InsertNextCell(idList);
@@ -636,25 +636,25 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
             }
 
             if(TwoSheetEdgeId) {
-              const ReebSpace::Sheet1 *sheet1
-                = reebSpace_.get1sheet(sheet->sheet1Id_);
-              triangleEdgeIds->SetTuple1(triangleNumber, sheet1->edgeList_[j]);
+              const ReebSpace::Sheet1 *sht1
+                = reebSpace_.get1sheet(sht2->sheet1Id_);
+              triangleEdgeIds->SetTuple1(triangleNumber, sht1->edgeList_[j]);
             }
 
             if(TwoSheetEdgeType) {
               SimplexId polygonEdgeId
-                = sheet->triangleList_[j][k].polygonEdgeId_;
+                = sht2->triangleList_[j][k].polygonEdgeId_;
               SimplexId edgeId = reebSpace_.getJacobi2Edge(polygonEdgeId);
               triangleEdgeType->SetTuple1(triangleNumber, (*edgeTypes)[edgeId]);
             }
 
             if(TwoSheetTetId) {
               triangleTetIds->SetTuple1(
-                triangleNumber, sheet->triangleList_[j][k].tetId_);
+                triangleNumber, sht2->triangleList_[j][k].tetId_);
             }
             if(TwoSheetCaseId) {
               triangleCaseIds->SetTuple1(
-                triangleNumber, sheet->triangleList_[j][k].caseId_);
+                triangleNumber, sht2->triangleList_[j][k].caseId_);
             }
 
             triangleNumber++;
@@ -720,10 +720,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     tetNumberField->SetNumberOfTuples(input->GetNumberOfPoints());
     tetNumberField->SetName("3-SheetTetNumber");
     for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++) {
-      const ReebSpace::Sheet3 *sheet3
-        = reebSpace_.get3sheet((*vertex3sheets)[i]);
-      if((sheet3) && (!sheet3->pruned_))
-        tetNumberField->SetTuple1(i, sheet3->tetList_.size());
+      const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*vertex3sheets)[i]);
+      if((sht3) && (!sht3->pruned_))
+        tetNumberField->SetTuple1(i, sht3->tetList_.size());
       else
         tetNumberField->SetTuple1(i, 0);
     }
@@ -736,10 +735,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     vertexNumberField->SetNumberOfTuples(input->GetNumberOfPoints());
     vertexNumberField->SetName("3-SheetVertexNumber");
     for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++) {
-      const ReebSpace::Sheet3 *sheet3
-        = reebSpace_.get3sheet((*vertex3sheets)[i]);
-      if((sheet3) && (!sheet3->pruned_))
-        vertexNumberField->SetTuple1(i, sheet3->vertexList_.size());
+      const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*vertex3sheets)[i]);
+      if((sht3) && (!sht3->pruned_))
+        vertexNumberField->SetTuple1(i, sht3->vertexList_.size());
       else
         vertexNumberField->SetTuple1(i, 0);
     }
@@ -755,10 +753,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     domainVolume->SetName("3-SheetDomainVolume");
 
     for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++) {
-      const ReebSpace::Sheet3 *sheet3
-        = reebSpace_.get3sheet((*vertex3sheets)[i]);
-      if((sheet3) && (!sheet3->pruned_)) {
-        domainVolume->SetTuple1(i, sheet3->domainVolume_);
+      const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*vertex3sheets)[i]);
+      if((sht3) && (!sht3->pruned_)) {
+        domainVolume->SetTuple1(i, sht3->domainVolume_);
       } else {
         domainVolume->SetTuple1(i, 0);
       }
@@ -776,10 +773,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     rangeArea->SetName("3-SheetRangeArea");
 
     for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++) {
-      const ReebSpace::Sheet3 *sheet3
-        = reebSpace_.get3sheet((*vertex3sheets)[i]);
-      if((sheet3) && (!sheet3->pruned_)) {
-        rangeArea->SetTuple1(i, sheet3->rangeArea_);
+      const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*vertex3sheets)[i]);
+      if((sht3) && (!sht3->pruned_)) {
+        rangeArea->SetTuple1(i, sht3->rangeArea_);
       } else {
         rangeArea->SetTuple1(i, 0);
       }
@@ -797,10 +793,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
     hyperVolume->SetName("3-SheetHyperVolume");
 
     for(SimplexId i = 0; i < input->GetNumberOfPoints(); i++) {
-      const ReebSpace::Sheet3 *sheet3
-        = reebSpace_.get3sheet((*vertex3sheets)[i]);
-      if((sheet3) && (!sheet3->pruned_)) {
-        hyperVolume->SetTuple1(i, sheet3->hyperVolume_);
+      const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*vertex3sheets)[i]);
+      if((sht3) && (!sht3->pruned_)) {
+        hyperVolume->SetTuple1(i, sht3->hyperVolume_);
       } else {
         hyperVolume->SetTuple1(i, 0);
       }
@@ -831,9 +826,9 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
   tetSegmentation->SetName("3-SheetId");
   tetSegmentation->SetNumberOfTuples(input->GetNumberOfCells());
   for(SimplexId i = 0; i < input->GetNumberOfCells(); i++) {
-    const ReebSpace::Sheet3 *sheet = reebSpace_.get3sheet((*tet3sheets)[i]);
-    if(sheet) {
-      tetSegmentation->SetTuple1(i, sheet->simplificationId_);
+    const ReebSpace::Sheet3 *sht3 = reebSpace_.get3sheet((*tet3sheets)[i]);
+    if(sht3) {
+      tetSegmentation->SetTuple1(i, sht3->simplificationId_);
     } else {
       tetSegmentation->SetTuple1(i, (*tet3sheets)[i]);
     }

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -201,7 +201,7 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
     vertexIds->SetName(ttk::VertexScalarFieldName);
 
     for(SimplexId i = 0; i < (SimplexId)criticalPoints_.size(); i++) {
-      vertexIds->SetTuple1(i, (SimplexId)criticalPoints_[i].first);
+      vertexIds->SetTuple1(i, criticalPoints_[i].first);
     }
 
     output->GetPointData()->AddArray(vertexIds);

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -413,13 +413,12 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
                                      FILE *fp) {
 
   double *p;
-  int i;
   unsigned char *c;
 
   // write out the points
   fprintf(fp, "            coord DEF VTKcoordinates Coordinate {\n");
   fprintf(fp, "              point [\n");
-  for(i = 0; i < points->GetNumberOfPoints(); i++) {
+  for(int i = 0; i < points->GetNumberOfPoints(); i++) {
     p = points->GetPoint(i);
     fprintf(fp, "              %g %g %g,\n", p[0], p[1], p[2]);
   }
@@ -431,7 +430,7 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
 
     fprintf(fp, "            normal DEF VTKnormals Normal {\n");
     fprintf(fp, "              vector [\n");
-    for(i = 0; i < normals->GetNumberOfTuples(); i++) {
+    for(int i = 0; i < normals->GetNumberOfTuples(); i++) {
       p = normals->GetTuple(i);
       fprintf(fp, "           %g %g %g,\n", p[0], p[1], p[2]);
     }
@@ -443,7 +442,7 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
   if(tcoords) {
     fprintf(fp, "            texCoord DEF VTKtcoords TextureCoordinate {\n");
     fprintf(fp, "              point [\n");
-    for(i = 0; i < tcoords->GetNumberOfTuples(); i++) {
+    for(int i = 0; i < tcoords->GetNumberOfTuples(); i++) {
       p = tcoords->GetTuple(i);
       fprintf(fp, "           %g %g,\n", p[0], p[1]);
     }
@@ -472,7 +471,7 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
   if(colors) {
     fprintf(fp, "            color DEF VTKcolors Color {\n");
     fprintf(fp, "              color [\n");
-    for(i = 0; i < colors->GetNumberOfTuples(); i++) {
+    for(int i = 0; i < colors->GetNumberOfTuples(); i++) {
       c = colors->GetPointer(4 * i);
       fprintf(
         fp, "           %g %g %g,\n", c[0] / 255.0, c[1] / 255.0, c[2] / 255.0);


### PR DESCRIPTION
Shadowing occurs when two variables sharing the same name have overlapping lifetime, i.e:

```c++
int a = 0;
{
  double a = 1.0;
}
```
This can lead to tricky bugs when using a variable that is not defined as the developer thinks it is.
