### PR TITLE
Fix memory leak in the FTM wrapper

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -319,24 +319,24 @@ int ttkFTMTree::doIt(vector<vtkDataSet *> &inputs,
           0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_CELLS, "RegionId");
         threshold->ThresholdBetween(cc, cc);
         threshold->Update();
-        connected_components_[cc] = ttkUnstructuredGrid::New();
+        connected_components_[cc] = vtkSmartPointer<ttkUnstructuredGrid>::New();
         connected_components_[cc]->ShallowCopy(threshold->GetOutput());
       }
     } else {
-      connected_components_[0] = ttkUnstructuredGrid::New();
+      connected_components_[0] = vtkSmartPointer<ttkUnstructuredGrid>::New();
       connected_components_[0]->ShallowCopy(input);
     }
   } else if(inputs[0]->IsA("vtkPolyData")) {
     // NOTE: CC check should not be implemented on a per vtk module layer.
     nbCC_ = 1;
     connected_components_.resize(nbCC_);
-    connected_components_[0] = ttkPolyData::New();
+    connected_components_[0] = vtkSmartPointer<ttkPolyData>::New();
     connected_components_[0]->ShallowCopy(inputs[0]);
     identify(connected_components_[0]);
   } else {
     nbCC_ = 1;
     connected_components_.resize(nbCC_);
-    connected_components_[0] = ttkImageData::New();
+    connected_components_[0] = vtkSmartPointer<ttkImageData>::New();
     connected_components_[0]->ShallowCopy(inputs[0]);
     identify(connected_components_[0]);
   }

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -172,7 +172,7 @@ private:
   ttk::ftm::Params params_;
 
   int nbCC_;
-  std::vector<vtkDataSet *> connected_components_;
+  std::vector<vtkSmartPointer<vtkDataSet>> connected_components_;
   std::vector<ttk::Triangulation *> triangulation_;
   std::vector<ttk::ftm::LocalFTM> ftmTree_;
   std::vector<vtkDataArray *> inputScalars_;


### PR DESCRIPTION
Dear Julien,

This PR fix a memory leak in the FTM wrapper. This was introduced by the hack to deal with multiple connected components, one of the array did not clean its memory.

Charles
 