### PR TITLE
Missing include for gcc

### DIFF
--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -17,6 +17,9 @@
 #define FTMTREE_MT_TPL_H
 
 #include <functional>
+#if (defined(__GNUC__) && !defined(__clang__))
+#include <parallel/algorithm>
+#endif
 
 #include "FTMTree_MT.h"
 


### PR DESCRIPTION
missing include for parallel sort in gcc (noticed in gcc 7.4 and 8.3)
```
06:03:25  .../ttk/core/base/ftmTree/FTMTree_MT_Template.h: In member function 'void ttk::ftm::FTMTree_MT::sortInput()':
06:03:25  .../ttk/core/base/ftmTree/FTMTree_MT_Template.h:59:4: error: '__gnu_parallel' has not been declared
06:03:25      __gnu_parallel::sort(sortedVect->begin(), sortedVect->end(), indirect_sort);
06:03:25      ^~~~~~~~~~~~~~
```