### PR TITLE
Fix build warnings/errors with Clang in ttkContourAroundPoint

### DIFF
--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -4,7 +4,6 @@
 
 #include <vtkCellData.h>
 #include <vtkDataSet.h>
-#include <vtkPointData.h>
 #include <vtkUnstructuredGrid.h>
 
 #if VTK_MAJOR_VERSION >= 7
@@ -72,7 +71,7 @@ bool ttkContourAroundPoint::preprocessDomain(vtkDataSet *dataset) {
   const auto errorCode
     = _wrappedModule.setupDomain(triangulation, scalars->GetVoidPointer(0));
   if(errorCode < 0) {
-    vtkErrorMacro("_wrappedModule.setupDomain failed with code " + errorCode);
+    vtkErrorMacro("_wrappedModule.setupDomain failed with code " << errorCode);
     return false;
   }
 
@@ -198,7 +197,7 @@ bool ttkContourAroundPoint::preprocessConstraints(vtkUnstructuredGrid *nodes,
   const auto errorCode = _wrappedModule.setupConstraints(
     _coords.data(), _isovals.data(), _isovals.size(), _flags.data());
   if(errorCode < 0) {
-    vtkErrorMacro("setInputPoints failed with code " + errorCode);
+    vtkErrorMacro("setInputPoints failed with code " << errorCode);
     return false;
   }
 
@@ -215,7 +214,7 @@ bool ttkContourAroundPoint::process() {
   }
   if(errorCode < 0) {
     vtkErrorMacro("_wrappedModule.execute failed with code "
-                  + errorCode) return false;
+                  << errorCode) return false;
   }
 
   return true;

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
@@ -25,6 +25,7 @@
 #include <vtkDataSetAlgorithm.h>
 #include <vtkFieldData.h>
 #include <vtkInformation.h>
+#include <vtkPointData.h>
 
 // TTK includes
 #include <ContourAroundPoint.hpp>
@@ -100,7 +101,7 @@ public:
   /// debugLevel-specific prefix and include a line end after the message.
   virtual int dMsg(std::ostream &stream,
                    std::string msg,
-                   const int &debugLevel = infoMsg) const {
+                   const int &debugLevel = infoMsg) const override {
     if(debugLevel > debugLevel_ && debugLevel > ttk::globalDebugLevel_)
       return 0;
     stream << "[ttkContourAroundPoint] ";


### PR DESCRIPTION
Building ttkContourAroundPoint with Clang has been failing with `'vtkPointData' is an incomplete type` error. 

To fix this, `vtkPointData.h` has been included.

Other minor warnings displayed by Clang have also been fixed for this new module.