### PR TITLE
Including VTK_USE_FILE only when it is not empty.

### DIFF
--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -17,7 +17,11 @@ if(NOT DEFINED VTK_USE_FILE)
     message(STATUS "No VTK provided, fallback to ParaView")
   endif()
 endif()
-include(${VTK_USE_FILE})
+
+if(DEFINED VTK_USE_FILE)
+    include(${VTK_USE_FILE})
+endif()
+
 include_directories(${VTK_INCLUDE_DIRS})
 
 set(VTKWRAPPER_LIB_LIST "")

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -12,7 +12,10 @@ if(NOT DEFINED VTK_USE_FILE)
     message(STATUS "No VTK provided, fallback to ParaView")
   endif()
 endif()
-include(${VTK_USE_FILE})
+
+if(DEFINED VTK_USE_FILE)
+    include(${VTK_USE_FILE})
+endif()
 
 set(TTK_INSTALL_BINARY_DIR "bin")
 file(GLOB STANDALONE_DIRS */cmd */gui)


### PR DESCRIPTION
Thanks for contributing to TTK!

Before submitting your pull request, please:

- [x] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/master/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.

- [x] Please provide a quick description of your contributions below:

Your description here

Hi,

I had the following two cmake errors on MacOS Mojave 10.14.5.

CMake Error at standalone/CMakeLists.txt:15 (include): include called with wrong number of arguments.  include() only takes one file.

CMake Error at core/vtk/CMakeLists.txt:20 (include): include called with wrong number of arguments.  include() only takes one  file.

The relevant line in both files that causes these problems is include(${VTK_USE_FILE}), and the issue is that the cmake variable VTK_USE_FILE was empty.

I can confirm that ttk compiles fine with the changes from this commit on OSX Mojave 10.14.5. 

