### PR TITLE
Fixed undefined VTK_MAJOR_VERSION

### DIFF
--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -1,5 +1,7 @@
 #include <ttkContourAroundPoint.h>
 
+#include <vtkVersion.h>
+
 #include <vtkProbeFilter.h>
 
 #include <vtkCellData.h>


### PR DESCRIPTION
VTK_MAJOR_VERSION was undefined, which falls into the "else" condition and therefore, it tries to use the deprecated vtkDataArrayTemplate. Including vtkVersion.h fixes this issue.

Specs:
- Windows10
- Visual Studio 2017 (15.9.11)
- VTK 8.2.0

