### PR TITLE
Issue when trying to include ttkFTRGraph.h in another Visual Studio 2017 project

### DIFF
--- a/core/base/ftrGraph/CMakeLists.txt
+++ b/core/base/ftrGraph/CMakeLists.txt
@@ -25,18 +25,27 @@ ttk_add_base_library(ftrGraph
     Mesh.cpp
     FTRSegmentation.cpp
   HEADERS
+    FTRAtomicUF.h
     FTRAtomicVector.h
+    FTRCommon.h
+    FTRDataTypes.h
     FTRGraph.h
     FTRGraph_Template.h
     FTRGraphPrint_Template.h
     FTRGraphPrivate_Template.h
+    Graph.h
+    Graph_Template.h
     DynamicGraph.h
+    DynamicGraph_Template.h
     FTRLazy.h
+    FTRNode.h
     Mesh.h
     FTRPropagation.h
     FTRPropagations.h
     FTRScalars.h
     FTRSegmentation.h
+    FTRSuperArc.h
+    FTRTasks.h
   LINK
     triangulation
     scalarFieldCriticalPoints

--- a/core/vtk/ttkFTRGraph/CMakeLists.txt
+++ b/core/vtk/ttkFTRGraph/CMakeLists.txt
@@ -3,6 +3,7 @@ ttk_add_vtk_library(ttkFTRGraph
     ttkFTRGraph.cpp
   HEADERS
     ttkFTRGraph.h
+    ttkFTRGraphStructures.h
   LINK
     ftrGraph
     ttkTriangulation


### PR DESCRIPTION
Lots of include files related to ttkFTRGraph.h were missing in my own VS Project, so I had to make them accessible for library linking.

Specs:

Windows10
Visual Studio 2017 (15.9.11)
VTK 8.2.0