### PR TITLE
Fix clang -Wunused-variable warning

### DIFF
--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -688,7 +688,6 @@ int ttk::TopologicalCompression::ReadFromFile(FILE *fp) {
   bool useZlib = ReadBool(fp);
   unsigned char *dest;
   std::vector<unsigned char> ddest;
-  unsigned long sourceLen;
   unsigned long destLen;
 
 #ifdef TTK_ENABLE_ZLIB
@@ -697,7 +696,7 @@ int ttk::TopologicalCompression::ReadFromFile(FILE *fp) {
     uLongf sl = ReadUnsignedLong(fp); // Compressed size...
     uLongf dl = ReadUnsignedLong(fp); // Uncompressed size...
 
-    sourceLen = (uLongf)sl;
+    unsigned long sourceLen = (uLongf)sl;
     destLen = dl;
     std::vector<Bytef> ssource(sl);
     Bytef *source = ssource.data();


### PR DESCRIPTION
Move declaration of variable ```sourceLen``` into ```#ifdef```macro to fix clang ```-Wunused-variable``` warning.