### PR TITLE
Fix control flow in ScalarFieldCriticalPoint

### DIFF
--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -240,51 +240,60 @@ int ttkJacobiSet::doIt(vector<vtkDataSet *> &inputs,
       vtkDataArray *scalarField = input->GetPointData()->GetArray(i);
       vtkSmartPointer<vtkDataArray> scalarArray;
 
+      auto copyToScalarArray = [&]() {
+        scalarArray->SetNumberOfComponents(
+          scalarField->GetNumberOfComponents());
+        scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
+        scalarArray->SetName(scalarField->GetName());
+        std::vector<double> value(scalarField->GetNumberOfComponents());
+        for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
+
+          SimplexId edgeId = jacobiSet_[j].first;
+          SimplexId vertexId0 = -1, vertexId1 = -1;
+          triangulation->getEdgeVertex(edgeId, 0, vertexId0);
+          triangulation->getEdgeVertex(edgeId, 1, vertexId1);
+
+          scalarField->GetTuple(vertexId0, value.data());
+          scalarArray->SetTuple(2 * j, value.data());
+
+          scalarField->GetTuple(vertexId1, value.data());
+          scalarArray->SetTuple(2 * j + 1, value.data());
+        }
+        output->GetPointData()->AddArray(scalarArray);
+      };
+
       switch(scalarField->GetDataType()) {
         case VTK_CHAR:
           scalarArray = vtkSmartPointer<vtkCharArray>::New();
+          copyToScalarArray();
           break;
         case VTK_DOUBLE:
           scalarArray = vtkSmartPointer<vtkDoubleArray>::New();
+          copyToScalarArray();
           break;
         case VTK_FLOAT:
           scalarArray = vtkSmartPointer<vtkFloatArray>::New();
+          copyToScalarArray();
           break;
         case VTK_INT:
           scalarArray = vtkSmartPointer<vtkIntArray>::New();
+          copyToScalarArray();
           break;
         case VTK_ID_TYPE:
           scalarArray = vtkSmartPointer<vtkIdTypeArray>::New();
+          copyToScalarArray();
           break;
         case VTK_UNSIGNED_SHORT:
           scalarArray = vtkSmartPointer<vtkUnsignedShortArray>::New();
+          copyToScalarArray();
           break;
         default: {
           stringstream msg;
           msg << "[ttkJacobiSet] Scalar attachment: "
               << "unsupported data type :(" << endl;
           dMsg(cerr, msg.str(), detailedInfoMsg);
-        }
-          return -4;
+        } break;
       }
-      scalarArray->SetNumberOfComponents(scalarField->GetNumberOfComponents());
-      scalarArray->SetNumberOfTuples(2 * jacobiSet_.size());
-      scalarArray->SetName(scalarField->GetName());
-      std::vector<double> value(scalarField->GetNumberOfComponents());
-      for(SimplexId j = 0; j < (SimplexId)jacobiSet_.size(); j++) {
-
-        SimplexId edgeId = jacobiSet_[j].first;
-        SimplexId vertexId0 = -1, vertexId1 = -1;
-        triangulation->getEdgeVertex(edgeId, 0, vertexId0);
-        triangulation->getEdgeVertex(edgeId, 1, vertexId1);
-
-        scalarField->GetTuple(vertexId0, value.data());
-        scalarArray->SetTuple(2 * j, value.data());
-
-        scalarField->GetTuple(vertexId1, value.data());
-        scalarArray->SetTuple(2 * j + 1, value.data());
-      }
-      output->GetPointData()->AddArray(scalarArray);
     }
   } else {
     for(int i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -216,39 +216,47 @@ int ttkScalarFieldCriticalPoints::doIt(vector<vtkDataSet *> &inputs,
       vtkDataArray *scalarField = input->GetPointData()->GetArray(i);
       vtkSmartPointer<vtkDataArray> scalarArray;
 
+      auto copyToScalarArray = [&]() {
+        scalarArray->SetNumberOfComponents(
+          scalarField->GetNumberOfComponents());
+        scalarArray->SetNumberOfTuples(criticalPoints_.size());
+        scalarArray->SetName(scalarField->GetName());
+        std::vector<double> value(scalarField->GetNumberOfComponents());
+        for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
+          scalarField->GetTuple(criticalPoints_[j].first, value.data());
+          scalarArray->SetTuple(j, value.data());
+        }
+        output->GetPointData()->AddArray(scalarArray);
+      };
+
       switch(scalarField->GetDataType()) {
         case VTK_CHAR:
           scalarArray = vtkSmartPointer<vtkCharArray>::New();
+          copyToScalarArray();
           break;
         case VTK_DOUBLE:
           scalarArray = vtkSmartPointer<vtkDoubleArray>::New();
+          copyToScalarArray();
           break;
         case VTK_FLOAT:
           scalarArray = vtkSmartPointer<vtkFloatArray>::New();
+          copyToScalarArray();
           break;
         case VTK_INT:
           scalarArray = vtkSmartPointer<vtkIntArray>::New();
+          copyToScalarArray();
           break;
         case VTK_ID_TYPE:
           scalarArray = vtkSmartPointer<vtkIdTypeArray>::New();
+          copyToScalarArray();
           break;
         default: {
           stringstream msg;
           msg << "[ttkScalarFieldCriticalPoints] Scalar attachment: "
               << "unsupported data type :(" << endl;
           dMsg(cerr, msg.str(), detailedInfoMsg);
-        }
-          return -1;
+        } break;
       }
-      scalarArray->SetNumberOfComponents(scalarField->GetNumberOfComponents());
-      scalarArray->SetNumberOfTuples(criticalPoints_.size());
-      scalarArray->SetName(scalarField->GetName());
-      std::vector<double> value(scalarField->GetNumberOfComponents());
-      for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-        scalarField->GetTuple(criticalPoints_[j].first, value.data());
-        scalarArray->SetTuple(j, value.data());
-      }
-      output->GetPointData()->AddArray(scalarArray);
     }
   } else {
     for(SimplexId i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {


### PR DESCRIPTION
Commit afdc4f2b in PR #236 replaced a `break` statement with a `return` one, skipping later statements to allow the outlining of the switch body instructions after this `return`. This `return` statement also skipped some valid statements, leading to issue #257.

This current PR fixes issue #257 by refactoring the outlined switch body into a lambda called in every case of the switch construct. It also replaces the faulty `return` by a `break`.

Fix issue #257.
Sorry for the inconvenience.

Pierre