### PR TITLE
Fix building/running MorseSmaleQuadrangulation filters with 64BIT_IDS

### DIFF
--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
@@ -45,7 +45,7 @@ int ttk::MorseSmaleQuadrangulation::detectCellSeps() {
   }
 
   // id of critical point in new triangulation
-  auto critPointId = [&](const SimplexId a) {
+  auto critPointId = [&](const SimplexId a) -> SimplexId {
     if(sepCellDims_[a] == 0) {
       return sepCellIds_[a];
     }

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -146,13 +146,13 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   output->SetCells(VTK_TRIANGLE, cells);
 
   // cell id
-  auto cellId = vtkSmartPointer<vtkIntArray>::New();
+  auto cellId = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellId->SetName("CellId");
   cellId->SetVoidArray(outPointId.data(), outPointId.size(), 1);
   output->GetPointData()->AddArray(cellId);
 
   // cell dimension
-  auto cellDim = vtkSmartPointer<vtkIntArray>::New();
+  auto cellDim = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellDim->SetName("CellDimension");
   cellDim->SetVoidArray(outPointDim.data(), outPointDim.size(), 1);
   output->GetPointData()->AddArray(cellDim);

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
@@ -147,19 +147,19 @@ int ttkMorseSmaleQuadrangulation::doIt(std::vector<vtkDataSet *> &inputs,
   output->SetPoints(points);
 
   // quad vertices identifiers
-  auto identifiers = vtkSmartPointer<vtkIntArray>::New();
+  auto identifiers = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   identifiers->SetName(ttk::VertexScalarFieldName);
   identifiers->SetVoidArray(outPointsIds.data(), outPointsIds.size(), 1);
   output->GetPointData()->AddArray(identifiers);
 
   // quad vertices type
-  auto type = vtkSmartPointer<vtkIntArray>::New();
+  auto type = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   type->SetName("QuadVertType");
   type->SetVoidArray(outPointsType.data(), outPointsType.size(), 1);
   output->GetPointData()->AddArray(type);
 
   // quad vertices cells
-  auto cellid = vtkSmartPointer<vtkIntArray>::New();
+  auto cellid = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellid->SetName("QuadCellId");
   cellid->SetVoidArray(outPointsCells.data(), outPointsCells.size(), 1);
   output->GetPointData()->AddArray(cellid);

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -147,18 +147,18 @@ int ttkQuadrangulationSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   output->SetPoints(points);
 
   // add data array of points valences
-  auto valences = vtkSmartPointer<vtkIntArray>::New();
+  auto valences = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   valences->SetName("Valence");
   valences->SetVoidArray(outVertexValences.data(), outVertexValences.size(), 1);
   output->GetPointData()->AddArray(valences);
 
   // add data array of points infos
-  auto infos = vtkSmartPointer<vtkIntArray>::New();
+  auto infos = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   infos->SetName("Type");
   infos->SetVoidArray(outVertexType.data(), outVertexType.size(), 1);
   output->GetPointData()->AddArray(infos);
 
-  auto subd = vtkSmartPointer<vtkIntArray>::New();
+  auto subd = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   subd->SetName("Subdivision");
   subd->SetVoidArray(outSubdvisionLevel.data(), outSubdvisionLevel.size(), 1);
   output->GetPointData()->AddArray(subd);
@@ -168,14 +168,14 @@ int ttkQuadrangulationSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     auto &projSucceeded = baseWorker_.projSucceeded_;
 
     // add data array of number of triangles checked
-    auto trChecked = vtkSmartPointer<vtkIntArray>::New();
+    auto trChecked = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
     trChecked->SetName("Triangles checked");
     trChecked->SetVoidArray(
       trianglesChecked.data(), trianglesChecked.size(), 1);
     output->GetPointData()->AddArray(trChecked);
 
     // add data array of projection success
-    auto projSucc = vtkSmartPointer<vtkIntArray>::New();
+    auto projSucc = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
     projSucc->SetName("Projection");
     projSucc->SetVoidArray(projSucceeded.data(), projSucceeded.size(), 1);
     output->GetPointData()->AddArray(projSucc);


### PR DESCRIPTION
After testing the quadrangulation with TTK_ENABLE_64BIT_IDS set, I noticed one build error and several run-time issues with data arrays.

This PR should fix those problems.