### PR TITLE
Fix bool to int conversion/comparison warnings in MSVC

### DIFF
--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
@@ -92,14 +92,14 @@ public:
   vtkSetMacro(PS, double);
   vtkGetMacro(PS, double);
 
-  vtkSetMacro(UseOutputMatching, int);
-  vtkGetMacro(UseOutputMatching, int);
+  vtkSetMacro(UseOutputMatching, bool);
+  vtkGetMacro(UseOutputMatching, bool);
 
   vtkSetMacro(BenchmarkSize, int);
   vtkGetMacro(BenchmarkSize, int);
 
-  vtkSetMacro(UsePersistenceMetric, int);
-  vtkGetMacro(UsePersistenceMetric, int);
+  vtkSetMacro(UsePersistenceMetric, bool);
+  vtkGetMacro(UsePersistenceMetric, bool);
 
   vtkSetMacro(WassersteinMetric, std::string);
   vtkGetMacro(WassersteinMetric, std::string);
@@ -110,8 +110,8 @@ public:
   vtkSetMacro(PVAlgorithm, int);
   vtkGetMacro(PVAlgorithm, int);
 
-  vtkSetMacro(UseGeometricSpacing, int);
-  vtkGetMacro(UseGeometricSpacing, int);
+  vtkSetMacro(UseGeometricSpacing, bool);
+  vtkGetMacro(UseGeometricSpacing, bool);
 
   vtkSetMacro(Spacing, double);
   vtkGetMacro(Spacing, double);

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
@@ -91,11 +91,11 @@ public:
   vtkSetMacro(VcomponentId, int);
   vtkGetMacro(VcomponentId, int);
 
-  vtkSetMacro(WithVaryingConnectivity, int);
-  vtkGetMacro(WithVaryingConnectivity, int);
+  vtkSetMacro(WithVaryingConnectivity, bool);
+  vtkGetMacro(WithVaryingConnectivity, bool);
 
-  vtkSetMacro(WithDummyValue, int);
-  vtkGetMacro(WithDummyValue, int);
+  vtkSetMacro(WithDummyValue, bool);
+  vtkGetMacro(WithDummyValue, bool);
 
   vtkSetMacro(DummyValue, double);
   vtkGetMacro(DummyValue, double);

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -102,8 +102,8 @@ public:
   vtkSetMacro(Method, int);
   vtkGetMacro(Method, int);
 
-  vtkSetMacro(KeepAllDataArrays, int);
-  vtkGetMacro(KeepAllDataArrays, int);
+  vtkSetMacro(KeepAllDataArrays, bool);
+  vtkGetMacro(KeepAllDataArrays, bool);
 
   // SE
   vtkSetMacro(se_Affinity, std::string);

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -71,26 +71,26 @@ public:
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);
 
-  vtkSetMacro(ReverseSaddleMaximumConnection, int);
-  vtkGetMacro(ReverseSaddleMaximumConnection, int);
+  vtkSetMacro(ReverseSaddleMaximumConnection, bool);
+  vtkGetMacro(ReverseSaddleMaximumConnection, bool);
 
-  vtkSetMacro(ReverseSaddleSaddleConnection, int);
-  vtkGetMacro(ReverseSaddleSaddleConnection, int);
+  vtkSetMacro(ReverseSaddleSaddleConnection, bool);
+  vtkGetMacro(ReverseSaddleSaddleConnection, bool);
 
-  vtkSetMacro(AllowSecondPass, int);
-  vtkGetMacro(AllowSecondPass, int);
+  vtkSetMacro(AllowSecondPass, bool);
+  vtkGetMacro(AllowSecondPass, bool);
 
-  vtkSetMacro(AllowThirdPass, int);
-  vtkGetMacro(AllowThirdPass, int);
+  vtkSetMacro(AllowThirdPass, bool);
+  vtkGetMacro(AllowThirdPass, bool);
 
-  vtkSetMacro(ComputeGradientGlyphs, int);
-  vtkGetMacro(ComputeGradientGlyphs, int);
+  vtkSetMacro(ComputeGradientGlyphs, bool);
+  vtkGetMacro(ComputeGradientGlyphs, bool);
 
   vtkSetMacro(IterationThreshold, int);
   vtkGetMacro(IterationThreshold, int);

--- a/core/vtk/ttkDistanceField/ttkDistanceField.h
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.h
@@ -81,8 +81,8 @@ public:
   vtkSetMacro(OutputScalarFieldName, std::string);
   vtkGetMacro(OutputScalarFieldName, std::string);
 
-  vtkSetMacro(ForceInputVertexScalarField, int);
-  vtkGetMacro(ForceInputVertexScalarField, int);
+  vtkSetMacro(ForceInputVertexScalarField, bool);
+  vtkGetMacro(ForceInputVertexScalarField, bool);
 
   vtkSetMacro(InputVertexScalarFieldName, std::string);
   vtkGetMacro(InputVertexScalarFieldName, std::string);

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -59,8 +59,8 @@ public:
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -85,8 +85,8 @@ public:
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
 
-  vtkSetMacro(UseInputOffsetScalarField, int);
-  vtkGetMacro(UseInputOffsetScalarField, int);
+  vtkSetMacro(UseInputOffsetScalarField, bool);
+  vtkGetMacro(UseInputOffsetScalarField, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.h
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.h
@@ -82,14 +82,14 @@ public:
   vtkSetMacro(OutputScalarFieldType, int);
   vtkGetMacro(OutputScalarFieldType, int);
 
-  vtkSetMacro(ForceInputVertexScalarField, int);
-  vtkGetMacro(ForceInputVertexScalarField, int);
+  vtkSetMacro(ForceInputVertexScalarField, bool);
+  vtkGetMacro(ForceInputVertexScalarField, bool);
 
   vtkSetMacro(InputVertexScalarFieldName, std::string);
   vtkGetMacro(InputVertexScalarFieldName, std::string);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
   vtkSetMacro(OffsetScalarFieldName, std::string);
   vtkGetMacro(OffsetScalarFieldName, std::string);
@@ -122,7 +122,7 @@ private:
   bool ForceInputVertexScalarField;
   std::string InputVertexScalarFieldName;
   int OffsetScalarFieldId;
-  int ForceInputOffsetScalarField;
+  bool ForceInputOffsetScalarField;
   std::string OffsetScalarFieldName;
 
   ttk::Triangulation *triangulation_;

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -91,8 +91,8 @@ public:
   vtkSetMacro(OffsetFieldId, int);
   vtkGetMacro(OffsetFieldId, int);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);
@@ -100,38 +100,38 @@ public:
   vtkSetMacro(IterationThreshold, int);
   vtkGetMacro(IterationThreshold, int);
 
-  vtkSetMacro(ReverseSaddleMaximumConnection, int);
-  vtkGetMacro(ReverseSaddleMaximumConnection, int);
+  vtkSetMacro(ReverseSaddleMaximumConnection, bool);
+  vtkGetMacro(ReverseSaddleMaximumConnection, bool);
 
-  vtkSetMacro(ReverseSaddleSaddleConnection, int);
-  vtkGetMacro(ReverseSaddleSaddleConnection, int);
+  vtkSetMacro(ReverseSaddleSaddleConnection, bool);
+  vtkGetMacro(ReverseSaddleSaddleConnection, bool);
 
-  vtkSetMacro(ComputeCriticalPoints, int);
-  vtkGetMacro(ComputeCriticalPoints, int);
+  vtkSetMacro(ComputeCriticalPoints, bool);
+  vtkGetMacro(ComputeCriticalPoints, bool);
 
-  vtkSetMacro(ComputeAscendingSeparatrices1, int);
-  vtkGetMacro(ComputeAscendingSeparatrices1, int);
+  vtkSetMacro(ComputeAscendingSeparatrices1, bool);
+  vtkGetMacro(ComputeAscendingSeparatrices1, bool);
 
-  vtkSetMacro(ComputeDescendingSeparatrices1, int);
-  vtkGetMacro(ComputeDescendingSeparatrices1, int);
+  vtkSetMacro(ComputeDescendingSeparatrices1, bool);
+  vtkGetMacro(ComputeDescendingSeparatrices1, bool);
 
-  vtkSetMacro(ComputeSaddleConnectors, int);
-  vtkGetMacro(ComputeSaddleConnectors, int);
+  vtkSetMacro(ComputeSaddleConnectors, bool);
+  vtkGetMacro(ComputeSaddleConnectors, bool);
 
-  vtkSetMacro(ComputeAscendingSeparatrices2, int);
-  vtkGetMacro(ComputeAscendingSeparatrices2, int);
+  vtkSetMacro(ComputeAscendingSeparatrices2, bool);
+  vtkGetMacro(ComputeAscendingSeparatrices2, bool);
 
-  vtkSetMacro(ComputeDescendingSeparatrices2, int);
-  vtkGetMacro(ComputeDescendingSeparatrices2, int);
+  vtkSetMacro(ComputeDescendingSeparatrices2, bool);
+  vtkGetMacro(ComputeDescendingSeparatrices2, bool);
 
-  vtkSetMacro(ComputeAscendingSegmentation, int);
-  vtkGetMacro(ComputeAscendingSegmentation, int);
+  vtkSetMacro(ComputeAscendingSegmentation, bool);
+  vtkGetMacro(ComputeAscendingSegmentation, bool);
 
-  vtkSetMacro(ComputeDescendingSegmentation, int);
-  vtkGetMacro(ComputeDescendingSegmentation, int);
+  vtkSetMacro(ComputeDescendingSegmentation, bool);
+  vtkGetMacro(ComputeDescendingSegmentation, bool);
 
-  vtkSetMacro(ComputeFinalSegmentation, int);
-  vtkGetMacro(ComputeFinalSegmentation, int);
+  vtkSetMacro(ComputeFinalSegmentation, bool);
+  vtkGetMacro(ComputeFinalSegmentation, bool);
 
   vtkSetMacro(ReturnSaddleConnectors, int);
   vtkGetMacro(ReturnSaddleConnectors, int);
@@ -139,8 +139,8 @@ public:
   vtkSetMacro(SaddleConnectorsPersistenceThreshold, double);
   vtkGetMacro(SaddleConnectorsPersistenceThreshold, double);
 
-  vtkSetMacro(PrioritizeSpeedOverMemory, int);
-  vtkGetMacro(PrioritizeSpeedOverMemory, int);
+  vtkSetMacro(PrioritizeSpeedOverMemory, bool);
+  vtkGetMacro(PrioritizeSpeedOverMemory, bool);
 
   int setupTriangulation(vtkDataSet *input);
   vtkDataArray *getScalars(vtkDataSet *input);

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -90,14 +90,14 @@ public:
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);
 
-  vtkSetMacro(ComputeSaddleConnectors, int);
-  vtkGetMacro(ComputeSaddleConnectors, int);
+  vtkSetMacro(ComputeSaddleConnectors, bool);
+  vtkGetMacro(ComputeSaddleConnectors, bool);
 
   vtkTable *GetOutput();
   vtkTable *GetOutput(int);

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -99,14 +99,14 @@ public:
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
-  vtkSetMacro(ConsiderIdentifierAsBlackList, int);
-  vtkGetMacro(ConsiderIdentifierAsBlackList, int);
+  vtkSetMacro(ConsiderIdentifierAsBlackList, bool);
+  vtkGetMacro(ConsiderIdentifierAsBlackList, bool);
 
-  vtkSetMacro(AddPerturbation, int);
-  vtkGetMacro(AddPerturbation, int);
+  vtkSetMacro(AddPerturbation, bool);
+  vtkGetMacro(AddPerturbation, bool);
 
   vtkSetMacro(InputOffsetScalarFieldName, std::string);
   vtkGetMacro(InputOffsetScalarFieldName, std::string);
@@ -114,8 +114,8 @@ public:
   vtkSetMacro(OutputOffsetScalarFieldName, std::string);
   vtkGetMacro(OutputOffsetScalarFieldName, std::string);
 
-  vtkSetMacro(ForceInputVertexScalarField, int);
-  vtkGetMacro(ForceInputVertexScalarField, int);
+  vtkSetMacro(ForceInputVertexScalarField, bool);
+  vtkGetMacro(ForceInputVertexScalarField, bool);
 
   vtkSetMacro(InputVertexScalarFieldName, std::string);
   vtkGetMacro(InputVertexScalarFieldName, std::string);

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
@@ -96,13 +96,13 @@ public:
   vtkSetMacro(PVAlgorithm, int);
   vtkGetMacro(PVAlgorithm, int);
 
-  vtkSetMacro(UseGeometricSpacing, int);
-  vtkGetMacro(UseGeometricSpacing, int);
+  vtkSetMacro(UseGeometricSpacing, bool);
+  vtkGetMacro(UseGeometricSpacing, bool);
 
   vtkSetMacro(Spacing, double);
   vtkGetMacro(Spacing, double);
-  vtkSetMacro(DoPostProc, int);
-  vtkGetMacro(DoPostProc, int);
+  vtkSetMacro(DoPostProc, bool);
+  vtkGetMacro(DoPostProc, bool);
 
   vtkSetMacro(PostProcThresh, double);
   vtkGetMacro(PostProcThresh, double);

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
@@ -90,14 +90,14 @@ public:
   vtkSetMacro(PVAlgorithm, int);
   vtkGetMacro(PVAlgorithm, int);
 
-  vtkSetMacro(UseGeometricSpacing, int);
-  vtkGetMacro(UseGeometricSpacing, int);
+  vtkSetMacro(UseGeometricSpacing, bool);
+  vtkGetMacro(UseGeometricSpacing, bool);
 
   vtkSetMacro(Spacing, double);
   vtkGetMacro(Spacing, double);
 
-  vtkSetMacro(DoPostProc, int);
-  vtkGetMacro(DoPostProc, int);
+  vtkSetMacro(DoPostProc, bool);
+  vtkGetMacro(DoPostProc, bool);
 
   vtkSetMacro(PostProcThresh, double);
   vtkGetMacro(PostProcThresh, double);


### PR DESCRIPTION
In the expansion of vtkSetMacro and vtkGetMacro, MSVC complains about bool to int comparisons.

In this PR, I tried to use the right variable type when using these macros to enforce better type-correctness.

These changes should not have any impact on run results.

Pierre