### PR TITLE
ContourTree: Fix non-const operator() in struct used in std::set

### DIFF
--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -33,7 +33,7 @@ struct MyCmp {
 
 struct filtrationCtCmp {
   bool operator()(const pair<bool, pair<double, pair<int, int>>> &v0,
-                  const pair<bool, pair<double, pair<int, int>>> &v1) {
+                  const pair<bool, pair<double, pair<int, int>>> &v1) const {
 
     if(v0.first) {
       return ((v0.second.first < v1.second.first)


### PR DESCRIPTION
The filtrationCtCmp struct defines a `bool operator()` to be used to
compare elements in sets (c.f. ContourTree.cpp, l.246 and l.1543).

However, recent compilers and C++ standards (>= C++17) require the
`bool operator()` method to be `const`.

So far, the current state has been causing build errors with the
latest MSVC (2019) and when upgrading the C++ standard to C++17 with GCC.

When trying to build with Clang/libc++, a warning is also emitted.

Just adding `const` to this method should fix the issue, while
providing forward compatibility with C++17 and MSVC 2019 at a low cost.

Pierre