### PR TITLE
Triangulation copy/move constructors

### DIFF
--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -19,7 +19,7 @@
 
 namespace ttk {
 
-  class ExplicitTriangulation : public AbstractTriangulation {
+  class ExplicitTriangulation final : public AbstractTriangulation {
 
   public:
     ExplicitTriangulation();
@@ -28,7 +28,7 @@ namespace ttk {
 
     inline int getCellEdge(const SimplexId &cellId,
                            const int &localEdgeId,
-                           SimplexId &edgeId) const {
+                           SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellEdgeList_.size()))
@@ -41,7 +41,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getCellEdgeNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellEdgeNumber(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellEdgeList_.size()))
         return -1;
@@ -49,14 +49,14 @@ namespace ttk {
       return cellEdgeList_[cellId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getCellEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getCellEdges() override {
 
       return &cellEdgeList_;
     }
 
     inline int getCellNeighbor(const SimplexId &cellId,
                                const int &localNeighborId,
-                               SimplexId &neighborId) const {
+                               SimplexId &neighborId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellNeighborList_.size()))
         return -1;
@@ -68,7 +68,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getCellNeighborNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellNeighborNumber(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellNeighborList_.size()))
         return -1;
@@ -76,13 +76,13 @@ namespace ttk {
       return cellNeighborList_[cellId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getCellNeighbors() {
+    inline const std::vector<std::vector<SimplexId>> *getCellNeighbors() override {
       return &cellNeighborList_;
     }
 
     inline int getCellTriangle(const SimplexId &cellId,
                                const int &localTriangleId,
-                               SimplexId &triangleId) const {
+                               SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellTriangleList_.size()))
@@ -96,7 +96,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getCellTriangleNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellTriangleNumber(const SimplexId &cellId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellTriangleList_.size()))
@@ -106,14 +106,14 @@ namespace ttk {
       return cellTriangleList_[cellId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getCellTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getCellTriangles() override {
 
       return &cellTriangleList_;
     }
 
     inline int getCellVertex(const SimplexId &cellId,
                              const int &localVertexId,
-                             SimplexId &vertexId) const {
+                             SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= cellNumber_))
         return -1;
@@ -124,7 +124,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getCellVertexNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellVertexNumber(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= cellNumber_))
         return -1;
@@ -134,7 +134,7 @@ namespace ttk {
       return cellArray_[0];
     }
 
-    int getDimensionality() const {
+    int getDimensionality() const override {
 
       if((cellArray_) && (cellNumber_)) {
         return cellArray_[0] - 1;
@@ -143,13 +143,13 @@ namespace ttk {
       return -1;
     }
 
-    inline const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() {
+    inline const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override {
       return &edgeList_;
     }
 
     inline int getEdgeLink(const SimplexId &edgeId,
                            const int &localLinkId,
-                           SimplexId &linkId) const {
+                           SimplexId &linkId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeLinkList_.size()))
         return -1;
@@ -161,7 +161,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeLinkList_.size()))
         return -1;
@@ -169,14 +169,14 @@ namespace ttk {
       return edgeLinkList_[edgeId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() override {
 
       return &edgeLinkList_;
     }
 
     inline int getEdgeStar(const SimplexId &edgeId,
                            const int &localStarId,
-                           SimplexId &starId) const {
+                           SimplexId &starId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeStarList_.size()))
         return -1;
@@ -188,7 +188,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getEdgeStarNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeStarList_.size()))
         return -1;
@@ -196,13 +196,13 @@ namespace ttk {
       return edgeStarList_[edgeId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getEdgeStars() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeStars() override {
       return &edgeStarList_;
     }
 
     inline int getEdgeTriangle(const SimplexId &edgeId,
                                const int &localTriangleId,
-                               SimplexId &triangleId) const {
+                               SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeTriangleList_.size()))
@@ -217,7 +217,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeTriangleList_.size()))
@@ -227,14 +227,14 @@ namespace ttk {
       return edgeTriangleList_[edgeId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getEdgeTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeTriangles() override {
 
       return &edgeTriangleList_;
     }
 
     inline int getEdgeVertex(const SimplexId &edgeId,
                              const int &localVertexId,
-                             SimplexId &vertexId) const {
+                             SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeList_.size()))
         return -1;
@@ -248,29 +248,29 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getNumberOfCells() const {
+    inline SimplexId getNumberOfCells() const override {
       return cellNumber_;
     }
 
-    inline SimplexId getNumberOfEdges() const {
+    inline SimplexId getNumberOfEdges() const override {
       return edgeList_.size();
     }
 
-    inline SimplexId getNumberOfTriangles() const {
+    inline SimplexId getNumberOfTriangles() const override {
       return triangleList_.size();
     }
 
-    inline SimplexId getNumberOfVertices() const {
+    inline SimplexId getNumberOfVertices() const override {
       return vertexNumber_;
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangles() override {
       return &triangleList_;
     }
 
     inline int getTriangleEdge(const SimplexId &triangleId,
                                const int &localEdgeId,
-                               SimplexId &edgeId) const {
+                               SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
@@ -285,7 +285,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
@@ -296,14 +296,14 @@ namespace ttk {
       return triangleEdgeList_[triangleId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getTriangleEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleEdges() override {
 
       return &triangleEdgeList_;
     }
 
     inline int getTriangleLink(const SimplexId &triangleId,
                                const int &localLinkId,
-                               SimplexId &linkId) const {
+                               SimplexId &linkId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleLinkList_.size()))
@@ -316,7 +316,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleLinkList_.size()))
@@ -325,13 +325,13 @@ namespace ttk {
       return triangleLinkList_[triangleId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getTriangleLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleLinks() override {
       return &triangleLinkList_;
     }
 
     inline int getTriangleStar(const SimplexId &triangleId,
                                const int &localStarId,
-                               SimplexId &starId) const {
+                               SimplexId &starId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleStarList_.size()))
@@ -344,7 +344,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getTriangleStarNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleStarList_.size()))
@@ -353,13 +353,13 @@ namespace ttk {
       return triangleStarList_[triangleId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getTriangleStars() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleStars() override {
       return &triangleStarList_;
     }
 
     inline int getTriangleVertex(const SimplexId &triangleId,
                                  const int &localVertexId,
-                                 SimplexId &vertexId) const {
+                                 SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0) || (triangleId >= (SimplexId)triangleList_.size()))
         return -1;
@@ -373,7 +373,7 @@ namespace ttk {
 
     inline int getVertexEdge(const SimplexId &vertexId,
                              const int &localEdgeId,
-                             SimplexId &edgeId) const {
+                             SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexEdgeList_.size()))
         return -1;
@@ -385,7 +385,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexEdgeList_.size()))
@@ -394,13 +394,13 @@ namespace ttk {
       return vertexEdgeList_[vertexId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getVertexEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexEdges() override {
       return &vertexEdgeList_;
     }
 
     inline int getVertexLink(const SimplexId &vertexId,
                              const int &localLinkId,
-                             SimplexId &linkId) const {
+                             SimplexId &linkId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexLinkList_.size()))
@@ -414,7 +414,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getVertexLinkNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexLinkList_.size()))
         return -1;
@@ -422,13 +422,13 @@ namespace ttk {
       return vertexLinkList_[vertexId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getVertexLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexLinks() override {
       return &vertexLinkList_;
     }
 
     inline int getVertexNeighbor(const SimplexId &vertexId,
                                  const int &localNeighborId,
-                                 SimplexId &neighborId) const {
+                                 SimplexId &neighborId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexNeighborList_.size()))
         return -1;
@@ -441,7 +441,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
         return -1;
@@ -449,14 +449,14 @@ namespace ttk {
       return vertexNeighborList_[vertexId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getVertexNeighbors() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override {
       return &vertexNeighborList_;
     }
 
     inline int getVertexPoint(const SimplexId &vertexId,
                               float &x,
                               float &y,
-                              float &z) const {
+                              float &z) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
@@ -478,7 +478,7 @@ namespace ttk {
 
     inline int getVertexStar(const SimplexId &vertexId,
                              const int &localStarId,
-                             SimplexId &starId) const {
+                             SimplexId &starId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexStarList_.size()))
         return -1;
@@ -490,7 +490,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getVertexStarNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexStarNumber(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexStarList_.size()))
         return -1;
@@ -498,13 +498,13 @@ namespace ttk {
       return vertexStarList_[vertexId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getVertexStars() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexStars() override {
       return &vertexStarList_;
     }
 
     inline int getVertexTriangle(const SimplexId &vertexId,
                                  const int &localTriangleId,
-                                 SimplexId &triangleId) const {
+                                 SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexTriangleList_.size()))
@@ -518,7 +518,7 @@ namespace ttk {
       return 0;
     }
 
-    inline SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexTriangleList_.size()))
@@ -527,92 +527,92 @@ namespace ttk {
       return vertexTriangleList_[vertexId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getVertexTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexTriangles() override {
 
       return &vertexTriangleList_;
     }
 
-    inline bool hasPreprocessedBoundaryEdges() const {
+    inline bool hasPreprocessedBoundaryEdges() const override {
       if(getDimensionality() == 1)
         return true;
       return (boundaryEdges_.size() != 0);
     }
 
-    inline bool hasPreprocessedBoundaryTriangles() const {
+    inline bool hasPreprocessedBoundaryTriangles() const override {
       if(getDimensionality() == 2)
         return true;
       return (boundaryTriangles_.size() != 0);
     }
 
-    inline bool hasPreprocessedBoundaryVertices() const {
+    inline bool hasPreprocessedBoundaryVertices() const override {
       return (boundaryVertices_.size() != 0);
     }
 
-    inline bool hasPreprocessedCellEdges() const {
+    inline bool hasPreprocessedCellEdges() const override {
       return (cellEdgeList_.size() != 0);
     }
 
-    inline bool hasPreprocessedCellNeighbors() const {
+    inline bool hasPreprocessedCellNeighbors() const override {
       return (cellNeighborList_.size() != 0);
     }
 
-    inline bool hasPreprocessedCellTriangles() const {
+    inline bool hasPreprocessedCellTriangles() const override {
       return (cellTriangleList_.size() != 0);
     }
 
-    inline bool hasPreprocessedEdges() const {
+    inline bool hasPreprocessedEdges() const override {
       return (edgeList_.size() != 0);
     }
 
-    inline bool hasPreprocessedEdgeLinks() const {
+    inline bool hasPreprocessedEdgeLinks() const override {
       return (edgeLinkList_.size() != 0);
     }
 
-    inline bool hasPreprocessedEdgeStars() const {
+    inline bool hasPreprocessedEdgeStars() const override {
       return (edgeStarList_.size() != 0);
     }
 
-    inline bool hasPreprocessedEdgeTriangles() const {
+    inline bool hasPreprocessedEdgeTriangles() const override {
       return (edgeTriangleList_.size() != 0);
     }
 
-    inline bool hasPreprocessedTriangles() const {
+    inline bool hasPreprocessedTriangles() const override {
       return (triangleList_.size() != 0);
     }
 
-    inline bool hasPreprocessedTriangleEdges() const {
+    inline bool hasPreprocessedTriangleEdges() const override {
       return (triangleEdgeList_.size() != 0);
     }
 
-    inline bool hasPreprocessedTriangleLinks() const {
+    inline bool hasPreprocessedTriangleLinks() const override {
       return (triangleLinkList_.size() != 0);
     }
 
-    inline bool hasPreprocessedTriangleStars() const {
+    inline bool hasPreprocessedTriangleStars() const override {
       return (triangleStarList_.size() != 0);
     }
 
-    inline bool hasPreprocessedVertexEdges() const {
+    inline bool hasPreprocessedVertexEdges() const override {
       return (vertexEdgeList_.size() != 0);
     }
 
-    inline bool hasPreprocessedVertexLinks() const {
+    inline bool hasPreprocessedVertexLinks() const override {
       return (vertexLinkList_.size() != 0);
     }
 
-    inline bool hasPreprocessedVertexNeighbors() const {
+    inline bool hasPreprocessedVertexNeighbors() const override {
       return (vertexNeighborList_.size() != 0);
     }
 
-    inline bool hasPreprocessedVertexStars() const {
+    inline bool hasPreprocessedVertexStars() const override {
       return (vertexStarList_.size() != 0);
     }
 
-    inline bool hasPreprocessedVertexTriangles() const {
+    inline bool hasPreprocessedVertexTriangles() const override {
       return (vertexTriangleList_.size() != 0);
     }
 
-    inline bool isEdgeOnBoundary(const SimplexId &edgeId) const {
+    inline bool isEdgeOnBoundary(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)boundaryEdges_.size()))
         return false;
@@ -620,11 +620,11 @@ namespace ttk {
       return boundaryEdges_[edgeId];
     }
 
-    inline bool isEmpty() const {
+    inline bool isEmpty() const override {
       return !vertexNumber_;
     }
 
-    inline bool isTriangleOnBoundary(const SimplexId &triangleId) const {
+    inline bool isTriangleOnBoundary(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)boundaryTriangles_.size()))
@@ -633,7 +633,7 @@ namespace ttk {
       return boundaryTriangles_[triangleId];
     }
 
-    inline bool isVertexOnBoundary(const SimplexId &vertexId) const {
+    inline bool isVertexOnBoundary(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)boundaryVertices_.size()))
         return false;
@@ -641,7 +641,7 @@ namespace ttk {
       return boundaryVertices_[vertexId];
     }
 
-    inline int preprocessBoundaryEdges() {
+    inline int preprocessBoundaryEdges() override {
 
       if((!boundaryEdges_.empty())
          && (boundaryEdges_.size() == edgeList_.size())) {
@@ -681,7 +681,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessBoundaryTriangles() {
+    inline int preprocessBoundaryTriangles() override {
 
       if(getDimensionality() == 2)
         return 0;
@@ -714,7 +714,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessBoundaryVertices() {
+    inline int preprocessBoundaryVertices() override {
 
       if((!boundaryVertices_.empty())
          && ((SimplexId)boundaryVertices_.size() == vertexNumber_))
@@ -758,7 +758,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessCellEdges() {
+    inline int preprocessCellEdges() override {
 
       if(!cellEdgeList_.size()) {
 
@@ -773,7 +773,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessCellNeighbors() {
+    inline int preprocessCellNeighbors() override {
 
       if(!cellNeighborList_.size()) {
         ThreeSkeleton threeSkeleton;
@@ -788,7 +788,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessCellTriangles() {
+    inline int preprocessCellTriangles() override {
 
       if(!cellTriangleList_.size()) {
 
@@ -827,7 +827,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessEdges() {
+    inline int preprocessEdges() override {
 
       if(!edgeList_.size()) {
         OneSkeleton oneSkeleton;
@@ -839,7 +839,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessEdgeLinks() {
+    inline int preprocessEdgeLinks() override {
 
       if(!edgeLinkList_.size()) {
 
@@ -873,7 +873,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessEdgeStars() {
+    inline int preprocessEdgeStars() override {
 
       if(!edgeStarList_.size()) {
         OneSkeleton oneSkeleton;
@@ -885,7 +885,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessEdgeTriangles() {
+    inline int preprocessEdgeTriangles() override {
 
       if(!edgeTriangleList_.size()) {
 
@@ -905,7 +905,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessTriangles() {
+    inline int preprocessTriangles() override {
 
       if(!triangleList_.size()) {
 
@@ -920,7 +920,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessTriangleEdges() {
+    inline int preprocessTriangleEdges() override {
 
       if(!triangleEdgeList_.size()) {
 
@@ -941,7 +941,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessTriangleLinks() {
+    inline int preprocessTriangleLinks() override {
 
       if(!triangleLinkList_.size()) {
 
@@ -956,7 +956,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessTriangleStars() {
+    inline int preprocessTriangleStars() override {
 
       if(!triangleStarList_.size()) {
 
@@ -970,7 +970,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessVertexEdges() {
+    inline int preprocessVertexEdges() override {
 
       if((SimplexId)vertexEdgeList_.size() != vertexNumber_) {
         ZeroSkeleton zeroSkeleton;
@@ -989,7 +989,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessVertexLinks() {
+    inline int preprocessVertexLinks() override {
 
       if((SimplexId)vertexLinkList_.size() != vertexNumber_) {
 
@@ -1021,7 +1021,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessVertexNeighbors() {
+    inline int preprocessVertexNeighbors() override {
 
       if((SimplexId)vertexNeighborList_.size() != vertexNumber_) {
         ZeroSkeleton zeroSkeleton;
@@ -1033,7 +1033,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessVertexStars() {
+    inline int preprocessVertexStars() override {
 
       if((SimplexId)vertexStarList_.size() != vertexNumber_) {
         ZeroSkeleton zeroSkeleton;
@@ -1045,7 +1045,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int preprocessVertexTriangles() {
+    inline int preprocessVertexTriangles() override {
 
       if((SimplexId)vertexTriangleList_.size() != vertexNumber_) {
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -20,7 +20,7 @@
 
 namespace ttk {
 
-  class ImplicitTriangulation : public AbstractTriangulation {
+  class ImplicitTriangulation final : public AbstractTriangulation {
 
   public:
     ImplicitTriangulation();
@@ -28,85 +28,85 @@ namespace ttk {
 
     int getCellEdge(const SimplexId &cellId,
                     const int &id,
-                    SimplexId &edgeId) const;
+                    SimplexId &edgeId) const override;
 
-    SimplexId getCellEdgeNumber(const SimplexId &cellId) const;
+    SimplexId getCellEdgeNumber(const SimplexId &cellId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getCellEdges();
+    const std::vector<std::vector<SimplexId>> *getCellEdges() override;
 
     int getCellNeighbor(const SimplexId &cellId,
                         const int &localNeighborId,
-                        SimplexId &neighborId) const;
+                        SimplexId &neighborId) const override;
 
-    SimplexId getCellNeighborNumber(const SimplexId &cellId) const;
+    SimplexId getCellNeighborNumber(const SimplexId &cellId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getCellNeighbors();
+    const std::vector<std::vector<SimplexId>> *getCellNeighbors() override;
 
     int getCellTriangle(const SimplexId &cellId,
                         const int &id,
-                        SimplexId &triangleId) const;
+                        SimplexId &triangleId) const override;
 
-    SimplexId getCellTriangleNumber(const SimplexId &cellId) const {
+    SimplexId getCellTriangleNumber(const SimplexId &cellId) const override {
       // NOTE: the output is always 4 here. let's keep the function in there
       // in case of further generalization to CW-complexes
       return 4;
     };
 
-    const std::vector<std::vector<SimplexId>> *getCellTriangles();
+    const std::vector<std::vector<SimplexId>> *getCellTriangles() override;
 
     int getCellVertex(const SimplexId &cellId,
                       const int &localVertexId,
-                      SimplexId &vertexId) const;
+                      SimplexId &vertexId) const override;
 
-    SimplexId getCellVertexNumber(const SimplexId &cellId) const;
+    SimplexId getCellVertexNumber(const SimplexId &cellId) const override;
 
-    int getDimensionality() const {
+    int getDimensionality() const override {
       return dimensionality_;
     };
 
     int getEdgeLink(const SimplexId &edgeId,
                     const int &localLinkId,
-                    SimplexId &linkId) const;
+                    SimplexId &linkId) const override;
 
-    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeLinks();
+    const std::vector<std::vector<SimplexId>> *getEdgeLinks() override;
 
     int getEdgeStar(const SimplexId &edgeId,
                     const int &localStarId,
-                    SimplexId &starId) const;
+                    SimplexId &starId) const override;
 
-    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeStars();
+    const std::vector<std::vector<SimplexId>> *getEdgeStars() override;
 
     int getEdgeTriangle(const SimplexId &edgeId,
                         const int &id,
-                        SimplexId &triangleId) const;
+                        SimplexId &triangleId) const override;
 
-    SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeTriangles();
+    const std::vector<std::vector<SimplexId>> *getEdgeTriangles() override;
 
     int getEdgeVertex(const SimplexId &edgeId,
                       const int &localVertexId,
-                      SimplexId &vertexId) const;
+                      SimplexId &vertexId) const override;
 
-    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges();
+    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override;
 
-    SimplexId getNumberOfCells() const {
+    SimplexId getNumberOfCells() const override {
       return cellNumber_;
     };
 
-    SimplexId getNumberOfEdges() const {
+    SimplexId getNumberOfEdges() const override {
       return edgeNumber_;
     };
 
-    SimplexId getNumberOfTriangles() const {
+    SimplexId getNumberOfTriangles() const override {
       return triangleNumber_;
     };
 
-    SimplexId getNumberOfVertices() const {
+    SimplexId getNumberOfVertices() const override {
       return vertexNumber_;
     };
 
@@ -137,25 +137,25 @@ namespace ttk {
 
     int getTriangleEdge(const SimplexId &triangleId,
                         const int &id,
-                        SimplexId &edgeId) const;
+                        SimplexId &edgeId) const override;
 
-    SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const {
+    SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const override {
       // NOTE: the output is always 3 here. let's keep the function in there
       // in case of further generalization to CW-complexes
       return 3;
     }
 
-    const std::vector<std::vector<SimplexId>> *getTriangleEdges();
+    const std::vector<std::vector<SimplexId>> *getTriangleEdges() override;
 
     int getTriangleEdges(std::vector<std::vector<SimplexId>> &edges) const;
 
     int getTriangleLink(const SimplexId &triangleId,
                         const int &localLinkId,
-                        SimplexId &linkId) const;
+                        SimplexId &linkId) const override;
 
-    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const;
+    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangleLinks();
+    const std::vector<std::vector<SimplexId>> *getTriangleLinks() override;
 
     int getTriangleNeighbor(const SimplexId &triangleId,
                             const int &localNeighborId,
@@ -167,72 +167,72 @@ namespace ttk {
 
     int getTriangleStar(const SimplexId &triangleId,
                         const int &localStarId,
-                        SimplexId &starId) const;
+                        SimplexId &starId) const override;
 
-    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const;
+    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangleStars();
+    const std::vector<std::vector<SimplexId>> *getTriangleStars() override;
 
     int getTriangleVertex(const SimplexId &triangleId,
                           const int &localVertexId,
-                          SimplexId &vertexId) const;
+                          SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangles();
+    const std::vector<std::vector<SimplexId>> *getTriangles() override;
 
     int getVertexEdge(const SimplexId &vertexId,
                       const int &id,
-                      SimplexId &edgeId) const;
+                      SimplexId &edgeId) const override;
 
-    SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexEdges();
+    const std::vector<std::vector<SimplexId>> *getVertexEdges() override;
 
     int getVertexLink(const SimplexId &vertexId,
                       const int &localLinkId,
-                      SimplexId &linkId) const;
+                      SimplexId &linkId) const override;
 
-    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexLinks();
+    const std::vector<std::vector<SimplexId>> *getVertexLinks() override;
 
     int getVertexNeighbor(const SimplexId &vertexId,
                           const int &localNeighborId,
-                          SimplexId &neighborId) const;
+                          SimplexId &neighborId) const override;
 
-    SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexNeighbors();
+    const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override;
 
     int getVertexPoint(const SimplexId &vertexId,
                        float &x,
                        float &y,
-                       float &z) const;
+                       float &z) const override;
 
     int getVertexStar(const SimplexId &vertexId,
                       const int &localStarId,
-                      SimplexId &starId) const;
+                      SimplexId &starId) const override;
 
-    SimplexId getVertexStarNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexStarNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexStars();
+    const std::vector<std::vector<SimplexId>> *getVertexStars() override;
 
     int getVertexTriangle(const SimplexId &vertexId,
                           const int &id,
-                          SimplexId &triangleId) const;
+                          SimplexId &triangleId) const override;
 
-    SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexTriangles();
+    const std::vector<std::vector<SimplexId>> *getVertexTriangles() override;
 
-    bool isEdgeOnBoundary(const SimplexId &edgeId) const;
+    bool isEdgeOnBoundary(const SimplexId &edgeId) const override;
 
-    bool isEmpty() const {
+    bool isEmpty() const override {
       return !vertexNumber_;
     };
 
-    bool isTriangleOnBoundary(const SimplexId &triangleId) const;
+    bool isTriangleOnBoundary(const SimplexId &triangleId) const override;
 
-    bool isVertexOnBoundary(const SimplexId &vertexId) const;
+    bool isVertexOnBoundary(const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,
                      const float &yOrigin,

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -22,7 +22,7 @@
 
 namespace ttk {
 
-  class PeriodicImplicitTriangulation : public AbstractTriangulation {
+  class PeriodicImplicitTriangulation final : public AbstractTriangulation {
 
   public:
     PeriodicImplicitTriangulation();
@@ -30,85 +30,85 @@ namespace ttk {
 
     int getCellEdge(const SimplexId &cellId,
                     const int &id,
-                    SimplexId &edgeId) const;
+                    SimplexId &edgeId) const override;
 
-    SimplexId getCellEdgeNumber(const SimplexId &cellId) const;
+    SimplexId getCellEdgeNumber(const SimplexId &cellId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getCellEdges();
+    const std::vector<std::vector<SimplexId>> *getCellEdges() override;
 
     int getCellNeighbor(const SimplexId &cellId,
                         const int &localNeighborId,
-                        SimplexId &neighborId) const;
+                        SimplexId &neighborId) const override;
 
-    SimplexId getCellNeighborNumber(const SimplexId &cellId) const;
+    SimplexId getCellNeighborNumber(const SimplexId &cellId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getCellNeighbors();
+    const std::vector<std::vector<SimplexId>> *getCellNeighbors() override;
 
     int getCellTriangle(const SimplexId &cellId,
                         const int &id,
-                        SimplexId &triangleId) const;
+                        SimplexId &triangleId) const override;
 
-    SimplexId getCellTriangleNumber(const SimplexId &cellId) const {
+    SimplexId getCellTriangleNumber(const SimplexId &cellId) const override {
       // NOTE: the output is always 4 here. let's keep the function in there
       // in case of further generalization to CW-complexes
       return 4;
     };
 
-    const std::vector<std::vector<SimplexId>> *getCellTriangles();
+    const std::vector<std::vector<SimplexId>> *getCellTriangles() override;
 
     int getCellVertex(const SimplexId &cellId,
                       const int &localVertexId,
-                      SimplexId &vertexId) const;
+                      SimplexId &vertexId) const override;
 
-    SimplexId getCellVertexNumber(const SimplexId &cellId) const;
+    SimplexId getCellVertexNumber(const SimplexId &cellId) const override;
 
-    int getDimensionality() const {
+    int getDimensionality() const override {
       return dimensionality_;
     };
 
     int getEdgeLink(const SimplexId &edgeId,
                     const int &localLinkId,
-                    SimplexId &linkId) const;
+                    SimplexId &linkId) const override;
 
-    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeLinks();
+    const std::vector<std::vector<SimplexId>> *getEdgeLinks() override;
 
     int getEdgeStar(const SimplexId &edgeId,
                     const int &localStarId,
-                    SimplexId &starId) const;
+                    SimplexId &starId) const override;
 
-    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeStars();
+    const std::vector<std::vector<SimplexId>> *getEdgeStars() override;
 
     int getEdgeTriangle(const SimplexId &edgeId,
                         const int &id,
-                        SimplexId &triangleId) const;
+                        SimplexId &triangleId) const override;
 
-    SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const;
+    SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getEdgeTriangles();
+    const std::vector<std::vector<SimplexId>> *getEdgeTriangles() override;
 
     int getEdgeVertex(const SimplexId &edgeId,
                       const int &localVertexId,
-                      SimplexId &vertexId) const;
+                      SimplexId &vertexId) const override;
 
-    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges();
+    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override;
 
-    SimplexId getNumberOfCells() const {
+    SimplexId getNumberOfCells() const override {
       return cellNumber_;
     };
 
-    SimplexId getNumberOfEdges() const {
+    SimplexId getNumberOfEdges() const override {
       return edgeNumber_;
     };
 
-    SimplexId getNumberOfTriangles() const {
+    SimplexId getNumberOfTriangles() const override {
       return triangleNumber_;
     };
 
-    SimplexId getNumberOfVertices() const {
+    SimplexId getNumberOfVertices() const override {
       return vertexNumber_;
     };
 
@@ -139,25 +139,25 @@ namespace ttk {
 
     int getTriangleEdge(const SimplexId &triangleId,
                         const int &id,
-                        SimplexId &edgeId) const;
+                        SimplexId &edgeId) const override;
 
-    SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const {
+    SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const override {
       // NOTE: the output is always 3 here. let's keep the function in there
       // in case of further generalization to CW-complexes
       return 3;
     }
 
-    const std::vector<std::vector<SimplexId>> *getTriangleEdges();
+    const std::vector<std::vector<SimplexId>> *getTriangleEdges() override;
 
     int getTriangleEdges(std::vector<std::vector<SimplexId>> &edges) const;
 
     int getTriangleLink(const SimplexId &triangleId,
                         const int &localLinkId,
-                        SimplexId &linkId) const;
+                        SimplexId &linkId) const override;
 
-    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const;
+    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangleLinks();
+    const std::vector<std::vector<SimplexId>> *getTriangleLinks() override;
 
     int getTriangleNeighbor(const SimplexId &triangleId,
                             const int &localNeighborId,
@@ -169,72 +169,72 @@ namespace ttk {
 
     int getTriangleStar(const SimplexId &triangleId,
                         const int &localStarId,
-                        SimplexId &starId) const;
+                        SimplexId &starId) const override;
 
-    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const;
+    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangleStars();
+    const std::vector<std::vector<SimplexId>> *getTriangleStars() override;
 
     int getTriangleVertex(const SimplexId &triangleId,
                           const int &localVertexId,
-                          SimplexId &vertexId) const;
+                          SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getTriangles();
+    const std::vector<std::vector<SimplexId>> *getTriangles() override;
 
     int getVertexEdge(const SimplexId &vertexId,
                       const int &id,
-                      SimplexId &edgeId) const;
+                      SimplexId &edgeId) const override;
 
-    SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexEdges();
+    const std::vector<std::vector<SimplexId>> *getVertexEdges() override;
 
     int getVertexLink(const SimplexId &vertexId,
                       const int &localLinkId,
-                      SimplexId &linkId) const;
+                      SimplexId &linkId) const override;
 
-    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexLinks();
+    const std::vector<std::vector<SimplexId>> *getVertexLinks() override;
 
     int getVertexNeighbor(const SimplexId &vertexId,
                           const int &localNeighborId,
-                          SimplexId &neighborId) const;
+                          SimplexId &neighborId) const override;
 
-    SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexNeighbors();
+    const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override;
 
     int getVertexPoint(const SimplexId &vertexId,
                        float &x,
                        float &y,
-                       float &z) const;
+                       float &z) const override;
 
     int getVertexStar(const SimplexId &vertexId,
                       const int &localStarId,
-                      SimplexId &starId) const;
+                      SimplexId &starId) const override;
 
-    SimplexId getVertexStarNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexStarNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexStars();
+    const std::vector<std::vector<SimplexId>> *getVertexStars() override;
 
     int getVertexTriangle(const SimplexId &vertexId,
                           const int &id,
-                          SimplexId &triangleId) const;
+                          SimplexId &triangleId) const override;
 
-    SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const;
+    SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *getVertexTriangles();
+    const std::vector<std::vector<SimplexId>> *getVertexTriangles() override;
 
-    bool isEdgeOnBoundary(const SimplexId &edgeId) const;
+    bool isEdgeOnBoundary(const SimplexId &edgeId) const override;
 
-    bool isEmpty() const {
+    bool isEmpty() const override {
       return !vertexNumber_;
     };
 
-    bool isTriangleOnBoundary(const SimplexId &triangleId) const;
+    bool isTriangleOnBoundary(const SimplexId &triangleId) const override;
 
-    bool isVertexOnBoundary(const SimplexId &vertexId) const;
+    bool isVertexOnBoundary(const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,
                      const float &yOrigin,

--- a/core/base/triangulation/Triangulation.cpp
+++ b/core/base/triangulation/Triangulation.cpp
@@ -3,13 +3,91 @@
 using namespace std;
 using namespace ttk;
 
-Triangulation::Triangulation() {
-
-  usePeriodicBoundaries_ = false;
-  debugLevel_ = 0;
-  gridDimensions_[0] = gridDimensions_[1] = gridDimensions_[2] = -1;
-  abstractTriangulation_ = NULL;
+Triangulation::Triangulation()
+  : AbstractTriangulation{}, gridDimensions_{-1, -1, -1},
+    abstractTriangulation_{nullptr}, usePeriodicBoundaries_{false} {
+  debugLevel_ = 0; // overrides the global debug level.
 }
 
-Triangulation::~Triangulation() {
+Triangulation::Triangulation(const Triangulation &rhs)
+  : AbstractTriangulation(rhs), gridDimensions_{rhs.gridDimensions_},
+    abstractTriangulation_{nullptr},
+    explicitTriangulation_{rhs.explicitTriangulation_},
+    implicitTriangulation_{rhs.implicitTriangulation_},
+    periodicImplicitTriangulation_{rhs.periodicImplicitTriangulation_},
+    usePeriodicBoundaries_{rhs.usePeriodicBoundaries_} {
+
+  if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
+    abstractTriangulation_ = &explicitTriangulation_;
+  } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
+    abstractTriangulation_ = &implicitTriangulation_;
+  } else if(rhs.abstractTriangulation_ == &rhs.periodicImplicitTriangulation_) {
+    abstractTriangulation_ = &periodicImplicitTriangulation_;
+  }
 }
+
+Triangulation::Triangulation(Triangulation &&rhs)
+  : AbstractTriangulation(std::move(rhs)), gridDimensions_{std::move(
+                                             rhs.gridDimensions_)},
+    abstractTriangulation_{nullptr}, explicitTriangulation_{std::move(
+                                       rhs.explicitTriangulation_)},
+    implicitTriangulation_{std::move(rhs.implicitTriangulation_)},
+    periodicImplicitTriangulation_{
+      std::move(rhs.periodicImplicitTriangulation_)},
+    usePeriodicBoundaries_{std::move(rhs.usePeriodicBoundaries_)} {
+
+  if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
+    abstractTriangulation_ = &explicitTriangulation_;
+  } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
+    abstractTriangulation_ = &implicitTriangulation_;
+  } else if(rhs.abstractTriangulation_ == &rhs.periodicImplicitTriangulation_) {
+    abstractTriangulation_ = &periodicImplicitTriangulation_;
+  }
+}
+
+Triangulation &Triangulation::operator=(const Triangulation &rhs) {
+  if(this != &rhs) {
+    AbstractTriangulation::operator=(rhs);
+    gridDimensions_ = rhs.gridDimensions_;
+    abstractTriangulation_ = nullptr;
+    explicitTriangulation_ = rhs.explicitTriangulation_;
+    implicitTriangulation_ = rhs.implicitTriangulation_;
+    periodicImplicitTriangulation_ = rhs.periodicImplicitTriangulation_;
+    usePeriodicBoundaries_ = rhs.usePeriodicBoundaries_;
+
+    if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
+      abstractTriangulation_ = &explicitTriangulation_;
+    } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
+      abstractTriangulation_ = &implicitTriangulation_;
+    } else if(rhs.abstractTriangulation_
+              == &rhs.periodicImplicitTriangulation_) {
+      abstractTriangulation_ = &periodicImplicitTriangulation_;
+    }
+  }
+  return *this;
+}
+
+Triangulation &Triangulation::operator=(Triangulation &&rhs) {
+  if(this != &rhs) {
+    AbstractTriangulation::operator=(std::move(rhs));
+    gridDimensions_ = std::move(rhs.gridDimensions_);
+    abstractTriangulation_ = nullptr;
+    explicitTriangulation_ = std::move(rhs.explicitTriangulation_);
+    implicitTriangulation_ = std::move(rhs.implicitTriangulation_);
+    periodicImplicitTriangulation_
+      = std::move(rhs.periodicImplicitTriangulation_);
+    usePeriodicBoundaries_ = std::move(rhs.usePeriodicBoundaries_);
+
+    if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
+      abstractTriangulation_ = &explicitTriangulation_;
+    } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
+      abstractTriangulation_ = &implicitTriangulation_;
+    } else if(rhs.abstractTriangulation_
+              == &rhs.periodicImplicitTriangulation_) {
+      abstractTriangulation_ = &periodicImplicitTriangulation_;
+    }
+  }
+  return *this;
+}
+
+Triangulation::~Triangulation() = default;

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -41,18 +41,25 @@
 #include <ImplicitTriangulation.h>
 #include <PeriodicImplicitTriangulation.h>
 
+#include <array>
+
 namespace ttk {
 
-  class Triangulation : public AbstractTriangulation {
+  class Triangulation final : public AbstractTriangulation {
 
   public:
     Triangulation();
+    Triangulation(const Triangulation&);
+    Triangulation(Triangulation&&);
+    Triangulation& operator=(const Triangulation&);
+    Triangulation& operator=(Triangulation&&);
+
 
     ~Triangulation();
 
     /// Reset the triangulation data-structures.
     /// \return Returns 0 upon success, negative values otherwise.
-    inline int clear() {
+    inline int clear() override  {
 
       if(abstractTriangulation_) {
         return abstractTriangulation_->clear();
@@ -63,7 +70,7 @@ namespace ttk {
 
     /// Computes and displays the memory footprint of the data-structure.
     /// \return Returns 0 upon success, negative values otherwise.
-    inline size_t footprint() const {
+    inline size_t footprint() const override {
 
       if(abstractTriangulation_) {
         return abstractTriangulation_->footprint();
@@ -95,7 +102,7 @@ namespace ttk {
     /// \sa getCellNeighbor()
     inline int getCellEdge(const SimplexId &cellId,
                            const int &localEdgeId,
-                           SimplexId &edgeId) const {
+                           SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -141,7 +148,7 @@ namespace ttk {
     /// \param cellId Input global cell identifier.
     /// \return Returns the number of cell edges.
     /// \sa getCellNeighborNumber()
-    inline SimplexId getCellEdgeNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellEdgeNumber(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -194,7 +201,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the cell edge list.
     /// \sa getCellNeighbors()
-    inline const std::vector<std::vector<SimplexId>> *getCellEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getCellEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -240,7 +247,7 @@ namespace ttk {
     /// \sa getCellNeighborNumber()
     inline int getCellNeighbor(const SimplexId &cellId,
                                const int &localNeighborId,
-                               SimplexId &neighborId) const {
+                               SimplexId &neighborId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -278,7 +285,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param cellId Input global cell identifier.
     /// \return Returns the number of cell neighbors.
-    inline SimplexId getCellNeighborNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellNeighborNumber(const SimplexId &cellId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -323,7 +330,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the cell neighbor list.
-    inline const std::vector<std::vector<SimplexId>> *getCellNeighbors() {
+    inline const std::vector<std::vector<SimplexId>> *getCellNeighbors() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -366,7 +373,7 @@ namespace ttk {
     /// \sa getCellNeighbor()
     inline int getCellTriangle(const SimplexId &cellId,
                                const int &localTriangleId,
-                               SimplexId &triangleId) const {
+                               SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -417,7 +424,7 @@ namespace ttk {
     /// \param cellId Input global cell identifier.
     /// \return Returns the number of cell triangles.
     /// \sa getCellNeighborNumber()
-    inline SimplexId getCellTriangleNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellTriangleNumber(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -476,7 +483,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the cell triangle list.
     /// \sa getCellNeighbors()
-    inline const std::vector<std::vector<SimplexId>> *getCellTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getCellTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -517,7 +524,7 @@ namespace ttk {
     /// \sa getCellVertexNumber()
     inline int getCellVertex(const SimplexId &cellId,
                              const int &localVertexId,
-                             SimplexId &vertexId) const {
+                             SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -537,7 +544,7 @@ namespace ttk {
     /// dimension (3D: tetrahedra, 2D: triangles, 1D: edges).
     /// \param cellId Input global cell identifier.
     /// \returns Number of vertices in the cell.
-    inline SimplexId getCellVertexNumber(const SimplexId &cellId) const {
+    inline SimplexId getCellVertexNumber(const SimplexId &cellId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -549,7 +556,7 @@ namespace ttk {
     /// Get the dimensionality of the triangulation (this value is equal to
     /// the dimension of the simplex with largest dimensionality).
     /// \return Returns the dimensionality of the triangulation.
-    inline int getDimensionality() const {
+    inline int getDimensionality() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -581,7 +588,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge list.
-    inline const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() {
+    inline const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -624,7 +631,7 @@ namespace ttk {
     /// \sa getEdgeLinkNumber()
     inline int getEdgeLink(const SimplexId &edgeId,
                            const int &localLinkId,
-                           SimplexId &linkId) const {
+                           SimplexId &linkId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       linkId = -1;
@@ -663,7 +670,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param edgeId Input global edge identifier.
     /// \return Returns the number of cells in the link of the edge.
-    inline SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -708,7 +715,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge link list.
-    inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -754,7 +761,7 @@ namespace ttk {
     /// \sa getEdgeStarNumber()
     inline int getEdgeStar(const SimplexId &edgeId,
                            const int &localStarId,
-                           SimplexId &starId) const {
+                           SimplexId &starId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       starId = -1;
@@ -796,7 +803,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param edgeId Input global edge identifier
     /// \return Returns the number of star cells.
-    inline SimplexId getEdgeStarNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -846,7 +853,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge star list.
-    inline const std::vector<std::vector<SimplexId>> *getEdgeStars() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -889,7 +896,7 @@ namespace ttk {
     /// \sa getEdgeStar()
     inline int getEdgeTriangle(const SimplexId &edgeId,
                                const int &localTriangleId,
-                               SimplexId &triangleId) const {
+                               SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -991,7 +998,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge triangle list.
     /// \sa getEdgeStars
-    inline const std::vector<std::vector<SimplexId>> *getEdgeTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getEdgeTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1039,7 +1046,7 @@ namespace ttk {
     /// \sa getCellVertex()
     inline int getEdgeVertex(const SimplexId &edgeId,
                              const int &localVertexId,
-                             SimplexId &vertexId) const {
+                             SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       vertexId = -1;
@@ -1094,7 +1101,7 @@ namespace ttk {
     /// Here the notion of cell refers to the simplicices of maximal
     /// dimension (3D: tetrahedra, 2D: triangles, 1D: edges).
     /// \return Returns the number of cells.
-    inline SimplexId getNumberOfCells() const {
+    inline SimplexId getNumberOfCells() const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -1117,7 +1124,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns the number of edges.
     /// \sa getNumberOfCells()
-    inline SimplexId getNumberOfEdges() const {
+    inline SimplexId getNumberOfEdges() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1153,7 +1160,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns the number of triangles.
     /// \sa getNumberOfCells()
-    inline SimplexId getNumberOfTriangles() const {
+    inline SimplexId getNumberOfTriangles() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
 
       if(isEmptyCheck())
@@ -1182,7 +1189,7 @@ namespace ttk {
 
     /// Get the number of vertices in the triangulation.
     /// \return Returns the number of vertices.
-    inline SimplexId getNumberOfVertices() const {
+    inline SimplexId getNumberOfVertices() const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -1215,7 +1222,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle list.
-    inline const std::vector<std::vector<SimplexId>> *getTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1254,7 +1261,7 @@ namespace ttk {
     /// \sa getCellEdge()
     inline int getTriangleEdge(const SimplexId &triangleId,
                                const int &localEdgeId,
-                               SimplexId &edgeId) const {
+                               SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       edgeId = -1;
@@ -1301,7 +1308,7 @@ namespace ttk {
     /// \param triangleId Input global triangle identifier.
     /// \return Returns the number of cells in the link of the triangle.
     /// \sa getCellEdgeNumber()
-    inline SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleEdgeNumber(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1354,7 +1361,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle edge list.
     /// \sa getCellEdges()
-    inline const std::vector<std::vector<SimplexId>> *getTriangleEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1403,7 +1410,7 @@ namespace ttk {
     /// \sa getTriangleLinkNumber()
     inline int getTriangleLink(const SimplexId &triangleId,
                                const int &localLinkId,
-                               SimplexId &linkId) const {
+                               SimplexId &linkId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       linkId = -1;
@@ -1444,7 +1451,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param triangleId Input global triangle identifier.
     /// \return Returns the number of simplices in the link of the triangle.
-    inline SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1490,7 +1497,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle link list.
-    inline const std::vector<std::vector<SimplexId>> *getTriangleLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleLinks() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1534,7 +1541,7 @@ namespace ttk {
     /// \sa getTriangleStarNumber()
     inline int getTriangleStar(const SimplexId &triangleId,
                                const int &localStarId,
-                               SimplexId &starId) const {
+                               SimplexId &starId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
       starId = -1;
@@ -1574,7 +1581,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param triangleId Input global triangle identifier.
     /// \return Returns the number of star cells.
-    inline SimplexId getTriangleStarNumber(const SimplexId &triangleId) const {
+    inline SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1621,7 +1628,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle star list.
-    inline const std::vector<std::vector<SimplexId>> *getTriangleStars() {
+    inline const std::vector<std::vector<SimplexId>> *getTriangleStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1662,7 +1669,7 @@ namespace ttk {
     /// \sa getCellVertex()
     inline int getTriangleVertex(const SimplexId &triangleId,
                                  const int &localVertexId,
-                                 SimplexId &vertexId) const {
+                                 SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -1716,7 +1723,7 @@ namespace ttk {
     /// \sa getVertexStar()
     inline int getVertexEdge(const SimplexId &vertexId,
                              const int &localEdgeId,
-                             SimplexId &edgeId) const {
+                             SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -1761,7 +1768,7 @@ namespace ttk {
     /// \param vertexId Input global vertex identifier.
     /// \return Returns the number of edges connected to the vertex.
     /// \sa getVertexStarNumber()
-    inline SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexEdgeNumber(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1812,7 +1819,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the vertex edge list.
     /// \sa getVertexStars()
-    inline const std::vector<std::vector<SimplexId>> *getVertexEdges() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -1858,7 +1865,7 @@ namespace ttk {
     /// \sa getVertexLinkNumber()
     inline int getVertexLink(const SimplexId &vertexId,
                              const int &localLinkId,
-                             SimplexId &linkId) const {
+                             SimplexId &linkId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -1896,7 +1903,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param vertexId Input global vertex identifier.
     /// \return Returns the number of cells in the link of the vertex.
-    inline SimplexId getVertexLinkNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -1940,7 +1947,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the vertex link list.
-    inline const std::vector<std::vector<SimplexId>> *getVertexLinks() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexLinks() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -1978,7 +1985,7 @@ namespace ttk {
     /// \sa getVertexNeighborNumber()
     inline int getVertexNeighbor(const SimplexId &vertexId,
                                  const int &localNeighborId,
-                                 SimplexId &neighborId) const {
+                                 SimplexId &neighborId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -2013,7 +2020,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param vertexId Input global vertex identifier.
     /// \return Returns the number vertex neighbors.
-    inline SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2056,7 +2063,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the vertex neighbor list.
-    inline const std::vector<std::vector<SimplexId>> *getVertexNeighbors() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -2084,7 +2091,7 @@ namespace ttk {
     inline int getVertexPoint(const SimplexId &vertexId,
                               float &x,
                               float &y,
-                              float &z) const {
+                              float &z) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variables before early return
@@ -2120,7 +2127,7 @@ namespace ttk {
     /// \sa getVertexStarNumber()
     inline int getVertexStar(const SimplexId &vertexId,
                              const int &localStarId,
-                             SimplexId &starId) const {
+                             SimplexId &starId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -2158,7 +2165,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param vertexId Input global vertex identifier
     /// \return Returns the number of star cells.
-    inline SimplexId getVertexStarNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexStarNumber(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -2202,7 +2209,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the vertex star list.
-    inline const std::vector<std::vector<SimplexId>> *getVertexStars() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -2243,7 +2250,7 @@ namespace ttk {
     /// \sa getVertexStar()
     inline int getVertexTriangle(const SimplexId &vertexId,
                                  const int &localTriangleId,
-                                 SimplexId &triangleId) const {
+                                 SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       // initialize output variable before early return
@@ -2291,7 +2298,7 @@ namespace ttk {
     /// \param vertexId Input global vertex identifier.
     /// \return Returns the number of vertex triangles.
     /// \sa getVertexStarNumber()
-    inline SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const {
+    inline SimplexId getVertexTriangleNumber(const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2346,7 +2353,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \return Returns a pointer to the vertex triangle list.
     /// \sa getVertexStars()
-    inline const std::vector<std::vector<SimplexId>> *getVertexTriangles() {
+    inline const std::vector<std::vector<SimplexId>> *getVertexTriangles() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2394,7 +2401,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param edgeId Input global edge identifier.
     /// \return Returns true if the edge is on the boundary, false otherwise.
-    inline bool isEdgeOnBoundary(const SimplexId &edgeId) const {
+    inline bool isEdgeOnBoundary(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return false;
@@ -2415,7 +2422,7 @@ namespace ttk {
 
     /// Check if the data structure is empty or not.
     /// \return Returns true if empty, false otherwise.
-    inline bool isEmpty() const {
+    inline bool isEmpty() const override {
       return !abstractTriangulation_;
     }
 
@@ -2439,7 +2446,7 @@ namespace ttk {
     /// \param triangleId Input global triangle identifier.
     /// \return Returns true if the triangle is on the boundary, false
     /// otherwise.
-    inline bool isTriangleOnBoundary(const SimplexId &triangleId) const {
+    inline bool isTriangleOnBoundary(const SimplexId &triangleId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return false;
@@ -2475,7 +2482,7 @@ namespace ttk {
     /// \param vertexId Input global vertex identifier.
     /// \return Returns true if the vertex is on the boundary, false
     /// otherwise.
-    inline bool isVertexOnBoundary(const SimplexId &vertexId) const {
+    inline bool isVertexOnBoundary(const SimplexId &vertexId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return false;
@@ -2507,7 +2514,7 @@ namespace ttk {
     /// any time performance measurement.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa isEdgeOnBoundary()
-    inline int preprocessBoundaryEdges() {
+    inline int preprocessBoundaryEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -2529,7 +2536,7 @@ namespace ttk {
     /// any time performance measurement.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa isTriangleOnBoundary()
-    inline int preprocessBoundaryTriangles() {
+    inline int preprocessBoundaryTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -2551,7 +2558,7 @@ namespace ttk {
     /// any time performance measurement.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa isVertexOnBoundary()
-    inline int preprocessBoundaryVertices() {
+    inline int preprocessBoundaryVertices() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -2575,7 +2582,7 @@ namespace ttk {
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa getCellEdge()
     /// \sa getCellEdgeNumber()
-    inline int preprocessCellEdges() {
+    inline int preprocessCellEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -2603,7 +2610,7 @@ namespace ttk {
     /// \sa getCellNeighbor()
     /// \sa getCellNeighbors()
     /// \sa getCellNeighborNumber()
-    inline int preprocessCellNeighbors() {
+    inline int preprocessCellNeighbors() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2630,7 +2637,7 @@ namespace ttk {
     /// \sa getCellTriangle()
     /// \sa getCellTriangles()
     /// \sa getCellTriangleNumber()
-    inline int preprocessCellTriangles() {
+    inline int preprocessCellTriangles() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2662,7 +2669,7 @@ namespace ttk {
     /// \sa getEdges()
     /// \sa getEdgeVertex()
     /// \sa getNumberOfEdges()
-    inline int preprocessEdges() {
+    inline int preprocessEdges() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2689,7 +2696,7 @@ namespace ttk {
     /// \sa getEdgeLink()
     /// \sa getEdgeLinks()
     /// \sa getEdgeLinkNumber()
-    inline int preprocessEdgeLinks() {
+    inline int preprocessEdgeLinks() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2719,7 +2726,7 @@ namespace ttk {
     /// \sa getEdgeStar()
     /// \sa getEdgeStars()
     /// \sa getEdgeStarNumber()
-    inline int preprocessEdgeStars() {
+    inline int preprocessEdgeStars() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2749,7 +2756,7 @@ namespace ttk {
     /// \sa getEdgeTriangle()
     /// \sa getEdgeTriangles()
     /// \sa getEdgeTriangleNumber()
-    inline int preprocessEdgeTriangles() {
+    inline int preprocessEdgeTriangles() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2783,7 +2790,7 @@ namespace ttk {
     /// \sa getNumberOfTriangles()
     /// \sa getTriangles()
     /// \sa getTriangleVertex()
-    inline int preprocessTriangles() {
+    inline int preprocessTriangles() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2816,7 +2823,7 @@ namespace ttk {
     /// \sa getTriangleEdge()
     /// \sa getTriangleEdges()
     /// \sa getTriangleEdgeNumber()
-    inline int preprocessTriangleEdges() {
+    inline int preprocessTriangleEdges() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2849,7 +2856,7 @@ namespace ttk {
     /// \sa getTriangleLink()
     /// \sa getTriangleLinks()
     /// \sa getTriangleLinkNumber()
-    inline int preprocessTriangleLinks() {
+    inline int preprocessTriangleLinks() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2879,7 +2886,7 @@ namespace ttk {
     /// \sa getTriangleStar()
     /// \sa getTriangleStars()
     /// \sa getTriangleStarNumber()
-    inline int preprocessTriangleStars() {
+    inline int preprocessTriangleStars() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2909,7 +2916,7 @@ namespace ttk {
     /// \sa getVertexEdge()
     /// \sa getVertexEdges()
     /// \sa getVertexEdgeNumber()
-    inline int preprocessVertexEdges() {
+    inline int preprocessVertexEdges() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2938,7 +2945,7 @@ namespace ttk {
     /// \sa getVertexLink()
     /// \sa getVertexLinks()
     /// \sa getVertexLinkNumber()
-    inline int preprocessVertexLinks() {
+    inline int preprocessVertexLinks() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2965,7 +2972,7 @@ namespace ttk {
     /// \sa getVertexNeighbor()
     /// \sa getVertexNeighbors()
     /// \sa getVertexNeighborNumber()
-    inline int preprocessVertexNeighbors() {
+    inline int preprocessVertexNeighbors() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -2992,7 +2999,7 @@ namespace ttk {
     /// \sa getVertexStar()
     /// \sa getVertexStars()
     /// \sa getVertexStarNumber()
-    inline int preprocessVertexStars() {
+    inline int preprocessVertexStars() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -3019,7 +3026,7 @@ namespace ttk {
     /// \sa getVertexTriangle()
     /// \sa getVertexTriangles()
     /// \sa getVertexTriangleNumber()
-    inline int preprocessVertexTriangles() {
+    inline int preprocessVertexTriangles() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
@@ -3035,7 +3042,7 @@ namespace ttk {
     }
 
     /// Tune the debug level (default: 0)
-    inline int setDebugLevel(const int &debugLevel) {
+    inline int setDebugLevel(const int &debugLevel) override {
       explicitTriangulation_.setDebugLevel(debugLevel);
       implicitTriangulation_.setDebugLevel(debugLevel);
       periodicImplicitTriangulation_.setDebugLevel(debugLevel);
@@ -3144,6 +3151,12 @@ namespace ttk {
       }
     }
 
+    /// Returns true if the grid uses period boundary conditions.
+    /// \see setPeriodicBoundaryConditions
+    bool usesPeriodicBoundaryConditions() const {
+        return usePeriodicBoundaries_;
+    }
+
     /// Set the input 3D points of the triangulation.
     /// \param pointNumber Number of input vertices.
     /// \param pointSet Pointer to the 3D points. This pointer should point to
@@ -3181,7 +3194,7 @@ namespace ttk {
 
     /// Internal usage. Pass the execution context (debug level, number of
     /// threads, etc.) to the implementing classes.
-    inline int setWrapper(const Wrapper *wrapper) {
+    inline int setWrapper(const Wrapper *wrapper) override {
       explicitTriangulation_.setWrapper(wrapper);
       implicitTriangulation_.setWrapper(wrapper);
       periodicImplicitTriangulation_.setWrapper(wrapper);
@@ -3200,7 +3213,7 @@ namespace ttk {
       return false;
     }
 
-    int gridDimensions_[3];
+    std::array<int, 3> gridDimensions_;
 
     AbstractTriangulation *abstractTriangulation_;
     ExplicitTriangulation explicitTriangulation_;


### PR DESCRIPTION
Fixes the copy/move constructors. Added override to overridden functions. Added final to classes to help the compiler devirtualize.

Closes #271
