### PR TITLE
Barycentric Subdivision: Fixes, Subdivision Level

### DIFF
--- a/core/base/barycentricSubdivision/BarycentricSubdivision.cpp
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.cpp
@@ -15,11 +15,7 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
     return 1;
   }
 
-  const SimplexId nVerts{inputTriangl_->getNumberOfVertices()};
-  const SimplexId nEdges{inputTriangl_->getNumberOfEdges()};
-  const SimplexId nTriangles{inputTriangl_->getNumberOfTriangles()};
-
-  const SimplexId newPoints{nVerts + nEdges + nTriangles};
+  const SimplexId newPoints{nVertices_ + nEdges_ + nTriangles_};
   const size_t dataPerPoint{3};
   points_.clear();
   points_.resize(newPoints * dataPerPoint);
@@ -27,7 +23,7 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
   const size_t dataPerCell{4};
   const size_t newTrianglesPerParent{6};
   cells_.clear();
-  cells_.resize(nTriangles * dataPerCell * newTrianglesPerParent);
+  cells_.resize(nTriangles_ * dataPerCell * newTrianglesPerParent);
 
   pointId_.clear();
   pointId_.resize(newPoints);
@@ -37,10 +33,10 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
 
   // copy input points
   std::copy(
-    inputPoints_, inputPoints_ + nVerts * dataPerPoint, points_.begin());
+    inputPoints_, inputPoints_ + nVertices_ * dataPerPoint, points_.begin());
 
   // set input point ids
-  for(SimplexId i = 0; i < nVerts; ++i) {
+  for(SimplexId i = 0; i < nVertices_; ++i) {
     pointId_[i] = i;
   }
 
@@ -48,7 +44,7 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
   points_.reserve(newPoints * dataPerPoint);
 
   // generate edge middles
-  for(SimplexId i = 0; i < nEdges; ++i) {
+  for(SimplexId i = 0; i < nEdges_; ++i) {
     // edge vertices
     SimplexId a{}, b{};
     inputTriangl_->getEdgeVertex(i, 0, a);
@@ -62,16 +58,16 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
     mid[1] = (pa[1] + pb[1]) / 2.0F;
     mid[2] = (pa[2] + pb[2]) / 2.0F;
 
-    const size_t offset = dataPerPoint * (nVerts + i);
+    const size_t offset = dataPerPoint * (nVertices_ + i);
     points_[offset + 0] = mid[0];
     points_[offset + 1] = mid[1];
     points_[offset + 2] = mid[2];
-    pointId_[nVerts + i] = i;
-    pointDim_[nVerts + i] = 1;
+    pointId_[nVertices_ + i] = i;
+    pointDim_[nVertices_ + i] = 1;
   }
 
   // generate triangle barycenters
-  for(SimplexId i = 0; i < nTriangles; ++i) {
+  for(SimplexId i = 0; i < nTriangles_; ++i) {
     // triangle vertices
     SimplexId a{}, b{}, c{};
     inputTriangl_->getTriangleVertex(i, 0, a);
@@ -87,18 +83,18 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
     bary[1] = (pa[1] + pb[1] + pc[1]) / 3.0F;
     bary[2] = (pa[2] + pb[2] + pc[2]) / 3.0F;
 
-    const size_t offset = dataPerPoint * (nVerts + nEdges + i);
+    const size_t offset = dataPerPoint * (nVertices_ + nEdges_ + i);
     points_[offset + 0] = bary[0];
     points_[offset + 1] = bary[1];
     points_[offset + 2] = bary[2];
-    pointId_[nVerts + nEdges + i] = i;
-    pointDim_[nVerts + nEdges + i] = 2;
+    pointId_[nVertices_ + nEdges_ + i] = i;
+    pointDim_[nVertices_ + nEdges_ + i] = 2;
   }
 
   // subdivise every triangle
-  for(SimplexId i = 0; i < nTriangles; ++i) {
+  for(SimplexId i = 0; i < nTriangles_; ++i) {
     // id of triangle barycenter
-    SimplexId bary = nVerts + nEdges + i;
+    SimplexId bary = nVertices_ + nEdges_ + i;
 
     for(SimplexId j = 0; j < inputTriangl_->getTriangleEdgeNumber(i); ++j) {
       // edge id
@@ -106,7 +102,7 @@ int ttk::BarycentricSubdivision::subdiviseTriangulation() {
       inputTriangl_->getTriangleEdge(i, j, e);
 
       // id of middle of edge e
-      SimplexId em = nVerts + e;
+      SimplexId em = nVertices_ + e;
 
       // edge vertices
       SimplexId a{}, b{};

--- a/core/base/barycentricSubdivision/BarycentricSubdivision.h
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.h
@@ -51,15 +51,21 @@ namespace ttk {
         inputTriangl_->preprocessTriangles();
         inputTriangl_->preprocessTriangleEdges();
       }
+      nVertices_ = inputTriangl_->getNumberOfVertices();
+      nEdges_ = inputTriangl_->getNumberOfEdges();
+      nTriangles_ = inputTriangl_->getNumberOfTriangles();
     }
 
+    /** @brief Return the number of vertices in the output triangulation
+     */
     inline SimplexId getNumberOfVertices() {
-      if(inputTriangl_ == nullptr) {
-        return 0;
-      }
-      return inputTriangl_->getNumberOfVertices()
-             + inputTriangl_->getNumberOfEdges()
-             + inputTriangl_->getNumberOfTriangles();
+      return nVertices_ + nEdges_ + nTriangles_;
+    }
+
+    /** @brief Return the number of triangles in the output triangulation
+     */
+    inline SimplexId getNumberOfTriangles() {
+      return nTriangles_ * 6;
     }
 
     int execute();
@@ -174,6 +180,11 @@ namespace ttk {
   private:
     int subdiviseTriangulation();
     int buildOutputTriangulation();
+
+    // input triangulation properties
+    SimplexId nVertices_{};
+    SimplexId nEdges_{};
+    SimplexId nTriangles_{};
 
     // input triangulation
     Triangulation *inputTriangl_{};

--- a/core/base/barycentricSubdivision/BarycentricSubdivision.h
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.h
@@ -30,6 +30,13 @@ namespace ttk {
   class BarycentricSubdivision : public Debug {
 
   public:
+    BarycentricSubdivision(std::vector<float> &points,
+                           std::vector<LongSimplexId> &cells,
+                           std::vector<SimplexId> &pointId,
+                           std::vector<SimplexId> &pointDim)
+      : points_{points}, cells_{cells}, pointId_{pointId}, pointDim_{pointDim} {
+    }
+
     inline void setOutputTriangulation(Triangulation *const triangulation) {
       outputTriangl_ = triangulation;
     }
@@ -177,18 +184,18 @@ namespace ttk {
     // list of input cell data
     std::vector<void *> cellData_{};
 
-  public:
     // output 3D coordinates of generated points: old points first, then edge
     // middles, then triangle barycenters
-    std::vector<float> points_{};
+    std::vector<float> &points_;
     // output triangles
-    std::vector<LongSimplexId> cells_{};
-    // output triangulation built on output points & output cells
-    Triangulation *outputTriangl_{};
+    std::vector<LongSimplexId> &cells_;
     // generated point cell id
-    std::vector<SimplexId> pointId_{};
+    std::vector<SimplexId> &pointId_;
     // generated points dimension: 0 vertex of parent triangulation, 1 edge
     // middle, 2 triangle barycenter
-    std::vector<SimplexId> pointDim_{};
+    std::vector<SimplexId> &pointDim_;
+
+    // output triangulation built on output points & output cells
+    Triangulation *outputTriangl_{};
   };
 } // namespace ttk

--- a/core/base/barycentricSubdivision/BarycentricSubdivision.h
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.h
@@ -87,32 +87,29 @@ namespace ttk {
       if(inputTriangl_ == nullptr || outputTriangl_ == nullptr) {
         return 1;
       }
-      const auto nInVerts = inputTriangl_->getNumberOfVertices();
-      const auto nInEdges = inputTriangl_->getNumberOfEdges();
-      const auto nInTriangles = inputTriangl_->getNumberOfTriangles();
-      const auto nOutVerts = outputTriangl_->getNumberOfVertices();
-      if(nOutVerts < 0 || nOutVerts != nInVerts + nInEdges + nInTriangles) {
+      const auto nOutVerts = this->getNumberOfVertices();
+      if(nOutVerts < 0 || nOutVerts != nVertices_ + nEdges_ + nTriangles_) {
         return 1;
       }
 
       // copy data on parent vertices
-      std::copy(data, data + nInVerts, output);
+      std::copy(data, data + nVertices_, output);
 
       // interpolate on edges
-      for(SimplexId i = 0; i < nInEdges; ++i) {
+      for(SimplexId i = 0; i < nEdges_; ++i) {
         SimplexId a{}, b{};
         inputTriangl_->getEdgeVertex(i, 0, a);
         inputTriangl_->getEdgeVertex(i, 0, b);
-        output[nInVerts + i] = (data[a] + data[b]) / T{2.0};
+        output[nVertices_ + i] = (data[a] + data[b]) / T{2.0};
       }
 
       // interpolate on triangle barycenters
-      for(SimplexId i = 0; i < nInTriangles; ++i) {
+      for(SimplexId i = 0; i < nTriangles_; ++i) {
         SimplexId a{}, b{}, c{};
         inputTriangl_->getTriangleVertex(i, 0, a);
         inputTriangl_->getTriangleVertex(i, 1, b);
         inputTriangl_->getTriangleVertex(i, 2, c);
-        output[nInVerts + nInEdges + i]
+        output[nVertices_ + nEdges_ + i]
           = (data[a] + data[b] + data[c]) / T{3.0};
       }
       return 0;
@@ -134,13 +131,12 @@ namespace ttk {
       if(inputTriangl_ == nullptr || outputTriangl_ == nullptr) {
         return 1;
       }
-      const auto nInVerts = inputTriangl_->getNumberOfVertices();
-      const auto nOutVerts = outputTriangl_->getNumberOfVertices();
-      if(nOutVerts < 0 || nOutVerts < nInVerts) {
+      const auto nOutVerts = this->getNumberOfVertices();
+      if(nOutVerts < 0 || nOutVerts < nVertices_) {
         return 1;
       }
       std::fill(output, output + nOutVerts, T{0});
-      std::copy(data, data + nInVerts, output);
+      std::copy(data, data + nVertices_, output);
       return 0;
     }
 
@@ -160,13 +156,12 @@ namespace ttk {
         return 1;
       }
       const size_t newTrianglesPerParent{6};
-      const size_t nInTriangles = inputTriangl_->getNumberOfTriangles();
-      const size_t nOutTriangles = outputTriangl_->getNumberOfTriangles();
+      const size_t nOutTriangles = this->getNumberOfTriangles();
       if(nOutTriangles < 0
-         || nOutTriangles != newTrianglesPerParent * nInTriangles) {
+         || nOutTriangles != newTrianglesPerParent * nTriangles_) {
         return 1;
       }
-      for(size_t i = 0; i < nInTriangles; ++i) {
+      for(SimplexId i = 0; i < nTriangles_; ++i) {
         output[i * newTrianglesPerParent + 0] = data[i];
         output[i * newTrianglesPerParent + 1] = data[i];
         output[i * newTrianglesPerParent + 2] = data[i];

--- a/core/base/barycentricSubdivision/BarycentricSubdivision.h
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.h
@@ -58,13 +58,13 @@ namespace ttk {
 
     /** @brief Return the number of vertices in the output triangulation
      */
-    inline SimplexId getNumberOfVertices() {
+    inline SimplexId getNumberOfVertices() const {
       return nVertices_ + nEdges_ + nTriangles_;
     }
 
     /** @brief Return the number of triangles in the output triangulation
      */
-    inline SimplexId getNumberOfTriangles() {
+    inline SimplexId getNumberOfTriangles() const {
       return nTriangles_ * 6;
     }
 
@@ -81,7 +81,7 @@ namespace ttk {
      * @return 0 in case of success
      */
     template <typename T>
-    int interpolateContinuousScalarField(const T *data, T *output) {
+    int interpolateContinuousScalarField(const T *data, T *output) const {
       static_assert(
         std::is_floating_point<T>::value, "Floating point type required.");
       if(inputTriangl_ == nullptr || outputTriangl_ == nullptr) {
@@ -126,7 +126,7 @@ namespace ttk {
      * @return 0 in case of success
      */
     template <typename T>
-    int interpolateDiscreteScalarField(const T *data, T *output) {
+    int interpolateDiscreteScalarField(const T *data, T *output) const {
       static_assert(std::is_integral<T>::value, "Integral type required.");
       if(inputTriangl_ == nullptr || outputTriangl_ == nullptr) {
         return 1;
@@ -151,7 +151,7 @@ namespace ttk {
      * @return 0 in case of success
      */
     template <typename T>
-    int interpolateCellDataField(const T *data, T *output) {
+    int interpolateCellDataField(const T *data, T *output) const {
       if(inputTriangl_ == nullptr || outputTriangl_ == nullptr) {
         return 1;
       }

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
@@ -20,8 +20,14 @@ struct Quad {
 };
 
 int ttk::MorseSmaleQuadrangulation::detectCellSeps() {
-  BarycentricSubdivision bs{};
+
   Triangulation newT{};
+
+  std::vector<float> points_{};
+  std::vector<ttk::LongSimplexId> cells_{};
+  std::vector<ttk::SimplexId> pointId_{};
+  std::vector<ttk::SimplexId> pointDim_{};
+  BarycentricSubdivision bs{points_, cells_, pointId_, pointDim_};
 
   bs.setupTriangulation(triangulation_);
   bs.setOutputTriangulation(&newT);

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -170,6 +170,11 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
 
     // generate the new triangulation
     baseWorker_.execute();
+
+    // temporary vtkUnstructuredGrid moved from output
+    vtkSmartPointer<vtkUnstructuredGrid> tmp(std::move(output));
+    // interpolate from tmp to output
+    InterpolateScalarFields(tmp, output);
   }
 
   // generated 3D coordinates

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -115,7 +115,7 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     output->GetPointData()->AddArray(outputScalarField);
   }
 
-  const auto outCellsNumber = triangulationSubdivision.getNumberOfTriangles();
+  const auto outCellsNumber = baseWorker_.getNumberOfTriangles();
 
   for(size_t i = 0; i < ncelldata; ++i) {
     auto inputScalarField = input->GetCellData()->GetArray(i);

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -104,6 +104,8 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     output->GetPointData()->AddArray(outputScalarField);
   }
 
+  const auto outCellsNumber = triangulationSubdivision.getNumberOfTriangles();
+
   for(size_t i = 0; i < ncelldata; ++i) {
     auto inputScalarField = input->GetCellData()->GetArray(i);
     if(inputScalarField == nullptr) {
@@ -113,7 +115,7 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     auto outputScalarField = allocateScalarField(inputScalarField);
     // only for scalar fields
     outputScalarField->SetNumberOfComponents(1);
-    outputScalarField->SetNumberOfTuples(outPointsNumber);
+    outputScalarField->SetNumberOfTuples(outCellsNumber);
     outputScalarField->SetName(inputScalarField->GetName());
     output->GetPointData()->AddArray(outputScalarField);
     switch(inputScalarField->GetDataType()) {

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -138,6 +138,13 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   }
 
   triangulation->setWrapper(this);
+
+  // early return: copy input if no subdivision
+  if(SubdivisionLevel == 0) {
+    output->ShallowCopy(input);
+    return 0;
+  }
+
   baseWorker_.setupTriangulation(triangulation);
   baseWorker_.setWrapper(this);
   baseWorker_.setOutputTriangulation(&triangulationSubdivision);

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -98,8 +98,8 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     baseWorker_.execute();
   }
 
-  size_t npointdata = input->GetPointData()->GetNumberOfArrays();
-  size_t ncelldata = input->GetCellData()->GetNumberOfArrays();
+  const size_t npointdata = input->GetPointData()->GetNumberOfArrays();
+  const size_t ncelldata = input->GetCellData()->GetNumberOfArrays();
 
   const auto outPointsNumber = baseWorker_.getNumberOfVertices();
 

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -61,7 +61,13 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
       case VTK_ID_TYPE:
         outputScalarField = vtkSmartPointer<vtkIdTypeArray>::New();
         break;
+      case VTK_LONG:
+        outputScalarField = vtkSmartPointer<vtkLongArray>::New();
+        break;
       default:
+        std::stringstream msg;
+        msg << MODULE_S "Unsupported data array type" << endl;
+        dMsg(std::cout, msg.str(), fatalMsg);
         break;
     }
     return outputScalarField;
@@ -89,6 +95,10 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     break
 
     auto outputScalarField = allocateScalarField(inputScalarField);
+    if(outputScalarField == nullptr) {
+      return -3;
+    }
+
     // only for scalar fields
     outputScalarField->SetNumberOfComponents(1);
     outputScalarField->SetNumberOfTuples(outPointsNumber);
@@ -97,6 +107,7 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     switch(inputScalarField->GetDataType()) {
       DISPATCH_INTERPOLATE_DIS(VTK_CHAR, char);
       DISPATCH_INTERPOLATE_DIS(VTK_INT, int);
+      DISPATCH_INTERPOLATE_DIS(VTK_LONG, long);
       DISPATCH_INTERPOLATE_DIS(VTK_ID_TYPE, vtkIdType);
       DISPATCH_INTERPOLATE_CONT(VTK_FLOAT, float);
       DISPATCH_INTERPOLATE_CONT(VTK_DOUBLE, double);
@@ -113,6 +124,10 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     }
 
     auto outputScalarField = allocateScalarField(inputScalarField);
+    if(outputScalarField == nullptr) {
+      return -3;
+    }
+
     // only for scalar fields
     outputScalarField->SetNumberOfComponents(1);
     outputScalarField->SetNumberOfTuples(outCellsNumber);

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -38,6 +38,29 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   // generate the new triangulation
   baseWorker_.execute();
 
+  for(unsigned int i = 1; i < SubdivisionLevel; ++i) {
+    // move previous points to temp vector
+    decltype(points_) tmpPoints{};
+    std::swap(points_, tmpPoints);
+    baseWorker_.setInputPoints(tmpPoints.data());
+
+    // move previous triangulation cells to temp vector
+    decltype(cells_) tmpCells{};
+    std::swap(cells_, tmpCells);
+
+    // move previous triangulation to temp triangulation
+    decltype(triangulationSubdivision) tmpTr{};
+    std::swap(triangulationSubdivision, tmpTr);
+
+    tmpTr.setInputCells(tmpCells.size() / 4, tmpCells.data());
+    tmpTr.setInputPoints(tmpPoints.size() / 3, tmpPoints.data());
+    baseWorker_.setupTriangulation(&tmpTr);
+    baseWorker_.setOutputTriangulation(&triangulationSubdivision);
+
+    // generate the new triangulation
+    baseWorker_.execute();
+  }
+
   size_t npointdata = input->GetPointData()->GetNumberOfArrays();
   size_t ncelldata = input->GetCellData()->GetNumberOfArrays();
 

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -124,37 +124,31 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     output->GetCellData()->AddArray(outputScalarField);
   }
 
-  // output variables
-  auto &outPoints = baseWorker_.points_;
-  auto &outCells = baseWorker_.cells_;
-  auto &outPointId = baseWorker_.pointId_;
-  auto &outPointDim = baseWorker_.pointDim_;
-
   // generated 3D coordinates
   auto points = vtkSmartPointer<vtkPoints>::New();
-  for(size_t i = 0; i < outPoints.size() / 3; i++) {
-    points->InsertNextPoint(&outPoints[3 * i]);
+  for(size_t i = 0; i < points_.size() / 3; i++) {
+    points->InsertNextPoint(&points_[3 * i]);
   }
   output->SetPoints(points);
 
   // generated triangles
   const size_t dataPerCell = 4;
   auto cells = vtkSmartPointer<vtkCellArray>::New();
-  for(size_t i = 0; i < outCells.size() / dataPerCell; i++) {
-    cells->InsertNextCell(3, &outCells[dataPerCell * i + 1]);
+  for(size_t i = 0; i < cells_.size() / dataPerCell; i++) {
+    cells->InsertNextCell(3, &cells_[dataPerCell * i + 1]);
   }
   output->SetCells(VTK_TRIANGLE, cells);
 
   // cell id
   auto cellId = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellId->SetName("CellId");
-  cellId->SetVoidArray(outPointId.data(), outPointId.size(), 1);
+  cellId->SetVoidArray(pointId_.data(), pointId_.size(), 1);
   output->GetPointData()->AddArray(cellId);
 
   // cell dimension
   auto cellDim = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellDim->SetName("CellDimension");
-  cellDim->SetVoidArray(outPointDim.data(), outPointDim.size(), 1);
+  cellDim->SetVoidArray(pointDim_.data(), pointDim_.size(), 1);
   output->GetPointData()->AddArray(cellDim);
 
   {

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -154,7 +154,8 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   baseWorker_.execute();
 
   // first iteration: interpolate input scalar fields
-  InterpolateScalarFields(input, output);
+  int ret = InterpolateScalarFields(input, output);
+  TTK_ABORT_KK(ret < 0, "Error interpolating input data array(s)", -1);
 
   for(unsigned int i = 1; i < SubdivisionLevel; ++i) {
     // move previous points to temp vector

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -143,10 +143,10 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   baseWorker_.setOutputTriangulation(&triangulationSubdivision);
   baseWorker_.setInputPoints(input->GetPoints()->GetVoidPointer(0));
 
-  // generate the new triangulation
+  // first iteration: generate the new triangulation
   baseWorker_.execute();
 
-  // interpolate input scalar fields
+  // first iteration: interpolate input scalar fields
   InterpolateScalarFields(input, output);
 
   for(unsigned int i = 1; i < SubdivisionLevel; ++i) {

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -80,6 +80,13 @@ protected:
 
   TTK_SETUP();
 
+  /**
+   * @brief Allocate an output array of same type that input array
+   */
+  vtkSmartPointer<vtkDataArray>
+    AllocateScalarField(vtkDataArray *const inputScalarField,
+                        int ntuples) const;
+
 private:
   // number of subdivisions
   unsigned int SubdivisionLevel{1};

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -31,6 +31,7 @@
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
 #include <vtkIntArray.h>
+#include <vtkLongArray.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -77,6 +77,17 @@ protected:
   TTK_SETUP();
 
 private:
+  // output 3D coordinates of generated points: old points first, then edge
+  // middles, then triangle barycenters
+  std::vector<float> points_{};
+  // output triangles
+  std::vector<ttk::LongSimplexId> cells_{};
+  // generated point cell id
+  std::vector<ttk::SimplexId> pointId_{};
+  // generated points dimension: 0 vertex of parent triangulation, 1 edge
+  // middle, 2 triangle barycenter
+  std::vector<ttk::SimplexId> pointDim_{};
+
   // base worker
-  ttk::BarycentricSubdivision baseWorker_{};
+  ttk::BarycentricSubdivision baseWorker_{points_, cells_, pointId_, pointDim_};
 };

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -55,6 +55,9 @@ public:
   // default ttk setters
   vtkSetMacro(debugLevel_, int);
 
+  vtkGetMacro(SubdivisionLevel, unsigned int);
+  vtkSetMacro(SubdivisionLevel, unsigned int);
+
   void SetThreadNumber(int threadNumber) {
     ThreadNumber = threadNumber;
     SetThreads();
@@ -78,6 +81,9 @@ protected:
   TTK_SETUP();
 
 private:
+  // number of subdivisions
+  unsigned int SubdivisionLevel{1};
+
   // output 3D coordinates of generated points: old points first, then edge
   // middles, then triangle barycenters
   std::vector<float> points_{};

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -87,6 +87,9 @@ protected:
     AllocateScalarField(vtkDataArray *const inputScalarField,
                         int ntuples) const;
 
+  int InterpolateScalarFields(vtkUnstructuredGrid *const input,
+                              vtkUnstructuredGrid *const output) const;
+
 private:
   // number of subdivisions
   unsigned int SubdivisionLevel{1};

--- a/paraview/BarycentricSubdivision/BarycentricSubdivision.xml
+++ b/paraview/BarycentricSubdivision/BarycentricSubdivision.xml
@@ -40,6 +40,17 @@
       </InputProperty>
 
       <IntVectorProperty
+          name="SubdivisionLevel"
+          label="Level of subdivisions"
+          command="SetSubdivisionLevel"
+          number_of_elements="1"
+          default_values="1">
+        <Documentation>
+          Number of subdivisions of the original triangulation.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
          name="UseAllCores"
          label="Use All Cores"
          command="SetUseAllCores"
@@ -80,6 +91,10 @@
            Debug level.
          </Documentation>
       </IntVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="SubdivisionLevel" />
+      </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Testing">
         <Property name="UseAllCores" />


### PR DESCRIPTION
The current PR focuses on the BarycentricSubdivision, which was introduced for the Morse-Smale Quadrangulation (#249).

This PR:
- tweaks the filter memory model to make the VTK layer own the data (instead of the base layer);
- adds support for a variable number of subdivision levels and interpolate the input data accordingly (using std::swap/move semantics to avoid copies);
- refactor methods in the VTK wrapper (and in the base layer too) to allow for said subdivision levels;
- fixes some issues with unsupported data types and incorrect number of triangles.