### PR TITLE
Moving GetCellIncenter to AbstractTriangulation

### DIFF
--- a/core/base/abstractTriangulation/CMakeLists.txt
+++ b/core/base/abstractTriangulation/CMakeLists.txt
@@ -5,5 +5,6 @@ ttk_add_base_library(abstractTriangulation
     AbstractTriangulation.h
   LINK
     common
+    geometry
     )
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -949,102 +949,22 @@ int DiscreteGradient::reverseDescendingPathOnWall(const vector<Cell> &vpath) {
 
 int DiscreteGradient::getEdgeIncenter(const SimplexId edgeId,
                                       float incenter[3]) const {
-  SimplexId vertexId[2];
-  inputTriangulation_->getEdgeVertex(edgeId, 0, vertexId[0]);
-  inputTriangulation_->getEdgeVertex(edgeId, 1, vertexId[1]);
-
-  float p[6];
-  inputTriangulation_->getVertexPoint(vertexId[0], p[0], p[1], p[2]);
-  inputTriangulation_->getVertexPoint(vertexId[1], p[3], p[4], p[5]);
-
-  incenter[0] = 0.5 * p[0] + 0.5 * p[3];
-  incenter[1] = 0.5 * p[1] + 0.5 * p[4];
-  incenter[2] = 0.5 * p[2] + 0.5 * p[5];
-
-  return 0;
+  return inputTriangulation_->getEdgeIncenter(edgeId, incenter);
 }
 
 int DiscreteGradient::getTriangleIncenter(const SimplexId triangleId,
                                           float incenter[3]) const {
-  SimplexId vertexId[3];
-  if(dimensionality_ == 2) {
-    inputTriangulation_->getCellVertex(triangleId, 0, vertexId[0]);
-    inputTriangulation_->getCellVertex(triangleId, 1, vertexId[1]);
-    inputTriangulation_->getCellVertex(triangleId, 2, vertexId[2]);
-  } else if(dimensionality_ == 3) {
-    inputTriangulation_->getTriangleVertex(triangleId, 0, vertexId[0]);
-    inputTriangulation_->getTriangleVertex(triangleId, 1, vertexId[1]);
-    inputTriangulation_->getTriangleVertex(triangleId, 2, vertexId[2]);
-  }
-
-  float p[9];
-  inputTriangulation_->getVertexPoint(vertexId[0], p[0], p[1], p[2]);
-  inputTriangulation_->getVertexPoint(vertexId[1], p[3], p[4], p[5]);
-  inputTriangulation_->getVertexPoint(vertexId[2], p[6], p[7], p[8]);
-
-  float d[3];
-  d[0] = Geometry::distance(p + 3, p + 6);
-  d[1] = Geometry::distance(p, p + 6);
-  d[2] = Geometry::distance(p, p + 3);
-  const float sum = d[0] + d[1] + d[2];
-
-  d[0] = d[0] / sum;
-  d[1] = d[1] / sum;
-  d[2] = d[2] / sum;
-
-  incenter[0] = d[0] * p[0] + d[1] * p[3] + d[2] * p[6];
-  incenter[1] = d[0] * p[1] + d[1] * p[4] + d[2] * p[7];
-  incenter[2] = d[0] * p[2] + d[1] * p[5] + d[2] * p[8];
-
-  return 0;
+  return inputTriangulation_->getTriangleIncenter(triangleId, incenter);
 }
 
 int DiscreteGradient::getTetraIncenter(const SimplexId tetraId,
                                        float incenter[3]) const {
-  incenter[0] = 0.0f;
-  incenter[1] = 0.0f;
-  incenter[2] = 0.0f;
-
-  float p[3];
-  for(int i = 0; i < 4; ++i) {
-    SimplexId triangleId;
-    inputTriangulation_->getCellTriangle(tetraId, i, triangleId);
-
-    getTriangleIncenter(triangleId, p);
-    incenter[0] += p[0];
-    incenter[1] += p[1];
-    incenter[2] += p[2];
-  }
-
-  incenter[0] /= 4.0f;
-  incenter[1] /= 4.0f;
-  incenter[2] /= 4.0f;
-
-  return 0;
+  return inputTriangulation_->getTetraIncenter(tetraId, incenter);
 }
 
 int DiscreteGradient::getCellIncenter(const Cell &cell,
                                       float incenter[3]) const {
-  switch(cell.dim_) {
-    case 0:
-      inputTriangulation_->getVertexPoint(
-        cell.id_, incenter[0], incenter[1], incenter[2]);
-      break;
-
-    case 1:
-      getEdgeIncenter(cell.id_, incenter);
-      break;
-
-    case 2:
-      getTriangleIncenter(cell.id_, incenter);
-      break;
-
-    case 3:
-      getTetraIncenter(cell.id_, incenter);
-      break;
-  }
-
-  return 0;
+  return inputTriangulation_->getCellIncenter(cell.id_, cell.dim_, incenter);
 }
 
 int DiscreteGradient::getCriticalPointMap(

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -20,6 +20,8 @@
 #include <ciso646>
 #endif
 
+#include <array>
+
 namespace ttk {
 
   class PeriodicImplicitTriangulation final : public AbstractTriangulation {
@@ -246,6 +248,144 @@ namespace ttk {
                      const int &xDim,
                      const int &yDim,
                      const int &zDim);
+
+    std::array<SimplexId, 3>
+      vertexToPositionNd(const SimplexId vertexId) const {
+      std::array<SimplexId, 3> p{};
+      if(dimensionality_ == 1) {
+        p[0] = vertexId;
+      } else if(dimensionality_ == 2) {
+        vertexToPosition2d(vertexId, p.data());
+      } else if(dimensionality_ == 3) {
+        vertexToPosition(vertexId, p.data());
+      }
+      return p;
+    }
+
+    /**
+     * Compute the barycenter of the points of the given edge identifier.
+     */
+    virtual int getEdgeIncenter(SimplexId edgeId,
+                                float incenter[3]) const override {
+      std::array<SimplexId, 2> vertexId;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getEdgeVertex(edgeId, i, vertexId[i]);
+      }
+
+      std::array<std::array<float, 3>, vertexId.size()> p;
+      std::array<std::array<SimplexId, 3>, vertexId.size()> ind;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getVertexPoint(vertexId[i], p[i][0], p[i][1], p[i][2]);
+        ind[i] = vertexToPositionNd(vertexId[i]);
+      }
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind[1][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[0][i] == nbvoxels_[i]) {
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = 0.5f * (p[0][i] + p[1][i]);
+      }
+
+      return 0;
+    }
+
+    /**
+     * Compute the incenter of the points of the given triangle
+     * identifier.
+     */
+    virtual int getTriangleIncenter(SimplexId triangleId,
+                                    float incenter[3]) const override {
+
+      std::array<SimplexId, 3> vertexId;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getTriangleVertex(triangleId, i, vertexId[i]);
+      }
+
+      std::array<std::array<float, 3>, vertexId.size()> p;
+      std::array<std::array<SimplexId, 3>, vertexId.size()> ind;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getVertexPoint(vertexId[i], p[i][0], p[i][1], p[i][2]);
+        ind[i] = vertexToPositionNd(vertexId[i]);
+      }
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind[0][i] == nbvoxels_[i]) {
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[1][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[2][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      std::array<float, p.size()> d;
+      for(int i = 0; i < d.size(); ++i) {
+        d[i] = Geometry::distance(p[(i + 1) % 3].data(), p[(i + 2) % 3].data());
+      }
+      const float sum = d[0] + d[1] + d[2];
+      for(int i = 0; i < d.size(); ++i) {
+        d[i] = d[i] / sum;
+      }
+
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = d[0] * p[0][i] + d[1] * p[1][i] + d[2] * p[2][i];
+      }
+
+      return 0;
+    }
+
+    /**
+     * Compute the barycenter of the incenters of the triangles of the
+     * given tetra identifier.
+     */
+    virtual int getTetraIncenter(SimplexId tetraId,
+                                 float incenter[3]) const override {
+
+      std::array<SimplexId, 4> vertexId;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getCellVertex(tetraId, i, vertexId[i]);
+      }
+
+      std::array<std::array<float, 3>, vertexId.size()> p;
+      std::array<std::array<SimplexId, 3>, vertexId.size()> ind;
+      for(int i = 0; i < vertexId.size(); ++i) {
+        getVertexPoint(vertexId[i], p[i][0], p[i][1], p[i][2]);
+        ind[i] = vertexToPositionNd(vertexId[i]);
+      }
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind[0][i] == nbvoxels_[i]) {
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[1][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[2][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind[3][i] == nbvoxels_[i]) {
+          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
+          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = 0.25f * (p[0][i] + p[1][i] + p[2][i] + p[3][i]);
+      }
+      return 0;
+    }
 
   protected:
     int dimensionality_; //

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -53,7 +53,6 @@ namespace ttk {
     Triangulation(Triangulation &&);
     Triangulation &operator=(const Triangulation &);
     Triangulation &operator=(Triangulation &&);
-
     ~Triangulation();
 
     /// Reset the triangulation data-structures.
@@ -3094,6 +3093,32 @@ namespace ttk {
       return !((!abstractTriangulation_->preprocessVertexTriangles())
                && (hasPreprocessedVertexTriangles_ = true));
     }
+
+    int getEdgeIncenter(SimplexId edgeId, float incenter[3]) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+
+      return abstractTriangulation_->getEdgeIncenter(edgeId, incenter);
+    };
+
+    int getTriangleIncenter(SimplexId triangleId,
+                            float incenter[3]) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->getTriangleIncenter(triangleId, incenter);
+    };
+
+    int getTetraIncenter(SimplexId tetraId, float incenter[3]) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->getTetraIncenter(tetraId, incenter);
+    };
 
     /// Tune the debug level (default: 0)
     inline int setDebugLevel(const int &debugLevel) override {


### PR DESCRIPTION
Hi
I propose moving the GetCellIncenter and related functions from DiscreteGradient into AbstractTriangulation. 
The reason being that the PeriodicImplicitTriangulation needs to customize the behavior, and DiscreteGradient only delegated the to the triangulation without using any of the DiscreteGradient  state.

The reason that the PeriodicImplicitTriangulation need to customize the functions can be understod if one considers an edge at the "boundary" of the grid, that edge will connect a vertices on both sides of the grid, and the GetCellIncenter will by default, return the mean position of the vertices, which will be in the middle of the grid. In the current proposal, that edge center point will be put in the higher side of the grid, after the last vertex. Same goes for the other types of cells. 

