### PR TITLE
Topological Compression Writer/Reader: Add scalar field name into compressed file

### DIFF
--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -14,6 +14,10 @@ ttk::TopologicalCompression::TopologicalCompression() {
 ttk::TopologicalCompression::~TopologicalCompression() {
 }
 
+const std::string ttk::TopologicalCompression::magicBytes_{
+  "TTKCompressedFileFormat"};
+const unsigned long ttk::TopologicalCompression::formatVersion_{1};
+
 // Dependencies.
 
 #ifdef TTK_ENABLE_ZFP

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -266,6 +266,30 @@ void ttk::TopologicalCompression::WriteUnsignedCharArray(FILE *fm,
   }
 }
 
+void ttk::TopologicalCompression::ReadCharArray(FILE *fm,
+                                                char *buffer,
+                                                size_t length) {
+  int ret = (int)std::fread(buffer, sizeof(char), length, fm);
+  if(!ret) {
+    std::stringstream msg;
+    ttk::Debug d;
+    msg << "[TopologicalCompression] Error reading char array!" << std::endl;
+    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
+  }
+}
+
+void ttk::TopologicalCompression::WriteConstCharArray(FILE *fm,
+                                                      const char *buffer,
+                                                      size_t length) {
+  int ret = (int)std::fwrite(buffer, sizeof(char), length, fm);
+  if(!ret) {
+    std::stringstream msg;
+    ttk::Debug d;
+    msg << "[TopologicalCompression] Error writing char array!" << std::endl;
+    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
+  }
+}
+
 int ttk::TopologicalCompression::ReadCompactSegmentation(
   FILE *fm,
   std::vector<int> &segmentation,

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -124,7 +124,12 @@ int ttkTopologicalCompressionReader::RequestData(
 
   decompressed = vtkSmartPointer<vtkDoubleArray>::New();
   decompressed->SetNumberOfTuples(vertexNumber);
-  decompressed->SetName(topologicalCompression.getDataArrayName().data());
+  auto name = topologicalCompression.getDataArrayName();
+  if(!name.empty()) {
+    decompressed->SetName(name.data());
+  } else {
+    decompressed->SetName("Decompressed");
+  }
   std::vector<double> decompressdeData
     = topologicalCompression.getDecompressedData();
   for(int i = 0; i < vertexNumber; ++i)

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -124,7 +124,7 @@ int ttkTopologicalCompressionReader::RequestData(
 
   decompressed = vtkSmartPointer<vtkDoubleArray>::New();
   decompressed->SetNumberOfTuples(vertexNumber);
-  decompressed->SetName("Decompressed");
+  decompressed->SetName(topologicalCompression.getDataArrayName().data());
   std::vector<double> decompressdeData
     = topologicalCompression.getDecompressedData();
   for(int i = 0; i < vertexNumber; ++i)

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -157,10 +157,13 @@ void ttkTopologicalCompressionWriter::WriteData() {
                  ->GetArray(inputScalarField->GetName())
                  ->GetVoidPointer(0);
 
+  std::string inputScalarFieldName = inputScalarField->GetName();
+
   topologicalCompression.setFileName(FileName);
   topologicalCompression.WriteToFile<double>(
     fp, CompressionType, ZFPOnly, SQMethod.c_str(), dt, vti->GetExtent(),
-    vti->GetSpacing(), vti->GetOrigin(), vp, Tolerance, ZFPBitBudget);
+    vti->GetSpacing(), vti->GetOrigin(), vp, Tolerance, ZFPBitBudget,
+    inputScalarFieldName);
 
   {
     ttk::Debug d;


### PR DESCRIPTION
This PR modifies the Topological Compression Writer and Reader to pass the scalar field name into the compressed file.

To do so, I edited the WriteMetaData and the ReadMetaData methods of the TopologicalCompression class to include the char array corresponding to the field name into the meta-data section of the compressed file.

Warning: this is a BREAKING CHANGE for the Reader. An old Reader won't be able to read new files (with the scalar field name). Segfaults expected.

To keep backward compatibility (new Reader reading old files), I also introduced two new meta-data in the file format: some magic bytes ("TTKCompressedFileFormat") and a file format version counter. Testing for the presence of the former let the Reader distinguish between the old and the new file format. The version number should be used to ensure backward compatibility in case of future file format modifications.

Enjoy!
Pierre
