### PR TITLE
Make destructor of base class virtual

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -23,7 +23,7 @@ namespace ttk {
   public:
     AbstractTriangulation();
 
-    ~AbstractTriangulation();
+    virtual ~AbstractTriangulation();
 
     virtual int clear();
 


### PR DESCRIPTION
The destructor of a base class should be declared virtual in order to avoid resource leaks.

See here:
https://stackoverflow.com/questions/461203/when-to-use-virtual-destructors
