### PR TITLE
[FTMTree] Triangulation => AbstractTriangulation

### DIFF
--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -73,7 +73,7 @@ namespace ttk {
         return this;
       }
 
-      inline void setupTriangulation(Triangulation *m,
+      inline void setupTriangulation(AbstractTriangulation *m,
                                      const bool preproc = true) {
         FTMTree_MT::setupTriangulation(m, preproc);
         jt_->setupTriangulation(m, false);

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -39,7 +39,7 @@ using namespace ftm;
 DebugTimer _launchGlobalTime;
 
 FTMTree_MT::FTMTree_MT(Params *const params,
-                       Triangulation *mesh,
+                       AbstractTriangulation *mesh,
                        Scalars *const scalars,
                        TreeType type)
   : params_(params), mesh_(mesh), scalars_(scalars) {

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -39,7 +39,7 @@
 #endif
 
 #include <Geometry.h>
-#include <Triangulation.h>
+#include <AbstractTriangulation.h>
 #include <Wrapper.h>
 
 #include "FTMAtomicUF.h"
@@ -102,7 +102,7 @@ namespace ttk {
     protected:
       // global
       Params *const params_;
-      Triangulation *mesh_;
+      AbstractTriangulation *mesh_;
       Scalars *const scalars_;
 
       // local
@@ -116,7 +116,7 @@ namespace ttk {
 
       // Tree with global data and partition number
       FTMTree_MT(Params *const params,
-                 Triangulation *mesh,
+                 AbstractTriangulation *mesh,
                  Scalars *const scalars,
                  TreeType type);
 
@@ -311,7 +311,7 @@ namespace ttk {
       // On this implementation, the warpper communicate with ContourForest
       // A child class of this one.
 
-      inline void setupTriangulation(Triangulation *m,
+      inline void setupTriangulation(AbstractTriangulation *m,
                                      const bool preproc = true) {
         mesh_ = m;
         if(mesh_ && preproc) {


### PR DESCRIPTION
Dear Julien,

FTMTree currently expects the triangulation to derive from the `Triangulation` class.
I propose to use `AbstractTriangulation` instead.

This makes it easier for users to pass their own triangulation class in third-party apps that use TTK.
(I am currently following this scenario actually.)

Please feel free to ask questions.

Sincerely,
Daisuke