### PR TITLE
Use Topological Compression in CinemaWriter/CinemaProductReader

### DIFF
--- a/core/vtk/ttkCinemaProductReader/CMakeLists.txt
+++ b/core/vtk/ttkCinemaProductReader/CMakeLists.txt
@@ -5,4 +5,5 @@ ttk_add_vtk_library(ttkCinemaProductReader
     ttkCinemaProductReader.h
   LINK
     ttkTriangulation
+    ttkTopologicalCompressionReader
     )

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -1,4 +1,5 @@
 #include <ttkCinemaProductReader.h>
+#include <ttkTopologicalCompressionReader.h>
 
 #include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
@@ -90,8 +91,16 @@ vtkStandardNewMacro(ttkCinemaProductReader)
         continue;
       }
 
+      if(ext == "ttk") {
+        vtkNew<ttkTopologicalCompressionReader> reader;
+        reader->SetFileName(path.data());
+        reader->Update();
+
+        output->SetBlock(i, reader->GetOutput());
+      }
+
       // Read any data using vtkXMLGenericDataObjectReader
-      {
+      else {
         auto reader = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();
         reader->SetFileName(path.data());
         reader->Update();

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -5,6 +5,7 @@
 #include <vtkFieldData.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkStringArray.h>
+#include <vtkTIFFReader.h>
 #include <vtkTable.h>
 #include <vtkVariantArray.h>
 #include <vtkXMLGenericDataObjectReader.h>
@@ -97,6 +98,15 @@ vtkStandardNewMacro(ttkCinemaProductReader)
         reader->Update();
 
         output->SetBlock(i, reader->GetOutput());
+      }
+
+      else if(ext == "tif" || ext == "tiff") {
+        vtkNew<vtkTIFFReader> reader;
+        if(reader->CanReadFile(path.data())) {
+          reader->SetFileName(path.data());
+          reader->Update();
+          output->SetBlock(i, reader->GetOutput());
+        }
       }
 
       // Read any data using vtkXMLGenericDataObjectReader

--- a/core/vtk/ttkCinemaWriter/CMakeLists.txt
+++ b/core/vtk/ttkCinemaWriter/CMakeLists.txt
@@ -1,8 +1,9 @@
 ttk_add_vtk_library(ttkCinemaWriter
-  SOURCES 
+  SOURCES
     ttkCinemaWriter.cpp
-  HEADERS 
+  HEADERS
     ttkCinemaWriter.h
-  LINK 
+  LINK
     ttkTriangulation
+    ttkTopologicalCompressionWriter
     )

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -85,10 +85,8 @@ vtkStandardNewMacro(ttkCinemaWriter)
     = input->IsA("vtkImageData") && this->UseTopologicalCompression;
 
   if(!doTopologicalCompression && this->UseTopologicalCompression) {
-    dMsg(cout,
-         "[ttkCinemaWriter] Cannot use Topological Compression, Input not a "
-         "vtkImageData instance\n",
-         infoMsg);
+    vtkErrorMacro("Cannot use Topological Compression without a vtkImageData");
+    return 0;
   }
 
   if(doTopologicalCompression) {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -162,9 +162,25 @@ vtkStandardNewMacro(ttkCinemaWriter)
     // Create data sub-directory if it does not exist yet
     vtkNew<vtkDirectory>()->MakeDirectory(pathPrefix.data());
 
+    // Fetch the scalar field array on which to perform Topological Compression
+    const auto ScalarFieldName = ttkCompWriter_->GetScalarField();
+    if(ScalarFieldName.empty()) {
+      vtkErrorMacro("Need a scalar field for Topological Compression");
+      return 0;
+    }
+    const auto inputData = vtkImageData::SafeDownCast(input);
+    const auto ScalarField
+      = inputData->GetPointData()->GetArray(ScalarFieldName.data());
+
+    // Check that input scalar field is indeed scalar
+    if(ScalarField->GetNumberOfComponents() != 1) {
+      vtkErrorMacro("Input scalar field should have only 1 component");
+      return 0;
+    }
+
     this->ttkCompWriter_->SetFileName(path.data());
     this->ttkCompWriter_->SetDebugLevel(debugLevel_);
-    this->ttkCompWriter_->execute(vtkImageData::SafeDownCast(input));
+    this->ttkCompWriter_->execute(inputData);
 
     dMsg(cout, "[ttkCinemaWriter] - Writing to disk                   ... ",
          timeMsg);

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -81,8 +81,17 @@ vtkStandardNewMacro(ttkCinemaWriter)
   string dataCsvPath = this->DatabasePath + "/data.csv";
   string pathSuffix = ".vtm";
 
-  if(input->IsA("vtkImageData")) {
-    this->UseTopologicalCompression = true;
+  bool doTopologicalCompression
+    = input->IsA("vtkImageData") && this->UseTopologicalCompression;
+
+  if(!doTopologicalCompression && this->UseTopologicalCompression) {
+    dMsg(cout,
+         "[ttkCinemaWriter] Cannot use Topological Compression, Input not a "
+         "vtkImageData instance\n",
+         infoMsg);
+  }
+
+  if(doTopologicalCompression) {
     pathSuffix = ".ttk";
   }
 
@@ -149,7 +158,7 @@ vtkStandardNewMacro(ttkCinemaWriter)
 
   t0 = t.getElapsedTime();
 
-  if(this->UseTopologicalCompression) {
+  if(doTopologicalCompression) {
     // Create data sub-directory if it does not exist yet
     vtkNew<vtkDirectory>()->MakeDirectory(pathPrefix.data());
 

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -159,12 +159,17 @@ vtkStandardNewMacro(ttkCinemaWriter)
   t0 = t.getElapsedTime();
 
   if(doTopologicalCompression) {
+    dMsg(cout, "\n", timeMsg);
+
     // Create data sub-directory if it does not exist yet
     vtkNew<vtkDirectory>()->MakeDirectory(pathPrefix.data());
 
     this->ttkCompWriter_->SetFileName(path.data());
     this->ttkCompWriter_->SetDebugLevel(debugLevel_);
     this->ttkCompWriter_->execute(vtkImageData::SafeDownCast(input));
+
+    dMsg(cout, "[ttkCinemaWriter] - Writing to disk                   ... ",
+         timeMsg);
   } else {
 
     auto mbWriter = vtkSmartPointer<vtkXMLMultiBlockDataWriter>::New();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -154,8 +154,6 @@ vtkStandardNewMacro(ttkCinemaWriter)
     vtkNew<vtkDirectory>()->MakeDirectory(pathPrefix.data());
 
     this->ttkCompWriter_->SetFileName(path.data());
-    this->ttkCompWriter_->SetScalarField("");
-    this->ttkCompWriter_->SetScalarFieldId(0);
     this->ttkCompWriter_->SetDebugLevel(debugLevel_);
     this->ttkCompWriter_->execute(vtkImageData::SafeDownCast(input));
   } else {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -1,5 +1,4 @@
 #include <ttkCinemaWriter.h>
-#include <ttkTopologicalCompressionWriter.h>
 
 #include <vtkVersion.h>
 
@@ -154,13 +153,11 @@ vtkStandardNewMacro(ttkCinemaWriter)
     // Create data sub-directory if it does not exist yet
     vtkNew<vtkDirectory>()->MakeDirectory(pathPrefix.data());
 
-    auto ttkCompWriter
-      = vtkSmartPointer<ttkTopologicalCompressionWriter>::New();
-    ttkCompWriter->SetFileName(path.data());
-    ttkCompWriter->SetScalarField("");
-    ttkCompWriter->SetScalarFieldId(0);
-    ttkCompWriter->SetDebugLevel(debugLevel_);
-    ttkCompWriter->execute(vtkImageData::SafeDownCast(input));
+    this->ttkCompWriter_->SetFileName(path.data());
+    this->ttkCompWriter_->SetScalarField("");
+    this->ttkCompWriter_->SetScalarFieldId(0);
+    this->ttkCompWriter_->SetDebugLevel(debugLevel_);
+    this->ttkCompWriter_->execute(vtkImageData::SafeDownCast(input));
   } else {
 
     auto mbWriter = vtkSmartPointer<vtkXMLMultiBlockDataWriter>::New();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -44,6 +44,67 @@ public:
   vtkSetMacro(UseTopologicalCompression, bool);
   vtkGetMacro(UseTopologicalCompression, bool);
 
+  void SetTolerance(double arg) {
+    this->ttkCompWriter_->SetTolerance(arg);
+  }
+  double GetTolerance() {
+    return this->ttkCompWriter_->GetTolerance();
+  }
+  void SetMaximumError(double arg) {
+    this->ttkCompWriter_->SetMaximumError(arg);
+  }
+  double GetMaximumError() {
+    return this->ttkCompWriter_->GetMaximumError();
+  }
+  void SetZFPBitBudget(double arg) {
+    this->ttkCompWriter_->SetZFPBitBudget(arg);
+  }
+  double GetZFPBitBudget() {
+    return this->ttkCompWriter_->GetZFPBitBudget();
+  }
+  void SetZFPOnly(bool arg) {
+    this->ttkCompWriter_->SetZFPOnly(arg);
+  }
+  bool GetZFPOnly() {
+    return this->ttkCompWriter_->GetZFPOnly();
+  }
+  void SetCompressionType(int arg) {
+    this->ttkCompWriter_->SetCompressionType(arg);
+  }
+  int GetCompressionType() {
+    return this->ttkCompWriter_->GetCompressionType();
+  }
+  void SetNbSegments(int arg) {
+    this->ttkCompWriter_->SetNbSegments(arg);
+  }
+  int GetNbSegments() {
+    return this->ttkCompWriter_->GetNbSegments();
+  }
+  void SetNbVertices(int arg) {
+    this->ttkCompWriter_->SetNbVertices(arg);
+  }
+  int GetNbVertices() {
+    return this->ttkCompWriter_->GetNbVertices();
+  }
+  void SetSQMethod(std::string arg) {
+    this->ttkCompWriter_->SetSQMethod(arg);
+  }
+  std::string GetSQMethod() {
+    return this->ttkCompWriter_->GetSQMethod();
+  }
+  void SetSubdivide(bool arg) {
+    this->ttkCompWriter_->SetSubdivide(arg);
+  }
+  bool GetSubdivide() {
+    return this->ttkCompWriter_->GetSubdivide();
+  }
+  void SetUseTopologicalSimplification(bool arg) {
+    this->ttkCompWriter_->SetUseTopologicalSimplification(arg);
+  }
+  bool GetUseTopologicalSimplification() {
+    return this->ttkCompWriter_->GetUseTopologicalSimplification();
+  }
+
   // default ttk setters
   vtkSetMacro(debugLevel_, int);
   void SetThreads() {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -17,6 +17,7 @@
 #include <vtkXMLPMultiBlockDataWriter.h>
 
 // TTK includes
+#include <ttkTopologicalCompressionWriter.h>
 #include <ttkWrapper.h>
 
 #ifndef TTK_PLUGIN
@@ -108,6 +109,7 @@ private:
   bool OverrideDatabase;
   int CompressLevel;
   bool UseTopologicalCompression;
+  vtkNew<ttkTopologicalCompressionWriter> ttkCompWriter_;
 
   bool needsToAbort() override {
     return GetAbortExecute();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -40,6 +40,9 @@ public:
   vtkSetMacro(CompressLevel, int);
   vtkGetMacro(CompressLevel, int);
 
+  vtkSetMacro(UseTopologicalCompression, bool);
+  vtkGetMacro(UseTopologicalCompression, bool);
+
   // default ttk setters
   vtkSetMacro(debugLevel_, int);
   void SetThreads() {
@@ -84,6 +87,7 @@ protected:
     SetDatabasePath("");
     SetOverrideDatabase(true);
     SetCompressLevel(9);
+    SetUseTopologicalCompression(false);
 
     UseAllCores = false;
 
@@ -103,6 +107,7 @@ private:
   std::string DatabasePath;
   bool OverrideDatabase;
   int CompressLevel;
+  bool UseTopologicalCompression;
 
   bool needsToAbort() override {
     return GetAbortExecute();

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -47,6 +47,7 @@ public:
 #define TopoCompWriterGetSetMacro(NAME, TYPE) \
   void Set##NAME(const TYPE _arg) {           \
     this->ttkCompWriter_->Set##NAME(_arg);    \
+    this->Modified();                         \
   }                                           \
   TYPE Get##NAME() {                          \
     return this->ttkCompWriter_->Get##NAME(); \

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -44,66 +44,52 @@ public:
   vtkSetMacro(UseTopologicalCompression, bool);
   vtkGetMacro(UseTopologicalCompression, bool);
 
-  void SetTolerance(double arg) {
-    this->ttkCompWriter_->SetTolerance(arg);
+#define TopoCompWriterSetMacro(NAME, TYPE)        \
+  void Set##NAME(TYPE _arg) {                     \
+    this->ttkCompWriter_->Set##NAME(_arg);        \
   }
-  double GetTolerance() {
-    return this->ttkCompWriter_->GetTolerance();
+#define TopoCompWriterGetMacro(NAME, TYPE)        \
+  TYPE Get##NAME() {                              \
+    return this->ttkCompWriter_->Get##NAME();     \
   }
-  void SetMaximumError(double arg) {
-    this->ttkCompWriter_->SetMaximumError(arg);
-  }
-  double GetMaximumError() {
-    return this->ttkCompWriter_->GetMaximumError();
-  }
-  void SetZFPBitBudget(double arg) {
-    this->ttkCompWriter_->SetZFPBitBudget(arg);
-  }
-  double GetZFPBitBudget() {
-    return this->ttkCompWriter_->GetZFPBitBudget();
-  }
-  void SetZFPOnly(bool arg) {
-    this->ttkCompWriter_->SetZFPOnly(arg);
-  }
-  bool GetZFPOnly() {
-    return this->ttkCompWriter_->GetZFPOnly();
-  }
-  void SetCompressionType(int arg) {
-    this->ttkCompWriter_->SetCompressionType(arg);
-  }
-  int GetCompressionType() {
-    return this->ttkCompWriter_->GetCompressionType();
-  }
-  void SetNbSegments(int arg) {
-    this->ttkCompWriter_->SetNbSegments(arg);
-  }
-  int GetNbSegments() {
-    return this->ttkCompWriter_->GetNbSegments();
-  }
-  void SetNbVertices(int arg) {
-    this->ttkCompWriter_->SetNbVertices(arg);
-  }
-  int GetNbVertices() {
-    return this->ttkCompWriter_->GetNbVertices();
-  }
-  void SetSQMethod(std::string arg) {
-    this->ttkCompWriter_->SetSQMethod(arg);
-  }
-  std::string GetSQMethod() {
-    return this->ttkCompWriter_->GetSQMethod();
-  }
-  void SetSubdivide(bool arg) {
-    this->ttkCompWriter_->SetSubdivide(arg);
-  }
-  bool GetSubdivide() {
-    return this->ttkCompWriter_->GetSubdivide();
-  }
-  void SetUseTopologicalSimplification(bool arg) {
-    this->ttkCompWriter_->SetUseTopologicalSimplification(arg);
-  }
-  bool GetUseTopologicalSimplification() {
-    return this->ttkCompWriter_->GetUseTopologicalSimplification();
-  }
+
+  TopoCompWriterSetMacro(ScalarField, std::string);
+  TopoCompWriterGetMacro(ScalarField, std::string);
+
+  TopoCompWriterSetMacro(ScalarFieldId, int);
+  TopoCompWriterGetMacro(ScalarFieldId, int);
+
+  TopoCompWriterGetMacro(Tolerance, double);
+  TopoCompWriterSetMacro(Tolerance, double);
+
+  TopoCompWriterGetMacro(MaximumError, double);
+  TopoCompWriterSetMacro(MaximumError, double);
+
+  TopoCompWriterGetMacro(ZFPBitBudget, double);
+  TopoCompWriterSetMacro(ZFPBitBudget, double);
+
+  TopoCompWriterGetMacro(ZFPOnly, bool);
+  TopoCompWriterSetMacro(ZFPOnly, bool);
+
+  TopoCompWriterGetMacro(CompressionType, int);
+  TopoCompWriterSetMacro(CompressionType, int);
+
+  TopoCompWriterGetMacro(NbSegments, int);
+  TopoCompWriterSetMacro(NbSegments, int);
+
+  TopoCompWriterGetMacro(NbVertices, int);
+  TopoCompWriterSetMacro(NbVertices, int);
+
+  TopoCompWriterGetMacro(SQMethod, std::string);
+  TopoCompWriterSetMacro(SQMethod, std::string);
+
+  TopoCompWriterGetMacro(Subdivide, bool);
+  TopoCompWriterSetMacro(Subdivide, bool);
+
+  TopoCompWriterGetMacro(UseTopologicalSimplification, bool);
+  TopoCompWriterSetMacro(UseTopologicalSimplification, bool);
+
+  TopoCompWriterSetMacro(SQMethodPV, int);
 
   // default ttk setters
   vtkSetMacro(debugLevel_, int);

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -44,52 +44,26 @@ public:
   vtkSetMacro(UseTopologicalCompression, bool);
   vtkGetMacro(UseTopologicalCompression, bool);
 
-#define TopoCompWriterSetMacro(NAME, TYPE)        \
-  void Set##NAME(TYPE _arg) {                     \
-    this->ttkCompWriter_->Set##NAME(_arg);        \
+#define TopoCompWriterGetSetMacro(NAME, TYPE) \
+  void Set##NAME(const TYPE _arg) {           \
+    this->ttkCompWriter_->Set##NAME(_arg);    \
+  }                                           \
+  TYPE Get##NAME() {                          \
+    return this->ttkCompWriter_->Get##NAME(); \
   }
-#define TopoCompWriterGetMacro(NAME, TYPE)        \
-  TYPE Get##NAME() {                              \
-    return this->ttkCompWriter_->Get##NAME();     \
+
+  TopoCompWriterGetSetMacro(ScalarField, std::string);
+  TopoCompWriterGetSetMacro(Tolerance, double);
+  TopoCompWriterGetSetMacro(MaximumError, double);
+  TopoCompWriterGetSetMacro(ZFPBitBudget, double);
+  TopoCompWriterGetSetMacro(ZFPOnly, bool);
+  TopoCompWriterGetSetMacro(CompressionType, int);
+  TopoCompWriterGetSetMacro(Subdivide, bool);
+  TopoCompWriterGetSetMacro(UseTopologicalSimplification, bool);
+
+  void SetSQMethodPV(const int arg) {
+    this->ttkCompWriter_->SetSQMethodPV(arg);
   }
-
-  TopoCompWriterSetMacro(ScalarField, std::string);
-  TopoCompWriterGetMacro(ScalarField, std::string);
-
-  TopoCompWriterSetMacro(ScalarFieldId, int);
-  TopoCompWriterGetMacro(ScalarFieldId, int);
-
-  TopoCompWriterGetMacro(Tolerance, double);
-  TopoCompWriterSetMacro(Tolerance, double);
-
-  TopoCompWriterGetMacro(MaximumError, double);
-  TopoCompWriterSetMacro(MaximumError, double);
-
-  TopoCompWriterGetMacro(ZFPBitBudget, double);
-  TopoCompWriterSetMacro(ZFPBitBudget, double);
-
-  TopoCompWriterGetMacro(ZFPOnly, bool);
-  TopoCompWriterSetMacro(ZFPOnly, bool);
-
-  TopoCompWriterGetMacro(CompressionType, int);
-  TopoCompWriterSetMacro(CompressionType, int);
-
-  TopoCompWriterGetMacro(NbSegments, int);
-  TopoCompWriterSetMacro(NbSegments, int);
-
-  TopoCompWriterGetMacro(NbVertices, int);
-  TopoCompWriterSetMacro(NbVertices, int);
-
-  TopoCompWriterGetMacro(SQMethod, std::string);
-  TopoCompWriterSetMacro(SQMethod, std::string);
-
-  TopoCompWriterGetMacro(Subdivide, bool);
-  TopoCompWriterSetMacro(Subdivide, bool);
-
-  TopoCompWriterGetMacro(UseTopologicalSimplification, bool);
-  TopoCompWriterSetMacro(UseTopologicalSimplification, bool);
-
-  TopoCompWriterSetMacro(SQMethodPV, int);
 
   // default ttk setters
   vtkSetMacro(debugLevel_, int);

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -99,6 +99,13 @@ void ttkTopologicalCompressionWriter::PerformCompression(
 }
 
 void ttkTopologicalCompressionWriter::WriteData() {
+  vtkDataObject *input = GetInput();
+  vtkImageData *vti = vtkImageData::SafeDownCast(input);
+
+  execute(vti);
+}
+
+void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
   bool zfpOnly = ZFPOnly;
   double zfpBitBudget = ZFPBitBudget;
   topologicalCompression.setThreadNumber(threadNumber_);
@@ -119,9 +126,6 @@ void ttkTopologicalCompressionWriter::WriteData() {
     d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
     return;
   }
-
-  vtkDataObject *input = GetInput();
-  vtkImageData *vti = vtkImageData::SafeDownCast(input);
 
   vtkDataArray *inputScalarField = GetInputScalarField(vti);
 

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -57,7 +57,6 @@ int ttkTopologicalCompressionWriter::AllocateOutput(
       outputScalarField = vtkSmartPointer<vtkIdTypeArray>::New();
       break;
     default: {
-      ttk::Debug d;
       std::stringstream msg;
       msg << "[vtkTopologicalCompression] Unsupported data type :(" << endl;
       d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
@@ -90,7 +89,6 @@ void ttkTopologicalCompressionWriter::PerformCompression(
   switch(inputScalarField->GetDataType()) {
     vtkTemplateMacro(topologicalCompression.execute<VTK_TT>(Tolerance));
     default: {
-      ttk::Debug d;
       std::stringstream msg;
       msg << "[ttkCompressionWriter] Unsupported data type." << std::endl;
       d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
@@ -111,14 +109,12 @@ void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
   topologicalCompression.setThreadNumber(threadNumber_);
 
   {
-    ttk::Debug d;
     std::stringstream msg;
     msg << "[ttkCompressionWriter] New writing task." << std::endl;
     d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
   }
 
   if(zfpOnly && (zfpBitBudget > 64 || zfpBitBudget < 1)) {
-    ttk::Debug d;
     std::stringstream msg;
     msg << "[ttkTopologicalCompressionReader] Wrong ZFP bit budget for "
            "ZFP-only use."
@@ -138,7 +134,6 @@ void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
   PerformCompression(inputScalarField);
 
   {
-    ttk::Debug d;
     std::stringstream msg;
     msg << "[ttkCompressionWriter] Compression successful." << std::endl;
     d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
@@ -147,7 +142,6 @@ void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
   // Open file.
   FILE *fp;
   if((fp = fopen(FileName, "wb")) == nullptr) {
-    ttk::Debug d;
     std::stringstream msg;
     msg << "[ttkCompressionWriter] System IO error while opening the file."
         << std::endl;
@@ -170,7 +164,6 @@ void ttkTopologicalCompressionWriter::execute(vtkImageData *vti) {
     inputScalarFieldName);
 
   {
-    ttk::Debug d;
     std::stringstream msg;
     msg << "[ttkTopologicalCompression] Wrote to " << FileName << "."
         << std::endl;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -173,6 +173,10 @@ private:
   // Whatever.
   ttkTopologicalCompressionWriter(const ttkTopologicalCompressionWriter &);
   void operator=(const ttkTopologicalCompressionWriter &);
+
+  // give ttkCinemaWriter access to ttkTopologicalCompressionWriter
+  // protected member functions
+  friend class ttkCinemaWriter;
 };
 
 #endif // _VTK_TOPOLOGICALCOMPRESSIONWRITER_H

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -127,6 +127,7 @@ protected:
   ~ttkTopologicalCompressionWriter();
   virtual int FillInputPortInformation(int port, vtkInformation *info) override;
   void WriteData() override;
+  void execute(vtkImageData *vti);
 
   // TTK management.
   vtkDataArray *GetInputScalarField(vtkImageData *vti);

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -106,6 +106,10 @@ public:
   vtkSetMacro(UseTopologicalSimplification, bool);
   vtkGetMacro(UseTopologicalSimplification, bool);
 
+  void SetDebugLevel(int debugLevel) {
+    d.setDebugLevel(debugLevel);
+  }
+
   inline void SetSQMethodPV(int c) {
     switch(c) {
       case 1:
@@ -163,6 +167,8 @@ private:
   ttk::TopologicalCompression topologicalCompression;
   int ThreadNumber;
   bool UseAllCores;
+
+  ttk::Debug d;
 
   // Whatever.
   ttkTopologicalCompressionWriter(const ttkTopologicalCompressionWriter &);

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -47,6 +47,131 @@
                 <Documentation>Debug level.</Documentation>
             </IntVectorProperty>
 
+      <StringVectorProperty
+          name="ScalarField"
+          command="SetScalarField"
+          number_of_elements="1"
+          animateable="0"
+          label="Scalar Field">
+        <ArrayListDomain
+            name="array_list"
+            default_values="0">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the scalar field to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+        name="CompressionType"
+        label="Compression type"
+        command="SetCompressionType"
+        number_of_elements="1"
+        default_values="0">
+        <EnumerationDomain name="enum">
+          <Entry value="0" text="Driven by persistence diagram"/>
+        </EnumerationDomain>
+        <Documentation>
+          Compression Type.
+        </Documentation>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty
+          name="Tolerance"
+          command="SetTolerance"
+          label="Topological loss (persistence percentage)"
+          number_of_elements="1"
+          default_values="10">
+        <Documentation>
+          Topological loss expressed as a persistence threshold (normalized
+            between 0 and 100).
+        </Documentation>
+        <DoubleRangeDomain name="range" min="1" max="100" />
+      </DoubleVectorProperty>
+
+      <IntVectorProperty
+        name="Subdivide"
+        label="Enable maximum pointwise error control"
+        command="SetSubdivide"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Enable maximum pointwise error control.
+        </Documentation>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty
+        name="MaximumError"
+        command="SetMaximumError"
+        label="Maximum pointwise error (percentage)"
+        number_of_elements="1"
+        default_values="10">
+        <Documentation>
+          Set the maximum allowed pointwise error (in percentage of the
+            function span).
+        </Documentation>
+        <DoubleRangeDomain name="range" min="1" max="100" />
+      </DoubleVectorProperty>
+
+      <IntVectorProperty
+              name="ZFPBitBudget"
+              label="ZFP bit budget (extra)"
+              command="SetZFPBitBudget"
+              number_of_elements="1"
+              default_values="0">
+        <IntRangeDomain name="range" min="0" max="64" />
+        <Documentation>
+          Additionally compress the data with ZFP for improved geometrical
+            quality (number of bits per vertex).
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+              name="ZFPOnly"
+              label="Use ZFP compressor only (no topological compression)"
+              command="SetZFPOnly"
+              number_of_elements="1"
+              default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Use ZFP only.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+        name="UseTopologicalSimplification"
+        label="Simplify at compression (slower)"
+        command="SetUseTopologicalSimplification"
+        number_of_elements="1"
+        default_values="1"
+        panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Enable topological simplification at compression time (higher
+          compression factors, slower compression time).
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+        name="SQMethod"
+        command="SetSQMethodPV"
+        animateable="0"
+        label="Use SQ compressor only (no topological compression)"
+        panel_visibility="advanced">
+        <EnumerationDomain name="enum">
+          <Entry value="0" text="No SQ (topological compression)."/>
+          <Entry value="1" text="Range-based SQ (lowest quality, faster)."/>
+          <Entry value="2" text="Domain-based SQ (highest quality, slower)."/>
+        </EnumerationDomain>
+        <Documentation>
+          Use SQ instead of topological compression.
+        </Documentation>
+      </IntVectorProperty>
+
             <PropertyGroup panel_widget="Line" label="Output Options">
                 <Property name="DatabasePath" />
                 <Property name="OverrideDatabase" />

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -29,6 +29,13 @@
             <IntVectorProperty name="CompressionLevel" label="Compression Level" command="SetCompressLevel" number_of_elements="1" default_values="9">
                 <IntRangeDomain name="range" min="0" max="9" />
                 <Documentation>Determines the compression level form 0 (fast + large files) to 9 (slow + small files).</Documentation>
+              <Hints>
+                <PropertyWidgetDecorator
+                    type="GenericDecorator"
+                    mode="visibility"
+                    property="UseTopologicalCompression"
+                    value="0" />
+              </Hints>
             </IntVectorProperty>
 
       <IntVectorProperty

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -31,6 +31,19 @@
                 <Documentation>Determines the compression level form 0 (fast + large files) to 9 (slow + small files).</Documentation>
             </IntVectorProperty>
 
+      <IntVectorProperty
+              name="UseTopologicalCompression"
+              label="Use Topological Compression"
+              command="SetUseTopologicalCompression"
+              number_of_elements="1"
+              default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Use TTK Topological Compression algorithm instead of writing
+          uncompressed data.
+        </Documentation>
+      </IntVectorProperty>
+
             <IntVectorProperty name="UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
                 <BooleanDomain name="bool" />
                 <Documentation>Use all available cores.</Documentation>
@@ -176,11 +189,31 @@
                 <Property name="DatabasePath" />
                 <Property name="OverrideDatabase" />
                 <Property name="CompressionLevel" />
+                <Property name="UseTopologicalCompression" />
             </PropertyGroup>
             <PropertyGroup panel_widget="Line" label="Testing">
                 <Property name="UseAllCores" />
                 <Property name="ThreadNumber" />
                 <Property name="DebugLevel" />
+            </PropertyGroup>
+
+            <PropertyGroup panel_widget="Line" label="Topological Compression" >
+              <Property name="ScalarField" />
+              <Property name="CompressionType" />
+              <Property name="Tolerance" />
+              <Property name="Subdivide" />
+              <Property name="MaximumError" />
+              <Property name="ZFPBitBudget" />
+              <Property name="ZFPOnly" />
+              <Property name="UseTopologicalSimplification" />
+              <Property name="SQMethod" />
+              <Hints>
+                <PropertyWidgetDecorator
+                    type="GenericDecorator"
+                    mode="visibility"
+                    property="UseTopologicalCompression"
+                    value="1" />
+              </Hints>
             </PropertyGroup>
 
             <Hints>

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -51,22 +51,6 @@
         </Documentation>
       </IntVectorProperty>
 
-            <IntVectorProperty name="UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                <BooleanDomain name="bool" />
-                <Documentation>Use all available cores.</Documentation>
-            </IntVectorProperty>
-            <IntVectorProperty name="ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                <IntRangeDomain name="range" min="1" max="100" />
-                <Documentation>Thread number.</Documentation>
-                <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseAllCores" value="0" />
-                </Hints>
-            </IntVectorProperty>
-            <IntVectorProperty name="DebugLevel" label="Debug Level" command="SetdebugLevel_" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                <IntRangeDomain name="range" min="0" max="100" />
-                <Documentation>Debug level.</Documentation>
-            </IntVectorProperty>
-
       <StringVectorProperty
           name="ScalarField"
           command="SetScalarField"
@@ -191,6 +175,23 @@
           Use SQ instead of topological compression.
         </Documentation>
       </IntVectorProperty>
+
+
+            <IntVectorProperty name="UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
+                <BooleanDomain name="bool" />
+                <Documentation>Use all available cores.</Documentation>
+            </IntVectorProperty>
+            <IntVectorProperty name="ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
+                <IntRangeDomain name="range" min="1" max="100" />
+                <Documentation>Thread number.</Documentation>
+                <Hints>
+                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseAllCores" value="0" />
+                </Hints>
+            </IntVectorProperty>
+            <IntVectorProperty name="DebugLevel" label="Debug Level" command="SetdebugLevel_" number_of_elements="1" default_values="3" panel_visibility="advanced">
+                <IntRangeDomain name="range" min="0" max="100" />
+                <Documentation>Debug level.</Documentation>
+            </IntVectorProperty>
 
             <PropertyGroup panel_widget="Line" label="Output Options">
                 <Property name="DatabasePath" />


### PR DESCRIPTION
This PR add the support of Topological Compression when reading and writing vtkImageData into cinema databases.

Here, the TopologicalCompressionWriter and the TopologicalCompressionReader modules are used as back-ends for the CinemaWriter and CinemaProductReader modules. Some Topological Compression options are re-exposed in the CinemaWriter GUI (under a checkbox).

Also included are a quick refactor of the log/debug message management logic in TopologicalCompression to let it be set from outside, and the support of TIFF images in CinemaProductReader.

Enjoy!

Pierre
