### PR TITLE
Add missing vtkNew includes for CinemaWriter/CinemaProductReader

### DIFF
--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -3,6 +3,7 @@
 
 #include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
+#include <vtkNew.h>
 #include <vtkStreamingDemandDrivenPipeline.h>
 #include <vtkStringArray.h>
 #include <vtkTIFFReader.h>

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -14,6 +14,7 @@
 
 // VTK includes
 #include <vtkInformation.h>
+#include <vtkNew.h>
 #include <vtkXMLPMultiBlockDataWriter.h>
 
 // TTK includes


### PR DESCRIPTION
These missing vtkNew.h includes were causing build errors with Travis (vtk6).

Pierre