### PR TITLE
PersistenceDiagramClustering: outline vtkTemplateMacro body

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -71,6 +71,138 @@ int ttkPersistenceDiagramClustering::updateProgress(const float &progress) {
   return 0;
 }
 
+template <typename VTK_TT>
+int ttkPersistenceDiagramClustering::dispatch(
+  int numInputs,
+  std::vector<vtkUnstructuredGrid *> &inputDiagram,
+  vtkUnstructuredGrid *outputClusters,
+  vtkUnstructuredGrid *outputCentroids,
+  vtkUnstructuredGrid *outputMatchings) {
+
+  int ret{};
+  vector<vector<macroDiagramTuple>> *intermediateDiagrams;
+  vector<vector<vector<macroMatchingTuple>>> *all_matchings;
+  vector<vector<macroDiagramTuple>> *final_centroids;
+  if(needUpdate_) {
+    if(intermediateDiagrams_) {
+      vector<vector<macroDiagramTuple>> *tmpPTR
+        = (vector<vector<macroDiagramTuple>> *)intermediateDiagrams_;
+      delete tmpPTR;
+    }
+    intermediateDiagrams_ = new vector<vector<macroDiagramTuple>>(numInputs);
+
+    if(final_centroids_) {
+      vector<vector<macroDiagramTuple>> *tmpPTR
+        = (vector<vector<macroDiagramTuple>> *)final_centroids_;
+      delete tmpPTR;
+    }
+    final_centroids_ = new vector<vector<macroDiagramTuple>>;
+
+    if(all_matchings_) {
+      vector<vector<vector<macroMatchingTuple>>> *tmpPTR
+        = (vector<vector<vector<macroMatchingTuple>>> *)all_matchings_;
+      delete tmpPTR;
+    }
+    all_matchings_ = new vector<vector<vector<macroMatchingTuple>>>(3);
+  }
+
+  final_centroids = (vector<vector<macroDiagramTuple>> *)final_centroids_;
+  intermediateDiagrams
+    = (vector<vector<macroDiagramTuple>> *)intermediateDiagrams_;
+  all_matchings = (vector<vector<vector<macroMatchingTuple>>> *)all_matchings_;
+
+  if(needUpdate_) {
+
+    max_dimension_total_ = 0;
+    for(int i = 0; i < numInputs; i++) {
+      double max_dimension = getPersistenceDiagram<VTK_TT>(
+        &(intermediateDiagrams->at(i)), inputDiagram[i], Spacing, 0);
+      if(max_dimension_total_ < max_dimension) {
+        max_dimension_total_ = max_dimension;
+      }
+    }
+
+    if(Method == 0) {
+      // Progressive approach
+      PersistenceDiagramClustering<VTK_TT> persistenceDiagramsClustering;
+      persistenceDiagramsClustering.setWrapper(this);
+
+      string wassersteinMetric = WassersteinMetric;
+
+      if(!UseInterruptible) {
+        TimeLimit = 999999999;
+      }
+      persistenceDiagramsClustering.setWasserstein(wassersteinMetric);
+      persistenceDiagramsClustering.setDeterministic(Deterministic);
+      persistenceDiagramsClustering.setForceUseOfAlgorithm(ForceUseOfAlgorithm);
+      persistenceDiagramsClustering.setPairTypeClustering(PairTypeClustering);
+      persistenceDiagramsClustering.setNumberOfInputs(numInputs);
+      persistenceDiagramsClustering.setDebugLevel(debugLevel_);
+      persistenceDiagramsClustering.setTimeLimit(TimeLimit);
+      persistenceDiagramsClustering.setUseProgressive(UseProgressive);
+      persistenceDiagramsClustering.setThreadNumber(threadNumber_);
+      persistenceDiagramsClustering.setAlpha(Alpha);
+      persistenceDiagramsClustering.setDeltaLim(DeltaLim);
+      persistenceDiagramsClustering.setUseDeltaLim(UseAdditionalPrecision);
+      persistenceDiagramsClustering.setLambda(Lambda);
+      persistenceDiagramsClustering.setNumberOfClusters(NumberOfClusters);
+      persistenceDiagramsClustering.setUseAccelerated(UseAccelerated);
+      persistenceDiagramsClustering.setUseKmeansppInit(UseKmeansppInit);
+      persistenceDiagramsClustering.setDistanceWritingOptions(
+        DistanceWritingOptions);
+
+      persistenceDiagramsClustering.setDiagrams((void *)intermediateDiagrams);
+      inv_clustering_
+        = persistenceDiagramsClustering.execute(final_centroids, all_matchings);
+
+      needUpdate_ = false;
+    }
+
+    else {
+      // AUCTION APPROACH
+      final_centroids->resize(1);
+      inv_clustering_.resize(numInputs);
+      for(int i_input = 0; i_input < numInputs; i_input++) {
+        inv_clustering_[i_input] = 0;
+      }
+      PersistenceDiagramBarycenter<VTK_TT> persistenceDiagramsBarycenter;
+      persistenceDiagramsBarycenter.setWrapper(this);
+
+      string wassersteinMetric = WassersteinMetric;
+      persistenceDiagramsBarycenter.setWasserstein(wassersteinMetric);
+      persistenceDiagramsBarycenter.setMethod(2);
+      persistenceDiagramsBarycenter.setNumberOfInputs(numInputs);
+      persistenceDiagramsBarycenter.setTimeLimit(TimeLimit);
+      persistenceDiagramsBarycenter.setDeterministic(Deterministic);
+      persistenceDiagramsBarycenter.setUseProgressive(UseProgressive);
+      persistenceDiagramsBarycenter.setDebugLevel(debugLevel_);
+      persistenceDiagramsBarycenter.setThreadNumber(threadNumber_);
+      persistenceDiagramsBarycenter.setAlpha(Alpha);
+      persistenceDiagramsBarycenter.setLambda(Lambda);
+      // persistenceDiagramsBarycenter.setReinitPrices(ReinitPrices);
+      // persistenceDiagramsBarycenter.setEpsilonDecreases(EpsilonDecreases);
+      // persistenceDiagramsBarycenter.setEarlyStoppage(EarlyStoppage);
+
+      persistenceDiagramsBarycenter.setDiagrams((void *)intermediateDiagrams);
+
+      persistenceDiagramsBarycenter.execute(
+        &(final_centroids->at(0)), all_matchings);
+
+      needUpdate_ = false;
+    }
+  }
+
+  outputMatchings->ShallowCopy(
+    createMatchings(final_centroids, inv_clustering_, *intermediateDiagrams,
+                    all_matchings, max_dimension_total_, Spacing));
+  outputClusters->ShallowCopy(createOutputClusteredDiagrams(
+    *intermediateDiagrams, inv_clustering_, max_dimension_total_, Spacing));
+  outputCentroids->ShallowCopy(createOutputCentroids<VTK_TT>(
+    final_centroids, inv_clustering_, max_dimension_total_, Spacing));
+
+  return ret;
+}
+
 int ttkPersistenceDiagramClustering::doIt(vtkDataSet **input,
                                           vtkUnstructuredGrid *outputClusters,
                                           vtkUnstructuredGrid *outputCentroids,
@@ -89,136 +221,9 @@ int ttkPersistenceDiagramClustering::doIt(vtkDataSet **input,
   int dataType
     = inputDiagram[0]->GetCellData()->GetArray("Persistence")->GetDataType();
 
-  // TODO If Windows, we need to get rid of one pair of parenthesis
   switch(dataType) {
-
-    vtkTemplateMacro(({
-      vector<vector<macroDiagramTuple>> *intermediateDiagrams;
-      vector<vector<vector<macroMatchingTuple>>> *all_matchings;
-      vector<vector<macroDiagramTuple>> *final_centroids;
-      if(needUpdate_) {
-        if(intermediateDiagrams_) {
-          vector<vector<macroDiagramTuple>> *tmpPTR
-            = (vector<vector<macroDiagramTuple>> *)intermediateDiagrams_;
-          delete tmpPTR;
-        }
-        intermediateDiagrams_
-          = new vector<vector<macroDiagramTuple>>(numInputs);
-
-        if(final_centroids_) {
-          vector<vector<macroDiagramTuple>> *tmpPTR
-            = (vector<vector<macroDiagramTuple>> *)final_centroids_;
-          delete tmpPTR;
-        }
-        final_centroids_ = new vector<vector<macroDiagramTuple>>;
-
-        if(all_matchings_) {
-          vector<vector<vector<macroMatchingTuple>>> *tmpPTR
-            = (vector<vector<vector<macroMatchingTuple>>> *)all_matchings_;
-          delete tmpPTR;
-        }
-        all_matchings_ = new vector<vector<vector<macroMatchingTuple>>>(3);
-      }
-
-      final_centroids = (vector<vector<macroDiagramTuple>> *)final_centroids_;
-      intermediateDiagrams
-        = (vector<vector<macroDiagramTuple>> *)intermediateDiagrams_;
-      all_matchings
-        = (vector<vector<vector<macroMatchingTuple>>> *)all_matchings_;
-
-      if(needUpdate_) {
-
-        max_dimension_total_ = 0;
-        for(int i = 0; i < numInputs; i++) {
-          double max_dimension = getPersistenceDiagram<VTK_TT>(
-            &(intermediateDiagrams->at(i)), inputDiagram[i], Spacing, 0);
-          if(max_dimension_total_ < max_dimension) {
-            max_dimension_total_ = max_dimension;
-          }
-        }
-
-        if(Method == 0) {
-          // Progressive approach
-          PersistenceDiagramClustering<VTK_TT> persistenceDiagramsClustering;
-          persistenceDiagramsClustering.setWrapper(this);
-
-          string wassersteinMetric = WassersteinMetric;
-
-          if(!UseInterruptible) {
-            TimeLimit = 999999999;
-          }
-          persistenceDiagramsClustering.setWasserstein(wassersteinMetric);
-          persistenceDiagramsClustering.setDeterministic(Deterministic);
-          persistenceDiagramsClustering.setForceUseOfAlgorithm(
-            ForceUseOfAlgorithm);
-          persistenceDiagramsClustering.setPairTypeClustering(
-            PairTypeClustering);
-          persistenceDiagramsClustering.setNumberOfInputs(numInputs);
-          persistenceDiagramsClustering.setDebugLevel(debugLevel_);
-          persistenceDiagramsClustering.setTimeLimit(TimeLimit);
-          persistenceDiagramsClustering.setUseProgressive(UseProgressive);
-          persistenceDiagramsClustering.setThreadNumber(threadNumber_);
-          persistenceDiagramsClustering.setAlpha(Alpha);
-          persistenceDiagramsClustering.setDeltaLim(DeltaLim);
-          persistenceDiagramsClustering.setUseDeltaLim(UseAdditionalPrecision);
-          persistenceDiagramsClustering.setLambda(Lambda);
-          persistenceDiagramsClustering.setNumberOfClusters(NumberOfClusters);
-          persistenceDiagramsClustering.setUseAccelerated(UseAccelerated);
-          persistenceDiagramsClustering.setUseKmeansppInit(UseKmeansppInit);
-          persistenceDiagramsClustering.setDistanceWritingOptions(
-            DistanceWritingOptions);
-
-          persistenceDiagramsClustering.setDiagrams(
-            (void *)intermediateDiagrams);
-          inv_clustering_ = persistenceDiagramsClustering.execute(
-            final_centroids, all_matchings);
-
-          needUpdate_ = false;
-        }
-
-        else {
-          // AUCTION APPROACH
-          final_centroids->resize(1);
-          inv_clustering_.resize(numInputs);
-          for(int i_input = 0; i_input < numInputs; i_input++) {
-            inv_clustering_[i_input] = 0;
-          }
-          PersistenceDiagramBarycenter<VTK_TT> persistenceDiagramsBarycenter;
-          persistenceDiagramsBarycenter.setWrapper(this);
-
-          string wassersteinMetric = WassersteinMetric;
-          persistenceDiagramsBarycenter.setWasserstein(wassersteinMetric);
-          persistenceDiagramsBarycenter.setMethod(2);
-          persistenceDiagramsBarycenter.setNumberOfInputs(numInputs);
-          persistenceDiagramsBarycenter.setTimeLimit(TimeLimit);
-          persistenceDiagramsBarycenter.setDeterministic(Deterministic);
-          persistenceDiagramsBarycenter.setUseProgressive(UseProgressive);
-          persistenceDiagramsBarycenter.setDebugLevel(debugLevel_);
-          persistenceDiagramsBarycenter.setThreadNumber(threadNumber_);
-          persistenceDiagramsBarycenter.setAlpha(Alpha);
-          persistenceDiagramsBarycenter.setLambda(Lambda);
-          // persistenceDiagramsBarycenter.setReinitPrices(ReinitPrices);
-          // persistenceDiagramsBarycenter.setEpsilonDecreases(EpsilonDecreases);
-          // persistenceDiagramsBarycenter.setEarlyStoppage(EarlyStoppage);
-
-          persistenceDiagramsBarycenter.setDiagrams(
-            (void *)intermediateDiagrams);
-
-          persistenceDiagramsBarycenter.execute(
-            &(final_centroids->at(0)), all_matchings);
-
-          needUpdate_ = false;
-        }
-      }
-
-      outputMatchings->ShallowCopy(
-        createMatchings(final_centroids, inv_clustering_, *intermediateDiagrams,
-                        all_matchings, max_dimension_total_, Spacing));
-      outputClusters->ShallowCopy(createOutputClusteredDiagrams(
-        *intermediateDiagrams, inv_clustering_, max_dimension_total_, Spacing));
-      outputCentroids->ShallowCopy(createOutputCentroids<VTK_TT>(
-        final_centroids, inv_clustering_, max_dimension_total_, Spacing));
-    }));
+    vtkTemplateMacro(dispatch<VTK_TT>(numInputs, inputDiagram, outputClusters,
+                                      outputCentroids, outputMatchings));
   }
 
   return 0;

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -354,6 +354,13 @@ private:
   bool needsToAbort();
 
   int updateProgress(const float &progress);
+
+  template <typename T>
+  int dispatch(int numInputs,
+               std::vector<vtkUnstructuredGrid *> &inputDiagram,
+               vtkUnstructuredGrid *outputClusters,
+               vtkUnstructuredGrid *outputCentroids,
+               vtkUnstructuredGrid *outputMatchings);
 };
 
 template <typename dataType>


### PR DESCRIPTION
Apply the logic of PR #236 to the PersistenceDiagramClustering module (which was in development at the time #236 landed).

Should fix issue #284.

The issue here is that the preprocessor logic is different between MSVC and GCC/Clang: the former can directly use blocks (statements inside braces) as macro arguments whereas the latter two expect them inside parentheses. We use to rely on a custom macro to wrap vtkTemplateMacro and add parentheses when needed.

The solution presented here also allows to keep using #ifdef constructs inside the function body (for example for KAMIKAZE checks) without resorting to *triplicated* code blocks (the initial rationale for #236).
