### PR TITLE
DimensionReduction: Input is a distance matrix

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -29,8 +29,13 @@ namespace ttk {
 
     inline int setSEParameters(std::string &Affinity,
                                float Gamma,
-                               std::string &EigenSolver) {
-      se_Affinity = Affinity;
+                               std::string &EigenSolver,
+                               bool InputIsADistanceMatrix) {
+      if(InputIsADistanceMatrix) {
+        se_Affinity = "precomputed";
+      } else {
+        se_Affinity = Affinity;
+      }
       se_Gamma = Gamma;
       se_EigenSolver = EigenSolver;
       return 0;

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -60,13 +60,17 @@ namespace ttk {
                                 int MaxIteration,
                                 int Verbose,
                                 float Epsilon,
-                                std::string &Dissimilarity) {
+                                bool Dissimilarity) {
       mds_Metric = Metric;
       mds_Init = Init;
       mds_MaxIteration = MaxIteration;
       mds_Verbose = Verbose;
       mds_Epsilon = Epsilon;
-      mds_Dissimilarity = Dissimilarity;
+      if(Dissimilarity) {
+        mds_Dissimilarity = "precomputed";
+      } else {
+        mds_Dissimilarity = "euclidean";
+      }
       return 0;
     }
 

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -42,7 +42,8 @@ vtkStandardNewMacro(ttkDimensionReduction)
     dimensionReduction_.setInputNumberOfComponents(NumberOfComponents);
     dimensionReduction_.setInputNumberOfNeighbors(NumberOfNeighbors);
     dimensionReduction_.setInputIsDeterministic(IsDeterministic);
-    dimensionReduction_.setSEParameters(se_Affinity, se_Gamma, se_EigenSolver);
+    dimensionReduction_.setSEParameters(
+      se_Affinity, se_Gamma, se_EigenSolver, InputIsADistanceMatrix);
     dimensionReduction_.setLLEParameters(
       lle_Regularization, lle_EigenSolver, lle_Tolerance, lle_MaxIteration,
       lle_Method, lle_HessianTolerance, lle_ModifiedTolerance,

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -1,3 +1,4 @@
+#include <regex>
 #include <ttkDimensionReduction.h>
 
 using namespace std;
@@ -7,6 +8,18 @@ vtkStandardNewMacro(ttkDimensionReduction)
 
   int ttkDimensionReduction::doIt(vtkTable *input, vtkTable *output) {
   Memory m;
+
+  if(SelectFieldsWithRegexp) {
+    // select all input columns whose name is matching the regexp
+    ScalarFields.clear();
+    const auto n = input->GetNumberOfColumns();
+    for(int i = 0; i < n; ++i) {
+      const auto &name = input->GetColumnName(i);
+      if(std::regex_match(name, std::regex(RegexpString))) {
+        ScalarFields.emplace_back(name);
+      }
+    }
+  }
 
   if(dimensionReduction_.isPythonFound()) {
     const SimplexId numberOfRows = input->GetNumberOfRows();

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -50,7 +50,7 @@ vtkStandardNewMacro(ttkDimensionReduction)
       lle_NeighborsAlgorithm);
     dimensionReduction_.setMDSParameters(mds_Metric, mds_Init, mds_MaxIteration,
                                          mds_Verbose, mds_Epsilon,
-                                         mds_Dissimilarity);
+                                         InputIsADistanceMatrix);
     dimensionReduction_.setTSNEParameters(
       tsne_Perplexity, tsne_Exaggeration, tsne_LearningRate, tsne_MaxIteration,
       tsne_MaxIterationProgress, tsne_GradientThreshold, tsne_Metric, tsne_Init,

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -160,9 +160,6 @@ public:
   vtkSetMacro(mds_Epsilon, float);
   vtkGetMacro(mds_Epsilon, float);
 
-  vtkSetMacro(mds_Dissimilarity, bool);
-  vtkGetMacro(mds_Dissimilarity, bool);
-
   // TSNE
   vtkSetMacro(tsne_Perplexity, float);
   vtkGetMacro(tsne_Perplexity, float);
@@ -283,7 +280,6 @@ protected:
     mds_MaxIteration = 300;
     mds_Verbose = 0;
     mds_Epsilon = 0;
-    mds_Dissimilarity = false;
 
     tsne_Perplexity = 30;
     tsne_Exaggeration = 12;
@@ -355,7 +351,6 @@ private:
   int mds_MaxIteration;
   int mds_Verbose;
   float mds_Epsilon;
-  bool mds_Dissimilarity;
 
   // tsne
   float tsne_Perplexity;

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -105,6 +105,10 @@ public:
   vtkSetMacro(KeepAllDataArrays, int);
   vtkGetMacro(KeepAllDataArrays, int);
 
+  // SE && MDS
+  vtkSetMacro(InputIsADistanceMatrix, bool);
+  vtkGetMacro(InputIsADistanceMatrix, bool);
+
   // SE
   vtkSetMacro(se_Affinity, std::string);
   vtkGetMacro(se_Affinity, std::string);
@@ -326,6 +330,9 @@ private:
   int Method;
   int IsDeterministic;
   bool KeepAllDataArrays;
+
+  // mds && se
+  bool InputIsADistanceMatrix{false};
 
   // se
   std::string se_Affinity;

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -90,6 +90,12 @@ public:
   }
 
   // default
+  vtkSetMacro(SelectFieldsWithRegexp, bool);
+  vtkGetMacro(SelectFieldsWithRegexp, bool);
+
+  vtkSetMacro(RegexpString, std::string);
+  vtkGetMacro(RegexpString, std::string);
+
   vtkSetMacro(NumberOfComponents, int);
   vtkGetMacro(NumberOfComponents, int);
 
@@ -321,6 +327,8 @@ private:
   int updateProgress(const float &progress) override;
 
   // default
+  bool SelectFieldsWithRegexp{false};
+  std::string RegexpString{".*"};
   int NumberOfComponents;
   int NumberOfNeighbors;
   int Method;

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -156,8 +156,8 @@ public:
   vtkSetMacro(mds_Epsilon, float);
   vtkGetMacro(mds_Epsilon, float);
 
-  vtkSetMacro(mds_Dissimilarity, std::string);
-  vtkGetMacro(mds_Dissimilarity, std::string);
+  vtkSetMacro(mds_Dissimilarity, bool);
+  vtkGetMacro(mds_Dissimilarity, bool);
 
   // TSNE
   vtkSetMacro(tsne_Perplexity, float);
@@ -279,7 +279,7 @@ protected:
     mds_MaxIteration = 300;
     mds_Verbose = 0;
     mds_Epsilon = 0;
-    mds_Dissimilarity = "euclidean";
+    mds_Dissimilarity = false;
 
     tsne_Perplexity = 30;
     tsne_Exaggeration = 12;
@@ -348,7 +348,7 @@ private:
   int mds_MaxIteration;
   int mds_Verbose;
   float mds_Epsilon;
-  std::string mds_Dissimilarity;
+  bool mds_Dissimilarity;
 
   // tsne
   float tsne_Perplexity;

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -145,8 +145,13 @@
         <StringListDomain name="enum">
           <String value="nearest_neighbors"/>
           <String value="rbf"/>
-          <String value="precomputed"/>
         </StringListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="InputDistanceMatrix"
+                                   value="0" />
+        </Hints>
         <Documentation>
         </Documentation>
       </StringVectorProperty>

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -340,17 +340,6 @@
         </Documentation>
       </DoubleVectorProperty>
 
-      <IntVectorProperty name="mds_Dissimilarity"
-        label="Input Is a Distance Matrix"
-        command="Setmds_Dissimilarity"
-        number_of_elements="1"
-        default_values="0"
-        panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-        </Documentation>
-      </IntVectorProperty>
-
       <DoubleVectorProperty name="tsne_Perplexity"
         label="Perplexity"
         command="Settsne_Perplexity"
@@ -738,7 +727,6 @@
         <Property name="mds_MaxIteration" />
         <Property name="mds_Verbose" />
         <Property name="mds_Epsilon" />
-        <Property name="mds_Dissimilarity" />
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
             mode="visibility"

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -32,6 +32,18 @@
         </Documentation>
       </InputProperty>
 
+      <IntVectorProperty
+        name="SelectFieldsWithRegexp"
+        label="Select Fields with a Regexp"
+        command="SetSelectFieldsWithRegexp"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Select input scalar fields matching a regular expression.
+        </Documentation>
+      </IntVectorProperty>
+
       <StringVectorProperty command="SetScalarFields"
         clean_command="ClearScalarFields"
         label="Input Columns"
@@ -49,12 +61,34 @@
         </ArrayListDomain>
         <Hints>
           <NoDefault />
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="0" />
         </Hints>
         <Documentation>
           Select the scalar fields to process.
         </Documentation>
       </StringVectorProperty>
-      
+
+      <StringVectorProperty
+         name="Regexp"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*"
+         panel_visibility="advanced">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="1" />
+        </Hints>
+         <Documentation>
+            This regexp will be used to filter the chosen fields. Only
+            matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
       <IntVectorProperty name="Method"
                          label="Method"
                          command="SetMethod"
@@ -681,7 +715,9 @@
       </IntVectorProperty>
 
       <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="SelectFieldsWithRegexp" />
         <Property name="ScalarFields" />
+        <Property name="Regexp" />
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -310,19 +310,16 @@
         </Documentation>
       </DoubleVectorProperty>
 
-      <StringVectorProperty name="mds_Dissimilarity"
-        label="Dissimilarity"
+      <IntVectorProperty name="mds_Dissimilarity"
+        label="Input Is a Distance Matrix"
         command="Setmds_Dissimilarity"
         number_of_elements="1"
-        default_values="euclidean"
+        default_values="0"
         panel_visibility="advanced">
-        <StringListDomain name="enum">
-          <String value="euclidean"/>
-          <String value="precomputed"/>
-        </StringListDomain>
+        <BooleanDomain name="bool"/>
         <Documentation>
         </Documentation>
-      </StringVectorProperty>
+      </IntVectorProperty>
 
       <DoubleVectorProperty name="tsne_Perplexity"
         label="Perplexity"

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -97,8 +97,6 @@
         </Documentation>
       </IntVectorProperty>
 
-      
-
       <IntVectorProperty
         name="KeepAllDataArrays"
         label="Keep All Data Arrays"
@@ -108,6 +106,33 @@
         <BooleanDomain name="bool"/>
         <Documentation>
           Keep all data arrays.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty name="InputDistanceMatrix"
+        label="Input Is a Distance Matrix"
+        command="SetInputIsADistanceMatrix"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="or">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="2" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          The Spectral Embedding and MDS methods can be fed directly
+          with dissimilarity (distance) matrices instead of raw point
+          clouds.
         </Documentation>
       </IntVectorProperty>
 
@@ -670,6 +695,7 @@
         <Property name="NumberOfComponents" />
         <Property name="NumberOfNeighbors" />
         <Property name="KeepAllDataArrays" />
+        <Property name="InputDistanceMatrix" />
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Spectral Embedding">


### PR DESCRIPTION
The DimensionReduction filter wraps several functions in the Scikit-Learn Python toolkit. Instead of passing raw point clouds as an input, two of the wrapped functions, Multi-Dimensional Scaling (MDS) and Spectral Embedding (SE), can work directly on pre-computed dissimilarity (or distance) matrices.

This PR factor this option for the two filters in a checkbox in the GUI.

Besides, this PR allows to select input Row Data columns with a regexp, as an alternative to the list of input columns with checkboxes. This change allows generated Python scripts/ParaView states to be more independent from the input data structure (especially with relation to the number and the names of the input columns).

