### PR TITLE
TopologicalCompressionReader: Display logs, fix segfault

### DIFF
--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -857,7 +857,7 @@ int ttk::TopologicalCompression::ReadFromFile(FILE *fp) {
     }
   }
 
-  return 0;
+  return status;
 }
 
 template <typename T>

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -95,6 +95,7 @@ vtkStandardNewMacro(ttkCinemaProductReader)
 
       if(ext == "ttk") {
         vtkNew<ttkTopologicalCompressionReader> reader;
+        reader->SetDebugLevel(this->debugLevel_);
         reader->SetFileName(path.data());
         reader->Update();
 

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -117,7 +117,11 @@ int ttkTopologicalCompressionReader::RequestData(
   triangulation.setInputData(mesh);
   topologicalCompression.setupTriangulation(triangulation.getTriangulation());
 
-  topologicalCompression.ReadFromFile<double>(fp);
+  const auto status = topologicalCompression.ReadFromFile<double>(fp);
+  if(status != 0) {
+    vtkWarningMacro("Failure when reading compressed TTK file");
+  }
+
 
   mesh->GetPointData()->RemoveArray(0);
   mesh->GetPointData()->SetNumberOfTuples(vertexNumber);

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -143,7 +143,7 @@ int ttkTopologicalCompressionReader::RequestData(
     vertexOffset->SetName(ttk::OffsetScalarFieldName);
     std::vector<int> voidOffsets
       = topologicalCompression.getDecompressedOffsets();
-    for(int i = 0; i < vertexNumber; ++i)
+    for(size_t i = 0; i < voidOffsets.size(); ++i)
       vertexOffset->SetTuple1(i, voidOffsets[i]);
     //    vertexOffset->SetVoidArray(
     //      topologicalCompression.getDecompressedOffsets(), vertexNumber, 0);

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -60,6 +60,10 @@ public:
   vtkSetMacro(DataScalarType, int);
   vtkGetMacro(DataScalarType, int);
 
+  void SetDebugLevel(const int val) {
+    this->topologicalCompression.setDebugLevel(val);
+  }
+
 protected:
   // Regular ImageData reader management.
   ttkTopologicalCompressionReader();


### PR DESCRIPTION
This PR aims to fix the ZFP dependency handling inside the TopologicalCompressionReader module: when ZFP is not installed, reading compressed files causes a segfault (a read into an empty vector).

This segfault has been fixed, and a vtkWarning is displayed instead.
I also displayed the TopologicalCompression logs when reading compressed files through CinemaProductReader.

For now, no logs are shown when reading directly .ttk files with ParaView. Should I change that too?

Pierre