### PR TITLE
Support multiple inputs in CinemaQuery

### DIFF
--- a/core/base/cinemaQuery/CinemaQuery.cpp
+++ b/core/base/cinemaQuery/CinemaQuery.cpp
@@ -30,10 +30,10 @@ ttk::CinemaQuery::CinemaQuery() {
 ttk::CinemaQuery::~CinemaQuery() {
 }
 
-int ttk::CinemaQuery::execute(const string &sqlTableDefinition,
-                              const string &sqlTableRows,
-                              const string &sqlQuery,
-                              string &resultCSV) const {
+int ttk::CinemaQuery::execute(
+  const std::vector<std::pair<string, string>> &sqlTablesDefinitionAndRows,
+  const string &sqlQuery,
+  string &resultCSV) const {
 
 #if TTK_ENABLE_SQLITE3
   // SQLite Variables
@@ -57,33 +57,35 @@ int ttk::CinemaQuery::execute(const string &sqlTableDefinition,
       return 0;
     }
 
-    // Create table
-    rc = sqlite3_exec(db, sqlTableDefinition.data(), nullptr, 0, &zErrMsg);
-    if(rc != SQLITE_OK) {
-      stringstream msg;
-      msg << "failed\n[ttkCinemaQuery] ERROR: " << zErrMsg << endl;
-      dMsg(cout, msg.str(), fatalMsg);
+    for(const auto &tables : sqlTablesDefinitionAndRows) {
+      // Create table
+      rc = sqlite3_exec(db, tables.first.data(), nullptr, 0, &zErrMsg);
+      if(rc != SQLITE_OK) {
+        stringstream msg;
+        msg << "failed\n[ttkCinemaQuery] ERROR: " << zErrMsg << endl;
+        dMsg(cout, msg.str(), fatalMsg);
 
-      sqlite3_free(zErrMsg);
-      sqlite3_close(db);
+        sqlite3_free(zErrMsg);
+        sqlite3_close(db);
 
-      return 0;
-    }
+        return 0;
+      }
 
-    // Fill table
-    rc = sqlite3_exec(db, sqlTableRows.data(), nullptr, 0, &zErrMsg);
-    if(rc != SQLITE_OK) {
-      stringstream msg;
-      msg << "failed\n[ttkCinemaQuery] ERROR: " << zErrMsg << endl;
-      dMsg(cout, msg.str(), fatalMsg);
+      // Fill table
+      rc = sqlite3_exec(db, tables.second.data(), nullptr, 0, &zErrMsg);
+      if(rc != SQLITE_OK) {
+        stringstream msg;
+        msg << "failed\n[ttkCinemaQuery] ERROR: " << zErrMsg << endl;
+        dMsg(cout, msg.str(), fatalMsg);
 
-      sqlite3_free(zErrMsg);
-      sqlite3_close(db);
-      return 0;
-    } else {
-      stringstream msg;
-      msg << "done (" << t.getElapsedTime() << " s)." << endl;
-      dMsg(cout, msg.str(), timeMsg);
+        sqlite3_free(zErrMsg);
+        sqlite3_close(db);
+        return 0;
+      } else {
+        stringstream msg;
+        msg << "done (" << t.getElapsedTime() << " s)." << endl;
+        dMsg(cout, msg.str(), timeMsg);
+      }
     }
   }
 

--- a/core/base/cinemaQuery/CinemaQuery.h
+++ b/core/base/cinemaQuery/CinemaQuery.h
@@ -21,11 +21,24 @@ namespace ttk {
     CinemaQuery();
     ~CinemaQuery();
 
-    // Creates a temporary database based on a SQL table definition and
-    // and table content to subsequentually return a query result.
-    int execute(const string &sqlTableDefinition,
-                const string &sqlTableRows,
-                const string &sqlQuery,
-                string &resultCSV) const;
+    /** @brief Create a temporary database to execute the SQL query
+     *
+     * Create a in-memory SQLite database, create tables in it and
+     * fill them with input data. Execute the provided SQL query onto
+     * those tables.
+     *
+     * @param[in] sqlTablesDefinitionAndRows Vector of string
+     * pairs. The first string is a CREATE TABLE query, the second is
+     * an INSERT INTO to fill data in the corresponding table.
+     * @param[in] sqlQuery SQL query that will be executed on the
+     * filled tables
+     * @param[out] resultCSV SQL query output in a CSV format
+     *
+     * @return 1 in case of success
+     */
+    int execute(
+      const std::vector<std::pair<string, string>> &sqlTablesDefinitionAndRows,
+      const string &sqlQuery,
+      string &resultCSV) const;
   };
 } // namespace ttk

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -89,23 +89,25 @@ vtkStandardNewMacro(ttkCinemaQuery)
   }
 
   // -------------------------------------------------------------------------
+  // Backward compatibility: replace "InputTable" with "InputTable0"
+  // in query string
+  // -------------------------------------------------------------------------
+  auto index = this->QueryString.find("InputTable");
+  while(index != std::string::npos) {
+    if(this->QueryString.size() == index + 10) {
+      this->QueryString.append("0");
+    } else if(!std::isdigit(this->QueryString[index + 10])) {
+      // replace "e" in "InputTable" with "e0"
+      this->QueryString.replace(index + 9, 1, "e0");
+    }
+    auto nextsearchpos = index + 1;
+    index = this->QueryString.find("InputTable", nextsearchpos);
+  }
+
+  // -------------------------------------------------------------------------
   // Replace Variables in QueryString (e.g. {time[2]})
   // -------------------------------------------------------------------------
   string finalQueryString = this->QueryString;
-
-  // Backward compatibility: replace "InputTable" with "InputTable0"
-  // in query string
-  auto index = finalQueryString.find("InputTable");
-  while(index != std::string::npos) {
-    if(finalQueryString.size() == index + 10) {
-      finalQueryString.append("0");
-    } else if(!std::isdigit(finalQueryString[index + 10])) {
-      // replace "e" in "InputTable" with "e0"
-      finalQueryString.replace(index + 9, 1, "e0");
-    }
-    auto nextsearchpos = index + 1;
-    index = finalQueryString.find("InputTable", nextsearchpos);
-  }
 
   // TODO: test replace variables with several input tables
   for(const auto &inTable : inTables) {

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -93,6 +93,18 @@ vtkStandardNewMacro(ttkCinemaQuery)
   // -------------------------------------------------------------------------
   string finalQueryString = this->QueryString;
 
+  // Backward compatibility: replace "InputTable" with "InputTable0"
+  // in query string
+  const auto index = finalQueryString.find("InputTable");
+  if(index != std::string::npos) {
+    if(finalQueryString.size() == index + 10) {
+      finalQueryString.append("0");
+    } else if(!std::isdigit(finalQueryString[index + 10])) {
+      // replace "e" in "InputTable" with "e0"
+      finalQueryString.replace(index + 9, 1, "e0");
+    }
+  }
+
   // TODO: test replace variables with several input tables
   for(const auto &inTable : inTables) {
     vtkFieldData *fieldData = inTable->GetFieldData();

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -92,16 +92,19 @@ vtkStandardNewMacro(ttkCinemaQuery)
   // Backward compatibility: replace "InputTable" with "InputTable0"
   // in query string
   // -------------------------------------------------------------------------
-  auto index = this->QueryString.find("InputTable");
+  const std::string needle{"InputTable"};
+  auto index = this->QueryString.find(needle);
   while(index != std::string::npos) {
-    if(this->QueryString.size() == index + 10) {
+    // move index to the end of needle
+    index += needle.size();
+    if(this->QueryString.size() == index) {
+      // add "0" to the end of the query
       this->QueryString.append("0");
-    } else if(!std::isdigit(this->QueryString[index + 10])) {
+    } else if(!std::isdigit(this->QueryString[index])) {
       // replace "e" in "InputTable" with "e0"
-      this->QueryString.replace(index + 9, 1, "e0");
+      this->QueryString.replace(index - 1, 1, "e0");
     }
-    auto nextsearchpos = index + 1;
-    index = this->QueryString.find("InputTable", nextsearchpos);
+    index = this->QueryString.find(needle, index);
   }
 
   // -------------------------------------------------------------------------

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -189,8 +189,17 @@ vtkStandardNewMacro(ttkCinemaQuery)
     reader->Update();
 
     outTable->ShallowCopy(reader->GetOutput());
-    // only copy the Field Data of the first input vtkTable
-    outTable->GetFieldData()->ShallowCopy(inTables[0]->GetFieldData());
+
+    // only copy first available Field Data
+    for(const auto &inTable : inTables) {
+      const auto fd = inTable->GetFieldData();
+      // pass database name
+      if(fd != nullptr && fd->HasArray("DatabasePath")) {
+        outTable->GetFieldData()->ShallowCopy(fd);
+        break;
+      }
+    }
+
 #endif
   }
 

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -95,14 +95,16 @@ vtkStandardNewMacro(ttkCinemaQuery)
 
   // Backward compatibility: replace "InputTable" with "InputTable0"
   // in query string
-  const auto index = finalQueryString.find("InputTable");
-  if(index != std::string::npos) {
+  auto index = finalQueryString.find("InputTable");
+  while(index != std::string::npos) {
     if(finalQueryString.size() == index + 10) {
       finalQueryString.append("0");
     } else if(!std::isdigit(finalQueryString[index + 10])) {
       // replace "e" in "InputTable" with "e0"
       finalQueryString.replace(index + 9, 1, "e0");
     }
+    auto nextsearchpos = index + 1;
+    index = finalQueryString.find("InputTable", nextsearchpos);
   }
 
   // TODO: test replace variables with several input tables

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
@@ -61,6 +61,7 @@ public:
   int FillInputPortInformation(int port, vtkInformation *info) override {
     switch(port) {
       case 0:
+        info->Set(vtkTableAlgorithm::INPUT_IS_REPEATABLE(), 1);
         info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
         break;
       default:

--- a/paraview/CinemaQuery/CinemaQuery.xml
+++ b/paraview/CinemaQuery/CinemaQuery.xml
@@ -15,7 +15,11 @@
                 <Documentation>vtkTable to run the query on.</Documentation>
             </InputProperty>
 
-            <StringVectorProperty name="QueryString" label="SQL Statement" command="SetQueryString" number_of_elements="1" default_values="SELECT * FROM InputTable">
+            <StringVectorProperty name="QueryString"
+                                  label="SQL Statement"
+                                  command="SetQueryString"
+                                  number_of_elements="1"
+                                  default_values="SELECT * FROM InputTable0">
                 <Documentation>SQL statement.</Documentation>
                 <Hints>
                     <Widget type="multi_line" />

--- a/paraview/CinemaQuery/CinemaQuery.xml
+++ b/paraview/CinemaQuery/CinemaQuery.xml
@@ -4,7 +4,7 @@
         <SourceProxy name="CinemaQuery" class="ttkCinemaQuery" label="TTK CinemaQuery">
             <Documentation long_help="TTK CinemaQuery" short_help="TTK CinemaQuery">This filter uses a SQL statement to select a subset of a vtkTable.</Documentation>
 
-            <InputProperty name="Table" command="SetInputConnection">
+            <InputProperty name="Table" command="AddInputConnection" multiple_input="1">
                 <ProxyGroupDomain name="groups">
                     <Group name="sources" />
                     <Group name="filters" />


### PR DESCRIPTION
The current PR provides multiple inputs support to the CinemaQuery filter.

As a consequence, one can perform JOIN queries onto several vtkTables.

The input tables are identified from InputTable0 to InputTableN (where N is the total number of input tables minus 1).

The first non-null input FieldData is transferred to the output.

To keep backward compatibility with the current ttk-data states, a step to convert "InputTable" to "InputTable0" has been introduced.

Enjoy,
Pierre