### PR TITLE
BackPort the PointDataSelection fix to stable

### DIFF
--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -1119,7 +1119,7 @@ namespace ttk {
     }
 
   protected:
-    int clear();
+    int clear() override;
 
     bool doublePrecision_;
     SimplexId cellNumber_, vertexNumber_;

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -948,7 +948,7 @@ namespace ttk {
     /// \param edgeId Input global edge identifier.
     /// \return Returns the number of edge triangles.
     /// \sa getEdgeStarNumber
-    inline SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const {
+    inline SimplexId getEdgeTriangleNumber(const SimplexId &edgeId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;

--- a/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
+++ b/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
@@ -95,7 +95,6 @@ public:
     vtkDataArraySelection* arr = vtkDataArraySelection::New();
     arr->SetArraySetting("0", true);
     arr->SetArraySetting(std::to_string(NbScalars).c_str(), true);
-    cout << "nb is " << NbScalars << endl;
     return arr;
   }
 

--- a/paraview/PointDataSelector/PointDataSelector.xml
+++ b/paraview/PointDataSelector/PointDataSelector.xml
@@ -40,6 +40,7 @@
         number_of_elements="0"
         default_values="1"
         number_of_elements_per_command="1"
+        animatable="0"
         repeat_command="1">
         <ArrayListDomain name="array_list"
           default_values="1">
@@ -55,6 +56,29 @@
           Select the scalar fields to process.
         </Documentation>
       </StringVectorProperty>
+
+      <StringVectorProperty name="NbScalarRange"
+        command="GetNbScalars"
+        number_of_elements_per_command="0"
+        information_only="1"
+        si_class="vtkSIDataArraySelectionProperty" />
+
+      <IntVectorProperty
+        name="RangeId"
+        label="Range Id"
+        command="SetRangeId"
+        number_of_elements="2"
+        default_values="0 999"
+        panel_visibility="advanced">
+        <IntRangeDomain name="range" default_mode="min,min,max,max">
+          <RequiredProperties>
+            <Property name="NbScalarRange" function="RangeInfo" />
+          </RequiredProperties>
+        </IntRangeDomain>
+        <Documentation>
+            First and last accepted scalar field id.
+        </Documentation>
+      </IntVectorProperty>
 
       <StringVectorProperty
          name="Filter"
@@ -78,7 +102,7 @@
 animations).
         </Documentation>
       </IntVectorProperty>
-      
+
       <StringVectorProperty
         name="SelectedName"
         label="Name for selected field"
@@ -95,7 +119,7 @@ animations).
           Name to be used for renaming the selected field.
         </Documentation>
       </StringVectorProperty>
-      
+
       <IntVectorProperty
         name="UseAllCores"
         label="Use All Cores"
@@ -141,6 +165,7 @@ animations).
 
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="ScalarFields" />
+        <Property name="RangeId" />
         <Property name="Filter" />
         <Property name="RenameSelected" />
         <Property name="SelectedName" />

--- a/paraview/PointDataSelector/PointDataSelector.xml
+++ b/paraview/PointDataSelector/PointDataSelector.xml
@@ -49,9 +49,6 @@
               function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
-        <Hints>
-          <NoDefault />
-        </Hints>
         <Documentation>
           Select the scalar fields to process.
         </Documentation>


### PR DESCRIPTION
Dear Julien,
This PR add a new filter for the PointDataSelection so that the new timeTracking.pvsm (see [here](https://github.com/topology-tool-kit/ttk-data/pull/20)) continue to work (tested succesfully with PV 6.3)

The same changes are going to be applied on CellDataSelection and FieldDataSelection on the dev branch.

