### PR TITLE
ParaViewFilter.cmake now executes preprocessor on XML files

### DIFF
--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -1,6 +1,34 @@
 # register a new filter to build in the TTK plugin
 # deduce the location of the corresonding vtk.module file
 # also register the xml file if given
+
+set(DEBUG_WIDGETS "\
+<IntVectorProperty name='Debug_UseAllCores' label='Use All Cores' command='SetUseAllCores' number_of_elements='1' default_values='1' panel_visibility='advanced'>\
+    <BooleanDomain name='bool' />\
+    <Documentation>Use all available cores.</Documentation>\
+</IntVectorProperty>\
+<IntVectorProperty name='Debug_ThreadNumber' label='Thread Number' command='SetThreadNumber' number_of_elements='1' default_values='1' panel_visibility='advanced'>\
+    <IntRangeDomain name='range' min='1' max='256' />\
+    <Hints>\
+        <PropertyWidgetDecorator type='GenericDecorator' mode='visibility' property='Debug_UseAllCores' value='0' />\
+    </Hints>\
+    <Documentation>The maximum number of threads.</Documentation>\
+</IntVectorProperty>\
+<IntVectorProperty name='Debug_DebugLevel' label='Debug Level' command='SetDebugLevel' number_of_elements='1' default_values='3' panel_visibility='advanced'>\
+    <IntRangeDomain name='range' min='0' max='5' />\
+    <Documentation>Debug level.</Documentation>\
+</IntVectorProperty>\
+<Property name='Debug_Execute' label='Execute' command='Modified' panel_widget='command_button'>\
+    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>\
+</Property>\
+<PropertyGroup panel_widget='Line' label='Testing'>\
+    <Property name='Debug_UseAllCores' />\
+    <Property name='Debug_ThreadNumber' />\
+    <Property name='Debug_DebugLevel' />\
+    <Property name='Debug_Execute' />\
+</PropertyGroup>\
+")
+
 macro(ttk_register_pv_filter vtkModuleDir xmlFile)
   if(NOT EXISTS "${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module")
     message(FATAL_ERROR
@@ -16,7 +44,12 @@ macro(ttk_register_pv_filter vtkModuleDir xmlFile)
   if(NOT "${TTK_TARGET}" STREQUAL "")
     list(APPEND TTK_MODULES ${TTK_TARGET})
     if(NOT "${xmlFile}" STREQUAL "")
-      list(APPEND TTK_XMLS ${CMAKE_CURRENT_LIST_DIR}/${xmlFile})
+
+      # replace variables of original XML file and store generated file in build dir
+      configure_file(${CMAKE_CURRENT_LIST_DIR}/${xmlFile} ${CMAKE_BINARY_DIR}/paraview/xmls/${xmlFile})
+
+      # use generated xml file for pv plugin
+      list(APPEND TTK_XMLS ${CMAKE_BINARY_DIR}/paraview/xmls/${xmlFile})
     endif()
   endif()
 endmacro()

--- a/paraview/HelloWorld/HelloWorld.xml
+++ b/paraview/HelloWorld/HelloWorld.xml
@@ -57,36 +57,7 @@
                 </PropertyGroup>
 
             <!-- DEBUG -->
-
-                <IntVectorProperty name="Debug_UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <BooleanDomain name="bool" />
-                    <Documentation>Use all available cores.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="1" max="256" />
-                    <Hints>
-                        <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="Debug_UseAllCores" value="0" />
-                    </Hints>
-                    <Documentation>The maximum number of threads.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_DebugLevel" label="Debug Level" command="SetDebugLevel" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="0" max="5" />
-                    <Documentation>Debug level.</Documentation>
-                </IntVectorProperty>
-
-                <Property name="Debug_Execute" label="Execute" command="Modified" panel_widget="command_button">
-                    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>
-                </Property>
-
-                <!-- Create a UI group that contains all debug parameter widgets -->
-                <PropertyGroup panel_widget="Line" label="Testing">
-                    <Property name="Debug_UseAllCores" />
-                    <Property name="Debug_ThreadNumber" />
-                    <Property name="Debug_DebugLevel" />
-                    <Property name="Debug_Execute" />
-                </PropertyGroup>
+            ${DEBUG_WIDGETS}
 
             <!-- MENU CATEGORY -->
                 <Hints>

--- a/paraview/IcoSphere/IcoSphere.xml
+++ b/paraview/IcoSphere/IcoSphere.xml
@@ -33,37 +33,7 @@
                 <Property name="Center" />
             </PropertyGroup>
 
-            <!-- DEBUG -->
-
-                <IntVectorProperty name="Debug_UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <BooleanDomain name="bool" />
-                    <Documentation>Use all available cores.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="1" max="256" />
-                    <Hints>
-                        <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="Debug_UseAllCores" value="0" />
-                    </Hints>
-                    <Documentation>The maximum number of threads.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_DebugLevel" label="Debug Level" command="SetDebugLevel" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="0" max="5" />
-                    <Documentation>Debug level.</Documentation>
-                </IntVectorProperty>
-
-                <Property name="Debug_Execute" label="Execute" command="Modified" panel_widget="command_button">
-                    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>
-                </Property>
-
-                <!-- Create a UI group that contains all debug parameter widgets -->
-                <PropertyGroup panel_widget="Line" label="Testing">
-                    <Property name="Debug_UseAllCores" />
-                    <Property name="Debug_ThreadNumber" />
-                    <Property name="Debug_DebugLevel" />
-                    <Property name="Debug_Execute" />
-                </PropertyGroup>
+            ${DEBUG_WIDGETS}
 
             <Hints>
                 <ShowInMenu category="TTK - Misc" />

--- a/paraview/IcoSphereFromObject/IcoSphereFromObject.xml
+++ b/paraview/IcoSphereFromObject/IcoSphereFromObject.xml
@@ -26,37 +26,7 @@
                 <Property name="Scale" />
             </PropertyGroup>
 
-            <!-- DEBUG -->
-
-                <IntVectorProperty name="Debug_UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <BooleanDomain name="bool" />
-                    <Documentation>Use all available cores.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="1" max="256" />
-                    <Hints>
-                        <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="Debug_UseAllCores" value="0" />
-                    </Hints>
-                    <Documentation>The maximum number of threads.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_DebugLevel" label="Debug Level" command="SetDebugLevel" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="0" max="5" />
-                    <Documentation>Debug level.</Documentation>
-                </IntVectorProperty>
-
-                <Property name="Debug_Execute" label="Execute" command="Modified" panel_widget="command_button">
-                    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>
-                </Property>
-
-                <!-- Create a UI group that contains all debug parameter widgets -->
-                <PropertyGroup panel_widget="Line" label="Testing">
-                    <Property name="Debug_UseAllCores" />
-                    <Property name="Debug_ThreadNumber" />
-                    <Property name="Debug_DebugLevel" />
-                    <Property name="Debug_Execute" />
-                </PropertyGroup>
+            ${DEBUG_WIDGETS}
 
             <Hints>
                 <RepresentationType view="RenderView" type="Wireframe" />

--- a/paraview/IcoSphereFromPoint/IcoSphereFromPoint.xml
+++ b/paraview/IcoSphereFromPoint/IcoSphereFromPoint.xml
@@ -34,37 +34,7 @@
                 <Property name="CopyPointData" />
             </PropertyGroup>
 
-            <!-- DEBUG -->
-
-                <IntVectorProperty name="Debug_UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <BooleanDomain name="bool" />
-                    <Documentation>Use all available cores.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="1" max="256" />
-                    <Hints>
-                        <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="Debug_UseAllCores" value="0" />
-                    </Hints>
-                    <Documentation>The maximum number of threads.</Documentation>
-                </IntVectorProperty>
-
-                <IntVectorProperty name="Debug_DebugLevel" label="Debug Level" command="SetDebugLevel" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                    <IntRangeDomain name="range" min="0" max="5" />
-                    <Documentation>Debug level.</Documentation>
-                </IntVectorProperty>
-
-                <Property name="Debug_Execute" label="Execute" command="Modified" panel_widget="command_button">
-                    <Documentation>Executes the filter with the last applied parameters, which is handy to re-start pipeline execution from a specific element without changing parameters.</Documentation>
-                </Property>
-
-                <!-- Create a UI group that contains all debug parameter widgets -->
-                <PropertyGroup panel_widget="Line" label="Testing">
-                    <Property name="Debug_UseAllCores" />
-                    <Property name="Debug_ThreadNumber" />
-                    <Property name="Debug_DebugLevel" />
-                    <Property name="Debug_Execute" />
-                </PropertyGroup>
+            ${DEBUG_WIDGETS}
 
             <Hints>
                 <Visibility replace_input="0" />


### PR DESCRIPTION
This commit enables developers to use preprocessor directives in the ParaView plugin XMLs.

In particular, there exists now a cmake variable called DEBUG_WIDGETS that can be included at the right location inside the XML file with the common syntax ${DEBUG_WIDGETS} (see HelloWorld.xml). This variable will provide the widgets for setting the UseAllCores flag, the ThreadNumber, the DebugLevel, and a button that (re)executes a filter even if parameters didn't change (handy for performance measurements and debugging).