### PR TITLE
Debug Updates

### DIFF
--- a/core/base/common/Debug.cpp
+++ b/core/base/common/Debug.cpp
@@ -1,5 +1,7 @@
 #include <Debug.h>
 
+ttk::debug::LineMode ttk::Debug::lastLineMode = ttk::debug::LineMode::NEW;
+
 bool ttk::welcomeMsg_ = true;
 bool ttk::goodbyeMsg_ = true;
 int ttk::globalDebugLevel_ = 0;
@@ -31,347 +33,504 @@ int Debug::dMsg(ostream &stream, string msg, const int &debugLevel) const {
     ttk::welcomeMsg_ = false;
     stringstream s;
 
-    s << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "                       " << debug::ENDCOLOR << debug::GREEN << ","
-      << debug::ENDCOLOR << debug::GREEN << ",⌂µµ▒▒▒▒▒▒▒▒▒▒▒▒µµµ,"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "                  ,µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒µµ," << debug::ENDCOLOR
-      << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "              " << debug::ENDCOLOR << debug::GREEN << ","
-      << debug::ENDCOLOR << debug::GREEN
-      << "µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒µ," << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "           ,µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::GREY << "░░░░▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒▒▒▒▒µ" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "         ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░░░"
-      << debug::ENDCOLOR << debug::BLUE << "░  " << debug::ENDCOLOR
-      << debug::BLUE << "░░░░░░░░░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░░░" << debug::ENDCOLOR
-      << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒µ" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "       ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░                    " << debug::ENDCOLOR
-      << debug::BLUE << "░" << debug::ENDCOLOR << debug::BLUE << "░░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒µ" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "      ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY
-      << "░" << debug::ENDCOLOR << debug::DARKGREY
-      << "░  ⌂µ▒▒▒▒▒▒▒▒▒▒▒▒∩         " << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "░" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒µ" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "    ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░ ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░▒       "
-      << debug::ENDCOLOR << debug::BLUE << "░" << debug::ENDCOLOR << debug::BLUE
-      << "░▒░" << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒µ" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "   ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░ "
-      << debug::ENDCOLOR << debug::DARKGREY << ",▒" << debug::ENDCOLOR
-      << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY << "▒▒▒▒▒▒▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY
-      << "░░▒░" << debug::ENDCOLOR << debug::DARKGREY << "▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "▒▒░░▒     " << debug::ENDCOLOR << debug::BLUE
-      << "░" << debug::ENDCOLOR << debug::BLUE << "░░▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░  "
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY
-      << "▒▒▒▒▒" << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::GREY << "▒▒▒" << debug::ENDCOLOR << debug::BRIGHTWHITE << "▒"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "▓▓▓█████" << debug::ENDCOLOR << debug::BRIGHTWHITE << "█▓▄"
-      << debug::ENDCOLOR << debug::GREY << "▄" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░▒   "
-      << debug::ENDCOLOR << debug::BLUE << "░" << debug::ENDCOLOR << debug::BLUE
-      << "░░░░▒ " << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "░" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░ " << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::GREY << "▒▒▒" << debug::ENDCOLOR
-      << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY << "▒▒▒▒"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "╣" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "▓╜^" << debug::ENDCOLOR << debug::GREY << "^"
-      << debug::ENDCOLOR << debug::GREY
-      << ""
-         "^"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "^" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "▀" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "▀█" << debug::ENDCOLOR << debug::BRIGHTWHITE << "███▓▓▓"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR
-      << debug::GREY << "µ" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░    " << debug::ENDCOLOR
-      << debug::BLUE << "░" << debug::ENDCOLOR << debug::BLUE << "░░░ "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░ "
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY
-      << "▒▒" << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::GREY << "▒▒▒" << debug::ENDCOLOR << debug::GREY << "╙"
-      << debug::ENDCOLOR << debug::DARKGREY << "░           " << debug::ENDCOLOR
-      << debug::DARKGREY << "░░" << debug::ENDCOLOR << debug::GREY << "T"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▀" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "██▓▓▓" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "▓" << debug::ENDCOLOR << debug::GREY << "µ" << debug::ENDCOLOR
-      << debug::DARKGREY << "▒   " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░░░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "░" << debug::ENDCOLOR
-      << debug::GREEN << "░" << debug::ENDCOLOR << debug::DARKGREY << "░ "
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY
-      << "▒▒▒▒" << debug::ENDCOLOR << debug::DARKGREY << "'                 "
-      << debug::ENDCOLOR << debug::DARKGREY << "░░" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "▀" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "█▓▓▓╪" << debug::ENDCOLOR << debug::GREY << "▓" << debug::ENDCOLOR
-      << debug::DARKGREY << "░   " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░░▒ " << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "░░" << debug::ENDCOLOR << debug::DARKGREY << "░ "
-      << debug::ENDCOLOR << debug::DARKGREY << "1" << debug::ENDCOLOR
-      << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "∩                     "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::BRIGHTWHITE << "█"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓▓╪@" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@    " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░▒▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░" << debug::ENDCOLOR << debug::DARKGREY << "░ "
-      << debug::ENDCOLOR << debug::DARKGREY << "▒∩                       ░"
-      << debug::ENDCOLOR << debug::DARKGREY << "µ" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "█" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "▓" << debug::ENDCOLOR << debug::BRIGHTWHITE << "@@" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::GREY << "h"
-      << debug::ENDCOLOR << debug::BLUE << "░  " << debug::ENDCOLOR
-      << debug::BLUE << "░░░░▒ " << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << " ░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░                       "
-      << debug::ENDCOLOR << debug::GREEN << "░ " << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREY << "▐"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "@" << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::GREY << "▒ " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░░░▒▒µ" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN << " "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << debug::GREEN
-      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY
-      << "░                      ░░" << debug::ENDCOLOR << debug::DARKGREY
-      << "░░" << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::BRIGHTWHITE
-      << "▒" << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "▒" << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░░░░▒▒µ" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "  ░░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY
-      << "░░               " << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << debug::GREEN << "░░░░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "j"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR << debug::BLUE
-      << "░" << debug::ENDCOLOR << debug::BLUE << "░░░░░░▒▒∩" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN << "  "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::GREEN << "░" << debug::ENDCOLOR << debug::GREEN
-      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░         ▒░░░░░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "{" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░░░▒▒▒▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN << "   "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::GREEN << "░" << debug::ENDCOLOR << debug::GREEN
-      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░░░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR
-      << debug::GREY << "▒" << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::BLUE << "▒" << debug::ENDCOLOR << debug::BLUE << "░░░▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN << "    "
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "▒" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "▓" << debug::ENDCOLOR << debug::GREY
-      << "▒" << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "░▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "     " << debug::ENDCOLOR << debug::BLUE << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << debug::GREEN << "║▓"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓▓@▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << debug::GREEN
-      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::BRIGHTWHITE << "@" << debug::ENDCOLOR << debug::GREY << "▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░ " << debug::ENDCOLOR
-      << debug::BLUE << "▒" << debug::ENDCOLOR << debug::BLUE << "▒▒▒▒▒▒▒▒▒░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "      " << debug::ENDCOLOR << debug::BLUE << "▒" << debug::ENDCOLOR
-      << debug::BLUE << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "░" << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "ß" << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓"
-      << debug::ENDCOLOR << debug::BRIGHTWHITE << "▓▓" << debug::ENDCOLOR
-      << debug::GREEN << "@" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "a" << debug::ENDCOLOR << debug::GREY
-      << "▒" << debug::ENDCOLOR << debug::DARKGREY << "M  " << debug::ENDCOLOR
-      << debug::BLUE << "▒" << debug::ENDCOLOR << debug::BLUE << "▒▒▒▒▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "      " << debug::ENDCOLOR << debug::BLUE << "░" << debug::ENDCOLOR
-      << debug::BLUE << "░▒░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "░" << debug::ENDCOLOR
-      << debug::GREEN << "░" << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒" << debug::ENDCOLOR
-      << debug::GREEN << "▒▒▒▒" << debug::ENDCOLOR << debug::GREEN << "▒"
-      << debug::ENDCOLOR << debug::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
-      << debug::ENDCOLOR << debug::GREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "e" << debug::ENDCOLOR << debug::GREY
-      << "M" << debug::ENDCOLOR << debug::DARKGREY << "░  " << debug::ENDCOLOR
-      << debug::BLUE << "," << debug::ENDCOLOR << debug::BLUE << "▒▒▒▒▒▒▒▒▒▒▒"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "        " << debug::ENDCOLOR << debug::BLUE << "▒" << debug::ENDCOLOR
-      << debug::BLUE << "░░░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░░" << debug::ENDCOLOR
-      << debug::GREEN << "▒" << debug::ENDCOLOR << debug::GREEN
-      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREY << "╓╜"
-      << debug::ENDCOLOR << debug::LIGHTBLUE << "º" << debug::ENDCOLOR
-      << debug::BLUE << ".   " << debug::ENDCOLOR << debug::BLUE
-      << "¿▒▒▒▒▒▒▒▒▒▒░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "         " << debug::ENDCOLOR << debug::BLUE << "░" << debug::ENDCOLOR
-      << debug::BLUE << "░░░░░░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░░" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "░" << debug::ENDCOLOR
-      << debug::GREEN << "░░▒▒▒▒▒▒▒▒░░" << debug::ENDCOLOR << debug::GREY << "░"
-      << debug::ENDCOLOR << debug::GREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░░"
-      << debug::ENDCOLOR << debug::GREY << "╓" << debug::ENDCOLOR << debug::GREY
-      << "m" << debug::ENDCOLOR << debug::LIGHTBLUE << "\"" << debug::ENDCOLOR
-      << debug::DARKGREY << "░      " << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "▒▒▒▒▒▒▒▒▒▒" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::GREEN << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "           " << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "░░░░░░░░░░░" << debug::ENDCOLOR
-      << debug::GREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░░░░░░░░∞⌐*\"░"
-      << debug::ENDCOLOR << debug::BLUE << ".        " << debug::ENDCOLOR
-      << debug::BLUE << "╓▒▒▒▒▒▒▒▒" << debug::ENDCOLOR << debug::LIGHTBLUE
-      << "▒▒" << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::GREEN << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "             " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE
-      << "░░░░░░░░░░░░░░░              ░░,▒▒▒▒▒" << debug::ENDCOLOR
-      << debug::LIGHTBLUE << "▒" << debug::ENDCOLOR << debug::LIGHTBLUE << "▒▒"
-      << debug::ENDCOLOR << debug::BLUE << "▒" << debug::ENDCOLOR << debug::BLUE
-      << "░" << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "               " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "▒░░░░░░░░░░░░░░░░░░░░░░░░░░╓▒"
-      << debug::ENDCOLOR << debug::LIGHTBLUE << "▒" << debug::ENDCOLOR
-      << debug::LIGHTBLUE << "▒▒▒▒▒" << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "░░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "                  " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░▒░░░░░░░░░░░░░░░░░░░░α"
-      << debug::ENDCOLOR << debug::LIGHTBLUE << "▒" << debug::ENDCOLOR
-      << debug::LIGHTBLUE << "▒▒▒▒" << debug::ENDCOLOR << debug::BLUE << "▒"
-      << debug::ENDCOLOR << debug::BLUE << "▒░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░"
-      << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "                        " << debug::ENDCOLOR << debug::BLUE << "░"
-      << debug::ENDCOLOR << debug::BLUE << "░░▒░░░░░░░░░░▒▒▒▒▒░░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << debug::GREEN
-      << "                                 " << debug::ENDCOLOR << debug::BLUE
-      << "░" << debug::ENDCOLOR << debug::GREY << "░" << debug::ENDCOLOR
-      << debug::DARKGREY << "░" << debug::ENDCOLOR << debug::DARKGREY << "░░░░"
-      << debug::ENDCOLOR << debug::DARKGREY << "░" << debug::ENDCOLOR << endl
-      << debug::BOLD << "[Common] " << debug::ENDCOLOR << endl;
+    s << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "                       "
+      << debug::output::ENDCOLOR << debug::output::GREEN << ","
+      << debug::output::ENDCOLOR << debug::output::GREEN
+      << ",⌂µµ▒▒▒▒▒▒▒▒▒▒▒▒µµµ," << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN
+      << "                  ,µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒µµ,"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "              " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "," << debug::output::ENDCOLOR
+      << debug::output::GREEN << "µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒µ,"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "           ,µ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░░░░▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒▒▒▒▒▒µ"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "         ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░░░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░  "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░░░░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░░░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒▒▒▒µ"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "       ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░                    " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒µ" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "      ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░  ⌂µ▒▒▒▒▒▒▒▒▒▒▒▒∩         " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒µ" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "    ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░ ,▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░▒       " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░▒░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒µ" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "   ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << ",▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒▒▒▒▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░░▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "▒▒░░▒     "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░  "
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓▓▓█████"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "█▓▄"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▄"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░▒   "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░░▒ "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "╣"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓╜^"
+      << debug::output::ENDCOLOR << debug::output::GREY << "^"
+      << debug::output::ENDCOLOR << debug::output::GREY << ""
+                                                           "^"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "^"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▀"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▀█"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "███▓▓▓"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓"
+      << debug::output::ENDCOLOR << debug::output::GREY << "µ"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░    "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░ "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "╙"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░           "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "T"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▀"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "██▓▓▓"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓"
+      << debug::output::ENDCOLOR << debug::output::GREY << "µ"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "▒   "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "'                 " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▀" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "█▓▓▓╪" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▓" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░   " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░▒ " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░ " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "1" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "∩                     "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "█"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓▓╪@"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "@    "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░▒▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "▒∩                       ░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "µ" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "█" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "@@" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "@" << debug::output::ENDCOLOR
+      << debug::output::GREY << "h" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░  " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░▒ " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " ░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░                       " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░ " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▐" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "@" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "@" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒ " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░▒▒µ" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << " " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░                      ░░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "@" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░░▒▒µ" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "  ░░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY
+      << "░░               " << debug::output::ENDCOLOR << debug::output::GREEN
+      << "░" << debug::output::ENDCOLOR << debug::output::GREEN << "░░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "j"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "▓"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "@"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░░░░▒▒∩"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "  " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN
+      << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░         ▒░░░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "{"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "@"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░░▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "   " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "@"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░░▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "▒"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "    " << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░░░░░▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▓"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "     " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "║▓" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓▓@▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::BRIGHTWHITE << "@"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░ "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "      " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "ß" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓" << debug::output::ENDCOLOR
+      << debug::output::BRIGHTWHITE << "▓▓" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "@" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "a"
+      << debug::output::ENDCOLOR << debug::output::GREY << "▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "M  "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒▒▒▒▒▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREEN << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "      " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░▒░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "e" << debug::output::ENDCOLOR
+      << debug::output::GREY << "M" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░  " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "," << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒▒▒▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "        " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "╓╜"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "º"
+      << debug::output::ENDCOLOR << debug::output::BLUE << ".   "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "¿▒▒▒▒▒▒▒▒▒▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "         " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░░░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░░▒▒▒▒▒▒▒▒░░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "╓" << debug::output::ENDCOLOR
+      << debug::output::GREY << "m" << debug::output::ENDCOLOR
+      << debug::output::LIGHTBLUE << "\"" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░      " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒▒▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "           " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░░░░░░░░" << debug::output::ENDCOLOR
+      << debug::output::GREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░░░░░░░∞⌐*\"░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << ".        " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "╓▒▒▒▒▒▒▒▒" << debug::output::ENDCOLOR
+      << debug::output::LIGHTBLUE << "▒▒" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::GREEN << "░" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "             " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░░░░░░░░░░░░░░░              ░░,▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "               " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "▒░░░░░░░░░░░░░░░░░░░░░░░░░░╓▒"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "                  " << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░" << debug::output::ENDCOLOR
+      << debug::output::BLUE << "░▒░░░░░░░░░░░░░░░░░░░░α"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::LIGHTBLUE << "▒▒▒▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒"
+      << debug::output::ENDCOLOR << debug::output::BLUE << "▒░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "                        "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::BLUE
+      << "░░▒░░░░░░░░░░▒▒▒▒▒░░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░" << debug::output::ENDCOLOR
+      << debug::output::DARKGREY << "░░" << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR
+      << debug::output::GREEN << "                                 "
+      << debug::output::ENDCOLOR << debug::output::BLUE << "░"
+      << debug::output::ENDCOLOR << debug::output::GREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░░░░"
+      << debug::output::ENDCOLOR << debug::output::DARKGREY << "░"
+      << debug::output::ENDCOLOR << endl
+      << debug::output::BOLD << "[Common] " << debug::output::ENDCOLOR << endl;
 
-    s << debug::BOLD << "[Common] ";
+    s << debug::output::BOLD << "[Common] ";
     s << " _____ _____ _  __                    __  __    ____   ___ ____   ___"
       << endl
       << "[Common] "
@@ -393,17 +552,18 @@ int Debug::dMsg(ostream &stream, string msg, const int &debugLevel) const {
       << endl
       << "[Common] "
          "                                     \\_\\  /_/"
-      << debug::ENDCOLOR << endl;
-    s << debug::BOLD << "[Common] Welcome!" << debug::ENDCOLOR << endl;
+      << debug::output::ENDCOLOR << endl;
+    s << debug::output::BOLD << "[Common] Welcome!" << debug::output::ENDCOLOR
+      << endl;
 #ifndef NDEBUG
-    s << debug::YELLOW << "[Common]" << endl;
+    s << debug::output::YELLOW << "[Common]" << endl;
     s << "[Common] WARNING:" << endl;
     s << "[Common] TTK has been built in debug mode! (developers only)" << endl;
     s << "[Common] Expect important performance degradation." << endl;
-    s << "[Common]" << debug::ENDCOLOR << endl;
+    s << "[Common]" << debug::output::ENDCOLOR << endl;
 #endif
 #ifndef TTK_ENABLE_KAMIKAZE
-    s << debug::YELLOW << "[Common]" << endl;
+    s << debug::output::YELLOW << "[Common]" << endl;
     s << "[Common] WARNING:" << endl;
     s << "[Common] TTK has *NOT* been built in performance mode!"
       << " (developers only)" << endl;
@@ -411,7 +571,7 @@ int Debug::dMsg(ostream &stream, string msg, const int &debugLevel) const {
     s << "[Common] " << endl;
     s << "[Common] To enable the performance mode, rebuild TTK with:" << endl;
     s << "[Common]   -DTTK_ENABLE_KAMIKAZE=ON" << endl;
-    s << "[Common]" << debug::ENDCOLOR << endl;
+    s << "[Common]" << debug::output::ENDCOLOR << endl;
 #endif
     dMsg(cout, s.str(), 1);
   }

--- a/core/base/helloWorld/HelloWorld.h
+++ b/core/base/helloWorld/HelloWorld.h
@@ -71,6 +71,7 @@ namespace ttk {
         {"#Threads", std::to_string(this->threadNumber_)},
         {"#Vertices", std::to_string(triangulation->getNumberOfVertices())},
       });
+      this->printMsg(ttk::debug::Separator::L1);
 
       // ---------------------------------------------------------------------
       // Compute Vertex Averages
@@ -80,8 +81,11 @@ namespace ttk {
         ttk::Timer localTimer;
 
         // print the progress of the current subprocedure (currently 0%)
-        this->printMsg("Computing Averages",
-                       0 // progress form 0-1
+        this->printMsg(
+          "Computing Averages",
+          0, // progress form 0-1
+          this->threadNumber_,
+          ttk::debug::LineMode::REPLACE
         );
 
         // compute the average of each vertex in parallel
@@ -109,8 +113,8 @@ namespace ttk {
         this->printMsg(
           "Computing Averages",
           1, // progress
-          localTimer.getElapsedTime(), // time
-          ttk::debug::LineMode::REPLACE // replace last line of output stream
+          localTimer.getElapsedTime(),
+          this->threadNumber_
         );
       }
 

--- a/core/base/icoSphere/IcoSphere.h
+++ b/core/base/icoSphere/IcoSphere.h
@@ -186,6 +186,7 @@ int ttk::IcoSphere::computeIcoSphere(
 
   // print input
   {
+    this->printMsg(ttk::debug::Separator::L1);
     this->printMsg({{"#Threads", std::to_string(this->threadNumber_)},
                     {"#Subdivisions", std::to_string(nSubdivisions)},
                     {"Radius", std::to_string(radius)}});
@@ -196,7 +197,7 @@ int ttk::IcoSphere::computeIcoSphere(
   Timer timer;
 
   // print status
-  this->printMsg("Computing icosphere", 0);
+  this->printMsg("Computing Icosphere", 0, ttk::debug::LineMode::REPLACE);
 
   idType vertexIndex = 0;
   idType triangleIndex = 0;
@@ -304,8 +305,7 @@ int ttk::IcoSphere::computeIcoSphere(
   }
 
   // print progress
-  this->printMsg("Computing icosphere", 1, timer.getElapsedTime(),
-                 ttk::debug::LineMode::REPLACE);
+  this->printMsg("Computing icosphere", 1, timer.getElapsedTime());
 
   // print stats
   {


### PR DESCRIPTION
+ Puts all special output characters (colors, font modes, etc) into a separate namespace (debug::output); In the future this namespace could be renamed to debug::style or something similar.  
+ Adds the option to print the used number of threads in performance msgs:
    [ttkFilter] Computing ................... [0.2s|8T|100%]
+ reorganizes how debug msgs are actually inserted into an output stream.
   Originally, the debug::LineMode was always applied at the beginning of a debug msg, which made it possible to override error and warning msgs. Now, the debug::LineMode is applied at the beginning of a msg and the last used debug::LineMode is tracked internally to make sure that error and warning msgs are always shown correctly. So, in the new version the correct way to use replaceable debug msgs is as follows:

this->printMsg(
  "Computing Something", progress, threadNumber,
  debug::LineMode::REPLACE
);

for(...)
  this->printMsg(
    "Computing Something", progress, threadNumber,
    debug::LineMode::REPLACE
  );
  
this->printMsg(
  "Computing Something", progress, threadNumber,
);

So every time a debug msg is printed with debug::LineMode::REPLACE, one should be aware that this debug msg will be replaced with the next msg (except errors and warnings which will automatically be put in the next line).

Best
Jonas