### PR TITLE
Various small improvement to the cmake

### DIFF
--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -18,7 +18,8 @@ macro(ttk_register_pv_filter vtkModuleDir xmlFile)
 
   ttk_get_target(${TTK_NAME} TTK_TARGET)
   if(NOT "${TTK_TARGET}" STREQUAL "")
-    list(APPEND TTK_MODULES ${TTK_TARGET})
+    list(APPEND TTK_MODULES ${vtkModuleDir})
+    list(APPEND TTK_VTK_MODULE_FILES ${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module)
     if(NOT "${xmlFile}" STREQUAL "")
 
       # replace variables of original XML file and store generated file in build dir

--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -18,7 +18,7 @@ macro(ttk_register_pv_filter vtkModuleDir xmlFile)
 
   ttk_get_target(${TTK_NAME} TTK_TARGET)
   if(NOT "${TTK_TARGET}" STREQUAL "")
-    list(APPEND TTK_MODULES ${vtkModuleDir})
+    list(APPEND TTK_MODULES ${TTK_TARGET})
     list(APPEND TTK_VTK_MODULE_FILES ${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module)
     if(NOT "${xmlFile}" STREQUAL "")
 

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -2,15 +2,15 @@
 # this list can then be parsed using the cmake_parse_arguments method
 macro(ttk_parse_module_file moduleFile)
   # reconfigure when the module file is changed
+  get_filename_component(moduleRealFile ${moduleFile} REALPATH)
   set_property(
     DIRECTORY
       "${CMAKE_CURRENT_SOURCE_DIR}"
     APPEND PROPERTY
     CMAKE_CONFIGURE_DEPENDS
-      ${moduleFile}
+      ${moduleRealFile}
   )
-  # add_custom_target(CHECK_FILE_LISTS ALL ${CMAKE_CURRENT_LIST_DIR}/ttk.module)
-  file(READ ${moduleFile} moduleFileContent)
+  file(READ ${moduleRealFile} moduleFileContent)
   # Replace comments.
   string(REGEX REPLACE "#[^\n]*\n" "\n" moduleFileContent "${moduleFileContent}")
   # Use argument splitting.
@@ -36,26 +36,26 @@ macro(ttk_add_vtk_module)
       HEADERS
         ${TTK_HEADERS}
       )
+
+    vtk_module_link(${TTK_NAME}
+      PUBLIC
+        ${VTK_LIBRARIES}
+        ${TTK_DEPENDS}
+      )
+
+    install(
+      TARGETS
+        ${TTK_NAME}
+      EXPORT
+        TTKVTKTargets
+      RUNTIME DESTINATION
+        bin/ttk
+      ARCHIVE DESTINATION
+        lib/ttk
+      LIBRARY DESTINATION
+        lib/ttk
+      )
   endif()
-
-  vtk_module_link(${TTK_NAME}
-    PUBLIC
-      ${VTK_LIBRARIES}
-      ${TTK_DEPENDS}
-    )
-
-  install(
-    TARGETS
-      ${TTK_NAME}
-    EXPORT
-      TTKVTKTargets
-    RUNTIME DESTINATION
-      bin/ttk
-    ARCHIVE DESTINATION
-      lib/ttk
-    LIBRARY DESTINATION
-      lib/ttk
-    )
 
   if(NOT "${TTK_INSTALL_PLUGIN_DIR}" STREQUAL "")
     install(
@@ -74,6 +74,11 @@ macro(ttk_add_vtk_module)
   # https://discourse.vtk.org/t/building-vtk-modules-with-dependencies-results-in-race-condition-in-make/1711
   if(TARGET ${TTK_NAME}-hierarchy)
     add_dependencies(${TTK_NAME} ${TTK_NAME}-hierarchy)
+    foreach(TTK_DEP_TARGET ${TTK_DEPENDS})
+      if(TARGET ${TTK_DEP_TARGET}-hierarchy)
+        add_dependencies(${TTK_NAME}-hierarchy ${TTK_DEP_TARGET}-hierarchy)
+      endif()
+    endforeach()
   endif()
 endmacro()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,33 @@ install(
     lib/cmake/ttk
   )
 
+# Paraview plugin
+# ---------------
+
+if(TTK_BUILD_PARAVIEW_PLUGINS)
+  include(CMake/ParaViewFilter.cmake)
+
+  # Install location
+  if(NOT "$ENV{PV_PLUGIN_PATH}" STREQUAL "")
+    set(TTK_INSTALL_PLUGIN_DIR
+      $ENV{PV_PLUGIN_PATH}
+      CACHE
+      PATH
+        "Directory where the ParaView plugin will be installed"
+      )
+  else()
+    message(WARNING "Please, set the PV_PLUGIN_PATH environement variable, the TTK ParaView plugin will be built but not installed.")
+    set(TTK_INSTALL_PLUGIN_DIR
+      ""
+      CACHE
+      PATH
+      "Directory where the ParaView plugin will be installed"
+      )
+  endif()
+
+  add_subdirectory(paraview)
+endif()
+
 # VTK Wrappers
 # ------------
 
@@ -118,34 +145,6 @@ if(TTK_BUILD_VTK_WRAPPERS)
     DESTINATION
       lib/cmake/ttk
     )
-endif()
-
-# Paraview plugin
-# ---------------
-
-if(TTK_BUILD_PARAVIEW_PLUGINS)
-  include(CMake/ParaViewFilter.cmake)
-
-  # Install location
-  if(NOT "$ENV{PV_PLUGIN_PATH}" STREQUAL "")
-    set(TTK_INSTALL_PLUGIN_DIR
-      $ENV{PV_PLUGIN_PATH}
-      CACHE
-      PATH
-        "Directory where the ParaView plugin will be installed"
-      )
-  else()
-    message(WARNING "Please, set the PV_PLUGIN_PATH environement variable, the TTK ParaView plugin will be built but not installed.")
-    set(TTK_INSTALL_PLUGIN_DIR
-      ""
-      CACHE
-      PATH
-      "Directory where the ParaView plugin will be installed"
-      )
-  endif()
-  mark_as_advanced(TTK_INSTALL_PLUGIN_DIR)
-
-  add_subdirectory(paraview)
 endif()
 
 # Standalones

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,15 @@ if(TTK_BUILD_PARAVIEW_PLUGINS)
         "Directory where the ParaView plugin will be installed"
       )
   else()
-    message(WARNING "Please, set the PV_PLUGIN_PATH environement variable, the TTK ParaView plugin will be built but not installed.")
     set(TTK_INSTALL_PLUGIN_DIR
-      ""
+      ${CMAKE_INSTALL_LIBDIR}/ttk/paraview-plugin
       CACHE
       PATH
       "Directory where the ParaView plugin will be installed"
       )
+    message(WARNING "Please, set the PV_PLUGIN_PATH environement variable."
+      "Ths TTK ParaView plugin wil be installed in ${CMAKE_INSTALL_PREFIX}/${TTK_INSTALL_PLUGIN_DIR} "
+      "and needs to be loaded manually.")
   endif()
 
   add_subdirectory(paraview)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,10 +149,6 @@ jobs:
     displayName: 'Configure TTK'
 
   - script: |
-      make ttkAlgorithm-hierarchy # TODO UGLY HOT FIX
-      make ttkIcoSphere-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionWriter-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
       cmake --build . --target install -- -j 4
     workingDirectory: 'build/'
     displayName: 'Build and install TTK'
@@ -202,10 +198,7 @@ jobs:
     displayName: 'Configure TTK'
 
   - script: |
-      make ttkAlgorithm-hierarchy # TODO UGLY HOT FIX
-      make ttkIcoSphere-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionWriter-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
+      # cmake --build . --target ttkAlgorithm-hierarchy ttkIcoSphere-hierarchy ttkTopologicalCompressionWriter-hierarchy ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
       cmake --build . --target install -- -j 4
     workingDirectory: 'build/'
     displayName: 'Build and install TTK'
@@ -285,10 +278,6 @@ jobs:
 
   - script: |
       $(compilerInitialization)
-      make ttkAlgorithm-hierarchy # TODO UGLY HOT FIX
-      make ttkIcoSphere-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionWriter-hierarchy # TODO UGLY HOT FIX
-      make ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
       cmake --build . --target install
     workingDirectory: build/
     displayName: 'Build and install TTK'

--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -22,10 +22,15 @@ foreach(TTK_MODULE ${TTK_PROVIDED_MODULES})
   endif()
 endforeach()
 
-vtk_module_build(
-  MODULES
-    ${TTK_ENABLED_MODULES}
-  )
+if(NOT ${TTK_BUILD_PARAVIEW_PLUGINS})
+  # when build against ParaView,
+  # vtk_module_build is already called
+  # by the paraview_add_plugin
+  vtk_module_build(
+    MODULES
+      ${TTK_ENABLED_MODULES}
+    )
+endif()
 
 if(VTK_WRAP_PYTHON)
   set(TTK_BUILD_VTK_PYTHON_MODULE

--- a/paraview/CMakeLists.txt
+++ b/paraview/CMakeLists.txt
@@ -5,6 +5,7 @@ set(VTKWRAPPER_DIR "${CMAKE_CURRENT_LIST_DIR}/../core/vtk/")
 # The goal is to create a single plugin for parview
 set(TTK_XMLS             "" CACHE INTERNAL "")
 set(TTK_MODULES          "" CACHE INTERNAL "")
+set(TTK_VTK_MODULE_FILES "" CACHE INTERNAL "")
 file(GLOB PARAVIEW_PLUGIN_DIRS *)
 foreach(PARAVIEW_PLUGIN ${PARAVIEW_PLUGIN_DIRS})
   if(IS_DIRECTORY ${PARAVIEW_PLUGIN})

--- a/paraview/CMakeLists.txt
+++ b/paraview/CMakeLists.txt
@@ -54,12 +54,10 @@ paraview_plugin_build(
     "${PARAVIEW_PLUGIN_SUBDIR}"
   )
 
-if(NOT "${TTK_INSTALL_PLUGIN_DIR}" STREQUAL "")
-  install(
-    TARGETS
-      TTKPVTargets
-    DESTINATION
-      "${TTK_INSTALL_PLUGIN_DIR}"
-    )
-endif()
+install(
+  TARGETS
+    TTKPVTargets
+  DESTINATION
+    "${TTK_INSTALL_PLUGIN_DIR}"
+  )
 

--- a/paraview/singlePlugin/CMakeLists.txt
+++ b/paraview/singlePlugin/CMakeLists.txt
@@ -8,6 +8,8 @@ paraview_add_plugin(TopologyToolKit
   REQUIRED_ON_SERVER
   MODULES
     ${TTK_MODULES}
+  MODULE_FILES
+    ${TTK_VTK_MODULE_FILES}
   MODULE_ARGS # BUG: see above
     INSTALL_HEADERS ON
   SERVER_MANAGER_XML


### PR DESCRIPTION
Dear Julien,

This PR, contains various small improvements for the cmake architecture of TTK:
* Fix hierarchy error for windows and linux (not mac yet)
* Reduce module dependency lists
* Install the ParaView plugin in lib/ttk/paraview-plugin if no PV_PLUGIN_PATH is set

For the last point, it is up to the user to clean the installed file if he has setup paraview to load it then finally add a PV_PLUGIN_PATH variable.

Charles
