### PR TITLE
Use protected inheritance for base layer to fix undefined symbols in Python wrapper libraries

### DIFF
--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -77,9 +77,15 @@ if(VTK_WRAP_PYTHON)
   endforeach()
   file(GENERATE
     OUTPUT
-    "${CMAKE_INSTALL_PREFIX}/${TTK_PYTHON_MODULE_DIR}/topologytoolkit/__init__.py"
+    "${CMAKE_BINARY_DIR}/${TTK_PYTHON_MODULE_DIR}/topologytoolkit/__init__.py"
     CONTENT
       "${InitContent}"
+    )
+  install(
+    FILES
+    "${CMAKE_BINARY_DIR}/${TTK_PYTHON_MODULE_DIR}/topologytoolkit/__init__.py"
+    DESTINATION
+    "${TTK_PYTHON_MODULE_DIR}/topologytoolkit/"
     )
   # Install TTK Python
   export(

--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -68,6 +68,20 @@ if(VTK_WRAP_PYTHON)
     TARGET
       TTK::Python
     )
+  # Generate __init__.py
+  set(InitContent "from __future__ import absolute_import\n")
+  foreach(MODULE ${TTK_ENABLED_MODULES})
+    if (NOT "${MODULE}" STREQUAL "ttkTriangulationAlgorithm")
+      string(APPEND InitContent "from .${MODULE} import *\n")
+    endif()
+  endforeach()
+  file(GENERATE
+    OUTPUT
+    "${CMAKE_INSTALL_PREFIX}/${TTK_PYTHON_MODULE_DIR}/topologytoolkit/__init__.py"
+    CONTENT
+      "${InitContent}"
+    )
+  # Install TTK Python
   export(
     EXPORT
       TTKPython

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -45,7 +45,7 @@
 
 class TTKBARYCENTRICSUBDIVISION_EXPORT ttkBarycentricSubdivision
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkBarycentricSubdivision *New();

--- a/core/vtk/ttkBlank/ttkBlank.h
+++ b/core/vtk/ttkBlank/ttkBlank.h
@@ -48,7 +48,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKBLANK_EXPORT ttkBlank : public vtkDataSetAlgorithm,
-                                 public ttk::Wrapper {
+                                 protected ttk::Wrapper {
 
 public:
   static ttkBlank *New();

--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
@@ -49,7 +49,7 @@
 
 class TTKBOTTLENECKDISTANCE_EXPORT ttkBottleneckDistance
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkBottleneckDistance *New();

--- a/core/vtk/ttkCellDataConverter/ttkCellDataConverter.h
+++ b/core/vtk/ttkCellDataConverter/ttkCellDataConverter.h
@@ -49,7 +49,7 @@
 
 class TTKCELLDATACONVERTER_EXPORT ttkCellDataConverter
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
   enum SupportedType {
     Char = 0,

--- a/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
+++ b/core/vtk/ttkCellDataSelector/ttkCellDataSelector.h
@@ -42,7 +42,7 @@
 
 class TTKCELLDATASELECTOR_EXPORT ttkCellDataSelector
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkCellDataSelector *New();

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
@@ -28,7 +28,7 @@
 #include <CinemaQuery.h>
 
 class TTKCINEMAQUERY_EXPORT ttkCinemaQuery : public ttkAlgorithm,
-                                             public ttk::CinemaQuery {
+                                             protected ttk::CinemaQuery {
 public:
   static ttkCinemaQuery *New();
   vtkTypeMacro(ttkCinemaQuery, ttkAlgorithm);

--- a/core/vtk/ttkComponentSize/ttkComponentSize.h
+++ b/core/vtk/ttkComponentSize/ttkComponentSize.h
@@ -47,7 +47,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKCOMPONENTSIZE_EXPORT ttkComponentSize : public vtkPointSetAlgorithm,
-                                                 public ttk::Wrapper {
+                                                 protected ttk::Wrapper {
 
 public:
   static ttkComponentSize *New();

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
@@ -59,7 +59,7 @@
 
 class TTKCONTINUOUSSCATTERPLOT_EXPORT ttkContinuousScatterPlot
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkContinuousScatterPlot *New();

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
@@ -38,7 +38,7 @@
 // class your wrapper should inherit.
 class TTKCONTOURAROUNDPOINT_EXPORT ttkContourAroundPoint
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkContourAroundPoint *New();

--- a/core/vtk/ttkContourForests/ttkContourForests.h
+++ b/core/vtk/ttkContourForests/ttkContourForests.h
@@ -73,7 +73,7 @@
 #include "DeprecatedDataTypes.h"
 
 class TTKCONTOURFORESTS_EXPORT ttkContourForests : public vtkDataSetAlgorithm,
-                                                   public ttk::Wrapper {
+                                                   protected ttk::Wrapper {
 
 public:
   static ttkContourForests *New();

--- a/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
+++ b/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
@@ -41,7 +41,7 @@
 
 class TTKDATASETINTERPOLATOR_EXPORT ttkDataSetInterpolator
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkDataSetInterpolator *New();

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
@@ -38,7 +38,7 @@
 #include <Wrapper.h>
 
 class TTKDATASETTOTABLE_EXPORT ttkDataSetToTable : public vtkDataSetAlgorithm,
-                                                   public ttk::Wrapper {
+                                                   protected ttk::Wrapper {
 
 public:
   enum AssociationType { Point = 0, Cell };

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
@@ -40,7 +40,7 @@
 class TTKDEPTHIMAGEBASEDGEOMETRYAPPROXIMATION_EXPORT
   ttkDepthImageBasedGeometryApproximation
   : public ttkAlgorithm,
-    public ttk::DepthImageBasedGeometryApproximation {
+    protected ttk::DepthImageBasedGeometryApproximation {
 
 public:
   static ttkDepthImageBasedGeometryApproximation *New();

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -43,7 +43,7 @@
 
 class TTKDIMENSIONREDUCTION_EXPORT ttkDimensionReduction
   : public vtkTableAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 public:
   enum Method {
     SpectralEmbedding = 0,

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -46,7 +46,7 @@
 
 class TTKDISCRETEGRADIENT_EXPORT ttkDiscreteGradient
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkDiscreteGradient *New();

--- a/core/vtk/ttkDistanceField/ttkDistanceField.h
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.h
@@ -54,7 +54,7 @@
 enum DistanceType { Float = 0, Double };
 
 class TTKDISTANCEFIELD_EXPORT ttkDistanceField : public vtkDataSetAlgorithm,
-                                                 public ttk::Wrapper {
+                                                 protected ttk::Wrapper {
 
 public:
   static ttkDistanceField *New();

--- a/core/vtk/ttkEigenField/ttkEigenField.h
+++ b/core/vtk/ttkEigenField/ttkEigenField.h
@@ -58,7 +58,7 @@
 enum EigenFieldType { Float = 0, Double };
 
 class TTKEIGENFIELD_EXPORT ttkEigenField : public vtkDataSetAlgorithm,
-                                           public ttk::Wrapper {
+                                           protected ttk::Wrapper {
 
 public:
   static ttkEigenField *New();

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -33,7 +33,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKFTMTREE_EXPORT ttkFTMTree : public vtkDataSetAlgorithm,
-                                     public ttk::Wrapper {
+                                     protected ttk::Wrapper {
 public:
   static ttkFTMTree *New();
 

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -33,7 +33,7 @@
 #include <ttkFTRGraphModule.h>
 
 class TTKFTRGRAPH_EXPORT ttkFTRGraph : public vtkDataSetAlgorithm,
-                                       public ttk::Wrapper {
+                                       protected ttk::Wrapper {
 private:
   std::string ScalarField;
   bool UseInputOffsetScalarField;

--- a/core/vtk/ttkFiber/ttkFiber.h
+++ b/core/vtk/ttkFiber/ttkFiber.h
@@ -47,7 +47,7 @@
 #include <Wrapper.h>
 
 class TTKFIBER_EXPORT ttkFiber : public vtkDataSetAlgorithm,
-                                 public ttk::Wrapper {
+                                 protected ttk::Wrapper {
 
 public:
   static ttkFiber *New();

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.h
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.h
@@ -63,7 +63,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKFIBERSURFACE_EXPORT ttkFiberSurface : public vtkDataSetAlgorithm,
-                                               public ttk::Wrapper {
+                                               protected ttk::Wrapper {
 
 public:
   static ttkFiberSurface *New();

--- a/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.h
+++ b/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.h
@@ -26,7 +26,7 @@
 
 class TTKGAUSSIANPOINTCLOUD_EXPORT ttkGaussianPointCloud
   : public vtkUnstructuredGridAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkGaussianPointCloud *New();

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -42,7 +42,7 @@
 
 class TTKGEOMETRYSMOOTHER_EXPORT ttkGeometrySmoother
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkGeometrySmoother *New();

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.h
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.h
@@ -62,7 +62,7 @@
 enum HarmonicFieldType { Float = 0, Double };
 
 class TTKHARMONICFIELD_EXPORT ttkHarmonicField : public vtkDataSetAlgorithm,
-                                                 public ttk::Wrapper {
+                                                 protected ttk::Wrapper {
 
 public:
   static ttkHarmonicField *New();

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.h
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.h
@@ -38,7 +38,7 @@
 class TTKHELLOWORLD_EXPORT ttkHelloWorld
   : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
   ,
-    public ttk::HelloWorld // and we inherit from the base class
+    protected ttk::HelloWorld // and we inherit from the base class
 {
 private:
   /**

--- a/core/vtk/ttkIcoSphere/ttkIcoSphere.h
+++ b/core/vtk/ttkIcoSphere/ttkIcoSphere.h
@@ -23,7 +23,7 @@
 #include <IcoSphere.h>
 
 class TTKICOSPHERE_EXPORT ttkIcoSphere : public ttkAlgorithm,
-                                         public ttk::IcoSphere {
+                                         protected ttk::IcoSphere {
 private:
   int NumberOfSubdivisions{0};
   float Radius{1};

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.h
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.h
@@ -44,7 +44,7 @@
 // class your wrapper should inherit.
 class TTKIDENTIFIERRANDOMIZER_EXPORT ttkIdentifierRandomizer
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkIdentifierRandomizer *New();

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.h
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.h
@@ -45,7 +45,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKIDENTIFIERS_EXPORT ttkIdentifiers : public vtkDataSetAlgorithm,
-                                             public ttk::Wrapper {
+                                             protected ttk::Wrapper {
 
 public:
   static ttkIdentifiers *New();

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
@@ -42,7 +42,7 @@
 
 class TTKIDENTIFYBYSCALARFIELD_EXPORT ttkIdentifyByScalarField
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkIdentifyByScalarField *New();

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
@@ -39,7 +39,7 @@
 
 class TTKIMPORTEMBEDDINGFROMTABLE_EXPORT ttkImportEmbeddingFromTable
   : public vtkPointSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkImportEmbeddingFromTable *New();

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.h
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.h
@@ -52,7 +52,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKINTEGRALLINES_EXPORT ttkIntegralLines : public vtkDataSetAlgorithm,
-                                                 public ttk::Wrapper {
+                                                 protected ttk::Wrapper {
 
 public:
   static ttkIntegralLines *New();

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.h
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.h
@@ -62,7 +62,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKJACOBISET_EXPORT ttkJacobiSet : public vtkDataSetAlgorithm,
-                                         public ttk::Wrapper {
+                                         protected ttk::Wrapper {
 
 public:
   static ttkJacobiSet *New();

--- a/core/vtk/ttkLDistance/ttkLDistance.h
+++ b/core/vtk/ttkLDistance/ttkLDistance.h
@@ -45,7 +45,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKLDISTANCE_EXPORT ttkLDistance : public vtkDataSetAlgorithm,
-                                         public ttk::Wrapper {
+                                         protected ttk::Wrapper {
 
 public:
   static ttkLDistance *New();

--- a/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.h
+++ b/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.h
@@ -81,7 +81,7 @@
 // class your wrapper should inherit.
 class TTKMANDATORYCRITICALPOINTS_EXPORT ttkMandatoryCriticalPoints
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkMandatoryCriticalPoints *New();

--- a/core/vtk/ttkManifoldCheck/ttkManifoldCheck.h
+++ b/core/vtk/ttkManifoldCheck/ttkManifoldCheck.h
@@ -54,7 +54,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKMANIFOLDCHECK_EXPORT ttkManifoldCheck : public vtkDataSetAlgorithm,
-                                                 public ttk::Wrapper {
+                                                 protected ttk::Wrapper {
 
 public:
   static ttkManifoldCheck *New();

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.h
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.h
@@ -29,7 +29,7 @@
 #include <MeshGraph.h>
 
 class TTKMESHGRAPH_EXPORT ttkMeshGraph : public ttkAlgorithm,
-                                         public ttk::MeshGraph {
+                                         protected ttk::MeshGraph {
 
 private:
   bool UseVariableSize{false};

--- a/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.h
+++ b/core/vtk/ttkMeshSubdivision/ttkMeshSubdivision.h
@@ -61,7 +61,7 @@
 // class your wrapper should inherit.
 class TTKMESHSUBDIVISION_EXPORT ttkMeshSubdivision
   : public vtkUnstructuredGridAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkMeshSubdivision *New();

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -60,7 +60,7 @@
 
 class TTKMORSESMALECOMPLEX_EXPORT ttkMorseSmaleComplex
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkMorseSmaleComplex *New();

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.h
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.h
@@ -54,7 +54,7 @@
 
 class TTKMORSESMALEQUADRANGULATION_EXPORT ttkMorseSmaleQuadrangulation
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkMorseSmaleQuadrangulation *New();

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -56,7 +56,7 @@
 
 class TTKPERSISTENCECURVE_EXPORT ttkPersistenceCurve
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkPersistenceCurve *New();

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -69,7 +69,7 @@
 
 class TTKPERSISTENCEDIAGRAM_EXPORT ttkPersistenceDiagram
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkPersistenceDiagram *New();

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -66,7 +66,7 @@
 // class your wrapper should inherit.
 class TTKPERSISTENCEDIAGRAMCLUSTERING_EXPORT ttkPersistenceDiagramClustering
   : public vtkMultiBlockDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   void setNumberOfInputsFromCommandLine(int number) {

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -51,7 +51,7 @@
 
 class TTKPLANARGRAPHLAYOUT_EXPORT ttkPlanarGraphLayout
   : public ttkAlgorithm,
-    public ttk::PlanarGraphLayout {
+    protected ttk::PlanarGraphLayout {
 
 private:
   // optional field data

--- a/core/vtk/ttkPointDataConverter/ttkPointDataConverter.h
+++ b/core/vtk/ttkPointDataConverter/ttkPointDataConverter.h
@@ -49,7 +49,7 @@
 
 class TTKPOINTDATACONVERTER_EXPORT ttkPointDataConverter
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
   enum SupportedType {
     Char = 0,

--- a/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
+++ b/core/vtk/ttkPointDataSelector/ttkPointDataSelector.h
@@ -43,7 +43,7 @@
 
 class TTKPOINTDATASELECTOR_EXPORT ttkPointDataSelector
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkPointDataSelector *New();

--- a/core/vtk/ttkPointMerger/ttkPointMerger.h
+++ b/core/vtk/ttkPointMerger/ttkPointMerger.h
@@ -47,7 +47,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKPOINTMERGER_EXPORT ttkPointMerger : public vtkDataSetAlgorithm,
-                                             public ttk::Wrapper {
+                                             protected ttk::Wrapper {
 
 public:
   static ttkPointMerger *New();

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -102,10 +102,6 @@ public:
   }
 
   virtual int run() {
-
-    ttkObject_->setDebugLevel(ttk::globalDebugLevel_);
-    ttkObject_->setThreadNumber(ttk::globalThreadNumber_);
-
     return ttkProgramBase::run();
   }
 

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -40,7 +40,7 @@
 
 class TTKPROJECTIONFROMFIELD_EXPORT ttkProjectionFromField
   : public vtkPointSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkProjectionFromField *New();

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.h
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.h
@@ -54,7 +54,7 @@
 
 class TTKQUADRANGULATIONSUBDIVISION_EXPORT ttkQuadrangulationSubdivision
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkQuadrangulationSubdivision *New();

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.h
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.h
@@ -71,7 +71,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKRANGEPOLYGON_EXPORT ttkRangePolygon : public vtkDataSetAlgorithm,
-                                               public ttk::Wrapper {
+                                               protected ttk::Wrapper {
 
 public:
   static ttkRangePolygon *New();

--- a/core/vtk/ttkReebSpace/ttkReebSpace.h
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.h
@@ -72,7 +72,7 @@
 // see the documentation of the vtkAlgorithm class to decide from which VTK
 // class your wrapper should inherit.
 class TTKREEBSPACE_EXPORT ttkReebSpace : public vtkDataSetAlgorithm,
-                                         public ttk::Wrapper {
+                                         protected ttk::Wrapper {
 
 public:
   static ttkReebSpace *New();

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -57,7 +57,7 @@
 // class your wrapper should inherit.
 class TTKSCALARFIELDCRITICALPOINTS_EXPORT ttkScalarFieldCriticalPoints
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkScalarFieldCriticalPoints *New();

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
@@ -47,7 +47,7 @@
 // class your wrapper should inherit.
 class TTKSCALARFIELDNORMALIZER_EXPORT ttkScalarFieldNormalizer
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkScalarFieldNormalizer *New();

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
@@ -48,7 +48,7 @@
 
 class TTKSCALARFIELDSMOOTHER_EXPORT ttkScalarFieldSmoother
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkScalarFieldSmoother *New();

--- a/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
+++ b/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
@@ -41,7 +41,7 @@
 #include <ttkTriangulationAlgorithm.h>
 
 class TTKSPHEREFROMPOINT_EXPORT ttkSphereFromPoint : public vtkDataSetAlgorithm,
-                                                     public ttk::Wrapper {
+                                                     protected ttk::Wrapper {
 
 public:
   static ttkSphereFromPoint *New();

--- a/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
+++ b/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
@@ -42,7 +42,7 @@
 
 class TTKTABLEDATASELECTOR_EXPORT ttkTableDataSelector
   : public vtkTableAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTableDataSelector *New();

--- a/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.h
+++ b/core/vtk/ttkTextureMapFromField/ttkTextureMapFromField.h
@@ -44,7 +44,7 @@
 
 class TTKTEXTUREMAPFROMFIELD_EXPORT ttkTextureMapFromField
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTextureMapFromField *New();

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -51,7 +51,7 @@
 // class your wrapper should inherit.
 class TTKTOPOLOGICALCOMPRESSION_EXPORT ttkTopologicalCompression
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTopologicalCompression *New();

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -77,7 +77,7 @@
 
 class TTKTOPOLOGICALSIMPLIFICATION_EXPORT ttkTopologicalSimplification
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTopologicalSimplification *New();

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
@@ -37,7 +37,7 @@
 
 class TTKTRACKINGFROMFIELDS_EXPORT ttkTrackingFromFields
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTrackingFromFields *New();

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -51,7 +51,7 @@
 
 class TTKTRACKINGFROMOVERLAP_EXPORT ttkTrackingFromOverlap
   : public vtkUnstructuredGridAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTrackingFromOverlap *New();

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
@@ -31,7 +31,7 @@
 
 class TTKTRACKINGFROMPERSISTENCEDIAGRAMS_EXPORT
   ttkTrackingFromPersistenceDiagrams : public vtkDataSetAlgorithm,
-                                       public ttk::Wrapper {
+                                       protected ttk::Wrapper {
 
 public:
   static ttkTrackingFromPersistenceDiagrams *New();

--- a/core/vtk/ttkTriangulationAlgorithm/ttkTriangulationAlgorithm.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkTriangulationAlgorithm.h
@@ -27,7 +27,7 @@
 
 class TTKTRIANGULATIONALGORITHM_EXPORT ttkTriangulationAlgorithm
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkTriangulationAlgorithm *New();

--- a/core/vtk/ttkTriangulationAlgorithm/vtk.module
+++ b/core/vtk/ttkTriangulationAlgorithm/vtk.module
@@ -2,6 +2,5 @@ NAME
   ttkTriangulationAlgorithm
 DEPENDS
   VTK::FiltersCore
-PRIVATE_DEPENDS
   VTK::CommonCore
 

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -43,7 +43,7 @@
 
 class TTKTRIANGULATIONREQUEST_EXPORT ttkTriangulationRequest
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   enum Simplex { Vertex = 0, Edge, Triangle, Tetra };

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.h
@@ -57,7 +57,7 @@
 // class your wrapper should inherit.
 class TTKUNCERTAINDATAESTIMATOR_EXPORT ttkUncertainDataEstimator
   : public vtkDataSetAlgorithm,
-    public ttk::Wrapper {
+    protected ttk::Wrapper {
 
 public:
   static ttkUncertainDataEstimator *New();

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -131,10 +131,6 @@ public:
   };
 
   virtual int run() {
-
-    ttkObject_->setDebugLevel(ttk::globalDebugLevel_);
-    ttkObject_->setThreadNumber(ttk::globalThreadNumber_);
-
     return ttkUserInterfaceBase::run();
   }
 

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -27,12 +27,19 @@ from vtk import (
     vtkXMLUnstructuredGridWriter,
 )
 
-from topologytoolkit import (
-    ttkMorseSmaleComplex,
-    ttkPersistenceCurve,
-    ttkPersistenceDiagram,
-    ttkTopologicalSimplification,
-)
+# temporary fix (till topologytoolkit package re-exports all its modules)
+from topologytoolkit.ttkMorseSmaleComplex import *
+from topologytoolkit.ttkPersistenceCurve import *
+from topologytoolkit.ttkPersistenceDiagram import *
+from topologytoolkit.ttkTopologicalSimplification import *
+
+## old import syntax
+# from topologytoolkit import (
+#     ttkMorseSmaleComplex,
+#     ttkPersistenceCurve,
+#     ttkPersistenceDiagram,
+#     ttkTopologicalSimplification,
+# )
 
 if len(sys.argv) == 2:
     inputFilePath = sys.argv[1]

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -27,19 +27,12 @@ from vtk import (
     vtkXMLUnstructuredGridWriter,
 )
 
-# temporary fix (till topologytoolkit package re-exports all its modules)
-from topologytoolkit.ttkMorseSmaleComplex import *
-from topologytoolkit.ttkPersistenceCurve import *
-from topologytoolkit.ttkPersistenceDiagram import *
-from topologytoolkit.ttkTopologicalSimplification import *
-
-## old import syntax
-# from topologytoolkit import (
-#     ttkMorseSmaleComplex,
-#     ttkPersistenceCurve,
-#     ttkPersistenceDiagram,
-#     ttkTopologicalSimplification,
-# )
+from topologytoolkit import (
+    ttkMorseSmaleComplex,
+    ttkPersistenceCurve,
+    ttkPersistenceDiagram,
+    ttkTopologicalSimplification,
+)
 
 if len(sys.argv) == 2:
     inputFilePath = sys.argv[1]


### PR DESCRIPTION
This PR switches all multiple inheritance to the base layer in the VTK layer from public to protected.

As a consequence, undefined symbols such as `PyvtkDataSetAlgorithm_ClassNew` should no more appear when executing Python scripts like examples/python/example.py.

Still, some undefined symbols (`PyvtkImageData_ClassNew`, `PyvtkPolyData_ClassNew` and `PyvtkUnstructuredGrid_ClassNew`) remain in ttkTriangulationAlgorithmPython.so. I don't know how to avoid this though. Hopefully, this library is not used through the Python wrapper?

I also noticed that the Python modules under the topologytoolkit package are not re-exported at the package level, meaning you have to use these kinds of imports

```py
from topologytoolkit.ttkMorseSmaleComplex import *
from topologytoolkit.ttkPersistenceCurve import *
from topologytoolkit.ttkPersistenceDiagram import *
from topologytoolkit.ttkTopologicalSimplification import *
```
instead of 

```py
from topologytoolkit import (
    ttkMorseSmaleComplex,
    ttkPersistenceCurve,
    ttkPersistenceDiagram,
    ttkTopologicalSimplification,
)
```
in examples/python/example.py.


No changes to ttk-data states have been noticed so far.

Pierre