### PR TITLE
WIP: Update for VTK master: Use range iterator

### DIFF
--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -36,13 +36,11 @@ macro(ttk_add_vtk_module)
       HEADERS
         ${TTK_HEADERS}
       )
-
     vtk_module_link(${TTK_NAME}
       PUBLIC
         ${VTK_LIBRARIES}
         ${TTK_DEPENDS}
       )
-
     install(
       TARGETS
         ${TTK_NAME}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,6 @@ jobs:
     displayName: 'Configure TTK'
 
   - script: |
-      # cmake --build . --target ttkAlgorithm-hierarchy ttkIcoSphere-hierarchy ttkTopologicalCompressionWriter-hierarchy ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
       cmake --build . --target install -- -j 4
     workingDirectory: 'build/'
     displayName: 'Build and install TTK'

--- a/core/base/common/ArrayIterator.h
+++ b/core/base/common/ArrayIterator.h
@@ -1,0 +1,107 @@
+/// \ingroup base
+/// \class ttk::ArrayIterator
+/// \author Charles Gueunet charles.gueunet@kitware.com
+/// \date 2020-01-08
+///
+///\brief TTK class to iterate over any array with a generic interface
+
+#pragma once
+
+#include "DataTypes.h"
+#include <iterator>
+
+template <typename ElementType>
+class GenericIterator
+  : public std::iterator<std::random_access_iterator_tag, ElementType> {
+  ElementType *p;
+
+public:
+  GenericIterator() : p(nullptr) {
+  }
+  GenericIterator(ElementType *x) : p(x) {
+  }
+  GenericIterator(const GenericIterator<ElementType> &it) : p(it.p) {
+  }
+  GenericIterator &operator++() {
+    ++p;
+    return *this;
+  }
+  GenericIterator operator++(int) {
+    GenericIterator tmp(*this);
+    operator++();
+    return tmp;
+  }
+  GenericIterator &operator--() {
+    --p;
+    return *this;
+  }
+  GenericIterator operator--(int) {
+    GenericIterator tmp(*this);
+    operator--();
+    return tmp;
+  }
+  GenericIterator operator+(int offset) const {
+    return this->p + offset;
+  }
+  GenericIterator &operator=(const GenericIterator<ElementType>& it)
+  {
+    this->p = it->p;
+    return *this;
+  }
+  bool operator==(const GenericIterator<ElementType> &rhs) const {
+    return this->p == rhs.p;
+  }
+  bool operator!=(const GenericIterator<ElementType> &rhs) const {
+    return this->p != rhs.p;
+  }
+  ElementType &operator*() {
+    return *this->p;
+  }
+  const ElementType &operator*() const {
+    return *this->p;
+  }
+};
+
+template <typename ElementType>
+class RangeHandler : public GenericIterator<ElementType> {
+
+  using iteratorT = GenericIterator<ElementType>;
+  iteratorT beginIt, endIt;
+
+public:
+  RangeHandler(iteratorT b, iteratorT e) : beginIt(b), endIt(e) {
+  }
+  RangeHandler(ElementType *b, ElementType *e) : beginIt(b), endIt(e) {
+  }
+  template<typename RangeType>
+  RangeHandler(RangeType range) : beginIt(std::begin(range)), endIt(std::end(range)) {
+  }
+
+  iteratorT begin()
+  {
+    return this->beginIt;
+  }
+  iteratorT end()
+  {
+    return this->endIt;
+  }
+  const iteratorT& cbegin() const
+  {
+    return this->beginIt;
+  }
+  const iteratorT& cend() const
+  {
+    return this->endIt;
+  }
+  // TODO: deal with reverse iterators...
+
+  // Access underlying data
+
+  ElementType &operator[](int idx) {
+    return *(this->beginIt + idx);
+  }
+
+  const ElementType &operator[](int idx) const {
+    return *(this->beginIt + idx);
+  }
+};

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -11,5 +11,6 @@ ttk_add_base_library(common
         Os.h
         ProgramBase.h
         Wrapper.h
+        ArrayIterator.h
         )
 

--- a/core/base/helloWorld/HelloWorld.h
+++ b/core/base/helloWorld/HelloWorld.h
@@ -21,6 +21,8 @@
 #include <Debug.h>
 #include <Triangulation.h>
 
+#include <ArrayIterator.h>
+
 namespace ttk {
 
   /**
@@ -59,8 +61,8 @@ namespace ttk {
      */
     template <class dataType,
               class TriangulationType = ttk::AbstractTriangulation>
-    int computeAverages(dataType *outputData,
-                        const dataType *inputData,
+    int computeAverages(RangeHandler<dataType> outputData,
+                        const RangeHandler<dataType> inputData,
                         const TriangulationType *triangulation) const {
       // start global timer
       ttk::Timer globalTimer;

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.h
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.h
@@ -31,6 +31,7 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 #include <ttkTriangulation.h>
+#include <ttkScalarWorker.h>
 
 // TTK Base Includes
 #include <HelloWorld.h>
@@ -89,4 +90,27 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
+
+  /**
+   * Here you call the basecode
+   * You need to implement a templated Compute
+   * method that recieve the input and output arrays.
+   * You can need to use GetRange to transform these vtk
+   * arrays into generic range for TTK.
+   * You can also access the triangulation here as well
+   * as the baseClass.
+   */
+  struct HelloWorldWorker
+    : public ScalarWorker<HelloWorldWorker, ttkHelloWorld> {
+    using ScalarWorker::GetRange;
+    using ScalarWorker::ScalarWorker;
+    using ScalarWorker::operator();
+
+    template <typename ArrayType1, typename ArrayType2>
+    void Compute(ArrayType1 *input, ArrayType2 *output) {
+      auto inputRange = GetRange(input);
+      auto outputRange = GetRange(output);
+      baseClass->computeAverages(outputRange, inputRange, triangulation->getData());
+    }
+  };
 };

--- a/core/vtk/ttkTriangulationAlgorithm/ttkScalarWorker.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkScalarWorker.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "ArrayIterator.h"
+#include "Triangulation.h"
+
+// vtk array manipulation
+#include "ArrayIterator.h"
+#include "vtkArrayDispatch.h"
+#include "vtkDataArrayRange.h"
+
+template <typename Wrapper, typename Algo>
+class ScalarWorker {
+
+public:
+  ScalarWorker(Algo *a, ttk::Triangulation *t)
+    : baseClass(a), triangulation(t) {
+  }
+
+  // Helper to transform VTK input into generic range
+  template <template <typename> class ArrayType, typename ElType>
+  RangeHandler<ElType> GetRange(ArrayType<ElType> *arr) {
+    return RangeHandler<ElType>(vtk::DataArrayValueRange<1>(arr));
+  }
+
+  Wrapper* getSelf(){
+    return reinterpret_cast<Wrapper*>(this);
+  }
+
+  // Define the required operator()
+  template <typename... Args>
+  auto operator()(Args &&... args) -> void {
+    return getSelf()->Compute(std::forward<Args>(args)...);
+  }
+
+  // User define method should look like this
+  // template<typename ArrayType1, typename ArrayType2>
+  // void Compute(ArrayType1 *input, ArrayType2 *output)
+  // {
+  //   auto inputRange = GetRange(input);
+  //   auto outputRange = GetRange(output);
+  //   baseClass->compute(inputRange, outputRange, triangulation);
+  // }
+
+protected:
+  ttk::Triangulation *triangulation;
+  Algo *baseClass;
+};


### PR DESCRIPTION
Dear Julien,

This PR is meant to be a place for discussion.
Benchs are not perfect yet (~1% loss), you may wait for me to solve this before reading the following. I will tag you when the PR is ready.

The current VTK has dropped `GetVoidPointer` which is a problem for the current TTK.
We can either replace it with a small snippet like this:
```
void* GetVoidPointer(vtkDataArray* array, IdType start)
{
  void* outPtr = nullptr;
  switch (array->GetDataType())
  {
    vtkTemplateMacro(
      vtkAOSDataArrayTemplate<VTK_TT>* aosArray =
        vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
      if (aosArray)
      {
        outPtr = aosArray->GetVoidPointer(start);
      }
    );
  }
  return outPtr;
}
```
or we can use this as an opportunity to handle AOS and SOA seamlessly in
TTK.

I have tried here to update the HelloWorld module to the new VTK architecture.
This PR does not address triangulation yet.

Main drawback of the current approach are detailed in the discussion below.
