### PR TITLE
ready: quick version for GetVoidPointer

### DIFF
--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -40,8 +40,19 @@ if(VTK_WRAP_PYTHON)
     "Build the python module"
     )
   if(NOT DEFINED TTK_PYTHON_MODULE_DIR)
+    if (IS_ABSOLUTE ${VTK_PYTHONPATH})
+      file(RELATIVE_PATH
+        PYTHON_SITE_PACKAGES_SUFFIX
+        ${VTK_PREFIX_PATH}
+        ${VTK_PYTHONPATH}
+        )
+    else()
+      set(PYTHON_SITE_PACKAGES_SUFFIX
+        ${VTK_PYTHONPATH}
+        )
+    endif()
     set(TTK_PYTHON_MODULE_DIR
-      ${VTK_PYTHONPATH}
+      ${PYTHON_SITE_PACKAGES_SUFFIX}
       CACHE
       PATH
       "Where the TTK python module in installed"

--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -40,13 +40,8 @@ if(VTK_WRAP_PYTHON)
     "Build the python module"
     )
   if(NOT DEFINED TTK_PYTHON_MODULE_DIR)
-    file(RELATIVE_PATH
-      PYTHON_SITE_PACKAGES_SUFFIX
-      ${VTK_PREFIX_PATH}
-      ${VTK_PYTHONPATH}
-      )
     set(TTK_PYTHON_MODULE_DIR
-      ${PYTHON_SITE_PACKAGES_SUFFIX}
+      ${VTK_PYTHONPATH}
       CACHE
       PATH
       "Where the TTK python module in installed"

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -1,4 +1,5 @@
 #include <ttkAlgorithm.h>
+#include <ttkUtils.h>
 
 #include <vtkDataObject.h> // For output port info
 #include <vtkObjectFactory.h> // for new macro

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -152,7 +152,7 @@ ttk::Triangulation *ttkAlgorithm::InitTriangulation(void *key,
         return nullptr;
       }
 
-      void *pointDataArray = ttkUtils::GetVoidPointer(points->GetData());
+      void *pointDataArray = ttkUtils::GetVoidPointer(points);
       triangulation->setInputPoints(points->GetNumberOfPoints(), pointDataArray,
                                     pointDataType == VTK_DOUBLE);
     }

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -33,7 +33,7 @@ namespace ttkUtils {
 
   vtkSmartPointer<vtkDoubleArray> csvToDoubleArray(std::string line);
 
-  void *GetVoidPointer(vtkDataArray *array, int start);
+  void *GetVoidPointer(vtkDataArray *array, int start = 0);
 }; // namespace ttkUtils
 
 #include <limits>
@@ -248,7 +248,7 @@ vtkSmartPointer<vtkDoubleArray> ttkUtils::csvToDoubleArray(std::string line) {
 /// Retrieve pointer to the internal data
 /// This method is a workaround to emulate
 /// the old GetVoidPointer in vtkDataArray
-void *GetVoidPointer(vtkDataArray *array, int start) {
+void *ttkUtils::GetVoidPointer(vtkDataArray *array, int start) {
   void *outPtr = nullptr;
   switch(array->GetDataType()) {
     vtkTemplateMacro(

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -10,6 +10,7 @@
 #include <vtkAbstractArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
+#include <vtkPoints.h>
 #include <vtkSmartPointer.h>
 
 namespace ttkUtils {
@@ -36,6 +37,7 @@ namespace ttkUtils {
   // Emultate old VTK functions
 
   void *GetVoidPointer(vtkDataArray *array, vtkIdType start = 0);
+  void *GetVoidPointer(vtkPoints *points, vtkIdType start = 0);
 
   void *WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
   void *WritePointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
@@ -263,6 +265,9 @@ void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
       if(aosArray) { outPtr = aosArray->GetVoidPointer(start); });
   }
   return outPtr;
+}
+void *ttkUtils::GetVoidPointer(vtkPoints *points, vtkIdType start) {
+  return GetVoidPointer(points->GetData(), start);
 }
 
 void *ttkUtils::WriteVoidPointer(vtkDataArray *array, vtkIdType valueIdx,

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -37,7 +37,10 @@ namespace ttkUtils {
 
   void *GetVoidPointer(vtkDataArray *array, vtkIdType start = 0);
 
+  void *WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
   void *WritePointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
+
+  void SetVoidArray(vtkDataArray *array, void* data, vtkIdType size, int save);
 }; // namespace ttkUtils
 
 #include <limits>
@@ -262,6 +265,17 @@ void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
   return outPtr;
 }
 
+void *ttkUtils::WriteVoidPointer(vtkDataArray *array, vtkIdType start,
+                             vtkIdType numValues) {
+  void *outPtr = nullptr;
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) { outPtr = aosArray->WriteVoidPointer(start, numValues); });
+  }
+  return outPtr;
+}
+
 void *ttkUtils::WritePointer(vtkDataArray *array,
                              vtkIdType start,
                              vtkIdType numValues) {
@@ -272,4 +286,20 @@ void *ttkUtils::WritePointer(vtkDataArray *array,
       if(aosArray) { outPtr = aosArray->WritePointer(start, numValues); });
   }
   return outPtr;
+}
+
+void ttkUtils::SetVoidArray(vtkDataArray *array,
+                            void *data,
+                            vtkIdType size,
+                            int save) {
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) {
+        aosArray->SetVoidArray(data, size, save);
+      } else {
+        std::cerr << "SetVoidArray on incompatible vtkDataArray:" << endl;
+        array->Print(std::cerr);
+      });
+  }
 }

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -265,25 +265,25 @@ void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
   return outPtr;
 }
 
-void *ttkUtils::WriteVoidPointer(vtkDataArray *array, vtkIdType start,
+void *ttkUtils::WriteVoidPointer(vtkDataArray *array, vtkIdType valueIdx,
                              vtkIdType numValues) {
   void *outPtr = nullptr;
   switch(array->GetDataType()) {
     vtkTemplateMacro(
       auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-      if(aosArray) { outPtr = aosArray->WriteVoidPointer(start, numValues); });
+      if(aosArray) { outPtr = aosArray->WriteVoidPointer(valueIdx, numValues); });
   }
   return outPtr;
 }
 
 void *ttkUtils::WritePointer(vtkDataArray *array,
-                             vtkIdType start,
+                             vtkIdType valueIdx,
                              vtkIdType numValues) {
   void *outPtr = nullptr;
   switch(array->GetDataType()) {
     vtkTemplateMacro(
       auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-      if(aosArray) { outPtr = aosArray->WritePointer(start, numValues); });
+      if(aosArray) { outPtr = aosArray->WritePointer(valueIdx, numValues); });
   }
   return outPtr;
 }

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -32,6 +32,8 @@ namespace ttkUtils {
   vtkSmartPointer<vtkAbstractArray> csvToVtkArray(std::string line);
 
   vtkSmartPointer<vtkDoubleArray> csvToDoubleArray(std::string line);
+
+  void *GetVoidPointer(vtkDataArray *array, int start);
 }; // namespace ttkUtils
 
 #include <limits>
@@ -242,3 +244,17 @@ vtkSmartPointer<vtkDoubleArray> ttkUtils::csvToDoubleArray(std::string line) {
 
   return array;
 }
+
+/// Retrieve pointer to the internal data
+/// This method is a workaround to emulate
+/// the old GetVoidPointer in vtkDataArray
+void *GetVoidPointer(vtkDataArray *array, int start) {
+  void *outPtr = nullptr;
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) { outPtr = aosArray->GetVoidPointer(start); });
+  }
+  return outPtr;
+}
+

--- a/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
+++ b/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
@@ -146,8 +146,8 @@ void ttkArrayEditor::ClearSourceFieldDataArrays() {
 
 template <typename VTK_T1, typename VTK_T2>
 int copyArrayData(vtkDataArray *target, vtkDataArray *copy) {
-  auto targetData = (VTK_T1 *)target->GetVoidPointer(0);
-  auto copyData = (VTK_T2 *)copy->GetVoidPointer(0);
+  auto targetData = (VTK_T1 *)ttkUtils::GetVoidPointer(target);
+  auto copyData = (VTK_T2 *)ttkUtils::GetVoidPointer(copy);
   for(size_t i = 0, n = target->GetNumberOfValues(); i < n; i++)
     copyData[i] = (VTK_T2)(targetData[i]);
   return 1;

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -23,22 +23,12 @@ vtkSmartPointer<vtkDataArray> ttkBarycentricSubdivision::AllocateScalarField(
   // allocate the memory for the output scalar field
   switch(inputScalarField->GetDataType()) {
     case VTK_CHAR:
-      res = vtkSmartPointer<vtkCharArray>::New();
-      break;
     case VTK_DOUBLE:
-      res = vtkSmartPointer<vtkDoubleArray>::New();
-      break;
     case VTK_FLOAT:
-      res = vtkSmartPointer<vtkFloatArray>::New();
-      break;
     case VTK_INT:
-      res = vtkSmartPointer<vtkIntArray>::New();
-      break;
     case VTK_ID_TYPE:
-      res = vtkSmartPointer<vtkIdTypeArray>::New();
-      break;
     case VTK_LONG:
-      res = vtkSmartPointer<vtkLongArray>::New();
+      res = inputScalarField->NewInstance();
       break;
     default:
       std::stringstream msg;
@@ -66,17 +56,17 @@ int ttkBarycentricSubdivision::InterpolateScalarFields(
       return -2;
     }
 
-#define DISPATCH_INTERPOLATE_DIS(CASE, TYPE)                      \
-  case CASE:                                                      \
-    baseWorker_.interpolateDiscreteScalarField<TYPE>(             \
-      static_cast<TYPE *>(inputScalarField->GetVoidPointer(0)),   \
-      static_cast<TYPE *>(outputScalarField->GetVoidPointer(0))); \
+#define DISPATCH_INTERPOLATE_DIS(CASE, TYPE)                             \
+  case CASE:                                                             \
+    baseWorker_.interpolateDiscreteScalarField<TYPE>(                    \
+      static_cast<TYPE *>(ttkUtils::GetVoidPointer(inputScalarField)),   \
+      static_cast<TYPE *>(ttkUtils::GetVoidPointer(outputScalarField))); \
     break
-#define DISPATCH_INTERPOLATE_CONT(CASE, TYPE)                     \
-  case CASE:                                                      \
-    baseWorker_.interpolateContinuousScalarField<TYPE>(           \
-      static_cast<TYPE *>(inputScalarField->GetVoidPointer(0)),   \
-      static_cast<TYPE *>(outputScalarField->GetVoidPointer(0))); \
+#define DISPATCH_INTERPOLATE_CONT(CASE, TYPE)                            \
+  case CASE:                                                             \
+    baseWorker_.interpolateContinuousScalarField<TYPE>(                  \
+      static_cast<TYPE *>(ttkUtils::GetVoidPointer(inputScalarField)),   \
+      static_cast<TYPE *>(ttkUtils::GetVoidPointer(outputScalarField))); \
     break
 
     auto outputScalarField
@@ -114,8 +104,8 @@ int ttkBarycentricSubdivision::InterpolateScalarFields(
     // only for scalar fields
     switch(inputScalarField->GetDataType()) {
       vtkTemplateMacro(baseWorker_.interpolateCellDataField<VTK_TT>(
-        static_cast<VTK_TT *>(inputScalarField->GetVoidPointer(0)),
-        static_cast<VTK_TT *>(outputScalarField->GetVoidPointer(0))));
+        static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
+        static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField))));
     }
     output->GetCellData()->AddArray(outputScalarField);
   }
@@ -149,7 +139,7 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   baseWorker_.setupTriangulation(triangulation);
   baseWorker_.setWrapper(this);
   baseWorker_.setOutputTriangulation(&triangulationSubdivision);
-  baseWorker_.setInputPoints(input->GetPoints()->GetVoidPointer(0));
+  baseWorker_.setInputPoints(ttkUtils::GetVoidPointer(input->GetPoints()));
 
   // first iteration: generate the new triangulation
   baseWorker_.execute();

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -1,4 +1,5 @@
 #include <ttkBarycentricSubdivision.h>
+#include <ttkUtils.h>
 
 #define MODULE_S "[ttkBarycentricSubdivision] "
 #define MODULE_ERROR_S MODULE_S "Error: "
@@ -203,13 +204,13 @@ int ttkBarycentricSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   // cell id
   auto cellId = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellId->SetName("CellId");
-  cellId->SetVoidArray(pointId_.data(), pointId_.size(), 1);
+  ttkUtils::SetVoidArray(cellId, pointId_.data(), pointId_.size(), 1);
   output->GetPointData()->AddArray(cellId);
 
   // cell dimension
   auto cellDim = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellDim->SetName("CellDimension");
-  cellDim->SetVoidArray(pointDim_.data(), pointDim_.size(), 1);
+  ttkUtils::SetVoidArray(cellDim, pointDim_.data(), pointDim_.size(), 1);
   output->GetPointData()->AddArray(cellDim);
 
   {

--- a/core/vtk/ttkBlank/ttk.module
+++ b/core/vtk/ttkBlank/ttk.module
@@ -6,4 +6,5 @@ HEADERS
   ttkBlank.h
 DEPENDS
   blank
+  ttkAlgorithm
   ttkTriangulationAlgorithm

--- a/core/vtk/ttkBlank/ttkBlank.cpp
+++ b/core/vtk/ttkBlank/ttkBlank.cpp
@@ -1,4 +1,5 @@
 #include <ttkBlank.h>
+#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;
@@ -98,11 +99,12 @@ vtkStandardNewMacro(ttkBlank)
   output->GetPointData()->AddArray(outputScalarField_);
 
   // calling the executing package
-  blank_.setInputDataPointer(inputScalarField->GetVoidPointer(0));
-  blank_.setOutputDataPointer(outputScalarField_->GetVoidPointer(0));
+  blank_.setInputDataPointer(ttkUtils::GetVoidPointer(inputScalarField));
+  blank_.setOutputDataPointer(ttkUtils::GetVoidPointer(outputScalarField_));
 
-  ttk::Triangulation::Type triangulationType = triangulation->getType();
-  int dataType = inputScalarField->GetDataType();
+  // scalar type
+  // ttk::Triangulation::Type triangulationType = triangulation->getType();
+  // int dataType = inputScalarField->GetDataType();
 
   ttkVtkTemplateMacro(
     triangulation->getType(), inputScalarField->GetDataType(),

--- a/core/vtk/ttkCellDataConverter/ttk.module
+++ b/core/vtk/ttkCellDataConverter/ttk.module
@@ -5,4 +5,5 @@ SOURCES
 HEADERS
   ttkCellDataConverter.h
 DEPENDS
+  ttkAlgorithm
   common

--- a/core/vtk/ttkCellDataConverter/ttkCellDataConverter.cpp
+++ b/core/vtk/ttkCellDataConverter/ttkCellDataConverter.cpp
@@ -1,4 +1,5 @@
 #include <ttkCellDataConverter.h>
+#include <ttkUtils.h>
 
 #ifdef _WIN32
 #include <ciso646>
@@ -39,7 +40,7 @@ int ttkCellDataConverter::updateProgress(const float &progress) {
 
 template <typename A, typename B, typename C>
 int ttkCellDataConverter::convert(vtkDataArray *inputData, vtkDataSet *output) {
-  A *input_ptr = static_cast<A *>(inputData->GetVoidPointer(0));
+  A *input_ptr = static_cast<A *>(ttkUtils::GetVoidPointer(inputData));
   int n = inputData->GetNumberOfComponents();
   vtkIdType N = inputData->GetNumberOfTuples();
   B *output_ptr = new B[N * n];

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -1,4 +1,5 @@
 #include <ttkCinemaImaging.h>
+#include <ttkUtils.h>
 
 #include <vtkVersion.h>
 
@@ -289,7 +290,7 @@ int ttkCinemaImaging::RequestData(vtkInformation *request,
         fakeArray->SetName("Fake");
         fakeArray->SetNumberOfComponents(1);
         fakeArray->SetNumberOfTuples(nP);
-        auto fakeArrayData = (signed char *)fakeArray->GetVoidPointer(0);
+        auto fakeArrayData = (signed char *)ttkUtils::GetVoidPointer(fakeArray);
         for(size_t i = 0; i < nP; i++)
           fakeArrayData[i] = 0;
         pd->AddArray(fakeArray);
@@ -370,7 +371,7 @@ int ttkCinemaImaging::RequestData(vtkInformation *request,
                 + "' is not a vtkDoubleArray with three components.");
               return 0;
             }
-            data = (double *)field->GetVoidPointer(0);
+            data = (double *)ttkUtils::GetVoidPointer(field);
             gridFieldNames += " '" + name + "'";
           }
           return 1;

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
@@ -1,4 +1,5 @@
 #include <ttkContinuousScatterPlot.h>
+#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;
@@ -194,8 +195,8 @@ int ttkContinuousScatterPlot::doIt(vector<vtkDataSet *> &inputs,
   continuousScatterPlot.setTriangulation(triangulation_);
   continuousScatterPlot.setResolutions(
     ScatterplotResolution[0], ScatterplotResolution[1]);
-  continuousScatterPlot.setInputScalarField1(inputScalars1_->GetVoidPointer(0));
-  continuousScatterPlot.setInputScalarField2(inputScalars2_->GetVoidPointer(0));
+  continuousScatterPlot.setInputScalarField1(ttkUtils::GetVoidPointer(inputScalars1_));
+  continuousScatterPlot.setInputScalarField2(ttkUtils::GetVoidPointer(inputScalars2_));
   continuousScatterPlot.setScalarMin(scalarMin_);
   continuousScatterPlot.setScalarMax(scalarMax_);
   continuousScatterPlot.setOutputDensity(&density_);

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1,5 +1,7 @@
 #include "ttkContourForests.h"
 
+#include <ttkUtils.h>
+
 using namespace std;
 using namespace ttk;
 using namespace cf;
@@ -1397,7 +1399,7 @@ void ttkContourForests::getTree() {
   // sequential params
   contourTree_.setDebugLevel(debugLevel_);
   contourTree_.setupTriangulation(triangulation_);
-  contourTree_.setVertexScalars(vtkInputScalars_->GetVoidPointer(0));
+  contourTree_.setVertexScalars(ttkUtils::GetVoidPointer(vtkInputScalars_));
   if(!vertexSoSoffsets_.empty()) {
     contourTree_.setVertexSoSoffsets(vertexSoSoffsets_);
   }

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -1,4 +1,5 @@
 #include <ttkDepthImageBasedGeometryApproximation.h>
+#include <ttkUtils.h>
 
 #include <vtkObjectFactory.h> // for new macro
 
@@ -124,7 +125,7 @@ int ttkDepthImageBasedGeometryApproximation::RequestData(
 
           // Output
           (float *)points->GetVoidPointer(0),
-          (vtkIdType *)cells->WritePointer(nTriangles, nTriangles * 4),
+          (vtkIdType *)ttkUtils::WritePointer(cells->GetData(), nTriangles, nTriangles * 4),
           (double *)triangleDistortions->GetVoidPointer(0));
       });
     }

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -125,7 +125,7 @@ int ttkDepthImageBasedGeometryApproximation::RequestData(
 
           // Output
           (float *)points->GetVoidPointer(0),
-          (vtkIdType *)ttkUtils::WritePointer(cells->GetData(), nTriangles, nTriangles * 4),
+          cells->WritePointer(nTriangles, nTriangles * 4),
           (double *)triangleDistortions->GetVoidPointer(0));
       });
     }

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -1,5 +1,7 @@
-#include <regex>
 #include <ttkDimensionReduction.h>
+#include <ttkUtils.h>
+
+#include <regex>
 
 using namespace std;
 using namespace ttk;
@@ -84,7 +86,7 @@ vtkStandardNewMacro(ttkDimensionReduction)
         string s = "Component_" + to_string(i);
         vtkSmartPointer<vtkDoubleArray> arr
           = vtkSmartPointer<vtkDoubleArray>::New();
-        arr->SetVoidArray(outputData_[i].data(), numberOfRows, 1);
+        ttkUtils::SetVoidArray(arr, outputData_[i].data(), numberOfRows, 1);
         arr->SetName(s.data());
         output->AddColumn(arr);
       }

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -276,7 +276,8 @@ int ttkExtract::RequestData(vtkInformation *request,
 
     // Input Topo
     size_t nInCells = inputAsUG->GetNumberOfCells();
-    auto inTopologyData = inputAsUG->GetCells()->GetPointer();
+    auto inTopologyData = static_cast<vtkIdType *>(
+      ttkUtils::GetVoidPointer(inputAsUG->GetCells()->GetData()));
 
     // Marked Points:
     //     -1: does not satisfy condition

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -1,4 +1,5 @@
 #include <ttkFTMTree.h>
+#include <ttkUtils.h>
 
 // only used on the cpp
 #include <vtkConnectivityFilter.h>
@@ -369,7 +370,8 @@ int ttkFTMTree::doIt(vector<vtkDataSet *> &inputs,
 
   // Build tree
   for(int cc = 0; cc < nbCC_; cc++) {
-    ftmTree_[cc].tree.setVertexScalars(inputScalars_[cc]->GetVoidPointer(0));
+    ftmTree_[cc].tree.setVertexScalars(
+      ttkUtils::GetVoidPointer(inputScalars_[cc]));
     ftmTree_[cc].tree.setVertexSoSoffsets(offsets_[cc].data());
     ftmTree_[cc].tree.setTreeType(GetTreeType());
     ftmTree_[cc].tree.setSegmentation(GetWithSegmentation());

--- a/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
+++ b/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
@@ -54,7 +54,8 @@ int ttkIcoSphere::RequestData(vtkInformation *request,
   if(!this->computeIcoSpheres<vtkIdType>(
        nSpheres, nSubdivisions, radius, centers,
        (float *)points->GetVoidPointer(0),
-       (vtkIdType*)ttkUtils::WritePointer(cells->GetData(),nSpheres * nTriangles, nSpheres * nTriangles * 4)))
+       cells->WritePointer(nSpheres * nTriangles, nSpheres * nTriangles * 4)))
+       // (vtkIdType*)ttkUtils::WritePointer(cells->GetData(),nSpheres * nTriangles, nSpheres * nTriangles * 4)))
     return 0;
 
   // finalize output

--- a/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
+++ b/core/vtk/ttkIcoSphere/ttkIcoSphere.cpp
@@ -1,4 +1,5 @@
 #include <ttkIcoSphere.h>
+#include <ttkUtils.h>
 
 #include <vtkDataObject.h> // For port info
 #include <vtkObjectFactory.h> // for new macro
@@ -53,7 +54,7 @@ int ttkIcoSphere::RequestData(vtkInformation *request,
   if(!this->computeIcoSpheres<vtkIdType>(
        nSpheres, nSubdivisions, radius, centers,
        (float *)points->GetVoidPointer(0),
-       cells->WritePointer(nSpheres * nTriangles, nSpheres * nTriangles * 4)))
+       (vtkIdType*)ttkUtils::WritePointer(cells->GetData(),nSpheres * nTriangles, nSpheres * nTriangles * 4)))
     return 0;
 
   // finalize output

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
@@ -1,4 +1,5 @@
 #include <ttkMorseSmaleQuadrangulation.h>
+#include <ttkUtils.h>
 
 #define MODULE_S "[ttkMorseSmaleQuadrangulation] "
 #define MODULE_ERROR_S MODULE_S "Error: "
@@ -149,19 +150,19 @@ int ttkMorseSmaleQuadrangulation::doIt(std::vector<vtkDataSet *> &inputs,
   // quad vertices identifiers
   auto identifiers = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   identifiers->SetName(ttk::VertexScalarFieldName);
-  identifiers->SetVoidArray(outPointsIds.data(), outPointsIds.size(), 1);
+  ttkUtils::SetVoidArray(identifiers, outPointsIds.data(), outPointsIds.size(), 1);
   output->GetPointData()->AddArray(identifiers);
 
   // quad vertices type
   auto type = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   type->SetName("QuadVertType");
-  type->SetVoidArray(outPointsType.data(), outPointsType.size(), 1);
+  ttkUtils::SetVoidArray(type, outPointsType.data(), outPointsType.size(), 1);
   output->GetPointData()->AddArray(type);
 
   // quad vertices cells
   auto cellid = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   cellid->SetName("QuadCellId");
-  cellid->SetVoidArray(outPointsCells.data(), outPointsCells.size(), 1);
+  ttkUtils::SetVoidArray(cellid, outPointsCells.data(), outPointsCells.size(), 1);
   output->GetPointData()->AddArray(cellid);
 
   // vtkCellArray of quadrangle values containing outArray

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -1,4 +1,5 @@
 #include <ttkQuadrangulationSubdivision.h>
+#include <ttkUtils.h>
 
 #define MODULE_S "[ttkQuadrangulationSubdivision] "
 #define MODULE_ERROR_S MODULE_S "Error: "
@@ -149,18 +150,20 @@ int ttkQuadrangulationSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
   // add data array of points valences
   auto valences = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   valences->SetName("Valence");
-  valences->SetVoidArray(outVertexValences.data(), outVertexValences.size(), 1);
+  ttkUtils::SetVoidArray(
+    valences, outVertexValences.data(), outVertexValences.size(), 1);
   output->GetPointData()->AddArray(valences);
 
   // add data array of points infos
   auto infos = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   infos->SetName("Type");
-  infos->SetVoidArray(outVertexType.data(), outVertexType.size(), 1);
+  ttkUtils::SetVoidArray(infos, outVertexType.data(), outVertexType.size(), 1);
   output->GetPointData()->AddArray(infos);
 
   auto subd = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
   subd->SetName("Subdivision");
-  subd->SetVoidArray(outSubdvisionLevel.data(), outSubdvisionLevel.size(), 1);
+  ttkUtils::SetVoidArray(
+    subd, outSubdvisionLevel.data(), outSubdvisionLevel.size(), 1);
   output->GetPointData()->AddArray(subd);
 
   if(RelaxationIterations > 0) {
@@ -170,46 +173,46 @@ int ttkQuadrangulationSubdivision::doIt(std::vector<vtkDataSet *> &inputs,
     // add data array of number of triangles checked
     auto trChecked = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
     trChecked->SetName("Triangles checked");
-    trChecked->SetVoidArray(
-      trianglesChecked.data(), trianglesChecked.size(), 1);
+    ttkUtils::SetVoidArray(
+      trChecked, trianglesChecked.data(), trianglesChecked.size(), 1);
     output->GetPointData()->AddArray(trChecked);
 
     // add data array of projection success
     auto projSucc = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
     projSucc->SetName("Projection");
-    projSucc->SetVoidArray(projSucceeded.data(), projSucceeded.size(), 1);
+    ttkUtils::SetVoidArray(
+      projSucc, projSucceeded.data(), projSucceeded.size(), 1);
     output->GetPointData()->AddArray(projSucc);
   }
 
   if(QuadStatistics) {
     auto quadArea = vtkSmartPointer<vtkFloatArray>::New();
     quadArea->SetName("Quad Area");
-    quadArea->SetVoidArray(
-      baseWorker_.quadArea_.data(), baseWorker_.quadArea_.size(), 1);
+    ttkUtils::SetVoidArray(
+      quadArea, baseWorker_.quadArea_.data(), baseWorker_.quadArea_.size(), 1);
     output->GetCellData()->AddArray(quadArea);
 
     auto diagsRatio = vtkSmartPointer<vtkFloatArray>::New();
     diagsRatio->SetName("Diagonals Ratio");
-    diagsRatio->SetVoidArray(baseWorker_.quadDiagsRatio_.data(),
-                             baseWorker_.quadDiagsRatio_.size(), 1);
+    ttkUtils::SetVoidArray(diagsRatio, baseWorker_.quadDiagsRatio_.data(), baseWorker_.quadDiagsRatio_.size(), 1);
     output->GetCellData()->AddArray(diagsRatio);
 
     auto edgesRatio = vtkSmartPointer<vtkFloatArray>::New();
     edgesRatio->SetName("Edges Ratio");
-    edgesRatio->SetVoidArray(baseWorker_.quadEdgesRatio_.data(),
-                             baseWorker_.quadEdgesRatio_.size(), 1);
+    ttkUtils::SetVoidArray(edgesRatio, baseWorker_.quadEdgesRatio_.data(),
+                           baseWorker_.quadEdgesRatio_.size(), 1);
     output->GetCellData()->AddArray(edgesRatio);
 
     auto anglesRatio = vtkSmartPointer<vtkFloatArray>::New();
     anglesRatio->SetName("Angles Ratio");
-    anglesRatio->SetVoidArray(baseWorker_.quadAnglesRatio_.data(),
-                              baseWorker_.quadAnglesRatio_.size(), 1);
+    ttkUtils::SetVoidArray(anglesRatio, baseWorker_.quadAnglesRatio_.data(),
+                           baseWorker_.quadAnglesRatio_.size(), 1);
     output->GetCellData()->AddArray(anglesRatio);
 
     auto hausDist = vtkSmartPointer<vtkFloatArray>::New();
     hausDist->SetName("Hausdorff");
-    hausDist->SetVoidArray(
-      baseWorker_.hausdorff_.data(), baseWorker_.hausdorff_.size(), 1);
+    ttkUtils::SetVoidArray(hausDist, baseWorker_.hausdorff_.data(),
+                           baseWorker_.hausdorff_.size(), 1);
     output->GetPointData()->AddArray(hausDist);
   }
 

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -692,8 +692,8 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
   //   pointData =
   //     vtkSmartPointer<vtkFloatArray>::New();
   //   pointData->SetNumberOfComponents(3);
-  //   pointData->SetVoidArray(
-  //     triangulationPoints->data(), triangulationPoints->size(), 1);
+  //   ttkUtils::SetVoidArray(
+  //     pointData, triangulationPoints->data(), triangulationPoints->size(), 1);
   //   sheet3Points->SetData(pointData);
   //   sheet3->SetPoints(sheet3Points);
   //
@@ -701,8 +701,8 @@ int ttkReebSpace::doIt(vector<vtkDataSet *> &inputs,
   //     = vtkSmartPointer<vtkCellArray>::New();
   //   vtkSmartPointer<ttkSimplexIdTypeArray> idArray
   //     = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-  //   idArray->SetVoidArray(
-  //     triangulationCells->data(), triangulationCells->size(), 1);
+  //   ttkUtils::SetVoidArray(
+  //     idArray, triangulationCells->data(), triangulationCells->size(), 1);
   //   sheet3Cells->SetCells(triangulationCells->size()/5, idArray);
   //   sheet3->SetCells(VTK_TETRA, sheet3Cells);
 

--- a/core/vtk/ttkTriangulationAlgorithm/ttk.module
+++ b/core/vtk/ttkTriangulationAlgorithm/ttk.module
@@ -12,3 +12,4 @@ HEADERS
   macro.h
 DEPENDS
   triangulation
+  ttkAlgorithm

--- a/core/vtk/ttkTriangulationAlgorithm/ttkTriangulation.cpp
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkTriangulation.cpp
@@ -199,13 +199,12 @@ int ttkTriangulation::setInputData(vtkDataSet *dataSet) {
         case VTK_FLOAT:
           triangulation_->setInputPoints(
             vtuDataSet->GetNumberOfPoints(),
-            vtuDataSet->GetPoints()->GetVoidPointer(0));
+            ttkUtils::GetVoidPointer(vtuDataSet->GetPoints()->GetData()));
           break;
         case VTK_DOUBLE:
           triangulation_->setInputPoints(
             vtuDataSet->GetNumberOfPoints(),
-            vtuDataSet->GetPoints()->GetVoidPointer(0),
-            true);
+            ttkUtils::GetVoidPointer(vtuDataSet->GetPoints()->GetData()), true);
         default:
           stringstream msg;
           msg << "[ttkTriangulation] Unsupported precision for input points!"
@@ -239,12 +238,12 @@ int ttkTriangulation::setInputData(vtkDataSet *dataSet) {
         case VTK_FLOAT:
           triangulation_->setInputPoints(
             vtpDataSet->GetNumberOfPoints(),
-            vtpDataSet->GetPoints()->GetVoidPointer(0));
+            ttkUtils::GetVoidPointer(vtpDataSet->GetPoints()->GetData()));
           break;
         case VTK_DOUBLE:
           triangulation_->setInputPoints(
             vtpDataSet->GetNumberOfPoints(),
-            vtpDataSet->GetPoints()->GetVoidPointer(0), true);
+            ttkUtils::GetVoidPointer(vtpDataSet->GetPoints()->GetData()), true);
           break;
         default:
           stringstream msg;

--- a/core/vtk/ttkTriangulationAlgorithm/ttkTriangulation.cpp
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkTriangulation.cpp
@@ -1,5 +1,6 @@
 #include <ttkTriangulation.h>
 #include <ttkTriangulationAlgorithm.h>
+#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;
@@ -188,74 +189,87 @@ int ttkTriangulation::setInputData(vtkDataSet *dataSet) {
     allocate();
   }
 
-  if((dataSet->GetDataObjectType() == VTK_UNSTRUCTURED_GRID)) {
+  if(dataSet->GetDataObjectType() == VTK_UNSTRUCTURED_GRID) {
 
-    if(((vtkUnstructuredGrid *)dataSet)->GetPoints()) {
-      if(((vtkUnstructuredGrid *)dataSet)->GetPoints()->GetDataType()
-         == VTK_FLOAT) {
-        triangulation_->setInputPoints(
-          dataSet->GetNumberOfPoints(),
-          ((vtkUnstructuredGrid *)dataSet)->GetPoints()->GetVoidPointer(0));
-      } else if(((vtkUnstructuredGrid *)dataSet)->GetPoints()->GetDataType()
-                == VTK_DOUBLE) {
-        triangulation_->setInputPoints(
-          dataSet->GetNumberOfPoints(),
-          ((vtkUnstructuredGrid *)dataSet)->GetPoints()->GetVoidPointer(0),
-          true);
-      } else {
-        stringstream msg;
-        msg << "[ttkTriangulation] Unsupported precision for input points!"
-            << endl;
-        dMsg(cerr, msg.str(), Debug::fatalMsg);
+    auto vtuDataSet = vtkUnstructuredGrid::SafeDownCast(dataSet);
+
+    // Points
+    if(vtuDataSet->GetPoints()) {
+      switch(vtuDataSet->GetPoints()->GetDataType()) {
+        case VTK_FLOAT:
+          triangulation_->setInputPoints(
+            vtuDataSet->GetNumberOfPoints(),
+            vtuDataSet->GetPoints()->GetVoidPointer(0));
+          break;
+        case VTK_DOUBLE:
+          triangulation_->setInputPoints(
+            vtuDataSet->GetNumberOfPoints(),
+            vtuDataSet->GetPoints()->GetVoidPointer(0),
+            true);
+        default:
+          stringstream msg;
+          msg << "[ttkTriangulation] Unsupported precision for input points!"
+              << endl;
+          dMsg(cerr, msg.str(), Debug::fatalMsg);
+          break;
       }
     }
-    if(((vtkUnstructuredGrid *)dataSet)->GetCells()) {
+
+    // Cells
+    if(vtuDataSet->GetCells()) {
+
+      auto cellsData = static_cast<LongSimplexId *>(
+        ttkUtils::GetVoidPointer(vtuDataSet->GetCells()->GetData(), 0));
 #if !defined(_WIN32) || defined(_WIN32) && defined(VTK_USE_64BIT_IDS)
-      triangulation_->setInputCells(
-        dataSet->GetNumberOfCells(),
-        ((vtkUnstructuredGrid *)dataSet)->GetCells()->GetPointer());
+      triangulation_->setInputCells(vtuDataSet->GetNumberOfCells(), cellsData);
 #else
-      int *pt = ((vtkUnstructuredGrid *)dataSet)->GetCells()->GetPointer();
-      long long extra_pt = *pt;
-      triangulation_->setInputCells(dataSet->GetNumberOfCells(), &extra_pt);
+      auto extra_pt = reinterpret_cast<long long*>(cellsData);
+      triangulation_->setInputCells(dataSet->GetNumberOfCells(), extra_pt);
 #endif
     }
-    inputDataSet_ = dataSet;
-  } else if((dataSet->GetDataObjectType() == VTK_POLY_DATA)) {
+    inputDataSet_ = vtuDataSet;
 
-    if(((vtkPolyData *)dataSet)->GetPoints()) {
-      if(((vtkPolyData *)dataSet)->GetPoints()->GetDataType() == VTK_FLOAT) {
-        triangulation_->setInputPoints(
-          dataSet->GetNumberOfPoints(),
-          ((vtkPolyData *)dataSet)->GetPoints()->GetVoidPointer(0));
-      } else if(((vtkPolyData *)dataSet)->GetPoints()->GetDataType()
-                == VTK_DOUBLE) {
-        triangulation_->setInputPoints(
-          dataSet->GetNumberOfPoints(),
-          ((vtkPolyData *)dataSet)->GetPoints()->GetVoidPointer(0), true);
-      } else {
-        stringstream msg;
-        msg << "[ttkTriangulation] Unsupported precision for input points!"
-            << endl;
-        dMsg(cerr, msg.str(), Debug::fatalMsg);
+  } else if(dataSet->GetDataObjectType() == VTK_POLY_DATA) {
+
+    auto vtpDataSet = vtkPolyData::SafeDownCast(dataSet);
+
+    // Points
+    if(vtpDataSet->GetPoints()) {
+      switch(vtpDataSet->GetPoints()->GetDataType()) {
+        case VTK_FLOAT:
+          triangulation_->setInputPoints(
+            vtpDataSet->GetNumberOfPoints(),
+            vtpDataSet->GetPoints()->GetVoidPointer(0));
+          break;
+        case VTK_DOUBLE:
+          triangulation_->setInputPoints(
+            vtpDataSet->GetNumberOfPoints(),
+            vtpDataSet->GetPoints()->GetVoidPointer(0), true);
+          break;
+        default:
+          stringstream msg;
+          msg << "[ttkTriangulation] Unsupported precision for input points!"
+              << endl;
+          dMsg(cerr, msg.str(), Debug::fatalMsg);
+          break;
       }
-      triangulation_->setInputPoints(
-        dataSet->GetNumberOfPoints(),
-        (float *)((vtkPolyData *)dataSet)->GetPoints()->GetVoidPointer(0));
     }
 
-    if(((vtkPolyData *)dataSet)->GetPolys()) {
+    // Cells
+    if(vtpDataSet->GetPolys()) {
+      auto polysData = static_cast<LongSimplexId *>(
+        ttkUtils::GetVoidPointer(vtpDataSet->GetPolys()->GetData(), 0));
+      auto linesData = static_cast<LongSimplexId *>(
+        ttkUtils::GetVoidPointer(vtpDataSet->GetPolys()->GetData(), 0));
 #if !defined(_WIN32) || defined(_WIN32) && defined(VTK_USE_64BIT_IDS)
-      if(((vtkPolyData *)dataSet)->GetPolys()->GetPointer()) {
+      if(polysData) {
         // 2D
         triangulation_->setInputCells(
-          dataSet->GetNumberOfCells(),
-          ((vtkPolyData *)dataSet)->GetPolys()->GetPointer());
-      } else if(((vtkPolyData *)dataSet)->GetLines()->GetPointer()) {
+          vtpDataSet->GetNumberOfCells(), polysData);
+      } else if(linesData) {
         // 1D
         triangulation_->setInputCells(
-          dataSet->GetNumberOfCells(),
-          ((vtkPolyData *)dataSet)->GetLines()->GetPointer());
+          vtpDataSet->GetNumberOfCells(), linesData);
       }
 #else
       int *pt = ((vtkPolyData *)dataSet)->GetPolys()->GetPointer();
@@ -263,25 +277,28 @@ int ttkTriangulation::setInputData(vtkDataSet *dataSet) {
         // 1D
         pt = ((vtkPolyData *)dataSet)->GetLines()->GetPointer();
       }
-      long long extra_pt = *pt;
-      triangulation_->setInputCells(dataSet->GetNumberOfCells(), &extra_pt);
+      auto extra_pt
+        = reinterpret_cast<long long *>(polysData ? polysData : linesData);
+      triangulation_->setInputCells(dataSet->GetNumberOfCells(), extra_pt);
 #endif
     }
-    inputDataSet_ = dataSet;
+    inputDataSet_ = vtpDataSet;
+
   } else if((dataSet->GetDataObjectType() == VTK_IMAGE_DATA)) {
-    vtkImageData *imageData = (vtkImageData *)dataSet;
+
+    auto vtiData = vtkImageData::SafeDownCast(dataSet);
 
     int extents[6];
-    imageData->GetExtent(extents);
+    vtiData->GetExtent(extents);
 
     double origin[3];
-    imageData->GetOrigin(origin);
+    vtiData->GetOrigin(origin);
 
     double spacing[3];
-    imageData->GetSpacing(spacing);
+    vtiData->GetSpacing(spacing);
 
     int gridDimensions[3];
-    imageData->GetDimensions(gridDimensions);
+    vtiData->GetDimensions(gridDimensions);
 
     double firstPoint[3];
     firstPoint[0] = origin[0] + extents[0] * spacing[0];

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -24,7 +24,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   double *tempd;
   vtkCellArray *cells;
   vtkIdType npts = 0;
-  vtkIdType *indx = 0;
+  vtkIdType const *indx = 0;
   int pointDataWritten = 0;
   vtkPolyDataMapper *pm;
   vtkUnsignedCharArray *colors;
@@ -454,7 +454,7 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
       fprintf(fp, "          texCoordIndex[\n");
       vtkCellArray *cells = ttkWRLExporterPolyData_->GetPolys();
       vtkIdType npts = 0;
-      vtkIdType *indx = NULL;
+      vtkIdType const *indx = NULL;
       for(cells->InitTraversal(); cells->GetNextCell(npts, indx);) {
         fprintf(fp, "            ");
         for(int i = 0; i < npts; i++) {

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -24,7 +24,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   double *tempd;
   vtkCellArray *cells;
   vtkIdType npts = 0;
-  vtkIdType const *indx = 0;
+  vtkIdType *indx = 0;
   int pointDataWritten = 0;
   vtkPolyDataMapper *pm;
   vtkUnsignedCharArray *colors;
@@ -454,7 +454,7 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
       fprintf(fp, "          texCoordIndex[\n");
       vtkCellArray *cells = ttkWRLExporterPolyData_->GetPolys();
       vtkIdType npts = 0;
-      vtkIdType const *indx = NULL;
+      vtkIdType *indx = NULL;
       for(cells->InitTraversal(); cells->GetNextCell(npts, indx);) {
         fprintf(fp, "            ");
         for(int i = 0; i < npts; i++) {


### PR DESCRIPTION
Dear Julien,

This PR contains the quick version for the `GetVoidPointer` fix.
It contains a helper function that emulate functions removed from VTK for when AOS is used:
* [x] GetVoidPointer
* [x] WritePointer ( :warning: vtkCellData changes in VTK 9, do not use `cells->GetData()` directly)
* [x] _SetVoidArray_

This PR is a step toward VTK 9 but is not enough.

Performance are not affected by these changes.

Best,
Charles