### PR TITLE
Fix infinite loop in DiscreteGradient when returning saddle connectors

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -465,6 +465,7 @@ int DiscreteGradient::getDescendingPathThroughWall(
   const Cell &saddle1,
   const vector<wallId_t> &isVisited,
   vector<Cell> *const vpath,
+  const bool stopIfMultiConnected,
   const bool enableCycleDetector) const {
   // debug
   const SimplexId numberOfEdges = inputTriangulation_->getNumberOfEdges();
@@ -498,7 +499,7 @@ int DiscreteGradient::getDescendingPathThroughWall(
           ++nconnections;
         }
       }
-      if(nconnections > 1) {
+      if(stopIfMultiConnected && nconnections > 1) {
         return 1;
       }
     }
@@ -552,7 +553,7 @@ int DiscreteGradient::getDescendingPathThroughWall(
           ++nconnections;
         }
       }
-      if(nconnections > 1) {
+      if(stopIfMultiConnected && nconnections > 1) {
         return 1;
       }
 
@@ -685,6 +686,7 @@ bool DiscreteGradient::getAscendingPathThroughWall(
   const Cell &saddle2,
   const vector<wallId_t> &isVisited,
   vector<Cell> *const vpath,
+  const bool stopIfMultiConnected,
   const bool enableCycleDetector) const {
   // debug
   const SimplexId numberOfTriangles
@@ -721,7 +723,7 @@ bool DiscreteGradient::getAscendingPathThroughWall(
           ++nconnections;
         }
       }
-      if(nconnections > 1) {
+      if(stopIfMultiConnected && nconnections > 1) {
         return true;
       }
     }
@@ -777,7 +779,7 @@ bool DiscreteGradient::getAscendingPathThroughWall(
           ++nconnections;
         }
       }
-      if(nconnections > 1) {
+      if(stopIfMultiConnected && nconnections > 1) {
         return true;
       }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -765,6 +765,7 @@ bool DiscreteGradient::getAscendingPathThroughWall(
         break;
       }
 
+      int nconnections = 0;
       const SimplexId triangleNumber
         = inputTriangulation_->getEdgeTriangleNumber(connectedEdgeId);
       for(SimplexId i = 0; i < triangleNumber; ++i) {
@@ -773,7 +774,11 @@ bool DiscreteGradient::getAscendingPathThroughWall(
 
         if(isVisited[triangleId] == wallId and triangleId != oldId) {
           currentId = triangleId;
+          ++nconnections;
         }
+      }
+      if(nconnections > 1) {
+        return true;
       }
 
       // stop at convergence caused by boundary effect

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -481,6 +481,7 @@ int DiscreteGradient::getDescendingPathThroughWall(
 
     SimplexId currentId = -1;
     {
+      int nconnections = 0;
       for(int i = 0; i < 3; ++i) {
         SimplexId edgeId;
         inputTriangulation_->getTriangleEdge(saddle2.id_, i, edgeId);
@@ -494,7 +495,11 @@ int DiscreteGradient::getDescendingPathThroughWall(
           }
 
           currentId = edgeId;
+          ++nconnections;
         }
+      }
+      if(nconnections > 1) {
+        return 1;
       }
     }
 
@@ -537,13 +542,18 @@ int DiscreteGradient::getDescendingPathThroughWall(
         break;
       }
 
+      int nconnections = 0;
       for(int i = 0; i < 3; ++i) {
         SimplexId edgeId;
         inputTriangulation_->getTriangleEdge(connectedTriangleId, i, edgeId);
 
         if(isVisited[edgeId] == wallId and edgeId != oldId) {
           currentId = edgeId;
+          ++nconnections;
         }
+      }
+      if(nconnections > 1) {
+        return 1;
       }
 
       // stop at convergence caused by boundary effect
@@ -692,6 +702,7 @@ bool DiscreteGradient::getAscendingPathThroughWall(
 
     SimplexId currentId = -1;
     {
+      int nconnections = 0;
       const SimplexId triangleNumber
         = inputTriangulation_->getEdgeTriangleNumber(saddle1.id_);
       for(SimplexId i = 0; i < triangleNumber; ++i) {
@@ -707,7 +718,11 @@ bool DiscreteGradient::getAscendingPathThroughWall(
           }
 
           currentId = triangleId;
+          ++nconnections;
         }
+      }
+      if(nconnections > 1) {
+        return true;
       }
     }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -459,7 +459,7 @@ int DiscreteGradient::getDescendingPath(const Cell &cell,
   return 0;
 }
 
-int DiscreteGradient::getDescendingPathThroughWall(
+bool DiscreteGradient::getDescendingPathThroughWall(
   const wallId_t wallId,
   const Cell &saddle2,
   const Cell &saddle1,
@@ -500,7 +500,7 @@ int DiscreteGradient::getDescendingPathThroughWall(
         }
       }
       if(stopIfMultiConnected && nconnections > 1) {
-        return 1;
+        return true;
       }
     }
 
@@ -554,14 +554,14 @@ int DiscreteGradient::getDescendingPathThroughWall(
         }
       }
       if(stopIfMultiConnected && nconnections > 1) {
-        return 1;
+        return true;
       }
 
       // stop at convergence caused by boundary effect
     } while(currentId != oldId);
   }
 
-  return 0;
+  return false;
 }
 
 int DiscreteGradient::getAscendingPath(const Cell &cell,

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -986,6 +986,7 @@ in the gradient.
                                        const Cell &saddle1,
                                        const std::vector<wallId_t> &isVisited,
                                        std::vector<Cell> *const vpath,
+                                       const bool stopIfMultiConnected = false,
                                        const bool enableCycleDetector
                                        = false) const;
 
@@ -998,6 +999,7 @@ in the gradient.
                                        const Cell &saddle2,
                                        const std::vector<wallId_t> &isVisited,
                                        std::vector<Cell> *const vpath,
+                                       const bool stopIfMultiConnected = false,
                                        const bool enableCycleDetector
                                        = false) const;
 

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -981,14 +981,14 @@ in the gradient.
        * Return the VPath terminating at the given 2-saddle restricted to the
 2-separatrice of the 1-saddle.
        */
-      int getDescendingPathThroughWall(const wallId_t wallId,
-                                       const Cell &saddle2,
-                                       const Cell &saddle1,
-                                       const std::vector<wallId_t> &isVisited,
-                                       std::vector<Cell> *const vpath,
-                                       const bool stopIfMultiConnected = false,
-                                       const bool enableCycleDetector
-                                       = false) const;
+      bool getDescendingPathThroughWall(const wallId_t wallId,
+                                        const Cell &saddle2,
+                                        const Cell &saddle1,
+                                        const std::vector<wallId_t> &isVisited,
+                                        std::vector<Cell> *const vpath,
+                                        const bool stopIfMultiConnected = false,
+                                        const bool enableCycleDetector
+                                        = false) const;
 
       /**
        * Return the VPath coming from the given 1-saddle restricted to the

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -896,7 +896,7 @@ int DiscreteGradient::initializeSaddleSaddleConnections1(
 
       std::vector<Cell> path;
       const bool isMultiConnected = getAscendingPathThroughWall(
-        savedDescendingWallId, saddle1, saddle2, isVisited, &path);
+        savedDescendingWallId, saddle1, saddle2, isVisited, &path, true);
 
       if(!isMultiConnected) {
         const SimplexId sourceIndex = saddle1Index[saddle1Id];
@@ -1051,7 +1051,7 @@ int DiscreteGradient::processSaddleSaddleConnections1(
       // check if there is multiple connections
       std::vector<Cell> path;
       const bool isMultiConnected = getAscendingPathThroughWall(
-        savedWallId, minSaddle1, minSaddle2, isVisited, &path);
+        savedWallId, minSaddle1, minSaddle2, isVisited, &path, true);
       if(isMultiConnected) {
         ++numberOfIterations;
         continue;
@@ -1264,7 +1264,7 @@ int DiscreteGradient::processSaddleSaddleConnections1(
 
           std::vector<Cell> path;
           const bool isMultiConnected = getAscendingPathThroughWall(
-            savedWallId, saddle1, saddle2, isVisited, &path);
+            savedWallId, saddle1, saddle2, isVisited, &path, true);
           if(isMultiConnected) {
             continue;
           }
@@ -1318,7 +1318,7 @@ int DiscreteGradient::processSaddleSaddleConnections1(
 
           std::vector<Cell> path;
           const bool isMultiConnected = getDescendingPathThroughWall(
-            savedWallId, saddle2, saddle1, isVisited, &path);
+            savedWallId, saddle2, saddle1, isVisited, &path, true);
           if(isMultiConnected) {
             continue;
           }
@@ -1504,7 +1504,7 @@ int DiscreteGradient::initializeSaddleSaddleConnections2(
 
       std::vector<Cell> path;
       const bool isMultiConnected = getDescendingPathThroughWall(
-        savedAscendingWallId, saddle2, saddle1, isVisited, &path);
+        savedAscendingWallId, saddle2, saddle1, isVisited, &path, true);
 
       if(!isMultiConnected) {
         const SimplexId destinationIndex = saddle2Index[saddle2Id];
@@ -1665,7 +1665,7 @@ int DiscreteGradient::processSaddleSaddleConnections2(
       // check if there is multiple connections
       std::vector<Cell> path;
       const bool isMultiConnected = getDescendingPathThroughWall(
-        savedWallId, minSaddle2, minSaddle1, isVisited, &path);
+        savedWallId, minSaddle2, minSaddle1, isVisited, &path, true);
       if(isMultiConnected) {
         ++numberOfIterations;
         continue;
@@ -1875,7 +1875,7 @@ int DiscreteGradient::processSaddleSaddleConnections2(
           const Cell saddle2(2, saddle2Id);
 
           const bool isMultiConnected = getDescendingPathThroughWall(
-            savedWallId, saddle2, saddle1, isVisited, nullptr);
+            savedWallId, saddle2, saddle1, isVisited, nullptr, true);
           if(isMultiConnected) {
             continue;
           }
@@ -1930,7 +1930,7 @@ int DiscreteGradient::processSaddleSaddleConnections2(
 
           std::vector<Cell> path;
           const bool isMultiConnected = getAscendingPathThroughWall(
-            savedWallId, saddle1, saddle2, isVisited, &path);
+            savedWallId, saddle1, saddle2, isVisited, &path, true);
           if(isMultiConnected) {
             continue;
           }


### PR DESCRIPTION
The current PR reverts is a new take on the missing separatrices issue in  the morseMolecule state file. The previous solution is causing infinite loops when returning saddle connectors for some data sets.

It's the removal of  the `nconnections` early returns in `getAscendingPathThroughWall` and `getDescendingPathThroughWall` to fix the missing dependencies in morseMolecule that has been causing those infinite loops.

The current solution is to keep the `nconnections` early returns and to introduce a new boolean parameter, by default set to false, to activate those early returns, especially when computing saddle connectors.

No change to the morseMolecule state file so far.

As a bonus, I made the `getDescendingPathThroughWall` method return bool instead of int, to make it more similar to the other `getAscendingPathThroughWall` method.

Pierre