### PR TITLE
Refactor Triangulation method signatures

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -19,6 +19,12 @@
 #include <array>
 #include <ostream>
 
+#ifdef TTK_ENABLE_KAMIKAZE
+#define TTK_TRIANGULATION_INTERNAL(NAME) NAME
+#else
+#define TTK_TRIANGULATION_INTERNAL(NAME) NAME##Internal
+#endif // TTK_ENABLE_KAMIKAZE
+
 #define ttkTemplateMacroCase(triangulationType, triangulationClass, call) \
   case triangulationType: {                                               \
     typedef triangulationClass TTK_TT;                                    \

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -1753,7 +1753,7 @@ namespace ttk {
 
     /// Check if the data structure is empty or not.
     /// \return Returns true if empty, false otherwise.
-    virtual inline bool isEmpty() {
+    virtual inline bool isEmpty() const {
       return true;
     };
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -52,7 +52,8 @@ namespace ttk {
       return cellEdgeList_[cellId].size();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *getCellEdgesInternal() {
+    inline const std::vector<std::vector<SimplexId>> *
+      getCellEdgesInternal() override {
 
       return &cellEdgeList_;
     }
@@ -251,7 +252,8 @@ namespace ttk {
 #ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *getEdgeStars() override {
 #else
-    inline const std::vector<std::vector<SimplexId>> *getEdgeStarsInternal() {
+    inline const std::vector<std::vector<SimplexId>> *
+      getEdgeStarsInternal() override {
 #endif
       return &edgeStarList_;
     }
@@ -634,7 +636,7 @@ namespace ttk {
       getVertexStarNumber(const SimplexId &vertexId) const override {
 #else
     inline SimplexId
-      getVertexStarNumberInternal(const SimplexId &vertexId) const {
+      getVertexStarNumberInternal(const SimplexId &vertexId) const override {
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexStarList_.size()))
         return -1;
 #endif
@@ -694,7 +696,7 @@ namespace ttk {
       return boundaryEdges_[edgeId];
     }
 
-    inline bool isEmpty() const {
+    inline bool isEmpty() const override {
       return !vertexNumber_;
     }
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -58,14 +58,11 @@ namespace ttk {
       return &cellEdgeList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getCellNeighbor(const SimplexId &cellId,
-                               const int &localNeighborId,
-                               SimplexId &neighborId) const override {
-#else
-    inline int getCellNeighborInternal(const SimplexId &cellId,
-                                       const int &localNeighborId,
-                                       SimplexId &neighborId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
+      const SimplexId &cellId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellNeighborList_.size()))
         return -1;
       if((localNeighborId < 0)
@@ -76,25 +73,17 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getCellNeighborNumber(const SimplexId &cellId) const override {
-#else
-    inline SimplexId
-      getCellNeighborNumberInternal(const SimplexId &cellId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getCellNeighborNumber)(
+      const SimplexId &cellId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= (SimplexId)cellNeighborList_.size()))
         return -1;
 #endif
       return cellNeighborList_[cellId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getCellNeighbors() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getCellNeighborsInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getCellNeighbors)() override {
       return &cellNeighborList_;
     }
 
@@ -131,14 +120,11 @@ namespace ttk {
       return &cellTriangleList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getCellVertex(const SimplexId &cellId,
-                             const int &localVertexId,
-                             SimplexId &vertexId) const override {
-#else
-    inline int getCellVertexInternal(const SimplexId &cellId,
-                                     const int &localVertexId,
-                                     SimplexId &vertexId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getCellVertex)(
+      const SimplexId &cellId,
+      const int &localVertexId,
+      SimplexId &vertexId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= cellNumber_))
         return -1;
       if((localVertexId < 0) || (localVertexId >= cellArray_[0]))
@@ -148,12 +134,9 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getCellVertexNumber(const SimplexId &cellId) const override {
-#else
-    inline SimplexId
-      getCellVertexNumberInternal(const SimplexId &cellId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getCellVertexNumber)(
+      const SimplexId &cellId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((cellId < 0) || (cellId >= cellNumber_))
         return -1;
       if((!cellArray_) || (!cellNumber_))
@@ -162,34 +145,24 @@ namespace ttk {
       return cellArray_[0];
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getDimensionality() const override {
-#else
-    int getDimensionalityInternal() const override {
+    int TTK_TRIANGULATION_INTERNAL(getDimensionality)() const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if(!((cellArray_) && (cellNumber_)))
         return -1;
 #endif
       return cellArray_[0] - 1;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::pair<SimplexId, SimplexId>> *
-      getEdges() override {
-#else
-    inline const std::vector<std::pair<SimplexId, SimplexId>> *
-      getEdgesInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getEdges)() override {
       return &edgeList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getEdgeLink(const SimplexId &edgeId,
-                           const int &localLinkId,
-                           SimplexId &linkId) const override {
-#else
-    inline int getEdgeLinkInternal(const SimplexId &edgeId,
-                                   const int &localLinkId,
-                                   SimplexId &linkId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
+      const SimplexId &edgeId,
+      const int &localLinkId,
+      SimplexId &linkId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeLinkList_.size()))
         return -1;
       if((localLinkId < 0)
@@ -200,34 +173,25 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override {
-#else
-    inline SimplexId
-      getEdgeLinkNumberInternal(const SimplexId &edgeId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
+      const SimplexId &edgeId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeLinkList_.size()))
         return -1;
 #endif
       return edgeLinkList_[edgeId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() override {
-#else
     inline const std::vector<std::vector<SimplexId>> *
-      getEdgeLinksInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() override {
       return &edgeLinkList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getEdgeStar(const SimplexId &edgeId,
-                           const int &localStarId,
-                           SimplexId &starId) const override {
-#else
-    inline int getEdgeStarInternal(const SimplexId &edgeId,
-                                   const int &localStarId,
-                                   SimplexId &starId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
+      const SimplexId &edgeId,
+      const int &localStarId,
+      SimplexId &starId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeStarList_.size()))
         return -1;
       if((localStarId < 0)
@@ -238,23 +202,17 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override {
-#else
-    inline SimplexId
-      getEdgeStarNumberInternal(const SimplexId &edgeId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+      const SimplexId &edgeId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)edgeStarList_.size()))
         return -1;
 #endif
       return edgeStarList_[edgeId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline const std::vector<std::vector<SimplexId>> *getEdgeStars() override {
-#else
     inline const std::vector<std::vector<SimplexId>> *
-      getEdgeStarsInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getEdgeStars)() override {
       return &edgeStarList_;
     }
 
@@ -308,11 +266,8 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId getNumberOfCells() const override {
-#else
-    inline SimplexId getNumberOfCellsInternal() const override {
-#endif
+    inline SimplexId
+      TTK_TRIANGULATION_INTERNAL(getNumberOfCells)() const override {
       return cellNumber_;
     }
 
@@ -324,20 +279,13 @@ namespace ttk {
       return triangleList_.size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId getNumberOfVertices() const override {
-#else
-    inline SimplexId getNumberOfVerticesInternal() const override {
-#endif
+    inline SimplexId
+      TTK_TRIANGULATION_INTERNAL(getNumberOfVertices)() const override {
       return vertexNumber_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline const std::vector<std::vector<SimplexId>> *getTriangles() override {
-#else
     inline const std::vector<std::vector<SimplexId>> *
-      getTrianglesInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getTriangles)() override {
       return &triangleList_;
     }
 
@@ -376,14 +324,11 @@ namespace ttk {
       return &triangleEdgeList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getTriangleLink(const SimplexId &triangleId,
-                               const int &localLinkId,
-                               SimplexId &linkId) const override {
-#else
-    inline int getTriangleLinkInternal(const SimplexId &triangleId,
-                                       const int &localLinkId,
-                                       SimplexId &linkId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
+      const SimplexId &triangleId,
+      const int &localLinkId,
+      SimplexId &linkId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleLinkList_.size()))
         return -1;
@@ -395,12 +340,9 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getTriangleLinkNumber(const SimplexId &triangleId) const override {
-#else
-    inline SimplexId getTriangleLinkNumberInternal(
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
       const SimplexId &triangleId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleLinkList_.size()))
         return -1;
@@ -408,24 +350,16 @@ namespace ttk {
       return triangleLinkList_[triangleId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getTriangleLinks() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getTriangleLinksInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() override {
       return &triangleLinkList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getTriangleStar(const SimplexId &triangleId,
-                               const int &localStarId,
-                               SimplexId &starId) const override {
-#else
-    inline int getTriangleStarInternal(const SimplexId &triangleId,
-                                       const int &localStarId,
-                                       SimplexId &starId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
+      const SimplexId &triangleId,
+      const int &localStarId,
+      SimplexId &starId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleStarList_.size()))
         return -1;
@@ -437,12 +371,9 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getTriangleStarNumber(const SimplexId &triangleId) const override {
-#else
-    inline SimplexId getTriangleStarNumberInternal(
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
       const SimplexId &triangleId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)triangleStarList_.size()))
         return -1;
@@ -450,13 +381,8 @@ namespace ttk {
       return triangleStarList_[triangleId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getTriangleStars() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getTriangleStarsInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getTriangleStars)() override {
       return &triangleStarList_;
     }
 
@@ -503,14 +429,11 @@ namespace ttk {
       return &vertexEdgeList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getVertexLink(const SimplexId &vertexId,
-                             const int &localLinkId,
-                             SimplexId &linkId) const override {
-#else
-    inline int getVertexLinkInternal(const SimplexId &vertexId,
-                                     const int &localLinkId,
-                                     SimplexId &linkId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
+      const SimplexId &vertexId,
+      const int &localLinkId,
+      SimplexId &linkId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexLinkList_.size()))
         return -1;
       if((localLinkId < 0)
@@ -522,37 +445,25 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getVertexLinkNumber(const SimplexId &vertexId) const override {
-#else
-    inline SimplexId
-      getVertexLinkNumberInternal(const SimplexId &vertexId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
+      const SimplexId &vertexId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexLinkList_.size()))
         return -1;
 #endif
       return vertexLinkList_[vertexId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getVertexLinks() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getVertexLinksInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexLinks)() override {
       return &vertexLinkList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getVertexNeighbor(const SimplexId &vertexId,
-                                 const int &localNeighborId,
-                                 SimplexId &neighborId) const override {
-#else
-    inline int getVertexNeighborInternal(const SimplexId &vertexId,
-                                         const int &localNeighborId,
-                                         SimplexId &neighborId) const override {
-
+    inline int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
+      const SimplexId &vertexId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexNeighborList_.size()))
         return -1;
       if((localNeighborId < 0)
@@ -564,38 +475,23 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getVertexNeighborNumber(const SimplexId &vertexId) const override {
-#else
-    inline SimplexId getVertexNeighborNumberInternal(
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
       const SimplexId &vertexId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
         return -1;
 #endif
       return vertexNeighborList_[vertexId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getVertexNeighbors() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getVertexNeighborsInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() override {
       return &vertexNeighborList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getVertexPoint(const SimplexId &vertexId,
-                              float &x,
-                              float &y,
-                              float &z) const override {
-#else
-    inline int getVertexPointInternal(const SimplexId &vertexId,
-                                      float &x,
-                                      float &y,
-                                      float &z) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
+      const SimplexId &vertexId, float &x, float &y, float &z) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
         return -1;
 #endif
@@ -613,14 +509,11 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline int getVertexStar(const SimplexId &vertexId,
-                             const int &localStarId,
-                             SimplexId &starId) const override {
-#else
-    inline int getVertexStarInternal(const SimplexId &vertexId,
-                                     const int &localStarId,
-                                     SimplexId &starId) const override {
+    inline int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
+      const SimplexId &vertexId,
+      const int &localStarId,
+      SimplexId &starId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexStarList_.size()))
         return -1;
       if((localStarId < 0)
@@ -631,25 +524,17 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getVertexStarNumber(const SimplexId &vertexId) const override {
-#else
-    inline SimplexId
-      getVertexStarNumberInternal(const SimplexId &vertexId) const override {
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
+      const SimplexId &vertexId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)vertexStarList_.size()))
         return -1;
 #endif
       return vertexStarList_[vertexId].size();
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
     inline const std::vector<std::vector<SimplexId>> *
-      getVertexStars() override {
-#else
-    inline const std::vector<std::vector<SimplexId>> *
-      getVertexStarsInternal() override {
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexStars)() override {
       return &vertexStarList_;
     }
 
@@ -685,11 +570,9 @@ namespace ttk {
       return &vertexTriangleList_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline bool isEdgeOnBoundary(const SimplexId &edgeId) const override {
-#else
-    inline bool
-      isEdgeOnBoundaryInternal(const SimplexId &edgeId) const override {
+    inline bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
+      const SimplexId &edgeId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((edgeId < 0) || (edgeId >= (SimplexId)boundaryEdges_.size()))
         return false;
 #endif
@@ -700,12 +583,9 @@ namespace ttk {
       return !vertexNumber_;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline bool
-      isTriangleOnBoundary(const SimplexId &triangleId) const override {
-#else
-    inline bool
-      isTriangleOnBoundaryInternal(const SimplexId &triangleId) const override {
+    inline bool TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
+      const SimplexId &triangleId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((triangleId < 0)
          || (triangleId >= (SimplexId)boundaryTriangles_.size()))
         return false;
@@ -713,11 +593,9 @@ namespace ttk {
       return boundaryTriangles_[triangleId];
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline bool isVertexOnBoundary(const SimplexId &vertexId) const override {
-#else
-    inline bool
-      isVertexOnBoundaryInternal(const SimplexId &vertexId) const override {
+    inline bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
+      const SimplexId &vertexId) const override {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= (SimplexId)boundaryVertices_.size()))
         return false;
 #endif

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -223,15 +223,13 @@ bool ImplicitTriangulation::isPowerOfTwo(unsigned long long int v,
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool ImplicitTriangulation::isVertexOnBoundary(
+bool ImplicitTriangulation::TTK_INTERNAL(isVertexOnBoundary)(
   const SimplexId &vertexId) const {
-#else
-bool ImplicitTriangulation::isVertexOnBoundaryInternal(
-  const SimplexId &vertexId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return false;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   if(dimensionality_ == 3) {
     SimplexId p[3];
@@ -250,14 +248,13 @@ bool ImplicitTriangulation::isVertexOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool ImplicitTriangulation::isEdgeOnBoundary(const SimplexId &edgeId) const {
-#else
-bool ImplicitTriangulation::isEdgeOnBoundaryInternal(
+bool ImplicitTriangulation::TTK_INTERNAL(isEdgeOnBoundary)(
   const SimplexId &edgeId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return false;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   if(dimensionality_ == 3) {
     SimplexId p[3];
@@ -302,15 +299,13 @@ bool ImplicitTriangulation::isEdgeOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool ImplicitTriangulation::isTriangleOnBoundary(
+bool ImplicitTriangulation::TTK_INTERNAL(isTriangleOnBoundary)(
   const SimplexId &triangleId) const {
-#else
-bool ImplicitTriangulation::isTriangleOnBoundaryInternal(
-  const SimplexId &triangleId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return false;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   if(dimensionality_ == 3)
     return (getTriangleStarNumber(triangleId) == 1);
@@ -318,19 +313,16 @@ bool ImplicitTriangulation::isTriangleOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getVertexNeighbor(const SimplexId &vertexId,
-                                             const int &localNeighborId,
-                                             SimplexId &neighborId) const {
-#else
-int ImplicitTriangulation::getVertexNeighborInternal(
+int ImplicitTriangulation::TTK_INTERNAL(getVertexNeighbor)(
   const SimplexId &vertexId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localNeighborId < 0
      or localNeighborId >= getVertexNeighborNumber(vertexId))
     return -1;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   neighborId = -1;
 
@@ -451,12 +443,8 @@ int ImplicitTriangulation::getVertexNeighborInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getVertexNeighbors() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getVertexNeighborsInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getVertexNeighbors)() {
   if(!vertexNeighborList_.size()) {
     Timer t;
     vertexNeighborList_.resize(vertexNumber_);
@@ -829,27 +817,18 @@ const vector<vector<SimplexId>> *
   return &vertexTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId
-  ImplicitTriangulation::getVertexLinkNumber(const SimplexId &vertexId) const {
-#else
-SimplexId ImplicitTriangulation::getVertexLinkNumberInternal(
+SimplexId ImplicitTriangulation::TTK_INTERNAL(getVertexLinkNumber)(
   const SimplexId &vertexId) const {
-#endif
   return getVertexStarNumber(vertexId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getVertexLink(const SimplexId &vertexId,
-                                         const int &localLinkId,
-                                         SimplexId &linkId) const {
-#else
-int ImplicitTriangulation::getVertexLinkInternal(const SimplexId &vertexId,
-                                                 const int &localLinkId,
-                                                 SimplexId &linkId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getVertexLink)(
+  const SimplexId &vertexId, const int &localLinkId, SimplexId &linkId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getVertexLinkNumber(vertexId))
     return -1;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   linkId = -1;
 
@@ -958,12 +937,8 @@ int ImplicitTriangulation::getVertexLinkInternal(const SimplexId &vertexId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getVertexLinks() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getVertexLinksInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getVertexLinks)() {
   if(!vertexLinkList_.size()) {
     Timer t;
 
@@ -981,15 +956,13 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId
-  ImplicitTriangulation::getVertexStarNumber(const SimplexId &vertexId) const {
-#else
-inline SimplexId ImplicitTriangulation::getVertexStarNumberInternal(
+inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getVertexStarNumber)(
   const SimplexId &vertexId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   if(dimensionality_ == 3) {
     SimplexId p[3];
@@ -1090,17 +1063,13 @@ inline SimplexId ImplicitTriangulation::getVertexStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getVertexStar(const SimplexId &vertexId,
-                                         const int &localStarId,
-                                         SimplexId &starId) const {
-#else
-int ImplicitTriangulation::getVertexStarInternal(const SimplexId &vertexId,
-                                                 const int &localStarId,
-                                                 SimplexId &starId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getVertexStar)(
+  const SimplexId &vertexId, const int &localStarId, SimplexId &starId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getVertexStarNumber(vertexId))
     return -1;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
   starId = -1;
 
@@ -1209,12 +1178,9 @@ int ImplicitTriangulation::getVertexStarInternal(const SimplexId &vertexId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getVertexStars() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getVertexStarsInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getVertexStars)() {
+
   if(!vertexStarList_.size()) {
     Timer t;
     vertexStarList_.resize(vertexNumber_);
@@ -1231,19 +1197,8 @@ const vector<vector<SimplexId>> *
   return &vertexStarList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getVertexPoint(const SimplexId &vertexId,
-                                          float &x,
-                                          float &y,
-                                          float &z) const {
-#else
-int ImplicitTriangulation::getVertexPointInternal(const SimplexId &vertexId,
-                                                  float &x,
-                                                  float &y,
-                                                  float &z) const {
-  if(vertexId < 0 or vertexId >= vertexNumber_)
-    return -1;
-#endif
+int ImplicitTriangulation::TTK_INTERNAL(getVertexPoint)(
+  const SimplexId &vertexId, float &x, float &y, float &z) const {
 
   if(dimensionality_ == 3) {
     SimplexId p[3];
@@ -1484,12 +1439,9 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<pair<SimplexId, SimplexId>> *ImplicitTriangulation::getEdges() {
-#else
 const vector<pair<SimplexId, SimplexId>> *
-  ImplicitTriangulation::getEdgesInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getEdges)() {
+
   if(!edgeList_.size()) {
     Timer t;
 
@@ -1849,24 +1801,16 @@ const vector<vector<SimplexId>> *
   return &edgeTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId
-  ImplicitTriangulation::getEdgeLinkNumber(const SimplexId &edgeId) const {
-#else
-inline SimplexId ImplicitTriangulation::getEdgeLinkNumberInternal(
+inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getEdgeLinkNumber)(
   const SimplexId &edgeId) const {
-#endif
   return getEdgeStarNumber(edgeId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getEdgeLink(const SimplexId &edgeId,
-                                       const int &localLinkId,
-                                       SimplexId &linkId) const {
-#else
-int ImplicitTriangulation::getEdgeLinkInternal(const SimplexId &edgeId,
-                                               const int &localLinkId,
-                                               SimplexId &linkId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                                     const int &localLinkId,
+                                                     SimplexId &linkId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getEdgeLinkNumber(edgeId))
     return -1;
 #endif
@@ -1921,11 +1865,9 @@ int ImplicitTriangulation::getEdgeLinkInternal(const SimplexId &edgeId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getEdgeLinks() {
-#else
-const vector<vector<SimplexId>> *ImplicitTriangulation::getEdgeLinksInternal() {
-#endif
+const vector<vector<SimplexId>> *
+  ImplicitTriangulation::TTK_INTERNAL(getEdgeLinks)() {
+
   if(!edgeLinkList_.size()) {
     Timer t;
 
@@ -1943,12 +1885,10 @@ const vector<vector<SimplexId>> *ImplicitTriangulation::getEdgeLinksInternal() {
   return &edgeLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId
-  ImplicitTriangulation::getEdgeStarNumber(const SimplexId &edgeId) const {
-#else
-inline SimplexId ImplicitTriangulation::getEdgeStarNumberInternal(
+inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getEdgeStarNumber)(
   const SimplexId &edgeId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
@@ -2094,14 +2034,11 @@ inline SimplexId ImplicitTriangulation::getEdgeStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getEdgeStar(const SimplexId &edgeId,
-                                       const int &localStarId,
-                                       SimplexId &starId) const {
-#else
-int ImplicitTriangulation::getEdgeStarInternal(const SimplexId &edgeId,
-                                               const int &localStarId,
-                                               SimplexId &starId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                                     const int &localStarId,
+                                                     SimplexId &starId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getEdgeStarNumber(edgeId))
     return -1;
 #endif
@@ -2157,11 +2094,9 @@ int ImplicitTriangulation::getEdgeStarInternal(const SimplexId &edgeId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getEdgeStars() {
-#else
-const vector<vector<SimplexId>> *ImplicitTriangulation::getEdgeStarsInternal() {
-#endif
+const vector<vector<SimplexId>> *
+  ImplicitTriangulation::TTK_INTERNAL(getEdgeStars)() {
+
   if(!edgeStarList_.size()) {
     Timer t;
 
@@ -2406,11 +2341,9 @@ const vector<vector<SimplexId>> *
   return &triangleEdgeList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getTriangles() {
-#else
-const vector<vector<SimplexId>> *ImplicitTriangulation::getTrianglesInternal() {
-#endif
+const vector<vector<SimplexId>> *
+  ImplicitTriangulation::TTK_INTERNAL(getTriangles)() {
+
   if(!triangleList_.size()) {
     Timer t;
 
@@ -2428,14 +2361,12 @@ const vector<vector<SimplexId>> *ImplicitTriangulation::getTrianglesInternal() {
   return &triangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getTriangleLink(const SimplexId &triangleId,
-                                           const int &localLinkId,
-                                           SimplexId &linkId) const {
-#else
-int ImplicitTriangulation::getTriangleLinkInternal(const SimplexId &triangleId,
-                                                   const int &localLinkId,
-                                                   SimplexId &linkId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getTriangleLink)(
+  const SimplexId &triangleId,
+  const int &localLinkId,
+  SimplexId &linkId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getTriangleLinkNumber(triangleId))
     return -1;
 #endif
@@ -2480,22 +2411,13 @@ int ImplicitTriangulation::getTriangleLinkInternal(const SimplexId &triangleId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId ImplicitTriangulation::getTriangleLinkNumber(
+inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getTriangleLinkNumber)(
   const SimplexId &triangleId) const {
-#else
-inline SimplexId ImplicitTriangulation::getTriangleLinkNumberInternal(
-  const SimplexId &triangleId) const {
-#endif
   return getTriangleStarNumber(triangleId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getTriangleLinks() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getTriangleLinksInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getTriangleLinks)() {
   if(!triangleLinkList_.size()) {
     Timer t;
 
@@ -2512,12 +2434,10 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId ImplicitTriangulation::getTriangleStarNumber(
+inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getTriangleStarNumber)(
   const SimplexId &triangleId) const {
-#else
-inline SimplexId ImplicitTriangulation::getTriangleStarNumberInternal(
-  const SimplexId &triangleId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return -1;
 #endif
@@ -2567,14 +2487,12 @@ inline SimplexId ImplicitTriangulation::getTriangleStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getTriangleStar(const SimplexId &triangleId,
-                                           const int &localStarId,
-                                           SimplexId &starId) const {
-#else
-int ImplicitTriangulation::getTriangleStarInternal(const SimplexId &triangleId,
-                                                   const int &localStarId,
-                                                   SimplexId &starId) const {
+int ImplicitTriangulation::TTK_INTERNAL(getTriangleStar)(
+  const SimplexId &triangleId,
+  const int &localStarId,
+  SimplexId &starId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getTriangleStarNumber(triangleId))
     return -1;
 #endif
@@ -2617,12 +2535,9 @@ int ImplicitTriangulation::getTriangleStarInternal(const SimplexId &triangleId,
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getTriangleStars() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getTriangleStarsInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getTriangleStars)() {
+
   if(!triangleStarList_.size()) {
     Timer t;
 
@@ -3041,25 +2956,15 @@ int ImplicitTriangulation::getTetrahedronNeighbors(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId
-  ImplicitTriangulation::getCellVertexNumber(const SimplexId &cellId) const {
-#else
-SimplexId ImplicitTriangulation::getCellVertexNumberInternal(
-  const SimplexId &cellId) const {
-#endif
+SimplexId ImplicitTriangulation::TTK_INTERNAL(getCellVertexNumber)(
+  const SimplexId & cellId) const {
   return dimensionality_ + 1;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getCellVertex(const SimplexId &cellId,
-                                         const int &localVertexId,
-                                         SimplexId &vertexId) const {
-#else
-int ImplicitTriangulation::getCellVertexInternal(const SimplexId &cellId,
-                                                 const int &localVertexId,
-                                                 SimplexId &vertexId) const {
-#endif
+int ImplicitTriangulation::TTK_INTERNAL(getCellVertex)(
+  const SimplexId &cellId,
+  const int &localVertexId,
+  SimplexId &vertexId) const {
 
   if(dimensionality_ == 3)
     getTetrahedronVertex(cellId, localVertexId, vertexId);
@@ -3135,13 +3040,8 @@ const vector<vector<SimplexId>> *
   return &cellTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId
-  ImplicitTriangulation::getCellNeighborNumber(const SimplexId &cellId) const {
-#else
-SimplexId ImplicitTriangulation::getCellNeighborNumberInternal(
+SimplexId ImplicitTriangulation::TTK_INTERNAL(getCellNeighborNumber)(
   const SimplexId &cellId) const {
-#endif
   if(dimensionality_ == 3)
     return getTetrahedronNeighborNumber(cellId);
   else if(dimensionality_ == 2)
@@ -3154,16 +3054,10 @@ SimplexId ImplicitTriangulation::getCellNeighborNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int ImplicitTriangulation::getCellNeighbor(const SimplexId &cellId,
-                                           const int &localNeighborId,
-                                           SimplexId &neighborId) const {
-#else
-int ImplicitTriangulation::getCellNeighborInternal(
+int ImplicitTriangulation::TTK_INTERNAL(getCellNeighbor)(
   const SimplexId &cellId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
-#endif
   if(dimensionality_ == 3)
     getTetrahedronNeighbor(cellId, localNeighborId, neighborId);
   else if(dimensionality_ == 2)
@@ -3176,12 +3070,8 @@ int ImplicitTriangulation::getCellNeighborInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *ImplicitTriangulation::getCellNeighbors() {
-#else
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::getCellNeighborsInternal() {
-#endif
+  ImplicitTriangulation::TTK_INTERNAL(getCellNeighbors)() {
   if(!cellNeighborList_.size()) {
     Timer t;
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -230,7 +230,7 @@ bool ImplicitTriangulation::isVertexOnBoundary(
 bool ImplicitTriangulation::isVertexOnBoundaryInternal(
   const SimplexId &vertexId) const {
   if(vertexId < 0 or vertexId >= vertexNumber_)
-    return -1;
+    return false;
 #endif
 
   if(dimensionality_ == 3) {
@@ -256,7 +256,7 @@ bool ImplicitTriangulation::isEdgeOnBoundary(const SimplexId &edgeId) const {
 bool ImplicitTriangulation::isEdgeOnBoundaryInternal(
   const SimplexId &edgeId) const {
   if(edgeId < 0 or edgeId >= edgeNumber_)
-    return -1;
+    return false;
 #endif
 
   if(dimensionality_ == 3) {
@@ -309,7 +309,7 @@ bool ImplicitTriangulation::isTriangleOnBoundary(
 bool ImplicitTriangulation::isTriangleOnBoundaryInternal(
   const SimplexId &triangleId) const {
   if(triangleId < 0 or triangleId >= triangleNumber_)
-    return -1;
+    return false;
 #endif
 
   if(dimensionality_ == 3)

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -223,7 +223,7 @@ bool ImplicitTriangulation::isPowerOfTwo(unsigned long long int v,
   return false;
 }
 
-bool ImplicitTriangulation::TTK_INTERNAL(isVertexOnBoundary)(
+bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
   const SimplexId &vertexId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -248,7 +248,7 @@ bool ImplicitTriangulation::TTK_INTERNAL(isVertexOnBoundary)(
   return false;
 }
 
-bool ImplicitTriangulation::TTK_INTERNAL(isEdgeOnBoundary)(
+bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
   const SimplexId &edgeId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -299,7 +299,7 @@ bool ImplicitTriangulation::TTK_INTERNAL(isEdgeOnBoundary)(
   return false;
 }
 
-bool ImplicitTriangulation::TTK_INTERNAL(isTriangleOnBoundary)(
+bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
   const SimplexId &triangleId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -313,7 +313,7 @@ bool ImplicitTriangulation::TTK_INTERNAL(isTriangleOnBoundary)(
   return false;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getVertexNeighbor)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
   const SimplexId &vertexId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
@@ -444,7 +444,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getVertexNeighbor)(
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getVertexNeighbors)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() {
   if(!vertexNeighborList_.size()) {
     Timer t;
     vertexNeighborList_.resize(vertexNumber_);
@@ -817,12 +817,12 @@ const vector<vector<SimplexId>> *
   return &vertexTriangleList_;
 }
 
-SimplexId ImplicitTriangulation::TTK_INTERNAL(getVertexLinkNumber)(
-  const SimplexId &vertexId) const {
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexLinkNumber)(const SimplexId &vertexId) const {
   return getVertexStarNumber(vertexId);
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getVertexLink)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
   const SimplexId &vertexId, const int &localLinkId, SimplexId &linkId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -938,7 +938,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getVertexLink)(
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getVertexLinks)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLinks)() {
   if(!vertexLinkList_.size()) {
     Timer t;
 
@@ -956,8 +956,8 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getVertexStarNumber)(
-  const SimplexId &vertexId) const {
+inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexStarNumber)(const SimplexId &vertexId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -1063,7 +1063,7 @@ inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getVertexStarNumber)(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getVertexStar)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
   const SimplexId &vertexId, const int &localStarId, SimplexId &starId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -1179,7 +1179,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getVertexStar)(
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getVertexStars)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStars)() {
 
   if(!vertexStarList_.size()) {
     Timer t;
@@ -1197,7 +1197,7 @@ const vector<vector<SimplexId>> *
   return &vertexStarList_;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getVertexPoint)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
   const SimplexId &vertexId, float &x, float &y, float &z) const {
 
   if(dimensionality_ == 3) {
@@ -1440,7 +1440,7 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
 }
 
 const vector<pair<SimplexId, SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getEdges)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
 
   if(!edgeList_.size()) {
     Timer t;
@@ -1801,14 +1801,13 @@ const vector<vector<SimplexId>> *
   return &edgeTriangleList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getEdgeLinkNumber)(
-  const SimplexId &edgeId) const {
+inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getEdgeLinkNumber)(const SimplexId &edgeId) const {
   return getEdgeStarNumber(edgeId);
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
-                                                     const int &localLinkId,
-                                                     SimplexId &linkId) const {
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
+  const SimplexId &edgeId, const int &localLinkId, SimplexId &linkId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getEdgeLinkNumber(edgeId))
@@ -1866,7 +1865,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getEdgeLinks)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() {
 
   if(!edgeLinkList_.size()) {
     Timer t;
@@ -1885,8 +1884,8 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getEdgeStarNumber)(
-  const SimplexId &edgeId) const {
+inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getEdgeStarNumber)(const SimplexId &edgeId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -2034,9 +2033,8 @@ inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getEdgeStarNumber)(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
-                                                     const int &localStarId,
-                                                     SimplexId &starId) const {
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
+  const SimplexId &edgeId, const int &localStarId, SimplexId &starId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getEdgeStarNumber(edgeId))
@@ -2095,7 +2093,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getEdgeStars)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStars)() {
 
   if(!edgeStarList_.size()) {
     Timer t;
@@ -2342,7 +2340,7 @@ const vector<vector<SimplexId>> *
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getTriangles)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
 
   if(!triangleList_.size()) {
     Timer t;
@@ -2361,7 +2359,7 @@ const vector<vector<SimplexId>> *
   return &triangleList_;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getTriangleLink)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
   const SimplexId &triangleId,
   const int &localLinkId,
   SimplexId &linkId) const {
@@ -2411,13 +2409,13 @@ int ImplicitTriangulation::TTK_INTERNAL(getTriangleLink)(
   return 0;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getTriangleLinkNumber)(
-  const SimplexId &triangleId) const {
+inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getTriangleLinkNumber)(const SimplexId &triangleId) const {
   return getTriangleStarNumber(triangleId);
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getTriangleLinks)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() {
   if(!triangleLinkList_.size()) {
     Timer t;
 
@@ -2434,8 +2432,8 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getTriangleStarNumber)(
-  const SimplexId &triangleId) const {
+inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getTriangleStarNumber)(const SimplexId &triangleId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
@@ -2487,7 +2485,7 @@ inline SimplexId ImplicitTriangulation::TTK_INTERNAL(getTriangleStarNumber)(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getTriangleStar)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
   const SimplexId &triangleId,
   const int &localStarId,
   SimplexId &starId) const {
@@ -2536,7 +2534,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getTriangleStar)(
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getTriangleStars)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStars)() {
 
   if(!triangleStarList_.size()) {
     Timer t;
@@ -2956,12 +2954,12 @@ int ImplicitTriangulation::getTetrahedronNeighbors(
   return 0;
 }
 
-SimplexId ImplicitTriangulation::TTK_INTERNAL(getCellVertexNumber)(
-  const SimplexId & cellId) const {
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getCellVertexNumber)(const SimplexId &cellId) const {
   return dimensionality_ + 1;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getCellVertex)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellVertex)(
   const SimplexId &cellId,
   const int &localVertexId,
   SimplexId &vertexId) const {
@@ -3040,8 +3038,8 @@ const vector<vector<SimplexId>> *
   return &cellTriangleList_;
 }
 
-SimplexId ImplicitTriangulation::TTK_INTERNAL(getCellNeighborNumber)(
-  const SimplexId &cellId) const {
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getCellNeighborNumber)(const SimplexId &cellId) const {
   if(dimensionality_ == 3)
     return getTetrahedronNeighborNumber(cellId);
   else if(dimensionality_ == 2)
@@ -3054,7 +3052,7 @@ SimplexId ImplicitTriangulation::TTK_INTERNAL(getCellNeighborNumber)(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_INTERNAL(getCellNeighbor)(
+int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
   const SimplexId &cellId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
@@ -3071,7 +3069,7 @@ int ImplicitTriangulation::TTK_INTERNAL(getCellNeighbor)(
 }
 
 const vector<vector<SimplexId>> *
-  ImplicitTriangulation::TTK_INTERNAL(getCellNeighbors)() {
+  ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellNeighbors)() {
   if(!cellNeighborList_.size()) {
     Timer t;
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -18,12 +18,6 @@
 #include <ciso646>
 #endif
 
-#ifdef TTK_ENABLE_KAMIKAZE
-#define TTK_TRIANGULATION_INTERNAL(NAME) NAME
-#else
-#define TTK_TRIANGULATION_INTERNAL(NAME) NAME##Internal
-#endif // TTK_ENABLE_KAMIKAZE
-
 namespace ttk {
 
   class ImplicitTriangulation final : public AbstractTriangulation {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -1616,8 +1616,6 @@ inline ttk::SimplexId
     return p[0] * 2 + p[1] * tshift_[0];
   else
     return p[0] * 2 + (p[1] - 1) * tshift_[0] + 1;
-
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -1632,7 +1630,6 @@ inline ttk::SimplexId
     return p[0] * 2 + p[1] * tshift_[0];
   else
     return (p[0] - 1) * 2 + p[1] * tshift_[0] + 1;
-  return -1;
 }
 
 inline void ttk::ImplicitTriangulation::vertexToPosition(const SimplexId vertex,
@@ -6911,7 +6908,6 @@ inline ttk::SimplexId
     else
       return p[0] / 2 + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0];
   }
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -6932,7 +6928,6 @@ inline ttk::SimplexId
     else
       return p[0] / 2 + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[1];
   }
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -6955,7 +6950,6 @@ inline ttk::SimplexId
       return (p[0] / 2) + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[1]
              + vshift_[0];
   }
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -6978,7 +6972,6 @@ inline ttk::SimplexId
       return p[0] / 2 + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[1]
              + vshift_[0];
   }
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -7002,7 +6995,6 @@ inline ttk::SimplexId
       return p[0] / 2 + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
              + vshift_[1];
   }
-  return -1;
 }
 
 inline ttk::SimplexId
@@ -7025,7 +7017,6 @@ inline ttk::SimplexId
       return p[0] / 2 + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
              + vshift_[1];
   }
-  return -1;
 }
 
 inline ttk::SimplexId

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -19,9 +19,9 @@
 #endif
 
 #ifdef TTK_ENABLE_KAMIKAZE
-#define TTK_INTERNAL(NAME) NAME
+#define TTK_TRIANGULATION_INTERNAL(NAME) NAME
 #else
-#define TTK_INTERNAL(NAME) NAME##Internal
+#define TTK_TRIANGULATION_INTERNAL(NAME) NAME##Internal
 #endif // TTK_ENABLE_KAMIKAZE
 
 namespace ttk {
@@ -40,15 +40,16 @@ namespace ttk {
 
     const std::vector<std::vector<SimplexId>> *getCellEdgesInternal() override;
 
-    int TTK_INTERNAL(getCellNeighbor)(const SimplexId &cellId,
-                                      const int &localNeighborId,
-                                      SimplexId &neighborId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
+      const SimplexId &cellId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
 
-    SimplexId TTK_INTERNAL(getCellNeighborNumber)(
+    SimplexId TTK_TRIANGULATION_INTERNAL(getCellNeighborNumber)(
       const SimplexId &cellId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getCellNeighbors)() override;
+      TTK_TRIANGULATION_INTERNAL(getCellNeighbors)() override;
 
     int getCellTriangleInternal(const SimplexId &cellId,
                                 const int &id,
@@ -64,36 +65,39 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() override;
 
-    int TTK_INTERNAL(getCellVertex)(const SimplexId &cellId,
-                                    const int &localVertexId,
-                                    SimplexId &vertexId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getCellVertex)(
+      const SimplexId &cellId,
+      const int &localVertexId,
+      SimplexId &vertexId) const override;
 
-    SimplexId
-      TTK_INTERNAL(getCellVertexNumber)(const SimplexId &cellId) const override;
+    SimplexId TTK_TRIANGULATION_INTERNAL(getCellVertexNumber)(
+      const SimplexId &cellId) const override;
 
-    int TTK_INTERNAL(getDimensionality)() const override {
+    int TTK_TRIANGULATION_INTERNAL(getDimensionality)() const override {
       return dimensionality_;
     };
 
-    int TTK_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
-                                  const int &localLinkId,
-                                  SimplexId &linkId) const override;
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                              const int &localLinkId,
+                                              SimplexId &linkId) const override;
 
-    SimplexId
-      TTK_INTERNAL(getEdgeLinkNumber)(const SimplexId &edgeId) const override;
-
-    const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getEdgeLinks)() override;
-
-    int TTK_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
-                                  const int &localStarId,
-                                  SimplexId &starId) const override;
-
-    SimplexId
-      TTK_INTERNAL(getEdgeStarNumber)(const SimplexId &edgeId) const override;
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
+      const SimplexId &edgeId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getEdgeStars)() override;
+      TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() override;
+
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                              const int &localStarId,
+                                              SimplexId &starId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+      const SimplexId &edgeId) const override;
+
+    const std::vector<std::vector<SimplexId>> *
+      TTK_TRIANGULATION_INTERNAL(getEdgeStars)() override;
 
     int getEdgeTriangleInternal(const SimplexId &edgeId,
                                 const int &id,
@@ -110,9 +114,9 @@ namespace ttk {
                               SimplexId &vertexId) const override;
 
     const std::vector<std::pair<SimplexId, SimplexId>> *
-      TTK_INTERNAL(getEdges)() override;
+      TTK_TRIANGULATION_INTERNAL(getEdges)() override;
 
-    SimplexId TTK_INTERNAL(getNumberOfCells)() const override {
+    SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfCells)() const override {
       return cellNumber_;
     };
 
@@ -124,7 +128,7 @@ namespace ttk {
       return triangleNumber_;
     };
 
-    SimplexId TTK_INTERNAL(getNumberOfVertices)() const override {
+    SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfVertices)() const override {
       return vertexNumber_;
     };
 
@@ -170,15 +174,16 @@ namespace ttk {
     int getTriangleEdgesInternal(
       std::vector<std::vector<SimplexId>> &edges) const;
 
-    int TTK_INTERNAL(getTriangleLink)(const SimplexId &triangleId,
-                                      const int &localLinkId,
-                                      SimplexId &linkId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
+      const SimplexId &triangleId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
 
-    SimplexId TTK_INTERNAL(getTriangleLinkNumber)(
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
       const SimplexId &triangleId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getTriangleLinks)() override;
+      TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() override;
 
     int getTriangleNeighbor(const SimplexId &triangleId,
                             const int &localNeighborId,
@@ -188,22 +193,23 @@ namespace ttk {
 
     int getTriangleNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-    int TTK_INTERNAL(getTriangleStar)(const SimplexId &triangleId,
-                                      const int &localStarId,
-                                      SimplexId &starId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
+      const SimplexId &triangleId,
+      const int &localStarId,
+      SimplexId &starId) const override;
 
-    SimplexId TTK_INTERNAL(getTriangleStarNumber)(
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
       const SimplexId &triangleId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getTriangleStars)() override;
+      TTK_TRIANGULATION_INTERNAL(getTriangleStars)() override;
 
     int getTriangleVertexInternal(const SimplexId &triangleId,
                                   const int &localVertexId,
                                   SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getTriangles)() override;
+      TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
 
     int getVertexEdgeInternal(const SimplexId &vertexId,
                               const int &id,
@@ -215,21 +221,23 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() override;
 
-    int TTK_INTERNAL(getVertexLink)(const SimplexId &vertexId,
-                                    const int &localLinkId,
-                                    SimplexId &linkId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
+      const SimplexId &vertexId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
 
-    SimplexId TTK_INTERNAL(getVertexLinkNumber)(
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
       const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getVertexLinks)() override;
+      TTK_TRIANGULATION_INTERNAL(getVertexLinks)() override;
 
-    int TTK_INTERNAL(getVertexNeighbor)(const SimplexId &vertexId,
-                                        const int &localNeighborId,
-                                        SimplexId &neighborId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
+      const SimplexId &vertexId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
 
-    inline SimplexId TTK_INTERNAL(getVertexNeighborNumber)(
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
       const SimplexId &vertexId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -342,22 +350,23 @@ namespace ttk {
     }
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getVertexNeighbors)() override;
+      TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() override;
 
-    int TTK_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
-                                     float &x,
-                                     float &y,
-                                     float &z) const override;
+    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
+                                                   float &x,
+                                                   float &y,
+                                                   float &z) const override;
 
-    int TTK_INTERNAL(getVertexStar)(const SimplexId &vertexId,
-                                    const int &localStarId,
-                                    SimplexId &starId) const override;
+    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
+      const SimplexId &vertexId,
+      const int &localStarId,
+      SimplexId &starId) const override;
 
-    SimplexId TTK_INTERNAL(getVertexStarNumber)(
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
       const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
-      TTK_INTERNAL(getVertexStars)() override;
+      TTK_TRIANGULATION_INTERNAL(getVertexStars)() override;
 
     int getVertexTriangleInternal(const SimplexId &vertexId,
                                   const int &id,
@@ -369,16 +378,17 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexTrianglesInternal() override;
 
-    bool TTK_INTERNAL(isEdgeOnBoundary)(const SimplexId &edgeId) const override;
+    bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
+      const SimplexId &edgeId) const override;
 
     bool isEmptyInternal() const {
       return !vertexNumber_;
     };
 
-    bool TTK_INTERNAL(isTriangleOnBoundary)(
+    bool TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
       const SimplexId &triangleId) const override;
 
-    bool TTK_INTERNAL(isVertexOnBoundary)(
+    bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
       const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -18,6 +18,12 @@
 #include <ciso646>
 #endif
 
+#ifdef TTK_ENABLE_KAMIKAZE
+#define TTK_INTERNAL(NAME) NAME
+#else
+#define TTK_INTERNAL(NAME) NAME##Internal
+#endif // TTK_ENABLE_KAMIKAZE
+
 namespace ttk {
 
   class ImplicitTriangulation final : public AbstractTriangulation {
@@ -34,29 +40,15 @@ namespace ttk {
 
     const std::vector<std::vector<SimplexId>> *getCellEdgesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getCellNeighbor(const SimplexId &cellId,
-                        const int &localNeighborId,
-                        SimplexId &neighborId) const override;
-#else
-    int getCellNeighborInternal(const SimplexId &cellId,
-                                const int &localNeighborId,
-                                SimplexId &neighborId) const override;
-#endif
+    int TTK_INTERNAL(getCellNeighbor)(const SimplexId &cellId,
+                                      const int &localNeighborId,
+                                      SimplexId &neighborId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getCellNeighborNumber(const SimplexId &cellId) const override;
-#else
-    SimplexId
-      getCellNeighborNumberInternal(const SimplexId &cellId) const override;
-#endif
+    SimplexId TTK_INTERNAL(getCellNeighborNumber)(
+      const SimplexId &cellId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getCellNeighbors() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getCellNeighborsInternal() override;
-#endif
+      TTK_INTERNAL(getCellNeighbors)() override;
 
     int getCellTriangleInternal(const SimplexId &cellId,
                                 const int &id,
@@ -72,74 +64,36 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getCellVertex(const SimplexId &cellId,
-                      const int &localVertexId,
-                      SimplexId &vertexId) const override;
-#else
-    int getCellVertexInternal(const SimplexId &cellId,
-                              const int &localVertexId,
-                              SimplexId &vertexId) const override;
-#endif
+    int TTK_INTERNAL(getCellVertex)(const SimplexId &cellId,
+                                    const int &localVertexId,
+                                    SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getCellVertexNumber(const SimplexId &cellId) const override;
-#else
     SimplexId
-      getCellVertexNumberInternal(const SimplexId &cellId) const override;
-#endif
+      TTK_INTERNAL(getCellVertexNumber)(const SimplexId &cellId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getDimensionality() const override {
-#else
-    int getDimensionalityInternal() const override {
-#endif
+    int TTK_INTERNAL(getDimensionality)() const override {
       return dimensionality_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getEdgeLink(const SimplexId &edgeId,
-                    const int &localLinkId,
-                    SimplexId &linkId) const override;
-#else
-    int getEdgeLinkInternal(const SimplexId &edgeId,
-                            const int &localLinkId,
-                            SimplexId &linkId) const override;
-#endif
+    int TTK_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                  const int &localLinkId,
+                                  SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override;
-#else
-    SimplexId getEdgeLinkNumberInternal(const SimplexId &edgeId) const override;
-#endif
+    SimplexId
+      TTK_INTERNAL(getEdgeLinkNumber)(const SimplexId &edgeId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getEdgeLinks() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getEdgeLinksInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_INTERNAL(getEdgeLinks)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getEdgeStar(const SimplexId &edgeId,
-                    const int &localStarId,
-                    SimplexId &starId) const override;
-#else
-    int getEdgeStarInternal(const SimplexId &edgeId,
-                            const int &localStarId,
-                            SimplexId &starId) const override;
-#endif
+    int TTK_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                  const int &localStarId,
+                                  SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override;
-#else
-    SimplexId getEdgeStarNumberInternal(const SimplexId &edgeId) const override;
-#endif
+    SimplexId
+      TTK_INTERNAL(getEdgeStarNumber)(const SimplexId &edgeId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getEdgeStars() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getEdgeStarsInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_INTERNAL(getEdgeStars)() override;
 
     int getEdgeTriangleInternal(const SimplexId &edgeId,
                                 const int &id,
@@ -155,18 +109,10 @@ namespace ttk {
                               const int &localVertexId,
                               SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override;
-#else
     const std::vector<std::pair<SimplexId, SimplexId>> *
-      getEdgesInternal() override;
-#endif
+      TTK_INTERNAL(getEdges)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getNumberOfCells() const override {
-#else
-    SimplexId getNumberOfCellsInternal() const override {
-#endif
+    SimplexId TTK_INTERNAL(getNumberOfCells)() const override {
       return cellNumber_;
     };
 
@@ -178,11 +124,7 @@ namespace ttk {
       return triangleNumber_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getNumberOfVertices() const override {
-#else
-    SimplexId getNumberOfVerticesInternal() const override {
-#endif
+    SimplexId TTK_INTERNAL(getNumberOfVertices)() const override {
       return vertexNumber_;
     };
 
@@ -228,29 +170,15 @@ namespace ttk {
     int getTriangleEdgesInternal(
       std::vector<std::vector<SimplexId>> &edges) const;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getTriangleLink(const SimplexId &triangleId,
-                        const int &localLinkId,
-                        SimplexId &linkId) const override;
-#else
-    int getTriangleLinkInternal(const SimplexId &triangleId,
-                                const int &localLinkId,
-                                SimplexId &linkId) const override;
-#endif
+    int TTK_INTERNAL(getTriangleLink)(const SimplexId &triangleId,
+                                      const int &localLinkId,
+                                      SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override;
-#else
-    SimplexId
-      getTriangleLinkNumberInternal(const SimplexId &triangleId) const override;
-#endif
+    SimplexId TTK_INTERNAL(getTriangleLinkNumber)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangleLinks() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getTriangleLinksInternal() override;
-#endif
+      TTK_INTERNAL(getTriangleLinks)() override;
 
     int getTriangleNeighbor(const SimplexId &triangleId,
                             const int &localNeighborId,
@@ -260,39 +188,22 @@ namespace ttk {
 
     int getTriangleNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getTriangleStar(const SimplexId &triangleId,
-                        const int &localStarId,
-                        SimplexId &starId) const override;
-#else
-    int getTriangleStarInternal(const SimplexId &triangleId,
-                                const int &localStarId,
-                                SimplexId &starId) const override;
-#endif
+    int TTK_INTERNAL(getTriangleStar)(const SimplexId &triangleId,
+                                      const int &localStarId,
+                                      SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override;
-#else
-    SimplexId
-      getTriangleStarNumberInternal(const SimplexId &triangleId) const override;
-#endif
+    SimplexId TTK_INTERNAL(getTriangleStarNumber)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangleStars() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getTriangleStarsInternal() override;
-#endif
+      TTK_INTERNAL(getTriangleStars)() override;
 
     int getTriangleVertexInternal(const SimplexId &triangleId,
                                   const int &localVertexId,
                                   SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangles() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getTrianglesInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_INTERNAL(getTriangles)() override;
 
     int getVertexEdgeInternal(const SimplexId &vertexId,
                               const int &id,
@@ -304,49 +215,27 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexLink(const SimplexId &vertexId,
-                      const int &localLinkId,
-                      SimplexId &linkId) const override;
-#else
-    int getVertexLinkInternal(const SimplexId &vertexId,
-                              const int &localLinkId,
-                              SimplexId &linkId) const override;
-#endif
+    int TTK_INTERNAL(getVertexLink)(const SimplexId &vertexId,
+                                    const int &localLinkId,
+                                    SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override;
-#else
-    SimplexId
-      getVertexLinkNumberInternal(const SimplexId &vertexId) const override;
-#endif
+    SimplexId TTK_INTERNAL(getVertexLinkNumber)(
+      const SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexLinks() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexLinksInternal() override;
-#endif
+      TTK_INTERNAL(getVertexLinks)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexNeighbor(const SimplexId &vertexId,
-                          const int &localNeighborId,
-                          SimplexId &neighborId) const override;
-#else
-    int getVertexNeighborInternal(const SimplexId &vertexId,
-                                  const int &localNeighborId,
-                                  SimplexId &neighborId) const override;
-#endif
+    int TTK_INTERNAL(getVertexNeighbor)(const SimplexId &vertexId,
+                                        const int &localNeighborId,
+                                        SimplexId &neighborId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    inline SimplexId
-      getVertexNeighborNumber(const SimplexId &vertexId) const override {
-#else
-    inline SimplexId getVertexNeighborNumberInternal(
+    inline SimplexId TTK_INTERNAL(getVertexNeighborNumber)(
       const SimplexId &vertexId) const override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
       if(vertexId < 0 or vertexId >= vertexNumber_)
         return -1;
-#endif
+#endif // !TTK_ENABLE_KAMIKAZE
 
       if(dimensionality_ == 3) {
         SimplexId p[3];
@@ -452,48 +341,23 @@ namespace ttk {
       return -1;
     }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexNeighborsInternal() override;
-#endif
+      TTK_INTERNAL(getVertexNeighbors)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexPoint(const SimplexId &vertexId,
-                       float &x,
-                       float &y,
-                       float &z) const override;
-#else
-    int getVertexPointInternal(const SimplexId &vertexId,
-                               float &x,
-                               float &y,
-                               float &z) const override;
-#endif
+    int TTK_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
+                                     float &x,
+                                     float &y,
+                                     float &z) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexStar(const SimplexId &vertexId,
-                      const int &localStarId,
-                      SimplexId &starId) const override;
-#else
-    int getVertexStarInternal(const SimplexId &vertexId,
-                              const int &localStarId,
-                              SimplexId &starId) const override;
-#endif
+    int TTK_INTERNAL(getVertexStar)(const SimplexId &vertexId,
+                                    const int &localStarId,
+                                    SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getVertexStarNumber(const SimplexId &vertexId) const override;
-#else
-    SimplexId
-      getVertexStarNumberInternal(const SimplexId &vertexId) const override;
-#endif
+    SimplexId TTK_INTERNAL(getVertexStarNumber)(
+      const SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexStars() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexStarsInternal() override;
-#endif
+      TTK_INTERNAL(getVertexStars)() override;
 
     int getVertexTriangleInternal(const SimplexId &vertexId,
                                   const int &id,
@@ -505,28 +369,17 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexTrianglesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isEdgeOnBoundary(const SimplexId &edgeId) const override;
-#else
-    bool isEdgeOnBoundaryInternal(const SimplexId &edgeId) const override;
-#endif
+    bool TTK_INTERNAL(isEdgeOnBoundary)(const SimplexId &edgeId) const override;
 
     bool isEmptyInternal() const {
       return !vertexNumber_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isTriangleOnBoundary(const SimplexId &triangleId) const override;
-#else
-    bool
-      isTriangleOnBoundaryInternal(const SimplexId &triangleId) const override;
-#endif
+    bool TTK_INTERNAL(isTriangleOnBoundary)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isVertexOnBoundary(const SimplexId &vertexId) const override;
-#else
-    bool isVertexOnBoundaryInternal(const SimplexId &vertexId) const override;
-#endif
+    bool TTK_INTERNAL(isVertexOnBoundary)(
+      const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,
                      const float &yOrigin,

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -231,12 +231,9 @@ bool PeriodicImplicitTriangulation::isPowerOfTwo(unsigned long long int v,
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool PeriodicImplicitTriangulation::isVertexOnBoundary(
-  const SimplexId &vertexId) const {
-#else
-bool PeriodicImplicitTriangulation::isVertexOnBoundaryInternal(
-  const SimplexId &vertexId) const {
+bool PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  isVertexOnBoundary)(const SimplexId &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
@@ -244,12 +241,9 @@ bool PeriodicImplicitTriangulation::isVertexOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool PeriodicImplicitTriangulation::isEdgeOnBoundary(
-  const SimplexId &edgeId) const {
-#else
-bool PeriodicImplicitTriangulation::isEdgeOnBoundaryInternal(
-  const SimplexId &edgeId) const {
+bool PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  isEdgeOnBoundary)(const SimplexId &edgeId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
@@ -257,12 +251,9 @@ bool PeriodicImplicitTriangulation::isEdgeOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-bool PeriodicImplicitTriangulation::isTriangleOnBoundary(
-  const SimplexId &triangleId) const {
-#else
-bool PeriodicImplicitTriangulation::isTriangleOnBoundaryInternal(
-  const SimplexId &triangleId) const {
+bool PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  isTriangleOnBoundary)(const SimplexId &triangleId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return -1;
 #endif
@@ -270,12 +261,9 @@ bool PeriodicImplicitTriangulation::isTriangleOnBoundaryInternal(
   return false;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getVertexNeighborNumber(
-  const SimplexId &vertexId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getVertexNeighborNumberInternal(
-  const SimplexId &vertexId) const {
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexNeighborNumber)(const SimplexId &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
@@ -291,16 +279,11 @@ inline SimplexId PeriodicImplicitTriangulation::getVertexNeighborNumberInternal(
   return -1;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getVertexNeighbor(
-  const SimplexId &vertexId,
-  const int &localNeighborId,
-  SimplexId &neighborId) const {
-#else
-int PeriodicImplicitTriangulation::getVertexNeighborInternal(
-  const SimplexId &vertexId,
-  const int &localNeighborId,
-  SimplexId &neighborId) const {
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexNeighbor)(const SimplexId &vertexId,
+                     const int &localNeighborId,
+                     SimplexId &neighborId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localNeighborId < 0
      or localNeighborId >= getVertexNeighborNumber(vertexId))
     return -1;
@@ -339,13 +322,9 @@ int PeriodicImplicitTriangulation::getVertexNeighborInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexNeighbors() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexNeighborsInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+    getVertexNeighbors)() {
   if(!vertexNeighborList_.size()) {
     Timer t;
     vertexNeighborList_.resize(vertexNumber_);
@@ -495,23 +474,14 @@ const vector<vector<SimplexId>> *
   return &vertexTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId PeriodicImplicitTriangulation::getVertexLinkNumber(
-  const SimplexId &vertexId) const {
-#else
-SimplexId PeriodicImplicitTriangulation::getVertexLinkNumberInternal(
-  const SimplexId &vertexId) const {
-#endif
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexLinkNumber)(const SimplexId &vertexId) const {
   return getVertexStarNumber(vertexId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getVertexLink(const SimplexId &vertexId,
-                                                 const int &localLinkId,
-                                                 SimplexId &linkId) const {
-#else
-int PeriodicImplicitTriangulation::getVertexLinkInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
   const SimplexId &vertexId, const int &localLinkId, SimplexId &linkId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getVertexLinkNumber(vertexId))
     return -1;
 #endif
@@ -531,13 +501,8 @@ int PeriodicImplicitTriangulation::getVertexLinkInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexLinks() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexLinksInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLinks)() {
   if(!vertexLinkList_.size()) {
     Timer t;
 
@@ -555,12 +520,9 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getVertexStarNumber(
-  const SimplexId &vertexId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getVertexStarNumberInternal(
-  const SimplexId &vertexId) const {
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getVertexStarNumber)(const SimplexId &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
@@ -574,13 +536,9 @@ inline SimplexId PeriodicImplicitTriangulation::getVertexStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getVertexStar(const SimplexId &vertexId,
-                                                 const int &localStarId,
-                                                 SimplexId &starId) const {
-#else
-int PeriodicImplicitTriangulation::getVertexStarInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
   const SimplexId &vertexId, const int &localStarId, SimplexId &starId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getVertexStarNumber(vertexId))
     return -1;
 #endif
@@ -600,13 +558,8 @@ int PeriodicImplicitTriangulation::getVertexStarInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexStars() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getVertexStarsInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStars)() {
   if(!vertexStarList_.size()) {
     Timer t;
     vertexStarList_.resize(vertexNumber_);
@@ -623,14 +576,9 @@ const vector<vector<SimplexId>> *
   return &vertexStarList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getVertexPoint(const SimplexId &vertexId,
-                                                  float &x,
-                                                  float &y,
-                                                  float &z) const {
-#else
-int PeriodicImplicitTriangulation::getVertexPointInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
   const SimplexId &vertexId, float &x, float &y, float &z) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
@@ -948,13 +896,9 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<pair<SimplexId, SimplexId>> *
-  PeriodicImplicitTriangulation::getEdges() {
-#else
-const vector<pair<SimplexId, SimplexId>> *
-  PeriodicImplicitTriangulation::getEdgesInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
+
   if(!edgeList_.size()) {
     Timer t;
 
@@ -1108,23 +1052,15 @@ const vector<vector<SimplexId>> *
   return &edgeTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getEdgeLinkNumber(
-  const SimplexId &edgeId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getEdgeLinkNumberInternal(
-  const SimplexId &edgeId) const {
-#endif
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getEdgeLinkNumber)(const SimplexId &edgeId) const {
+
   return getEdgeStarNumber(edgeId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getEdgeLink(const SimplexId &edgeId,
-                                               const int &localLinkId,
-                                               SimplexId &linkId) const {
-#else
-int PeriodicImplicitTriangulation::getEdgeLinkInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
   const SimplexId &edgeId, const int &localLinkId, SimplexId &linkId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getEdgeLinkNumber(edgeId))
     return -1;
 #endif
@@ -1179,12 +1115,9 @@ int PeriodicImplicitTriangulation::getEdgeLinkInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *PeriodicImplicitTriangulation::getEdgeLinks() {
-#else
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getEdgeLinksInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() {
+
   if(!edgeLinkList_.size()) {
     Timer t;
 
@@ -1202,12 +1135,9 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getEdgeStarNumber(
-  const SimplexId &edgeId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getEdgeStarNumberInternal(
-  const SimplexId &edgeId) const {
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getEdgeStarNumber)(const SimplexId &edgeId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
@@ -1247,13 +1177,9 @@ inline SimplexId PeriodicImplicitTriangulation::getEdgeStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getEdgeStar(const SimplexId &edgeId,
-                                               const int &localStarId,
-                                               SimplexId &starId) const {
-#else
-int PeriodicImplicitTriangulation::getEdgeStarInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
   const SimplexId &edgeId, const int &localStarId, SimplexId &starId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getEdgeStarNumber(edgeId))
     return -1;
 #endif
@@ -1309,12 +1235,9 @@ int PeriodicImplicitTriangulation::getEdgeStarInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *PeriodicImplicitTriangulation::getEdgeStars() {
-#else
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getEdgeStarsInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStars)() {
+
   if(!edgeStarList_.size()) {
     Timer t;
 
@@ -1574,12 +1497,9 @@ const vector<vector<SimplexId>> *
   return &triangleEdgeList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-const vector<vector<SimplexId>> *PeriodicImplicitTriangulation::getTriangles() {
-#else
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getTrianglesInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
+
   if(!triangleList_.size()) {
     Timer t;
 
@@ -1597,15 +1517,11 @@ const vector<vector<SimplexId>> *
   return &triangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getTriangleLink(const SimplexId &triangleId,
-                                                   const int &localLinkId,
-                                                   SimplexId &linkId) const {
-#else
-int PeriodicImplicitTriangulation::getTriangleLinkInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
   const SimplexId &triangleId,
   const int &localLinkId,
   SimplexId &linkId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getTriangleLinkNumber(triangleId))
     return -1;
 #endif
@@ -1650,23 +1566,16 @@ int PeriodicImplicitTriangulation::getTriangleLinkInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getTriangleLinkNumber(
-  const SimplexId &triangleId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getTriangleLinkNumberInternal(
-  const SimplexId &triangleId) const {
-#endif
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getTriangleLinkNumber)(const SimplexId &triangleId) const {
+
   return getTriangleStarNumber(triangleId);
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getTriangleLinks() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getTriangleLinksInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+    getTriangleLinks)() {
+
   if(!triangleLinkList_.size()) {
     Timer t;
 
@@ -1683,12 +1592,9 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-inline SimplexId PeriodicImplicitTriangulation::getTriangleStarNumber(
-  const SimplexId &triangleId) const {
-#else
-inline SimplexId PeriodicImplicitTriangulation::getTriangleStarNumberInternal(
-  const SimplexId &triangleId) const {
+inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getTriangleStarNumber)(const SimplexId &triangleId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return -1;
 #endif
@@ -1699,15 +1605,11 @@ inline SimplexId PeriodicImplicitTriangulation::getTriangleStarNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getTriangleStar(const SimplexId &triangleId,
-                                                   const int &localStarId,
-                                                   SimplexId &starId) const {
-#else
-int PeriodicImplicitTriangulation::getTriangleStarInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
   const SimplexId &triangleId,
   const int &localStarId,
   SimplexId &starId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getTriangleStarNumber(triangleId))
     return -1;
 #endif
@@ -1750,13 +1652,10 @@ int PeriodicImplicitTriangulation::getTriangleStarInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getTriangleStars() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getTriangleStarsInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+    getTriangleStars)() {
+
   if(!triangleStarList_.size()) {
     Timer t;
 
@@ -2138,26 +2037,17 @@ int PeriodicImplicitTriangulation::getTetrahedronNeighbors(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId PeriodicImplicitTriangulation::getCellVertexNumber(
-  const SimplexId &cellId) const {
-#else
-SimplexId PeriodicImplicitTriangulation::getCellVertexNumberInternal(
-  const SimplexId &cellId) const {
-#endif
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getCellVertexNumber)(const SimplexId &cellId) const {
+
   return dimensionality_ + 1;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getCellVertex(const SimplexId &cellId,
-                                                 const int &localVertexId,
-                                                 SimplexId &vertexId) const {
-#else
-int PeriodicImplicitTriangulation::getCellVertexInternal(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellVertex)(
   const SimplexId &cellId,
   const int &localVertexId,
   SimplexId &vertexId) const {
-#endif
+
   if(dimensionality_ == 3)
     getTetrahedronVertex(cellId, localVertexId, vertexId);
   else if(dimensionality_ == 2)
@@ -2232,13 +2122,9 @@ const vector<vector<SimplexId>> *
   return &cellTriangleList_;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-SimplexId PeriodicImplicitTriangulation::getCellNeighborNumber(
-  const SimplexId &cellId) const {
-#else
-SimplexId PeriodicImplicitTriangulation::getCellNeighborNumberInternal(
-  const SimplexId &cellId) const {
-#endif
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+  getCellNeighborNumber)(const SimplexId &cellId) const {
+
   if(dimensionality_ == 3)
     return getTetrahedronNeighborNumber(cellId);
   else if(dimensionality_ == 2)
@@ -2251,17 +2137,11 @@ SimplexId PeriodicImplicitTriangulation::getCellNeighborNumberInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
-int PeriodicImplicitTriangulation::getCellNeighbor(
+int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
   const SimplexId &cellId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
-#else
-int PeriodicImplicitTriangulation::getCellNeighborInternal(
-  const SimplexId &cellId,
-  const int &localNeighborId,
-  SimplexId &neighborId) const {
-#endif
+
   if(dimensionality_ == 3)
     getTetrahedronNeighbor(cellId, localNeighborId, neighborId);
   else if(dimensionality_ == 2)
@@ -2274,13 +2154,10 @@ int PeriodicImplicitTriangulation::getCellNeighborInternal(
   return 0;
 }
 
-#ifdef TTK_ENABLE_KAMIKAZE
 const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getCellNeighbors() {
-#else
-const vector<vector<SimplexId>> *
-  PeriodicImplicitTriangulation::getCellNeighborsInternal() {
-#endif
+  PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+    getCellNeighbors)() {
+
   if(!cellNeighborList_.size()) {
     Timer t;
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -408,7 +408,7 @@ namespace ttk {
     bool isEdgeOnBoundaryInternal(const SimplexId &edgeId) const override;
 #endif
 
-    bool isEmpty() const {
+    bool isEmpty() const override {
       return !vertexNumber_;
     };
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -38,29 +38,16 @@ namespace ttk {
 
     const std::vector<std::vector<SimplexId>> *getCellEdgesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getCellNeighbor(const SimplexId &cellId,
-                        const int &localNeighborId,
-                        SimplexId &neighborId) const override;
-#else
-    int getCellNeighborInternal(const SimplexId &cellId,
-                                const int &localNeighborId,
-                                SimplexId &neighborId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
+      const SimplexId &cellId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getCellNeighborNumber(const SimplexId &cellId) const override;
-#else
-    SimplexId
-      getCellNeighborNumberInternal(const SimplexId &cellId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getCellNeighborNumber)(
+      const SimplexId &cellId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getCellNeighbors() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getCellNeighborsInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getCellNeighbors)() override;
 
     int getCellTriangleInternal(const SimplexId &cellId,
                                 const int &id,
@@ -76,74 +63,39 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getCellVertex(const SimplexId &cellId,
-                      const int &localVertexId,
-                      SimplexId &vertexId) const override;
-#else
-    int getCellVertexInternal(const SimplexId &cellId,
-                              const int &localVertexId,
-                              SimplexId &vertexId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getCellVertex)(
+      const SimplexId &cellId,
+      const int &localVertexId,
+      SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getCellVertexNumber(const SimplexId &cellId) const override;
-#else
-    SimplexId
-      getCellVertexNumberInternal(const SimplexId &cellId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getCellVertexNumber)(
+      const SimplexId &cellId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getDimensionality() const override {
-#else
-    int getDimensionalityInternal() const override {
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getDimensionality)() const override {
       return dimensionality_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getEdgeLink(const SimplexId &edgeId,
-                    const int &localLinkId,
-                    SimplexId &linkId) const override;
-#else
-    int getEdgeLinkInternal(const SimplexId &edgeId,
-                            const int &localLinkId,
-                            SimplexId &linkId) const override;
-#endif
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                              const int &localLinkId,
+                                              SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getEdgeLinkNumber(const SimplexId &edgeId) const override;
-#else
-    SimplexId getEdgeLinkNumberInternal(const SimplexId &edgeId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
+      const SimplexId &edgeId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getEdgeLinks() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getEdgeLinksInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getEdgeStar(const SimplexId &edgeId,
-                    const int &localStarId,
-                    SimplexId &starId) const override;
-#else
-    int getEdgeStarInternal(const SimplexId &edgeId,
-                            const int &localStarId,
-                            SimplexId &starId) const override;
-#endif
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                              const int &localStarId,
+                                              SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getEdgeStarNumber(const SimplexId &edgeId) const override;
-#else
-    SimplexId getEdgeStarNumberInternal(const SimplexId &edgeId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+      const SimplexId &edgeId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getEdgeStars() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getEdgeStarsInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_TRIANGULATION_INTERNAL(getEdgeStars)() override;
 
     int getEdgeTriangleInternal(const SimplexId &edgeId,
                                 const int &id,
@@ -159,18 +111,10 @@ namespace ttk {
                               const int &localVertexId,
                               SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() override;
-#else
     const std::vector<std::pair<SimplexId, SimplexId>> *
-      getEdgesInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getEdges)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getNumberOfCells() const override {
-#else
-    SimplexId getNumberOfCellsInternal() const override {
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfCells)() const override {
       return cellNumber_;
     };
 
@@ -182,11 +126,7 @@ namespace ttk {
       return triangleNumber_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getNumberOfVertices() const override {
-#else
-    SimplexId getNumberOfVerticesInternal() const override {
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfVertices)() const override {
       return vertexNumber_;
     };
 
@@ -232,29 +172,16 @@ namespace ttk {
     int getTriangleEdgesInternal(
       std::vector<std::vector<SimplexId>> &edges) const;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getTriangleLink(const SimplexId &triangleId,
-                        const int &localLinkId,
-                        SimplexId &linkId) const override;
-#else
-    int getTriangleLinkInternal(const SimplexId &triangleId,
-                                const int &localLinkId,
-                                SimplexId &linkId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
+      const SimplexId &triangleId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getTriangleLinkNumber(const SimplexId &triangleId) const override;
-#else
-    SimplexId
-      getTriangleLinkNumberInternal(const SimplexId &triangleId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangleLinks() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getTriangleLinksInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() override;
 
     int getTriangleNeighbor(const SimplexId &triangleId,
                             const int &localNeighborId,
@@ -264,39 +191,23 @@ namespace ttk {
 
     int getTriangleNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getTriangleStar(const SimplexId &triangleId,
-                        const int &localStarId,
-                        SimplexId &starId) const override;
-#else
-    int getTriangleStarInternal(const SimplexId &triangleId,
-                                const int &localStarId,
-                                SimplexId &starId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
+      const SimplexId &triangleId,
+      const int &localStarId,
+      SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getTriangleStarNumber(const SimplexId &triangleId) const override;
-#else
-    SimplexId
-      getTriangleStarNumberInternal(const SimplexId &triangleId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangleStars() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getTriangleStarsInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getTriangleStars)() override;
 
     int getTriangleVertexInternal(const SimplexId &triangleId,
                                   const int &localVertexId,
                                   SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getTriangles() override;
-#else
-    const std::vector<std::vector<SimplexId>> *getTrianglesInternal() override;
-#endif
+    const std::vector<std::vector<SimplexId>> *
+      TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
 
     int getVertexEdgeInternal(const SimplexId &vertexId,
                               const int &id,
@@ -308,89 +219,43 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexLink(const SimplexId &vertexId,
-                      const int &localLinkId,
-                      SimplexId &linkId) const override;
-#else
-    int getVertexLinkInternal(const SimplexId &vertexId,
-                              const int &localLinkId,
-                              SimplexId &linkId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
+      const SimplexId &vertexId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getVertexLinkNumber(const SimplexId &vertexId) const override;
-#else
-    SimplexId
-      getVertexLinkNumberInternal(const SimplexId &vertexId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
+      const SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexLinks() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexLinksInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexLinks)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexNeighbor(const SimplexId &vertexId,
-                          const int &localNeighborId,
-                          SimplexId &neighborId) const override;
-#else
-    int getVertexNeighborInternal(const SimplexId &vertexId,
-                                  const int &localNeighborId,
-                                  SimplexId &neighborId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
+      const SimplexId &vertexId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const override;
-#else
-    SimplexId
-      getVertexNeighborNumberInternal(const SimplexId &vertexId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
+      const SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexNeighbors() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexNeighborsInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexPoint(const SimplexId &vertexId,
-                       float &x,
-                       float &y,
-                       float &z) const override;
-#else
-    int getVertexPointInternal(const SimplexId &vertexId,
-                               float &x,
-                               float &y,
-                               float &z) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
+                                                   float &x,
+                                                   float &y,
+                                                   float &z) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    int getVertexStar(const SimplexId &vertexId,
-                      const int &localStarId,
-                      SimplexId &starId) const override;
-#else
-    int getVertexStarInternal(const SimplexId &vertexId,
-                              const int &localStarId,
-                              SimplexId &starId) const override;
-#endif
+    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
+      const SimplexId &vertexId,
+      const int &localStarId,
+      SimplexId &starId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    SimplexId getVertexStarNumber(const SimplexId &vertexId) const override;
-#else
-    SimplexId
-      getVertexStarNumberInternal(const SimplexId &vertexId) const override;
-#endif
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
+      const SimplexId &vertexId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    const std::vector<std::vector<SimplexId>> *getVertexStars() override;
-#else
     const std::vector<std::vector<SimplexId>> *
-      getVertexStarsInternal() override;
-#endif
+      TTK_TRIANGULATION_INTERNAL(getVertexStars)() override;
 
     int getVertexTriangleInternal(const SimplexId &vertexId,
                                   const int &id,
@@ -402,28 +267,18 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexTrianglesInternal() override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isEdgeOnBoundary(const SimplexId &edgeId) const override;
-#else
-    bool isEdgeOnBoundaryInternal(const SimplexId &edgeId) const override;
-#endif
+    bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
+      const SimplexId &edgeId) const override;
 
     bool isEmpty() const override {
       return !vertexNumber_;
     };
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isTriangleOnBoundary(const SimplexId &triangleId) const override;
-#else
-    bool
-      isTriangleOnBoundaryInternal(const SimplexId &triangleId) const override;
-#endif
+    bool TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
+      const SimplexId &triangleId) const override;
 
-#ifdef TTK_ENABLE_KAMIKAZE
-    bool isVertexOnBoundary(const SimplexId &vertexId) const override;
-#else
-    bool isVertexOnBoundaryInternal(const SimplexId &vertexId) const override;
-#endif
+    bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
+      const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,
                      const float &yOrigin,


### PR DESCRIPTION
This PR refactors all uses of the following pattern:
```cpp
#ifdef TTK_ENABLE_KAMIKAZE
int function(int arg) {
#else
int functionInternal(int arg) {
#endif
```
into 
```cpp
int TTK_TRIANGULATION_INTERNAL(function)(int arg) {
```

through all triangulation variants. Here, `TTK_TRIANGULATION_INTERNAL` is a macro that concatenates the function name with "Internal" if the KAMIKAZE flag is not defined.

In the end, there should be only one `#ifdef TTK_ENABLE_KAMIKAZE` throughout the entire TTK codebase.

In addition, I took the liberty to fix some Clang warnings about missing qualifiers and types.

Enjoy!
Pierre