### PR TITLE
Ready: Delegate cell acces to a new class (compatibility vtk9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ install(
 
 if(TTK_BUILD_PARAVIEW_PLUGINS)
   include(CMake/ParaViewFilter.cmake)
+  add_compile_definitions("TTK_BUILD_PARAVIEW_PLUGINS")
 
   # Install location
   if(NOT "$ENV{PV_PLUGIN_PATH}" STREQUAL "")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ jobs:
 # VTK
 
 - job:
+  condition: true
   displayName: Ubuntu-VTK-Python3-OpenMP-Ninja
   strategy:
     matrix:
@@ -58,7 +59,7 @@ jobs:
   - script: |
       git clone --quiet https://gitlab.kitware.com/vtk/vtk.git
       cd vtk
-      git checkout 2c04a6b393
+      git checkout e4e8a4df9cc67fd2bb3dbb3b1c50a25177cbfe68
       git submodule update --init --recursive
     displayName: 'Clone VTK'
 
@@ -93,6 +94,7 @@ jobs:
 # ParaView
 
 - job:
+  condition: true
   displayName: Ubuntu-PV-Python3-Eigen-Make
   timeoutInMinutes: 180
   pool:
@@ -166,6 +168,7 @@ jobs:
 # ------------------------------
 
 - job:
+  condition: true
   displayName: MacOS-PV-Python3-OpenMP-Make (no install)
   timeoutInMinutes: 180
   pool:
@@ -173,7 +176,7 @@ jobs:
   steps:
   - script: |
       brew cask install xquartz
-      brew install wget python ffmpeg libomp mesa glew boost
+      brew install wget python libomp mesa glew boost vtk
     displayName: 'Install dependencies'
 
   - script: |
@@ -201,7 +204,6 @@ jobs:
     displayName: 'Configure TTK'
 
   - script: |
-      # cmake --build . --target ttkAlgorithm-hierarchy ttkIcoSphere-hierarchy ttkTopologicalCompressionWriter-hierarchy ttkTopologicalCompressionReader-hierarchy # TODO UGLY HOT FIX
       cmake --build . --target install -- -j 4
     workingDirectory: 'build/'
     displayName: 'Build and install TTK'
@@ -212,15 +214,16 @@ jobs:
       otool -L ./bin/ttkBlankCmd
       echo "otoo l"
       otool -l ./bin/ttkBlankCmd
-#      DYLD_PRINT_LIBRARIES=1 ./bin/ttkBlankCmd -i $(Build.SourcesDirectory)/examples/data/inputData.vtu
+      # DYLD_PRINT_LIBRARIES=1 ./bin/ttkBlankCmd -i $(Build.SourcesDirectory)/examples/data/inputData.vtu
     workingDirectory: '$(Build.ArtifactStagingDirectory)/ttk-install/'
-    displayName: 'Test TTK Command line'
+    displayName: 'Test TTK Command line (DISABLED FOR NOW)'
 
 # ------------------------------
 # Windows build
 # ------------------------------
 
 - job:
+  condition: true
   displayName: Windows-VTK
   strategy:
     matrix:
@@ -254,7 +257,7 @@ jobs:
   - bash: |
       git clone --quiet https://gitlab.kitware.com/vtk/vtk.git
       cd vtk
-      git checkout 2c04a6b393
+      git checkout e4e8a4df9cc67fd2bb3dbb3b1c50a25177cbfe68
       git submodule update --init --recursive
       mkdir build
     displayName: 'Clone VTK'

--- a/config.cmake
+++ b/config.cmake
@@ -12,8 +12,15 @@ endif()
 # Find Paraview OR VTK if needed
 if(TTK_BUILD_PARAVIEW_PLUGINS)
   find_package(ParaView REQUIRED)
+  # hande version manually so we do not have to include
+  # files from VTK / ParaView in the code.
+  # this is necessary to work with build folder directly (MacOS)
+  add_definitions(-DPARAVIEW_VERSION_MAJOR=${ParaView_VERSION_MAJOR})
+  add_definitions(-DPARAVIEW_VERSION_MINOR=${ParaView_VERSION_MINOR})
 elseif(TTK_BUILD_VTK_WRAPPERS)
   find_package(VTK REQUIRED)
+  add_definitions(-DVTK_VERSION_MAJOR=${VTK_VERSION_MAJOR})
+  add_definitions(-DVTK_VERSION_MINOR=${VTK_VERSION_MINOR})
 endif()
 
 option(TTK_ENABLE_64BIT_IDS "Enable processing on large datasets" OFF)

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -23,6 +23,7 @@ int ExplicitTriangulation::clear() {
 
   printMsg(
     "[ExplicitTriangulation] Triangulation cleared.", debug::Priority::DETAIL);
+  // clear twice ??
 
   return AbstractTriangulation::clear();
 }

--- a/core/base/jacobiSet/JacobiSet.inl
+++ b/core/base/jacobiSet/JacobiSet.inl
@@ -1,22 +1,22 @@
-#include <JacobiSet.h>
+#include "JacobiSet.h"
 
 template <class dataTypeU, class dataTypeV>
 ttk::JacobiSet<dataTypeU, dataTypeV>::JacobiSet() {
 
   vertexNumber_ = 0;
 
-  uField_ = NULL;
-  vField_ = NULL;
+  uField_ = nullptr;
+  vField_ = nullptr;
 
-  tetList_ = NULL;
+  tetList_ = nullptr;
 
-  edgeList_ = NULL;
-  edgeFanLinkEdgeLists_ = NULL;
-  edgeFans_ = NULL;
-  sosOffsetsU_ = NULL;
-  sosOffsetsV_ = NULL;
+  edgeList_ = nullptr;
+  edgeFanLinkEdgeLists_ = nullptr;
+  edgeFans_ = nullptr;
+  sosOffsetsU_ = nullptr;
+  sosOffsetsV_ = nullptr;
 
-  triangulation_ = NULL;
+  triangulation_ = nullptr;
 }
 
 template <class dataTypeU, class dataTypeV>

--- a/core/base/jacobiSet/JacobiSet.inl
+++ b/core/base/jacobiSet/JacobiSet.inl
@@ -137,14 +137,16 @@ int ttk::JacobiSet<dataTypeU, dataTypeV>::connectivityPreprocessing(
         }
       }
 
+      // Wrap edgeFans data in cellArray
+      CellArray edgeFansCells(edgeFans[i].data(), edgeFans[i].size() / 4, 3);
+
       // set-up the link of the edge fan
       threadedLinkers[threadId].buildVertexLink(
-        pivotVertexId, edgeFans[i].size() / 4, edgeFans[i].data(),
-        threadedLinks[threadId]);
+        pivotVertexId, edgeFansCells, threadedLinks[threadId]);
 
       // now compute the edge list of the link
       threadedEdgeListers[threadId].buildEdgeSubList(
-        edgeFans[i].size() / 4, edgeFans[i].data(), edgeFanLinkEdgeLists[i]);
+        edgeFansCells, edgeFanLinkEdgeLists[i]);
 
       // update the progress bar of the wrapping code -- to adapt
       if(debugLevel_ > advancedInfoMsg) {

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.inl
@@ -1,7 +1,7 @@
 #ifndef SCALARFIELDCRITICALPOINTS_INL
 #define SCALARFIELDCRITICALPOINTS_INL
 
-#include <ScalarFieldCriticalPoints.h>
+#include "ScalarFieldCriticalPoints.h"
 
 template <class dataType>
 ttk::ScalarFieldCriticalPoints<dataType>::ScalarFieldCriticalPoints() {

--- a/core/base/skeleton/CMakeLists.txt
+++ b/core/base/skeleton/CMakeLists.txt
@@ -1,10 +1,12 @@
 ttk_add_base_library(skeleton
   SOURCES
+    CellArray.cpp
     ZeroSkeleton.cpp
     OneSkeleton.cpp
     TwoSkeleton.cpp
     ThreeSkeleton.cpp
   HEADERS
+    CellArray.h
     ZeroSkeleton.h
     OneSkeleton.h
     TwoSkeleton.h

--- a/core/base/skeleton/CellArray.cpp
+++ b/core/base/skeleton/CellArray.cpp
@@ -1,0 +1,35 @@
+#include <CellArray.h>
+
+#include <iostream>
+
+using namespace ttk;
+
+CellArray::CellArray(const LongSimplexId *cellArray,
+                     const LongSimplexId nbCells,
+                     const unsigned char dimension)
+  : cellArray_{cellArray}, nbCells_{nbCells}, dimension_{dimension} {
+}
+
+SimplexId CellArray::getCellVertexNumber(const LongSimplexId cellId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(cellId >= this->nbCells_) {
+    std::cerr << "TTK: access to cell " << cellId << " on " << this->nbCells_
+              << std::endl;
+  }
+#endif
+  // Assume regular mesh
+  return this->dimension_ + 1;
+}
+
+LongSimplexId CellArray::getCellVertex(const LongSimplexId cellId,
+                                       const SimplexId localVertId) const {
+  const SimplexId locNbVert = this->getCellVertexNumber(cellId);
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(localVertId >= locNbVert) {
+    std::cerr << "TTK: access to local vert " << localVertId << " on "
+              << locNbVert << std::endl;
+  }
+#endif
+  // Assume VTK < 9 layout
+  return this->cellArray_[(locNbVert + 1) * cellId + 1 + localVertId];
+}

--- a/core/base/skeleton/CellArray.cpp
+++ b/core/base/skeleton/CellArray.cpp
@@ -9,27 +9,3 @@ CellArray::CellArray(const LongSimplexId *cellArray,
                      const unsigned char dimension)
   : cellArray_{cellArray}, nbCells_{nbCells}, dimension_{dimension} {
 }
-
-SimplexId CellArray::getCellVertexNumber(const LongSimplexId cellId) const {
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(cellId >= this->nbCells_) {
-    std::cerr << "TTK: access to cell " << cellId << " on " << this->nbCells_
-              << std::endl;
-  }
-#endif
-  // Assume regular mesh
-  return this->dimension_ + 1;
-}
-
-LongSimplexId CellArray::getCellVertex(const LongSimplexId cellId,
-                                       const SimplexId localVertId) const {
-  const SimplexId locNbVert = this->getCellVertexNumber(cellId);
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(localVertId >= locNbVert) {
-    std::cerr << "TTK: access to local vert " << localVertId << " on "
-              << locNbVert << std::endl;
-  }
-#endif
-  // Assume VTK < 9 layout
-  return this->cellArray_[(locNbVert + 1) * cellId + 1 + localVertId];
-}

--- a/core/base/skeleton/CellArray.h
+++ b/core/base/skeleton/CellArray.h
@@ -1,0 +1,71 @@
+/// \ingroup base
+/// \class ttk::CellArray
+/// \author Charles Gueunet <charles.gueunet@kitware.com>
+/// \date March 2020.
+///
+/// \brief %CellArray generic array of cells
+///
+/// %CellArray is a generic container that allows to deal with various cell
+/// layouts in memory \sa Triangulation \sa ttkTriangulation
+
+#ifndef _CELLARRAY_H
+#define _CELLARRAY_H
+
+#include <DataTypes.h>
+
+#ifndef TTK_ENABLE_KAMIKAZE
+#include <iostream>
+#endif
+
+namespace ttk {
+
+  // This is not a Debug class as we want to keep it as light as possible
+  class CellArray {
+  public:
+    CellArray(const LongSimplexId *cellArray,
+              const LongSimplexId nbCells,
+              const unsigned char dimension);
+
+    virtual ~CellArray() {
+      if(ownerShip_) {
+        delete[] cellArray_;
+      }
+    }
+
+    /// Deal with data ownership
+    void setOwnership(const bool o) {
+      ownerShip_ = o;
+    }
+
+    /// Retrieve the dimension
+    const unsigned char getDimension() const {
+      return dimension_;
+    }
+
+    /// Get the number of cells in the array
+    LongSimplexId getNbCells() const {
+      return nbCells_;
+    }
+
+    /// Get the number of vertices in the cell with the id: cellid
+    /// \param cellid global id of the cell
+    /// \return dimension + 1 for now as we only accept regular meshes
+    SimplexId getCellVertexNumber(const LongSimplexId cellid) const;
+
+    /// Get the vertex id of the "localVertId"'nt vertex of the cell.
+    /// \param cellId global id of the cell
+    /// \param localVertId id of the vertex local to the cell,
+    /// usually lower than 4 in 3D and lower than 3 in 2D.
+    /// \return the global id of the vertex
+    LongSimplexId getCellVertex(const LongSimplexId cellId,
+                                const SimplexId localVertId) const;
+
+  protected:
+    const LongSimplexId *cellArray_;
+    const LongSimplexId nbCells_;
+    const unsigned char dimension_;
+    bool ownerShip_ = false;
+  };
+} // namespace ttk
+
+#endif

--- a/core/base/skeleton/CellArray.h
+++ b/core/base/skeleton/CellArray.h
@@ -38,27 +38,45 @@ namespace ttk {
     }
 
     /// Retrieve the dimension
-    const unsigned char getDimension() const {
+    inline const unsigned char getDimension() const {
       return dimension_;
     }
 
     /// Get the number of cells in the array
-    LongSimplexId getNbCells() const {
+    inline LongSimplexId getNbCells() const {
       return nbCells_;
     }
 
     /// Get the number of vertices in the cell with the id: cellid
     /// \param cellid global id of the cell
     /// \return dimension + 1 for now as we only accept regular meshes
-    SimplexId getCellVertexNumber(const LongSimplexId cellid) const;
-
+    inline SimplexId getCellVertexNumber(const LongSimplexId cellId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(cellId >= this->nbCells_) {
+        std::cerr << "TTK: access to cell " << cellId << " on "
+                  << this->nbCells_ << std::endl;
+      }
+#endif
+      // WARNING: ASSUME Regular Mesh here
+      return this->dimension_ + 1;
+    }
     /// Get the vertex id of the "localVertId"'nt vertex of the cell.
     /// \param cellId global id of the cell
     /// \param localVertId id of the vertex local to the cell,
     /// usually lower than 4 in 3D and lower than 3 in 2D.
     /// \return the global id of the vertex
-    LongSimplexId getCellVertex(const LongSimplexId cellId,
-                                const SimplexId localVertId) const;
+    inline LongSimplexId getCellVertex(const LongSimplexId cellId,
+                                       const SimplexId localVertId) const {
+      const SimplexId locNbVert = this->getCellVertexNumber(cellId);
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(localVertId >= locNbVert) {
+        std::cerr << "TTK: access to local vert " << localVertId << " on "
+                  << locNbVert << std::endl;
+      }
+#endif
+      // Assume VTK < 9 layout
+      return this->cellArray_[(locNbVert + 1) * cellId + 1 + localVertId];
+    }
 
   protected:
     const LongSimplexId *cellArray_;

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -13,16 +13,14 @@ OneSkeleton::~OneSkeleton() {
 int OneSkeleton::buildEdgeLinks(
   const vector<pair<SimplexId, SimplexId>> &edgeList,
   const vector<vector<SimplexId>> &edgeStars,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> &edgeLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeList.empty())
     return -1;
-  if((edgeStars.empty()) || (edgeStars.size() != edgeList.size()))
+  if(edgeStars.size() != edgeList.size())
     return -2;
-  if(!cellArray)
-    return -3;
 #endif
 
   Timer t;
@@ -32,26 +30,24 @@ int OneSkeleton::buildEdgeLinks(
 
   edgeLinks.resize(edgeList.size());
 
-  SimplexId verticesPerCell = cellArray[0];
-
+  const SimplexId nbEdges = edgeLinks.size();
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)edgeLinks.size(); i++) {
-    for(SimplexId j = 0; j < (SimplexId)edgeStars[i].size(); j++) {
+  for(SimplexId i = 0; i < nbEdges; i++) {
+    const SimplexId localNbTriangle = edgeStars[i].size();
+    for(SimplexId j = 0; j < localNbTriangle; j++) {
 
-      SimplexId vertexId = -1;
+      // Look for the right vertex in each triangle
       for(int k = 0; k < 3; k++) {
-        if((cellArray[(verticesPerCell + 1) * edgeStars[i][j] + 1 + k]
-            != edgeList[i].first)
-           && (cellArray[(verticesPerCell + 1) * edgeStars[i][j] + 1 + k]
-               != edgeList[i].second)) {
-          vertexId = cellArray[(verticesPerCell + 1) * edgeStars[i][j] + 1 + k];
+        const SimplexId tmpVertexId
+          = cellArray.getCellVertex(edgeStars[i][j], k);
+        if(tmpVertexId != edgeList[i].first
+           && tmpVertexId != edgeList[i].second) {
+          // found the vertex in the triangle
+          edgeLinks[i].push_back(tmpVertexId);
           break;
         }
-      }
-      if(vertexId != -1) {
-        edgeLinks[i].push_back(vertexId);
       }
     }
   }
@@ -120,49 +116,45 @@ int OneSkeleton::buildEdgeLinks(
 
 int OneSkeleton::buildEdgeList(
   const SimplexId &vertexNumber,
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<pair<SimplexId, SimplexId>> &edgeList) const {
 
   ThreadId oldThreadNumber = threadNumber_;
 
   // NOTE: parallel implementation not efficient (see bench at the bottom)
   // let's force the usage of only 1 thread.
+  // TODO: we should remove parallel part, only dead code.
   threadNumber_ = 1;
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!cellArray)
-    return -1;
-#endif
 
   Timer t;
 
+  // TODO: describe the content of this complex container
+  // for each thread
+  // - a vector of size nb vertices containing
+  // - -
   vector<vector<vector<SimplexId>>> threadedEdgeTable(threadNumber_);
 
-  for(SimplexId i = 0; i < (SimplexId)threadedEdgeTable.size(); i++) {
-    threadedEdgeTable[i].resize(vertexNumber);
+  for(auto &vect : threadedEdgeTable) {
+    vect.resize(vertexNumber);
   }
-
-  // WARNING!
-  // assuming triangulations here
-  SimplexId verticesPerCell = cellArray[0];
 
   printMsg("Building edges", 0, 0, 1, ttk::debug::LineMode::REPLACE);
 
-  int timeBuckets = 10;
-  if(cellNumber < timeBuckets)
-    timeBuckets = cellNumber;
+  const SimplexId cellNumber = cellArray.getNbCells();
+  const int timeBuckets = std::min(10, cellNumber);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < cellNumber; i++) {
+  for(SimplexId cid = 0; cid < cellNumber; cid++) {
 
-    ThreadId threadId = 0, tmpVertexId = 0;
+    ThreadId threadId = 0;
     pair<SimplexId, SimplexId> edgeIds;
 #ifdef TTK_ENABLE_OPENMP
     threadId = omp_get_thread_num();
 #endif
+
+    const SimplexId nbVertsInCell = cellArray.getCellVertexNumber(cid);
 
     // tet case
     // 0 - 1
@@ -171,37 +163,35 @@ int OneSkeleton::buildEdgeList(
     // 1 - 2
     // 1 - 3
     // 2 - 3
-    for(SimplexId j = 0; j <= verticesPerCell - 2; j++) {
-      for(SimplexId k = j + 1; k <= verticesPerCell - 1; k++) {
+    for(SimplexId j = 0; j <= nbVertsInCell - 2; j++) {
+      for(SimplexId k = j + 1; k <= nbVertsInCell - 1; k++) {
         // edge processing
-        edgeIds.first = cellArray[(verticesPerCell + 1) * i + 1 + j];
-        edgeIds.second = cellArray[(verticesPerCell + 1) * i + 1 + k];
+        edgeIds.first = cellArray.getCellVertex(cid, j);
+        edgeIds.second = cellArray.getCellVertex(cid, k);
 
         if(edgeIds.first > edgeIds.second) {
-          tmpVertexId = edgeIds.first;
-          edgeIds.first = edgeIds.second;
-          edgeIds.second = tmpVertexId;
+          std::swap(edgeIds.first, edgeIds.second);
         }
 
         bool hasFound = false;
-        for(SimplexId l = 0;
-            l < (SimplexId)threadedEdgeTable[threadId][edgeIds.first].size();
-            l++) {
-          if(edgeIds.second == threadedEdgeTable[threadId][edgeIds.first][l]) {
+        // TODO Traversing the list each time is suboptimal. Sort + uniq
+        for(const auto &l : threadedEdgeTable[threadId][edgeIds.first]) {
+          if(edgeIds.second == l) {
             hasFound = true;
             break;
           }
         }
         if(!hasFound) {
-          threadedEdgeTable[threadId][edgeIds.first].push_back(edgeIds.second);
+          threadedEdgeTable[threadId][edgeIds.first].emplace_back(
+            edgeIds.second);
         }
         // end of edge processing
       }
     }
     if(debugLevel_ >= (int)(debug::Priority::INFO)) {
-      if(!(i % ((cellNumber) / timeBuckets)))
-        printMsg("Building edges", (i / (float)cellNumber), t.getElapsedTime(),
-                 1, debug::LineMode::REPLACE);
+      if(!(cid % ((cellNumber) / timeBuckets)))
+        printMsg("Building edges", (cid / (float)cellNumber),
+                 t.getElapsedTime(), 1, debug::LineMode::REPLACE);
     }
   }
 
@@ -211,25 +201,29 @@ int OneSkeleton::buildEdgeList(
 
   if(threadNumber_ > 1) {
     edgeTable.resize(vertexNumber);
-    for(SimplexId i = 0; i < (SimplexId)threadedEdgeTable.size(); i++) {
+    // All these .size are recomputed each time. Us
+    const SimplexId nbThreads = threadedEdgeTable.size();
+    for(SimplexId i = 0; i < nbThreads; i++) {
 
-      for(SimplexId j = 0; j < (SimplexId)threadedEdgeTable[i].size(); j++) {
+      const LongSimplexId nbVertThreadI = threadedEdgeTable[i].size();
+      for(LongSimplexId j = 0; j < nbVertThreadI; j++) {
 
-        for(SimplexId k = 0; k < (SimplexId)threadedEdgeTable[i][j].size();
-            k++) {
+        const LongSimplexId nbAttachedVertsJ = threadedEdgeTable[i][j].size();
+        for(LongSimplexId k = 0; k < nbAttachedVertsJ; k++) {
 
           // search if it already exists
           bool hasFound = false;
 
-          for(SimplexId l = 0; l < (SimplexId)edgeTable[j].size(); l++) {
-
+          // TODO here again, linear search is not optimal.
+          const LongSimplexId nbVertEdgeJ = edgeTable[j].size();
+          for(SimplexId l = 0; l < nbVertEdgeJ; l++) {
             if(edgeTable[j][l] == threadedEdgeTable[i][j][k]) {
               hasFound = true;
               break;
             }
           }
           if(!hasFound) {
-            edgeTable[j].push_back(threadedEdgeTable[i][j][k]);
+            edgeTable[j].emplace_back(threadedEdgeTable[i][j][k]);
             edgeCount++;
           }
         }
@@ -269,63 +263,49 @@ int OneSkeleton::buildEdgeList(
   return 0;
 }
 
-int OneSkeleton::buildEdgeLists(
-  const vector<vector<LongSimplexId>> &cellArrays,
-  vector<vector<pair<SimplexId, SimplexId>>> &edgeLists) const {
-
-  Timer t;
-
-  printMsg(
-    "Building edge lists", 0, 0, threadNumber_, debug::LineMode::REPLACE);
-
-  edgeLists.resize(cellArrays.size());
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(SimplexId i = 0; i < (SimplexId)cellArrays.size(); i++) {
-    buildEdgeSubList(cellArrays[i].size() / (cellArrays[i][0] + 1),
-                     cellArrays[i].data(), edgeLists[i]);
-  }
-
-  printMsg("Built " + to_string(edgeLists.size()) + " edge lists", 1,
-           t.getElapsedTime(), threadNumber_);
-
-  if(debugLevel_ >= (int)(debug::Priority::DETAIL)) {
-    for(SimplexId i = 0; i < (SimplexId)edgeLists.size(); i++) {
-      {
-        stringstream stringStream;
-        stringStream << "Surface #" << i << " (" << edgeLists[i].size()
-                     << " edges):";
-        printMsg(stringStream.str(), debug::Priority::DETAIL);
-      }
-      for(SimplexId j = 0; j < (SimplexId)edgeLists[i].size(); j++) {
-        stringstream stringStream;
-        stringStream << "- [" << edgeLists[i][j].first << " - "
-                     << edgeLists[i][j].second << "]";
-        printMsg(stringStream.str(), debug::Priority::DETAIL);
-      }
-    }
-  }
-
-  // computing the edge list of each vertex link:
-  // 24 threads (12 cores): 1.69s.
-  // 1 thread: 7.2 (> x4)
-
-  return 0;
-}
+// int OneSkeleton::buildEdgeLists(
+//   const vector<vector<LongSimplexId>> &cellArrays,
+//   vector<vector<pair<SimplexId, SimplexId>>> &edgeLists) const {
+//   Timer t;
+//   printMsg(
+//     "Building edge lists", 0, 0, threadNumber_, debug::LineMode::REPLACE);
+//   edgeLists.resize(cellArrays.size());
+// #ifdef TTK_ENABLE_OPENMP
+// #pragma omp parallel for num_threads(threadNumber_)
+// #endif
+//   for(SimplexId i = 0; i < (SimplexId)cellArrays.size(); i++) {
+//     buildEdgeSubList(cellArrays[i].size() / (cellArrays[i][0] + 1),
+//                      cellArrays[i].data(), edgeLists[i]);
+//   }
+//   printMsg("Built " + to_string(edgeLists.size()) + " edge lists", 1,
+//            t.getElapsedTime(), threadNumber_);
+//   if(debugLevel_ >= (int)(debug::Priority::DETAIL)) {
+//     for(SimplexId i = 0; i < (SimplexId)edgeLists.size(); i++) {
+//       {
+//         stringstream stringStream;
+//         stringStream << "Surface #" << i << " (" << edgeLists[i].size()
+//                      << " edges):";
+//         printMsg(stringStream.str(), debug::Priority::DETAIL);
+//       }
+//       for(SimplexId j = 0; j < (SimplexId)edgeLists[i].size(); j++) {
+//         stringstream stringStream;
+//         stringStream << "- [" << edgeLists[i][j].first << " - "
+//                      << edgeLists[i][j].second << "]";
+//         printMsg(stringStream.str(), debug::Priority::DETAIL);
+//       }
+//     }
+//   }
+//   // computing the edge list of each vertex link:
+//   // 24 threads (12 cores): 1.69s.
+//   // 1 thread: 7.2 (> x4)
+//   return 0;
+// }
 
 int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
-                                const SimplexId &cellNumber,
-                                const LongSimplexId *cellArray,
+                                const CellArray &cellArray,
                                 vector<vector<SimplexId>> &starList,
                                 vector<pair<SimplexId, SimplexId>> *edgeList,
                                 vector<vector<SimplexId>> *vertexStars) const {
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!cellArray)
-    return -1;
-#endif
 
   auto localEdgeList = edgeList;
   vector<pair<SimplexId, SimplexId>> defaultEdgeList{};
@@ -334,7 +314,7 @@ int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
   }
 
   if(!localEdgeList->size()) {
-    buildEdgeList(vertexNumber, cellNumber, cellArray, *localEdgeList);
+    buildEdgeList(vertexNumber, cellArray, *localEdgeList);
   }
 
   starList.resize(localEdgeList->size());
@@ -351,7 +331,7 @@ int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
     zeroSkeleton.setThreadNumber(threadNumber_);
     zeroSkeleton.setDebugLevel(debugLevel_);
     zeroSkeleton.buildVertexStars(
-      vertexNumber, cellNumber, cellArray, *localVertexStars);
+      vertexNumber, cellArray, *localVertexStars);
   }
 
   Timer t;
@@ -398,8 +378,7 @@ int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
 }
 
 int OneSkeleton::buildEdgeSubList(
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<pair<SimplexId, SimplexId>> &edgeList) const {
 
   // NOTE: here we're dealing with a subportion of the mesh.
@@ -412,8 +391,9 @@ int OneSkeleton::buildEdgeSubList(
   map<pair<SimplexId, SimplexId>, bool> edgeMap;
   edgeList.clear();
 
-  SimplexId verticesPerCell = cellArray[0];
-  for(SimplexId i = 0; i < cellNumber; i++) {
+  const SimplexId cellNumber = cellArray.getNbCells();
+  for(SimplexId cid = 0; cid < cellNumber; cid++) {
+    const SimplexId nbVertCell = cellArray.getCellVertexNumber(cid);
 
     pair<SimplexId, SimplexId> edgeIds;
     int tmpVertexId;
@@ -424,11 +404,11 @@ int OneSkeleton::buildEdgeSubList(
     // 1 - 2
     // 1 - 3
     // 2 - 3
-    for(SimplexId j = 0; j <= verticesPerCell - 2; j++) {
-      for(SimplexId k = j + 1; k <= verticesPerCell - 1; k++) {
+    for(SimplexId j = 0; j <= nbVertCell - 2; j++) {
+      for(SimplexId k = j + 1; k <= nbVertCell - 1; k++) {
 
-        edgeIds.first = cellArray[(verticesPerCell + 1) * i + 1 + j];
-        edgeIds.second = cellArray[(verticesPerCell + 1) * i + 1 + k];
+        edgeIds.first = cellArray.getCellVertex(cid, j);
+        edgeIds.second = cellArray.getCellVertex(cid, k);
 
         if(edgeIds.first > edgeIds.second) {
           tmpVertexId = edgeIds.first;

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -16,6 +16,7 @@
 #include <map>
 
 // base code includes
+#include <CellArray.h>
 #include <Wrapper.h>
 #include <ZeroSkeleton.h>
 
@@ -34,21 +35,19 @@ namespace ttk {
     /// should be equal to the number of edges in the triangulation. Each
     /// entry is a std::pair of vertex identifiers.
     /// \param edgeStars List of edge stars. The size of this std::vector
-    /// should be
-    /// equal to the number of edges. Each entry is a std::vector of triangle
-    /// identifiers.
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
-    /// \param edgeLinks Output edge links. The size of this std::vector
-    /// will be equal to the number of edges in the triangulation. Each
-    /// entry will be a std::vector listing the vertices in the link of the
-    /// corresponding vertex.
+    /// should be equal to the number of edges. Each entry is a std::vector of
+    /// triangle identifiers.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
+    /// \param edgeLinks Output edge links. The size of this std::vector will be
+    /// equal to the number of edges in the triangulation. Each entry will be a
+    /// std::vector listing the vertices in the link of the corresponding
+    /// vertex.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildEdgeLinks(
       const std::vector<std::pair<SimplexId, SimplexId>> &edgeList,
       const std::vector<std::vector<SimplexId>> &edgeStars,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &edgeLinks) const;
 
     /// Compute the link of each edge of a 3D triangulation (unspecified
@@ -57,10 +56,8 @@ namespace ttk {
     /// should be equal to the number of edges in the triangulation. Each
     /// entry is a std::pair of vertex identifiers.
     /// \param edgeStars List of edge stars. The size of this std::vector
-    /// should be
-    /// equal to the number of edges. Each entry is a std::vector of
-    /// tetrahedron
-    /// identifiers.
+    /// should be equal to the number of edges. Each entry is a std::vector of
+    /// tetrahedron identifiers.
     /// \param cellEdges List of celle edges. The size of this std::vector
     /// should be equal to the number of tetrahedra in the triangulation. Each
     /// entry is a std::vector of edge identifiers.
@@ -77,19 +74,15 @@ namespace ttk {
 
     /// Compute the list of edges of a valid triangulation.
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param edgeList Output edge list (each entry is an ordered std::pair
     /// of
     /// vertex identifiers).
     /// \return Returns 0 upon success, negative values otherwise.
     int buildEdgeList(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::pair<SimplexId, SimplexId>> &edgeList) const;
 
     /// Compute the list of edges of multiple triangulations.
@@ -97,79 +90,59 @@ namespace ttk {
     /// starts by the number of vertices in the cell, followed by the vertex
     /// identifiers of the cell.
     /// \param edgeList Output edge list (each entry is an ordered std::pair
-    //  of
-    /// vertex identifiers).
+    ///  of vertex identifiers).
     /// \return Returns 0 upon success, negative values otherwise.
-    int
-      buildEdgeLists(const std::vector<std::vector<LongSimplexId>> &cellArrays,
-                     std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
-                       &edgeLists) const;
+    // int
+    //   buildEdgeLists(const std::vector<std::vector<LongSimplexId>> &cellArrays,
+    //                  std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
+    //                    &edgeLists) const;
+    // Need to change to be compatible with CellArray, but not used in TTK...
 
     /// Compute the 3-star of all the edges of a triangulation (for each
     /// edge, list of the 3-dimensional cells connected to it).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param starList Output list of 3-stars. The size of this std::vector
-    /// will
-    /// be equal to the number of edges in the mesh. Each entry stores a
+    /// will be equal to the number of edges in the mesh. Each entry stores a
     /// std::vector that lists the identifiers of all 3-dimensional cells
     /// connected to the entry's edge.
-    /// \param edgeList Optional list of edges. If NULL, the function will
-    /// compute this list anyway and free the related memory upon return.
-    /// If not NULL but pointing to an empty std::vector, the function will
-    /// fill
-    /// this empty std::vector (useful if this list needs to be used later on
-    /// by
-    /// the calling program). If not NULL but pointing to a non-empty
-    /// std::vector,
-    /// this function will use this std::vector as internal edge list. If
-    /// this
-    /// std::vector is not empty but incorrect, the behavior is unspecified.
-    /// \param vertexStars Optional list of vertex stars (list of
-    /// 3-dimensional cells connected to each vertex). If NULL, the
-    /// function will compute this list anyway and free the related memory
-    /// upon return. If not NULL but pointing to an empty std::vector, the
-    /// function will fill this empty std::vector (useful if this list needs
-    /// to be used later on by the calling program). If not NULL but pointing
-    /// to a non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
+    /// \param edgeList Optional list of edges. If nullptr, the function will
+    /// compute this list anyway and free the related memory upon return. If not
+    /// nullptr but pointing to an empty std::vector, the function will fill
+    /// this empty std::vector (useful if this list needs to be used later on by
+    /// the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal edge
+    /// list. If this std::vector is not empty but incorrect, the behavior is
+    /// unspecified.
+    /// \param vertexStars Optional list of vertex stars (list of 3-dimensional
+    /// cells connected to each vertex). If nullptr, the function will compute
+    /// this list anyway and free the related memory upon return. If not nullptr
+    /// but pointing to an empty std::vector, the function will fill this empty
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal vertex
+    /// star list. If this std::vector is not empty but incorrect, the behavior
+    /// is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildEdgeStars(const SimplexId &vertexNumber,
-                       const SimplexId &cellNumber,
-                       const LongSimplexId *cellArray,
+                       const CellArray &cellArray,
                        std::vector<std::vector<SimplexId>> &starList,
                        std::vector<std::pair<SimplexId, SimplexId>> *edgeList
-                       = NULL,
+                       = nullptr,
                        std::vector<std::vector<SimplexId>> *vertexStars
-                       = NULL) const;
+                       = nullptr) const;
 
     /// Compute the list of edges of a sub-portion of a valid triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// considered subset of the triangulation (number of tetrahedra in 3D,
-    /// triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param edgeList Output edge list (each entry is an ordered std::pair
-    /// of
-    /// vertex identifiers).
+    /// of vertex identifiers).
     /// \return Returns 0 upon success, negative values otherwise.
     int buildEdgeSubList(
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::pair<SimplexId, SimplexId>> &edgeList) const;
-
-  protected:
   };
 } // namespace ttk
-
-// if the package is not a template, comment the following line
-// #include                  <OneSkeleton.cpp>
 
 #endif // ONESKELETON_H

--- a/core/base/skeleton/ThreeSkeleton.h
+++ b/core/base/skeleton/ThreeSkeleton.h
@@ -32,45 +32,36 @@ namespace ttk {
 
     /// Compute the list of edges of each cell of a triangulation.
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param cellEdges Output edge lists. The size of this std::vector
     /// will be equal to the number of cells in the mesh. Each entry will be
     /// a std::vector listing the edge identifiers of the entry's cell's
     /// edges.
-    /// \param edgeList Optional list of edges. If NULL, the function will
-    /// compute this list anyway and free the related memory upon return.
-    /// If not NULL but pointing to an empty std::vector, the function will
-    /// fill
-    /// this empty std::vector (useful if this list needs to be used later on
-    /// by
-    /// the calling program). If not NULL but pointing to a non-empty
-    /// std::vector,
-    /// this function will use this std::vector as internal edge list. If
-    /// this
-    /// std::vector is not empty but incorrect, the behavior is unspecified.
-    /// \param vertexEdges Optional list of edges for each vertex. If NULL,
-    /// the function will compute this list anyway and free the related
-    /// memory upon return. If not NULL but pointing to an empty std::vector,
-    /// the function will fill this empty std::vector (useful if this list
-    /// needs to
-    /// be used later on by the calling program). If not NULL but pointing to
-    /// a non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex edge list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
+    /// \param edgeList Optional list of edges. If nullptr, the function will
+    /// compute this list anyway and free the related memory upon return. If not
+    /// nullptr but pointing to an empty std::vector, the function will fill
+    /// this empty std::vector (useful if this list needs to be used later on by
+    /// the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal edge
+    /// list. If this std::vector is not empty but incorrect, the behavior is
+    /// unspecified.
+    /// \param vertexEdges Optional list of edges for each vertex.
+    /// If nullptr, the function will compute this list anyway and free the
+    /// related memory upon return. If not nullptr but pointing to an empty
+    /// std::vector, the function will fill this empty std::vector (useful if
+    /// this list needs to be used later on by the calling program). If not
+    /// nullptr but pointing to a non-empty std::vector, this function will use
+    /// this std::vector as internal vertex edge list. If this std::vector is
+    /// not empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildCellEdges(const SimplexId &vertexNumber,
-                       const SimplexId &cellNumber,
-                       const LongSimplexId *cellArray,
+                       const CellArray &cellArray,
                        std::vector<std::vector<SimplexId>> &cellEdges,
                        std::vector<std::pair<SimplexId, SimplexId>> *edgeList
-                       = NULL,
+                       = nullptr,
                        std::vector<std::vector<SimplexId>> *vertexEdges
-                       = NULL) const;
+                       = nullptr) const;
 
     /// Compute the list of cell-neighbors of each cell of a triangulation
     /// (unspecified behavior if the input mesh is not a triangulation).
@@ -78,71 +69,53 @@ namespace ttk {
     /// stars computed. Otherwise, please use
     /// ThreeSkeleton::buildCellNeighborsFromVertices instead.
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
-    /// \param cellNeighbors Output neighbor list. The size of this
-    /// std::vector
-    /// will be equal to the number of cells in the mesh. Each entry will be
-    /// a std::vector listing the cell identifiers of the entry's cell's
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
+    /// \param cellNeighbors Output neighbor list. The size of this std::vector
+    /// will be equal to the number of cells in the mesh. Each entry will be a
+    /// std::vector listing the cell identifiers of the entry's cell's
     /// neighbors.
     /// \param triangleStars Optional list of triangle stars (list of
-    /// 3-dimensional cells connected to each triangle). If NULL, the
+    /// 3-dimensional cells connected to each triangle). If nullptr, the
     /// function will compute this list anyway and free the related memory
-    /// upon return. If not NULL but pointing to an empty std::vector, the
+    /// upon return. If not nullptr but pointing to an empty std::vector, the
     /// function will fill this empty std::vector (useful if this list needs
-    /// to be used later on by the calling program). If not NULL but pointing
+    /// to be used later on by the calling program). If not nullptr but pointing
     /// to a non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// triangle star list. If this std::vector is not empty but incorrect,
-    /// the
-    /// behavior is unspecified.
-    /// \return Returns 0 upon success, negative values otherwise.
+    /// internal triangle star list. If this std::vector is not empty but
+    /// incorrect, the behavior is unspecified. \return Returns 0 upon success,
+    /// negative values otherwise.
     int buildCellNeighborsFromTriangles(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &cellNeighbors,
-      std::vector<std::vector<SimplexId>> *triangleStars = NULL) const;
+      std::vector<std::vector<SimplexId>> *triangleStars = nullptr) const;
 
     /// Compute the list of cell-neighbors of each cell of a triangulation
     /// (unspecified behavior if the input mesh is not a triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param cellNeighbors Output neighbor list. The size of this
-    /// std::vector
-    /// will be equal to the number of cells in the mesh. Each entry will be
-    /// a std::vector listing the cell identifiers of the entry's cell's
+    /// std::vector will be equal to the number of cells in the mesh. Each entry
+    /// will be a std::vector listing the cell identifiers of the entry's cell's
     /// neighbors.
     /// \param vertexStars Optional list of vertex stars (list of
-    /// 3-dimensional cells connected to each vertex). If NULL, the
+    /// 3-dimensional cells connected to each vertex). If nullptr, the
     /// function will compute this list anyway and free the related memory
-    /// upon return. If not NULL but pointing to an empty std::vector, the
+    /// upon return. If not nullptr but pointing to an empty std::vector, the
     /// function will fill this empty std::vector (useful if this list needs
-    /// to be used later on by the calling program). If not NULL but pointing
+    /// to be used later on by the calling program). If not nullptr but pointing
     /// to a non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
+    /// internal vertex star list. If this std::vector is not empty but
+    /// incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildCellNeighborsFromVertices(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &cellNeighbors,
-      std::vector<std::vector<SimplexId>> *vertexStars = NULL) const;
-
-  protected:
+      std::vector<std::vector<SimplexId>> *vertexStars = nullptr) const;
   };
 } // namespace ttk
-
-// if the package is not a template, comment the following line
-// #include                  <ThreeSkeleton.cpp>
 
 #endif // THREESKELETON_H

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -13,8 +13,7 @@ TwoSkeleton::~TwoSkeleton() {
 
 int TwoSkeleton::buildCellNeighborsFromVertices(
   const SimplexId &vertexNumber,
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> &cellNeighbors,
   vector<vector<SimplexId>> *vertexStars) const {
 
@@ -26,12 +25,10 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
   }
 
   if(!localVertexStars->size()) {
-
     ZeroSkeleton zeroSkeleton;
     zeroSkeleton.setThreadNumber(threadNumber_);
     zeroSkeleton.setDebugLevel(debugLevel_);
-    zeroSkeleton.buildVertexStars(
-      vertexNumber, cellNumber, cellArray, *localVertexStars);
+    zeroSkeleton.buildVertexStars(vertexNumber, cellArray, *localVertexStars);
   }
 
   Timer t;
@@ -39,13 +36,14 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
   printMsg(
     "Building cell neighbors", 0, 0, threadNumber_, debug::LineMode::REPLACE);
 
-  SimplexId vertexPerCell = cellArray[0];
-
+  const SimplexId cellNumber = cellArray.getNbCells();
   cellNeighbors.resize(cellNumber);
-  for(SimplexId i = 0; i < (SimplexId)cellNeighbors.size(); i++)
-    cellNeighbors[i].reserve(vertexPerCell);
+  for(SimplexId cid = 0; cid < cellNumber; cid++) {
+    const SimplexId nbVertCell = cellArray.getCellVertexNumber(cid);
+    cellNeighbors[cid].reserve(nbVertCell);
+  }
 
-    // pre-sort vertex stars
+  // pre-sort vertex stars
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
@@ -55,13 +53,13 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < cellNumber; i++) {
+  for(SimplexId cid = 0; cid < cellNumber; cid++) {
+    const SimplexId nbVertCell = cellArray.getCellVertexNumber(cid);
 
-    for(SimplexId j = 0; j < vertexPerCell; j++) {
+    for(SimplexId j = 0; j < nbVertCell; j++) {
 
-      SimplexId v0 = cellArray[(vertexPerCell + 1) * i + 1 + j];
-      SimplexId v1
-        = cellArray[(vertexPerCell + 1) * i + 1 + (j + 1) % vertexPerCell];
+      SimplexId v0 = cellArray.getCellVertex(cid, j);
+      SimplexId v1 = cellArray.getCellVertex(cid, (j + 1) % nbVertCell);
 
       // perform an intersection of the 2 sorted star lists
       SimplexId pos0 = 0, pos1 = 0;
@@ -94,7 +92,7 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
 
         if((*localVertexStars)[v0][pos0] == (*localVertexStars)[v1][pos1]) {
 
-          if((*localVertexStars)[v0][pos0] != i) {
+          if((*localVertexStars)[v0][pos0] != cid) {
             intersection = (*localVertexStars)[v0][pos0];
             break;
           }
@@ -105,7 +103,7 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
       }
 
       if(intersection != -1) {
-        cellNeighbors[i].push_back(intersection);
+        cellNeighbors[cid].emplace_back(intersection);
       }
     }
   }
@@ -118,8 +116,7 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
 
 int TwoSkeleton::buildEdgeTriangles(
   const SimplexId &vertexNumber,
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> &edgeTriangleList,
   vector<vector<SimplexId>> *vertexStarList,
   vector<pair<SimplexId, SimplexId>> *edgeList,
@@ -132,10 +129,6 @@ int TwoSkeleton::buildEdgeTriangles(
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexNumber <= 0)
     return -1;
-  if(cellNumber <= 0)
-    return -2;
-  if(!cellArray)
-    return -3;
 #endif
 
   // NOTE:
@@ -176,18 +169,16 @@ int TwoSkeleton::buildEdgeTriangles(
 
   // now do the pre-computation
   if(localEdgeList->empty()) {
-    oneSkeleton.buildEdgeList(
-      vertexNumber, cellNumber, cellArray, (*localEdgeList));
+    oneSkeleton.buildEdgeList(vertexNumber, cellArray, (*localEdgeList));
   }
 
   if(localEdgeStarList->empty()) {
-    oneSkeleton.buildEdgeStars(vertexNumber, cellNumber, cellArray,
-                               (*localEdgeStarList), localEdgeList,
-                               vertexStarList);
+    oneSkeleton.buildEdgeStars(vertexNumber, cellArray, (*localEdgeStarList),
+                               localEdgeList, vertexStarList);
   }
 
   if((localTriangleList->empty()) || (localCellTriangleList->empty())) {
-    buildTriangleList(vertexNumber, cellNumber, cellArray, localTriangleList,
+    buildTriangleList(vertexNumber, cellArray, localTriangleList,
                       triangleStarList, localCellTriangleList);
   }
 
@@ -266,8 +257,7 @@ int TwoSkeleton::buildEdgeTriangles(
 
 int TwoSkeleton::buildTriangleList(
   const SimplexId &vertexNumber,
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> *triangleList,
   vector<vector<SimplexId>> *triangleStars,
   vector<vector<SimplexId>> *cellTriangleList) const {
@@ -285,16 +275,13 @@ int TwoSkeleton::buildTriangleList(
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexNumber <= 0)
     return -1;
-  if(cellNumber <= 0)
-    return -2;
-  if(!cellArray)
-    return -3;
   if((!triangleList) && (!triangleStars) && (!cellTriangleList)) {
     // we've got nothing to do here.
-    return -4;
+    return -2;
   }
 #endif
 
+  const SimplexId cellNumber = cellArray.getNbCells();
   if(triangleList) {
     // NOTE: 9 is pretty empirical here...
     triangleList->clear();
@@ -322,16 +309,14 @@ int TwoSkeleton::buildTriangleList(
     vector<vector<pair<vector<SimplexId>, SimplexId>>> triangleTable(
       vertexNumber);
 
-    int timeBuckets = 10;
-    if(timeBuckets > cellNumber)
-      timeBuckets = cellNumber;
+    const SimplexId timeBuckets = std::min(10, cellNumber);
 
     for(SimplexId i = 0; i < vertexNumber; i++)
       triangleTable[i].reserve(32);
 
-    for(SimplexId i = 0; i < cellNumber; i++) {
+    for(SimplexId cid = 0; cid < cellNumber; cid++) {
 
-      if((!wrapper_) || ((wrapper_) && (!wrapper_->needsToAbort()))) {
+      if(!wrapper_ || (wrapper_ && !wrapper_->needsToAbort())) {
 
         vector<SimplexId> triangle(3);
 
@@ -339,7 +324,8 @@ int TwoSkeleton::buildTriangleList(
           // doing triangle j
 
           for(int k = 0; k < 3; k++) {
-            triangle[k] = cellArray[5 * i + 1 + (j + k) % 4];
+            // TODO: ASSUME Regular Mesh Here!
+            triangle[k] = cellArray.getCellVertex(cid, (j + k) % 4);
           }
           sort(triangle.begin(), triangle.end());
 
@@ -369,20 +355,20 @@ int TwoSkeleton::buildTriangleList(
               triangleStars->resize(triangleStars->size() + 1);
               triangleStars->back().resize(1);
               // store the tet i in the triangleStars list
-              triangleStars->back().back() = i;
+              triangleStars->back().back() = cid;
             }
           } else {
             if(triangleStars) {
               // add tet i as a neighbor of triangleId
-              (*triangleStars)[triangleId].push_back(i);
+              (*triangleStars)[triangleId].push_back(cid);
             }
           }
 
           if(cellTriangleList) {
             // add the triangle to the cell
             for(int k = 0; k < 4; k++) {
-              if((*cellTriangleList)[i][k] == -1) {
-                (*cellTriangleList)[i][k] = triangleId;
+              if((*cellTriangleList)[cid][k] == -1) {
+                (*cellTriangleList)[cid][k] = triangleId;
                 break;
               }
             }
@@ -392,12 +378,12 @@ int TwoSkeleton::buildTriangleList(
         // update the progress bar of the wrapping code -- to adapt
         if(debugLevel_ >= (int)(debug::Priority::INFO)) {
 
-          if(!(i % ((cellNumber) / timeBuckets))) {
-            printMsg("Building triangles", (i / (float)cellNumber),
+          if(!(cid % ((cellNumber) / timeBuckets))) {
+            printMsg("Building triangles", (cid / (float)cellNumber),
                      t.getElapsedTime(), threadNumber_,
                      ttk::debug::LineMode::REPLACE);
             if(wrapper_) {
-              wrapper_->updateProgress((i) / (float)cellNumber);
+              wrapper_->updateProgress(cid / (float)cellNumber);
             }
           }
         }
@@ -424,12 +410,14 @@ int TwoSkeleton::buildTriangleList(
 
     int count = 0;
 
+    // TODO: duplicate code, almost same as above.
+
     // the following open-mp processing is only relevant for embarassingly
     // parallel algorithms (such as smoothing) -- to adapt
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId)cellNumber; i++) {
+    for(SimplexId cid = 0; cid < (SimplexId)cellNumber; cid++) {
 
       // avoid any processing if the abort signal is sent
       if((!wrapper_) || ((wrapper_) && (!wrapper_->needsToAbort()))) {
@@ -445,29 +433,24 @@ int TwoSkeleton::buildTriangleList(
           // doing triangle j
 
           for(int k = 0; k < 3; k++) {
-            triangle[k] = cellArray[5 * i + 1 + (j + k) % 4];
+            // TODO: ASSUME Regular Mesh Here!
+            triangle[k] = cellArray.getCellVertex(cid, (j + k) % 4);
           }
           sort(triangle.begin(), triangle.end());
 
           SimplexId triangleId = -1;
-          for(SimplexId k = 0;
-              k
-              < (SimplexId)threadedTriangleTable[threadId][triangle[0]].size();
-              k++) {
 
+          for(auto triVerts : threadedTriangleTable[threadId][triangle[0]]) {
             // processing a triangle stored for that vertex
-            if((threadedTriangleTable[threadId][triangle[0]][k].first[1]
-                == triangle[1])
-               && (threadedTriangleTable[threadId][triangle[0]][k].first[2]
-                   == triangle[2])) {
-              triangleId
-                = threadedTriangleTable[threadId][triangle[0]][k].second;
+            if(triVerts.first[1] == triangle[1]
+               && triVerts.first[2] == triangle[2]) {
+              triangleId = triVerts.second;
               break;
             }
           }
           if(triangleId == -1) {
             // not visited by this thread
-            threadedTriangleTable[threadId][triangle[0]].push_back(
+            threadedTriangleTable[threadId][triangle[0]].emplace_back(
               pair<vector<SimplexId>, SimplexId>(
                 triangle, triangleNumbers[threadId]));
             triangleNumbers[threadId]++;
@@ -476,11 +459,11 @@ int TwoSkeleton::buildTriangleList(
               threadedTriangleStars[threadId].resize(
                 threadedTriangleStars[threadId].size() + 1);
               threadedTriangleStars[threadId].back().resize(1);
-              threadedTriangleStars[threadId].back().back() = i;
+              threadedTriangleStars[threadId].back().back() = cid;
             }
           } else {
             if(triangleStars) {
-              threadedTriangleStars[threadId][triangleId].push_back(i);
+              threadedTriangleStars[threadId][triangleId].emplace_back(cid);
             }
           }
         }
@@ -590,35 +573,22 @@ int TwoSkeleton::buildTriangleList(
       }
     }
   }
-
   printMsg("Built " + to_string(triangleNumber) + " triangles", 1,
            t.getElapsedTime(), threadNumber_);
-
   threadNumber_ = oldThreadNumber;
-
-  // ethaneDiolMedium.vtu, 70Mtets, hal9000 (12coresHT)
-  // 1 thread: 58.5631 s
-  // 24 threads: 87.5816 s (~)
-
-  // ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - no tet adj
-  // 1 thread: 5.7427 s
-  // 4 threads: 9.14764 s (~)
-
-  // ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - tet adjacency
-  // 1 thread: 8.59854 s
-  // 4 threads: 15.837 s (~)
-
-  // ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - tet adjacency only
-  // 1 thread: 6.85897 s
-  // 4 threads: 14.78 s (~)
-
+  // ethaneDiolMedium.vtu, 70Mtets, hal9000 (12coresHT)// 1 thread: 58.5631 s//
+  // 24 threads: 87.5816 s (~) ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - no
+  // tet adj// 1 thread: 5.7427 s// 4 threads: 9.14764 s (~)
+  // ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - tet adjacency// 1
+  // thread: 8.59854 s// 4 threads: 15.837 s
+  // (~) ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - tet adjacency only// 1
+  // thread: 6.85897 s// 4 threads: 14.78 s (~)
   return 0;
 }
 
 int TwoSkeleton::buildTriangleEdgeList(
   const SimplexId &vertexNumber,
-  const SimplexId &cellNumber,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> &triangleEdgeList,
   vector<vector<SimplexId>> *vertexEdgeList,
   vector<pair<SimplexId, SimplexId>> *edgeList,
@@ -637,8 +607,7 @@ int TwoSkeleton::buildTriangleEdgeList(
     oneSkeleton.setDebugLevel(debugLevel_);
     oneSkeleton.setThreadNumber(threadNumber_);
 
-    oneSkeleton.buildEdgeList(
-      vertexNumber, cellNumber, cellArray, (*localEdgeList));
+    oneSkeleton.buildEdgeList(vertexNumber, cellArray, (*localEdgeList));
   }
 
   auto localVertexEdgeList = vertexEdgeList;
@@ -668,7 +637,7 @@ int TwoSkeleton::buildTriangleEdgeList(
   }
   if(!localTriangleList->size()) {
 
-    buildTriangleList(vertexNumber, cellNumber, cellArray, localTriangleList,
+    buildTriangleList(vertexNumber, cellArray, localTriangleList,
                       triangleStarList, cellTriangleList);
   }
 
@@ -736,7 +705,7 @@ int TwoSkeleton::buildTriangleEdgeList(
 int TwoSkeleton::buildTriangleLinks(
   const vector<vector<SimplexId>> &triangleList,
   const vector<vector<SimplexId>> &triangleStars,
-  const LongSimplexId *cellArray,
+  const CellArray &cellArray,
   vector<vector<SimplexId>> &triangleLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -744,8 +713,6 @@ int TwoSkeleton::buildTriangleLinks(
     return -1;
   if((triangleStars.empty()) || (triangleStars.size() != triangleList.size()))
     return -2;
-  if(!cellArray)
-    return -3;
 #endif
 
   Timer t;
@@ -763,7 +730,7 @@ int TwoSkeleton::buildTriangleLinks(
     for(SimplexId j = 0; j < (SimplexId)triangleStars[i].size(); j++) {
 
       for(int k = 0; k < 4; k++) {
-        SimplexId vertexId = cellArray[5 * triangleStars[i][j] + 1 + k];
+        SimplexId vertexId = cellArray.getCellVertex(triangleStars[i][j], k);
 
         if((vertexId != triangleList[i][0]) && (vertexId != triangleList[i][1])
            && (vertexId != triangleList[i][2])) {

--- a/core/base/skeleton/TwoSkeleton.h
+++ b/core/base/skeleton/TwoSkeleton.h
@@ -32,262 +32,204 @@ namespace ttk {
     /// Compute the list of cell-neighbors of each cell of a 2D triangulation
     /// (unspecified behavior if the input mesh is not a triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
-    /// \param cellNeighbors Output neighbor list. The size of this
-    /// std::vector
-    /// will be equal to the number of cells in the mesh. Each entry will be
-    /// a std::vector listing the cell identifiers of the entry's cell's
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
+    /// \param cellNeighbors Output neighbor list. The size of this std::vector
+    /// will be equal to the number of cells in the mesh. Each entry will be a
+    /// std::vector listing the cell identifiers of the entry's cell's
     /// neighbors.
     /// \param vertexStars Optional list of vertex stars (list of
-    /// 2-dimensional cells connected to each vertex). If NULL, the
+    /// 2-dimensional cells connected to each vertex). If nullptr, the
     /// function will compute this list anyway and free the related memory
-    /// upon return. If not NULL but pointing to an empty std::vector, the
+    /// upon return. If not nullptr but pointing to an empty std::vector, the
     /// function will fill this empty std::vector (useful if this list needs
-    /// to be used later on by the calling program). If not NULL but pointing
+    /// to be used later on by the calling program). If not nullptr but pointing
     /// to a non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
-    /// \return Returns 0 upon success, negative values otherwise.
+    /// internal vertex star list. If this std::vector is not empty but
+    /// incorrect, the behavior is unspecified.
+    ///  \return Returns 0 upon success, negative values otherwise.
     int buildCellNeighborsFromVertices(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &cellNeighbors,
-      std::vector<std::vector<SimplexId>> *vertexStars = NULL) const;
+      std::vector<std::vector<SimplexId>> *vertexStars = nullptr) const;
 
     /// Compute the list of triangles connected to each edge for 3D
     /// triangulations (unspecified behavior if the input mesh is not a
     /// triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param edgeTriangleList Output edge triangle list. The size of this
     /// std::vector will be equal to the number of edges in the triangulation.
-    /// Each
-    /// entry will be a std::vector listing the triangle identifiers for each
-    /// triangle connected to the entry's edge.
+    /// Each entry will be a std::vector listing the triangle identifiers for
+    /// each triangle connected to the entry's edge.
     /// \param vertexStarList Optional output vertex star list (list of
-    /// tetrahedron identifiers for each vertex). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
-    /// \param edgeList Optional output edge list (list of std::pairs of
-    /// vertex
-    /// identifiers). If NULL, the function will compute this list anyway and
-    /// free the related memory upon return. If not NULL but pointing to an
-    /// empty std::vector, the function will fill this empty std::vector
-    /// (useful if this
-    /// list needs to be used later on by the calling program). If not NULL
-    /// but pointing to a non-empty std::vector, this function will use this
-    /// std::vector
-    /// as internal edge list. If this std::vector is not empty but
-    /// incorrect, the
-    /// behavior is unspecified.
-    /// \param edgeStarList Optional output edge star list (list of
-    /// tetrahedron identifiers for each edge). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// edge star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
-    /// \param triangleList Optional output triangle list (list of
-    /// std::vectors of
-    /// vertex identifiers). If NULL, the function will compute this list
-    /// anyway and free the related memory upon return. If not NULL but
+    /// tetrahedron identifiers for each vertex). If nullptr, the function will
+    /// compute this list anyway and free the related memory upon return. If not
+    /// nullptr but pointing to an empty std::vector, the function will fill
+    /// this empty std::vector (useful if this list needs to be used later on by
+    /// the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal vertex
+    /// star list. If this std::vector is not empty but incorrect, the behavior
+    /// is unspecified.
+    /// \param edgeList Optional output edge list (list of std::pairs of vertex
+    /// identifiers). If nullptr, the function will compute this list anyway and
+    /// free the related memory upon return. If not nullptr but pointing to an
+    /// empty std::vector, the function will fill this empty std::vector (useful
+    /// if this list needs to be used later on by the calling program). If not
+    /// nullptr but pointing to a non-empty std::vector, this function will use
+    /// this std::vector as internal edge list. If this std::vector is not empty
+    /// but incorrect, the behavior is unspecified.
+    /// \param edgeStarList Optional output edge star list (list of tetrahedron
+    /// identifiers for each edge). If nullptr, the function will compute this
+    /// list anyway and free the related memory upon return. If not nullptr but
     /// pointing to an empty std::vector, the function will fill this empty
-    /// std::vector
-    /// (useful if this list needs to be used later on by the calling
-    /// program). If not NULL but pointing to a non-empty std::vector, this
-    /// function will use this std::vector as internal triangle list. If this
-    /// std::vector is not empty but incorrect, the behavior is unspecified.
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal edge
+    /// star list. If this std::vector is not empty but incorrect, the behavior
+    /// is unspecified.
+    /// \param triangleList Optional output triangle list (list of std::vectors
+    /// of vertex identifiers). If nullptr, the function will compute this list
+    /// anyway and free the related memory upon return. If not nullptr but
+    /// pointing to an empty std::vector, the function will fill this empty
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal
+    /// triangle list. If this std::vector is not empty but incorrect, the
+    /// behavior is unspecified.
     /// \param triangleStarList Optional output triangle star list (list of
-    /// tetrahedron identifiers for each triangle). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// triangle star list. If this std::vector is not empty but incorrect,
-    /// the
+    /// tetrahedron identifiers for each triangle). If nullptr, the function
+    /// will compute this list anyway and free the related memory upon return.
+    /// If not nullptr but pointing to an empty std::vector, the function will
+    /// fill this empty std::vector (useful if this list needs to be used later
+    /// on by the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal
+    /// triangle star list. If this std::vector is not empty but incorrect, the
     /// behavior is unspecified.
     /// \param cellTriangleList Optional output cell triangle list (list of
-    /// triangle identifiers for each tetrahedron). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// cell triangle list. If this std::vector is not empty but incorrect,
-    /// the
+    /// triangle identifiers for each tetrahedron). If nullptr, the function
+    /// will compute this list anyway and free the related memory upon return.
+    /// If not nullptr but pointing to an empty std::vector, the function will
+    /// fill this empty std::vector (useful if this list needs to be used later
+    /// on by the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal cell
+    /// triangle list. If this std::vector is not empty but incorrect, the
     /// behavior is unspecified.
     int buildEdgeTriangles(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &edgeTriangleList,
-      std::vector<std::vector<SimplexId>> *vertexStarList = NULL,
-      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = NULL,
-      std::vector<std::vector<SimplexId>> *edgeStarList = NULL,
-      std::vector<std::vector<SimplexId>> *triangleList = NULL,
-      std::vector<std::vector<SimplexId>> *triangleStarList = NULL,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = NULL) const;
+      std::vector<std::vector<SimplexId>> *vertexStarList = nullptr,
+      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = nullptr,
+      std::vector<std::vector<SimplexId>> *edgeStarList = nullptr,
+      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::vector<SimplexId>> *triangleStarList = nullptr,
+      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
 
     /// Compute the list of triangles of a triangulation represented by a
     /// vtkUnstructuredGrid object. Unspecified behavior if the input mesh is
     /// not a valid triangulation.
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, only)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param triangleList Optional output triangle list (each entry is the
-    /// ordered std::vector of the vertex identifiers of the entry's
-    /// triangle).
+    /// ordered std::vector of the vertex identifiers of the entry's triangle).
     /// \param triangleStars Optional output for triangle tet-adjacency (for
     /// each triangle, list of its adjacent tetrahedra).
     /// \return Returns 0 upon success, negative values otherwise.
     int buildTriangleList(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
-      std::vector<std::vector<SimplexId>> *triangleList = NULL,
-      std::vector<std::vector<SimplexId>> *triangleStars = NULL,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = NULL) const;
+      const CellArray &cellArray,
+      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::vector<SimplexId>> *triangleStars = nullptr,
+      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
 
     /// Compute the list of edges connected to each triangle for 3D
     /// triangulations (unspecified behavior if the input mesh is not a
     /// 3D triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param triangleEdgeList Output triangle edge list. The size of this
     /// std::vector will be equal to the number of triangles in the
-    /// triangulation.
-    /// Each entry will be a std::vector listing the edge identifiers for
-    /// each
-    /// edge connected to the entry's triangle.
-    /// \param vertexEdgeList Optional output vertex edge list (list of
-    /// edge identifiers for each vertex). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// vertex edge list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
-    /// \param edgeList Optional output edge list (list of std::pairs of
-    /// vertex
-    /// identifiers). If NULL, the function will compute this list anyway and
-    /// free the related memory upon return. If not NULL but pointing to an
-    /// empty std::vector, the function will fill this empty std::vector
-    /// (useful if this
-    /// list needs to be used later on by the calling program). If not NULL
-    /// but pointing to a non-empty std::vector, this function will use this
-    /// std::vector
-    /// as internal edge list. If this std::vector is not empty but
-    /// incorrect, the
-    /// behavior is unspecified.
-    /// \param triangleList Optional output triangle list (list of
-    /// std::vectors of
-    /// vertex identifiers). If NULL, the function will compute this list
-    /// anyway and free the related memory upon return. If not NULL but
+    /// triangulation. Each entry will be a std::vector listing the edge
+    /// identifiers for each edge connected to the entry's triangle.
+    /// \param vertexEdgeList Optional output vertex edge list (list of edge
+    /// identifiers for each vertex). If nullptr, the function will compute this
+    /// list anyway and free the related memory upon return. If not nullptr but
     /// pointing to an empty std::vector, the function will fill this empty
-    /// std::vector
-    /// (useful if this list needs to be used later on by the calling
-    /// program). If not NULL but pointing to a non-empty std::vector, this
-    /// function will use this std::vector as internal triangle list. If this
-    /// std::vector is not empty but incorrect, the behavior is unspecified.
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal vertex
+    /// edge list. If this std::vector is not empty but incorrect, the behavior
+    /// is unspecified.
+    /// \param edgeList Optional output edge list (list of std::pairs of vertex
+    /// identifiers). If nullptr, the function will compute this list anyway and
+    /// free the related memory upon return. If not nullptr but pointing to an
+    /// empty std::vector, the function will fill this empty std::vector (useful
+    /// if this list needs to be used later on by the calling program). If not
+    /// nullptr but pointing to a non-empty std::vector, this function will use
+    /// this std::vector as internal edge list. If this std::vector is not empty
+    /// but incorrect, the behavior is unspecified.
+    /// \param triangleList Optional output triangle list (list of std::vectors
+    /// of vertex identifiers). If nullptr, the function will compute this list
+    /// anyway and free the related memory upon return. If not nullptr but
+    /// pointing to an empty std::vector, the function will fill this empty
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal
+    /// triangle list. If this std::vector is not empty but incorrect, the
+    /// behavior is unspecified.
     /// \param triangleStarList Optional output triangle star list (list of
-    /// tetrahedron identifiers for each triangle). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// triangle star list. If this std::vector is not empty but incorrect,
-    /// the
+    /// tetrahedron identifiers for each triangle). If nullptr, the function
+    /// will compute this list anyway and free the related memory upon return.
+    /// If not nullptr but pointing to an empty std::vector, the function will
+    /// fill this empty std::vector (useful if this list needs to be used later
+    /// on by the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal
+    /// triangle star list. If this std::vector is not empty but incorrect, the
     /// behavior is unspecified.
     /// \param cellTriangleList Optional output cell triangle list (list of
-    /// triangle identifiers for each tetrahedron). If NULL, the function
-    /// will compute this list anyway and free the related memory upon
-    /// return. If not NULL but pointing to an empty std::vector, the
-    /// function
-    /// will fill this empty std::vector (useful if this list needs to be
-    /// used
-    /// later on by the calling program). If not NULL but pointing to a
-    /// non-empty std::vector, this function will use this std::vector as
-    /// internal
-    /// cell triangle list. If this std::vector is not empty but incorrect,
-    /// the
+    /// triangle identifiers for each tetrahedron). If nullptr, the function
+    /// will compute this list anyway and free the related memory upon return.
+    /// If not nullptr but pointing to an empty std::vector, the function will
+    /// fill this empty std::vector (useful if this list needs to be used later
+    /// on by the calling program). If not nullptr but pointing to a non-empty
+    /// std::vector, this function will use this std::vector as internal cell
+    /// triangle list. If this std::vector is not empty but incorrect, the
     /// behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildTriangleEdgeList(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &triangleEdgeList,
-      std::vector<std::vector<SimplexId>> *vertexEdgeList = NULL,
-      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = NULL,
-      std::vector<std::vector<SimplexId>> *triangleList = NULL,
-      std::vector<std::vector<SimplexId>> *triangleStarList = NULL,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = NULL) const;
+      std::vector<std::vector<SimplexId>> *vertexEdgeList = nullptr,
+      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = nullptr,
+      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::vector<SimplexId>> *triangleStarList = nullptr,
+      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
 
     /// Compute the links of triangles in a 3D triangulation.
     /// \param triangleList Input triangle list. The number of entries of this
     /// list is equal to the number of triangles in the triangulation. Each
     /// entry lists the vertex identifiers of the corresponding triangle.
     /// \param triangleStar Input triangle star list. The number of entries of
-    /// this list is equal to the number of triangles in the triangulation.
-    /// Each entry lists the identifiers of the tetrahedra which are the
-    /// co-faces of the corresponding triangle.
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
-    /// \param triangleLinks Output triangle link list. The number of entries
-    /// of this list is equal to the number of triangles in the triangulation.
-    /// Each entry lists the identifiers of the vertices in the link of the
+    /// this list is equal to the number of triangles in the triangulation. Each
+    /// entry lists the identifiers of the tetrahedra which are the co-faces of
+    /// the corresponding triangle.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
+    /// \param triangleLinks Output triangle link list. The number of entries of
+    /// this list is equal to the number of triangles in the triangulation. Each
+    /// entry lists the identifiers of the vertices in the link of the
     /// corresponding triangle.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildTriangleLinks(
       const std::vector<std::vector<SimplexId>> &triangeList,
       const std::vector<std::vector<SimplexId>> &triangleStars,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &triangleLinks) const;
 
     /// Compute the list of triangles connected to each vertex for 3D
@@ -302,12 +244,7 @@ namespace ttk {
       const SimplexId &vertexNumber,
       const std::vector<std::vector<SimplexId>> &triangleList,
       std::vector<std::vector<SimplexId>> &vertexTriangleList) const;
-
-  protected:
   };
 } // namespace ttk
-
-// if the package is not a template, comment the following line
-// #include                  <TwoSkeleton.cpp>
 
 #endif // TWOSKELETON_H

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -16,6 +16,7 @@
 #include <map>
 
 // base code includes
+#include <CellArray.h>
 #include <Wrapper.h>
 
 namespace ttk {
@@ -44,51 +45,40 @@ namespace ttk {
     /// Compute the link of a single vertex of a triangulation (unspecified
     /// behavior if the input mesh is not a valid triangulation).
     /// \param vertexId Input vertex.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param vertexLink Output vertex link. This std::vector contains, for
-    /// each
-    /// simplex of the link, the number of vertices in the simplex (triangles:
-    /// 3, edges: 2) followed by the corresponding vertex identifiers.
+    /// each simplex of the link, the number of vertices in the simplex
+    /// (triangles: 3, edges: 2) followed by the corresponding vertex
+    /// identifiers.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildVertexLink(const SimplexId &vertexId,
-                        const SimplexId &cellNumber,
-                        const LongSimplexId *cellArray,
+                        const CellArray &cellArray,
                         std::vector<LongSimplexId> &vertexLink) const;
 
     /// Compute the link of each vertex of a triangulation (unspecified
     /// behavior if the input mesh is not a valid triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param vertexLinks Output vertex links. The size of this std::vector
     /// will be equal to the number of vertices in the mesh. Each entry will
     /// be a std::vector listing the simplices of the link of the entry's
-    /// vertex.
-    /// In particular, this std::vector contains, for each simplex, the
-    /// number of
-    /// vertices in the simplex (triangles: 3, edges: 2) followed by the
-    /// corresponding vertex identifiers.
-    /// \param vertexStars Optional list of vertex stars (list of
-    /// 3-dimensional cells connected to each vertex). If NULL, the
-    /// function will compute this list anyway and free the related memory
-    /// upon return. If not NULL but pointing to an empty std::vector, the
-    /// function will fill this empty std::vector (useful if this list needs
-    /// to be used later on by the calling program). If not NULL but pointing
-    /// to a non-empty std::vector, this function will use this std::vector
-    /// as internal
-    /// vertex star list. If this std::vector is not empty but incorrect, the
-    /// behavior is unspecified.
+    /// vertex. In particular, this std::vector contains, for each simplex, the
+    /// number of vertices in the simplex (triangles: 3, edges: 2) followed by
+    /// the corresponding vertex identifiers.
+    /// \param vertexStars Optional list of vertex stars (list of 3-dimensional
+    /// cells connected to each vertex). If NULL, the function will compute this
+    /// list anyway and free the related memory upon return. If not NULL but
+    /// pointing to an empty std::vector, the function will fill this empty
+    /// std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not NULL but pointing to a non-empty std::vector,
+    /// this function will use this std::vector as internal vertex star list. If
+    /// this std::vector is not empty but incorrect, the behavior is
+    /// unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildVertexLinks(const SimplexId &vertexNumber,
-                         const SimplexId &cellNumber,
-                         const LongSimplexId *cellArray,
+                         const CellArray &cellArray,
                          std::vector<std::vector<LongSimplexId>> &vertexLinks,
                          std::vector<std::vector<SimplexId>> *vertexStars
                          = NULL) const;
@@ -99,9 +89,8 @@ namespace ttk {
     /// should be equal to the number of vertices in the triangulation. Each
     /// entry is a std::vector listing the identifiers of triangles.
     /// \param cellEdges List of cell edges. The size of this std::vector
-    /// should be
-    /// equal to the number of triangles. Each entry is a std::vector of
-    /// identifiers of edges.
+    /// should be equal to the number of triangles. Each entry is a std::vector
+    /// of identifiers of edges.
     /// \param vertexLinks Output vertex links. The size of this std::vector
     /// will be equal to the number of vertices in the triangulation. Each
     /// entry will be a std::vector listing the edges in the link of the
@@ -137,53 +126,40 @@ namespace ttk {
     /// Compute the list of neighbors of each vertex of a triangulation.
     /// Unspecified behavior if the input mesh is not a valid triangulation).
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices ids
+    /// of each cell.
     /// \param vertexNeighbors Output neighbor list. The size of this
-    /// std::vector
-    /// will be equal to the number of vertices in the mesh. Each entry will
-    /// be std::vector listing the vertex identifiers of the entry's vertex'
-    /// neighbors.
+    /// std::vector will be equal to the number of vertices in the mesh. Each
+    /// entry will be std::vector listing the vertex identifiers of the entry's
+    /// vertex' neighbors.
     /// \param edgeList Optional list of edges. If NULL, the function will
-    /// compute this list anyway and free the related memory upon return.
-    /// If not NULL but pointing to an empty std::vector, the function will
-    /// fill
-    /// this empty std::vector (useful if this list needs to be used later on
-    /// by
-    /// the calling program). If not NULL but pointing to a non-empty
-    /// std::vector,
-    /// this function will use this std::vector as internal edge list. If
-    /// this
+    /// compute this list anyway and free the related memory upon return. If not
+    /// NULL but pointing to an empty std::vector, the function will fill this
+    /// empty std::vector (useful if this list needs to be used later on by the
+    /// calling program). If not NULL but pointing to a non-empty std::vector,
+    /// this function will use this std::vector as internal edge list. If this
     /// std::vector is not empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildVertexNeighbors(
       const SimplexId &vertexNumber,
-      const SimplexId &cellNumber,
-      const LongSimplexId *cellArray,
+      const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &vertexNeighbors,
       std::vector<std::pair<SimplexId, SimplexId>> *edgeList = NULL) const;
 
     /// Compute the star of each vertex of a triangulation. Unspecified
     /// behavior if the input mesh is not a valid triangulation.
     /// \param vertexNumber Number of vertices in the triangulation.
-    /// \param cellNumber Number of maximum-dimensional cells in the
-    /// triangulation (number of tetrahedra in 3D, triangles in 2D, etc.)
-    /// \param cellArray Pointer to a contiguous array of cells. Each entry
-    /// starts by the number of vertices in the cell, followed by the vertex
-    /// identifiers of the cell.
+    /// \param cellArray Cell container allowing to retrieve the vertices
+    /// of each cell.
     /// \param vertexStars Output vertex stars. The size of this std::vector
     /// will be equal to the number of vertices in the mesh. Each entry will
     /// be a std::vector listing the identifiers of the maximum-dimensional
-    /// cells
-    /// (3D: tetrahedra, 2D: triangles, etc.) connected to the entry's vertex.
+    /// cells (3D: tetrahedra, 2D: triangles, etc.) connected to the entry's
+    /// vertex.
     /// \return Returns 0 upon success, negative values otherwise.
     int
       buildVertexStars(const SimplexId &vertexNumber,
-                       const SimplexId &cellNumber,
-                       const LongSimplexId *cellArray,
+                       const CellArray &cellArray,
                        std::vector<std::vector<SimplexId>> &vertexStars) const;
 
   protected:

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.h
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.h
@@ -15,6 +15,7 @@
 // VTK Module
 #include <ttkOBJWriterModule.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -39,7 +40,7 @@ protected:
   virtual void WriteData() override;
 
   char *Filename;
-  ofstream Stream{};
+  std::ofstream Stream{};
 
 private:
   ttkOBJWriter(const ttkOBJWriter &) = delete;

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.h
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.h
@@ -14,6 +14,7 @@
 
 #include <ttkOFFWriterModule.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ protected:
   virtual void WriteData() override;
 
   char *Filename;
-  ofstream Stream{};
+  std::ofstream Stream{};
 
 private:
   ttkOFFWriter(const ttkOFFWriter &) = delete;

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -1,9 +1,15 @@
 #include <ttkWRLExporter.h>
 
+#ifdef TTK_BUILD_PARAVIEW_PLUGINS
+#include <vtkPVConfig.h>
+#else
+#include <vtkVersion.h>
+#endif
+
 using namespace std;
 using namespace ttk;
 
-vtkPolyData *ttkWRLExporterPolyData_ = NULL;
+vtkPolyData *ttkWRLExporterPolyData_ = nullptr;
 
 // Over-ride the appropriate functions of the vtkVRMLExporter class.
 void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
@@ -18,16 +24,25 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   vtkSmartPointer<vtkPolyData> pd;
   vtkPointData *pntData;
   vtkPoints *points;
-  vtkDataArray *normals = NULL;
-  vtkDataArray *tcoords = NULL;
+  vtkDataArray *normals = nullptr;
+  vtkDataArray *tcoords = nullptr;
   int i, i1, i2;
   double *tempd;
   vtkCellArray *cells;
   vtkIdType npts = 0;
-#if VTK_MAJOR_VERSION > 8 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION > 2)
-  vtkIdType const *indx = NULL;
+#ifdef PARAVIEW_VERSION_MAJOR
+#if PARAVIEW_VERSION_MAJOR > 5 \
+  || (PARAVIEW_VERSION_MAJOR == 5 && PARAVIEW_VERSION_MINOR > 7)
+  vtkIdType const *indx = nullptr;
 #else
-  vtkIdType *indx = NULL;
+  vtkIdType *indx = nullptr;
+#endif
+#else
+#if VTK_VERSION_MAJOR > 8
+  vtkIdType const *indx = nullptr;
+#else
+  vtkIdType *indx = nullptr;
+#endif
 #endif
   int pointDataWritten = 0;
   vtkPolyDataMapper *pm;
@@ -37,7 +52,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   vtkTransform *trans;
 
   // see if the actor has a mapper. it could be an assembly
-  if(anActor->GetMapper() == NULL) {
+  if(anActor->GetMapper() == nullptr) {
     return;
   }
 
@@ -62,7 +77,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
 
   vtkDataObject *inputDO = anActor->GetMapper()->GetInputDataObject(0, 0);
 
-  if(inputDO == NULL) {
+  if(inputDO == nullptr) {
     return;
   }
 
@@ -213,7 +228,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
     fprintf(fp, "          geometry IndexedLineSet {\n");
 
     if(!pointDataWritten) {
-      this->WritePointData(points, NULL, NULL, colors, fp);
+      this->WritePointData(points, nullptr, nullptr, colors, fp);
     } else {
       fprintf(fp, "            coord  USE VTKcoordinates\n");
 
@@ -302,7 +317,7 @@ void vtkVRMLExporter::WriteData() {
   FILE *fp;
 
   // make sure the user specified a FileName or FilePointer
-  if(!this->FilePointer && (this->FileName == NULL)) {
+  if(!this->FilePointer && (this->FileName == nullptr)) {
     vtkErrorMacro(<< "Please specify FileName to use");
     return;
   }
@@ -458,10 +473,19 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
       fprintf(fp, "          texCoordIndex[\n");
       vtkCellArray *cells = ttkWRLExporterPolyData_->GetPolys();
       vtkIdType npts = 0;
-#if VTK_MAJOR_VERSION > 8 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION > 2)
-      vtkIdType const *indx = NULL;
+#ifdef PARAVIEW_VERSION_MAJOR
+#if PARAVIEW_VERSION_MAJOR > 5 \
+  || (PARAVIEW_VERSION_MAJOR == 5 && PARAVIEW_VERSION_MINOR > 7)
+      vtkIdType const *indx = nullptr;
 #else
-      vtkIdType *indx = NULL;
+      vtkIdType *indx = nullptr;
+#endif
+#else
+#if VTK_VERSION_MAJOR > 8
+      vtkIdType const *indx = nullptr;
+#else
+      vtkIdType *indx = nullptr;
+#endif
 #endif
       for(cells->InitTraversal(); cells->GetNextCell(npts, indx);) {
         fprintf(fp, "            ");

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -24,7 +24,11 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   double *tempd;
   vtkCellArray *cells;
   vtkIdType npts = 0;
-  vtkIdType *indx = 0;
+#if VTK_MAJOR_VERSION > 8 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION > 2)
+  vtkIdType const *indx = NULL;
+#else
+  vtkIdType *indx = NULL;
+#endif
   int pointDataWritten = 0;
   vtkPolyDataMapper *pm;
   vtkUnsignedCharArray *colors;
@@ -454,7 +458,11 @@ void vtkVRMLExporter::WritePointData(vtkPoints *points,
       fprintf(fp, "          texCoordIndex[\n");
       vtkCellArray *cells = ttkWRLExporterPolyData_->GetPolys();
       vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION > 8 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION > 2)
+      vtkIdType const *indx = NULL;
+#else
       vtkIdType *indx = NULL;
+#endif
       for(cells->InitTraversal(); cells->GetNextCell(npts, indx);) {
         fprintf(fp, "            ");
         for(int i = 0; i < npts; i++) {

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -1,11 +1,5 @@
 #include <ttkWRLExporter.h>
 
-#ifdef TTK_BUILD_PARAVIEW_PLUGINS
-#include <vtkPVConfig.h>
-#else
-#include <vtkVersion.h>
-#endif
-
 using namespace std;
 using namespace ttk;
 


### PR DESCRIPTION
Dear Julien,

The work to update the TTK to the new `vtkCellArray` layout rely on a new class handling access to cell data.

* [x] Add CellArray class
* [x] Migrate ZeroSkeleton
* [x] Migrate OneSkeleton
* [x] Migrate TwoSkeleton
* [x] Migrate TheeSkeleton
* [x] Migrate ExplicitTriangulation
* [x] Migrate JacobiSet
* [x] Test all states
    * [x] working
    * [x] perf impact -> none (ctBones, morseMolecule)
* [x] List untested modules
* [x] Compile on mac: missing header file

This first PR will not implement the VTK 9 version but only handle the creation of the new CellArray class.
All this work is done with cell genericity in mind. On the VTK 9 version, only minor changes should be done to handle any simplicial complex (mixing points, edges, triangles and tetra in the cell array).

Best,
Charles