### PR TITLE
Fix C3848 compile error with VS2019 (Version 16.4.0)

### DIFF
--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -33,7 +33,7 @@ struct MyCmp {
 
 struct filtrationCtCmp {
   bool operator()(const pair<bool, pair<double, pair<int, int>>> &v0,
-                  const pair<bool, pair<double, pair<int, int>>> &v1) {
+                  const pair<bool, pair<double, pair<int, int>>> &v1) const {
 
     if(v0.first) {
       return ((v0.second.first < v1.second.first)


### PR DESCRIPTION
Rebrand of #339

Compiling TTK on Visual Studio 2019 (v 16.4.0), I got

![image](https://user-images.githubusercontent.com/2997626/76404193-5c16ff80-6386-11ea-9cf0-62be3f8f0aca.png)

Const-qualifying the `operator()` for `filtrationCtCmp` fixes the issue.