### PR TITLE
Conflict with FTMAtomicVector.h and FTRAtomicVector.h

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Thanks for contributing to TTK!
 
 Before submitting your pull request, please:
 
-- [ ] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/master/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.
+- [ ] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/dev/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.
 
 - [ ] Please provide a quick description of your contributions below:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - stable
 dist: trusty
 sudo: required
 language: cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Thanks for contributing to TTK!
 Please find below a few guidelines that we invite you to consider before making a pull request.
 
 # 1. Authorship
-  - Please enter in header files doxygen style information regarding authorship and, if applicable, related publications. See [core/base/topologicalSimplification/TopologicalSimplification.h](https://github.com/topology-tool-kit/ttk/blob/master/core/base/topologicalSimplification/TopologicalSimplification.h) for a base layer example, [core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h](https://github.com/topology-tool-kit/ttk/blob/master/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h) for a vtk wrapper example and [paraview/TopologicalSimplification/TopologicalSimplification.xml](https://github.com/topology-tool-kit/ttk/blob/master/paraview/TopologicalSimplification/TopologicalSimplification.xml) for a ParaView plugin example.
+  - Please enter in header files doxygen style information regarding authorship and, if applicable, related publications. See [core/base/topologicalSimplification/TopologicalSimplification.h](https://github.com/topology-tool-kit/ttk/blob/dev/core/base/topologicalSimplification/TopologicalSimplification.h) for a base layer example, [core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h](https://github.com/topology-tool-kit/ttk/blob/dev/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h) for a vtk wrapper example and [paraview/TopologicalSimplification/TopologicalSimplification.xml](https://github.com/topology-tool-kit/ttk/blob/dev/paraview/TopologicalSimplification/TopologicalSimplification.xml) for a ParaView plugin example.
 
 # 2. Code formatting
   - To make TTK's source code more homogeneous and readable, we use [clang-format](https://clang.llvm.org/docs/ClangFormat.html). A style file is already available in TTK's source tree.
@@ -16,15 +16,16 @@ For this, we recommend to use scripts such as [this one](https://github.com/bari
 
 
 # 3. Continuous integration
-  - TTK uses some basic continuous integration, which consists in testing for build success under Linux (with [travis](https://travis-ci.org/)) and Windows (with [app-veyor](https://www.appveyor.com/)) upon each commit or pull request. **Your pull request will not be merged if it fails these tests**.
-  - To make your life easier, we recommend that you sign up for both services (which both offer free plans) and that you connect your TTK github fork to these services. This will run the build tests upon each of your commits to your local TTK repository.
+  - TTK uses some basic continuous integration, which consists in testing for build success under Linux, Windows and MacOs (with [Azure](https://azure.microsoft.com/en-us/services/devops/pipelines/)) upon each commit or pull request. **Your pull request will not be merged if it fails these tests**.
+  - To make your life easier, we recommend that you sign up for this (free) service and that you connect your TTK github fork to it. This will run the build tests upon each of your commits to your local TTK repository.
 
 
 # 4. Submitting a new module
-  - **Before submitting a new module**, we invite you to read our [Guidelines for Developing a New TTK Module](https://github.com/topology-tool-kit/ttk/wiki/Guidelines-for-Developing-a-New-TTK-Module). Also, before submitting your pull-request to [TTK's source repository](https://github.com/topology-tool-kit/ttk), please make sure that your fork is in sync with the latest version of TTK's source tree (typically by entering a command like <code>git pull ttk-public master</code>, where <code>ttk-public</code> is the name of your remote pointing to TTK's public source tree).
-  - Please submit a pull-request with an example to [ttk-data](https://github.com/topology-tool-kit/ttk-data):
-    - Provide a ParaView state file (*.pvsm) in the [<code>states/</code>](https://github.com/topology-tool-kit/ttk-data/tree/master/states) directory which runs your new module. This example will be used to both test and demo your module.
-    - Provide new data sets if needed. For new data sets, please update the [README](https://github.com/topology-tool-kit/ttk-data/blob/master/README) file to include the corresponding references.
+  - **Before submitting a new module**, we invite you to read our [Guidelines for Developing a New TTK Module](https://github.com/topology-tool-kit/ttk/wiki/Guidelines-for-Developing-a-New-TTK-Module). 
+  - Prepare your pull-request to the **dev** branch of [TTK](https://github.com/topology-tool-kit/ttk/tree/dev)). Before submitting it, please make sure that your fork is in sync with the latest version of TTK's source tree (typically by entering a command like <code>git pull ttk-public dev</code>, where <code>ttk-public</code> is the name of your remote pointing to TTK's public source tree).
+  - Please submit a pull-request with an example to the **dev** branch of [ttk-data](https://github.com/topology-tool-kit/ttk-data/tree/dev):
+    - Provide a ParaView state file (*.pvsm) in the [<code>states/</code>](https://github.com/topology-tool-kit/ttk-data/tree/dev/states) directory which runs your new module. This example will be used to both test and demo your module.
+    - Provide new data sets if needed. For new data sets, please update the [README](https://github.com/topology-tool-kit/ttk-data/blob/dev/README) file to include the corresponding references.
     - Make sure to remove all absolute paths from the state file example generated by ParaView (with a text editor). The state files are supposed to be run with ParaView from the root directory of [ttk-data](https://github.com/topology-tool-kit/ttk-data) (see [TTK's tutorial page](https://topology-tool-kit.github.io/tutorials.html) for examples).
   - Please submit a pull-request to [topology-tool-kit.github.io](https://github.com/topology-tool-kit/topology-tool-kit.github.io):
     - For this, generate a screenshot for the above ParaView state file example. Please include on the left of your screenshot a terminal with TTK's output (see examples on [TTK's gallery page](https://topology-tool-kit.github.io/gallery.html)). Please use a dark color theme if possible.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## TTK - The Topology ToolKit 
 
-[![BSD licensed](https://api.travis-ci.org/topology-tool-kit/ttk.svg)](https://travis-ci.org/topology-tool-kit/ttk) [![BSD licensed](https://img.shields.io/badge/license-BSD-blue.svg?maxAge=2592000)](https://github.com/topology-tool-kit/ttk/blob/master/LICENSE) [![Release version](https://img.shields.io/github/release/topology-tool-kit/ttk.svg?maxAge=86400)](https://github.com/topology-tool-kit/ttk/releases/latest) [![Anaconda Cloud](https://anaconda.org/conda-forge/topologytoolkit/badges/version.svg)](https://anaconda.org/conda-forge/topologytoolkit) [![Anaconda downloads](https://anaconda.org/conda-forge/topologytoolkit/badges/downloads.svg)](https://anaconda.org/conda-forge/topologytoolkit)
+[![BSD licensed](https://img.shields.io/badge/license-BSD-blue.svg?maxAge=2592000)](https://github.com/topology-tool-kit/ttk/blob/master/LICENSE) [![Release version](https://img.shields.io/github/release/topology-tool-kit/ttk.svg?maxAge=86400)](https://github.com/topology-tool-kit/ttk/releases/latest) [![Anaconda Cloud](https://anaconda.org/conda-forge/topologytoolkit/badges/version.svg)](https://anaconda.org/conda-forge/topologytoolkit) [![Anaconda downloads](https://anaconda.org/conda-forge/topologytoolkit/badges/downloads.svg)](https://anaconda.org/conda-forge/topologytoolkit)
 
 
 Topological Data Analysis and Visualization

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -145,6 +145,10 @@ namespace ttk {
       return this->begin() + nextId;
     }
 
+    const_iterator end() const {
+      return this->begin() + nextId;
+    }
+
     const_iterator cend() const {
       return this->cbegin() + nextId;
     }

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -122,7 +122,6 @@ int ttkTopologicalCompressionReader::RequestData(
     vtkWarningMacro("Failure when reading compressed TTK file");
   }
 
-
   mesh->GetPointData()->RemoveArray(0);
   mesh->GetPointData()->SetNumberOfTuples(vertexNumber);
 


### PR DESCRIPTION
Both core/base/ftmTree/FTMAtomicVector.h and core/base/ftrGraph/FTRAtomicVector.h use the following definition:

#ifndef ATOMICVECTOR_H
#define ATOMICVECTOR_H

Therefore, it seems that when both files are included, it sometimes causes the compiler to use the incorrect version. This was made apparent when compiling the examples/c++ sample code with the addition of the "#include <FTRGraph.h>" line. In this particular example, it was looking into the FTMAtomicVector.h file for a const definition of end() while it should be looking into the FTRAtomicVector.h file. This causes the compilation to break.

Updating the FTMAtomicVector.h file to include the member definition allows the example code to compile and run properly, however this is a partial fix. The ifndef's should probably be updated to include unique identifiers and tested to make sure it doesn't break anything else in the hierarchy. 
