### PR TITLE
Update FTMAtomicVector.h for naming conflict (FTMAtomicVector.h and FTRAtomicVector.h)

### DIFF
--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -145,6 +145,10 @@ namespace ttk {
       return this->begin() + nextId;
     }
 
+    const_iterator end() const {
+      return this->begin() + nextId;
+    }
+
     const_iterator cend() const {
       return this->cbegin() + nextId;
     }


### PR DESCRIPTION
Both core/base/ftmTree/FTMAtomicVector.h and core/base/ftrGraph/FTRAtomicVector.h use the following definition:

#ifndef ATOMICVECTOR_H 
#define ATOMICVECTOR_H

Therefore, it seems that when both files are included, it sometimes causes the compiler to use the incorrect version. This was made apparent when compiling the examples/c++ sample code with the addition of the "#include <FTRGraph.h>" line. In this particular example, it was looking into the FTMAtomicVector.h file for a const definition of end() while it should be looking into the FTRAtomicVector.h file. This causes the compilation to break.

Updating the FTMAtomicVector.h file to include the member definition allows the example code to compile and run properly, however this is a partial fix. The ifndef's should probably be updated to include unique identifiers and tested to make sure it doesn't break anything else in the hierarchy.

