### PR TITLE
CinemaProductReader: Overwrite FILE column in products FieldData

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -238,21 +238,7 @@ jobs:
   steps:
   - script: |
       mkdir build
-      SET "FILENAME=%~dp0\boost.zip"
-      bitsadmin /transfer myDownloadJob /download /priority normal "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.zip" "%FILENAME%"
-      move  "%FILENAME%" boost.zip
-      unzip boost.zip
-    displayName: 'Download and extract Boost'
-
-  - script: |
-      echo "compiler initialization"
-      $(compilerInitialization)
-      echo "bootstrap"
-      bootstrap
-      echo "b2"
-      .\b2
-    workingDirectory: 'boost_1_67_0'
-    displayName: 'Build boost'
+    displayName: 'Create build directory'
 
   - bash: |
       git clone --quiet https://gitlab.kitware.com/vtk/vtk.git
@@ -277,7 +263,8 @@ jobs:
     # need to disable filters linked to rendering
   - script: |
       $(compilerInitialization)
-      cmake -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-8.90 -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF -DVTK_MODULE_ENABLE_ttkAddFieldData=NO -DVTK_MODULE_ENABLE_ttkWRLExporter=NO -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO -DVTK_MODULE_ENABLE_ttkCinemaReader=NO -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO -GNinja ..
+      set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
+      cmake -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-8.90 -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF -DVTK_MODULE_ENABLE_ttkAddFieldData=NO -DVTK_MODULE_ENABLE_ttkWRLExporter=NO -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO -DVTK_MODULE_ENABLE_ttkCinemaReader=NO -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO -GNinja ..
       ninja
     workingDirectory: build/
     displayName: 'Configure TTK'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -265,12 +265,12 @@ jobs:
       $(compilerInitialization)
       set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
       cmake -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-8.90 -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF -DVTK_MODULE_ENABLE_ttkAddFieldData=NO -DVTK_MODULE_ENABLE_ttkWRLExporter=NO -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO -DVTK_MODULE_ENABLE_ttkCinemaReader=NO -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO -GNinja ..
-      ninja
     workingDirectory: build/
     displayName: 'Configure TTK'
 
   - script: |
       $(compilerInitialization)
+      ninja
       cmake --build . --target install
     workingDirectory: build/
     displayName: 'Build and install TTK'

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -159,7 +159,9 @@ int ttkCinemaProductReader::RequestData(vtkInformation *request,
         for(size_t j = 0; j < m; j++) {
           auto columnName = inputTable->GetColumnName(j);
 
-          if(!fieldData->HasArray(columnName)) {
+          // always write FILE column
+          if(!fieldData->HasArray(columnName)
+             || columnName == this->FilepathColumnName) {
             if(inputTable->GetColumn(j)->IsNumeric()) {
               auto c = vtkSmartPointer<vtkDoubleArray>::New();
               c->SetName(columnName);


### PR DESCRIPTION
I came upon the following behavior while using the TTK Cinema filters to extract a subset of a first Cinema Database and writing it in a second one.

Since CinemaProductReader adds only non-existing Field Data Arrays to database products, extracts from the first database will contain a FILE Field Data Array relative to this first database. This Field Data will be written in the second database along the product, preventing another CinemaProductReader on the second database to replace it with a updated and correct path.

This PR aims at fixing this behavior by always overwriting the FILE array.

@JonasLukasczyk Do you think this fix is compatible with the Cinema Database spec?

Pierre
