### PR TITLE
Accelerate integer power computations

### DIFF
--- a/core/base/auction/Auction.h
+++ b/core/base/auction/Auction.h
@@ -255,7 +255,7 @@ namespace ttk {
           max_persistence = persistence;
         }
       }
-      this->epsilon_ = 5 / 4 * Geometry::powInt(max_persistence, wasserstein_);
+      this->epsilon_ = 5 / 4 * Geometry::pow(max_persistence, wasserstein_);
     }
 
     void buildUnassignedBidders() {

--- a/core/base/auction/Auction.h
+++ b/core/base/auction/Auction.h
@@ -295,7 +295,7 @@ namespace ttk {
       if(denominator <= 0) {
         return 1;
       } else {
-        return std::pow(d / denominator, 1 / ((float)wasserstein_)) - 1;
+        return Geometry::pow(d / denominator, 1 / ((float)wasserstein_)) - 1;
       }
     }
 

--- a/core/base/auction/Auction.h
+++ b/core/base/auction/Auction.h
@@ -255,7 +255,7 @@ namespace ttk {
           max_persistence = persistence;
         }
       }
-      this->epsilon_ = 5 / 4 * pow(max_persistence, wasserstein_);
+      this->epsilon_ = 5 / 4 * Geometry::powInt(max_persistence, wasserstein_);
     }
 
     void buildUnassignedBidders() {
@@ -295,7 +295,7 @@ namespace ttk {
       if(denominator <= 0) {
         return 1;
       } else {
-        return pow(d / denominator, 1 / ((float)wasserstein_)) - 1;
+        return std::pow(d / denominator, 1 / ((float)wasserstein_)) - 1;
       }
     }
 

--- a/core/base/auction/AuctionActor.h
+++ b/core/base/auction/AuctionActor.h
@@ -134,9 +134,9 @@ namespace ttk {
   template <typename dataType>
   double AuctionActor<dataType>::getPairGeometricalLength(
     const int wasserstein) const {
-    return Geometry::powInt(geom_pair_length_[0], wasserstein)
-           + Geometry::powInt(geom_pair_length_[1], wasserstein)
-           + Geometry::powInt(geom_pair_length_[2], wasserstein);
+    return Geometry::pow(geom_pair_length_[0], wasserstein)
+           + Geometry::pow(geom_pair_length_[1], wasserstein)
+           + Geometry::pow(geom_pair_length_[2], wasserstein);
   }
 
   template <typename dataType>
@@ -148,26 +148,25 @@ namespace ttk {
     } else if(is_diagonal_) {
       return geometricalFactor
                * (2
-                  * Geometry::powInt(
+                  * Geometry::pow(
                     abs<dataType>(g.y_ / 2 - g.x_ / 2), wasserstein))
              + (1 - geometricalFactor) * getPairGeometricalLength(wasserstein);
     } else if(g.isDiagonal()) {
       return geometricalFactor
                * (2
-                  * Geometry::powInt(
-                    abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
+                  * Geometry::pow(abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
              + (1 - geometricalFactor)
                  * g.getPairGeometricalLength(wasserstein);
     } else {
       return geometricalFactor
-               * (Geometry::powInt(abs<dataType>(x_ - g.x_), wasserstein)
-                  + Geometry::powInt(abs<dataType>(y_ - g.y_), wasserstein))
+               * (Geometry::pow(abs<dataType>(x_ - g.x_), wasserstein)
+                  + Geometry::pow(abs<dataType>(y_ - g.y_), wasserstein))
              + (1 - geometricalFactor)
-                 * (Geometry::powInt(
+                 * (Geometry::pow(
                       abs<dataType>(coords_x_ - g.coords_x_), wasserstein)
-                    + Geometry::powInt(
+                    + Geometry::pow(
                       abs<dataType>(coords_y_ - g.coords_y_), wasserstein)
-                    + Geometry::powInt(
+                    + Geometry::pow(
                       abs<dataType>(coords_z_ - g.coords_z_), wasserstein));
     }
   }

--- a/core/base/auction/AuctionActor.h
+++ b/core/base/auction/AuctionActor.h
@@ -76,6 +76,22 @@ namespace ttk {
       return (var >= 0) ? var : -var;
     }
 
+    inline dataType pow(const dataType var, int n) {
+      if(n < 0) {
+        return 1.0 / this->pow(var, -n);
+      } else if(n == 0) {
+        return 1;
+      } else if(n == 1) {
+        return var;
+      } else if(n == 2) {
+        return var * var;
+      } else if(n == 3) {
+        return var * var * var;
+      } else {
+        return this->pow(var, n - 1) * var;
+      }
+    }
+
     dataType
       cost(const AuctionActor &g, int &wasserstein, double &geometricalFactor);
 
@@ -148,23 +164,24 @@ namespace ttk {
       return 0;
     } else if(is_diagonal_) {
       return geometricalFactor
-               * (2 * std::pow(abs<dataType>(g.y_ / 2 - g.x_ / 2), wasserstein))
+               * (2
+                  * this->pow(abs<dataType>(g.y_ / 2 - g.x_ / 2), wasserstein))
              + (1 - geometricalFactor) * getPairGeometricalLength(wasserstein);
     } else if(g.isDiagonal()) {
       return geometricalFactor
-               * (2 * std::pow(abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
+               * (2 * this->pow(abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
              + (1 - geometricalFactor)
                  * g.getPairGeometricalLength(wasserstein);
     } else {
       return geometricalFactor
-               * (std::pow(abs<dataType>(x_ - g.x_), wasserstein)
-                  + std::pow(abs<dataType>(y_ - g.y_), wasserstein))
+               * (this->pow(abs<dataType>(x_ - g.x_), wasserstein)
+                  + this->pow(abs<dataType>(y_ - g.y_), wasserstein))
              + (1 - geometricalFactor)
-                 * (std::pow(
+                 * (this->pow(
                       abs<dataType>(coords_x_ - g.coords_x_), wasserstein)
-                    + std::pow(
+                    + this->pow(
                       abs<dataType>(coords_y_ - g.coords_y_), wasserstein)
-                    + std::pow(
+                    + this->pow(
                       abs<dataType>(coords_z_ - g.coords_z_), wasserstein));
     }
   }

--- a/core/base/auction/AuctionActor.h
+++ b/core/base/auction/AuctionActor.h
@@ -1,4 +1,3 @@
-
 #ifndef _AUCTIONACTOR_H
 #define _AUCTIONACTOR_H
 
@@ -76,22 +75,6 @@ namespace ttk {
       return (var >= 0) ? var : -var;
     }
 
-    inline dataType pow(const dataType var, int n) {
-      if(n < 0) {
-        return 1.0 / this->pow(var, -n);
-      } else if(n == 0) {
-        return 1;
-      } else if(n == 1) {
-        return var;
-      } else if(n == 2) {
-        return var * var;
-      } else if(n == 3) {
-        return var * var * var;
-      } else {
-        return this->pow(var, n - 1) * var;
-      }
-    }
-
     dataType
       cost(const AuctionActor &g, int &wasserstein, double &geometricalFactor);
 
@@ -151,9 +134,9 @@ namespace ttk {
   template <typename dataType>
   double AuctionActor<dataType>::getPairGeometricalLength(
     const int wasserstein) const {
-    return std::pow(geom_pair_length_[0], wasserstein)
-           + std::pow(geom_pair_length_[1], wasserstein)
-           + std::pow(geom_pair_length_[2], wasserstein);
+    return Geometry::powInt(geom_pair_length_[0], wasserstein)
+           + Geometry::powInt(geom_pair_length_[1], wasserstein)
+           + Geometry::powInt(geom_pair_length_[2], wasserstein);
   }
 
   template <typename dataType>
@@ -165,23 +148,26 @@ namespace ttk {
     } else if(is_diagonal_) {
       return geometricalFactor
                * (2
-                  * this->pow(abs<dataType>(g.y_ / 2 - g.x_ / 2), wasserstein))
+                  * Geometry::powInt(
+                    abs<dataType>(g.y_ / 2 - g.x_ / 2), wasserstein))
              + (1 - geometricalFactor) * getPairGeometricalLength(wasserstein);
     } else if(g.isDiagonal()) {
       return geometricalFactor
-               * (2 * this->pow(abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
+               * (2
+                  * Geometry::powInt(
+                    abs<dataType>(y_ / 2 - x_ / 2), wasserstein))
              + (1 - geometricalFactor)
                  * g.getPairGeometricalLength(wasserstein);
     } else {
       return geometricalFactor
-               * (this->pow(abs<dataType>(x_ - g.x_), wasserstein)
-                  + this->pow(abs<dataType>(y_ - g.y_), wasserstein))
+               * (Geometry::powInt(abs<dataType>(x_ - g.x_), wasserstein)
+                  + Geometry::powInt(abs<dataType>(y_ - g.y_), wasserstein))
              + (1 - geometricalFactor)
-                 * (this->pow(
+                 * (Geometry::powInt(
                       abs<dataType>(coords_x_ - g.coords_x_), wasserstein)
-                    + this->pow(
+                    + Geometry::powInt(
                       abs<dataType>(coords_y_ - g.coords_y_), wasserstein)
-                    + this->pow(
+                    + Geometry::powInt(
                       abs<dataType>(coords_z_ - g.coords_z_), wasserstein));
     }
   }
@@ -416,7 +402,7 @@ namespace ttk {
       this->SetCriticalCoordinates(coords_x, coords_y, coords_z);
 
       if(std::abs(static_cast<double>(x) - static_cast<double>(y))
-         < std::pow(10, -12)) {
+         < Geometry::powIntTen<double>(-12)) {
         AuctionActor<dataType>::is_diagonal_ = true;
       } else {
         AuctionActor<dataType>::is_diagonal_ = false;

--- a/core/base/auction/AuctionImpl.h
+++ b/core/base/auction/AuctionImpl.h
@@ -107,8 +107,7 @@ dataType ttk::Auction<dataType>::getMatchingsAndDistance(
                     << std::endl;
         }
         cost
-          = 2
-            * Geometry::powInt(abs<dataType>((b.y_ - b.x_) / 2), wasserstein_);
+          = 2 * Geometry::pow(abs<dataType>((b.y_ - b.x_) / 2), wasserstein_);
         if(get_diagonal_matches) {
           matchingTuple t = std::make_tuple(i, good_id, cost);
           matchings->push_back(t);
@@ -119,7 +118,7 @@ dataType ttk::Auction<dataType>::getMatchingsAndDistance(
       // b is diagonal
       const Good<dataType> &g = b.getProperty();
       dataType cost
-        = 2 * Geometry::powInt(abs<dataType>((g.y_ - g.x_) / 2), wasserstein_);
+        = 2 * Geometry::pow(abs<dataType>((g.y_ - g.x_) / 2), wasserstein_);
       if(get_diagonal_matches) {
         matchingTuple t = std::make_tuple(b.id_, g.id_, cost);
         matchings->push_back(t);

--- a/core/base/auction/AuctionImpl.h
+++ b/core/base/auction/AuctionImpl.h
@@ -106,7 +106,9 @@ dataType ttk::Auction<dataType>::getMatchingsAndDistance(
                        "diagonal points"
                     << std::endl;
         }
-        cost = 2 * pow(abs<dataType>((b.y_ - b.x_) / 2), wasserstein_);
+        cost
+          = 2
+            * Geometry::powInt(abs<dataType>((b.y_ - b.x_) / 2), wasserstein_);
         if(get_diagonal_matches) {
           matchingTuple t = std::make_tuple(i, good_id, cost);
           matchings->push_back(t);
@@ -116,7 +118,8 @@ dataType ttk::Auction<dataType>::getMatchingsAndDistance(
     } else {
       // b is diagonal
       const Good<dataType> &g = b.getProperty();
-      dataType cost = 2 * pow(abs<dataType>((g.y_ - g.x_) / 2), wasserstein_);
+      dataType cost
+        = 2 * Geometry::powInt(abs<dataType>((g.y_ - g.x_) / 2), wasserstein_);
       if(get_diagonal_matches) {
         matchingTuple t = std::make_tuple(b.id_, g.id_, cost);
         matchings->push_back(t);

--- a/core/base/bottleneckDistance/BottleneckDistanceImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceImpl.h
@@ -174,7 +174,9 @@ double BottleneckDistance::computeGeometricalRange(
   minZ = std::min(minZ1, minZ2);
   maxZ = std::max(maxZ1, maxZ2);
 
-  return sqrt(pow(maxX - minX, 2) + pow(maxY - minY, 2) + pow(maxZ - minZ, 2));
+  return sqrt(Geometry::powInt(maxX - minX, 2)
+              + Geometry::powInt(maxY - minY, 2)
+              + Geometry::powInt(maxZ - minZ, 2));
 }
 
 template <typename dataType>

--- a/core/base/bottleneckDistance/BottleneckDistanceImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceImpl.h
@@ -174,9 +174,8 @@ double BottleneckDistance::computeGeometricalRange(
   minZ = std::min(minZ1, minZ2);
   maxZ = std::max(maxZ1, maxZ2);
 
-  return sqrt(Geometry::powInt(maxX - minX, 2)
-              + Geometry::powInt(maxY - minY, 2)
-              + Geometry::powInt(maxZ - minZ, 2));
+  return sqrt(Geometry::pow(maxX - minX, 2) + Geometry::pow(maxY - minY, 2)
+              + Geometry::pow(maxZ - minZ, 2));
 }
 
 template <typename dataType>

--- a/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
@@ -102,7 +102,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
         const diagramTuple a, const diagramTuple b) -> dataType {
     BNodeType ta1 = std::get<1>(a);
     BNodeType ta2 = std::get<3>(a);
-    double w = wasserstein > 1 ? wasserstein : 1; // L_inf not managed.
+    const int w = wasserstein > 1 ? wasserstein : 1; // L_inf not managed.
 
     // We don't match critical points of different index.
     // This must be ensured before calling the distance function.
@@ -116,33 +116,38 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
     dataType rY = std::get<10>(a);
     dataType cX = std::get<6>(b);
     dataType cY = std::get<10>(b);
-    dataType x
-      = ((isMin1 && !isMax1) ? pe : ps) * pow(abs_diff<dataType>(rX, cX), w);
-    dataType y = (isMax1 ? pe : ps) * pow(abs_diff<dataType>(rY, cY), w);
+    dataType x = ((isMin1 && !isMax1) ? pe : ps)
+                 * Geometry::powInt(abs_diff<dataType>(rX, cX), w);
+    dataType y
+      = (isMax1 ? pe : ps) * Geometry::powInt(abs_diff<dataType>(rY, cY), w);
     double geoDistance
       = isMax1
-          ? (px * pow(abs(std::get<11>(a) - std::get<11>(b)), w)
-             + py * pow(abs(std::get<12>(a) - std::get<12>(b)), w)
-             + pz * pow(abs(std::get<13>(a) - std::get<13>(b)), w))
-          : isMin1 ? (px * pow(abs(std::get<7>(a) - std::get<7>(b)), w)
-                      + py * pow(abs(std::get<8>(a) - std::get<8>(b)), w)
-                      + pz * pow(abs(std::get<9>(a) - std::get<9>(b)), w))
+          ? (px * Geometry::powInt(abs(std::get<11>(a) - std::get<11>(b)), w)
+             + py * Geometry::powInt(abs(std::get<12>(a) - std::get<12>(b)), w)
+             + pz * Geometry::powInt(abs(std::get<13>(a) - std::get<13>(b)), w))
+          : isMin1 ? (
+              px * Geometry::powInt(abs(std::get<7>(a) - std::get<7>(b)), w)
+              + py * Geometry::powInt(abs(std::get<8>(a) - std::get<8>(b)), w)
+              + pz * Geometry::powInt(abs(std::get<9>(a) - std::get<9>(b)), w))
                    : (px
-                        * pow(abs(std::get<7>(a) + std::get<11>(a)) / 2
-                                - abs(std::get<7>(b) + std::get<11>(b)) / 2,
-                              w)
+                        * Geometry::powInt(
+                          abs(std::get<7>(a) + std::get<11>(a)) / 2
+                            - abs(std::get<7>(b) + std::get<11>(b)) / 2,
+                          w)
                       + py
-                          * pow(abs(std::get<8>(a) + std::get<12>(a)) / 2
-                                  - abs(std::get<8>(b) + std::get<12>(b)) / 2,
-                                w)
+                          * Geometry::powInt(
+                            abs(std::get<8>(a) + std::get<12>(a)) / 2
+                              - abs(std::get<8>(b) + std::get<12>(b)) / 2,
+                            w)
                       + pz
-                          * pow(abs(std::get<9>(a) + std::get<13>(a)) / 2
-                                  - abs(std::get<9>(b) + std::get<13>(b)) / 2,
-                                w));
+                          * Geometry::powInt(
+                            abs(std::get<9>(a) + std::get<13>(a)) / 2
+                              - abs(std::get<9>(b) + std::get<13>(b)) / 2,
+                            w));
 
     double persDistance = x + y;
     double val = persDistance + geoDistance;
-    val = pow(val, 1 / w);
+    val = std::pow(val, 1.0 / w);
     return val;
   };
 
@@ -150,7 +155,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
     = [wasserstein, px, py, pz, ps, pe](const diagramTuple a) -> dataType {
     BNodeType ta1 = std::get<1>(a);
     BNodeType ta2 = std::get<3>(a);
-    double w = wasserstein > 1 ? wasserstein : 1;
+    const int w = wasserstein > 1 ? wasserstein : 1;
     bool isMin1 = ta1 == BLocalMin;
     bool isMax1 = ta2 == BLocalMax;
 
@@ -163,12 +168,13 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
     double y2 = std::get<12>(a);
     double z2 = std::get<13>(a);
 
-    double infDistance
-      = (isMin1 || isMax1 ? pe : ps) * pow(abs_diff<dataType>(rX, rY), w);
-    double geoDistance = (px * pow(abs(x2 - x1), w) + py * pow(abs(y2 - y1), w)
-                          + pz * pow(abs(z2 - z1), w));
+    double infDistance = (isMin1 || isMax1 ? pe : ps)
+                         * Geometry::powInt(abs_diff<dataType>(rX, rY), w);
+    double geoDistance = (px * Geometry::powInt(abs(x2 - x1), w)
+                          + py * Geometry::powInt(abs(y2 - y1), w)
+                          + pz * Geometry::powInt(abs(z2 - z1), w));
     double val = infDistance + geoDistance;
-    return pow(val, 1 / w);
+    return std::pow(val, 1.0 / w);
   };
 
   const bool transposeMin = nbRowMin > nbColMin;
@@ -307,7 +313,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
 
   dataType affectationD = d;
   d = wasserstein > 0
-        ? pow(
+        ? std::pow(
           d + addedMaxPersistence + addedMinPersistence + addedSadPersistence,
           (1.0 / (double)wasserstein))
         : std::max(

--- a/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
@@ -117,33 +117,33 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
     dataType cX = std::get<6>(b);
     dataType cY = std::get<10>(b);
     dataType x = ((isMin1 && !isMax1) ? pe : ps)
-                 * Geometry::powInt(abs_diff<dataType>(rX, cX), w);
+                 * Geometry::pow(abs_diff<dataType>(rX, cX), w);
     dataType y
-      = (isMax1 ? pe : ps) * Geometry::powInt(abs_diff<dataType>(rY, cY), w);
+      = (isMax1 ? pe : ps) * Geometry::pow(abs_diff<dataType>(rY, cY), w);
     double geoDistance
       = isMax1
-          ? (px * Geometry::powInt(abs(std::get<11>(a) - std::get<11>(b)), w)
-             + py * Geometry::powInt(abs(std::get<12>(a) - std::get<12>(b)), w)
-             + pz * Geometry::powInt(abs(std::get<13>(a) - std::get<13>(b)), w))
-          : isMin1 ? (
-              px * Geometry::powInt(abs(std::get<7>(a) - std::get<7>(b)), w)
-              + py * Geometry::powInt(abs(std::get<8>(a) - std::get<8>(b)), w)
-              + pz * Geometry::powInt(abs(std::get<9>(a) - std::get<9>(b)), w))
-                   : (px
-                        * Geometry::powInt(
-                          abs(std::get<7>(a) + std::get<11>(a)) / 2
-                            - abs(std::get<7>(b) + std::get<11>(b)) / 2,
-                          w)
-                      + py
-                          * Geometry::powInt(
-                            abs(std::get<8>(a) + std::get<12>(a)) / 2
-                              - abs(std::get<8>(b) + std::get<12>(b)) / 2,
-                            w)
-                      + pz
-                          * Geometry::powInt(
-                            abs(std::get<9>(a) + std::get<13>(a)) / 2
-                              - abs(std::get<9>(b) + std::get<13>(b)) / 2,
-                            w));
+          ? (px * Geometry::pow(abs(std::get<11>(a) - std::get<11>(b)), w)
+             + py * Geometry::pow(abs(std::get<12>(a) - std::get<12>(b)), w)
+             + pz * Geometry::pow(abs(std::get<13>(a) - std::get<13>(b)), w))
+          : isMin1
+              ? (px * Geometry::pow(abs(std::get<7>(a) - std::get<7>(b)), w)
+                 + py * Geometry::pow(abs(std::get<8>(a) - std::get<8>(b)), w)
+                 + pz * Geometry::pow(abs(std::get<9>(a) - std::get<9>(b)), w))
+              : (
+                px
+                  * Geometry::pow(abs(std::get<7>(a) + std::get<11>(a)) / 2
+                                    - abs(std::get<7>(b) + std::get<11>(b)) / 2,
+                                  w)
+                + py
+                    * Geometry::pow(
+                      abs(std::get<8>(a) + std::get<12>(a)) / 2
+                        - abs(std::get<8>(b) + std::get<12>(b)) / 2,
+                      w)
+                + pz
+                    * Geometry::pow(
+                      abs(std::get<9>(a) + std::get<13>(a)) / 2
+                        - abs(std::get<9>(b) + std::get<13>(b)) / 2,
+                      w));
 
     double persDistance = x + y;
     double val = persDistance + geoDistance;
@@ -169,10 +169,10 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
     double z2 = std::get<13>(a);
 
     double infDistance = (isMin1 || isMax1 ? pe : ps)
-                         * Geometry::powInt(abs_diff<dataType>(rX, rY), w);
-    double geoDistance = (px * Geometry::powInt(abs(x2 - x1), w)
-                          + py * Geometry::powInt(abs(y2 - y1), w)
-                          + pz * Geometry::powInt(abs(z2 - z1), w));
+                         * Geometry::pow(abs_diff<dataType>(rX, rY), w);
+    double geoDistance = (px * Geometry::pow(abs(x2 - x1), w)
+                          + py * Geometry::pow(abs(y2 - y1), w)
+                          + pz * Geometry::pow(abs(z2 - z1), w));
     double val = infDistance + geoDistance;
     return Geometry::pow(val, 1.0 / w);
   };

--- a/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
+++ b/core/base/bottleneckDistance/BottleneckDistanceMainImpl.h
@@ -147,7 +147,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
 
     double persDistance = x + y;
     double val = persDistance + geoDistance;
-    val = std::pow(val, 1.0 / w);
+    val = Geometry::pow(val, 1.0 / w);
     return val;
   };
 
@@ -174,7 +174,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
                           + py * Geometry::powInt(abs(y2 - y1), w)
                           + pz * Geometry::powInt(abs(z2 - z1), w));
     double val = infDistance + geoDistance;
-    return std::pow(val, 1.0 / w);
+    return Geometry::pow(val, 1.0 / w);
   };
 
   const bool transposeMin = nbRowMin > nbColMin;
@@ -313,7 +313,7 @@ int BottleneckDistance::computeBottleneck(const std::vector<diagramTuple> &d1,
 
   dataType affectationD = d;
   d = wasserstein > 0
-        ? std::pow(
+        ? Geometry::pow(
           d + addedMaxPersistence + addedMinPersistence + addedSadPersistence,
           (1.0 / (double)wasserstein))
         : std::max(

--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -29,8 +29,6 @@
 #include <string>
 #include <vector>
 
-#define pow10(x) pow(10, x)
-
 //#define SINGLE_PRECISION
 
 #ifdef SINGLE_PRECISION

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -1495,8 +1495,8 @@ int SubLevelSetTree::getPersistencePlot(
 
   for(int i = 0; i < (int)plot.size(); i++) {
     plot[i].first = (*persistencePairs)[i].second;
-    if(plot[i].first < pow(10, -REAL_SIGNIFICANT_DIGITS)) {
-      plot[i].first = pow(10, -REAL_SIGNIFICANT_DIGITS);
+    if(plot[i].first < Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS)) {
+      plot[i].first = Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS);
     }
     plot[i].second = persistencePairs->size() - i;
   }
@@ -2923,8 +2923,8 @@ int ContourTree::getPersistencePlot(
 
   for(int i = 0; i < (int)plot.size(); i++) {
     plot[i].first = (*pairs)[i].second;
-    if(plot[i].first < pow(10, -REAL_SIGNIFICANT_DIGITS)) {
-      plot[i].first = pow(10, -REAL_SIGNIFICANT_DIGITS);
+    if(plot[i].first < Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS)) {
+      plot[i].first = Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS);
     }
     plot[i].second = pairs->size() - i;
   }

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -5,8 +5,8 @@ using namespace ttk;
 
 static const float PREC_FLT{powf(10.F, -FLT_DIG)};
 static const float PREC_FLT_2{powf(10.F, -FLT_DIG + 2)};
-static const double PREC_DBL{std::pow(10.0, -DBL_DIG)};
-static const double PREC_DBL_4{std::pow(10.0, -DBL_DIG + 4)};
+static const double PREC_DBL{Geometry::pow(10.0, -DBL_DIG)};
+static const double PREC_DBL_4{Geometry::pow(10.0, -DBL_DIG + 4)};
 
 struct _fiberSurfaceVertexCmpX {
 

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -3,16 +3,21 @@
 using namespace std;
 using namespace ttk;
 
+static const float PREC_FLT{powf(10.F, -FLT_DIG)};
+static const float PREC_FLT_2{powf(10.F, -FLT_DIG + 2)};
+static const double PREC_DBL{std::pow(10.0, -DBL_DIG)};
+static const double PREC_DBL_4{std::pow(10.0, -DBL_DIG + 4)};
+
 struct _fiberSurfaceVertexCmpX {
 
   bool operator()(const FiberSurface::Vertex &v0,
                   const FiberSurface::Vertex &v1) {
 
-    if(fabs(v0.p_[0] - v1.p_[0]) < pow(10, -DBL_DIG)) {
+    if(fabs(v0.p_[0] - v1.p_[0]) < PREC_DBL) {
       // let's consider x coordinates are equal
-      if(fabs(v0.p_[1] - v1.p_[1]) < pow(10, -DBL_DIG)) {
+      if(fabs(v0.p_[1] - v1.p_[1]) < PREC_DBL) {
         // let's consider y coordinates are equal
-        if(fabs(v0.p_[2] - v1.p_[2]) < pow(10, -DBL_DIG)) {
+        if(fabs(v0.p_[2] - v1.p_[2]) < PREC_DBL) {
           // let's consider z coordinates are equal
           // NOTE: the local Id should be sufficient
           return v0.globalId_ < v1.globalId_;
@@ -31,11 +36,11 @@ struct _fiberSurfaceVertexCmpY {
   bool operator()(const FiberSurface::Vertex &v0,
                   const FiberSurface::Vertex &v1) {
 
-    if(fabs(v0.p_[1] - v1.p_[1]) < pow(10, -DBL_DIG)) {
+    if(fabs(v0.p_[1] - v1.p_[1]) < PREC_DBL) {
       // let's consider y coordinates are equal
-      if(fabs(v0.p_[2] - v1.p_[2]) < pow(10, -DBL_DIG)) {
+      if(fabs(v0.p_[2] - v1.p_[2]) < PREC_DBL) {
         // let's consider z coordinates are equal
-        if(fabs(v0.p_[0] - v1.p_[0]) < pow(10, -DBL_DIG)) {
+        if(fabs(v0.p_[0] - v1.p_[0]) < PREC_DBL) {
           // let's consider x coordinates are equal
           // NOTE: the local Id should be sufficient
           return v0.globalId_ < v1.globalId_;
@@ -54,11 +59,11 @@ struct _fiberSurfaceVertexCmpZ {
   bool operator()(const FiberSurface::Vertex &v0,
                   const FiberSurface::Vertex &v1) {
 
-    if(fabs(v0.p_[2] - v1.p_[2]) < pow(10, -DBL_DIG)) {
+    if(fabs(v0.p_[2] - v1.p_[2]) < PREC_DBL) {
       // let's consider z coordinates are equal
-      if(fabs(v0.p_[0] - v1.p_[0]) < pow(10, -DBL_DIG)) {
+      if(fabs(v0.p_[0] - v1.p_[0]) < PREC_DBL) {
         // let's consider x coordinates are equal
-        if(fabs(v0.p_[1] - v1.p_[1]) < pow(10, -DBL_DIG)) {
+        if(fabs(v0.p_[1] - v1.p_[1]) < PREC_DBL) {
           // let's consider y coordinates are equal
           // NOTE: the local Id should be sufficient
           return v0.globalId_ < v1.globalId_;
@@ -145,7 +150,7 @@ int FiberSurface::getNumberOfCommonVertices(
       for(int k = 0; k < 3; k++) {
         p1[k] = tetIntersections[tetId][triangleId1].p_[j][k];
 
-        if(fabs(p0[k] - p1[k]) > Geometry::powIntTen(-FLT_DIG)) {
+        if(fabs(p0[k] - p1[k]) > PREC_FLT) {
           isTheSame = false;
           break;
         }
@@ -176,16 +181,16 @@ int FiberSurface::computeTriangleFiber(
   for(int i = 0; i < 3; i++) {
     if((fabs(intersection.first
              - tetIntersections[tetId][triangleId].uv_[i].first)
-        < Geometry::powIntTen(-DBL_DIG + 4))
+        < PREC_DBL_4)
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[i].second)
-            < Geometry::powIntTen(-DBL_DIG + 4)
+            < PREC_DBL_4
        && fabs(intersection.first
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].first)
-            < Geometry::powIntTen(-DBL_DIG + 4)
+            < PREC_DBL_4
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].second)
-            < Geometry::powIntTen(-DBL_DIG + 4)) {
+            < PREC_DBL_4) {
       // edge 0 - 1 is on the fiber. the pivot is 2
       pivotVertexId = (i + 2) % 3;
       edgeFiber = true;
@@ -351,14 +356,14 @@ int FiberSurface::computeTriangleIntersection(
   // we need to make sure p0a and p1a are not the same (vertex case)
   bool vertexA = false;
   bool vertexB = false;
-  if((fabs(p0a[0] - p1a[0]) < pow(10, -DBL_DIG))
-     && (fabs(p0a[1] - p1a[1]) < pow(10, -DBL_DIG))
-     && (fabs(p0a[2] - p1a[2]) < pow(10, -DBL_DIG))) {
+  if((fabs(p0a[0] - p1a[0]) < PREC_DBL)
+     && (fabs(p0a[1] - p1a[1]) < PREC_DBL)
+     && (fabs(p0a[2] - p1a[2]) < PREC_DBL)) {
     vertexA = true;
   }
-  if((fabs(p0b[0] - p1b[0]) < pow(10, -DBL_DIG))
-     && (fabs(p0b[1] - p1b[1]) < pow(10, -DBL_DIG))
-     && (fabs(p0b[2] - p1b[2]) < pow(10, -DBL_DIG))) {
+  if((fabs(p0b[0] - p1b[0]) < PREC_DBL)
+     && (fabs(p0b[1] - p1b[1]) < PREC_DBL)
+     && (fabs(p0b[2] - p1b[2]) < PREC_DBL)) {
     vertexB = true;
   }
   if((vertexA) || (vertexB)) {
@@ -383,9 +388,9 @@ int FiberSurface::computeTriangleIntersection(
       foundA = true;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p1a[0]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[1] - p1a[1]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[2] - p1a[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p1a[0]) > PREC_DBL_4)
+         || (fabs(pA[1] - p1a[1]) > PREC_DBL_4)
+         || (fabs(pA[2] - p1a[2]) > PREC_DBL_4)) {
         pB = p1a;
         foundB = true;
       }
@@ -399,9 +404,9 @@ int FiberSurface::computeTriangleIntersection(
       foundA = true;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p0b[0]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[1] - p0b[1]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[2] - p0b[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p0b[0]) > PREC_DBL_4)
+         || (fabs(pA[1] - p0b[1]) > PREC_DBL_4)
+         || (fabs(pA[2] - p0b[2]) > PREC_DBL_4)) {
         pB = p0b;
         foundB = true;
       }
@@ -414,9 +419,9 @@ int FiberSurface::computeTriangleIntersection(
       pA = p1b;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p1b[0]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[1] - p1b[1]) > Geometry::powIntTen(-DBL_DIG + 4))
-         || (fabs(pA[2] - p1b[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p1b[0]) > PREC_DBL_4)
+         || (fabs(pA[1] - p1b[1]) > PREC_DBL_4)
+         || (fabs(pA[2] - p1b[2]) > PREC_DBL_4)) {
         pB = p1b;
       }
     }
@@ -456,10 +461,10 @@ int FiberSurface::computeTriangleIntersection(
   // check if the triangle has already been intersected on that fiber
   if((fabs(tetIntersections[tetId][triangleId].intersection_.first
            - intersection.first)
-      < Geometry::powIntTen(-FLT_DIG))
+      < PREC_FLT)
      && (fabs(tetIntersections[tetId][triangleId].intersection_.second
               - intersection.second)
-         < Geometry::powIntTen(-FLT_DIG))) {
+         < PREC_FLT)) {
 
     return -2;
   }
@@ -468,16 +473,16 @@ int FiberSurface::computeTriangleIntersection(
   for(int i = 0; i < 3; i++) {
     if((fabs(intersection.first
              - tetIntersections[tetId][triangleId].uv_[i].first)
-        < Geometry::powIntTen(-FLT_DIG))
+        < PREC_FLT)
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[i].second)
-            < Geometry::powIntTen(-FLT_DIG)
+            < PREC_FLT
        && fabs(intersection.first
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].first)
-            < Geometry::powIntTen(-FLT_DIG)
+            < PREC_FLT
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].second)
-            < Geometry::powIntTen(-FLT_DIG)) {
+            < PREC_FLT) {
       return -3;
     }
   }
@@ -510,14 +515,14 @@ int FiberSurface::computeTriangleIntersection(
 
   bool isAVertex = false;
   for(int i = 0; i < 3; i++) {
-    if(fabs(baryA[i] - 1) < Geometry::powIntTen(-DBL_DIG)) {
+    if(fabs(baryA[i] - 1) < PREC_DBL) {
       isAVertex = true;
       break;
     }
   }
   bool isBVertex = false;
   for(int i = 0; i < 3; i++) {
-    if(fabs(baryB[i] - 1) < Geometry::powIntTen(-DBL_DIG)) {
+    if(fabs(baryB[i] - 1) < PREC_DBL) {
       isBVertex = true;
       break;
     }
@@ -1004,8 +1009,7 @@ int FiberSurface::getTriangleRangeExtremities(
     p1[0] = tetIntersections[tetId][triangleId].uv_[(i + 2) % 3].first;
     p1[1] = tetIntersections[tetId][triangleId].uv_[(i + 2) % 3].second;
 
-    if((fabs(p0[0] - p1[0]) < Geometry::powIntTen(-FLT_DIG))
-       && (fabs(p0[1] - p1[1]) < Geometry::powIntTen(-FLT_DIG))) {
+    if((fabs(p0[0] - p1[0]) < PREC_FLT) && (fabs(p0[1] - p1[1]) < PREC_FLT)) {
       // one edge of the triangle projects to a point
       extremity0.first = p[0];
       extremity0.second = p[1];
@@ -1034,8 +1038,7 @@ int FiberSurface::getTriangleRangeExtremities(
     isInBetween = true;
     for(int j = 0; j < 2; j++) {
 
-      if((baryCentrics[j] < -Geometry::powIntTen(-FLT_DIG))
-         || (baryCentrics[j] > 1 + Geometry::powIntTen(-FLT_DIG))) {
+      if((baryCentrics[j] < -PREC_FLT) || (baryCentrics[j] > 1 + PREC_FLT)) {
         isInBetween = false;
         break;
       }
@@ -1735,12 +1738,11 @@ int FiberSurface::snapVertexBarycentrics(
         }
       }
 
-      if((minimum != -DBL_MAX)
-         && (minimum < Geometry::powIntTen(-FLT_DIG + 2))) {
+      if((minimum != -DBL_MAX) && (minimum < PREC_FLT_2)) {
         double sum = 0;
         int numberOfZeros = 0;
         for(int k = 0; k < 3; k++) {
-          if(minBarycentrics[k] < Geometry::powIntTen(-FLT_DIG + 2)) {
+          if(minBarycentrics[k] < PREC_FLT_2) {
             minBarycentrics[k] = 0;
             numberOfZeros++;
           }
@@ -1750,7 +1752,7 @@ int FiberSurface::snapVertexBarycentrics(
         sum = (1 - sum) / numberOfZeros;
 
         for(int k = 0; k < 3; k++) {
-          if(minBarycentrics[k] >= Geometry::powIntTen(-FLT_DIG + 2)) {
+          if(minBarycentrics[k] >= PREC_FLT_2) {
             minBarycentrics[k] += sum;
           }
         }

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -114,8 +114,8 @@ FiberSurface::FiberSurface() {
   edgeImplicitEncoding_[11] = 3;
 
   pointSnapping_ = false;
-  pointSnappingThreshold_ = pow10(-FLT_DIG + 1);
-  edgeCollapseThreshold_ = pow10(-FLT_DIG + 2);
+  pointSnappingThreshold_ = Geometry::powIntTen(-FLT_DIG + 1);
+  edgeCollapseThreshold_ = Geometry::powIntTen(-FLT_DIG + 2);
 }
 
 FiberSurface::~FiberSurface() {
@@ -145,7 +145,7 @@ int FiberSurface::getNumberOfCommonVertices(
       for(int k = 0; k < 3; k++) {
         p1[k] = tetIntersections[tetId][triangleId1].p_[j][k];
 
-        if(fabs(p0[k] - p1[k]) > pow10(-FLT_DIG)) {
+        if(fabs(p0[k] - p1[k]) > Geometry::powIntTen(-FLT_DIG)) {
           isTheSame = false;
           break;
         }
@@ -176,16 +176,16 @@ int FiberSurface::computeTriangleFiber(
   for(int i = 0; i < 3; i++) {
     if((fabs(intersection.first
              - tetIntersections[tetId][triangleId].uv_[i].first)
-        < pow10(-DBL_DIG + 4))
+        < Geometry::powIntTen(-DBL_DIG + 4))
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[i].second)
-            < pow10(-DBL_DIG + 4)
+            < Geometry::powIntTen(-DBL_DIG + 4)
        && fabs(intersection.first
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].first)
-            < pow10(-DBL_DIG + 4)
+            < Geometry::powIntTen(-DBL_DIG + 4)
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].second)
-            < pow10(-DBL_DIG + 4)) {
+            < Geometry::powIntTen(-DBL_DIG + 4)) {
       // edge 0 - 1 is on the fiber. the pivot is 2
       pivotVertexId = (i + 2) % 3;
       edgeFiber = true;
@@ -383,9 +383,9 @@ int FiberSurface::computeTriangleIntersection(
       foundA = true;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p1a[0]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[1] - p1a[1]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[2] - p1a[2]) > pow10(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p1a[0]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[1] - p1a[1]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[2] - p1a[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
         pB = p1a;
         foundB = true;
       }
@@ -399,9 +399,9 @@ int FiberSurface::computeTriangleIntersection(
       foundA = true;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p0b[0]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[1] - p0b[1]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[2] - p0b[2]) > pow10(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p0b[0]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[1] - p0b[1]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[2] - p0b[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
         pB = p0b;
         foundB = true;
       }
@@ -414,9 +414,9 @@ int FiberSurface::computeTriangleIntersection(
       pA = p1b;
     } else if(!foundB) {
       // check it's far enough from pA
-      if((fabs(pA[0] - p1b[0]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[1] - p1b[1]) > pow10(-DBL_DIG + 4))
-         || (fabs(pA[2] - p1b[2]) > pow10(-DBL_DIG + 4))) {
+      if((fabs(pA[0] - p1b[0]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[1] - p1b[1]) > Geometry::powIntTen(-DBL_DIG + 4))
+         || (fabs(pA[2] - p1b[2]) > Geometry::powIntTen(-DBL_DIG + 4))) {
         pB = p1b;
       }
     }
@@ -456,10 +456,10 @@ int FiberSurface::computeTriangleIntersection(
   // check if the triangle has already been intersected on that fiber
   if((fabs(tetIntersections[tetId][triangleId].intersection_.first
            - intersection.first)
-      < pow10(-FLT_DIG))
+      < Geometry::powIntTen(-FLT_DIG))
      && (fabs(tetIntersections[tetId][triangleId].intersection_.second
               - intersection.second)
-         < pow10(-FLT_DIG))) {
+         < Geometry::powIntTen(-FLT_DIG))) {
 
     return -2;
   }
@@ -468,16 +468,16 @@ int FiberSurface::computeTriangleIntersection(
   for(int i = 0; i < 3; i++) {
     if((fabs(intersection.first
              - tetIntersections[tetId][triangleId].uv_[i].first)
-        < pow10(-FLT_DIG))
+        < Geometry::powIntTen(-FLT_DIG))
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[i].second)
-            < pow10(-FLT_DIG)
+            < Geometry::powIntTen(-FLT_DIG)
        && fabs(intersection.first
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].first)
-            < pow10(-FLT_DIG)
+            < Geometry::powIntTen(-FLT_DIG)
        && fabs(intersection.second
                - tetIntersections[tetId][triangleId].uv_[(i + 1) % 3].second)
-            < pow10(-FLT_DIG)) {
+            < Geometry::powIntTen(-FLT_DIG)) {
       return -3;
     }
   }
@@ -510,14 +510,14 @@ int FiberSurface::computeTriangleIntersection(
 
   bool isAVertex = false;
   for(int i = 0; i < 3; i++) {
-    if(fabs(baryA[i] - 1) < pow10(-DBL_DIG)) {
+    if(fabs(baryA[i] - 1) < Geometry::powIntTen(-DBL_DIG)) {
       isAVertex = true;
       break;
     }
   }
   bool isBVertex = false;
   for(int i = 0; i < 3; i++) {
-    if(fabs(baryB[i] - 1) < pow10(-DBL_DIG)) {
+    if(fabs(baryB[i] - 1) < Geometry::powIntTen(-DBL_DIG)) {
       isBVertex = true;
       break;
     }
@@ -1004,8 +1004,8 @@ int FiberSurface::getTriangleRangeExtremities(
     p1[0] = tetIntersections[tetId][triangleId].uv_[(i + 2) % 3].first;
     p1[1] = tetIntersections[tetId][triangleId].uv_[(i + 2) % 3].second;
 
-    if((fabs(p0[0] - p1[0]) < pow10(-FLT_DIG))
-       && (fabs(p0[1] - p1[1]) < pow10(-FLT_DIG))) {
+    if((fabs(p0[0] - p1[0]) < Geometry::powIntTen(-FLT_DIG))
+       && (fabs(p0[1] - p1[1]) < Geometry::powIntTen(-FLT_DIG))) {
       // one edge of the triangle projects to a point
       extremity0.first = p[0];
       extremity0.second = p[1];
@@ -1034,8 +1034,8 @@ int FiberSurface::getTriangleRangeExtremities(
     isInBetween = true;
     for(int j = 0; j < 2; j++) {
 
-      if((baryCentrics[j] < -pow10(-FLT_DIG))
-         || (baryCentrics[j] > 1 + pow10(-FLT_DIG))) {
+      if((baryCentrics[j] < -Geometry::powIntTen(-FLT_DIG))
+         || (baryCentrics[j] > 1 + Geometry::powIntTen(-FLT_DIG))) {
         isInBetween = false;
         break;
       }
@@ -1735,11 +1735,12 @@ int FiberSurface::snapVertexBarycentrics(
         }
       }
 
-      if((minimum != -DBL_MAX) && (minimum < pow10(-FLT_DIG + 2))) {
+      if((minimum != -DBL_MAX)
+         && (minimum < Geometry::powIntTen(-FLT_DIG + 2))) {
         double sum = 0;
         int numberOfZeros = 0;
         for(int k = 0; k < 3; k++) {
-          if(minBarycentrics[k] < pow10(-FLT_DIG + 2)) {
+          if(minBarycentrics[k] < Geometry::powIntTen(-FLT_DIG + 2)) {
             minBarycentrics[k] = 0;
             numberOfZeros++;
           }
@@ -1749,7 +1750,7 @@ int FiberSurface::snapVertexBarycentrics(
         sum = (1 - sum) / numberOfZeros;
 
         for(int k = 0; k < 3; k++) {
-          if(minBarycentrics[k] >= pow10(-FLT_DIG + 2)) {
+          if(minBarycentrics[k] >= Geometry::powIntTen(-FLT_DIG + 2)) {
             minBarycentrics[k] += sum;
           }
         }

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -2232,7 +2232,8 @@ inline int ttk::FiberSurface::processTetrahedron(
               }
             }
           }
-          if((minDistance != -1) && (minDistance < pow10(-DBL_DIG))) {
+          if((minDistance != -1)
+             && (minDistance < Geometry::powIntTen(-DBL_DIG))) {
             //           if((minDistance != -1)&&(minDistance <
             //           pointSnappingThreshold_)){
             // snap them to another colinear vertex

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -1850,6 +1850,8 @@ inline int ttk::FiberSurface::processTetrahedron(
   rangeNormal[0] = -rangeEdge[1];
   rangeNormal[1] = rangeEdge[0];
 
+  const double prec_dbl = Geometry::powInt(10.0, -DBL_DIG);
+
   // 1. compute the distance to the range line carrying the saddleEdge
   SimplexId upperNumber = 0;
   SimplexId lowerNumber = 0;
@@ -1875,7 +1877,7 @@ inline int ttk::FiberSurface::processTetrahedron(
     d[i] = vertexRangeEdge[0] * rangeNormal[0]
            + vertexRangeEdge[1] * rangeNormal[1];
 
-    if(fabs(d[i]) < Geometry::powIntTen(-DBL_DIG))
+    if(fabs(d[i]) < prec_dbl)
       d[i] = 0;
 
     if(d[i] > 0)
@@ -2232,8 +2234,7 @@ inline int ttk::FiberSurface::processTetrahedron(
               }
             }
           }
-          if((minDistance != -1)
-             && (minDistance < Geometry::powIntTen(-DBL_DIG))) {
+          if((minDistance != -1) && (minDistance < prec_dbl)) {
             //           if((minDistance != -1)&&(minDistance <
             //           pointSnappingThreshold_)){
             // snap them to another colinear vertex

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -1875,7 +1875,7 @@ inline int ttk::FiberSurface::processTetrahedron(
     d[i] = vertexRangeEdge[0] * rangeNormal[0]
            + vertexRangeEdge[1] * rangeNormal[1];
 
-    if(fabs(d[i]) < pow(10, -DBL_DIG))
+    if(fabs(d[i]) < Geometry::powIntTen(-DBL_DIG))
       d[i] = 0;
 
     if(d[i] > 0)
@@ -2482,13 +2482,13 @@ inline int ttk::FiberSurface::remeshIntersections() const {
             // check if that intersection has been registered before
             // in the end, only one intersection per triangle, no matter what
             /*&&(((fabs(tetIntersections[tetId][j].intersection_.first 
-              - intersection.first) > pow(10, -FLT_DIG))
+              - intersection.first) > Geometry::powIntTen(-FLT_DIG))
             ||(fabs(tetIntersections[tetId][j].intersection_.second
-              - intersection.second) > pow(10, -FLT_DIG)))
+              - intersection.second) > Geometry::powIntTen(-FLT_DIG)))
             &&((fabs(tetIntersections[tetId][k].intersection_.first 
-              - intersection.first) > pow(10, -FLT_DIG))
+              - intersection.first) > Geometry::powIntTen(-FLT_DIG))
             ||(fabs(tetIntersections[tetId][k].intersection_.second
-              - intersection.second) > pow(10, -FLT_DIG))))*/){
+              - intersection.second) > Geometry::powIntTen(-FLT_DIG))))*/){
 
             computeTriangleIntersection(tetId, j, k, polygonEdgeId0,
                                         polygonEdgeId1, intersection,

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -520,9 +520,6 @@ template int
                                                   double const *,
                                                   std::vector<double> &,
                                                   int const &);
-// template int Geometry::computeBarycentricCoordinates<double>(
-//     double const &, double const &, double const &, double const &,
-//     double const &, double const &, std::vector<double> &);
 template int
   Geometry::computeBarycentricCoordinates<double>(double const *,
                                                   double const *,
@@ -603,9 +600,6 @@ template int
                                                  float const *,
                                                  std::vector<float> &,
                                                  int const &);
-// template int Geometry::computeBarycentricCoordinates<float>(
-//     float const &, float const &, float const &, float const &,
-//     float const &, float const &, std::vector<float> &);
 template int
   Geometry::computeBarycentricCoordinates<float>(float const *,
                                                  float const *,

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 using namespace ttk;
 
-static const double PREC_DBL{std::pow(10.0, -DBL_DIG)};
+static const double PREC_DBL{Geometry::pow(10.0, -DBL_DIG)};
 static const float PREC_FLT{powf(10.0F, -FLT_DIG)};
 static const float PREC_FLT_1{powf(10.0F, -FLT_DIG + 1)};
 

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -5,6 +5,10 @@
 using namespace std;
 using namespace ttk;
 
+static const double PREC_DBL{std::pow(10.0, -DBL_DIG)};
+static const float PREC_FLT{powf(10.0F, -FLT_DIG)};
+static const float PREC_FLT_1{powf(10.0F, -FLT_DIG + 1)};
+
 template <typename T>
 T Geometry::angle(const T *vA0, const T *vA1, const T *vB0, const T *vB1) {
   return M_PI
@@ -24,11 +28,11 @@ bool Geometry::areVectorsColinear(const T *vA0,
   vector<T> a(3), b(3);
   for(int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
-    if(fabs(a[i]) < powIntTen<float>(-FLT_DIG)) {
+    if(fabs(a[i]) < PREC_FLT) {
       aNullComponents++;
     }
     b[i] = vB1[i] - vB0[i];
-    if(fabs(b[i]) < powIntTen<float>(-FLT_DIG)) {
+    if(fabs(b[i]) < PREC_FLT) {
       bNullComponents++;
     }
   }
@@ -61,13 +65,13 @@ bool Geometry::areVectorsColinear(const T *vA0,
   int isNan = -1, maximizer = 0;
   for(int i = 0; i < 3; i++) {
     if(useDenominatorA) {
-      if(fabs(a[i]) > powIntTen<float>(-FLT_DIG)) {
+      if(fabs(a[i]) > PREC_FLT) {
         k[i] = b[i] / a[i];
       } else {
         isNan = i;
       }
     } else {
-      if(fabs(b[i]) > powIntTen<float>(-FLT_DIG)) {
+      if(fabs(b[i]) > PREC_FLT) {
         k[i] = a[i] / b[i];
       } else {
         isNan = i;
@@ -87,7 +91,7 @@ bool Geometry::areVectorsColinear(const T *vA0,
 
   T colinearityThreshold;
 
-  colinearityThreshold = powIntTen<float>(-FLT_DIG);
+  colinearityThreshold = PREC_FLT;
   if(tolerance) {
     colinearityThreshold = *tolerance;
   }
@@ -153,8 +157,8 @@ int Geometry::computeBarycentricCoordinates(const T *p0,
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
   }
 
-  if((!((fabs(test[0] - p[0]) < powIntTen<float>(-FLT_DIG + 1))
-        && (fabs(test[1] - p[1]) < powIntTen<float>(-FLT_DIG + 1))))) {
+  if((!((fabs(test[0] - p[0]) < PREC_FLT_1)
+        && (fabs(test[1] - p[1]) < PREC_FLT_1)))) {
     for(int i = 0; i < 2; i++) {
       baryCentrics[i] = -baryCentrics[i];
     }
@@ -233,7 +237,7 @@ bool Geometry::computeSegmentIntersection(const T &xA,
 
   T d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
 
-  if(fabs(d) < powIntTen(-DBL_DIG)) {
+  if(fabs(d) < PREC_DBL) {
     return false;
   }
 
@@ -241,13 +245,11 @@ bool Geometry::computeSegmentIntersection(const T &xA,
 
   y = ((yC - yD) * (xA * yB - yA * xB) - (yA - yB) * (xC * yD - yC * xD)) / d;
 
-  if((x < std::min(xA, xB) - powIntTen<float>(-FLT_DIG))
-     || (x > std::max(xA, xB) + powIntTen<float>(-FLT_DIG))) {
+  if((x < std::min(xA, xB) - PREC_FLT) || (x > std::max(xA, xB) + PREC_FLT)) {
     return false;
   }
 
-  if((x < std::min(xC, xD) - powIntTen<float>(-FLT_DIG))
-     || (x > std::max(xC, xD) + powIntTen<float>(-FLT_DIG))) {
+  if((x < std::min(xC, xD) - PREC_FLT) || (x > std::max(xC, xD) + PREC_FLT)) {
     return false;
   }
 
@@ -389,10 +391,10 @@ bool Geometry::isPointInTriangle(const T *p0,
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
 
   for(int i = 0; i < static_cast<int>(barycentrics.size()); i++) {
-    if(barycentrics[i] < -powIntTen(-DBL_DIG)) {
+    if(barycentrics[i] < -PREC_DBL) {
       return false;
     }
-    if(barycentrics[i] > 1 + powIntTen(-DBL_DIG)) {
+    if(barycentrics[i] > 1 + PREC_DBL) {
       return false;
     }
   }
@@ -428,10 +430,9 @@ bool Geometry::isPointOnSegment(const T *p,
 
   Geometry::computeBarycentricCoordinates(pA, pB, p, baryCentrics, dimension);
 
-  return (((baryCentrics[0] > -powIntTen(-DBL_DIG))
-           && (baryCentrics[0] < 1 + powIntTen(-DBL_DIG)))
-          && ((baryCentrics[1] > -powIntTen(-DBL_DIG))
-              && (baryCentrics[1] < 1 + powIntTen(-DBL_DIG))));
+  return (
+    ((baryCentrics[0] > -PREC_DBL) && (baryCentrics[0] < 1 + PREC_DBL))
+    && ((baryCentrics[1] > -PREC_DBL) && (baryCentrics[1] < 1 + PREC_DBL)));
 }
 
 template <typename T>

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -503,23 +503,6 @@ T Geometry::magnitude(const T *o, const T *d) {
 }
 
 template <typename T>
-T Geometry::powInt(const T val, const int n) {
-  if(n < 0) {
-    return 1.0 / powInt(val, -n);
-  } else if(n == 0) {
-    return 1;
-  } else if(n == 1) {
-    return val;
-  } else if(n == 2) {
-    return val * val;
-  } else if(n == 3) {
-    return val * val * val;
-  } else {
-    return powInt(val, n - 1) * val;
-  }
-}
-
-template <typename T>
 T Geometry::powIntTen(const int n) {
   return powInt(static_cast<T>(10), n);
 }
@@ -606,7 +589,6 @@ template bool Geometry::isTriangleColinear<double>(double const *,
                                                    double const *);
 template double Geometry::magnitude<double>(double const *);
 template double Geometry::magnitude<double>(double const *, double const *);
-template double Geometry::powInt<double>(const double, const int);
 template double Geometry::powIntTen<double>(const int);
 
 // explicit instantiations for float
@@ -691,5 +673,4 @@ template bool Geometry::isTriangleColinear<float>(float const *,
                                                   float const *);
 template float Geometry::magnitude<float>(float const *);
 template float Geometry::magnitude<float>(float const *, float const *);
-template float Geometry::powInt<float>(const float, const int);
 template float Geometry::powIntTen<float>(const int);

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -2,9 +2,6 @@
 
 #include <algorithm>
 
-// TODO:
-// for faster computations, remove all pow10
-
 using namespace std;
 using namespace ttk;
 
@@ -27,11 +24,11 @@ bool Geometry::areVectorsColinear(const T *vA0,
   vector<T> a(3), b(3);
   for(int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
-    if(fabs(a[i]) < pow10(-FLT_DIG)) {
+    if(fabs(a[i]) < powIntTen<float>(-FLT_DIG)) {
       aNullComponents++;
     }
     b[i] = vB1[i] - vB0[i];
-    if(fabs(b[i]) < pow10(-FLT_DIG)) {
+    if(fabs(b[i]) < powIntTen<float>(-FLT_DIG)) {
       bNullComponents++;
     }
   }
@@ -64,13 +61,13 @@ bool Geometry::areVectorsColinear(const T *vA0,
   int isNan = -1, maximizer = 0;
   for(int i = 0; i < 3; i++) {
     if(useDenominatorA) {
-      if(fabs(a[i]) > pow10(-FLT_DIG)) {
+      if(fabs(a[i]) > powIntTen<float>(-FLT_DIG)) {
         k[i] = b[i] / a[i];
       } else {
         isNan = i;
       }
     } else {
-      if(fabs(b[i]) > pow10(-FLT_DIG)) {
+      if(fabs(b[i]) > powIntTen<float>(-FLT_DIG)) {
         k[i] = a[i] / b[i];
       } else {
         isNan = i;
@@ -90,7 +87,7 @@ bool Geometry::areVectorsColinear(const T *vA0,
 
   T colinearityThreshold;
 
-  colinearityThreshold = pow10(-FLT_DIG);
+  colinearityThreshold = powIntTen<float>(-FLT_DIG);
   if(tolerance) {
     colinearityThreshold = *tolerance;
   }
@@ -156,8 +153,8 @@ int Geometry::computeBarycentricCoordinates(const T *p0,
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
   }
 
-  if((!((fabs(test[0] - p[0]) < pow(10, -FLT_DIG + 1))
-        && (fabs(test[1] - p[1]) < pow(10, -FLT_DIG + 1))))) {
+  if((!((fabs(test[0] - p[0]) < powIntTen<float>(-FLT_DIG + 1))
+        && (fabs(test[1] - p[1]) < powIntTen<float>(-FLT_DIG + 1))))) {
     for(int i = 0; i < 2; i++) {
       baryCentrics[i] = -baryCentrics[i];
     }
@@ -236,7 +233,7 @@ bool Geometry::computeSegmentIntersection(const T &xA,
 
   T d = (xA - xB) * (yC - yD) - (yA - yB) * (xC - xD);
 
-  if(fabs(d) < pow(10, -DBL_DIG)) {
+  if(fabs(d) < powIntTen(-DBL_DIG)) {
     return false;
   }
 
@@ -244,13 +241,13 @@ bool Geometry::computeSegmentIntersection(const T &xA,
 
   y = ((yC - yD) * (xA * yB - yA * xB) - (yA - yB) * (xC * yD - yC * xD)) / d;
 
-  if((x < std::min(xA, xB) - pow10(-FLT_DIG))
-     || (x > std::max(xA, xB) + pow10(-FLT_DIG))) {
+  if((x < std::min(xA, xB) - powIntTen<float>(-FLT_DIG))
+     || (x > std::max(xA, xB) + powIntTen<float>(-FLT_DIG))) {
     return false;
   }
 
-  if((x < std::min(xC, xD) - pow10(-FLT_DIG))
-     || (x > std::max(xC, xD) + pow10(-FLT_DIG))) {
+  if((x < std::min(xC, xD) - powIntTen<float>(-FLT_DIG))
+     || (x > std::max(xC, xD) + powIntTen<float>(-FLT_DIG))) {
     return false;
   }
 
@@ -392,10 +389,10 @@ bool Geometry::isPointInTriangle(const T *p0,
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
 
   for(int i = 0; i < static_cast<int>(barycentrics.size()); i++) {
-    if(barycentrics[i] < -pow10(-DBL_DIG)) {
+    if(barycentrics[i] < -powIntTen(-DBL_DIG)) {
       return false;
     }
-    if(barycentrics[i] > 1 + pow10(-DBL_DIG)) {
+    if(barycentrics[i] > 1 + powIntTen(-DBL_DIG)) {
       return false;
     }
   }
@@ -431,10 +428,10 @@ bool Geometry::isPointOnSegment(const T *p,
 
   Geometry::computeBarycentricCoordinates(pA, pB, p, baryCentrics, dimension);
 
-  return (((baryCentrics[0] > -pow10(-DBL_DIG))
-           && (baryCentrics[0] < 1 + pow10(-DBL_DIG)))
-          && ((baryCentrics[1] > -pow10(-DBL_DIG))
-              && (baryCentrics[1] < 1 + pow10(-DBL_DIG))));
+  return (((baryCentrics[0] > -powIntTen(-DBL_DIG))
+           && (baryCentrics[0] < 1 + powIntTen(-DBL_DIG)))
+          && ((baryCentrics[1] > -powIntTen(-DBL_DIG))
+              && (baryCentrics[1] < 1 + powIntTen(-DBL_DIG))));
 }
 
 template <typename T>
@@ -502,6 +499,28 @@ T Geometry::magnitude(const T *o, const T *d) {
   }
 
   return sqrt(mag);
+}
+
+template <typename T>
+T Geometry::powInt(const T val, const int n) {
+  if(n < 0) {
+    return 1.0 / powInt(val, -n);
+  } else if(n == 0) {
+    return 1;
+  } else if(n == 1) {
+    return val;
+  } else if(n == 2) {
+    return val * val;
+  } else if(n == 3) {
+    return val * val * val;
+  } else {
+    return powInt(val, n - 1) * val;
+  }
+}
+
+template <typename T>
+T Geometry::powIntTen(const int n) {
+  return powInt(static_cast<T>(10), n);
 }
 
 // explicit instantiations for double
@@ -586,6 +605,8 @@ template bool Geometry::isTriangleColinear<double>(double const *,
                                                    double const *);
 template double Geometry::magnitude<double>(double const *);
 template double Geometry::magnitude<double>(double const *, double const *);
+template double Geometry::powInt<double>(const double, const int);
+template double Geometry::powIntTen<double>(const int);
 
 // explicit instantiations for float
 
@@ -669,3 +690,5 @@ template bool Geometry::isTriangleColinear<float>(float const *,
                                                   float const *);
 template float Geometry::magnitude<float>(float const *);
 template float Geometry::magnitude<float>(float const *, float const *);
+template float Geometry::powInt<float>(const float, const int);
+template float Geometry::powIntTen<float>(const int);

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -502,162 +502,50 @@ T Geometry::magnitude(const T *o, const T *d) {
   return sqrt(mag);
 }
 
-// explicit instantiations for double
+#define GEOMETRY_SPECIALIZE(TYPE)                                             \
+  template TYPE Geometry::angle<TYPE>(                                        \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
+  template bool Geometry::areVectorsColinear<TYPE>(                           \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *,                   \
+    std::vector<TYPE> *, TYPE const *);                                       \
+  template int Geometry::computeBarycentricCoordinates<TYPE>(                 \
+    TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &,            \
+    int const &);                                                             \
+  template int Geometry::computeBarycentricCoordinates<TYPE>(                 \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *,                   \
+    std::vector<TYPE> &);                                                     \
+  template bool Geometry::computeSegmentIntersection<TYPE>(                   \
+    TYPE const &, TYPE const &, TYPE const &, TYPE const &, TYPE const &,     \
+    TYPE const &, TYPE const &, TYPE const &, TYPE &, TYPE &);                \
+  template int Geometry::computeTriangleAngles<TYPE>(                         \
+    TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &);           \
+  template int Geometry::computeTriangleArea<TYPE>(                           \
+    TYPE const *, TYPE const *, TYPE const *, TYPE &);                        \
+  template int Geometry::crossProduct<TYPE>(TYPE const *, TYPE const *,       \
+                                            TYPE const *, TYPE const *,       \
+                                            std::vector<TYPE> &);             \
+  template int Geometry::crossProduct<TYPE>(                                  \
+    TYPE const *, TYPE const *, TYPE *);                                      \
+  template TYPE Geometry::distance<TYPE>(                                     \
+    TYPE const *, TYPE const *, int const &);                                 \
+  template TYPE Geometry::dotProduct<TYPE>(                                   \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
+  template TYPE Geometry::dotProduct<TYPE>(TYPE const *, TYPE const *);       \
+  template int Geometry::getBoundingBox<TYPE>(                                \
+    std::vector<std::vector<float>> const &,                                  \
+    std::vector<std::pair<TYPE, TYPE>> &);                                    \
+  template bool Geometry::isPointInTriangle<TYPE>(                            \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
+  template bool Geometry::isPointOnSegment<TYPE>(TYPE const &, TYPE const &,  \
+                                                 TYPE const &, TYPE const &,  \
+                                                 TYPE const &, TYPE const &); \
+  template bool Geometry::isPointOnSegment<TYPE>(                             \
+    TYPE const *, TYPE const *, TYPE const *, int const &);                   \
+  template bool Geometry::isTriangleColinear<TYPE>(                           \
+    TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
+  template TYPE Geometry::magnitude<TYPE>(TYPE const *);                      \
+  template TYPE Geometry::magnitude<TYPE>(TYPE const *, TYPE const *)
 
-template double Geometry::angle<double>(double const *,
-                                        double const *,
-                                        double const *,
-                                        double const *);
-template bool Geometry::areVectorsColinear<double>(double const *,
-                                                   double const *,
-                                                   double const *,
-                                                   double const *,
-                                                   std::vector<double> *,
-                                                   double const *);
-template int
-  Geometry::computeBarycentricCoordinates<double>(double const *,
-                                                  double const *,
-                                                  double const *,
-                                                  std::vector<double> &,
-                                                  int const &);
-template int
-  Geometry::computeBarycentricCoordinates<double>(double const *,
-                                                  double const *,
-                                                  double const *,
-                                                  double const *,
-                                                  std::vector<double> &);
-template bool Geometry::computeSegmentIntersection<double>(double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double const &,
-                                                           double &,
-                                                           double &);
-template int Geometry::computeTriangleAngles<double>(double const *,
-                                                     double const *,
-                                                     double const *,
-                                                     std::vector<double> &);
-template int Geometry::computeTriangleArea<double>(double const *,
-                                                   double const *,
-                                                   double const *,
-                                                   double &);
-template int Geometry::crossProduct<double>(double const *,
-                                            double const *,
-                                            double const *,
-                                            double const *,
-                                            std::vector<double> &);
-template int
-  Geometry::crossProduct<double>(double const *, double const *, double *);
-template double
-  Geometry::distance<double>(double const *, double const *, int const &);
-template double Geometry::dotProduct<double>(double const *,
-                                             double const *,
-                                             double const *,
-                                             double const *);
-template double Geometry::dotProduct<double>(double const *, double const *);
-template int
-  Geometry::getBoundingBox<double>(std::vector<std::vector<float>> const &,
-                                   std::vector<std::pair<double, double>> &);
-template bool Geometry::isPointInTriangle<double>(double const *,
-                                                  double const *,
-                                                  double const *,
-                                                  double const *);
-template bool Geometry::isPointOnSegment<double>(double const &,
-                                                 double const &,
-                                                 double const &,
-                                                 double const &,
-                                                 double const &,
-                                                 double const &);
-template bool Geometry::isPointOnSegment<double>(double const *,
-                                                 double const *,
-                                                 double const *,
-                                                 int const &);
-template bool Geometry::isTriangleColinear<double>(double const *,
-                                                   double const *,
-                                                   double const *,
-                                                   double const *);
-template double Geometry::magnitude<double>(double const *);
-template double Geometry::magnitude<double>(double const *, double const *);
-
-// explicit instantiations for float
-
-template float Geometry::angle<float>(float const *,
-                                      float const *,
-                                      float const *,
-                                      float const *);
-template bool Geometry::areVectorsColinear<float>(float const *,
-                                                  float const *,
-                                                  float const *,
-                                                  float const *,
-                                                  std::vector<float> *,
-                                                  float const *);
-template int
-  Geometry::computeBarycentricCoordinates<float>(float const *,
-                                                 float const *,
-                                                 float const *,
-                                                 std::vector<float> &,
-                                                 int const &);
-template int
-  Geometry::computeBarycentricCoordinates<float>(float const *,
-                                                 float const *,
-                                                 float const *,
-                                                 float const *,
-                                                 std::vector<float> &);
-template bool Geometry::computeSegmentIntersection<float>(float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float const &,
-                                                          float &,
-                                                          float &);
-template int Geometry::computeTriangleAngles<float>(float const *,
-                                                    float const *,
-                                                    float const *,
-                                                    std::vector<float> &);
-template int Geometry::computeTriangleArea<float>(float const *,
-                                                  float const *,
-                                                  float const *,
-                                                  float &);
-template int Geometry::crossProduct<float>(float const *,
-                                           float const *,
-                                           float const *,
-                                           float const *,
-                                           std::vector<float> &);
-template int
-  Geometry::crossProduct<float>(float const *, float const *, float *);
-template float
-  Geometry::distance<float>(float const *, float const *, int const &);
-template float Geometry::dotProduct<float>(float const *,
-                                           float const *,
-                                           float const *,
-                                           float const *);
-template float Geometry::dotProduct<float>(float const *, float const *);
-template int
-  Geometry::getBoundingBox<float>(std::vector<std::vector<float>> const &,
-                                  std::vector<std::pair<float, float>> &);
-template bool Geometry::isPointInTriangle<float>(float const *,
-                                                 float const *,
-                                                 float const *,
-                                                 float const *);
-template bool Geometry::isPointOnSegment<float>(float const &,
-                                                float const &,
-                                                float const &,
-                                                float const &,
-                                                float const &,
-                                                float const &);
-template bool Geometry::isPointOnSegment<float>(float const *,
-                                                float const *,
-                                                float const *,
-                                                int const &);
-template bool Geometry::isTriangleColinear<float>(float const *,
-                                                  float const *,
-                                                  float const *,
-                                                  float const *);
-template float Geometry::magnitude<float>(float const *);
-template float Geometry::magnitude<float>(float const *, float const *);
+// explicit specializations for float and double
+GEOMETRY_SPECIALIZE(float);
+GEOMETRY_SPECIALIZE(double);

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -502,11 +502,6 @@ T Geometry::magnitude(const T *o, const T *d) {
   return sqrt(mag);
 }
 
-template <typename T>
-T Geometry::powIntTen(const int n) {
-  return powInt(static_cast<T>(10), n);
-}
-
 // explicit instantiations for double
 
 template double Geometry::angle<double>(double const *,
@@ -589,7 +584,6 @@ template bool Geometry::isTriangleColinear<double>(double const *,
                                                    double const *);
 template double Geometry::magnitude<double>(double const *);
 template double Geometry::magnitude<double>(double const *, double const *);
-template double Geometry::powIntTen<double>(const int);
 
 // explicit instantiations for float
 
@@ -673,4 +667,3 @@ template bool Geometry::isTriangleColinear<float>(float const *,
                                                   float const *);
 template float Geometry::magnitude<float>(float const *);
 template float Geometry::magnitude<float>(float const *, float const *);
-template float Geometry::powIntTen<float>(const int);

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -261,10 +261,24 @@ namespace ttk {
     /// Compute the integer power of a floating-point value
     /// (std::pow is optimised for floating-point exponents)
     template <typename T>
-    T powInt(const T val, const int n);
+    inline T powInt(const T val, const int n) {
+      if(n < 0) {
+        return 1.0 / powInt(val, -n);
+      } else if(n == 0) {
+        return 1;
+      } else if(n == 1) {
+        return val;
+      } else if(n == 2) {
+        return val * val;
+      } else if(n == 3) {
+        return val * val * val;
+      } else {
+        return powInt(val, n - 1) * val;
+      }
+    }
 
     /// Compute the nth power of ten
-    template<typename T = double>
+    template <typename T = double>
     T powIntTen(const int n);
 
   } // namespace Geometry

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -253,7 +253,11 @@ namespace ttk {
       } else if(n == 3) {
         return val * val * val;
       } else {
-        return powInt(val, n - 1) * val;
+        T ret = val;
+        for(int i = 0; i < n - 1; ++i) {
+          ret *= val;
+        }
+        return ret;
       }
     }
 

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -57,26 +57,6 @@ namespace ttk {
                                       std::vector<T> &baryCentrics,
                                       const int &dimension = 3);
 
-    /// Compute the barycentric coordinates of point \p xyz with regard to
-    /// the edge defined by the points \p xy0 and \p xy1.
-    /// \param x0 x coordinate of the first vertex of the edge
-    /// \param y0 y coordinate of the first vertex of the edge
-    /// \param x1 x coordinate of the second vertex of the edge
-    /// \param y1 y coordinate of the second vertex of the edge
-    /// \param x x coordinate of the queried point
-    /// \param y y coordinate of the queried point
-    /// \param baryCentrics Output barycentric coordinates (all in [0, 1] if
-    /// \p p belongs to the edge).
-    /// \return Returns 0 upon success, negative values otherwise.
-    template <typename T>
-    int computeBarycentricCoordinates(const T &x0,
-                                      const T &y0,
-                                      const T &x1,
-                                      const T &y1,
-                                      const T &x,
-                                      const T &y,
-                                      std::vector<T> &baryCentrics);
-
     /// Compute the barycentric coordinates of point \p p with regard to the
     /// triangle defined by the 3D points \p p0, \p p1, and \p p2.
     /// \param p0 xyz coordinates of the first vertex of the triangle

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -258,6 +258,15 @@ namespace ttk {
     template <typename T>
     T magnitude(const T *o, const T *d);
 
+    /// Compute the integer power of a floating-point value
+    /// (std::pow is optimised for floating-point exponents)
+    template <typename T>
+    T powInt(const T val, const int n);
+
+    /// Compute the nth power of ten
+    template<typename T = double>
+    T powIntTen(const int n);
+
   } // namespace Geometry
 } // namespace ttk
 

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -267,6 +267,22 @@ namespace ttk {
       return powInt(static_cast<T>(10), n);
     }
 
+    /// Compute the power of an arithmetic value
+    /// (redirect to std::pow with a floating-point exponent and to
+    /// Geometry::powInt with an integer exponent)
+    template <typename T1, typename T2>
+    inline T1 pow(const T1 val, const T2 n) {
+      static_assert(
+        std::is_arithmetic<T1>::value && std::is_arithmetic<T2>::value,
+        "pow can only be applied on arithmetic values");
+
+      if(std::is_integral<T2>::value) {
+        return powInt(val, n);
+      } else if(std::is_floating_point<T2>::value) {
+        return std::pow(val, n);
+      }
+    }
+
   } // namespace Geometry
 } // namespace ttk
 

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -279,7 +279,9 @@ namespace ttk {
 
     /// Compute the nth power of ten
     template <typename T = double>
-    T powIntTen(const int n);
+    inline T powIntTen(const int n) {
+      return powInt(static_cast<T>(10), n);
+    }
 
   } // namespace Geometry
 } // namespace ttk

--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -135,7 +135,7 @@ int ttk::HarmonicField::execute(const TriangulationType &triangulation,
   // penalty matrix
   SpMat penalty(vertexNumber, vertexNumber);
   // penalty value
-  const T alpha = pow10(logAlpha);
+  const T alpha = Geometry::powIntTen(logAlpha);
 
   std::vector<TripletType> triplets;
   triplets.reserve(uniqueConstraintNumber);

--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -51,8 +51,9 @@ namespace ttk {
 
     char getCriticalType(const SimplexId &edgeId);
 
-    int perturbate(const dataTypeU &uEpsilon = pow(10, -DBL_DIG),
-                   const dataTypeV &vEpsilon = pow(10, -DBL_DIG)) const;
+    int perturbate(const dataTypeU &uEpsilon = Geometry::powIntTen(-DBL_DIG),
+                   const dataTypeV &vEpsilon
+                   = Geometry::powIntTen(-DBL_DIG)) const;
 
     int setEdgeFans(const std::vector<std::vector<SimplexId>> *edgeFans) {
       edgeFans_ = edgeFans;

--- a/core/base/kdTree/CMakeLists.txt
+++ b/core/base/kdTree/CMakeLists.txt
@@ -1,5 +1,4 @@
 ttk_add_base_library(kdTree
-	SOURCES KDTree.cpp
-	HEADERS KDTree.h
-	LINK triangulation)
-
+  SOURCES KDTree.cpp
+  HEADERS KDTree.h
+  LINK triangulation geometry)

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -13,7 +13,7 @@
 
 // base code includes
 #include <Debug.h>
-#include <Geometry.h> // for powInt
+#include <Geometry.h> // for pow
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -419,7 +419,7 @@ namespace ttk {
   dataType KDTree<dataType>::cost(const std::vector<dataType> &coordinates) {
     dataType cost = 0;
     for(size_t i = 0; i < coordinates.size(); i++) {
-      cost += Geometry::powInt(abs(coordinates[i] - coordinates_[i]), p_);
+      cost += Geometry::pow(abs(coordinates[i] - coordinates_[i]), p_);
     }
     return cost;
   }
@@ -431,11 +431,11 @@ namespace ttk {
     dataType d_min = 0;
     for(size_t axis = 0; axis < coordinates.size(); axis++) {
       if(subtree->coords_min_[axis] > coordinates[axis]) {
-        d_min += Geometry::powInt(
-          subtree->coords_min_[axis] - coordinates[axis], p_);
+        d_min
+          += Geometry::pow(subtree->coords_min_[axis] - coordinates[axis], p_);
       } else if(subtree->coords_max_[axis] < coordinates[axis]) {
-        d_min += Geometry::powInt(
-          coordinates[axis] - subtree->coords_max_[axis], p_);
+        d_min
+          += Geometry::pow(coordinates[axis] - subtree->coords_max_[axis], p_);
       }
     }
     return d_min;

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -13,6 +13,7 @@
 
 // base code includes
 #include <Debug.h>
+#include <Geometry.h> // for powInt
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -130,21 +131,6 @@ namespace ttk {
     template <typename type>
     inline static type abs(const type var) {
       return (var > 0) ? var : -var;
-    }
-    inline double pow(const double var, int n) {
-      if(n < 0) {
-        return 1.0 / this->pow(var, -n);
-      } else if(n == 0) {
-        return 1;
-      } else if(n == 1) {
-        return var;
-      } else if(n == 2) {
-        return var * var;
-      } else if(n == 3) {
-        return var * var * var;
-      } else {
-        return this->pow(var, n - 1) * var;
-      }
     }
 
   protected:
@@ -433,7 +419,7 @@ namespace ttk {
   dataType KDTree<dataType>::cost(const std::vector<dataType> &coordinates) {
     dataType cost = 0;
     for(size_t i = 0; i < coordinates.size(); i++) {
-      cost += this->pow(abs(coordinates[i] - coordinates_[i]), p_);
+      cost += Geometry::powInt(abs(coordinates[i] - coordinates_[i]), p_);
     }
     return cost;
   }
@@ -445,9 +431,11 @@ namespace ttk {
     dataType d_min = 0;
     for(size_t axis = 0; axis < coordinates.size(); axis++) {
       if(subtree->coords_min_[axis] > coordinates[axis]) {
-        d_min += this->pow(subtree->coords_min_[axis] - coordinates[axis], p_);
+        d_min += Geometry::powInt(
+          subtree->coords_min_[axis] - coordinates[axis], p_);
       } else if(subtree->coords_max_[axis] < coordinates[axis]) {
-        d_min += this->pow(coordinates[axis] - subtree->coords_max_[axis], p_);
+        d_min += Geometry::powInt(
+          coordinates[axis] - subtree->coords_max_[axis], p_);
       }
     }
     return d_min;

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -131,6 +131,21 @@ namespace ttk {
     inline static type abs(const type var) {
       return (var > 0) ? var : -var;
     }
+    inline double pow(const double var, int n) {
+      if(n < 0) {
+        return 1.0 / this->pow(var, -n);
+      } else if(n == 0) {
+        return 1;
+      } else if(n == 1) {
+        return var;
+      } else if(n == 2) {
+        return var * var;
+      } else if(n == 3) {
+        return var * var * var;
+      } else {
+        return this->pow(var, n - 1) * var;
+      }
+    }
 
   protected:
     bool is_left_; // Boolean indicating if the current node is a left node of
@@ -417,8 +432,8 @@ namespace ttk {
   template <typename dataType>
   dataType KDTree<dataType>::cost(const std::vector<dataType> &coordinates) {
     dataType cost = 0;
-    for(unsigned int i = 0; i < coordinates.size(); i++) {
-      cost += pow(abs(coordinates[i] - coordinates_[i]), p_);
+    for(size_t i = 0; i < coordinates.size(); i++) {
+      cost += this->pow(abs(coordinates[i] - coordinates_[i]), p_);
     }
     return cost;
   }
@@ -428,11 +443,11 @@ namespace ttk {
     KDTree<dataType>::distanceToBox(KDTree<dataType> *subtree,
                                     const std::vector<dataType> &coordinates) {
     dataType d_min = 0;
-    for(unsigned int axis = 0; axis < coordinates.size(); axis++) {
+    for(size_t axis = 0; axis < coordinates.size(); axis++) {
       if(subtree->coords_min_[axis] > coordinates[axis]) {
-        d_min += pow(subtree->coords_min_[axis] - coordinates[axis], p_);
+        d_min += this->pow(subtree->coords_min_[axis] - coordinates[axis], p_);
       } else if(subtree->coords_max_[axis] < coordinates[axis]) {
-        d_min += pow(coordinates[axis] - subtree->coords_max_[axis], p_);
+        d_min += this->pow(coordinates[axis] - subtree->coords_max_[axis], p_);
       }
     }
     return d_min;

--- a/core/base/lDistance/CMakeLists.txt
+++ b/core/base/lDistance/CMakeLists.txt
@@ -4,6 +4,5 @@ ttk_add_base_library(lDistance
   HEADERS
     LDistance.h
   LINK
-    triangulation
+    geometry
     )
-

--- a/core/base/lDistance/LDistance.h
+++ b/core/base/lDistance/LDistance.h
@@ -166,7 +166,7 @@ int ttk::LDistance::computeLn(dataType *input1,
       output[i] = power;
   }
 
-  sum = std::pow(sum, 1.0 / (double)n);
+  sum = Geometry::pow(sum, 1.0 / (double)n);
 
   // Affect result.
   result = (double)sum;

--- a/core/base/lDistance/LDistance.h
+++ b/core/base/lDistance/LDistance.h
@@ -155,7 +155,7 @@ int ttk::LDistance::computeLn(dataType *input1,
 #endif
   for(ttk::SimplexId i = 0; i < vertexNumber; ++i) {
     const dataType diff = abs_diff<dataType>(input1[i], input2[i]);
-    const dataType power = Geometry::powInt(diff, n);
+    const dataType power = Geometry::pow(diff, n);
 
     // Careful: huge dataset + huge values
     // may exceed double capacity.

--- a/core/base/lDistance/LDistance.h
+++ b/core/base/lDistance/LDistance.h
@@ -19,6 +19,7 @@
 #include <string>
 
 // Base code.
+#include <Geometry.h>
 #include <Wrapper.h>
 
 namespace ttk {
@@ -154,7 +155,7 @@ int ttk::LDistance::computeLn(dataType *input1,
 #endif
   for(ttk::SimplexId i = 0; i < vertexNumber; ++i) {
     const dataType diff = abs_diff<dataType>(input1[i], input2[i]);
-    const dataType power = pow(diff, (double)n);
+    const dataType power = Geometry::powInt(diff, n);
 
     // Careful: huge dataset + huge values
     // may exceed double capacity.
@@ -165,7 +166,7 @@ int ttk::LDistance::computeLn(dataType *input1,
       output[i] = power;
   }
 
-  sum = pow(sum, 1.0 / (double)n);
+  sum = std::pow(sum, 1.0 / (double)n);
 
   // Affect result.
   result = (double)sum;

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
@@ -106,15 +106,15 @@ int ttk::MorseSmaleQuadrangulation::detectCellSeps() {
     prev = curr;
   }
 
-  // store saddle points id in the subdivised triangulation
-  std::set<SimplexId> saddlesId{};
+  // if vertex is saddle in the subdivised triangulation
+  std::vector<bool> isSaddle(newT.getNumberOfVertices(), false);
 
   for(SimplexId i = 0; i < criticalPointsNumber_; ++i) {
     // keep only saddle points
     if(criticalPointsType_[i] != 1) {
       continue;
     }
-    saddlesId.emplace(verticesNumber_ + criticalPointsCellIds_[i]);
+    isSaddle[verticesNumber_ + criticalPointsCellIds_[i]] = true;
   }
 
   auto getTriangleEdges
@@ -149,9 +149,7 @@ int ttk::MorseSmaleQuadrangulation::detectCellSeps() {
     newT.getTriangleVertex(tr, 0, a);
     newT.getTriangleVertex(tr, 1, b);
     newT.getTriangleVertex(tr, 2, c);
-    return (saddlesId.find(a) != saddlesId.end()
-            || saddlesId.find(b) != saddlesId.end()
-            || saddlesId.find(c) != saddlesId.end());
+    return (isSaddle[a] || isSaddle[b] || isSaddle[c]);
   };
 
   // propagate from triangles around saddle

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -114,7 +114,7 @@ int ttk::PersistenceCurve::computePersistencePlot(
 
   // build curve
   const scalarType epsilon
-    = static_cast<scalarType>(pow(10, -REAL_SIGNIFICANT_DIGITS));
+    = static_cast<scalarType>(Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS));
   for(SimplexId i = 0; i < nbElmnt; ++i) {
     plot[i].first = std::max(std::get<2>(pairs[i]), epsilon);
     plot[i].second = pairs.size() - i;

--- a/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
@@ -317,8 +317,8 @@ dataType PDBarycenter<dataType>::updateBarycenter(
       // TODO adjust shift with geometrical_factor_
       dataType dx = barycenter_goods_[0].get(i).x_ - new_x;
       dataType dy = barycenter_goods_[0].get(i).y_ - new_y;
-      dataType shift = Geometry::powInt(abs(dx), wasserstein_)
-                       + Geometry::powInt(abs(dy), wasserstein_);
+      dataType shift = Geometry::pow(abs(dx), wasserstein_)
+                       + Geometry::pow(abs(dy), wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
       }
@@ -349,7 +349,7 @@ dataType PDBarycenter<dataType>::updateBarycenter(
       points_deleted_ += 1;
       dataType shift
         = 2
-          * Geometry::powInt(
+          * Geometry::pow(
             barycenter_goods_[0].get(i).getPersistence() / 2., wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
@@ -380,10 +380,10 @@ dataType PDBarycenter<dataType>::updateBarycenter(
                                  std::get<2>(critical_coordinates));
       }
       barycenter_goods_[j].addGood(g);
-      dataType shift = 2
-                       * Geometry::powInt(
-                         barycenter_goods_[j].get(g.id_).getPersistence() / 2.,
-                         wasserstein_);
+      dataType shift
+        = 2
+          * Geometry::pow(barycenter_goods_[j].get(g.id_).getPersistence() / 2.,
+                          wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
       }

--- a/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
@@ -317,7 +317,8 @@ dataType PDBarycenter<dataType>::updateBarycenter(
       // TODO adjust shift with geometrical_factor_
       dataType dx = barycenter_goods_[0].get(i).x_ - new_x;
       dataType dy = barycenter_goods_[0].get(i).y_ - new_y;
-      dataType shift = pow(abs(dx), wasserstein_) + pow(abs(dy), wasserstein_);
+      dataType shift = Geometry::powInt(abs(dx), wasserstein_)
+                       + Geometry::powInt(abs(dy), wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
       }
@@ -346,9 +347,10 @@ dataType PDBarycenter<dataType>::updateBarycenter(
   for(unsigned int i = 0; i < n_goods; i++) {
     if(count_diag_matchings[i] == n_diagrams) {
       points_deleted_ += 1;
-      dataType shift = 2
-                       * pow(barycenter_goods_[0].get(i).getPersistence() / 2.,
-                             wasserstein_);
+      dataType shift
+        = 2
+          * Geometry::powInt(
+            barycenter_goods_[0].get(i).getPersistence() / 2., wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
       }
@@ -378,10 +380,10 @@ dataType PDBarycenter<dataType>::updateBarycenter(
                                  std::get<2>(critical_coordinates));
       }
       barycenter_goods_[j].addGood(g);
-      dataType shift
-        = 2
-          * pow(barycenter_goods_[j].get(g.id_).getPersistence() / 2.,
-                wasserstein_);
+      dataType shift = 2
+                       * Geometry::powInt(
+                         barycenter_goods_[j].get(g.id_).getPersistence() / 2.,
+                         wasserstein_);
       if(shift > max_shift) {
         max_shift = shift;
       }
@@ -412,7 +414,7 @@ dataType PDBarycenter<dataType>::updateBarycenter(
 
 template <typename dataType>
 dataType PDBarycenter<dataType>::getEpsilon(dataType rho) {
-  return pow(rho, 2) / 8.0;
+  return rho * rho / 8.0;
 }
 
 template <typename dataType>
@@ -954,7 +956,7 @@ dataType PDBarycenter<dataType>::computeRealCost() {
     dataType cost = auction.run(&fake_matchings);
     total_real_cost += cost * cost;
   }
-  return pow(total_real_cost, 1. / 2);
+  return sqrt(total_real_cost);
 }
 
 template <typename dataType>

--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -121,7 +121,7 @@ std::vector<int> PDClustering<dataType>::execute(
       lowest_persistence[i_crit] = getLessPersistent(i_crit);
       min_persistence[i_crit] = 0;
       // std::cout<<"size eps "<<epsilon_.size()<<std::endl;
-      epsilon_[i_crit] = Geometry::powInt(0.5 * max_persistence[i_crit], 2)
+      epsilon_[i_crit] = Geometry::pow(0.5 * max_persistence[i_crit], 2)
                          / 8.; // max_persistence actually holds 2 times the
                                // highest persistence
       epsilon0[i_crit] = epsilon_[i_crit];
@@ -243,7 +243,7 @@ std::vector<int> PDClustering<dataType>::execute(
           for(int i_crit = 0; i_crit < 3; i_crit++) {
             if(*(current_dos[i_crit])) {
               epsilon_candidate[i_crit]
-                = Geometry::powInt(min_persistence[i_crit], 2) / 8.;
+                = Geometry::pow(min_persistence[i_crit], 2) / 8.;
               if(epsilon_candidate[i_crit] > epsilon_[i_crit]) {
                 // Should always be the case except if min_persistence is
                 // equal to zero
@@ -323,7 +323,7 @@ std::vector<int> PDClustering<dataType>::execute(
             // cout<<"maxshift : "<<max_shift_vec[2]<<endl;
             epsilon_candidate[i_crit] = std::min(
               std::max(max_shift_vec[i_crit] / 8., epsilon_[i_crit] / 5.),
-              epsilon0[i_crit] / Geometry::powInt(n_iterations_, 2));
+              epsilon0[i_crit] / Geometry::pow(n_iterations_, 2));
 
             if(epsilon_candidate[i_crit] < epsilon_[i_crit]
                && (!diagrams_complete[i_crit])) {
@@ -1168,7 +1168,7 @@ void PDClustering<dataType>::initializeCentroidsKMeanspp() {
           // cout<<"test "<<j<<endl;
         }
       }
-      probabilities[i] = Geometry::powInt(min_distance_to_centroid[i], 2);
+      probabilities[i] = Geometry::pow(min_distance_to_centroid[i], 2);
 
       // The following block is useful in case of need for a deterministic
       // algoritm
@@ -2269,7 +2269,7 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
         for(int i = 0; i < numberOfInputs_; ++i) {
           // Step 5 of Accelerated KMeans: Update the lower bound on distance
           // thanks to the triangular inequality
-          l_[i][c] = Geometry::powInt(
+          l_[i][c] = Geometry::pow(
             Geometry::pow(l_[i][c], 1. / wasserstein_)
               - Geometry::pow(wasserstein_shift, 1. / wasserstein_),
             wasserstein_);
@@ -2280,7 +2280,7 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
         for(int idx : clustering_[c]) {
           // Step 6, update the upper bound on the distance to the centroid
           // thanks to the triangle inequality
-          u_[idx] = Geometry::powInt(
+          u_[idx] = Geometry::pow(
             Geometry::pow(u_[idx], 1. / wasserstein_)
               + Geometry::pow(wasserstein_shift, 1. / wasserstein_),
             wasserstein_);
@@ -2592,16 +2592,16 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
               l_[i][c]
-                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
-                                     - persistence / sqrt(2),
-                                   wasserstein_);
+                = Geometry::pow(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                  - persistence / sqrt(2),
+                                wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i] = Geometry::powInt(
+            u_[i] = Geometry::pow(
               Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
@@ -2667,16 +2667,16 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
               l_[i][c]
-                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
-                                     - persistence / sqrt(2),
-                                   wasserstein_);
+                = Geometry::pow(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                  - persistence / sqrt(2),
+                                wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i] = Geometry::powInt(
+            u_[i] = Geometry::pow(
               Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
@@ -2734,16 +2734,16 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
               l_[i][c]
-                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
-                                     - persistence / sqrt(2),
-                                   wasserstein_);
+                = Geometry::pow(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                  - persistence / sqrt(2),
+                                wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i] = Geometry::powInt(
+            u_[i] = Geometry::pow(
               Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
@@ -3048,8 +3048,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
-                          + Geometry::powInt((gy - by), wasserstein_);
+          dataType cost = Geometry::pow((gx - bx), wasserstein_)
+                          + Geometry::pow((gy - by), wasserstein_);
           Good<dataType> g
             = Good<dataType>(gx, gy, false, centroids_min_[0].size());
           // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
@@ -3104,8 +3104,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
-                          + Geometry::powInt((gy - by), wasserstein_);
+          dataType cost = Geometry::pow((gx - bx), wasserstein_)
+                          + Geometry::pow((gy - by), wasserstein_);
           matchingTuple t2
             = make_tuple(bidderId, centroids_saddle_[0].size(), cost);
           Good<dataType> g
@@ -3160,8 +3160,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
-                          + Geometry::powInt((gy - by), wasserstein_);
+          dataType cost = Geometry::pow((gx - bx), wasserstein_)
+                          + Geometry::pow((gy - by), wasserstein_);
           matchingTuple t2
             = make_tuple(bidderId, centroids_max_[0].size(), cost);
           Good<dataType> g

--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -121,7 +121,7 @@ std::vector<int> PDClustering<dataType>::execute(
       lowest_persistence[i_crit] = getLessPersistent(i_crit);
       min_persistence[i_crit] = 0;
       // std::cout<<"size eps "<<epsilon_.size()<<std::endl;
-      epsilon_[i_crit] = pow(0.5 * max_persistence[i_crit], 2)
+      epsilon_[i_crit] = Geometry::powInt(0.5 * max_persistence[i_crit], 2)
                          / 8.; // max_persistence actually holds 2 times the
                                // highest persistence
       epsilon0[i_crit] = epsilon_[i_crit];
@@ -242,7 +242,8 @@ std::vector<int> PDClustering<dataType>::execute(
 
           for(int i_crit = 0; i_crit < 3; i_crit++) {
             if(*(current_dos[i_crit])) {
-              epsilon_candidate[i_crit] = pow(min_persistence[i_crit], 2) / 8.;
+              epsilon_candidate[i_crit]
+                = Geometry::powInt(min_persistence[i_crit], 2) / 8.;
               if(epsilon_candidate[i_crit] > epsilon_[i_crit]) {
                 // Should always be the case except if min_persistence is
                 // equal to zero
@@ -322,7 +323,7 @@ std::vector<int> PDClustering<dataType>::execute(
             // cout<<"maxshift : "<<max_shift_vec[2]<<endl;
             epsilon_candidate[i_crit] = std::min(
               std::max(max_shift_vec[i_crit] / 8., epsilon_[i_crit] / 5.),
-              epsilon0[i_crit] / pow(n_iterations_, 2));
+              epsilon0[i_crit] / Geometry::powInt(n_iterations_, 2));
 
             if(epsilon_candidate[i_crit] < epsilon_[i_crit]
                && (!diagrams_complete[i_crit])) {
@@ -1167,7 +1168,7 @@ void PDClustering<dataType>::initializeCentroidsKMeanspp() {
           // cout<<"test "<<j<<endl;
         }
       }
-      probabilities[i] = pow(min_distance_to_centroid[i], 2);
+      probabilities[i] = Geometry::powInt(min_distance_to_centroid[i], 2);
 
       // The following block is useful in case of need for a deterministic
       // algoritm
@@ -2268,9 +2269,10 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
         for(int i = 0; i < numberOfInputs_; ++i) {
           // Step 5 of Accelerated KMeans: Update the lower bound on distance
           // thanks to the triangular inequality
-          l_[i][c] = pow(pow(l_[i][c], 1. / wasserstein_)
-                           - pow(wasserstein_shift, 1. / wasserstein_),
-                         wasserstein_);
+          l_[i][c] = Geometry::powInt(
+            std::pow(l_[i][c], 1. / wasserstein_)
+              - std::pow(wasserstein_shift, 1. / wasserstein_),
+            wasserstein_);
           if(l_[i][c] < 0) {
             l_[i][c] = 0;
           }
@@ -2278,9 +2280,10 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
         for(int idx : clustering_[c]) {
           // Step 6, update the upper bound on the distance to the centroid
           // thanks to the triangle inequality
-          u_[idx] = pow(pow(u_[idx], 1. / wasserstein_)
-                          + pow(wasserstein_shift, 1. / wasserstein_),
-                        wasserstein_);
+          u_[idx] = Geometry::powInt(
+            std::pow(u_[idx], 1. / wasserstein_)
+              + std::pow(wasserstein_shift, 1. / wasserstein_),
+            wasserstein_);
           r_[idx] = true;
         }
       }
@@ -2588,8 +2591,8 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = pow(
-                pow(l_[i][c], 1. / wasserstein_) - persistence / pow(2, 0.5),
+              l_[i][c] = Geometry::powInt(
+                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
                 wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
@@ -2597,9 +2600,9 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i]
-              = pow(pow(u_[i], 1. / wasserstein_) + persistence / pow(2, 0.5),
-                    wasserstein_);
+            u_[i] = Geometry::powInt(
+              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              wasserstein_);
             r_[i] = true;
           }
           int to_be_added_to_barycenter
@@ -2662,8 +2665,8 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = pow(
-                pow(l_[i][c], 1. / wasserstein_) - persistence / pow(2, 0.5),
+              l_[i][c] = Geometry::powInt(
+                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
                 wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
@@ -2671,9 +2674,9 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i]
-              = pow(pow(u_[i], 1. / wasserstein_) + persistence / pow(2, 0.5),
-                    wasserstein_);
+            u_[i] = Geometry::powInt(
+              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              wasserstein_);
             r_[i] = true;
           }
           int to_be_added_to_barycenter
@@ -2728,8 +2731,8 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = pow(
-                pow(l_[i][c], 1. / wasserstein_) - persistence / pow(2, 0.5),
+              l_[i][c] = Geometry::powInt(
+                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
                 wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
@@ -2737,9 +2740,9 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             }
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
-            u_[i]
-              = pow(pow(u_[i], 1. / wasserstein_) + persistence / pow(2, 0.5),
-                    wasserstein_);
+            u_[i] = Geometry::powInt(
+              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              wasserstein_);
             r_[i] = true;
           }
           int to_be_added_to_barycenter
@@ -3042,8 +3045,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost
-            = pow((gx - bx), wasserstein_) + pow((gy - by), wasserstein_);
+          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
+                          + Geometry::powInt((gy - by), wasserstein_);
           Good<dataType> g
             = Good<dataType>(gx, gy, false, centroids_min_[0].size());
           // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
@@ -3098,8 +3101,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost
-            = pow((gx - bx), wasserstein_) + pow((gy - by), wasserstein_);
+          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
+                          + Geometry::powInt((gy - by), wasserstein_);
           matchingTuple t2
             = make_tuple(bidderId, centroids_saddle_[0].size(), cost);
           Good<dataType> g
@@ -3154,8 +3157,8 @@ void PDClustering<dataType>::computeBarycenterForTwo(
           dataType gy = (bx + by) / 2;
           gx = (gx + bx) / 2;
           gy = (gy + by) / 2;
-          dataType cost
-            = pow((gx - bx), wasserstein_) + pow((gy - by), wasserstein_);
+          dataType cost = Geometry::powInt((gx - bx), wasserstein_)
+                          + Geometry::powInt((gy - by), wasserstein_);
           matchingTuple t2
             = make_tuple(bidderId, centroids_max_[0].size(), cost);
           Good<dataType> g

--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -2270,8 +2270,8 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
           // Step 5 of Accelerated KMeans: Update the lower bound on distance
           // thanks to the triangular inequality
           l_[i][c] = Geometry::powInt(
-            std::pow(l_[i][c], 1. / wasserstein_)
-              - std::pow(wasserstein_shift, 1. / wasserstein_),
+            Geometry::pow(l_[i][c], 1. / wasserstein_)
+              - Geometry::pow(wasserstein_shift, 1. / wasserstein_),
             wasserstein_);
           if(l_[i][c] < 0) {
             l_[i][c] = 0;
@@ -2281,8 +2281,8 @@ std::vector<dataType> PDClustering<dataType>::updateCentroidsPosition(
           // Step 6, update the upper bound on the distance to the centroid
           // thanks to the triangle inequality
           u_[idx] = Geometry::powInt(
-            std::pow(u_[idx], 1. / wasserstein_)
-              + std::pow(wasserstein_shift, 1. / wasserstein_),
+            Geometry::pow(u_[idx], 1. / wasserstein_)
+              + Geometry::pow(wasserstein_shift, 1. / wasserstein_),
             wasserstein_);
           r_[idx] = true;
         }
@@ -2591,9 +2591,10 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = Geometry::powInt(
-                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
-                wasserstein_);
+              l_[i][c]
+                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                     - persistence / sqrt(2),
+                                   wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
@@ -2601,7 +2602,7 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
             u_[i] = Geometry::powInt(
-              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
           }
@@ -2665,9 +2666,10 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = Geometry::powInt(
-                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
-                wasserstein_);
+              l_[i][c]
+                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                     - persistence / sqrt(2),
+                                   wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
@@ -2675,7 +2677,7 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
             u_[i] = Geometry::powInt(
-              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
           }
@@ -2731,9 +2733,10 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             for(int c = 0; c < k_; ++c) {
               // Step 5 of Accelerated KMeans: Update the lower bound on
               // distance thanks to the triangular inequality
-              l_[i][c] = Geometry::powInt(
-                std::pow(l_[i][c], 1. / wasserstein_) - persistence / sqrt(2),
-                wasserstein_);
+              l_[i][c]
+                = Geometry::powInt(Geometry::pow(l_[i][c], 1. / wasserstein_)
+                                     - persistence / sqrt(2),
+                                   wasserstein_);
               if(l_[i][c] < 0) {
                 l_[i][c] = 0;
               }
@@ -2741,7 +2744,7 @@ std::vector<dataType> PDClustering<dataType>::enrichCurrentBidderDiagrams(
             // Step 6, update the upper bound on the distance to the centroid
             // thanks to the triangle inequality
             u_[i] = Geometry::powInt(
-              std::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
+              Geometry::pow(u_[i], 1. / wasserstein_) + persistence / sqrt(2),
               wasserstein_);
             r_[i] = true;
           }

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
@@ -34,6 +34,12 @@ ttk::SimplexId
     float n = vertexDistance_[b][i];
     // stay on the shortest path between a and b
     float sum = m + n;
+
+    // skip further computation
+    if(sum > minValue[tid]) {
+      continue;
+    }
+
     if(m != std::numeric_limits<float>::infinity()
        && n != std::numeric_limits<float>::infinity()) {
       // try to get the middle of the shortest path

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
@@ -77,10 +77,14 @@ ttk::SimplexId ttk::QuadrangulationSubdivision::findQuadBary(
   for(size_t i = 0; i < sum.size(); ++i) {
 
     // skip following computation if too far from any parent quad vertex
-    bool skip = std::any_of(
-      quadVertices.begin(), quadVertices.end(), [&](const size_t &a) {
-        return vertexDistance_[a][i] == std::numeric_limits<float>::infinity();
-      });
+    bool skip = false;
+
+    for(const auto vert : quadVertices) {
+      if(vertexDistance_[vert][i] == std::numeric_limits<float>::infinity()) {
+        skip = true;
+        break;
+      }
+    }
 
     if(skip) {
       continue;

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
@@ -9,6 +9,8 @@
 
 #define MODULE_S "[QuadrangulationSubdivision] "
 
+static const float PREC_FLT{powf(10, -FLT_DIG)};
+
 ttk::SimplexId
   ttk::QuadrangulationSubdivision::findEdgeMiddle(const size_t a,
                                                   const size_t b) const {
@@ -268,7 +270,7 @@ ttk::QuadrangulationSubdivision::Point
     // magnitude
     auto mag = Geometry::magnitude(&crossP.x);
     // ensure normal not null
-    if(mag > powf(10, -FLT_DIG)) {
+    if(mag > PREC_FLT) {
       // unitary normal vector
       normals.emplace_back(crossP / mag);
     }
@@ -378,7 +380,7 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
       auto denom = Geometry::dotProduct(&normalsMean.x, &normTri.x);
 
       // check if triangle plane is parallel to quad normal
-      if(std::abs(denom) < powf(10, -FLT_DIG)) {
+      if(std::abs(denom) < PREC_FLT) {
         // skip this iteration after filling pipeline
         trianglesTested[i] = true;
         // fill pipeline with neighboring triangles
@@ -419,10 +421,10 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
     // check if projection in triangle
     bool inTriangle = true;
     for(auto &coord : baryCoords) {
-      if(coord < powf(10, -FLT_DIG)) {
+      if(coord < PREC_FLT) {
         inTriangle = false;
       }
-      if(coord > 1 + powf(10, -FLT_DIG)) {
+      if(coord > 1 + PREC_FLT) {
         inTriangle = false;
       }
     }

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
@@ -330,6 +330,8 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
   // (takes more memory to reduce computation time)
   std::vector<bool> trianglesTested(
     triangulation_->getNumberOfTriangles(), false);
+  // number of triangles tested
+  size_t trChecked{0};
   // vertex in triangle with highest barycentric coordinate
   SimplexId nearestVertex = nearestVertexIdentifier_[a];
 
@@ -431,6 +433,7 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
 
     // mark triangle as tested
     trianglesTested[i] = true;
+    trChecked++;
 
     if(inTriangle) {
       success = true;
@@ -487,8 +490,6 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
     }
   }
 
-  size_t trChecked
-    = std::count(trianglesTested.begin(), trianglesTested.end(), true);
   const size_t maxTrChecked = 100;
 
   if(success && trChecked > maxTrChecked) {

--- a/core/base/reebSpace/ReebSpace.cpp
+++ b/core/base/reebSpace/ReebSpace.cpp
@@ -1730,7 +1730,7 @@ int ReebSpace::simplifySheets(
 //           double distance = Geometry::distance(
 //             fiberSurfaceVertexList_[globalVertexId].p_,
 //             tetPoint.data());
-//           if(distance < pow10(-FLT_DIG)){
+//           if(distance < Geometry::powIntTen(-FLT_DIG)){
 //             localId = k;
 //             tetVertex = true;
 //             break;

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -203,8 +203,10 @@ namespace ttk {
     //       }
 
     template <class dataTypeU, class dataTypeV>
-    inline int perturbate(const dataTypeU &uEpsilon = pow(10, -DBL_DIG),
-                          const dataTypeV &vEpsilon = pow(10, -DBL_DIG)) const;
+    inline int perturbate(const dataTypeU &uEpsilon
+                          = Geometry::powIntTen(-DBL_DIG),
+                          const dataTypeV &vEpsilon
+                          = Geometry::powIntTen(-DBL_DIG)) const;
 
     inline int setExpand3Sheets(const bool &onOff) {
       expand3sheets_ = onOff;

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -282,9 +282,9 @@ int ttk::TopologicalSimplification::addPerturbation(dataType *scalars,
   dataType epsilon{};
 
   if(std::is_same<dataType, double>::value)
-    epsilon = pow10(1 - DBL_DIG);
+    epsilon = Geometry::powIntTen<dataType>(1 - DBL_DIG);
   else if(std::is_same<dataType, float>::value)
-    epsilon = pow10(1 - FLT_DIG);
+    epsilon = Geometry::powIntTen<dataType>(1 - FLT_DIG);
   else
     return -1;
 

--- a/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
+++ b/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
@@ -391,8 +391,8 @@ int ttk::TrackingFromPersistenceDiagrams::performPostProcess(
         bool hasMatched = false;
         if(doMatch1 && ((t3Max && t1Max) || (t3Min && t1Min))) {
           double dist13
-            = sqrt(Geometry::powInt(x1 - x3, 2) + Geometry::powInt(y1 - y3, 2)
-                   + Geometry::powInt(z1 - z3, 2));
+            = sqrt(Geometry::pow(x1 - x3, 2) + Geometry::pow(y1 - y3, 2)
+                   + Geometry::pow(z1 - z3, 2));
           dist = dist13;
           if(dist13 >= postProcThresh)
             continue;
@@ -401,8 +401,8 @@ int ttk::TrackingFromPersistenceDiagrams::performPostProcess(
 
         if(doMatch2 && ((t3Max && t2Max) || (t3Min && t2Min))) {
           double dist23
-            = sqrt(Geometry::powInt(x2 - x3, 2) + Geometry::powInt(y2 - y3, 2)
-                   + Geometry::powInt(z2 - z3, 2));
+            = sqrt(Geometry::pow(x2 - x3, 2) + Geometry::pow(y2 - y3, 2)
+                   + Geometry::pow(z2 - z3, 2));
           dist = dist23;
           if(dist23 >= postProcThresh)
             continue;

--- a/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
+++ b/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
@@ -390,8 +390,9 @@ int ttk::TrackingFromPersistenceDiagrams::performPostProcess(
         double dist = 0;
         bool hasMatched = false;
         if(doMatch1 && ((t3Max && t1Max) || (t3Min && t1Min))) {
-          double dist13 = sqrt(std::pow(x1 - x3, 2) + std::pow(y1 - y3, 2)
-                               + std::pow(z1 - z3, 2));
+          double dist13
+            = sqrt(Geometry::powInt(x1 - x3, 2) + Geometry::powInt(y1 - y3, 2)
+                   + Geometry::powInt(z1 - z3, 2));
           dist = dist13;
           if(dist13 >= postProcThresh)
             continue;
@@ -399,8 +400,9 @@ int ttk::TrackingFromPersistenceDiagrams::performPostProcess(
         }
 
         if(doMatch2 && ((t3Max && t2Max) || (t3Min && t2Min))) {
-          double dist23 = sqrt(std::pow(x2 - x3, 2) + std::pow(y2 - y3, 2)
-                               + std::pow(z2 - z3, 2));
+          double dist23
+            = sqrt(Geometry::powInt(x2 - x3, 2) + Geometry::powInt(y2 - y3, 2)
+                   + Geometry::powInt(z2 - z3, 2));
           dist = dist23;
           if(dist23 >= postProcThresh)
             continue;

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -62,7 +62,7 @@ int ttkScalarFieldNormalizer::normalize(vtkDataArray *input,
   for(SimplexId i = 0; i < input->GetNumberOfTuples(); i++) {
     double value = input->GetTuple1(i);
 
-    value = (value - min) / (max - min) + pow10(-FLT_DIG);
+    value = (value - min) / (max - min) + Geometry::powIntTen(-FLT_DIG);
 
     output->SetTuple1(i, value);
   }


### PR DESCRIPTION
std::pow is often used to compute powers throughout the TTK codebase. However, std::pow is optimized for floating-point exponents and can be quite slow with an integer exponent. As an example, std::pow is a bottleneck in the PersistenceDiagramClustering module even though this module computes only squares and square root (with the default wasserstein distance).

This PR introduces two new templated power functions dedicated to integer exponents (in the Geometry module) and replaces the calls to std::pow when applicable. In several modules using similar powers of ten to compute a precision value, those values have been pre-computed and stored into global variables.

As a consequence, time spend in the PersistencDiagramClustering for the two relevant state files in ttk-data has been halved. Other state files using modified functions should perform either the same or a little bit better than before if std::pow was not the main bottleneck of the used filters.

Additionally, the template specialization code in the Geometry module has been refactored using a macro to reduce the number of lines of code (and one function declaration without an implementation has been removed).

Also, I run some profiling tool yesterday evening on the quadrangulation state file and found some minor performance bottlenecks that have been fixed and attached to this PR.

Enjoy,
Pierre

