### PR TITLE
TTKCinemaWriter: Support avoiding to forward input to output

### DIFF
--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -495,7 +495,9 @@ int ttkCinemaWriter::RequestData(vtkInformation *request,
   auto input = vtkDataObject::GetData(inputVector[0]);
   auto output = vtkDataObject::GetData(outputVector);
 
-  output->ShallowCopy(input);
+  if(this->ForwardInput) {
+    output->ShallowCopy(input);
+  }
 
   // -------------------------------------------------------------------------
   // Prepare Database

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -40,6 +40,9 @@ public:
   vtkSetMacro(IterateMultiBlock, bool);
   vtkGetMacro(IterateMultiBlock, bool);
 
+  vtkSetMacro(ForwardInput, bool);
+  vtkGetMacro(ForwardInput, bool);
+
   int DeleteDatabase();
 
   // TopologicalCompressionWriter options
@@ -83,6 +86,7 @@ private:
   std::string DatabasePath{""};
   int CompressionLevel{5};
   bool IterateMultiBlock{true};
+  bool ForwardInput{true};
   int Mode{0};
   vtkNew<ttkTopologicalCompressionWriter> topologicalCompressionWriter{};
 };

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -50,6 +50,17 @@ NOTE:
                 <Documentation>If set to true and the input is a 'vtkMultiBlockDataSet' then store blocks individually.</Documentation>
             </IntVectorProperty>
 
+            <IntVectorProperty name="ForwardInput"
+                               label="Forward Input"
+                               command="SetForwardInput"
+                               number_of_elements="1"
+                               default_values="1">
+                <BooleanDomain name="bool" />
+                <Documentation>
+                  Forward input data to filter output.
+                </Documentation>
+            </IntVectorProperty>
+
             <Property name="DeleteDatabase" label="Delete Database" command="DeleteDatabase" panel_widget="command_button">
                 <Documentation>Delete the database folder. WARNING: NO UNDO</Documentation>
             </Property>


### PR DESCRIPTION
The TTKCinemaWriter filter shallow copies its input to its output. In an Catalyst environment where filters are triggered by downstream Catalyst writers, this could lead to writing twice the same data: the first in the Cinema Database through TTKCinemaWriter and the second time with the downstream Catalyst writer. 

Even though the Catalyst writer can overwrite previously-written data (and, this way, reducing disk occupancy), the second disk write is still happening.

I propose with this PR to add a new property to TTKCinemaWriter that controls the shallow copying of the input. When activated, it prevents this shallow copy and acts like a sink node for input data. The downstream Catalyst writer will only receive empty data and the disk write will be reduced to minimum.

Enjoy,
Pierre