### PR TITLE
PersistenceDiagramClustering: Fix switching the distance approach in ttk-data/persistenceDiagramDistance.pvsm

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -37,6 +37,11 @@ int ttkPersistenceDiagramClustering::doIt(
 
   int ret{};
   if(needUpdate_) {
+    // clear data before computation
+    intermediateDiagrams_ = {};
+    all_matchings_ = {};
+    final_centroids_ = {};
+
     intermediateDiagrams_.resize(numInputs);
     all_matchings_.resize(3);
 


### PR DESCRIPTION
This PR clean some member variables of the `ttkPersistenceDiagramClustering` class before computation.
This fixes the bug in the ttk-data state `persistenceDiagramDistance.pvsm` when switching from the auction to the progressive approach led to data corruption.

Enjoy,
Pierre