### PR TITLE
Share compiler warnings between base, VTK and standalone layers

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -145,7 +145,7 @@ endfunction()
 function(ttk_set_compile_options library)
 
   # compilation flags
-  target_compile_options(${library} PRIVATE ${COMPILER_FLAGS})
+  target_compile_options(${library} PRIVATE ${TTK_COMPILER_FLAGS})
 
   if(Boost_FOUND)
     target_link_libraries(${library} PUBLIC Boost::boost)

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -247,7 +247,7 @@ function(ttk_find_python)
   find_package(PythonLibs QUIET)
 
   if(PYTHON_INCLUDE_DIRS)
-    include_directories(${PYTHON_INCLUDE_DIRS})
+    include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
 
     #     if (${CMAKE_VERSION} VERSION_GREATER "3.12"
     #       OR ${CMAKE_VERSION} VERSION_EQUAL "3.12")
@@ -278,7 +278,7 @@ function(ttk_find_python)
       /usr/local/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include)
     if(PYTHON_NUMPY_INCLUDE_DIR)
       message(STATUS "Numpy headers: ${PYTHON_NUMPY_INCLUDE_DIR}")
-      include_directories(${PYTHON_NUMPY_INCLUDE_DIR})
+      include_directories(SYSTEM ${PYTHON_NUMPY_INCLUDE_DIR})
     else()
       message(STATUS "Numpy headers: NOT-FOUND")
     endif()

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -145,13 +145,7 @@ endfunction()
 function(ttk_set_compile_options library)
 
   # compilation flags
-  if (NOT MSVC)
-    # GCC and Clang
-    target_compile_options(${library} PRIVATE -Wall -Wshadow)
-  else()
-    # MSVC
-    target_compile_options(${library} PRIVATE /W4)
-  endif()
+  target_compile_options(${library} PRIVATE ${COMPILER_FLAGS})
 
   if(Boost_FOUND)
     target_link_libraries(${library} PUBLIC Boost::boost)
@@ -163,19 +157,6 @@ function(ttk_set_compile_options library)
 
   if (TTK_ENABLE_KAMIKAZE)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_KAMIKAZE)
-  endif()
-
-  if(NOT MSVC)
-    if (TTK_ENABLE_CPU_OPTIMIZATION)
-      target_compile_options(${library}
-        PRIVATE $<$<CONFIG:Release>:-march=native -O3 -Wfatal-errors>)
-    endif()
-
-    target_compile_options(${library} PRIVATE $<$<CONFIG:Debug>:-O0 -g -pg>)
-  endif()
-  if(MSVC)
-    # disable warnings
-    target_compile_options(${library} PUBLIC /bigobj /wd4005 /wd4061 /wd4100 /wd4146 /wd4221 /wd4242 /wd4244 /wd4245 /wd4263 /wd4264 /wd4267 /wd4273 /wd4275 /wd4296 /wd4305 /wd4365 /wd4371 /wd4435 /wd4456 /wd4457 /wd4514 /wd4619 /wd4625 /wd4626 /wd4628 /wd4668 /wd4701 /wd4702 /wd4710 /wd4800 /wd4820 /wd4996 /wd5027 /wd5029 /wd5031)
   endif()
 
   if (TTK_ENABLE_OPENMP)

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -64,7 +64,7 @@ function(ttk_add_base_template_library library)
 
   string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
   if(uppercase_CMAKE_BUILD_TYPE MATCHES RELEASE)
-    if(TTK_ENABLE_CPU_OPTIMIZATION)
+    if(TTK_ENABLE_CPU_OPTIMIZATION AND NOT MSVC)
       target_compile_options(${library} INTERFACE -march=native -O3)
     endif()
   endif()

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -1,0 +1,29 @@
+# Compiler flags to be shared by all base, VTK and standalone targets
+
+if (NOT MSVC) # GCC and Clang
+
+  # warning flags
+  list(APPEND COMPILER_FLAGS -Wall -Wshadow)
+
+  # performance and debug flags
+  if(TTK_ENABLE_CPU_OPTIMIZATION AND CMAKE_BUILD_TYPE MATCHES Release)
+    list(APPEND COMPILER_FLAGS -march=native -O3 -Wfatal-errors)
+  endif()
+
+  if(CMAKE_BUILD_TYPE MATCHES Debug)
+    list(APPEND COMPILER_FLAGS -O0 -g -pg)
+  endif()
+
+else() # MSVC
+
+  # warning flags
+  list(APPEND COMPILER_FLAGS /W4)
+
+  # disabled warnings
+  list(APPEND COMPILER_FLAGS /bigobj /wd4005 /wd4061 /wd4100 /wd4146
+  /wd4221 /wd4242 /wd4244 /wd4245 /wd4263 /wd4264 /wd4267 /wd4273
+  /wd4275 /wd4296 /wd4305 /wd4365 /wd4371 /wd4435 /wd4456 /wd4457
+  /wd4514 /wd4619 /wd4625 /wd4626 /wd4628 /wd4668 /wd4701 /wd4702
+  /wd4710 /wd4800 /wd4820 /wd4996 /wd5027 /wd5029 /wd5031)
+
+endif()

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -3,28 +3,28 @@
 if (NOT MSVC) # GCC and Clang
 
   # warning flags
-  list(APPEND COMPILER_FLAGS -Wall -Wshadow)
+  list(APPEND TTK_COMPILER_FLAGS -Wall -Wshadow)
 
   # performance and debug flags
   if(TTK_ENABLE_CPU_OPTIMIZATION AND CMAKE_BUILD_TYPE MATCHES Release)
     # -O3 already enabled by CMake's Release configuration
-    list(APPEND COMPILER_FLAGS -march=native -Wfatal-errors)
+    list(APPEND TTK_COMPILER_FLAGS -march=native -Wfatal-errors)
   endif()
 
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND COMPILER_FLAGS -O0 -g -pg)
+    list(APPEND TTK_COMPILER_FLAGS -O0 -g -pg)
   endif()
 
 else() # MSVC
 
   # warning flags
-  list(APPEND COMPILER_FLAGS /W4)
+  list(APPEND TTK_COMPILER_FLAGS /W4)
 
   # disabled warnings
-  list(APPEND COMPILER_FLAGS /bigobj /wd4005 /wd4061 /wd4100 /wd4146
-  /wd4221 /wd4242 /wd4244 /wd4245 /wd4263 /wd4264 /wd4267 /wd4273
-  /wd4275 /wd4296 /wd4305 /wd4365 /wd4371 /wd4435 /wd4456 /wd4457
-  /wd4514 /wd4619 /wd4625 /wd4626 /wd4628 /wd4668 /wd4701 /wd4702
-  /wd4710 /wd4800 /wd4820 /wd4996 /wd5027 /wd5029 /wd5031)
+  list(APPEND TTK_COMPILER_FLAGS /bigobj /wd4005 /wd4061 /wd4100
+  /wd4146 /wd4221 /wd4242 /wd4244 /wd4245 /wd4263 /wd4264 /wd4267
+  /wd4273 /wd4275 /wd4296 /wd4305 /wd4365 /wd4371 /wd4435 /wd4456
+  /wd4457 /wd4514 /wd4619 /wd4625 /wd4626 /wd4628 /wd4668 /wd4701
+  /wd4702 /wd4710 /wd4800 /wd4820 /wd4996 /wd5027 /wd5029 /wd5031)
 
 endif()

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -7,7 +7,8 @@ if (NOT MSVC) # GCC and Clang
 
   # performance and debug flags
   if(TTK_ENABLE_CPU_OPTIMIZATION AND CMAKE_BUILD_TYPE MATCHES Release)
-    list(APPEND COMPILER_FLAGS -march=native -O3 -Wfatal-errors)
+    # -O3 already enabled by CMake's Release configuration
+    list(APPEND COMPILER_FLAGS -march=native -Wfatal-errors)
   endif()
 
   if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -37,7 +37,7 @@ macro(ttk_add_vtk_module)
         ${TTK_HEADERS}
       )
 
-    vtk_module_compile_options(${TTK_NAME} PRIVATE ${COMPILER_FLAGS})
+    vtk_module_compile_options(${TTK_NAME} PRIVATE ${TTK_COMPILER_FLAGS})
 
     vtk_module_link(${TTK_NAME}
       PUBLIC

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -37,6 +37,8 @@ macro(ttk_add_vtk_module)
         ${TTK_HEADERS}
       )
 
+    vtk_module_compile_options(${TTK_NAME} PRIVATE ${COMPILER_FLAGS})
+
     vtk_module_link(${TTK_NAME}
       PUBLIC
         ${VTK_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 # Base code
 # ---------
 
+include(CMake/CompilerFlags.cmake)
 include(CMake/BaseCode.cmake)
 add_subdirectory(core)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,7 +264,7 @@ jobs:
   - script: |
       $(compilerInitialization)
       set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
-      cmake -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-8.90 -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF -DVTK_MODULE_ENABLE_ttkAddFieldData=NO -DVTK_MODULE_ENABLE_ttkWRLExporter=NO -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO -DVTK_MODULE_ENABLE_ttkCinemaReader=NO -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO -GNinja ..
+      cmake -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_POLICY_DEFAULT_CMP0092=NEW -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-8.90 -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF -DVTK_MODULE_ENABLE_ttkAddFieldData=NO -DVTK_MODULE_ENABLE_ttkWRLExporter=NO -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO -DVTK_MODULE_ENABLE_ttkCinemaReader=NO -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO -GNinja ..
     workingDirectory: build/
     displayName: 'Configure TTK'
 

--- a/core/base/blank/Blank.h
+++ b/core/base/blank/Blank.h
@@ -147,7 +147,7 @@ int ttk::blank::Blank::execute(const triangulationType *triangulation,
 
   SimplexId vertexNumber = triangulation->getNumberOfVertices();
 
-  SimplexId cellEdgeId = -1, edgeNumber = -1;
+  //   SimplexId cellEdgeId = -1, edgeNumber = -1;
   //   edgeNumber = triangulation->getNumberOfEdges();
   //     triangulation->getCellEdge(0, 0, cellEdgeId);
 

--- a/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
+++ b/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
@@ -126,9 +126,6 @@ int ttk::DepthImageBasedGeometryApproximation::execute(
   camUpTrue[1] /= temp;
   camUpTrue[2] /= temp;
 
-  // Compute Index Map
-  size_t n = resolutionST[0] * resolutionST[1];
-
   // -------------------------------------------------------------------------
   // Create Vertices
   // -------------------------------------------------------------------------

--- a/core/base/ftrGraph/Graph.cpp
+++ b/core/base/ftrGraph/Graph.cpp
@@ -28,7 +28,7 @@ std::string Graph::print(const int verbosity) const {
 
   if(verbosity >= 3) {
     res << "Leaves: " << endl;
-    for(const auto v : leaves_) {
+    for(const auto &v : leaves_) {
       res << get<0>(v) << " ";
     }
     res << endl;

--- a/core/base/icoSphere/IcoSphere.h
+++ b/core/base/icoSphere/IcoSphere.h
@@ -270,7 +270,7 @@ int ttk::IcoSphere::computeIcoSphere(
       idType nOldTriangles = triangleIndex;
       triangleIndex = 0;
 
-      for(size_t i = 0; i < nOldTriangles; i++) {
+      for(idType i = 0; i < nOldTriangles; i++) {
         idType offset = i * 4;
 
         // compute mid points

--- a/core/base/skeleton/CellArray.h
+++ b/core/base/skeleton/CellArray.h
@@ -38,7 +38,7 @@ namespace ttk {
     }
 
     /// Retrieve the dimension
-    inline const unsigned char getDimension() const {
+    inline unsigned char getDimension() const {
       return dimension_;
     }
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -47,7 +47,7 @@ struct ttkOnDeleteCommand : public vtkCommand {
       this->owner->RemoveObserver(this);
   }
 
-  void Execute(vtkObject *, unsigned long eventId, void *callData) {
+  void Execute(vtkObject *, unsigned long eventId, void *callData) override {
     this->deleteEventFired = true;
 
     void *key = this->owner;

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -30,33 +30,33 @@ DataSetToTriangulationMapType ttkAlgorithm::DataSetToTriangulationMap;
 
 struct ttkOnDeleteCommand : public vtkCommand {
   bool deleteEventFired{false};
-  vtkObject *owner;
-  DataSetToTriangulationMapType *dataSetToTriangulationMap;
+  vtkObject *owner_;
+  DataSetToTriangulationMapType *dataSetToTriangulationMap_;
 
   static ttkOnDeleteCommand *New();
   vtkTypeMacro(ttkOnDeleteCommand, vtkCommand);
 
   void Init(vtkObject *owner,
             DataSetToTriangulationMapType *dataSetToTriangulationMap) {
-    this->owner = owner;
-    this->owner->AddObserver(vtkCommand::DeleteEvent, this, 1);
-    this->dataSetToTriangulationMap = dataSetToTriangulationMap;
+    this->owner_ = owner;
+    this->owner_->AddObserver(vtkCommand::DeleteEvent, this, 1);
+    this->dataSetToTriangulationMap_ = dataSetToTriangulationMap;
   }
   ~ttkOnDeleteCommand() {
     if(!this->deleteEventFired)
-      this->owner->RemoveObserver(this);
+      this->owner_->RemoveObserver(this);
   }
 
   void Execute(vtkObject *, unsigned long eventId, void *callData) override {
     this->deleteEventFired = true;
 
-    void *key = this->owner;
-    if(this->owner->IsA("vtkImageData"))
-      key = vtkImageData::SafeDownCast(owner)->GetScalarPointer();
+    void *key = this->owner_;
+    if(this->owner_->IsA("vtkImageData"))
+      key = vtkImageData::SafeDownCast(owner_)->GetScalarPointer();
 
-    auto it = this->dataSetToTriangulationMap->find(key);
-    if(it != this->dataSetToTriangulationMap->end())
-      this->dataSetToTriangulationMap->erase(it);
+    auto it = this->dataSetToTriangulationMap_->find(key);
+    if(it != this->dataSetToTriangulationMap_->end())
+      this->dataSetToTriangulationMap_->erase(it);
   }
 };
 vtkStandardNewMacro(ttkOnDeleteCommand);

--- a/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
+++ b/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
@@ -177,7 +177,6 @@ int ttkArrayEditor::RequestData(vtkInformation *request,
 
   // Pass Input to Output
   auto target = vtkDataObject::GetData(inputVector[0], 0);
-  auto source = vtkDataObject::GetData(inputVector[1], 0);
 
   auto output = vtkDataObject::GetData(outputVector, 0);
 
@@ -340,8 +339,6 @@ int ttkArrayEditor::RequestData(vtkInformation *request,
                    0, ttk::debug::LineMode::REPLACE);
 
     if(selection.size() > 0) {
-      auto outputArraysByAttributeType = getarraysByAttributeType(output);
-
       for(size_t i = 0; i < selection.size(); i++) {
         auto &s = selection[i];
 

--- a/core/vtk/ttkCellDataConverter/ttkCellDataConverter.cpp
+++ b/core/vtk/ttkCellDataConverter/ttkCellDataConverter.cpp
@@ -46,8 +46,8 @@ int ttkCellDataConverter::convert(vtkDataArray *inputData, vtkDataSet *output) {
   B *output_ptr = new B[N * n];
 
   if(UseNormalization) {
-    double type_min = numeric_limits<B>::min();
-    double type_max = numeric_limits<B>::max();
+    auto type_min = static_cast<double>(numeric_limits<B>::min());
+    auto type_max = static_cast<double>(numeric_limits<B>::max());
 
     for(int k = 0; k < n; ++k) {
       double *input_limits = inputData->GetRange();

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -66,7 +66,7 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
     this->printMsg("Converting input VTK tables to SQL tables", 0,
                    ttk::debug::LineMode::REPLACE);
 
-    for(size_t i = 0; i < nTables; i++) {
+    for(int i = 0; i < nTables; i++) {
       auto inTable = inTables[i];
 
       size_t nc = inTable->GetNumberOfColumns();
@@ -77,11 +77,11 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
       // Table Definition
       std::string sqlTableDefinition
         = "CREATE TABLE InputTable" + std::to_string(i) + " (";
-      for(size_t i = 0; i < nc; i++) {
-        auto c = inTable->GetColumn(i);
-        isNumeric[i] = c->IsNumeric();
-        sqlTableDefinition += (i > 0 ? "," : "") + std::string(c->GetName())
-                              + " " + (isNumeric[i] ? "REAL" : "TEXT");
+      for(size_t j = 0; j < nc; j++) {
+        auto c = inTable->GetColumn(j);
+        isNumeric[j] = c->IsNumeric();
+        sqlTableDefinition += (j > 0 ? "," : "") + std::string(c->GetName())
+                              + " " + (isNumeric[j] ? "REAL" : "TEXT");
       }
       sqlTableDefinition += ")";
       sqlTableDefinitions.push_back(sqlTableDefinition);
@@ -97,14 +97,14 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
             sqlInsertStatement += ",";
 
           sqlInsertStatement += "(";
-          for(size_t i = 0; i < nc; i++) {
-            if(i > 0)
+          for(size_t k = 0; k < nc; k++) {
+            if(k > 0)
               sqlInsertStatement += ",";
-            if(isNumeric[i])
-              sqlInsertStatement += inTable->GetValue(q, i).ToString();
+            if(isNumeric[k])
+              sqlInsertStatement += inTable->GetValue(q, k).ToString();
             else
               sqlInsertStatement
-                += "'" + inTable->GetValue(q, i).ToString() + "'";
+                += "'" + inTable->GetValue(q, k).ToString() + "'";
           }
           sqlInsertStatement += ")";
           q++;

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -154,15 +154,15 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     } else {
       for(size_t i = 0; i < nFields; i++) {
         auto array = inputFD->GetAbstractArray(i);
-        size_t n = array->GetNumberOfTuples();
-        size_t m = array->GetNumberOfComponents();
+        auto n = array->GetNumberOfTuples();
+        auto m = array->GetNumberOfComponents();
         std::string value;
         if(n < 0) {
           value = "null";
         } else {
           value = "";
-          for(size_t j = 0; j < n; j++) {
-            for(size_t k = 0; k < m; k++) {
+          for(int j = 0; j < n; j++) {
+            for(int k = 0; k < m; k++) {
               value += array->GetVariantValue(j * m + k).ToString() + ";";
             }
             if(j < n - 1)

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -80,7 +80,7 @@ protected:
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
-                  vtkInformationVector *outputVector);
+                  vtkInformationVector *outputVector) override;
 
 private:
   std::string DatabasePath{""};

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -142,7 +142,7 @@ int ttkDepthImageBasedGeometryApproximation::RequestData(
     {
       auto meshPD = mesh->GetPointData();
       auto inputPD = inputImage->GetPointData();
-      for(size_t p = 0; p < inputPD->GetNumberOfArrays(); p++)
+      for(int p = 0; p < inputPD->GetNumberOfArrays(); p++)
         meshPD->AddArray(inputPD->GetAbstractArray(p));
 
       outputMBD->SetBlock(i, mesh);

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -196,7 +196,7 @@ int ttkExtract::RequestData(vtkInformation *request,
 
       for(size_t i = 0; i < nValues; i++) {
         size_t blockIndex = (size_t)valuesAsD[i];
-        if(0 <= blockIndex && blockIndex < inputAsMB->GetNumberOfBlocks()) {
+        if(blockIndex < inputAsMB->GetNumberOfBlocks()) {
           auto block = inputAsMB->GetBlock(blockIndex);
           auto copy
             = vtkSmartPointer<vtkDataObject>::Take(block->NewInstance());
@@ -216,7 +216,7 @@ int ttkExtract::RequestData(vtkInformation *request,
       }
 
       size_t blockIndex = (size_t)valuesAsD[0];
-      if(0 <= blockIndex && blockIndex < inputAsMB->GetNumberOfBlocks()) {
+      if(blockIndex < inputAsMB->GetNumberOfBlocks()) {
         auto block = inputAsMB->GetBlock(blockIndex);
         if(block->GetDataObjectType() != this->GetOutputType()) {
           this->printErr("BlockType does not match OutputType");

--- a/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
+++ b/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
@@ -46,8 +46,8 @@ int ttkPointDataConverter::convert(vtkDataArray *inputData,
   B *output_ptr = new B[N * n];
 
   if(UseNormalization) {
-    double type_min = numeric_limits<B>::min();
-    double type_max = numeric_limits<B>::max();
+    auto type_min = static_cast<double>(numeric_limits<B>::min());
+    auto type_max = static_cast<double>(numeric_limits<B>::max());
     for(int k = 0; k < n; ++k) {
       double *input_limits = inputData->GetRange(k);
 

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -40,7 +40,7 @@ public:
   ~ttkProgramBase() override{};
 
   /// Set the arguments of your ttk module and execute it here.
-  int execute();
+  int execute() override;
 
   vtkDataSet *getInput(const int &inputId) {
     if((inputId < 0) || (inputId >= (int)inputs_.size()))
@@ -52,7 +52,7 @@ public:
     return inputs_.size();
   };
 
-  virtual int run() {
+  virtual int run() override {
 
     if(!vtkWrapper_) {
       return -1;
@@ -68,7 +68,7 @@ public:
   }
 
   /// Save the output(s) of the TTK module.
-  virtual int save() const;
+  virtual int save() const override;
 
   virtual int setTTKmodule(vtkDataSetAlgorithm *ttkModule) {
 
@@ -91,7 +91,7 @@ protected:
            std::vector<vtkSmartPointer<vtkReaderClass>> &readerList);
 
   /// Load a sequence of input data-sets.
-  virtual int load(const std::vector<std::string> &inputPaths);
+  virtual int load(const std::vector<std::string> &inputPaths) override;
 
   template <class vtkWriterClass>
   int save(const int &outputPortId) const;

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -85,11 +85,11 @@ public:
     return 0;
   }
 
-  int init(int &argc, char **argv);
+  int init(int &argc, char **argv) override;
 
   int refresh();
 
-  int run();
+  int run() override;
 
   int setKeyHandler(ttkKeyHandler *handler) {
     keyHandler_ = handler;

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -9,6 +9,8 @@ if(NOT TARGET ttkUserInterfaceBase)
   set(gui_dirs "")
 endif()
 
+# warning: use deprecated `add_compile_option` here to avoid modifying
+# every standalone CMakeLists.txt
 add_compile_options(${TTK_COMPILER_FLAGS})
 
 file(GLOB STANDALONE_DIRS ${cmd_dirs} ${gui_dirs})

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT TARGET ttkUserInterfaceBase)
   set(gui_dirs "")
 endif()
 
-add_compile_options(${COMPILER_FLAGS})
+add_compile_options(${TTK_COMPILER_FLAGS})
 
 file(GLOB STANDALONE_DIRS ${cmd_dirs} ${gui_dirs})
 foreach(STANDALONE ${STANDALONE_DIRS})

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -9,6 +9,8 @@ if(NOT TARGET ttkUserInterfaceBase)
   set(gui_dirs "")
 endif()
 
+add_compile_options(${COMPILER_FLAGS})
+
 file(GLOB STANDALONE_DIRS ${cmd_dirs} ${gui_dirs})
 foreach(STANDALONE ${STANDALONE_DIRS})
   if(IS_DIRECTORY ${STANDALONE})

--- a/standalone/PersistenceDiagramClustering/cmd/main.cpp
+++ b/standalone/PersistenceDiagramClustering/cmd/main.cpp
@@ -13,7 +13,6 @@ int main(int argc, char **argv) {
 
   // specify local parameters to the TTK module with default values.
   double timeLimit = -1;
-  int numberOfInputs = 1;
   int numberOfClusters = 1;
   double geometry_penalization = 1.;
   int kmeanspp = 1;


### PR DESCRIPTION
Since the ParaView 5.7 migration, compiler flags that were previously applied on both base and VTK layer have been reduced to only the base layer. Such flags include:
* -Wall
* -Wshadow
* -march=native
* /W4 for MSVC

This PR reworks the corresponding CMake code to gather all compiler flags into a CMake variable, TTK_COMPILER_FLAGS, used in base, VTK and standalone. I chose this approach instead of turning the target_compile_options from PRIVATE to PUBLIC in CMake/BaseCode.cmake to avoid warnings from VTK-generated code (for instance the Python wrapper).

The `ttk_add_base_template_library` has been left untouched by this modification (apart from one small fix). In the majority of the TTK setups, base template libraries are compiled through the VTK layer.

Subsequent compiler warnings were fixed in the TTK codebase. Most of them were variable renaming to accomodate -Wshadow. TTK should now build without warnings with GCC and LLVM.

Other small CMake quirks were also fixed during the process.

@CharlesGueunet Do you think this is the right way to do this?

Enjoy,
Pierre