### PR TITLE
Interface persistence diagram clustering and distance matrices

### DIFF
--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.h
@@ -36,6 +36,12 @@ public:
   vtkSetMacro(SQLStatement, std::string);
   vtkGetMacro(SQLStatement, std::string);
 
+  vtkSetMacro(ExcludeColumnsWithRegexp, bool);
+  vtkGetMacro(ExcludeColumnsWithRegexp, bool);
+
+  vtkSetMacro(RegexpString, std::string);
+  vtkGetMacro(RegexpString, std::string);
+
 protected:
   ttkCinemaQuery();
   ~ttkCinemaQuery();
@@ -49,4 +55,6 @@ protected:
 
 private:
   std::string SQLStatement{"SELECT * FROM InputTable0"};
+  bool ExcludeColumnsWithRegexp{false};
+  std::string RegexpString{".*"};
 };

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.cpp
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.cpp
@@ -29,7 +29,7 @@ int ttkDataSetToTable::doIt(vtkDataSet *input, vtkTable *output) {
 
   vtkSmartPointer<vtkTable> table = vtkSmartPointer<vtkTable>::New();
 
-  switch(DataAssociation) {
+  switch(static_cast<AssociationType>(DataAssociation)) {
     case AssociationType::Point: {
       vtkPointData *inputPointData = input->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -68,6 +68,26 @@ int ttkDataSetToTable::doIt(vtkDataSet *input, vtkTable *output) {
 #endif
 
       table->GetRowData()->ShallowCopy(inputCellData);
+    } break;
+
+    case AssociationType::Field: {
+      vtkFieldData *inputFieldData = input->GetFieldData();
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(!inputFieldData) {
+        cerr << "[ttkDataSetToTable] Error: input has no field data." << endl;
+        return -1;
+      }
+#endif
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      const SimplexId numberOfArrays = inputFieldData->GetNumberOfArrays();
+      if(numberOfArrays <= 0) {
+        cerr << "[ttkDataSetToTable] Error: input field data is empty." << endl;
+        return -1;
+      }
+#endif
+
+      table->GetRowData()->ShallowCopy(inputFieldData);
     } break;
   }
 

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
@@ -41,7 +41,7 @@ class TTKDATASETTOTABLE_EXPORT ttkDataSetToTable : public vtkDataSetAlgorithm,
                                                    protected ttk::Wrapper {
 
 public:
-  enum AssociationType { Point = 0, Cell };
+  enum class AssociationType { Point = 0, Cell, Field };
 
   static ttkDataSetToTable *New();
   vtkTypeMacro(ttkDataSetToTable, vtkDataSetAlgorithm)

--- a/core/vtk/ttkEigenField/ttkEigenField.cpp
+++ b/core/vtk/ttkEigenField/ttkEigenField.cpp
@@ -26,7 +26,7 @@ ttkEigenField::ttkEigenField() {
 
 int ttkEigenField::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
     return 1;
   }
   return 0;

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -26,11 +26,13 @@ ttkHarmonicField::ttkHarmonicField() {
 
 int ttkHarmonicField::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkDataSet");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
   } else if(port == 1) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPointSet");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
+    return 1;
   }
-  return 1;
+  return 0;
 }
 
 int ttkHarmonicField::FillOutputPortInformation(int port,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -762,75 +762,74 @@ vtkSmartPointer<vtkUnstructuredGrid>
       ids[0] = 2 * count;
       ids[1] = 2 * count + 1;
       matchingType m = matchings_j[i];
-      int bidder_id = std::get<0>(m);
-      int good_id = std::get<1>(m);
-      if(NumberOfClusters == 1 && good_id > -1) {
+      const size_t bidder_id = std::get<0>(m);
+      const size_t good_id = std::get<1>(m);
+
+      // avoid out-of-bound accesses
+      if(good_id >= matchings_count.size() || bidder_id >= diagram.size()) {
+        continue;
+      }
+
+      if(NumberOfClusters == 1) {
         matchings_count[good_id] += 1;
         count_to_good.push_back(good_id);
       }
-
-      // avoid a weird out-of-bound access
-      good_id
-        = std::min(good_id, static_cast<int>(final_centroids_[c].size() - 1));
 
       diagramType t1 = final_centroids_[c][good_id];
       double x1 = std::get<6>(t1);
       double y1 = std::get<10>(t1);
       double z1 = 0;
 
-      // endl;
-      if(bidder_id < (int)diagram.size()) {
-        diagramType t2 = diagram[bidder_id];
-        double x2 = std::get<6>(t2);
-        double y2 = std::get<10>(t2);
-        double z2 = 0; // Change 1 to j if you want to isolate the diagrams
+      diagramType t2 = diagram[bidder_id];
+      double x2 = std::get<6>(t2);
+      double y2 = std::get<10>(t2);
+      double z2 = 0; // Change 1 to j if you want to isolate the diagrams
 
-        if(DisplayMethod == 1 && Spacing > 0) {
-          double angle
-            = 2 * 3.1415926 * (double)(idxInCluster[j]) / cluster_size[c];
-          x1 += (abs(Spacing) + .2) * 3 * max_dimension_total_ * c;
-          x2 += (abs(Spacing) + .2) * 3 * max_dimension_total_ * c
-                + Spacing * max_dimension_total_ * cos(angle);
-          y2 += Spacing * max_dimension_total_ * sin(angle);
-        } else if(DisplayMethod == 2) {
-          z2 = Spacing;
-          if(intermediateDiagrams_.size() == 2 and j == 0) {
-            z2 = -Spacing;
-          }
-        }
-        if(good_id > -1) {
-          matchingPoints->InsertNextPoint(x1, y1, z1);
-          matchingPoints->InsertNextPoint(x2, y2, z2);
-          matchingMesh->InsertNextCell(VTK_LINE, 2, ids);
-          idOfDiagramMatching->InsertTuple1(count, j);
-          idOfCluster->InsertTuple1(count, inv_clustering_[j]);
-          cost->InsertTuple1(count, std::get<2>(m));
-          idOfDiagramMatchingPoint->InsertTuple1(2 * count, j);
-          idOfDiagramMatchingPoint->InsertTuple1(2 * count + 1, j);
-          idOfPoint->InsertTuple1(2 * count, good_id);
-          idOfPoint->InsertTuple1(2 * count + 1, bidder_id);
-
-          const ttk::SimplexId type = std::get<5>(t2);
-          switch(type) {
-            case 0:
-              pairType->InsertTuple1(count, 0);
-              break;
-
-            case 1:
-              pairType->InsertTuple1(count, 1);
-              break;
-
-            case 2:
-              pairType->InsertTuple1(count, 2);
-              break;
-            default:
-              pairType->InsertTuple1(count, 0);
-          }
-          count++;
+      if(DisplayMethod == 1 && Spacing > 0) {
+        double angle
+          = 2 * 3.1415926 * (double)(idxInCluster[j]) / cluster_size[c];
+        x1 += (abs(Spacing) + .2) * 3 * max_dimension_total_ * c;
+        x2 += (abs(Spacing) + .2) * 3 * max_dimension_total_ * c
+              + Spacing * max_dimension_total_ * cos(angle);
+        y2 += Spacing * max_dimension_total_ * sin(angle);
+      } else if(DisplayMethod == 2) {
+        z2 = Spacing;
+        if(intermediateDiagrams_.size() == 2 and j == 0) {
+          z2 = -Spacing;
         }
       }
+
+      matchingPoints->InsertNextPoint(x1, y1, z1);
+      matchingPoints->InsertNextPoint(x2, y2, z2);
+      matchingMesh->InsertNextCell(VTK_LINE, 2, ids);
+      idOfDiagramMatching->InsertTuple1(count, j);
+      idOfCluster->InsertTuple1(count, inv_clustering_[j]);
+      cost->InsertTuple1(count, std::get<2>(m));
+      idOfDiagramMatchingPoint->InsertTuple1(2 * count, j);
+      idOfDiagramMatchingPoint->InsertTuple1(2 * count + 1, j);
+      idOfPoint->InsertTuple1(2 * count, good_id);
+      idOfPoint->InsertTuple1(2 * count + 1, bidder_id);
+
+      const ttk::SimplexId type = std::get<5>(t2);
+      switch(type) {
+        case 0:
+          pairType->InsertTuple1(count, 0);
+          break;
+
+        case 1:
+          pairType->InsertTuple1(count, 1);
+          break;
+
+        case 2:
+          pairType->InsertTuple1(count, 2);
+          break;
+        default:
+          pairType->InsertTuple1(count, 0);
+      }
+      count++;
     }
   }
+
   if(NumberOfClusters == 1 and intermediateDiagrams_.size() == 2) {
     for(int i = 0; i < count; i++) {
       matchingCount->InsertTuple1(i, matchings_count[count_to_good[i]]);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -1,4 +1,5 @@
 #include <ttkPersistenceDiagramClustering.h>
+#include <vtkFieldData.h>
 
 using namespace std;
 using namespace ttk;
@@ -124,6 +125,22 @@ int ttkPersistenceDiagramClustering::doIt(
   outputMatchings->ShallowCopy(createMatchings());
   outputClusters->ShallowCopy(createOutputClusteredDiagrams());
   outputCentroids->ShallowCopy(createOutputCentroids());
+
+  // collect input FieldData to annotate outputClusters
+  auto fd = outputClusters->GetFieldData();
+  bool hasStructure{false};
+  for(const auto diag : inputDiagram) {
+    if(diag->GetFieldData() != nullptr) {
+      // ensure fd has the same structure as the first non-null input
+      // FieldData
+      if(!hasStructure) {
+        fd->CopyStructure(diag->GetFieldData());
+        hasStructure = true;
+      }
+      // copy data
+      fd->InsertNextTuple(0, diag->GetFieldData());
+    }
+  }
 
   return ret;
 }

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -142,6 +142,14 @@ int ttkPersistenceDiagramClustering::doIt(
     }
   }
 
+  // add clusterId to outputClusters FieldData
+  vtkNew<vtkIntArray> cid{};
+  cid->SetName("ClusterId");
+  for(const auto c : this->inv_clustering_) {
+    cid->InsertNextValue(c);
+  }
+  fd->AddArray(cid);
+
   return ret;
 }
 

--- a/paraview/CinemaQuery/CinemaQuery.xml
+++ b/paraview/CinemaQuery/CinemaQuery.xml
@@ -22,9 +22,43 @@
                 </Hints>
             </StringVectorProperty>
 
-            <PropertyGroup panel_widget="Line" label="Output Options">
-                <Property name="SQLStatement" />
-            </PropertyGroup>
+      <IntVectorProperty
+        name="ExcludeColumnsWithRegexp"
+        label="Exclude columns with a Regexp"
+        command="SetExcludeColumnsWithRegexp"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Allow to exclude selected table columns from being used by
+          the query. The intended use case is when the input table has
+          more columns than allowed by SQLite.
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+         name="Regexp"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*"
+         panel_visibility="advanced">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ExcludeColumnsWithRegexp"
+                                   value="1" />
+        </Hints>
+         <Documentation>
+            This regexp will be used to filter the chosen
+            columns. Only matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Output Options">
+        <Property name="SQLStatement" />
+        <Property name="ExcludeColumnsWithRegexp" />
+        <Property name="Regexp" />
+      </PropertyGroup>
 
             ${DEBUG_WIDGETS}
 

--- a/paraview/DataSetToTable/DataSetToTable.xml
+++ b/paraview/DataSetToTable/DataSetToTable.xml
@@ -42,9 +42,10 @@
         <EnumerationDomain name="enum">
           <Entry value="0" text="Point"/>
           <Entry value="1" text="Cell"/>
+          <Entry value="2" text="Field"/>
         </EnumerationDomain>
         <Documentation>
-          Set the input data association (point or cell).
+          Set the input data association (point, cell or field data).
         </Documentation>
       </IntVectorProperty>
 


### PR DESCRIPTION
This PR allows users to use `PersistenceDiagramClustering` in conjunction with `PersistenceDiagramDistanceMatrix`, i.e. adding clustering results to distance matrices (…kind of).

To do so:

- `PersistenceDiagramClustering` now exports its clustering information alongside input FieldData into its first output FieldData,
- `DataSetToTable` now also converts FieldData into vtkTables,
- `CinemaQuery` can optionally prevent several vtkTable columns to be forwarded to SQLite (using a regexp). This is useful not to exceed SQLite maximum number of columns.

Other fixes in this PR include:

- no more segfaults when `EigenField` and `HarmonicField` are used in a `ForEach` loop. `HarmonicField` still returns an error when used in such a loop though, related to the multi-block input,
- improved out-of-bounds checking for `PersistenceDiagramClustering` when computing the matchings representation.

No modifications were observed in ttk-data states using `PersistenceDiagramClustering` and `CinemaQuery`.

Enjoy,
Pierre