### PR TITLE
CreateModule fix

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -1,3 +1,24 @@
+#pragma once
+
+#define TTK_COMMA ,
+
+#define ttkVtkTemplateMacroCase(                         \
+  dataType, triangulationType, triangulationClass, call) \
+  case triangulationType: {                              \
+    typedef triangulationClass TTK_TT;                   \
+    switch(dataType) { vtkTemplateMacro((call)); };      \
+  }; break;
+
+#define ttkVtkTemplateMacro(triangulationType, dataType, call)            \
+  switch(triangulationType) {                                             \
+    ttkVtkTemplateMacroCase(dataType, ttk::Triangulation::Type::EXPLICIT, \
+                            ttk::ExplicitTriangulation, call);            \
+    ttkVtkTemplateMacroCase(dataType, ttk::Triangulation::Type::IMPLICIT, \
+                            ttk::ImplicitTriangulation, call);            \
+    ttkVtkTemplateMacroCase(dataType, ttk::Triangulation::Type::PERIODIC, \
+                            ttk::PeriodicImplicitTriangulation, call);    \
+  }
+
 #define ttkTemplate2IdMacro(call)                                           \
   vtkTemplate2MacroCase1(VTK_LONG_LONG, long long, call);                   \
   vtkTemplate2MacroCase1(VTK_UNSIGNED_LONG_LONG, unsigned long long, call); \

--- a/core/vtk/ttkHelloWorld/ttk.module
+++ b/core/vtk/ttkHelloWorld/ttk.module
@@ -7,4 +7,3 @@ HEADERS
 DEPENDS
   helloWorld
   ttkAlgorithm
-  ttkTriangulationAlgorithm

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
@@ -1,12 +1,12 @@
 #include <ttkHelloWorld.h>
 
-#include <vtkDataObject.h> // For port information
-#include <vtkObjectFactory.h> // for new macro
-
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>
+
+#include <ttkUtils.h>
+#include <ttkMacros.h>
 
 // A VTK macro that enables the instantiation of this class via ::New()
 // You do not have to modify this

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.h
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.h
@@ -30,8 +30,6 @@
 
 // VTK Includes
 #include <ttkAlgorithm.h>
-#include <ttkTriangulation.h>
-#include <ttkUtils.h>
 
 // TTK Base Includes
 #include <HelloWorld.h>


### PR DESCRIPTION
This commit just moves the ttkUtils.h inclusion in .../core/vtk/ttkHelloWorld.h to .../core/vtk/ttkHelloWorld.cpp. This also removes the dependency to ttkTriangulationAlgorithm, but needed some small additions to the new ttkMacros.h files.

Note, the inclusion of ttkUtils that just defines a namespace with static functions causes for some reason linking errors if included in other header files! So we need to always include ttkUtils.h in the .cpp files (this is also the actual place where it should be).