### PR TITLE
Fixes for CinemaWriter/TopologicalCompression, PersistenceDiagramDistanceMatrix

### DIFF
--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -2684,7 +2684,7 @@ int ImplicitTriangulation::preconditionVerticesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
+      auto &p = vertexCoords_[i];
       vertexToPosition2d(i, p.data());
 
       if(0 < p[0] and p[0] < nbvoxels_[Di_]) {
@@ -2709,7 +2709,6 @@ int ImplicitTriangulation::preconditionVerticesInternal() {
         else
           vertexPositions_[i] = VertexPosition::BOTTOM_RIGHT_CORNER_2D; // d
       }
-      vertexCoords_[i] = std::move(p);
     }
 
   } else if(dimensionality_ == 3) {
@@ -2717,7 +2716,7 @@ int ImplicitTriangulation::preconditionVerticesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
+      auto &p = vertexCoords_[i];
       vertexToPosition(i, p.data());
 
       if(0 < p[0] and p[0] < nbvoxels_[0]) {
@@ -2795,7 +2794,6 @@ int ImplicitTriangulation::preconditionVerticesInternal() {
               = VertexPosition::BOTTOM_RIGHT_BACK_CORNER_3D; // h
         }
       }
-      vertexCoords_[i] = std::move(p);
     }
   }
   return 0;
@@ -2810,7 +2808,7 @@ int ImplicitTriangulation::preconditionEdgesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < edgeNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
+      auto &p = edgeCoords_[i];
 
       if(i < esetshift_[0]) {
         edgeToPosition(i, 0, p.data());
@@ -2918,7 +2916,6 @@ int ImplicitTriangulation::preconditionEdgesInternal() {
         edgeToPosition(i, 6, p.data());
         edgePositions_[i] = EdgePosition::D4_3D;
       }
-      edgeCoords_[i] = std::move(p);
     }
 
   } else if(dimensionality_ == 2) {
@@ -2926,7 +2923,7 @@ int ImplicitTriangulation::preconditionEdgesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < edgeNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
+      auto &p = edgeCoords_[i];
 
       if(i < esetshift_[0]) {
         edgeToPosition2d(i, 0, p.data());
@@ -2950,7 +2947,6 @@ int ImplicitTriangulation::preconditionEdgesInternal() {
         edgeToPosition2d(i, 2, p.data());
         edgePositions_[i] = EdgePosition::D1_2D;
       }
-      edgeCoords_[i] = std::move(p);
     }
 
   } else if(dimensionality_ == 1) {
@@ -2974,27 +2970,25 @@ int ImplicitTriangulation::preconditionTrianglesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < triangleNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
       if(i < tsetshift_[0]) {
-        triangleToPosition(i, 0, p.data());
+        triangleToPosition(i, 0, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::F_3D;
       } else if(i < tsetshift_[1]) {
-        triangleToPosition(i, 1, p.data());
+        triangleToPosition(i, 1, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::H_3D;
       } else if(i < tsetshift_[2]) {
-        triangleToPosition(i, 2, p.data());
+        triangleToPosition(i, 2, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::C_3D;
       } else if(i < tsetshift_[3]) {
-        triangleToPosition(i, 3, p.data());
+        triangleToPosition(i, 3, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::D1_3D;
       } else if(i < tsetshift_[4]) {
-        triangleToPosition(i, 4, p.data());
+        triangleToPosition(i, 4, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::D2_3D;
       } else if(i < tsetshift_[5]) {
-        triangleToPosition(i, 5, p.data());
+        triangleToPosition(i, 5, triangleCoords_[i].data());
         trianglePositions_[i] = TrianglePosition::D3_3D;
       }
-      triangleCoords_[i] = std::move(p);
     }
 
   } else if(dimensionality_ == 2) {
@@ -3002,9 +2996,7 @@ int ImplicitTriangulation::preconditionTrianglesInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < triangleNumber_; ++i) {
-      std::array<SimplexId, 3> p{};
-      triangleToPosition2d(i, p.data());
-      triangleCoords_[i] = std::move(p);
+      triangleToPosition2d(i, triangleCoords_[i].data());
       if(i % 2 == 0) {
         trianglePositions_[i] = TrianglePosition::TOP_2D;
       } else {
@@ -3025,9 +3017,7 @@ int ImplicitTriangulation::preconditionTetrahedronsInternal() {
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(SimplexId i = 0; i < tetrahedronNumber_; ++i) {
-    std::array<SimplexId, 3> p{};
-    tetrahedronToPosition(i, p.data());
-    tetrahedronCoords_[i] = std::move(p);
+    tetrahedronToPosition(i, tetrahedronCoords_[i].data());
   }
   return 0;
 }

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -205,7 +205,8 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
       b.setPositionInAuction(bidders.size());
       bidders.addBidder(b);
       if(b.isDiagonal() || b.x_ == b.y_) {
-        this->printWrn("Diagonal point in diagram!");
+        this->printMsg("Diagonal point in diagram " + std::to_string(i) + "!",
+                       ttk::debug::Priority::DETAIL);
       }
     }
   }

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -233,9 +233,6 @@ double PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
   std::vector<std::vector<int>> candidates_to_be_added(nInputs);
   std::vector<std::vector<size_t>> idx(nInputs);
 
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; i++) {
     double local_min_persistence = std::numeric_limits<double>::min();
     std::vector<double> persistences;

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -47,7 +47,6 @@ int ttk::TopologicalCompression::WritePersistenceTopology(FILE *fm) {
 
   int numberOfVertices = getNbVertices();
   int numberOfSegments = getNbSegments();
-  std::vector<int> segmentation = getSegmentation();
 
   // Test arguments.
   if(numberOfSegments < 1)
@@ -60,7 +59,7 @@ int ttk::TopologicalCompression::WritePersistenceTopology(FILE *fm) {
   WriteInt(fm, numberOfSegments);
 
   numberOfBytesWritten += WriteCompactSegmentation(
-    fm, segmentation.data(), numberOfVertices, numberOfSegments);
+    fm, getSegmentation(), numberOfVertices, numberOfSegments);
 
   rawFileLength += numberOfBytesWritten;
 

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -765,7 +765,11 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   }
 
   // 4. Affect segment value to all points.
-  segmentation_.resize(vertexNumber);
+
+  // (pad buffer to avoid an out-of-bounds access/buffer overflow in
+  // WriteCompactSegmentation while loop)
+  segmentation_.resize(vertexNumber + 32);
+
   std::sort(segments.begin(), segments.end(), cmp);
   for(int i = 0; i < vertexNumber; ++i) {
     dataType scalar = inputData[i];

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -398,7 +398,10 @@ int ttk::TopologicalCompression::ReadCompactSegmentation(
 
 // Returns number of bytes written.
 int ttk::TopologicalCompression::WriteCompactSegmentation(
-  FILE *fm, int *segmentation, int numberOfVertices, int numberOfSegments) {
+  FILE *fm,
+  const std::vector<int> &segmentation,
+  int numberOfVertices,
+  int numberOfSegments) {
   auto WriteInt = ttk::TopologicalCompression::WriteInt;
 
   int numberOfBytesWritten = 0;

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -427,6 +427,8 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
     // two containers.
     while(offset + numberOfBitsPerSegment <= 32) {
 
+      // out-of-bounds here if segmentation.size() == numberOfVertices
+      // (segmentation allocated in compressForPersistenceDiagram)
       int currentSegment = segmentation[currentCell];
 
       // If applicable, fill last part of current segment.

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -255,7 +255,7 @@ namespace ttk {
     static void
       WriteConstCharArray(FILE *fm, const char *buffer, size_t length);
     static int WriteCompactSegmentation(FILE *fm,
-                                        int *segmentation,
+                                        const std::vector<int> &segmentation,
                                         int numberOfVertices,
                                         int numberOfSegments);
     static int WritePersistenceIndex(

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -61,7 +61,7 @@ vtkSmartPointer<vtkDataObject>
   } else {
     // Check if dataset is XML encoded
     std::ifstream is(pathToFile.data());
-    char prefix[9] = "";
+    char prefix[10] = "";
     is.get(prefix, 10);
     bool isXML = std::string(prefix).compare("<VTKFile ") == 0
                  || std::string(prefix).compare("<?xml ver") == 0;

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -443,29 +443,35 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
           "Cannot use Topological Compression without a vtkImageData");
         return 0;
       }
+      vtkNew<ttkTopologicalCompressionWriter> topologicalCompressionWriter{};
+      topologicalCompressionWriter->SetScalarField(this->ScalarField);
+      topologicalCompressionWriter->SetTolerance(this->Tolerance);
+      topologicalCompressionWriter->SetMaximumError(this->MaximumError);
+      topologicalCompressionWriter->SetZFPBitBudget(this->ZFPBitBudget);
+      topologicalCompressionWriter->SetCompressionType(this->CompressionType);
+      topologicalCompressionWriter->SetSQMethodPV(this->SQMethodPV);
+      topologicalCompressionWriter->SetZFPOnly(this->ZFPOnly);
+      topologicalCompressionWriter->SetSubdivide(this->Subdivide);
+      topologicalCompressionWriter->SetUseTopologicalSimplification(
+        this->UseTopologicalSimplification);
 
-      // Fetch the scalar field array on which to perform Topological
-      // Compression
-      const auto ScalarFieldName
-        = this->topologicalCompressionWriter->GetScalarField();
-      if(ScalarFieldName.empty()) {
+      if(ScalarField.empty()) {
         vtkErrorMacro("Need a scalar field for Topological Compression");
         return 0;
       }
       const auto inputData = vtkImageData::SafeDownCast(input);
-      const auto ScalarField
-        = inputData->GetPointData()->GetArray(ScalarFieldName.data());
+      const auto sf = inputData->GetPointData()->GetArray(ScalarField.data());
 
       // Check that input scalar field is indeed scalar
-      if(ScalarField->GetNumberOfComponents() != 1) {
+      if(sf->GetNumberOfComponents() != 1) {
         vtkErrorMacro("Input scalar field should have only 1 component");
         return 0;
       }
-      this->topologicalCompressionWriter->SetDebugLevel(this->debugLevel_);
-      this->topologicalCompressionWriter->SetFileName(
+      topologicalCompressionWriter->SetDebugLevel(this->debugLevel_);
+      topologicalCompressionWriter->SetFileName(
         (this->DatabasePath + "/" + rDataProductPath).data());
-      this->topologicalCompressionWriter->SetInputData(inputData);
-      this->topologicalCompressionWriter->WriteData();
+      topologicalCompressionWriter->SetInputData(inputData);
+      topologicalCompressionWriter->WriteData();
     }
 
     this->printMsg("Writing data product to disk", 1, t.getElapsedTime(),

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -477,6 +477,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     this->printMsg("Writing data product to disk", 1, t.getElapsedTime(),
                    ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);
   }
+  this->printMsg("Wrote " + productId + "." + productExtension);
   this->printMsg(ttk::debug::Separator::L2, ttk::debug::Priority::DETAIL);
   return 1;
 }

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -45,28 +45,23 @@ public:
 
   int DeleteDatabase();
 
-  // TopologicalCompressionWriter options
-#define TopoCompWriterGetSetMacro(NAME, TYPE)               \
-  void Set##NAME(const TYPE _arg) {                         \
-    this->topologicalCompressionWriter->Set##NAME(_arg);    \
-    this->Modified();                                       \
-  }                                                         \
-  TYPE Get##NAME() {                                        \
-    return this->topologicalCompressionWriter->Get##NAME(); \
-  }
-
-  TopoCompWriterGetSetMacro(ScalarField, std::string);
-  TopoCompWriterGetSetMacro(Tolerance, double);
-  TopoCompWriterGetSetMacro(MaximumError, double);
-  TopoCompWriterGetSetMacro(ZFPBitBudget, double);
-  TopoCompWriterGetSetMacro(ZFPOnly, bool);
-  TopoCompWriterGetSetMacro(CompressionType, int);
-  TopoCompWriterGetSetMacro(Subdivide, bool);
-  TopoCompWriterGetSetMacro(UseTopologicalSimplification, bool);
-
-  void SetSQMethodPV(const int arg) {
-    this->topologicalCompressionWriter->SetSQMethodPV(arg);
-  }
+  vtkGetMacro(ScalarField, std::string);
+  vtkSetMacro(ScalarField, std::string);
+  vtkGetMacro(Tolerance, double);
+  vtkSetMacro(Tolerance, double);
+  vtkGetMacro(MaximumError, double);
+  vtkSetMacro(MaximumError, double);
+  vtkGetMacro(ZFPBitBudget, double);
+  vtkSetMacro(ZFPBitBudget, double);
+  vtkGetMacro(ZFPOnly, bool);
+  vtkSetMacro(ZFPOnly, bool);
+  vtkGetMacro(CompressionType, int);
+  vtkSetMacro(CompressionType, int);
+  vtkGetMacro(Subdivide, bool);
+  vtkSetMacro(Subdivide, bool);
+  vtkGetMacro(UseTopologicalSimplification, bool);
+  vtkSetMacro(UseTopologicalSimplification, bool);
+  vtkSetMacro(SQMethodPV, int);
 
 protected:
   ttkCinemaWriter();
@@ -88,5 +83,15 @@ private:
   bool IterateMultiBlock{true};
   bool ForwardInput{true};
   int Mode{0};
-  vtkNew<ttkTopologicalCompressionWriter> topologicalCompressionWriter{};
+
+  // topological compression
+  std::string ScalarField{};
+  double Tolerance{1.0};
+  double MaximumError{};
+  double ZFPBitBudget{0};
+  int CompressionType{static_cast<int>(ttk::CompressionType::PersistenceDiagram)};
+  int SQMethodPV{};
+  bool ZFPOnly{false};
+  bool Subdivide{false};
+  bool UseTopologicalSimplification{true};
 };

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -60,6 +60,14 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
 
   const int numInputs = inputDiagrams.size();
 
+  // Sanity check
+  for(const auto vtu: inputDiagrams) {
+    if(vtu == nullptr) {
+      this->printErr("Input diagrams are not all vtkUnstructuredGrid");
+      return 0;
+    }
+  }
+
   // Set output
   auto diagramsDistTable = vtkTable::GetData(outputVector);
 


### PR DESCRIPTION
This PR fixes bugs related to VESTEC pipelines and some were arguably introduced by me in previous PRs. Those include:

- a race condition in a (not so) parallel loop in PersistenceDiagramDistanceMatrix (no time penalty by removing the parallelism)
- one buffer overflow in TopologicalCompression leading to a segfault in the VESTEC Space Weather  prototype after 80 to 120 cycles. This segfault was occuring in the zlib compression routine but was ultimately linked to the state of the TopologyCompressionWriter member variable inside the CinemaWriter class. This member variable was not reset after each use. In the end, the member variable was demoted to a local variable to get a clean state before each use.
- a second buffer overflow in the TopologicalCompression. This one cause the read of garbage values out of the bounds of a vector but does not provoke side-effects (and the overflow seems to be managed by the code). To avoid further complaints of the Address Sanitizer, the vector has been padded.
- a buffer overflow in CinemaProductReader.
- some ImplicitTriangulation copies were replaced by references (for std::array with fundamental types, move is a copy).

Enjoy,
Pierre
