### PR TITLE
Fix Python wrapping for ttkTriangulationAlgorithm

### DIFF
--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -81,9 +81,7 @@ if(VTK_WRAP_PYTHON)
   # Generate __init__.py
   set(InitContent "from __future__ import absolute_import\n")
   foreach(MODULE ${TTK_ENABLED_MODULES})
-    if (NOT "${MODULE}" STREQUAL "ttkTriangulationAlgorithm")
-      string(APPEND InitContent "from .${MODULE} import *\n")
-    endif()
+    string(APPEND InitContent "from .${MODULE} import *\n")
   endforeach()
   file(GENERATE
     OUTPUT

--- a/core/vtk/ttkTriangulationAlgorithm/ttkImageData.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkImageData.h
@@ -8,7 +8,10 @@
 
 #include <ttkTriangulationAlgorithmModule.h>
 
-class TTKTRIANGULATIONALGORITHM_EXPORT ttkImageData : public ttkTriangulation,
+class TTKTRIANGULATIONALGORITHM_EXPORT ttkImageData : 
+#ifndef __VTK_WRAP__
+                                                      public ttkTriangulation,
+#endif
                                                       public vtkImageData {
 
 public:

--- a/core/vtk/ttkTriangulationAlgorithm/ttkImageData.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkImageData.h
@@ -8,11 +8,11 @@
 
 #include <ttkTriangulationAlgorithmModule.h>
 
-class TTKTRIANGULATIONALGORITHM_EXPORT ttkImageData : 
+class TTKTRIANGULATIONALGORITHM_EXPORT ttkImageData :
 #ifndef __VTK_WRAP__
-                                                      public ttkTriangulation,
+  public ttkTriangulation,
 #endif
-                                                      public vtkImageData {
+  public vtkImageData {
 
 public:
   static ttkImageData *New();

--- a/core/vtk/ttkTriangulationAlgorithm/ttkPolyData.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkPolyData.h
@@ -8,11 +8,11 @@
 
 #include <ttkTriangulationAlgorithmModule.h>
 
-class TTKTRIANGULATIONALGORITHM_EXPORT ttkPolyData : 
+class TTKTRIANGULATIONALGORITHM_EXPORT ttkPolyData :
 #ifndef __VTK_WRAP__
-                                                     public ttkTriangulation,
+  public ttkTriangulation,
 #endif
-                                                     public vtkPolyData {
+  public vtkPolyData {
 
 public:
   static ttkPolyData *New();

--- a/core/vtk/ttkTriangulationAlgorithm/ttkPolyData.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkPolyData.h
@@ -8,7 +8,10 @@
 
 #include <ttkTriangulationAlgorithmModule.h>
 
-class TTKTRIANGULATIONALGORITHM_EXPORT ttkPolyData : public ttkTriangulation,
+class TTKTRIANGULATIONALGORITHM_EXPORT ttkPolyData : 
+#ifndef __VTK_WRAP__
+                                                     public ttkTriangulation,
+#endif
                                                      public vtkPolyData {
 
 public:

--- a/core/vtk/ttkTriangulationAlgorithm/ttkUnstructuredGrid.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkUnstructuredGrid.h
@@ -8,12 +8,11 @@
 
 #include <ttkTriangulationAlgorithmModule.h>
 
-class TTKTRIANGULATIONALGORITHM_EXPORT ttkUnstructuredGrid
-  : 
+class TTKTRIANGULATIONALGORITHM_EXPORT ttkUnstructuredGrid :
 #ifndef __VTK_WRAP__
-    public ttkTriangulation,
+  public ttkTriangulation,
 #endif
-    public vtkUnstructuredGrid {
+  public vtkUnstructuredGrid {
 
 public:
   static ttkUnstructuredGrid *New();

--- a/core/vtk/ttkTriangulationAlgorithm/ttkUnstructuredGrid.h
+++ b/core/vtk/ttkTriangulationAlgorithm/ttkUnstructuredGrid.h
@@ -9,7 +9,10 @@
 #include <ttkTriangulationAlgorithmModule.h>
 
 class TTKTRIANGULATIONALGORITHM_EXPORT ttkUnstructuredGrid
-  : public ttkTriangulation,
+  : 
+#ifndef __VTK_WRAP__
+    public ttkTriangulation,
+#endif
     public vtkUnstructuredGrid {
 
 public:


### PR DESCRIPTION
Python wrapping `ttkTriangulationAlgorithm` has produced undefined symbols (e.g., `PyvtkPolyData_ClassNew`), because the TTK classes `ttkImageData`, `ttkPolyData` and `ttkUnstructuredGrid` have a non-VTK base class.

This PR fixes wrapping by simply hiding the non-VTK base classes from the VTK wrapper. Similar workarounds can be found in the VTK code base itself, for example in [VTK/Common/Core/vtkDoubleArray.h](https://gitlab.kitware.com/vtk/vtk/-/blob/master/Common/Core/vtkDoubleArray.h#L31).