### PR TITLE
hello world standalone

### DIFF
--- a/core/base/common/CommandLineParser.h
+++ b/core/base/common/CommandLineParser.h
@@ -75,7 +75,7 @@ namespace ttk {
 
         if(isAnOption_) {
           s += " (default: ";
-          s += *boolValue_;
+          s += std::to_string(*boolValue_);
           s += ")";
         }
 
@@ -109,9 +109,12 @@ namespace ttk {
     };
 
     CommandLineParser() {
+      // running from the command line, add a default value.
+      ttk::globalDebugLevel_ = 3;
       setArgument("d", &(ttk::globalDebugLevel_), "Global debug level", true);
       setArgument("t", &ttk::globalThreadNumber_, "Global thread number", true);
       debugLevel_ = (int)(debug::Priority::INFO);
+      
       setDebugMsgPrefix("CMD");
     };
 
@@ -183,6 +186,8 @@ namespace ttk {
           }
         }
       }
+      
+      setDebugLevel(ttk::globalDebugLevel_);
 
       return 0;
     };
@@ -226,14 +231,14 @@ namespace ttk {
           if(!arguments_[i].isSet_) {
             s += "(not set)";
           } else {
-            s += *(arguments_[i].intValue_);
+            s += std::to_string(*(arguments_[i].intValue_));
           }
         } else if(arguments_[i].intValueList_) {
           if(!arguments_[i].isSet_) {
             s += "(not set)";
           } else {
             for(int j = 0; j < (int)arguments_[i].intValueList_->size(); j++) {
-              s += (*(arguments_[i].intValueList_))[j];
+              s += std::to_string((*(arguments_[i].intValueList_))[j]);
               s += " ";
             }
           }
@@ -241,7 +246,7 @@ namespace ttk {
           if(!arguments_[i].isSet_) {
             s += "(not set)";
           } else {
-            s += *(arguments_[i].doubleValue_);
+            s += std::to_string(*(arguments_[i].doubleValue_));
           }
         } else if(arguments_[i].doubleValueList_) {
           if(!arguments_[i].isSet_) {
@@ -249,7 +254,7 @@ namespace ttk {
           } else {
             for(int j = 0; j < (int)arguments_[i].doubleValueList_->size();
                 j++) {
-              s += (*(arguments_[i].doubleValueList_))[j];
+              s += std::to_string((*(arguments_[i].doubleValueList_))[j]);
               s += " ";
             }
           }

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
@@ -155,6 +155,8 @@ int ttkHelloWorld::RequestData(vtkInformation *request,
   // Precondition the triangulation (e.g., enable fetching of vertex neighbors)
   this->preconditionTriangulation(triangulation); // implemented in base class
 
+  printMsg("Starting computation on array `" 
+    + std::string(inputArray->GetName()) + "'...");
   // Templatize over the different input array data types and call the base code
   int status = 0; // this integer checks if the base code returns an error
   ttkVtkTemplateMacro(triangulation->getType(), inputArray->GetDataType(),

--- a/scripts/cloneTTKmodule.sh
+++ b/scripts/cloneTTKmodule.sh
@@ -75,21 +75,32 @@ mv "core/vtk/ttk${NameDestination}/ttk${NameSource}.h" \
 replace "core/vtk/ttk${NameDestination}/ttk${NameDestination}.h"
 
 # 3) duplicate the source standalone modules
-if [ -d "standalone/${NameSource}/cmd" ]; then
-  echo "Creating command line standalone program 'standalone/${NameDestination}/cmd'..."
-  mkdir -p "standalone/${NameDestination}"
-  cp -R "standalone/${NameSource}/cmd/" \
-        "standalone/${NameDestination}/cmd"
-  replace "standalone/${NameDestination}/cmd/CMakeLists.txt"
-  replace "standalone/${NameDestination}/cmd/main.cpp"
-fi
-if [ -d "standalone/${NameSource}/gui" ]; then
-  echo "Creating GUI standalone program 'standalone/${NameDestination}/gui'..."
-  mkdir -p "standalone/${NameDestination}"
-  cp -R "standalone/${NameSource}/gui/" \
-        "standalone/${NameDestination}/gui"
-  replace "standalone/${NameDestination}/gui/CMakeLists.txt"
-  replace "standalone/${NameDestination}/gui/main.cpp"
+if [ -d "standalone/${NameSource}/" ]; then
+  if [ ! -d "standalone/${NameSource}/cmd" ] \
+    && [ ! -d "standalone/${NameSource}/gui" ]; then
+    # new standalone case
+    echo "Creating command line standalone program 'standalone/${NameDestination}'..."
+    cp -R "standalone/${NameSource}/" \
+          "standalone/${NameDestination}/"
+    replace "standalone/${NameDestination}/CMakeLists.txt"
+    replace "standalone/${NameDestination}/main.cpp"
+  fi
+  if [ -d "standalone/${NameSource}/cmd" ]; then
+    echo "Creating command line standalone program 'standalone/${NameDestination}/cmd'..."
+    mkdir -p "standalone/${NameDestination}"
+    cp -R "standalone/${NameSource}/cmd/" \
+          "standalone/${NameDestination}/cmd"
+    replace "standalone/${NameDestination}/cmd/CMakeLists.txt"
+    replace "standalone/${NameDestination}/cmd/main.cpp"
+  fi
+  if [ -d "standalone/${NameSource}/gui" ]; then
+    echo "Creating GUI standalone program 'standalone/${NameDestination}/gui'..."
+    mkdir -p "standalone/${NameDestination}"
+    cp -R "standalone/${NameSource}/gui/" \
+          "standalone/${NameDestination}/gui"
+    replace "standalone/${NameDestination}/gui/CMakeLists.txt"
+    replace "standalone/${NameDestination}/gui/main.cpp"
+  fi
 fi
 
 # 4) duplicate the source paraview filter

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -13,9 +13,9 @@ endif()
 # every standalone CMakeLists.txt
 add_compile_options(${TTK_COMPILER_FLAGS})
 
-file(GLOB STANDALONE_DIRS ${cmd_dirs} ${gui_dirs})
+file(GLOB STANDALONE_DIRS ${cmd_dirs} ${gui_dirs} "./*")
 foreach(STANDALONE ${STANDALONE_DIRS})
-  if(IS_DIRECTORY ${STANDALONE})
+  if(IS_DIRECTORY ${STANDALONE} AND EXISTS ${STANDALONE}/CMakeLists.txt)
     add_subdirectory(${STANDALONE})
   endif()
 endforeach()

--- a/standalone/HelloWorld/CMakeLists.txt
+++ b/standalone/HelloWorld/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(ttkHelloWorldCmd)
+
+if(TARGET ttkHelloWorld)
+  add_executable(${PROJECT_NAME} main.cpp)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ttkHelloWorld
+      ttkProgramBase
+    )
+  set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+      INSTALL_RPATH
+        "${CMAKE_INSTALL_RPATH}"
+    )
+  install(
+    TARGETS
+      ${PROJECT_NAME}
+    RUNTIME DESTINATION
+      ${TTK_INSTALL_BINARY_DIR}
+    )
+endif()

--- a/standalone/HelloWorld/CMakeLists.txt
+++ b/standalone/HelloWorld/CMakeLists.txt
@@ -7,7 +7,6 @@ if(TARGET ttkHelloWorld)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkHelloWorld
-      ttkProgramBase
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/HelloWorld/main.cpp
+++ b/standalone/HelloWorld/main.cpp
@@ -1,0 +1,123 @@
+/// \author Your Name Here <Your Email Address Here>.
+/// \date The Date Here.
+///
+/// \brief dummy program example.
+
+// TTK Includes
+#include <CommandLineParser.h>
+#include <ttkHelloWorld.h>
+
+// VTK Includes
+#include <vtkCellData.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkXMLDataObjectWriter.h>
+#include <vtkXMLGenericDataObjectReader.h>
+
+int main(int argc, char **argv) {
+
+  // ---------------------------------------------------------------------------
+  // Program variables
+  // ---------------------------------------------------------------------------
+  std::vector<std::string> inputFilePaths;
+  std::vector<std::string> inputArrayNames;
+  std::string outputPathPrefix{""};
+  int listArrays{0};
+
+  // ---------------------------------------------------------------------------
+  // Set program variables based on command line arguments
+  // ---------------------------------------------------------------------------
+  {
+    ttk::CommandLineParser parser;
+    parser.setArgument(
+      "i", &inputFilePaths, "Input data-sets (*.vti, *vtu, *vtp)", false);
+    parser.setArgument("a", &inputArrayNames, "Input array names", true);
+    parser.setArgument(
+      "o", &outputPathPrefix, "Output file prefix (no extension)", true);
+    parser.setArgument("l", &listArrays, "List available arrays", true);
+
+    parser.parse(argc, argv);
+    parser.printArgs();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Initialize ttkHelloWorld module (adjust parameters)
+  // ---------------------------------------------------------------------------
+  auto helloWorld = vtkSmartPointer<ttkHelloWorld>::New();
+  // helloWorld->SetOutputArrayName("AveragedArray");
+
+  // ---------------------------------------------------------------------------
+  // Read input vtkDataObjects (optionally: print available arrays)
+  // ---------------------------------------------------------------------------
+  for(size_t i = 0; i < inputFilePaths.size(); i++) {
+    // init a reader that can parse any vtkDataObject stored in xml format
+    auto reader = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();
+    reader->SetFileName(inputFilePaths[i].data());
+    reader->Update();
+
+    // check if input vtkDataObject was successfully read
+    auto inputDataObject = reader->GetOutput();
+    if(!inputDataObject) {
+      std::cout << "ERROR: Unable to read input vtkDataObject " << i << "\n";
+      return 0;
+    }
+
+    // if requested print list of arrays, otherwise proceed with execution
+    if(listArrays) {
+      std::cout << "vtkDataObject " << i << ":\n";
+      if(auto inputAsVtkDataSet = vtkDataSet::SafeDownCast(inputDataObject)) {
+        // Point Data
+        std::cout << "  PointData:\n";
+        auto pointData = inputAsVtkDataSet->GetPointData();
+        for(int j = 0; j < pointData->GetNumberOfArrays(); j++)
+          std::cout << "    " << pointData->GetArrayName(j) << "\n";
+
+        // Cell Data
+        std::cout << "  CellData:\n";
+        auto cellData = inputAsVtkDataSet->GetCellData();
+        for(int j = 0; j < cellData->GetNumberOfArrays(); j++)
+          std::cout << "    " << cellData->GetArrayName(j) << "\n";
+      } else {
+        std::cout << "ERROR: Unable to list arrays of non vtkDataSet input.";
+        return 0;
+      }
+    } else {
+      // feed input object to ttkHelloWorld filter
+      helloWorld->SetInputDataObject(i, reader->GetOutput());
+    }
+  }
+
+  // terminate program if it was just asked to list arrays
+  if(listArrays) {
+    return 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Specify which arrays of the input vtkDataObjects will be processed
+  // ---------------------------------------------------------------------------
+  for(size_t i = 0; i < inputArrayNames.size(); i++)
+    helloWorld->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());
+
+  // ---------------------------------------------------------------------------
+  // Execute ttkHelloWorld filter
+  // ---------------------------------------------------------------------------
+  helloWorld->Update();
+
+  // ---------------------------------------------------------------------------
+  // If output prefix is specified then write all output objects to disk
+  // ---------------------------------------------------------------------------
+  if(!outputPathPrefix.empty()) {
+    for(int i = 0; i < helloWorld->GetNumberOfOutputPorts(); i++) {
+      auto output = helloWorld->GetOutputDataObject(i);
+      auto writer
+        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      writer->SetInputDataObject(output);
+      writer->SetFileName((outputPathPrefix + "_port_" + std::to_string(i) + "."
+                           + writer->GetDefaultFileExtension())
+                            .data());
+      writer->Update();
+    }
+  }
+
+  return 1;
+}

--- a/standalone/HelloWorld/main.cpp
+++ b/standalone/HelloWorld/main.cpp
@@ -145,10 +145,13 @@ int main(int argc, char **argv) {
       auto output = helloWorld->GetOutputDataObject(i);
       auto writer
         = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      
+      std::string outputFileName = outputPathPrefix 
+          + "_port_" + std::to_string(i) 
+          + "." + writer->GetDefaultFileExtension();
+      msg.printMsg("Writing output file `" + outputFileName + "'...");
       writer->SetInputDataObject(output);
-      writer->SetFileName((outputPathPrefix + "_port_" + std::to_string(i) + "."
-                           + writer->GetDefaultFileExtension())
-                            .data());
+      writer->SetFileName(outputFileName.data());
       writer->Update();
     }
   }


### PR DESCRIPTION
Hi Julien,
this PR adds a hello world standalone program and modifies the standalone CMakeLists.txt file to also build programs that are not inside a cmg/gui folder.

Some things to consider:
* The ttkCommandLineParser (ttkCLP) does not correctly print integer arguments. For example, after setting the thread level to 4, the ttkCLP prints this parameter as an empty string: "-t: ".
* ttkCLP does not support bool parameters.
* The "-l" option controls if the program should list all available arrays, but the current ttkCLP requires that the value of "l" must be set explicitly. So instead of "ttkHelloWorld -i SomePath -l" one has to write "ttkHelloWorld -i SomePath -l 1", which is a bit unintuitive.
* Since the standalone builds already require vtk, I champion the vtksys/CommandLineArguments (vtkCLP) class to replace the ttkCLP. If I remember correctly, you pointed out that the advantage of the ttkCLP is that it already sets some default values (debug level/thread number), but this could also be achieved by just inheriting from vtkCLP. I think this would reduce the amount of code we have to maintain, and it solves the issues mentioned above. Here is the corresponding header file:
https://github.com/Kitware/VTK/blob/master/Utilities/KWSys/vtksys/CommandLineArguments.hxx.in

Best
Jonas