### PR TITLE
PersistenceDiagramDistanceMatrix: Support more ways to filter pairs

### DIFF
--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -70,18 +70,12 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
 
   if(this->do_min_) {
     setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min);
-    enrichCurrentBidderDiagrams(
-      bidder_diagrams_min, current_bidder_diagrams_min);
   }
   if(this->do_sad_) {
     setBidderDiagrams(nInputs, inputDiagramsSad, bidder_diagrams_sad);
-    enrichCurrentBidderDiagrams(
-      bidder_diagrams_sad, current_bidder_diagrams_sad);
   }
   if(this->do_max_) {
     setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max);
-    enrichCurrentBidderDiagrams(
-      bidder_diagrams_max, current_bidder_diagrams_max);
   }
 
   std::vector<std::vector<double>> distMat(nInputs);
@@ -89,6 +83,18 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     getDiagramsDistMat(nInputs, distMat, bidder_diagrams_min,
                        bidder_diagrams_sad, bidder_diagrams_max);
   } else {
+    if(this->do_min_) {
+      enrichCurrentBidderDiagrams(
+        bidder_diagrams_min, current_bidder_diagrams_min);
+    }
+    if(this->do_sad_) {
+      enrichCurrentBidderDiagrams(
+        bidder_diagrams_sad, current_bidder_diagrams_sad);
+    }
+    if(this->do_max_) {
+      enrichCurrentBidderDiagrams(
+        bidder_diagrams_max, current_bidder_diagrams_max);
+    }
     getDiagramsDistMat(nInputs, distMat, current_bidder_diagrams_min,
                        current_bidder_diagrams_sad,
                        current_bidder_diagrams_max);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -72,6 +72,9 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     }
   }
 
+  const auto maxPersistence
+    = *std::max_element(maxDiagPersistence.begin(), maxDiagPersistence.end());
+
   if(this->do_min_) {
     setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min);
   }
@@ -100,7 +103,7 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
       this->printMsg(
         "Use the "
         + std::to_string(static_cast<int>(100 * (1 - this->MinPersistence)))
-        + "% most persistent pairs of each diagram");
+        + "% most persistent pairs");
       break;
   }
 
@@ -111,15 +114,15 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   } else {
     if(this->do_min_) {
       enrichCurrentBidderDiagrams(
-        bidder_diagrams_min, current_bidder_diagrams_min, maxDiagPersistence);
+        bidder_diagrams_min, current_bidder_diagrams_min, maxPersistence);
     }
     if(this->do_sad_) {
       enrichCurrentBidderDiagrams(
-        bidder_diagrams_sad, current_bidder_diagrams_sad, maxDiagPersistence);
+        bidder_diagrams_sad, current_bidder_diagrams_sad, maxPersistence);
     }
     if(this->do_max_) {
       enrichCurrentBidderDiagrams(
-        bidder_diagrams_max, current_bidder_diagrams_max, maxDiagPersistence);
+        bidder_diagrams_max, current_bidder_diagrams_max, maxPersistence);
     }
     getDiagramsDistMat(nInputs, distMat, current_bidder_diagrams_min,
                        current_bidder_diagrams_sad,
@@ -242,7 +245,7 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
 void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
   const std::vector<BidderDiagram<double>> &bidder_diags,
   std::vector<BidderDiagram<double>> &current_bidder_diags,
-  const std::vector<double> &maxDiagPersistence) const {
+  const double maxPersistence) const {
 
   current_bidder_diags.resize(bidder_diags.size());
   const auto nInputs = current_bidder_diags.size();
@@ -257,10 +260,9 @@ void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
           (this->Constraint == ConstraintType::ABSOLUTE_PERSISTENCE
            && b.getPersistence() > this->MinPersistence)
           || // filter out pairs below persistence threshold relative to
-          // current diagram global min-max pair
+          // the most persistent pair in all diagrams
           (this->Constraint == ConstraintType::RELATIVE_PERSISTENCE
-           && b.getPersistence()
-                > this->MinPersistence * maxDiagPersistence[i])) {
+           && b.getPersistence() > this->MinPersistence * maxPersistence)) {
           b.id_ = current_bidder_diags[i].size();
           b.setPositionInAuction(current_bidder_diags[i].size());
           current_bidder_diags[i].addBidder(b);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -88,7 +88,7 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   }
 
   std::vector<std::vector<double>> distMat(nInputs);
-  if(this->UseFullDiagrams) {
+  if(this->Constraint == ConstraintType::FULL_DIAGRAMS) {
     getDiagramsDistMat(nInputs, distMat, bidder_diagrams_min,
                        bidder_diagrams_sad, bidder_diagrams_max);
   } else {

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -12,13 +12,13 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   const auto nInputs = intermediateDiagrams.size();
 
   if(do_min_ && do_sad_ && do_max_) {
-    this->printMsg("Process all critical pairs");
+    this->printMsg("Processing all critical pairs types");
   } else if(do_min_) {
-    this->printMsg("Process only MIN-SAD pairs");
+    this->printMsg("Processing only MIN-SAD pairs");
   } else if(do_sad_) {
-    this->printMsg("Process only SAD-SAD pairs");
+    this->printMsg("Processing only SAD-SAD pairs");
   } else if(do_max_) {
-    this->printMsg("Process only SAD-MAX pairs");
+    this->printMsg("Processing only SAD-MAX pairs");
   }
 
   std::vector<std::vector<DiagramTuple>> inputDiagramsMin(nInputs);
@@ -80,6 +80,28 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   }
   if(this->do_max_) {
     setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max);
+  }
+
+  switch(this->Constraint) {
+    case ConstraintType::FULL_DIAGRAMS:
+      this->printMsg("Using all diagram pairs");
+      break;
+    case ConstraintType::NUMBER_PAIRS:
+      this->printMsg("Using the " + std::to_string(this->MaxNumberOfPairs)
+                     + " most persistent pairs");
+      break;
+    case ConstraintType::ABSOLUTE_PERSISTENCE: {
+      std::stringstream pers{};
+      pers << std::fixed << std::setprecision(2) << this->MinPersistence;
+      this->printMsg("Using diagram pairs above a persistence threshold of "
+                     + pers.str());
+    } break;
+    case ConstraintType::RELATIVE_PERSISTENCE:
+      this->printMsg(
+        "Use the "
+        + std::to_string(static_cast<int>(100 * (1 - this->MinPersistence)))
+        + "% most persistent pairs of each diagram");
+      break;
   }
 
   std::vector<std::vector<double>> distMat(nInputs);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -69,20 +69,17 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   }
 
   if(this->do_min_) {
-    setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min,
-                      current_bidder_diagrams_min);
+    setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min);
     enrichCurrentBidderDiagrams(
       bidder_diagrams_min, current_bidder_diagrams_min);
   }
   if(this->do_sad_) {
-    setBidderDiagrams(nInputs, inputDiagramsSad, bidder_diagrams_sad,
-                      current_bidder_diagrams_sad);
+    setBidderDiagrams(nInputs, inputDiagramsSad, bidder_diagrams_sad);
     enrichCurrentBidderDiagrams(
       bidder_diagrams_sad, current_bidder_diagrams_sad);
   }
   if(this->do_max_) {
-    setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max,
-                      current_bidder_diagrams_max);
+    setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max);
     enrichCurrentBidderDiagrams(
       bidder_diagrams_max, current_bidder_diagrams_max);
   }
@@ -189,15 +186,13 @@ void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
 void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   const size_t nInputs,
   std::vector<std::vector<DiagramTuple>> &inputDiagrams,
-  std::vector<BidderDiagram<double>> &bidder_diags,
-  std::vector<BidderDiagram<double>> &current_bidder_diags) const {
+  std::vector<BidderDiagram<double>> &bidder_diags) const {
+
+  bidder_diags.resize(nInputs);
 
   for(size_t i = 0; i < nInputs; i++) {
-    bidder_diags.emplace_back();
-    current_bidder_diags.emplace_back();
-
     auto &diag = inputDiagrams[i];
-    auto &bidders = bidder_diags.back();
+    auto &bidders = bidder_diags[i];
 
     for(size_t j = 0; j < diag.size(); j++) {
       // Add bidder to bidders
@@ -215,6 +210,8 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
 double PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
   const std::vector<BidderDiagram<double>> &bidder_diags,
   std::vector<BidderDiagram<double>> &current_bidder_diags) const {
+
+  current_bidder_diags.resize(bidder_diags.size());
 
   const double prev_min_persistence = 2.0 * getMostPersistent(bidder_diags);
   double new_min_persistence = 0.0;

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -258,8 +258,8 @@ void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
       std::sort(
         pairs.begin(), pairs.end(),
         [](const PairIV &a, const PairIV &b) { return a.second < b.second; });
-      const auto firstId = pairs.size() > this->MinPointsToAdd
-                             ? pairs.size() - this->MinPointsToAdd
+      const auto firstId = pairs.size() > this->MaxNumberOfPairs
+                             ? pairs.size() - this->MaxNumberOfPairs
                              : 0;
       // take the last (most persistent) pairs
       for(size_t j = firstId; j < pairs.size(); ++j) {

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -245,64 +245,25 @@ void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
         }
       }
     }
-    return;
-  }
 
-  const double prev_min_persistence = 2.0 * getMostPersistent(bidder_diags);
-  double new_min_persistence = 0.0;
-
-  // 1. Get size of the largest current diagram, deduce the maximal number
-  // of points to append
-  size_t max_diagram_size = 0;
-  for(const auto &diag : current_bidder_diags) {
-    max_diagram_size
-      = std::max(static_cast<size_t>(diag.size()), max_diagram_size);
-  }
-  size_t max_points_to_add = std::max(
-    this->MinPointsToAdd, this->MinPointsToAdd + max_diagram_size / 10);
-  // 2. Get which points can be added, deduce the new minimal persistence
-  std::vector<std::vector<int>> candidates_to_be_added(nInputs);
-  std::vector<std::vector<size_t>> idx(nInputs);
-
-  for(size_t i = 0; i < nInputs; i++) {
-    double local_min_persistence = std::numeric_limits<double>::min();
-    std::vector<double> persistences;
-    for(int j = 0; j < bidder_diags[i].size(); j++) {
-      Bidder<double> b = bidder_diags[i].get(j);
-      double persistence = b.getPersistence();
-      if(persistence >= 0.0 && persistence <= prev_min_persistence) {
-        candidates_to_be_added[i].emplace_back(j);
-        idx[i].emplace_back(idx[i].size());
-        persistences.emplace_back(persistence);
+  } else if(this->Constraint == ConstraintType::NUMBER_PAIRS) {
+    for(size_t i = 0; i < nInputs; ++i) {
+      // index of pair in bidder_diags + corresponding persistence value
+      using PairIV = std::pair<size_t, double>;
+      std::vector<PairIV> pairs(bidder_diags[i].size());
+      for(int j = 0; j < bidder_diags[i].size(); ++j) {
+        pairs.emplace_back(j, bidder_diags[i].get(j).getPersistence());
       }
-    }
-    const auto cmp = [&persistences](const size_t a, const size_t b) {
-      return ((persistences[a] > persistences[b])
-              || ((persistences[a] == persistences[b]) && (a > b)));
-    };
-    std::sort(idx[i].begin(), idx[i].end(), cmp);
-    const auto size = candidates_to_be_added[i].size();
-    if(size >= max_points_to_add) {
-      double last_persistence_added
-        = persistences[idx[i][max_points_to_add - 1]];
-      if(last_persistence_added > local_min_persistence) {
-        local_min_persistence = last_persistence_added;
-      }
-    }
-    if(i == 0) {
-      new_min_persistence = local_min_persistence;
-    } else {
-      if(local_min_persistence < new_min_persistence) {
-        new_min_persistence = local_min_persistence;
-      }
-    }
-    // 3. Add the points to the current diagrams
-    const auto s = candidates_to_be_added[i].size();
-    for(size_t j = 0; j < std::min(max_points_to_add, s); j++) {
-      Bidder<double> b
-        = bidder_diags[i].get(candidates_to_be_added[i][idx[i][j]]);
-      const double persistence = b.getPersistence();
-      if(persistence >= new_min_persistence) {
+      // sort diagram pairs by persistence value
+      std::sort(
+        pairs.begin(), pairs.end(),
+        [](const PairIV &a, const PairIV &b) { return a.second < b.second; });
+      const auto firstId = pairs.size() > this->MinPointsToAdd
+                             ? pairs.size() - this->MinPointsToAdd
+                             : 0;
+      // take the last (most persistent) pairs
+      for(size_t j = firstId; j < pairs.size(); ++j) {
+        auto b = bidder_diags[i].get(pairs[j].first);
         b.id_ = current_bidder_diags[i].size();
         b.setPositionInAuction(current_bidder_diags[i].size());
         current_bidder_diags[i].addBidder(b);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -72,19 +72,19 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min,
                       current_bidder_diagrams_min);
     enrichCurrentBidderDiagrams(
-      this->MinPointsToAdd, bidder_diagrams_min, current_bidder_diagrams_min);
+      bidder_diagrams_min, current_bidder_diagrams_min);
   }
   if(this->do_sad_) {
     setBidderDiagrams(nInputs, inputDiagramsSad, bidder_diagrams_sad,
                       current_bidder_diagrams_sad);
     enrichCurrentBidderDiagrams(
-      this->MinPointsToAdd, bidder_diagrams_sad, current_bidder_diagrams_sad);
+      bidder_diagrams_sad, current_bidder_diagrams_sad);
   }
   if(this->do_max_) {
     setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max,
                       current_bidder_diagrams_max);
     enrichCurrentBidderDiagrams(
-      this->MinPointsToAdd, bidder_diagrams_max, current_bidder_diagrams_max);
+      bidder_diagrams_max, current_bidder_diagrams_max);
   }
 
   std::vector<std::vector<double>> distMat(nInputs);
@@ -213,7 +213,6 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
 }
 
 double PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
-  const size_t min_points_to_add,
   const std::vector<BidderDiagram<double>> &bidder_diags,
   std::vector<BidderDiagram<double>> &current_bidder_diags) const {
 
@@ -228,8 +227,8 @@ double PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
     max_diagram_size
       = std::max(static_cast<size_t>(diag.size()), max_diagram_size);
   }
-  size_t max_points_to_add
-    = std::max(min_points_to_add, min_points_to_add + max_diagram_size / 10);
+  size_t max_points_to_add = std::max(
+    this->MinPointsToAdd, this->MinPointsToAdd + max_diagram_size / 10);
   // 2. Get which points can be added, deduce the new minimal persistence
   std::vector<std::vector<int>> candidates_to_be_added(nInputs);
   std::vector<std::vector<size_t>> idx(nInputs);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -113,7 +113,7 @@ namespace ttk {
     void enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags,
-      const std::vector<double> &maxDiagPersistence) const;
+      const double maxDiagPersistence) const;
 
     int Wasserstein{2};
     double Alpha{1.0};

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -77,11 +77,22 @@ namespace ttk {
     inline void setDeltaLim(const double deltaLim) {
       DeltaLim = deltaLim;
     }
-    inline void setUseFullDiagrams(const bool arg) {
-      UseFullDiagrams = arg;
-    }
     inline void setMinPointsToAdd(const size_t data) {
       MinPointsToAdd = data;
+    }
+    inline void setMinPersistence(const double data) {
+      MinPersistence = data;
+    }
+    inline void setConstraint(const int data) {
+      if(data == 0) {
+        this->Constraint = ConstraintType::FULL_DIAGRAMS;
+      } else if(data == 1) {
+        this->Constraint = ConstraintType::NUMBER_PAIRS;
+      } else if(data == 2) {
+        this->Constraint = ConstraintType::ABSOLUTE_PERSISTENCE;
+      } else if(data == 3) {
+        this->Constraint = ConstraintType::RELATIVE_PERSISTENCE;
+      }
     }
 
   protected:
@@ -115,7 +126,15 @@ namespace ttk {
     // of the 2 critical points of the pair
     double Lambda;
     size_t MinPointsToAdd{20};
-    bool UseFullDiagrams{false};
+    double MinPersistence{};
     bool do_min_{true}, do_sad_{true}, do_max_{true};
+
+    enum class ConstraintType {
+      FULL_DIAGRAMS,
+      NUMBER_PAIRS,
+      ABSOLUTE_PERSISTENCE,
+      RELATIVE_PERSISTENCE
+    };
+    ConstraintType Constraint{ConstraintType::NUMBER_PAIRS};
   };
 } // namespace ttk

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -112,7 +112,6 @@ namespace ttk {
       std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags) const;
     double enrichCurrentBidderDiagrams(
-      const size_t min_points_to_add,
       const std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags) const;
 

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -114,7 +114,7 @@ namespace ttk {
     // pair sad-max) lambda = 0 : saddle (bad stability) lambda = 1/2 : middle
     // of the 2 critical points of the pair
     double Lambda;
-    size_t MinPointsToAdd{10};
+    size_t MinPointsToAdd{20};
     bool UseFullDiagrams{false};
     bool do_min_{true}, do_sad_{true}, do_max_{true};
   };

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -91,7 +91,9 @@ namespace ttk {
       } else if(data == 2) {
         this->Constraint = ConstraintType::ABSOLUTE_PERSISTENCE;
       } else if(data == 3) {
-        this->Constraint = ConstraintType::RELATIVE_PERSISTENCE;
+        this->Constraint = ConstraintType::RELATIVE_PERSISTENCE_PER_DIAG;
+      } else if(data == 4) {
+        this->Constraint = ConstraintType::RELATIVE_PERSISTENCE_GLOBAL;
       }
     }
 
@@ -113,7 +115,7 @@ namespace ttk {
     void enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags,
-      const double maxDiagPersistence) const;
+      const std::vector<double> &maxDiagPersistence) const;
 
     int Wasserstein{2};
     double Alpha{1.0};
@@ -132,7 +134,8 @@ namespace ttk {
       FULL_DIAGRAMS,
       NUMBER_PAIRS,
       ABSOLUTE_PERSISTENCE,
-      RELATIVE_PERSISTENCE
+      RELATIVE_PERSISTENCE_PER_DIAG,
+      RELATIVE_PERSISTENCE_GLOBAL,
     };
     ConstraintType Constraint{ConstraintType::NUMBER_PAIRS};
   };

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -106,11 +106,10 @@ namespace ttk {
       const std::vector<BidderDiagram<double>> &diags_min,
       const std::vector<BidderDiagram<double>> &diags_sad,
       const std::vector<BidderDiagram<double>> &diags_max) const;
-    void setBidderDiagrams(
-      const size_t nInputs,
-      std::vector<std::vector<DiagramTuple>> &inputDiagrams,
-      std::vector<BidderDiagram<double>> &bidder_diags,
-      std::vector<BidderDiagram<double>> &current_bidder_diags) const;
+    void
+      setBidderDiagrams(const size_t nInputs,
+                        std::vector<std::vector<DiagramTuple>> &inputDiagrams,
+                        std::vector<BidderDiagram<double>> &bidder_diags) const;
     double enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags) const;

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -110,7 +110,7 @@ namespace ttk {
       setBidderDiagrams(const size_t nInputs,
                         std::vector<std::vector<DiagramTuple>> &inputDiagrams,
                         std::vector<BidderDiagram<double>> &bidder_diags) const;
-    double enrichCurrentBidderDiagrams(
+    void enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,
       std::vector<BidderDiagram<double>> &current_bidder_diags,
       const std::vector<double> &maxDiagPersistence) const;

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -112,7 +112,8 @@ namespace ttk {
                         std::vector<BidderDiagram<double>> &bidder_diags) const;
     double enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,
-      std::vector<BidderDiagram<double>> &current_bidder_diags) const;
+      std::vector<BidderDiagram<double>> &current_bidder_diags,
+      const std::vector<double> &maxDiagPersistence) const;
 
     int Wasserstein{2};
     double Alpha{1.0};

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -127,7 +127,7 @@ namespace ttk {
     // of the 2 critical points of the pair
     double Lambda;
     size_t MaxNumberOfPairs{20};
-    double MinPersistence{};
+    double MinPersistence{0.1};
     bool do_min_{true}, do_sad_{true}, do_max_{true};
 
     enum class ConstraintType {
@@ -137,6 +137,6 @@ namespace ttk {
       RELATIVE_PERSISTENCE_PER_DIAG,
       RELATIVE_PERSISTENCE_GLOBAL,
     };
-    ConstraintType Constraint{ConstraintType::NUMBER_PAIRS};
+    ConstraintType Constraint{ConstraintType::RELATIVE_PERSISTENCE_GLOBAL};
   };
 } // namespace ttk

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -77,8 +77,8 @@ namespace ttk {
     inline void setDeltaLim(const double deltaLim) {
       DeltaLim = deltaLim;
     }
-    inline void setMinPointsToAdd(const size_t data) {
-      MinPointsToAdd = data;
+    inline void setMaxNumberOfPairs(const size_t data) {
+      MaxNumberOfPairs = data;
     }
     inline void setMinPersistence(const double data) {
       MinPersistence = data;
@@ -124,7 +124,7 @@ namespace ttk {
     // pair sad-max) lambda = 0 : saddle (bad stability) lambda = 1/2 : middle
     // of the 2 critical points of the pair
     double Lambda;
-    size_t MinPointsToAdd{20};
+    size_t MaxNumberOfPairs{20};
     double MinPersistence{};
     bool do_min_{true}, do_sad_{true}, do_max_{true};
 

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
@@ -96,11 +96,29 @@ public:
     return -1;
   }
 
-  vtkSetMacro(UseFullDiagrams, bool);
-  vtkGetMacro(UseFullDiagrams, bool);
+  void SetConstraint(const int arg_) {
+    this->setConstraint(arg_);
+    this->Modified();
+  }
+  int GetConstraint() {
+    switch(this->Constraint) {
+      case ConstraintType::FULL_DIAGRAMS:
+        return 0;
+      case ConstraintType::NUMBER_PAIRS:
+        return 1;
+      case ConstraintType::ABSOLUTE_PERSISTENCE:
+        return 2;
+      case ConstraintType::RELATIVE_PERSISTENCE:
+        return 3;
+    }
+    return -1;
+  }
 
   vtkSetMacro(MinPointsToAdd, unsigned int);
   vtkGetMacro(MinPointsToAdd, unsigned int);
+
+  vtkSetMacro(MinPersistence, double);
+  vtkGetMacro(MinPersistence, double);
 
 protected:
   ttkPersistenceDiagramDistanceMatrix();

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
@@ -114,8 +114,8 @@ public:
     return -1;
   }
 
-  vtkSetMacro(MinPointsToAdd, unsigned int);
-  vtkGetMacro(MinPointsToAdd, unsigned int);
+  vtkSetMacro(MaxNumberOfPairs, unsigned int);
+  vtkGetMacro(MaxNumberOfPairs, unsigned int);
 
   vtkSetMacro(MinPersistence, double);
   vtkGetMacro(MinPersistence, double);

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
@@ -108,8 +108,10 @@ public:
         return 1;
       case ConstraintType::ABSOLUTE_PERSISTENCE:
         return 2;
-      case ConstraintType::RELATIVE_PERSISTENCE:
+      case ConstraintType::RELATIVE_PERSISTENCE_PER_DIAG:
         return 3;
+      case ConstraintType::RELATIVE_PERSISTENCE_GLOBAL:
+        return 4;
     }
     return -1;
   }

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -125,7 +125,7 @@
           label="Filter Pairs"
           command="SetConstraint"
           number_of_elements="1"
-          default_values="1"
+          default_values="4"
           panel_visibility="advanced"
           >
         <EnumerationDomain name="enum">
@@ -187,7 +187,7 @@
           command="SetMinPersistence"
           label="Minimum Relative Persistence"
           number_of_elements="1"
-          default_values="0.0"
+          default_values="0.1"
           panel_visibility="advanced"
           >
         <DoubleRangeDomain name="range" min="0.0" max="1.0" />

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -121,9 +121,28 @@
       </DoubleVectorProperty>
 
       <IntVectorProperty
+          name="Constraint"
+          label="Constrain Pairs"
+          command="SetConstraint"
+          number_of_elements="1"
+          default_values="1"
+          panel_visibility="advanced"
+          >
+        <EnumerationDomain name="enum">
+          <Entry value="0" text="Use Full Diagrams (SLOW!)"/>
+          <Entry value="1" text="Number Of Pairs"/>
+          <Entry value="2" text="Absolute Persistence"/>
+          <Entry value="3" text="Relative Persistence"/>
+        </EnumerationDomain>
+        <Documentation>
+          Filter the input diagrams pairs.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
           name="MinPointsToAdd"
           command="SetMinPointsToAdd"
-          label="Number of Pairs"
+          label="Number Of Pairs"
           number_of_elements="1"
           default_values="20"
           panel_visibility="advanced"
@@ -132,8 +151,8 @@
           <PropertyWidgetDecorator
               type="GenericDecorator"
               mode="visibility"
-              property="UseFullDiagrams"
-              value="0" />
+              property="Constraint"
+              value="1" />
         </Hints>
         <Documentation>
           Number of high-persistence diagrams pairs to take into
@@ -141,18 +160,48 @@
         </Documentation>
       </IntVectorProperty>
 
-      <IntVectorProperty
-          name="UseFullDiagrams"
-          label="Use Full Diagrams (SLOW!)"
-          command="SetUseFullDiagrams"
+      <DoubleVectorProperty
+          name="MinAbsPersistence"
+          command="SetMinPersistence"
+          label="Minimum Absolute Persistence"
           number_of_elements="1"
-          default_values="0"
-          panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
+          default_values="0.0"
+          panel_visibility="advanced"
+          >
+        <Hints>
+          <PropertyWidgetDecorator
+              type="GenericDecorator"
+              mode="visibility"
+              property="Constraint"
+              value="2" />
+        </Hints>
         <Documentation>
-          Compute the distance matrix between the full diagrams.
+          Minimum absolute persistence of diagram pairs to take into
+          account to compute distance.
         </Documentation>
-      </IntVectorProperty>
+      </DoubleVectorProperty>
+
+      <DoubleVectorProperty
+          name="MinRelPersistence"
+          command="SetMinPersistence"
+          label="Minimum Relative Persistence"
+          number_of_elements="1"
+          default_values="0.0"
+          panel_visibility="advanced"
+          >
+        <DoubleRangeDomain name="range" min="0.0" max="1.0" />
+        <Hints>
+          <PropertyWidgetDecorator
+              type="GenericDecorator"
+              mode="visibility"
+              property="Constraint"
+              value="3" />
+        </Hints>
+        <Documentation>
+          Minimum relative persistence of diagram pairs to take into
+          account to compute distance.
+        </Documentation>
+      </DoubleVectorProperty>
 
       ${DEBUG_WIDGETS}
 

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -132,7 +132,8 @@
           <Entry value="0" text="Use Full Diagrams (SLOW!)"/>
           <Entry value="1" text="Number Of Pairs"/>
           <Entry value="2" text="Absolute Persistence"/>
-          <Entry value="3" text="Relative Persistence"/>
+          <Entry value="3" text="Relative Persistence (Per Diagram)"/>
+          <Entry value="4" text="Relative Persistence (All Diagrams)"/>
         </EnumerationDomain>
         <Documentation>
           Filter the input diagrams pairs.
@@ -191,11 +192,18 @@
           >
         <DoubleRangeDomain name="range" min="0.0" max="1.0" />
         <Hints>
-          <PropertyWidgetDecorator
-              type="GenericDecorator"
-              mode="visibility"
-              property="Constraint"
-              value="3" />
+          <Expression type="or">
+            <PropertyWidgetDecorator
+                type="GenericDecorator"
+                mode="visibility"
+                property="Constraint"
+                value="3" />
+            <PropertyWidgetDecorator
+                type="GenericDecorator"
+                mode="visibility"
+                property="Constraint"
+                value="4" />
+          </Expression>
         </Hints>
         <Documentation>
           Minimum relative persistence of diagram pairs to take into

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -125,7 +125,7 @@
           command="SetMinPointsToAdd"
           label="Number of Pairs"
           number_of_elements="1"
-          default_values="10"
+          default_values="20"
           panel_visibility="advanced"
           >
         <Hints>

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -122,7 +122,7 @@
 
       <IntVectorProperty
           name="Constraint"
-          label="Constrain Pairs"
+          label="Filter Pairs"
           command="SetConstraint"
           number_of_elements="1"
           default_values="1"
@@ -140,8 +140,8 @@
       </IntVectorProperty>
 
       <IntVectorProperty
-          name="MinPointsToAdd"
-          command="SetMinPointsToAdd"
+          name="MaxNumberOfPairs"
+          command="SetMaxNumberOfPairs"
           label="Number Of Pairs"
           number_of_elements="1"
           default_values="20"


### PR DESCRIPTION
This PR adds the support of three new ways of filtering out pairs in the PersistenceDiagramDistanceMatrix module:

- filtering out pairs under a global, absolute persistence level threshold,
- filtering out pairs under a per-diagram persistence threshold relative to the diagram's highest persistence pair,
- filtering out pairs under a persistence threshold relative to the highest persistence pair of all diagrams.

The two other methods, using all pairs and only using the N most persistence pairs, were left unaltered. Although the code for using the N most persistence pairs is complex and might be buggy (according to Jules), it is quicker and seems to produce better results than my alternative and simpler re-implementation. This is still the default filter method, however, I raised the default number of pairs to keep from 10 to 20 (after some tests, 10 seems to not be enough).

Enjoy,
Pierre