### PR TITLE
[api-migration-hackathon] ttkBlockAggregator Update

### DIFF
--- a/core/vtk/ttkBlockAggregator/ttkBlockAggregator.h
+++ b/core/vtk/ttkBlockAggregator/ttkBlockAggregator.h
@@ -3,10 +3,10 @@
 /// \author Jonas Lukasczyk <jl@jluk.de>
 /// \date 01.11.2020
 ///
-/// \brief TTK VTK-filter that iteratively adds its input data objects as blocks
-/// to a vtkMultiBlockDataSet.
+/// \brief TTK VTK-filter that appends every input vtkDataObject as a block to
+/// an output vtkMultiBlockDataSet.
 ///
-/// This filter iteratively appends its input as a block to a
+/// This filter appends every input vtkDataObject as a block to an output
 /// vtkMultiBlockDataSet.
 ///
 /// \param Input vtkDataObject that will be added as a block.
@@ -21,6 +21,7 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 #include <vtkSmartPointer.h>
+
 class vtkMultiBlockDataSet;
 
 class TTKBLOCKAGGREGATOR_EXPORT ttkBlockAggregator : public ttkAlgorithm {
@@ -28,7 +29,6 @@ private:
   bool ForceReset{false};
   bool FlattenInput{true};
   vtkSmartPointer<vtkMultiBlockDataSet> AggregatedMultiBlockDataSet;
-  int Reset();
 
 public:
   vtkSetMacro(ForceReset, bool);
@@ -39,6 +39,8 @@ public:
   static ttkBlockAggregator *New();
   vtkTypeMacro(ttkBlockAggregator, ttkAlgorithm);
 
+  int Reset();
+
 protected:
   ttkBlockAggregator();
   ~ttkBlockAggregator() override;
@@ -48,5 +50,5 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
-  int AggregateBlock(vtkDataObject *dataObject, bool useShallowCopy);
+  int AggregateBlock(vtkDataObject *dataObject);
 };

--- a/paraview/BlockAggregator/BlockAggregator.xml
+++ b/paraview/BlockAggregator/BlockAggregator.xml
@@ -2,56 +2,16 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
         <SourceProxy name="BlockAggregator" class="ttkBlockAggregator" label="TTK BlockAggregator">
-           <Documentation long_help="TODO" short_help="TODO">
-               TODO
-           </Documentation>
+            <Documentation long_help="ttkBlockAggregator" short_help="ttkBlockAggregator">
+            This filter appends every input vtkDataObject as a block to an output vtkMultiBlockDataSet.
+            </Documentation>
 
-           <InputProperty name="Block0" port_index="0" command="SetInputConnection">
+            <InputProperty name="Input" port_index="0" clean_command="RemoveAllInputs" command="AddInputConnection" multiple_input="1">
                 <ProxyGroupDomain name="groups">
                     <Group name="sources" />
                     <Group name="filters" />
                 </ProxyGroupDomain>
-                <Documentation>vtkDataObject that will be added as a block.</Documentation>
-            </InputProperty>
-            <InputProperty name="Block1" port_index="1" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <Documentation>vtkDataObject that will be added as a block.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="Block2" port_index="2" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <Documentation>vtkDataObject that will be added as a block.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="Block3" port_index="3" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <Documentation>vtkDataObject that will be added as a block.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
-            </InputProperty>
-            <InputProperty name="Block4" port_index="4" command="SetInputConnection">
-                <ProxyGroupDomain name="groups">
-                    <Group name="sources" />
-                    <Group name="filters" />
-                </ProxyGroupDomain>
-                <Documentation>vtkDataObject that will be added as a block.</Documentation>
-                <Hints>
-                    <Optional />
-                </Hints>
+                <Documentation>vtkDataObjects that will be added as blocks.</Documentation>
             </InputProperty>
 
             <IntVectorProperty name="ForceReset" label="Force Reset" command="SetForceReset" number_of_elements="1" default_values="0">
@@ -60,7 +20,7 @@
             </IntVectorProperty>
             <IntVectorProperty name="FlattenInput" label="Flatten Input" command="SetFlattenInput" number_of_elements="1" default_values="1">
                 <BooleanDomain name="bool" />
-                <Documentation>If enabled and input is a 'vtkMultiBlockDataSet' then this filter will add its blocks to the output and not the vtkMultiBlockDataSet.</Documentation>
+                <Documentation>If enabled and if the input vtkDataObject is a 'vtkMultiBlockDataSet' then this filter will add its blocks to the output and not the vtkMultiBlockDataSet itself.</Documentation>
             </IntVectorProperty>
 
             ${DEBUG_WIDGETS}


### PR DESCRIPTION
This PR updates the ttkBlockAggregator module to now accept an unlimited number of input data objects by making the first port repeatable. In the past this filter had 5 hardcoded  optional inputs.

This update effects the nestedTrackingGraph state file in ttk-data (see related PR in ttk-data).