### PR TITLE
[api-migration-hackathon] New data array management for PointSetToCurve, StringArrayConverter & LDistanteMatrix

### DIFF
--- a/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.cpp
+++ b/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.cpp
@@ -83,12 +83,11 @@ int ttkLDistanceMatrix::RequestData(vtkInformation * /*request*/,
 
   std::vector<void *> inputPtrs(nInputs);
   for(size_t i = 0; i < nInputs; ++i) {
-    inputPtrs[i] = ttkUtils::GetVoidPointer(
-      inputData[i]->GetPointData()->GetArray(this->ScalarField.data()));
+    inputPtrs[i]
+      = ttkUtils::GetVoidPointer(this->GetInputArrayToProcess(0, inputData[i]));
   }
 
-  const auto firstField
-    = inputData[0]->GetPointData()->GetArray(this->ScalarField.data());
+  const auto firstField = this->GetInputArrayToProcess(0, inputData[0]);
   const auto dataType = firstField->GetDataType();
   const size_t nPoints = firstField->GetNumberOfTuples();
 

--- a/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.h
+++ b/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.h
@@ -26,9 +26,6 @@ public:
 
   vtkTypeMacro(ttkLDistanceMatrix, ttkAlgorithm);
 
-  vtkSetMacro(ScalarField, std::string);
-  vtkGetMacro(ScalarField, std::string);
-
   vtkSetMacro(DistanceType, std::string);
   vtkGetMacro(DistanceType, std::string);
 
@@ -42,7 +39,4 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
-
-private:
-  std::string ScalarField{};
 };

--- a/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
+++ b/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
@@ -63,14 +63,11 @@ int ttkPointSetToCurve::RequestData(vtkInformation *request,
     return 0;
   }
 
-  // point data
-  const auto pd = input->GetPointData();
   // ordering array
-  const auto oa = pd->GetAbstractArray(this->InputOrderingArray.data());
+  const auto oa = this->GetInputArrayToProcess(0, inputVector);
 
   if(oa == nullptr) {
-    this->printErr("Cannot find any data array with the name "
-                   + this->InputOrderingArray);
+    this->printErr("Cannot find the required data array");
     return 0;
   }
 

--- a/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.h
+++ b/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.h
@@ -25,9 +25,6 @@ public:
   static ttkPointSetToCurve *New();
   vtkTypeMacro(ttkPointSetToCurve, ttkAlgorithm);
 
-  vtkSetMacro(InputOrderingArray, std::string);
-  vtkGetMacro(InputOrderingArray, std::string);
-
   vtkSetMacro(CloseCurve, bool);
   vtkGetMacro(CloseCurve, bool);
 
@@ -47,6 +44,5 @@ protected:
                 const size_t nvalues);
 
 private:
-  std::string InputOrderingArray{};
   bool CloseCurve{false};
 };

--- a/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.cpp
+++ b/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.cpp
@@ -3,6 +3,7 @@
 #include <vtkDataSet.h>
 #include <vtkFieldData.h>
 #include <vtkIdTypeArray.h>
+#include <vtkInformation.h>
 #include <vtkPointData.h>
 #include <vtkStringArray.h>
 
@@ -49,15 +50,12 @@ int ttkStringArrayConverter::RequestData(vtkInformation *request,
     return 0;
   }
 
-  // point data
-  const auto pd = input->GetPointData();
   // string array
   const auto sa = vtkStringArray::SafeDownCast(
-    pd->GetAbstractArray(this->InputStringArray.data()));
+    this->GetInputAbstractArrayToProcess(0, inputVector));
 
   if(sa == nullptr) {
-    this->printErr("Cannot find any string array with the name "
-                   + this->InputStringArray);
+    this->printErr("Cannot find the required string array");
     return 0;
   }
 
@@ -87,7 +85,8 @@ int ttkStringArrayConverter::RequestData(vtkInformation *request,
   // array of indices
   vtkNew<vtkIdTypeArray> ia{};
   // array name
-  std::string colname = this->InputStringArray + "Int";
+  std::string colname{sa->GetName()};
+  colname += "Int";
   ia->SetName(colname.data());
   ia->SetNumberOfTuples(nvalues);
   // fill array with corresponding string values indices

--- a/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.h
+++ b/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.h
@@ -18,7 +18,6 @@
 
 // VTK includes
 #include <ttkAlgorithm.h>
-#include <vtkInformation.h>
 
 class TTKSTRINGARRAYCONVERTER_EXPORT ttkStringArrayConverter
   : public ttkAlgorithm {
@@ -26,9 +25,6 @@ class TTKSTRINGARRAYCONVERTER_EXPORT ttkStringArrayConverter
 public:
   static ttkStringArrayConverter *New();
   vtkTypeMacro(ttkStringArrayConverter, ttkAlgorithm);
-
-  vtkSetMacro(InputStringArray, std::string);
-  vtkGetMacro(InputStringArray, std::string);
 
 protected:
   ttkStringArrayConverter();
@@ -40,7 +36,4 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
-
-private:
-  std::string InputStringArray{};
 };

--- a/paraview/LDistanceMatrix/LDistanceMatrix.xml
+++ b/paraview/LDistanceMatrix/LDistanceMatrix.xml
@@ -29,11 +29,12 @@
       </InputProperty>
 
       <StringVectorProperty
-        name="ScalarField"
-        command="SetScalarField"
-        number_of_elements="1"
+        name="Scalar Field"
+        command="SetInputArrayToProcess"
+        element_types="0 0 0 0 2"
+        number_of_elements="5"
+        default_values="0"
         animateable="0"
-        label="Scalar Field"
         >
         <ArrayListDomain
           name="array_list"

--- a/paraview/PointSetToCurve/PointSetToCurve.xml
+++ b/paraview/PointSetToCurve/PointSetToCurve.xml
@@ -30,15 +30,15 @@
 
       <StringVectorProperty
           name="InputOrderingArray"
-          command="SetInputOrderingArray"
+          command="SetInputArrayToProcess"
           label="Input Ordering Array"
-          number_of_elements="1"
+          element_types="0 0 0 0 2"
+          default_values="0"
+          number_of_elements="5"
           animateable="0"
           >
         <ArrayListDomain
             name="array_list"
-            attribute_type="Scalars"
-            input_domain_name="inputs_array"
             default_values="0"
             >
           <RequiredProperties>

--- a/paraview/StringArrayConverter/StringArrayConverter.xml
+++ b/paraview/StringArrayConverter/StringArrayConverter.xml
@@ -31,10 +31,11 @@
       </InputProperty>
 
       <StringVectorProperty
-          name="InputStringArray"
-          command="SetInputStringArray"
-          label="Input String Array"
-          number_of_elements="1"
+          name="Input String Array"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
           animateable="0"
           >
         <ArrayListDomain
@@ -54,7 +55,7 @@
       </StringVectorProperty>
 
       <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="InputStringArray" />
+        <Property name="Input String Array" />
       </PropertyGroup>
 
       <Hints>


### PR DESCRIPTION
In this PR, PointSetToCurve, StringArrayConverter and LDistanceMatrix were converted to use the `GetInputArrayToProcess` and `SetInputArrayToProcess` methods.

Since no ttk-data state file use those filters, no PR for ttk-data.

Enjoy,
Pierre
