### PR TITLE
[api-migration-hackathon] Tracking from overlap migration

### DIFF
--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -24,9 +24,7 @@
 #include <boost/variant.hpp>
 #include <map>
 #include <unordered_map>
-
-// base code includes
-#include <Wrapper.h>
+#include <Debug.h>
 
 using namespace std;
 
@@ -82,16 +80,18 @@ struct CoordinateComparator {
 };
 
 namespace ttk {
-  class TrackingFromOverlap : public Debug {
+  class TrackingFromOverlap : virtual public Debug {
   public:
-    TrackingFromOverlap(){};
+    TrackingFromOverlap(){
+        this->setDebugMsgPrefix("TrackingFromOverlap");
+    };
     ~TrackingFromOverlap(){};
 
     // This function sorts points based on their x, y, and then z coordinate
     int sortCoordinates(const float *pointCoordinates,
                         const size_t nPoints,
                         vector<size_t> &sortedIndicies) const {
-      dMsg(cout, "[ttkTrackingFromOverlap] Sorting coordinates ... ", timeMsg);
+      printMsg("Sorting coordinates ... ", debug::Priority::PERFORMANCE);
       Timer t;
 
       sortedIndicies.resize(nPoints);
@@ -101,15 +101,15 @@ namespace ttk {
       sort(sortedIndicies.begin(), sortedIndicies.end(), c);
 
       stringstream msg;
-      msg << "done (" << t.getElapsedTime() << " s)." << endl;
-      dMsg(cout, msg.str(), timeMsg);
+      msg << "done (" << t.getElapsedTime() << " s).";
+      printMsg(msg.str(), debug::Priority::PERFORMANCE);
 
       return 1;
     }
 
     int computeBranches(vector<Edges> &timeEdgesMap,
                         vector<Nodes> &timeNodesMap) const {
-      dMsg(cout, "[ttkTrackingFromOverlap] Computing branches  ... ", timeMsg);
+      printMsg("Computing branches  ... ", debug::Priority::PERFORMANCE);
       Timer tm;
 
       size_t nT = timeNodesMap.size();
@@ -199,8 +199,8 @@ namespace ttk {
       }
 
       stringstream msg;
-      msg << "done (" << tm.getElapsedTime() << " s)." << endl;
-      dMsg(cout, msg.str(), timeMsg);
+      msg << "done (" << tm.getElapsedTime() << " s).";
+      printMsg(msg.str(), debug::Priority::PERFORMANCE);
 
       return 1;
     }
@@ -259,7 +259,7 @@ int ttk::TrackingFromOverlap::computeNodes(const float *pointCoordinates,
                                            const labelType *pointLabels,
                                            const size_t nPoints,
                                            Nodes &nodes) const {
-  dMsg(cout, "[ttkTrackingFromOverlap] Identifying nodes ..... ", timeMsg);
+  printMsg("Identifying nodes ..... ", debug::Priority::PERFORMANCE);
 
   Timer t;
 
@@ -290,9 +290,8 @@ int ttk::TrackingFromOverlap::computeNodes(const float *pointCoordinates,
   // Print Status
   {
     stringstream msg;
-    msg << "done (#" << nNodes << " in " << t.getElapsedTime() << " s)."
-        << endl;
-    dMsg(cout, msg.str(), timeMsg);
+    msg << "done (#" << nNodes << " in " << t.getElapsedTime() << " s).";
+    printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 1;
@@ -329,7 +328,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   // -------------------------------------------------------------------------
   // Track Nodes
   // -------------------------------------------------------------------------
-  dMsg(cout, "[ttkTrackingFromOverlap] Tracking .............. ", timeMsg);
+  printMsg("Tracking .............. ", debug::Priority::PERFORMANCE);
   Timer t;
 
   /* Function that determines configuration of point p0 and p1:
@@ -424,9 +423,8 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   // Print Status
   {
     stringstream msg;
-    msg << "done (#" << nEdges << " in " << t.getElapsedTime() << " s)."
-        << endl;
-    dMsg(cout, msg.str(), timeMsg);
+    msg << "done (#" << nEdges << " in " << t.getElapsedTime() << " s).";
+    printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 0;

--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include <Debug.h>
 #include <algorithm>
 #include <boost/variant.hpp>
 #include <map>
 #include <unordered_map>
-#include <Debug.h>
 
 using namespace std;
 
@@ -82,8 +82,8 @@ struct CoordinateComparator {
 namespace ttk {
   class TrackingFromOverlap : virtual public Debug {
   public:
-    TrackingFromOverlap(){
-        this->setDebugMsgPrefix("TrackingFromOverlap");
+    TrackingFromOverlap() {
+      this->setDebugMsgPrefix("TrackingFromOverlap");
     };
     ~TrackingFromOverlap(){};
 

--- a/core/vtk/ttkTrackingFromOverlap/ttk.module
+++ b/core/vtk/ttkTrackingFromOverlap/ttk.module
@@ -6,6 +6,6 @@ HEADERS
   ttkTrackingFromOverlap.h
 DEPENDS
   trackingFromOverlap
-  ttkTriangulationAlgorithm
+  ttkAlgorithm
   Boost::boost
   Boost::system

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -11,6 +11,11 @@
 #include <vtkIdTypeArray.h>
 #include <vtkLongLongArray.h>
 #include <vtkPointData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+
+#include <ttkUtils.h>
+#include <ttkMacros.h>
 
 using namespace std;
 using namespace ttk;
@@ -23,10 +28,10 @@ vtkStandardNewMacro(ttkTrackingFromOverlap)
                size_t level,
                string labelFieldName,
                vtkPointSet *&pointSet,
-               vtkAbstractArray *&labels) {
+               vtkDataArray *&labels) {
   auto timesteps = vtkMultiBlockDataSet::SafeDownCast(mb->GetBlock(level));
   pointSet = vtkPointSet::SafeDownCast(timesteps->GetBlock(time));
-  labels = pointSet->GetPointData()->GetAbstractArray(labelFieldName.data());
+  labels = pointSet->GetPointData()->GetArray(labelFieldName.data());
 };
 
 // Function to compute number of levels and timesteps contained in a
@@ -71,28 +76,28 @@ int finalize(vector<vector<Nodes>> &levelTimeNodesMap,
 
     auto points = vtkSmartPointer<vtkPoints>::New();
     points->SetNumberOfPoints(nNodes);
-    auto pointCoords = (float *)points->GetVoidPointer(0);
+    auto pointCoords = (float *)ttkUtils::GetVoidPointer(points);
 
     auto sequence = vtkSmartPointer<vtkLongLongArray>::New();
     prepArray(sequence, "SequenceIndex", 1, nNodes);
-    auto sequenceData = (long long *)sequence->GetVoidPointer(0);
+    auto sequenceData = (long long *)ttkUtils::GetVoidPointer(sequence);
 
     auto level = vtkSmartPointer<vtkLongLongArray>::New();
     prepArray(level, "LevelIndex", 1, nNodes);
-    auto levelData = (long long *)level->GetVoidPointer(0);
+    auto levelData = (long long *)ttkUtils::GetVoidPointer(level);
 
     auto size = vtkSmartPointer<vtkFloatArray>::New();
     prepArray(size, "Size", 1, nNodes);
-    auto sizeData = (float *)size->GetVoidPointer(0);
+    auto sizeData = (float *)ttkUtils::GetVoidPointer(size);
 
     auto branch = vtkSmartPointer<vtkLongLongArray>::New();
     prepArray(branch, "BranchId", 1, nNodes);
-    auto branchData = (long long *)branch->GetVoidPointer(0);
+    auto branchData = (long long *)ttkUtils::GetVoidPointer(branch);
 
     auto label = vtkSmartPointer<vtkDataArray>::Take(
       vtkDataArray::CreateDataArray(labelTypeId));
     prepArray(label, labelFieldName, 1, nNodes);
-    auto labelData = (labelType *)label->GetVoidPointer(0);
+    auto labelData = (labelType *)ttkUtils::GetVoidPointer(label);
 
     size_t q1 = 0, q2 = 0;
     for(size_t t = 0; t < nT; t++) {
@@ -152,19 +157,19 @@ int finalize(vector<vector<Nodes>> &levelTimeNodesMap,
 
     auto cells = vtkSmartPointer<vtkIdTypeArray>::New();
     cells->SetNumberOfValues(3 * nEdgesT + 3 * nEdgesN);
-    auto cellIds = (vtkIdType *)cells->GetVoidPointer(0);
+    auto cellIds = (vtkIdType *)ttkUtils::GetVoidPointer(cells);
 
     auto overlap = vtkSmartPointer<vtkFloatArray>::New();
     prepArray(overlap, "Overlap", 1, nEdgesT + nEdgesN);
-    auto overlapData = (float *)overlap->GetVoidPointer(0);
+    auto overlapData = (float *)ttkUtils::GetVoidPointer(overlap);
 
     auto branch = vtkSmartPointer<vtkLongLongArray>::New();
     prepArray(branch, "BranchId", 1, nEdgesT + nEdgesN);
-    auto branchData = (long long *)branch->GetVoidPointer(0);
+    auto branchData = (long long *)ttkUtils::GetVoidPointer(branch);
 
     auto type = vtkSmartPointer<vtkCharArray>::New();
     prepArray(type, "Type", 1, nEdgesT + nEdgesN);
-    auto typeData = (char *)type->GetVoidPointer(0);
+    auto typeData = (char *)ttkUtils::GetVoidPointer(type);
 
     size_t q0 = 0, q1 = 0;
 
@@ -227,12 +232,9 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
   vtkDataObject *trackingGraph) {
   Timer t;
 
-  dMsg(cout,
-       "[ttkTrackingFromOverlap] "
-       "=======================================================\n",
-       infoMsg);
-  dMsg(
-    cout, "[ttkTrackingFromOverlap] Meshing nested tracking graph\n", infoMsg);
+  printMsg("=======================================================\n",
+       debug::Priority::INFO);
+  printMsg("Meshing nested tracking graph\n", debug::Priority::INFO);
 
   switch(this->LabelDataType) {
     vtkTemplateMacro(
@@ -241,14 +243,11 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
                        this->GetLabelFieldName(), trackingGraph));
   }
 
+  printMsg("-------------------------------------------------------");
   stringstream msg;
-  msg << "[ttkTrackingFromOverlap] "
-         "-------------------------------------------------------"
-      << endl
-      << "[ttkTrackingFromOverlap] Nested tracking graph meshed in "
-      << t.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
-      << endl;
-  dMsg(cout, msg.str(), timeMsg);
+  msg << "Nested tracking graph meshed in "
+      << t.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
+  printMsg( msg.str(), debug::Priority::PERFORMANCE);
 
   return 1;
 }
@@ -331,10 +330,8 @@ int ttkTrackingFromOverlap::packInputData(
   }
 
   if(error) {
-    dMsg(cerr,
-         "[ttkTrackingFromOverlap] ERROR: Unable to convert input into "
-         "'vtkPointSet' collection.\n",
-         fatalMsg);
+    printErr("Unable to convert input into "
+         "'vtkPointSet' collection.\n");
     return 0;
   }
 
@@ -349,10 +346,8 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
   size_t nT = 0;
 
   if(nL < 1) {
-    dMsg(cerr,
-         "[ttkTrackingFromOverlap] ERROR: Input must have at least one "
-         "vtkPointSet.\n",
-         fatalMsg);
+    printErr("Input must have at least one "
+         "vtkPointSet.\n");
     return 0;
   }
 
@@ -360,18 +355,14 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
     auto timesteps = vtkMultiBlockDataSet::SafeDownCast(data->GetBlock(l));
     size_t n = timesteps->GetNumberOfBlocks();
     if(n < 1) {
-      dMsg(cerr,
-           "[ttkTrackingFromOverlap] ERROR: Input must have at least one "
-           "vtkPointSet.\n",
-           fatalMsg);
+      printErr("Input must have at least one "
+           "vtkPointSet.\n");
       return 0;
     }
     if(nT == 0)
       nT = n;
     if(nT != n) {
-      dMsg(cerr,
-           "[ttkTrackingFromOverlap] ERROR: Timeseries have unequal length.\n",
-           fatalMsg);
+      printErr("Timeseries have unequal length.\n");
       return 0;
     }
 
@@ -382,10 +373,8 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
         this->GetLabelFieldName().data());
 
       if(nPoints > 0 && labels == nullptr) {
-        dMsg(cout,
-             "[ttkTrackingFromOverlap] ERROR: Point labels '"
-               + this->GetLabelFieldName() + "' not found.\n",
-             fatalMsg);
+        printErr("Point labels '"
+               + this->GetLabelFieldName() + "' not found.\n");
         return 0;
       }
       if(labels == nullptr)
@@ -395,10 +384,8 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
       if(this->LabelDataType < 0)
         this->LabelDataType = labelDataType;
       if(this->LabelDataType != labelDataType) {
-        dMsg(cout,
-             "[ttkTrackingFromOverlap] ERROR: Point labels do not have same "
-             "type across point sets.\n",
-             fatalMsg);
+        printErr("Point labels do not have same "
+             "type across point sets.\n");
         return 0;
       }
     }
@@ -415,9 +402,7 @@ int ttkTrackingFromOverlap::packStreamedData(vtkMultiBlockDataSet *streamedData,
   size_t nL_PI = this->previousIterationData->GetNumberOfBlocks();
   size_t nL_CI = streamedData->GetNumberOfBlocks();
   if(nL_PI != nL_CI) {
-    dMsg(cout,
-         "[ttkTrackingFromOverlap] ERROR: Number of levels differ over time.\n",
-         fatalMsg);
+    printErr("Number of levels differ over time.\n");
     return 0;
   }
   for(size_t l = 0; l < nL_PI; l++) {
@@ -480,27 +465,23 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
 
   // Reusable variables
   vtkPointSet *pointSet = nullptr;
-  vtkAbstractArray *labels = nullptr;
+  vtkDataArray *labels = nullptr;
 
   // Compute Nodes
   {
-    dMsg(cout,
-         "[ttkTrackingFromOverlap] "
-         "=======================================================\n",
-         infoMsg);
-    dMsg(cout, "[ttkTrackingFromOverlap] Computing nodes\n", infoMsg);
+    printMsg("=======================================================\n",
+         debug::Priority::INFO);
+    printMsg( "Computing nodes\n", debug::Priority::INFO);
 
     if(this->levelTimeNodesMap.size() != nL)
       this->levelTimeNodesMap.resize(nL);
 
     for(size_t l = 0; l < nL; l++) {
       {
+          printMsg("-------------------------------------------------------");
         stringstream msg;
-        msg << "[ttkTrackingFromOverlap] "
-               "-------------------------------------------------------"
-            << endl
-            << "[ttkTrackingFromOverlap] Level Index: " << l << endl;
-        dMsg(cout, msg.str(), infoMsg);
+        msg << "Level Index: " << l;
+        printMsg( msg.str(), debug::Priority::INFO);
       }
 
       vector<Nodes> &timeNodesMap = this->levelTimeNodesMap[l];
@@ -515,23 +496,21 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
           continue;
 
         switch(this->LabelDataType) {
-          vtkTemplateMacro(this->trackingFromOverlap.computeNodes<VTK_TT>(
-            (float *)pointSet->GetPoints()->GetVoidPointer(0),
-            (VTK_TT *)labels->GetVoidPointer(0), nPoints,
+          vtkTemplateMacro(this->ttk::TrackingFromOverlap::computeNodes<VTK_TT>(
+            (float *)ttkUtils::GetVoidPointer(pointSet->GetPoints()),
+            (VTK_TT *)ttkUtils::GetVoidPointer(labels), nPoints,
             timeNodesMap[timeOffset + t]));
         }
       }
     }
 
     {
+        printMsg("-------------------------------------------------------");
       stringstream msg;
-      msg << "[ttkTrackingFromOverlap] "
-             "-------------------------------------------------------"
-          << endl
-          << "[ttkTrackingFromOverlap] Nodes computed in "
+      msg << "Nodes computed in "
           << timer.getElapsedTime() << " s. (" << threadNumber_
-          << " thread(s))." << endl;
-      dMsg(cout, msg.str(), timeMsg);
+          << " thread(s)).";
+      printMsg( msg.str(), debug::Priority::PERFORMANCE);
     }
   }
 
@@ -554,26 +533,22 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
   // Reusable variables
   vtkPointSet *pointSet0 = nullptr;
   vtkPointSet *pointSet1 = nullptr;
-  vtkAbstractArray *labels0 = nullptr;
-  vtkAbstractArray *labels1 = nullptr;
+  vtkDataArray *labels0 = nullptr;
+  vtkDataArray *labels1 = nullptr;
 
-  dMsg(cout,
-       "[ttkTrackingFromOverlap] "
-       "=======================================================\n",
-       infoMsg);
-  dMsg(cout, "[ttkTrackingFromOverlap] Computing tracking graphs\n", infoMsg);
+  printMsg("=======================================================\n",
+       debug::Priority::INFO);
+  printMsg( "Computing tracking graphs\n", debug::Priority::INFO);
 
   if(this->levelTimeEdgesTMap.size() != nL)
     this->levelTimeEdgesTMap.resize(nL);
 
   for(size_t l = 0; l < nL; l++) {
     {
+        printMsg("-------------------------------------------------------");
       stringstream msg;
-      msg << "[ttkTrackingFromOverlap] "
-             "-------------------------------------------------------"
-          << endl
-          << "[ttkTrackingFromOverlap] Level Index: " << l << endl;
-      dMsg(cout, msg.str(), infoMsg);
+      msg << "Level Index: " << l;
+      printMsg( msg.str(), debug::Priority::INFO);
     }
 
     vector<Edges> &timeEdgesTMap = this->levelTimeEdgesTMap[l];
@@ -590,25 +565,22 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
         continue;
 
       switch(this->LabelDataType) {
-        vtkTemplateMacro(this->trackingFromOverlap.computeOverlap<VTK_TT>(
-          (float *)pointSet0->GetPoints()->GetVoidPointer(0),
-          (float *)pointSet1->GetPoints()->GetVoidPointer(0),
-          (VTK_TT *)labels0->GetVoidPointer(0),
-          (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
+        vtkTemplateMacro(this->computeOverlap<VTK_TT>(
+          (float *)ttkUtils::GetVoidPointer(pointSet0->GetPoints()),
+          (float *)ttkUtils::GetVoidPointer(pointSet1->GetPoints()),
+          (VTK_TT *)ttkUtils::GetVoidPointer(labels0),
+          (VTK_TT *)ttkUtils::GetVoidPointer(labels1), nPoints0, nPoints1,
           timeEdgesTMap[timeOffset + t - 1]));
       }
     }
   }
 
   {
+      printMsg("-------------------------------------------------------");
     stringstream msg;
-    msg << "[ttkTrackingFromOverlap] "
-           "-------------------------------------------------------"
-        << endl
-        << "[ttkTrackingFromOverlap] Tracking graphs computed in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
-        << endl;
-    dMsg(cout, msg.str(), timeMsg);
+    msg << "Tracking graphs computed in "
+        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
+    printMsg( msg.str(), debug::Priority::PERFORMANCE);
   }
   return 1;
 }
@@ -629,26 +601,22 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
   // Reusable variables
   vtkPointSet *pointSet0 = nullptr;
   vtkPointSet *pointSet1 = nullptr;
-  vtkAbstractArray *labels0 = nullptr;
-  vtkAbstractArray *labels1 = nullptr;
+  vtkDataArray *labels0 = nullptr;
+  vtkDataArray *labels1 = nullptr;
 
-  dMsg(cout,
-       "[ttkTrackingFromOverlap] "
-       "=======================================================\n",
-       infoMsg);
-  dMsg(cout, "[ttkTrackingFromOverlap] Computing nesting trees\n", infoMsg);
+  printMsg("=======================================================\n",
+       debug::Priority::INFO);
+  printMsg( "Computing nesting trees\n", debug::Priority::INFO);
 
   size_t timeOffset = this->timeLevelEdgesNMap.size();
   this->timeLevelEdgesNMap.resize(timeOffset + nT);
 
   for(size_t t = 0; t < nT; t++) {
     {
+        printMsg("-------------------------------------------------------");
       stringstream msg;
-      msg << "[ttkTrackingFromOverlap] "
-             "-------------------------------------------------------"
-          << endl
-          << "[ttkTrackingFromOverlap] Time Index: " << t << endl;
-      dMsg(cout, msg.str(), infoMsg);
+      msg << "Time Index: " << t;
+      printMsg( msg.str(), debug::Priority::INFO);
     }
 
     vector<Edges> &levelEdgesNMap = this->timeLevelEdgesNMap[timeOffset + t];
@@ -664,25 +632,22 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
         continue;
 
       switch(this->LabelDataType) {
-        vtkTemplateMacro(this->trackingFromOverlap.computeOverlap<VTK_TT>(
-          (float *)pointSet0->GetPoints()->GetVoidPointer(0),
-          (float *)pointSet1->GetPoints()->GetVoidPointer(0),
-          (VTK_TT *)labels0->GetVoidPointer(0),
-          (VTK_TT *)labels1->GetVoidPointer(0), nPoints0, nPoints1,
+        vtkTemplateMacro(this->computeOverlap<VTK_TT>(
+          (float *)ttkUtils::GetVoidPointer(pointSet0->GetPoints()),
+          (float *)ttkUtils::GetVoidPointer(pointSet1->GetPoints()),
+          (VTK_TT *)ttkUtils::GetVoidPointer(labels0),
+          (VTK_TT *)ttkUtils::GetVoidPointer(labels1), nPoints0, nPoints1,
           levelEdgesNMap[l - 1]));
       }
     }
   }
 
   {
+      printMsg("-------------------------------------------------------");
     stringstream msg;
-    msg << "[ttkTrackingFromOverlap] "
-           "-------------------------------------------------------"
-        << endl
-        << "[ttkTrackingFromOverlap] Nesting trees computed in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
-        << endl;
-    dMsg(cout, msg.str(), timeMsg);
+    msg << "Nesting trees computed in "
+        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
+    printMsg( msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 1;
@@ -696,7 +661,7 @@ int ttkTrackingFromOverlap::computeBranches() {
   size_t nL = this->levelTimeEdgesTMap.size();
 
   for(size_t l = 0; l < nL; l++)
-    this->trackingFromOverlap.computeBranches(
+    this->ttk::TrackingFromOverlap::computeBranches(
       this->levelTimeEdgesTMap[l], this->levelTimeNodesMap[l]);
 
   return 1;
@@ -712,16 +677,9 @@ int ttkTrackingFromOverlap::RequestData(vtkInformation *request,
 
   // Print Status
   {
-    stringstream msg;
-    msg << "==================================================================="
-           "============="
-        << endl
-        << "[ttkTrackingFromOverlap] RequestData" << endl;
-    dMsg(cout, msg.str(), infoMsg);
+      printMsg("===================================================================");
+    printMsg( "RequestData", debug::Priority::INFO);
   }
-
-  // Set Wrapper
-  this->trackingFromOverlap.setWrapper(this);
 
   // Get Input Object
   vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
@@ -805,14 +763,11 @@ int ttkTrackingFromOverlap::RequestData(vtkInformation *request,
   // Print total performance
   // -------------------------------------------------------------------------
   if(!useStreamingOverTime) {
+      printMsg("=======================================================");
     stringstream msg;
-    msg << "[ttkTrackingFromOverlap] "
-           "======================================================="
-        << endl
-        << "[ttkTrackingFromOverlap] Nested tracking graph generated in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
-        << endl;
-    dMsg(cout, msg.str(), timeMsg);
+    msg << "Nested tracking graph generated in "
+        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
+    printMsg( msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 1;

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -373,8 +373,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
         this->GetLabelFieldName().data());
 
       if(nPoints > 0 && labels == nullptr) {
-        printErr("Point labels '" + this->GetLabelFieldName()
-                 + "' not found.");
+        printErr("Point labels '" + this->GetLabelFieldName() + "' not found.");
         return 0;
       }
       if(labels == nullptr)

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -9,13 +9,13 @@
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
 #include <vtkIdTypeArray.h>
-#include <vtkLongLongArray.h>
-#include <vtkPointData.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
+#include <vtkLongLongArray.h>
+#include <vtkPointData.h>
 
-#include <ttkUtils.h>
 #include <ttkMacros.h>
+#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;
@@ -233,7 +233,7 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
   Timer t;
 
   printMsg("=======================================================\n",
-       debug::Priority::INFO);
+           debug::Priority::INFO);
   printMsg("Meshing nested tracking graph\n", debug::Priority::INFO);
 
   switch(this->LabelDataType) {
@@ -245,9 +245,9 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
 
   printMsg("-------------------------------------------------------");
   stringstream msg;
-  msg << "Nested tracking graph meshed in "
-      << t.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
-  printMsg( msg.str(), debug::Priority::PERFORMANCE);
+  msg << "Nested tracking graph meshed in " << t.getElapsedTime() << " s. ("
+      << threadNumber_ << " thread(s)).";
+  printMsg(msg.str(), debug::Priority::PERFORMANCE);
 
   return 1;
 }
@@ -331,7 +331,7 @@ int ttkTrackingFromOverlap::packInputData(
 
   if(error) {
     printErr("Unable to convert input into "
-         "'vtkPointSet' collection.\n");
+             "'vtkPointSet' collection.\n");
     return 0;
   }
 
@@ -347,7 +347,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
 
   if(nL < 1) {
     printErr("Input must have at least one "
-         "vtkPointSet.\n");
+             "vtkPointSet.\n");
     return 0;
   }
 
@@ -356,7 +356,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
     size_t n = timesteps->GetNumberOfBlocks();
     if(n < 1) {
       printErr("Input must have at least one "
-           "vtkPointSet.\n");
+               "vtkPointSet.\n");
       return 0;
     }
     if(nT == 0)
@@ -373,8 +373,8 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
         this->GetLabelFieldName().data());
 
       if(nPoints > 0 && labels == nullptr) {
-        printErr("Point labels '"
-               + this->GetLabelFieldName() + "' not found.\n");
+        printErr("Point labels '" + this->GetLabelFieldName()
+                 + "' not found.\n");
         return 0;
       }
       if(labels == nullptr)
@@ -385,7 +385,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
         this->LabelDataType = labelDataType;
       if(this->LabelDataType != labelDataType) {
         printErr("Point labels do not have same "
-             "type across point sets.\n");
+                 "type across point sets.\n");
         return 0;
       }
     }
@@ -470,18 +470,18 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
   // Compute Nodes
   {
     printMsg("=======================================================\n",
-         debug::Priority::INFO);
-    printMsg( "Computing nodes\n", debug::Priority::INFO);
+             debug::Priority::INFO);
+    printMsg("Computing nodes\n", debug::Priority::INFO);
 
     if(this->levelTimeNodesMap.size() != nL)
       this->levelTimeNodesMap.resize(nL);
 
     for(size_t l = 0; l < nL; l++) {
       {
-          printMsg("-------------------------------------------------------");
+        printMsg("-------------------------------------------------------");
         stringstream msg;
         msg << "Level Index: " << l;
-        printMsg( msg.str(), debug::Priority::INFO);
+        printMsg(msg.str(), debug::Priority::INFO);
       }
 
       vector<Nodes> &timeNodesMap = this->levelTimeNodesMap[l];
@@ -505,12 +505,11 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
     }
 
     {
-        printMsg("-------------------------------------------------------");
+      printMsg("-------------------------------------------------------");
       stringstream msg;
-      msg << "Nodes computed in "
-          << timer.getElapsedTime() << " s. (" << threadNumber_
-          << " thread(s)).";
-      printMsg( msg.str(), debug::Priority::PERFORMANCE);
+      msg << "Nodes computed in " << timer.getElapsedTime() << " s. ("
+          << threadNumber_ << " thread(s)).";
+      printMsg(msg.str(), debug::Priority::PERFORMANCE);
     }
   }
 
@@ -537,18 +536,18 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
   vtkDataArray *labels1 = nullptr;
 
   printMsg("=======================================================\n",
-       debug::Priority::INFO);
-  printMsg( "Computing tracking graphs\n", debug::Priority::INFO);
+           debug::Priority::INFO);
+  printMsg("Computing tracking graphs\n", debug::Priority::INFO);
 
   if(this->levelTimeEdgesTMap.size() != nL)
     this->levelTimeEdgesTMap.resize(nL);
 
   for(size_t l = 0; l < nL; l++) {
     {
-        printMsg("-------------------------------------------------------");
+      printMsg("-------------------------------------------------------");
       stringstream msg;
       msg << "Level Index: " << l;
-      printMsg( msg.str(), debug::Priority::INFO);
+      printMsg(msg.str(), debug::Priority::INFO);
     }
 
     vector<Edges> &timeEdgesTMap = this->levelTimeEdgesTMap[l];
@@ -576,11 +575,11 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
   }
 
   {
-      printMsg("-------------------------------------------------------");
+    printMsg("-------------------------------------------------------");
     stringstream msg;
-    msg << "Tracking graphs computed in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
-    printMsg( msg.str(), debug::Priority::PERFORMANCE);
+    msg << "Tracking graphs computed in " << timer.getElapsedTime() << " s. ("
+        << threadNumber_ << " thread(s)).";
+    printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
   return 1;
 }
@@ -605,18 +604,18 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
   vtkDataArray *labels1 = nullptr;
 
   printMsg("=======================================================\n",
-       debug::Priority::INFO);
-  printMsg( "Computing nesting trees\n", debug::Priority::INFO);
+           debug::Priority::INFO);
+  printMsg("Computing nesting trees\n", debug::Priority::INFO);
 
   size_t timeOffset = this->timeLevelEdgesNMap.size();
   this->timeLevelEdgesNMap.resize(timeOffset + nT);
 
   for(size_t t = 0; t < nT; t++) {
     {
-        printMsg("-------------------------------------------------------");
+      printMsg("-------------------------------------------------------");
       stringstream msg;
       msg << "Time Index: " << t;
-      printMsg( msg.str(), debug::Priority::INFO);
+      printMsg(msg.str(), debug::Priority::INFO);
     }
 
     vector<Edges> &levelEdgesNMap = this->timeLevelEdgesNMap[timeOffset + t];
@@ -643,11 +642,11 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
   }
 
   {
-      printMsg("-------------------------------------------------------");
+    printMsg("-------------------------------------------------------");
     stringstream msg;
-    msg << "Nesting trees computed in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
-    printMsg( msg.str(), debug::Priority::PERFORMANCE);
+    msg << "Nesting trees computed in " << timer.getElapsedTime() << " s. ("
+        << threadNumber_ << " thread(s)).";
+    printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 1;
@@ -677,8 +676,9 @@ int ttkTrackingFromOverlap::RequestData(vtkInformation *request,
 
   // Print Status
   {
-      printMsg("===================================================================");
-    printMsg( "RequestData", debug::Priority::INFO);
+    printMsg(
+      "===================================================================");
+    printMsg("RequestData", debug::Priority::INFO);
   }
 
   // Get Input Object
@@ -763,11 +763,11 @@ int ttkTrackingFromOverlap::RequestData(vtkInformation *request,
   // Print total performance
   // -------------------------------------------------------------------------
   if(!useStreamingOverTime) {
-      printMsg("=======================================================");
+    printMsg("=======================================================");
     stringstream msg;
-    msg << "Nested tracking graph generated in "
-        << timer.getElapsedTime() << " s. (" << threadNumber_ << " thread(s)).";
-    printMsg( msg.str(), debug::Priority::PERFORMANCE);
+    msg << "Nested tracking graph generated in " << timer.getElapsedTime()
+        << " s. (" << threadNumber_ << " thread(s)).";
+    printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
 
   return 1;

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -232,9 +232,9 @@ int ttkTrackingFromOverlap::meshNestedTrackingGraph(
   vtkDataObject *trackingGraph) {
   Timer t;
 
-  printMsg("=======================================================\n",
+  printMsg("=======================================================",
            debug::Priority::INFO);
-  printMsg("Meshing nested tracking graph\n", debug::Priority::INFO);
+  printMsg("Meshing nested tracking graph", debug::Priority::INFO);
 
   switch(this->LabelDataType) {
     vtkTemplateMacro(
@@ -331,7 +331,7 @@ int ttkTrackingFromOverlap::packInputData(
 
   if(error) {
     printErr("Unable to convert input into "
-             "'vtkPointSet' collection.\n");
+             "'vtkPointSet' collection.");
     return 0;
   }
 
@@ -347,7 +347,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
 
   if(nL < 1) {
     printErr("Input must have at least one "
-             "vtkPointSet.\n");
+             "vtkPointSet.");
     return 0;
   }
 
@@ -356,13 +356,13 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
     size_t n = timesteps->GetNumberOfBlocks();
     if(n < 1) {
       printErr("Input must have at least one "
-               "vtkPointSet.\n");
+               "vtkPointSet.");
       return 0;
     }
     if(nT == 0)
       nT = n;
     if(nT != n) {
-      printErr("Timeseries have unequal length.\n");
+      printErr("Timeseries have unequal length.");
       return 0;
     }
 
@@ -374,7 +374,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
 
       if(nPoints > 0 && labels == nullptr) {
         printErr("Point labels '" + this->GetLabelFieldName()
-                 + "' not found.\n");
+                 + "' not found.");
         return 0;
       }
       if(labels == nullptr)
@@ -385,7 +385,7 @@ int ttkTrackingFromOverlap::checkData(vtkMultiBlockDataSet *data) {
         this->LabelDataType = labelDataType;
       if(this->LabelDataType != labelDataType) {
         printErr("Point labels do not have same "
-                 "type across point sets.\n");
+                 "type across point sets.");
         return 0;
       }
     }
@@ -402,7 +402,7 @@ int ttkTrackingFromOverlap::packStreamedData(vtkMultiBlockDataSet *streamedData,
   size_t nL_PI = this->previousIterationData->GetNumberOfBlocks();
   size_t nL_CI = streamedData->GetNumberOfBlocks();
   if(nL_PI != nL_CI) {
-    printErr("Number of levels differ over time.\n");
+    printErr("Number of levels differ over time.");
     return 0;
   }
   for(size_t l = 0; l < nL_PI; l++) {
@@ -469,9 +469,9 @@ int ttkTrackingFromOverlap::computeNodes(vtkMultiBlockDataSet *data) {
 
   // Compute Nodes
   {
-    printMsg("=======================================================\n",
+    printMsg("=======================================================",
              debug::Priority::INFO);
-    printMsg("Computing nodes\n", debug::Priority::INFO);
+    printMsg("Computing nodes", debug::Priority::INFO);
 
     if(this->levelTimeNodesMap.size() != nL)
       this->levelTimeNodesMap.resize(nL);
@@ -535,9 +535,9 @@ int ttkTrackingFromOverlap::computeTrackingGraphs(vtkMultiBlockDataSet *data) {
   vtkDataArray *labels0 = nullptr;
   vtkDataArray *labels1 = nullptr;
 
-  printMsg("=======================================================\n",
+  printMsg("=======================================================",
            debug::Priority::INFO);
-  printMsg("Computing tracking graphs\n", debug::Priority::INFO);
+  printMsg("Computing tracking graphs", debug::Priority::INFO);
 
   if(this->levelTimeEdgesTMap.size() != nL)
     this->levelTimeEdgesTMap.resize(nL);
@@ -603,9 +603,9 @@ int ttkTrackingFromOverlap::computeNestingTrees(vtkMultiBlockDataSet *data) {
   vtkDataArray *labels0 = nullptr;
   vtkDataArray *labels1 = nullptr;
 
-  printMsg("=======================================================\n",
+  printMsg("=======================================================",
            debug::Priority::INFO);
-  printMsg("Computing nesting trees\n", debug::Priority::INFO);
+  printMsg("Computing nesting trees", debug::Priority::INFO);
 
   size_t timeOffset = this->timeLevelEdgesNMap.size();
   this->timeLevelEdgesNMap.resize(timeOffset + nT);

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -63,7 +63,8 @@ public:
   int FillInputPortInformation(int port, vtkInformation *info) override {
     switch(port) {
       case 0:
-        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+        info->Set(
+          vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
         break;
       default:
         return 0;

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -60,29 +60,6 @@ public:
     vtkSetMacro(LabelFieldName, string);
   vtkGetMacro(LabelFieldName, string);
 
-  int FillInputPortInformation(int port, vtkInformation *info) override {
-    switch(port) {
-      case 0:
-        info->Set(
-          vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
-        break;
-      default:
-        return 0;
-    }
-    return 1;
-  }
-
-  int FillOutputPortInformation(int port, vtkInformation *info) override {
-    switch(port) {
-      case 0:
-        info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
-        break;
-      default:
-        return 0;
-    }
-    return 1;
-  }
-
 protected:
   ttkTrackingFromOverlap() {
     SetLabelFieldName("RegionId");
@@ -116,6 +93,31 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override {
+    switch(port) {
+      case 0:
+        info->Remove(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE());
+        info->Append(
+          vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+        info->Append(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+        break;
+      default:
+        return 0;
+    }
+    return 1;
+  }
+
+  int FillOutputPortInformation(int port, vtkInformation *info) override {
+    switch(port) {
+      case 0:
+        info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+        break;
+      default:
+        return 0;
+    }
+    return 1;
+  }
 
 private:
   int LabelDataType;

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -47,44 +47,23 @@
 
 // TTK includes
 #include <TrackingFromOverlap.h>
-#include <ttkTriangulationAlgorithm.h>
+#include <ttkAlgorithm.h>
 
 class TTKTRACKINGFROMOVERLAP_EXPORT ttkTrackingFromOverlap
-  : public vtkUnstructuredGridAlgorithm,
-    protected ttk::Wrapper {
+  : public ttkAlgorithm,
+    protected ttk::TrackingFromOverlap {
 
 public:
   static ttkTrackingFromOverlap *New();
-  vtkTypeMacro(ttkTrackingFromOverlap, vtkUnstructuredGridAlgorithm)
+  vtkTypeMacro(ttkTrackingFromOverlap, ttkAlgorithm)
 
     vtkSetMacro(LabelFieldName, string);
   vtkGetMacro(LabelFieldName, string);
 
-  // default ttk setters
-  void SetDebugLevel(int debugLevel) {
-    setDebugLevel(debugLevel);
-    Modified();
-  }
-
-  void SetThreads() {
-    threadNumber_
-      = !UseAllCores ? ThreadNumber : ttk::OsCall::getNumberOfCores();
-    Modified();
-  }
-  void SetThreadNumber(int threadNumber) {
-    ThreadNumber = threadNumber;
-    SetThreads();
-  }
-  void SetUseAllCores(bool onOff) {
-    UseAllCores = onOff;
-    SetThreads();
-  }
-  // end of default ttk setters
-
   int FillInputPortInformation(int port, vtkInformation *info) override {
     switch(port) {
       case 0:
-        info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkMultiBlockDataSet");
+        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
         break;
       default:
         return 0;
@@ -140,7 +119,6 @@ protected:
 private:
   int LabelDataType;
   string LabelFieldName;
-  ttk::TrackingFromOverlap trackingFromOverlap;
 
   vtkSmartPointer<vtkMultiBlockDataSet> previousIterationData;
 
@@ -149,10 +127,10 @@ private:
   vector<vector<Edges>> levelTimeEdgesTMap; // E_T
   vector<vector<Edges>> timeLevelEdgesNMap; // E_N
 
-  bool needsToAbort() override {
+  bool needsToAbort() /*override*/ {
     return GetAbortExecute();
   };
-  int updateProgress(const float &progress) override {
+  int updateProgress(const float &progress) /*override*/ {
     UpdateProgress(progress);
     return 0;
   };

--- a/core/vtk/ttkTrackingFromOverlap/vtk.module
+++ b/core/vtk/ttkTrackingFromOverlap/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkTrackingFromOverlap
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+  ttkAlgorithm

--- a/paraview/TrackingFromOverlap/TrackingFromOverlap.xml
+++ b/paraview/TrackingFromOverlap/TrackingFromOverlap.xml
@@ -34,30 +34,10 @@ Type:
                 <Documentation>Point data that associates a label with each point.</Documentation>
             </StringVectorProperty>
 
-            <IntVectorProperty name="UseAllCores" label="Use All Cores" command="SetUseAllCores" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                <BooleanDomain name="bool" />
-                <Documentation>Use all available cores.</Documentation>
-            </IntVectorProperty>
-            <IntVectorProperty name="ThreadNumber" label="Thread Number" command="SetThreadNumber" number_of_elements="1" default_values="1" panel_visibility="advanced">
-                <IntRangeDomain name="range" min="1" max="100" />
-                <Documentation>Thread number.</Documentation>
-                <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseAllCores" value="0" />
-                </Hints>
-            </IntVectorProperty>
-            <IntVectorProperty name="DebugLevel" label="Debug Level" command="SetDebugLevel" number_of_elements="1" default_values="3" panel_visibility="advanced">
-                <IntRangeDomain name="range" min="0" max="100" />
-                <Documentation>Debug level.</Documentation>
-            </IntVectorProperty>
+            ${DEBUG_WIDGETS}
 
             <PropertyGroup panel_widget="Line" label="Input Options">
                 <Property name="LabelFieldName" />
-            </PropertyGroup>
-
-            <PropertyGroup panel_widget="Line" label="Testing">
-                <Property name="UseAllCores" />
-                <Property name="ThreadNumber" />
-                <Property name="DebugLevel" />
             </PropertyGroup>
 
             <Hints>


### PR DESCRIPTION
The TrackingFromOverlap module was migrated to the new API. Changes in style (e.g. member variable definition and use of SetInputArrayToProcess) were omitted, because the module will get a large revision/update soon after the official release. Since no changes were made to how the input array is set, the example state files stayed the same.

