### PR TITLE
Renamed input port of ttkIcoSpheresFromPoints (NO impact on ttk-data / NO need for CI)

### DIFF
--- a/paraview/IcospheresFromPoints/IcospheresFromPoints.xml
+++ b/paraview/IcospheresFromPoints/IcospheresFromPoints.xml
@@ -6,7 +6,7 @@
                 This filter creates for every vertex of an input vtkPointSet an IcoSphere with a specified number of subdivisions and radius.
             </Documentation>
 
-            <InputProperty name="Object" port_index="0" command="SetInputConnection">
+            <InputProperty name="Input" port_index="0" command="SetInputConnection">
                 <ProxyGroupDomain name="groups">
                     <Group name="sources" />
                     <Group name="filters" />


### PR DESCRIPTION
Hi Julien,
this tiny PR just changes name of the input port name of ttkIcoSpheresFromPoints in the paraview.xml file. It has no impact on ttk-data and does not require CI. In the future we can profit from this PR by simply running
`sed -i 's/SphereFromPoint/IcospheresFromPoints/g' ./states/*.pvsm`
and manually adjusting the refinement level and enable normals. Then we could delete the SphereFromPoint module.

Best
Jonas