### PR TITLE
[api-migration-hackathon] Import embedding from table migration

### DIFF
--- a/core/vtk/ttkImportEmbeddingFromTable/ttk.module
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttk.module
@@ -5,4 +5,4 @@ SOURCES
 HEADERS
   ttkImportEmbeddingFromTable.h
 DEPENDS
-  common
+  ttkAlgorithm

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
@@ -2,6 +2,14 @@
 #include <regex>
 #include <ttkImportEmbeddingFromTable.h>
 
+#include <ttkUtils.h>
+#include <ttkMacros.h>
+
+// VTK includes
+#include <vtkInformation.h>
+#include <vtkPointSet.h>
+#include <vtkTable.h>
+
 using namespace std;
 using namespace ttk;
 
@@ -12,14 +20,35 @@ vtkStandardNewMacro(ttkImportEmbeddingFromTable)
   return GetAbortExecute();
 }
 
+int ttkImportEmbeddingFromTable::FillInputPortInformation(int port, vtkInformation *info){
+    if(port == 0) {
+        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
+        return 1;
+    }
+    if(port == 1) {
+        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+        return 1;
+    }
+
+    return 0;
+}
+
+int ttkImportEmbeddingFromTable::FillOutputPortInformation(int port, vtkInformation *info) {
+    if(port == 0){
+        info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+        return 1;
+    }
+    return 0;
+}
+
 // transmit progress status
 int ttkImportEmbeddingFromTable::updateProgress(const float &progress) {
 
   {
     stringstream msg;
-    msg << "[ttkImportEmbeddingFromTable] " << progress * 100
-        << "% processed...." << endl;
-    dMsg(cout, msg.str(), advancedInfoMsg);
+    msg << progress * 100
+        << "% processed....";
+    printMsg(msg.str(), debug::Priority::VERBOSE);
   }
 
   UpdateProgress(progress);
@@ -41,90 +70,60 @@ inline void setPointFromData(vtkSmartPointer<vtkPoints> points,
   }
 }
 
-int ttkImportEmbeddingFromTable::doIt(vtkPointSet *inputDataSet,
-                                      vtkTable *inputTable,
-                                      vtkPointSet *output) {
-  Memory m;
-
-  const SimplexId numberOfPoints = inputDataSet->GetNumberOfPoints();
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(numberOfPoints <= 0) {
-    cerr << "[ttkImportEmbeddingFromTable] Error: input has no point." << endl;
-    return -1;
-  }
-#endif
-
-  vtkAbstractArray *xarr
-    = XColumn.empty() ? nullptr : inputTable->GetColumnByName(XColumn.data());
-  vtkAbstractArray *yarr
-    = YColumn.empty() ? nullptr : inputTable->GetColumnByName(YColumn.data());
-  vtkAbstractArray *zarr
-    = ZColumn.empty() ? nullptr : inputTable->GetColumnByName(ZColumn.data());
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(xarr == nullptr or yarr == nullptr or zarr == nullptr) {
-    cerr << "[ttkImportEmbeddingFromTable] Error: invalid input columns."
-         << endl;
-    return -1;
-  }
-  if(xarr->GetNumberOfTuples() != numberOfPoints
-     or yarr->GetNumberOfTuples() != numberOfPoints
-     or zarr->GetNumberOfTuples() != numberOfPoints) {
-    cerr << "[ttkImportEmbeddingFromTable] Error: number of points on inputs "
-            "mismatch."
-         << endl;
-    return -1;
-  }
-  if(xarr->GetDataType() != yarr->GetDataType()
-     or xarr->GetDataType() != zarr->GetDataType()) {
-    cerr << "[ttkImportEmbeddingFromTable] Error: input columns has different "
-            "data types."
-         << endl;
-    return -1;
-  }
-#endif
-
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-  points->SetNumberOfPoints(numberOfPoints);
-
-  switch(xarr->GetDataType()) {
-    vtkTemplateMacro(setPointFromData(
-      points, static_cast<VTK_TT *>(xarr->GetVoidPointer(0)),
-      static_cast<VTK_TT *>(yarr->GetVoidPointer(0)),
-      static_cast<VTK_TT *>(zarr->GetVoidPointer(0)), Embedding2D));
-  }
-
-  output->ShallowCopy(inputDataSet);
-  output->SetPoints(points);
-
-  {
-    stringstream msg;
-    msg << "[ttkImportEmbeddingFromTable] Memory usage: " << m.getElapsedUsage()
-        << " MB." << endl;
-    dMsg(cout, msg.str(), memoryMsg);
-  }
-
-  return 0;
-}
-
 int ttkImportEmbeddingFromTable::RequestData(
   vtkInformation *request,
   vtkInformationVector **inputVector,
   vtkInformationVector *outputVector) {
-  Memory m;
 
   vtkPointSet *inputDataSet = vtkPointSet::GetData(inputVector[0]);
   vtkTable *inputTable = vtkTable::GetData(inputVector[1]);
   vtkPointSet *output = vtkPointSet::GetData(outputVector);
 
-  doIt(inputDataSet, inputTable, output);
+    const SimplexId numberOfPoints = inputDataSet->GetNumberOfPoints();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(numberOfPoints <= 0) {
+        printErr("input has no point.");
+        return -1;
+    }
+#endif
 
-  {
-    stringstream msg;
-    msg << "[ttkImportEmbeddingFromTable] Memory usage: " << m.getElapsedUsage()
-        << " MB." << endl;
-    dMsg(cout, msg.str(), memoryMsg);
-  }
+    vtkDataArray *xarr
+            = XColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(XColumn.data()));
+    vtkDataArray *yarr
+            = YColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(YColumn.data()));
+    vtkDataArray *zarr
+            = ZColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(ZColumn.data()));
+
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(xarr == nullptr or yarr == nullptr or zarr == nullptr) {
+        printErr("invalid input columns.");
+        return -1;
+    }
+    if(xarr->GetNumberOfTuples() != numberOfPoints
+       or yarr->GetNumberOfTuples() != numberOfPoints
+       or zarr->GetNumberOfTuples() != numberOfPoints) {
+       printErr("number of points on inputs mismatch.");
+        return -1;
+    }
+    if(xarr->GetDataType() != yarr->GetDataType()
+       or xarr->GetDataType() != zarr->GetDataType()) {
+       printErr("input columns has different data types.");
+        return -1;
+    }
+#endif
+
+    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+    points->SetNumberOfPoints(numberOfPoints);
+
+    switch(xarr->GetDataType()) {
+        vtkTemplateMacro(setPointFromData(
+                points, static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(xarr)),
+                static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(yarr)),
+                static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(zarr)), Embedding2D));
+    }
+
+    output->ShallowCopy(inputDataSet);
+    output->SetPoints(points);
 
   return 1;
 }

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
@@ -2,8 +2,8 @@
 #include <regex>
 #include <ttkImportEmbeddingFromTable.h>
 
-#include <ttkUtils.h>
 #include <ttkMacros.h>
+#include <ttkUtils.h>
 
 // VTK includes
 #include <vtkInformation.h>
@@ -20,25 +20,27 @@ vtkStandardNewMacro(ttkImportEmbeddingFromTable)
   return GetAbortExecute();
 }
 
-int ttkImportEmbeddingFromTable::FillInputPortInformation(int port, vtkInformation *info){
-    if(port == 0) {
-        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
-        return 1;
-    }
-    if(port == 1) {
-        info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
-        return 1;
-    }
+int ttkImportEmbeddingFromTable::FillInputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
+    return 1;
+  }
+  if(port == 1) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
-int ttkImportEmbeddingFromTable::FillOutputPortInformation(int port, vtkInformation *info) {
-    if(port == 0){
-        info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
-        return 1;
-    }
-    return 0;
+int ttkImportEmbeddingFromTable::FillOutputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
 }
 
 // transmit progress status
@@ -46,8 +48,7 @@ int ttkImportEmbeddingFromTable::updateProgress(const float &progress) {
 
   {
     stringstream msg;
-    msg << progress * 100
-        << "% processed....";
+    msg << progress * 100 << "% processed....";
     printMsg(msg.str(), debug::Priority::VERBOSE);
   }
 
@@ -79,51 +80,57 @@ int ttkImportEmbeddingFromTable::RequestData(
   vtkTable *inputTable = vtkTable::GetData(inputVector[1]);
   vtkPointSet *output = vtkPointSet::GetData(outputVector);
 
-    const SimplexId numberOfPoints = inputDataSet->GetNumberOfPoints();
+  const SimplexId numberOfPoints = inputDataSet->GetNumberOfPoints();
 #ifndef TTK_ENABLE_KAMIKAZE
-    if(numberOfPoints <= 0) {
-        printErr("input has no point.");
-        return -1;
-    }
+  if(numberOfPoints <= 0) {
+    printErr("input has no point.");
+    return -1;
+  }
 #endif
 
-    vtkDataArray *xarr
-            = XColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(XColumn.data()));
-    vtkDataArray *yarr
-            = YColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(YColumn.data()));
-    vtkDataArray *zarr
-            = ZColumn.empty() ? nullptr : vtkDataArray::SafeDownCast(inputTable->GetColumnByName(ZColumn.data()));
+  vtkDataArray *xarr = XColumn.empty()
+                         ? nullptr
+                         : vtkDataArray::SafeDownCast(
+                             inputTable->GetColumnByName(XColumn.data()));
+  vtkDataArray *yarr = YColumn.empty()
+                         ? nullptr
+                         : vtkDataArray::SafeDownCast(
+                             inputTable->GetColumnByName(YColumn.data()));
+  vtkDataArray *zarr = ZColumn.empty()
+                         ? nullptr
+                         : vtkDataArray::SafeDownCast(
+                             inputTable->GetColumnByName(ZColumn.data()));
 
 #ifndef TTK_ENABLE_KAMIKAZE
-    if(xarr == nullptr or yarr == nullptr or zarr == nullptr) {
-        printErr("invalid input columns.");
-        return -1;
-    }
-    if(xarr->GetNumberOfTuples() != numberOfPoints
-       or yarr->GetNumberOfTuples() != numberOfPoints
-       or zarr->GetNumberOfTuples() != numberOfPoints) {
-       printErr("number of points on inputs mismatch.");
-        return -1;
-    }
-    if(xarr->GetDataType() != yarr->GetDataType()
-       or xarr->GetDataType() != zarr->GetDataType()) {
-       printErr("input columns has different data types.");
-        return -1;
-    }
+  if(xarr == nullptr or yarr == nullptr or zarr == nullptr) {
+    printErr("invalid input columns.");
+    return -1;
+  }
+  if(xarr->GetNumberOfTuples() != numberOfPoints
+     or yarr->GetNumberOfTuples() != numberOfPoints
+     or zarr->GetNumberOfTuples() != numberOfPoints) {
+    printErr("number of points on inputs mismatch.");
+    return -1;
+  }
+  if(xarr->GetDataType() != yarr->GetDataType()
+     or xarr->GetDataType() != zarr->GetDataType()) {
+    printErr("input columns has different data types.");
+    return -1;
+  }
 #endif
 
-    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
-    points->SetNumberOfPoints(numberOfPoints);
+  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  points->SetNumberOfPoints(numberOfPoints);
 
-    switch(xarr->GetDataType()) {
-        vtkTemplateMacro(setPointFromData(
-                points, static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(xarr)),
-                static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(yarr)),
-                static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(zarr)), Embedding2D));
-    }
+  switch(xarr->GetDataType()) {
+    vtkTemplateMacro(setPointFromData(
+      points, static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(xarr)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(yarr)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(zarr)), Embedding2D));
+  }
 
-    output->ShallowCopy(inputDataSet);
-    output->SetPoints(points);
+  output->ShallowCopy(inputDataSet);
+  output->SetPoints(points);
 
   return 1;
 }

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
@@ -16,60 +16,18 @@
 /// VTK pipeline.
 #pragma once
 
-// VTK includes
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkIntArray.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkPointSet.h>
-#include <vtkPointSetAlgorithm.h>
-#include <vtkSmartPointer.h>
-#include <vtkTable.h>
-
 // VTK Module
 #include <ttkImportEmbeddingFromTableModule.h>
 
 // ttk code includes
-#include <Wrapper.h>
+#include <ttkAlgorithm.h>
 
 class TTKIMPORTEMBEDDINGFROMTABLE_EXPORT ttkImportEmbeddingFromTable
-  : public vtkPointSetAlgorithm,
-    protected ttk::Wrapper {
+  : public ttkAlgorithm{
 
 public:
   static ttkImportEmbeddingFromTable *New();
-  vtkTypeMacro(ttkImportEmbeddingFromTable, vtkPointSetAlgorithm)
-
-    // default ttk setters
-    void SetDebugLevel(int debugLevel) {
-    setDebugLevel(debugLevel);
-    Modified();
-  }
-
-  void SetThreads() {
-    if(!UseAllCores)
-      threadNumber_ = ThreadNumber;
-    else {
-      threadNumber_ = ttk::OsCall::getNumberOfCores();
-    }
-    Modified();
-  }
-
-  void SetThreadNumber(int threadNumber) {
-    ThreadNumber = threadNumber;
-    SetThreads();
-  }
-
-  void SetUseAllCores(bool onOff) {
-    UseAllCores = onOff;
-    SetThreads();
-  }
-  // end of default ttk setters
+  vtkTypeMacro(ttkImportEmbeddingFromTable, ttkAlgorithm)
 
   vtkSetMacro(XColumn, std::string);
   vtkGetMacro(XColumn, std::string);
@@ -83,20 +41,11 @@ public:
   vtkSetMacro(Embedding2D, bool);
   vtkGetMacro(Embedding2D, bool);
 
-  int FillInputPortInformation(int port, vtkInformation *info) override {
-    if(port == 0)
-      info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPointSet");
-    if(port == 1)
-      info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
-
-    return 1;
-  }
-
 protected:
   ttkImportEmbeddingFromTable() {
-    UseAllCores = true;
-
+      this->setDebugMsgPrefix("ttkImportEmbeddingFromTable");
     SetNumberOfInputPorts(2);
+    SetNumberOfOutputPorts(1);
   }
 
   ~ttkImportEmbeddingFromTable() override{};
@@ -105,18 +54,15 @@ protected:
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
 
+    int FillInputPortInformation(int port, vtkInformation *info) override;
+    int FillOutputPortInformation(int port, vtkInformation *info) override;
+
 private:
   std::string XColumn;
   std::string YColumn;
   std::string ZColumn;
   bool Embedding2D;
 
-  bool UseAllCores;
-  int ThreadNumber;
-
-  int doIt(vtkPointSet *inputDataSet,
-           vtkTable *inputTable,
-           vtkPointSet *output);
-  bool needsToAbort() override;
-  int updateProgress(const float &progress) override;
+  bool needsToAbort();
+  int updateProgress(const float &progress);
 };

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
@@ -23,13 +23,13 @@
 #include <ttkAlgorithm.h>
 
 class TTKIMPORTEMBEDDINGFROMTABLE_EXPORT ttkImportEmbeddingFromTable
-  : public ttkAlgorithm{
+  : public ttkAlgorithm {
 
 public:
   static ttkImportEmbeddingFromTable *New();
   vtkTypeMacro(ttkImportEmbeddingFromTable, ttkAlgorithm)
 
-  vtkSetMacro(XColumn, std::string);
+    vtkSetMacro(XColumn, std::string);
   vtkGetMacro(XColumn, std::string);
 
   vtkSetMacro(YColumn, std::string);
@@ -43,7 +43,7 @@ public:
 
 protected:
   ttkImportEmbeddingFromTable() {
-      this->setDebugMsgPrefix("ttkImportEmbeddingFromTable");
+    this->setDebugMsgPrefix("ttkImportEmbeddingFromTable");
     SetNumberOfInputPorts(2);
     SetNumberOfOutputPorts(1);
   }
@@ -54,8 +54,8 @@ protected:
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
 
-    int FillInputPortInformation(int port, vtkInformation *info) override;
-    int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
 
 private:
   std::string XColumn;

--- a/core/vtk/ttkImportEmbeddingFromTable/vtk.module
+++ b/core/vtk/ttkImportEmbeddingFromTable/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkImportEmbeddingFromTable
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+  ttkAlgorithm

--- a/paraview/ImportEmbeddingFromTable/ImportEmbeddingFromTable.xml
+++ b/paraview/ImportEmbeddingFromTable/ImportEmbeddingFromTable.xml
@@ -6,19 +6,19 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="ImportEmbeddingFromTable"
-      class="ttkImportEmbeddingFromTable"
-      label="TTK ImportEmbeddingFromTable">
+            name="ImportEmbeddingFromTable"
+            class="ttkImportEmbeddingFromTable"
+            label="TTK ImportEmbeddingFromTable">
       <Documentation
-        long_help="TTK fieldSelector plugin."
-        short_help="TTK fieldSelector plugin.">
+              long_help="TTK fieldSelector plugin."
+              short_help="TTK fieldSelector plugin.">
         TTK fieldSelector plugin documentation.
       </Documentation>
 
       <InputProperty
-        name="DataSet"
-        port_index="0"
-        command="SetInputConnection">
+              name="DataSet"
+              port_index="0"
+              command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>
@@ -27,7 +27,7 @@
           <DataType value="vtkPointSet"/>
         </DataTypeDomain>
         <InputArrayDomain name="input_scalars"
-          attribute_type="point">
+                          attribute_type="point">
           <Property name="DataSet" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>
@@ -36,9 +36,9 @@
       </InputProperty>
 
       <InputProperty
-        name="Table"
-        port_index="1"
-        command="SetInputConnection">
+              name="Table"
+              port_index="1"
+              command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>
@@ -52,15 +52,15 @@
       </InputProperty>
 
       <StringVectorProperty
-        name="X Column"
-        command="SetXColumn"
-        number_of_elements="1"
-        animateable="0"
-        label="X Column"
-        >
+              name="X Column"
+              command="SetXColumn"
+              number_of_elements="1"
+              animateable="0"
+              label="X Column"
+      >
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+                name="array_list"
+                default_values="0">
           <RequiredProperties>
             <Property name="Table" function="Input" />
           </RequiredProperties>
@@ -71,15 +71,15 @@
       </StringVectorProperty>
 
       <StringVectorProperty
-        name="Y Column"
-        command="SetYColumn"
-        number_of_elements="1"
-        animateable="0"
-        label="Y Column"
-        >
+              name="Y Column"
+              command="SetYColumn"
+              number_of_elements="1"
+              animateable="0"
+              label="Y Column"
+      >
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+                name="array_list"
+                default_values="0">
           <RequiredProperties>
             <Property name="Table" function="Input" />
           </RequiredProperties>
@@ -90,15 +90,15 @@
       </StringVectorProperty>
 
       <StringVectorProperty
-        name="Z Column"
-        command="SetZColumn"
-        number_of_elements="1"
-        animateable="0"
-        label="Z Column"
-        >
+              name="Z Column"
+              command="SetZColumn"
+              number_of_elements="1"
+              animateable="0"
+              label="Z Column"
+      >
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+                name="array_list"
+                default_values="0">
           <RequiredProperties>
             <Property name="Table" function="Input" />
           </RequiredProperties>
@@ -109,57 +109,17 @@
       </StringVectorProperty>
 
       <IntVectorProperty name="2D Points"
-        label="2DPoints"
-        command="SetEmbedding2D"
-        number_of_elements="1"
-        default_values="0"
-        panel_visibility="default">
+                         label="2DPoints"
+                         command="SetEmbedding2D"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="default">
         <BooleanDomain name="bool"/>
         <Documentation>
         </Documentation>
       </IntVectorProperty>
 
-      <IntVectorProperty
-        name="UseAllCores"
-        label="Use All Cores"
-        command="SetUseAllCores"
-        number_of_elements="1"
-        default_values="1" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Use all available cores.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-        name="ThreadNumber"
-        label="Thread Number"
-        command="SetThreadNumber"
-        number_of_elements="1"
-        default_values="1" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="1" max="100" />
-        <Documentation>
-          Thread number.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-        name="DebugLevel"
-        label="Debug Level"
-        command="SetDebugLevel"
-        number_of_elements="1"
-        default_values="3" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="0" max="100" />
-        <Documentation>
-          Debug level.
-        </Documentation>
-      </IntVectorProperty>
-
-      <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="UseAllCores" />
-        <Property name="ThreadNumber" />
-        <Property name="DebugLevel" />
-      </PropertyGroup>
+      ${DEBUG_WIDGET}
 
       <Hints>
         <ShowInMenu category="TTK - Misc" />


### PR DESCRIPTION
ImportEmbeddingFromTable module was migrated to new API. The module still uses string inputs instead of SetArrayToProcess, because we were not able to use this function for columns of a vtkTable in the paraview layer.
This module has no example state files in ttk-data.

