### PR TITLE
[api-migration-hackathon] DimensionReduction

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -54,11 +54,11 @@ int DimensionReduction::execute() const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(majorVersion_ < '3')
     return -1;
-  if(modulePath_.length() <= 0)
+  if(ModulePath.length() <= 0)
     return -1;
-  if(moduleName_.length() <= 0)
+  if(ModuleName.length() <= 0)
     return -1;
-  if(functionName_.length() <= 0)
+  if(FunctionName.length() <= 0)
     return -1;
   if(!matrix_)
     return -1;
@@ -139,10 +139,10 @@ int DimensionReduction::execute() const {
 #endif
   gc.push_back(pPath);
 
-  if(modulePath_ == "default")
+  if(ModulePath == "default")
     modulePath = VALUE(TTK_SCRIPTS_PATH);
   else
-    modulePath = modulePath_;
+    modulePath = ModulePath;
 
   this->printMsg("Loading Python script from: " + modulePath);
   PyList_Append(pPath, PyUnicode_FromString(modulePath.data()));
@@ -192,7 +192,7 @@ int DimensionReduction::execute() const {
 #endif
 
   // load module
-  pName = PyUnicode_FromString(moduleName_.data());
+  pName = PyUnicode_FromString(ModuleName.data());
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!pName) {
     this->printErr("Python: moduleName parsing failed.");
@@ -211,7 +211,7 @@ int DimensionReduction::execute() const {
   gc.push_back(pModule);
 
   // configure function
-  pFunc = PyObject_GetAttrString(pModule, functionName_.data());
+  pFunc = PyObject_GetAttrString(pModule, FunctionName.data());
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!pFunc) {
     this->printErr("Python: functionName parsing failed.");

--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -11,10 +11,9 @@
 using namespace std;
 using namespace ttk;
 
-DimensionReduction::DimensionReduction()
-  : numberOfRows_{0}, numberOfColumns_{0}, numberOfComponents_{0},
-    numberOfNeighbors_{0}, randomState_{0}, matrix_{nullptr},
-    embedding_{nullptr}, majorVersion_{'0'} {
+DimensionReduction::DimensionReduction() {
+  this->setDebugMsgPrefix("DimensionReduction");
+
 #ifdef TTK_ENABLE_SCIKIT_LEARN
   auto finalize_callback = []() { Py_Finalize(); };
 
@@ -36,9 +35,6 @@ DimensionReduction::DimensionReduction()
 
   majorVersion_ = version[0];
 #endif
-}
-
-DimensionReduction::~DimensionReduction() {
 }
 
 bool DimensionReduction::isPythonFound() const {

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -129,17 +129,17 @@ namespace ttk {
     }
 
     inline int setInputModulePath(const std::string &modulePath) {
-      modulePath_ = modulePath;
+      ModulePath = modulePath;
       return 0;
     }
 
     inline int setInputModuleName(const std::string &moduleName) {
-      moduleName_ = moduleName;
+      ModuleName = moduleName;
       return 0;
     }
 
     inline int setInputFunctionName(const std::string &functionName) {
-      functionName_ = functionName;
+      FunctionName = functionName;
       return 0;
     }
 
@@ -186,58 +186,60 @@ namespace ttk {
 
   protected:
     // se
-    std::string se_Affinity{};
-    float se_Gamma{};
-    std::string se_EigenSolver{};
+    std::string se_Affinity{"nearest_neighbors"};
+    float se_Gamma{1};
+    std::string se_EigenSolver{"auto"};
 
     // lle
-    float lle_Regularization{};
-    std::string lle_EigenSolver{};
-    float lle_Tolerance{};
-    int lle_MaxIteration{};
-    std::string lle_Method{};
-    float lle_HessianTolerance{};
-    float lle_ModifiedTolerance{};
-    std::string lle_NeighborsAlgorithm{};
+    float lle_Regularization{1e-3};
+    std::string lle_EigenSolver{"auto"};
+    float lle_Tolerance{1e-3};
+    int lle_MaxIteration{300};
+    std::string lle_Method{"standard"};
+    float lle_HessianTolerance{1e-3};
+    float lle_ModifiedTolerance{1e-3};
+    std::string lle_NeighborsAlgorithm{"auto"};
 
     // mds
-    bool mds_Metric{};
-    int mds_Init{};
-    int mds_MaxIteration{};
-    int mds_Verbose{};
-    float mds_Epsilon{};
+    bool mds_Metric{true};
+    int mds_Init{4};
+    int mds_MaxIteration{300};
+    int mds_Verbose{0};
+    float mds_Epsilon{0};
     std::string mds_Dissimilarity{};
 
     // tsne
-    float tsne_Perplexity{};
-    float tsne_Exaggeration{};
-    float tsne_LearningRate{};
-    int tsne_MaxIteration{};
-    int tsne_MaxIterationProgress{};
-    float tsne_GradientThreshold{};
-    std::string tsne_Metric{};
-    std::string tsne_Init{};
-    int tsne_Verbose{};
-    std::string tsne_Method{};
-    float tsne_Angle{};
+    float tsne_Perplexity{30};
+    float tsne_Exaggeration{12};
+    float tsne_LearningRate{200};
+    int tsne_MaxIteration{1000};
+    int tsne_MaxIterationProgress{300};
+    float tsne_GradientThreshold{1e-7};
+    std::string tsne_Metric{"euclidian"};
+    std::string tsne_Init{"random"};
+    int tsne_Verbose{0};
+    std::string tsne_Method{"barnes_hut"};
+    float tsne_Angle{0.5};
 
     // iso
-    std::string iso_EigenSolver{};
-    float iso_Tolerance{};
-    int iso_MaxIteration{};
-    std::string iso_PathMethod{};
-    std::string iso_NeighborsAlgorithm{};
+    std::string iso_EigenSolver{"auto"};
+    float iso_Tolerance{1e-3};
+    int iso_MaxIteration{300};
+    std::string iso_PathMethod{"auto"};
+    std::string iso_NeighborsAlgorithm{"auto"};
 
     // pca
-    bool pca_Copy{};
-    bool pca_Whiten{};
-    std::string pca_SVDSolver{};
-    float pca_Tolerance{};
-    std::string pca_MaxIteration{};
+    bool pca_Copy{true};
+    bool pca_Whiten{false};
+    std::string pca_SVDSolver{"auto"};
+    float pca_Tolerance{0};
+    std::string pca_MaxIteration{"auto"};
 
-    std::string modulePath_{};
-    std::string moduleName_{};
-    std::string functionName_{};
+    // testing
+    std::string ModulePath{};
+    std::string ModuleName{};
+    std::string FunctionName{};
+
     SimplexId numberOfRows_{0};
     SimplexId numberOfColumns_{0};
     int method_{};

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -206,7 +206,7 @@ namespace ttk {
     int mds_MaxIteration{300};
     int mds_Verbose{0};
     float mds_Epsilon{0};
-    std::string mds_Dissimilarity{};
+    std::string mds_Dissimilarity{"euclidean"};
 
     // tsne
     float tsne_Perplexity{30};
@@ -215,7 +215,7 @@ namespace ttk {
     int tsne_MaxIteration{1000};
     int tsne_MaxIterationProgress{300};
     float tsne_GradientThreshold{1e-7};
-    std::string tsne_Metric{"euclidian"};
+    std::string tsne_Metric{"euclidean"};
     std::string tsne_Init{"random"};
     int tsne_Verbose{0};
     std::string tsne_Method{"barnes_hut"};

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -16,16 +16,14 @@
 
 #pragma once
 
-#include <Triangulation.h>
-#include <Wrapper.h>
+#include <Debug.h>
 
 namespace ttk {
 
-  class DimensionReduction : public Debug {
+  class DimensionReduction : virtual public Debug {
 
   public:
     DimensionReduction();
-    ~DimensionReduction();
 
     inline int setSEParameters(std::string &Affinity,
                                float Gamma,
@@ -188,66 +186,66 @@ namespace ttk {
 
   protected:
     // se
-    std::string se_Affinity;
-    float se_Gamma;
-    std::string se_EigenSolver;
+    std::string se_Affinity{};
+    float se_Gamma{};
+    std::string se_EigenSolver{};
 
     // lle
-    float lle_Regularization;
-    std::string lle_EigenSolver;
-    float lle_Tolerance;
-    int lle_MaxIteration;
-    std::string lle_Method;
-    float lle_HessianTolerance;
-    float lle_ModifiedTolerance;
-    std::string lle_NeighborsAlgorithm;
+    float lle_Regularization{};
+    std::string lle_EigenSolver{};
+    float lle_Tolerance{};
+    int lle_MaxIteration{};
+    std::string lle_Method{};
+    float lle_HessianTolerance{};
+    float lle_ModifiedTolerance{};
+    std::string lle_NeighborsAlgorithm{};
 
     // mds
-    bool mds_Metric;
-    int mds_Init;
-    int mds_MaxIteration;
-    int mds_Verbose;
-    float mds_Epsilon;
-    std::string mds_Dissimilarity;
+    bool mds_Metric{};
+    int mds_Init{};
+    int mds_MaxIteration{};
+    int mds_Verbose{};
+    float mds_Epsilon{};
+    std::string mds_Dissimilarity{};
 
     // tsne
-    float tsne_Perplexity;
-    float tsne_Exaggeration;
-    float tsne_LearningRate;
-    int tsne_MaxIteration;
-    int tsne_MaxIterationProgress;
-    float tsne_GradientThreshold;
-    std::string tsne_Metric;
-    std::string tsne_Init;
-    int tsne_Verbose;
-    std::string tsne_Method;
-    float tsne_Angle;
+    float tsne_Perplexity{};
+    float tsne_Exaggeration{};
+    float tsne_LearningRate{};
+    int tsne_MaxIteration{};
+    int tsne_MaxIterationProgress{};
+    float tsne_GradientThreshold{};
+    std::string tsne_Metric{};
+    std::string tsne_Init{};
+    int tsne_Verbose{};
+    std::string tsne_Method{};
+    float tsne_Angle{};
 
     // iso
-    std::string iso_EigenSolver;
-    float iso_Tolerance;
-    int iso_MaxIteration;
-    std::string iso_PathMethod;
-    std::string iso_NeighborsAlgorithm;
+    std::string iso_EigenSolver{};
+    float iso_Tolerance{};
+    int iso_MaxIteration{};
+    std::string iso_PathMethod{};
+    std::string iso_NeighborsAlgorithm{};
 
     // pca
-    bool pca_Copy;
-    bool pca_Whiten;
-    std::string pca_SVDSolver;
-    float pca_Tolerance;
-    std::string pca_MaxIteration;
+    bool pca_Copy{};
+    bool pca_Whiten{};
+    std::string pca_SVDSolver{};
+    float pca_Tolerance{};
+    std::string pca_MaxIteration{};
 
-    std::string modulePath_;
-    std::string moduleName_;
-    std::string functionName_;
-    SimplexId numberOfRows_;
-    SimplexId numberOfColumns_;
-    int method_;
-    int numberOfComponents_;
-    int numberOfNeighbors_;
-    int randomState_;
-    void *matrix_;
-    std::vector<std::vector<double>> *embedding_;
-    char majorVersion_;
+    std::string modulePath_{};
+    std::string moduleName_{};
+    std::string functionName_{};
+    SimplexId numberOfRows_{0};
+    SimplexId numberOfColumns_{0};
+    int method_{};
+    int numberOfComponents_{0};
+    int numberOfNeighbors_{0};
+    int randomState_{0};
+    void *matrix_{};
+    std::vector<std::vector<double>> *embedding_{};
+    char majorVersion_{'0'};
   };
 } // namespace ttk

--- a/core/base/dimensionReduction/dimensionReduction.py
+++ b/core/base/dimensionReduction/dimensionReduction.py
@@ -2,31 +2,17 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
 
     import importlib
 
-    # check if numpy is installed
-    loader = importlib.find_loader("numpy")
-    found = loader is not None
-    if found:
-        print("[DimensionReduction] Python: numpy module found.")
-    else:
-        print("[DimensionReduction] Python error: numpy module not found.")
-        return 0
+    # if numpy, scipy and sklearn are not found
+    not_found = False
 
-    # check if scipy is installed
-    loader = importlib.find_loader("scipy")
-    found = loader is not None
-    if found:
-        print("[DimensionReduction] Python: scipy module found.")
-    else:
-        print("[DimensionReduction] Python error: scipy module not found.")
-        return 0
+    # check if modules are installed
+    for mod in ["numpy", "scipy", "sklearn"]:
+        if importlib.find_loader(mod) is None:
+            not_found = True
+            print("[DimensionReduction] Python error: " + mod + " module not found.")
 
-    # check if scikit-learn is installed
-    loader = importlib.find_loader("sklearn")
-    found = loader is not None
-    if found:
-        print("[DimensionReduction] Python: sklearn module found.")
-    else:
-        print("[DimensionReduction] Python error: sklearn module not found.")
+    if not_found:
+        # at least one module is not installed, aborting...
         return 0
 
     from sklearn import manifold

--- a/core/base/dimensionReduction/dimensionReduction.py
+++ b/core/base/dimensionReduction/dimensionReduction.py
@@ -3,7 +3,7 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
     import importlib
 
     # check if numpy is installed
-    loader = importlib.find_loader('numpy')
+    loader = importlib.find_loader("numpy")
     found = loader is not None
     if found:
         print("[DimensionReduction] Python: numpy module found.")
@@ -12,7 +12,7 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
         return 0
 
     # check if scipy is installed
-    loader = importlib.find_loader('scipy')
+    loader = importlib.find_loader("scipy")
     found = loader is not None
     if found:
         print("[DimensionReduction] Python: scipy module found.")
@@ -21,7 +21,7 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
         return 0
 
     # check if scikit-learn is installed
-    loader = importlib.find_loader('sklearn')
+    loader = importlib.find_loader("sklearn")
     found = loader is not None
     if found:
         print("[DimensionReduction] Python: sklearn module found.")
@@ -33,10 +33,11 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
     from sklearn import decomposition
     import numpy as np
     from sys import platform
-    
+
     if platform == "darwin":
         import sklearn
-        sklearn.utils.parallel_backend('threading')
+
+        sklearn.utils.parallel_backend("threading")
 
     if rstate > 0:
         np.random.seed(0)
@@ -45,94 +46,112 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
         if method == 0:
             seParams = params[0]
             if seParams[2] == "None":
-                se = manifold.SpectralEmbedding(n_components=ncomponents,
-                                                affinity=seParams[0],
-                                                gamma=seParams[1],
-                                                eigen_solver=None,
-                                                n_neighbors=nneighbors,
-                                                n_jobs=njobs)
+                se = manifold.SpectralEmbedding(
+                    n_components=ncomponents,
+                    affinity=seParams[0],
+                    gamma=seParams[1],
+                    eigen_solver=None,
+                    n_neighbors=nneighbors,
+                    n_jobs=njobs,
+                )
             else:
-                se = manifold.SpectralEmbedding(n_components=ncomponents,
-                                                affinity=seParams[0],
-                                                gamma=seParams[1],
-                                                eigen_solver=seParams[2],
-                                                n_neighbors=nneighbors,
-                                                n_jobs=njobs)
+                se = manifold.SpectralEmbedding(
+                    n_components=ncomponents,
+                    affinity=seParams[0],
+                    gamma=seParams[1],
+                    eigen_solver=seParams[2],
+                    n_neighbors=nneighbors,
+                    n_jobs=njobs,
+                )
             Y = se.fit_transform(X)
         elif method == 1:
             lleParams = params[1]
-            lle = manifold.LocallyLinearEmbedding(n_neighbors=nneighbors,
-                                                  n_components=ncomponents,
-                                                  reg=lleParams[0],
-                                                  eigen_solver=lleParams[1],
-                                                  tol=lleParams[2],
-                                                  max_iter=lleParams[3],
-                                                  method=lleParams[4],
-                                                  hessian_tol=lleParams[5],
-                                                  modified_tol=lleParams[6],
-                                                  neighbors_algorithm=lleParams[7],
-                                                  n_jobs=njobs)
+            lle = manifold.LocallyLinearEmbedding(
+                n_neighbors=nneighbors,
+                n_components=ncomponents,
+                reg=lleParams[0],
+                eigen_solver=lleParams[1],
+                tol=lleParams[2],
+                max_iter=lleParams[3],
+                method=lleParams[4],
+                hessian_tol=lleParams[5],
+                modified_tol=lleParams[6],
+                neighbors_algorithm=lleParams[7],
+                n_jobs=njobs,
+            )
             Y = lle.fit_transform(X)
         elif method == 2:
             mdsParams = params[2]
-            mds = manifold.MDS(n_components=ncomponents,
-                               metric=mdsParams[0],
-                               n_init=mdsParams[1],
-                               max_iter=mdsParams[2],
-                               verbose=mdsParams[3],
-                               eps=mdsParams[4],
-                               dissimilarity=mdsParams[5],
-                               n_jobs=njobs)
+            mds = manifold.MDS(
+                n_components=ncomponents,
+                metric=mdsParams[0],
+                n_init=mdsParams[1],
+                max_iter=mdsParams[2],
+                verbose=mdsParams[3],
+                eps=mdsParams[4],
+                dissimilarity=mdsParams[5],
+                n_jobs=njobs,
+            )
             Y = mds.fit_transform(X)
         elif method == 3:
             tsneParams = params[3]
-            tsne = manifold.TSNE(n_components=ncomponents,
-                                 perplexity=tsneParams[0],
-                                 early_exaggeration=tsneParams[1],
-                                 learning_rate=tsneParams[2],
-                                 n_iter=tsneParams[3],
-                                 n_iter_without_progress=tsneParams[4],
-                                 min_grad_norm=tsneParams[5],
-                                 metric=tsneParams[6],
-                                 init=tsneParams[7],
-                                 verbose=tsneParams[8],
-                                 method=tsneParams[9],
-                                 angle=tsneParams[10])
+            tsne = manifold.TSNE(
+                n_components=ncomponents,
+                perplexity=tsneParams[0],
+                early_exaggeration=tsneParams[1],
+                learning_rate=tsneParams[2],
+                n_iter=tsneParams[3],
+                n_iter_without_progress=tsneParams[4],
+                min_grad_norm=tsneParams[5],
+                metric=tsneParams[6],
+                init=tsneParams[7],
+                verbose=tsneParams[8],
+                method=tsneParams[9],
+                angle=tsneParams[10],
+            )
             Y = tsne.fit_transform(X)
         elif method == 4:
             isoParams = params[4]
-            iso = manifold.Isomap(n_neighbors=nneighbors,
-                                  n_components=ncomponents,
-                                  eigen_solver=isoParams[0],
-                                  tol=isoParams[1],
-                                  max_iter=isoParams[2],
-                                  path_method=isoParams[3],
-                                  neighbors_algorithm=isoParams[4],
-                                  n_jobs=njobs)
+            iso = manifold.Isomap(
+                n_neighbors=nneighbors,
+                n_components=ncomponents,
+                eigen_solver=isoParams[0],
+                tol=isoParams[1],
+                max_iter=isoParams[2],
+                path_method=isoParams[3],
+                neighbors_algorithm=isoParams[4],
+                n_jobs=njobs,
+            )
             Y = iso.fit_transform(X)
         elif method == 5:
             pcaParams = params[5]
             if pcaParams[4] == "auto":
-                pca = decomposition.PCA(n_components=ncomponents,
-                                        copy=pcaParams[0],
-                                        whiten=pcaParams[1],
-                                        svd_solver=pcaParams[2],
-                                        tol=pcaParams[3],
-                                        iterated_power="auto")
+                pca = decomposition.PCA(
+                    n_components=ncomponents,
+                    copy=pcaParams[0],
+                    whiten=pcaParams[1],
+                    svd_solver=pcaParams[2],
+                    tol=pcaParams[3],
+                    iterated_power="auto",
+                )
             else:
-                pca = decomposition.PCA(n_components=ncomponents,
-                                        copy=pcaParams[0],
-                                        whiten=pcaParams[1],
-                                        svd_solver=pcaParams[2],
-                                        tol=pcaParams[3],
-                                        iterated_power=int(pcaParams[4]))
+                pca = decomposition.PCA(
+                    n_components=ncomponents,
+                    copy=pcaParams[0],
+                    whiten=pcaParams[1],
+                    svd_solver=pcaParams[2],
+                    tol=pcaParams[3],
+                    iterated_power=int(pcaParams[4]),
+                )
             Y = pca.fit_transform(X)
 
-        L = [Y.shape[0], Y.shape[1], np.ravel(Y, 'F')]
+        L = [Y.shape[0], Y.shape[1], np.ravel(Y, "F")]
         return L
     except Exception as inst:
-        print('[DimensionReduction] Error: unexpected behaviour detected in the python script.')
-        print(type(inst))    # the exception instance
-        print(inst.args)     # arguments stored in .args
+        print(
+            "[DimensionReduction] Error: unexpected behaviour detected in the python script."
+        )
+        print(type(inst))  # the exception instance
+        print(inst.args)  # arguments stored in .args
         print(inst)
         return []

--- a/core/vtk/ttkDimensionReduction/ttk.module
+++ b/core/vtk/ttkDimensionReduction/ttk.module
@@ -6,4 +6,4 @@ HEADERS
   ttkDimensionReduction.h
 DEPENDS
   dimensionReduction
-  ttkTriangulationAlgorithm
+  ttkAlgorithm

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -54,7 +54,7 @@ int ttkDimensionReduction::RequestData(vtkInformation *request,
     }
   }
 
-  if(dimensionReduction_.isPythonFound()) {
+  if(this->isPythonFound()) {
     const SimplexId numberOfRows = input->GetNumberOfRows();
     const SimplexId numberOfColumns = ScalarFields.size();
 
@@ -76,35 +76,32 @@ int ttkDimensionReduction::RequestData(vtkInformation *request,
 
     outputData_.clear();
 
-    dimensionReduction_.setInputModulePath(ModulePath);
-    dimensionReduction_.setInputModuleName(ModuleName);
-    dimensionReduction_.setInputFunctionName(FunctionName);
-    dimensionReduction_.setInputMatrixDimensions(numberOfRows, numberOfColumns);
-    dimensionReduction_.setInputMatrix(inputData.data());
-    dimensionReduction_.setInputMethod(Method);
-    dimensionReduction_.setInputNumberOfComponents(NumberOfComponents);
-    dimensionReduction_.setInputNumberOfNeighbors(NumberOfNeighbors);
-    dimensionReduction_.setInputIsDeterministic(IsDeterministic);
-    dimensionReduction_.setSEParameters(
+    this->setInputModulePath(ModulePath);
+    this->setInputModuleName(ModuleName);
+    this->setInputFunctionName(FunctionName);
+    this->setInputMatrixDimensions(numberOfRows, numberOfColumns);
+    this->setInputMatrix(inputData.data());
+    this->setInputMethod(Method);
+    this->setInputNumberOfComponents(NumberOfComponents);
+    this->setInputNumberOfNeighbors(NumberOfNeighbors);
+    this->setInputIsDeterministic(IsDeterministic);
+    this->setSEParameters(
       se_Affinity, se_Gamma, se_EigenSolver, InputIsADistanceMatrix);
-    dimensionReduction_.setLLEParameters(
-      lle_Regularization, lle_EigenSolver, lle_Tolerance, lle_MaxIteration,
-      lle_Method, lle_HessianTolerance, lle_ModifiedTolerance,
-      lle_NeighborsAlgorithm);
-    dimensionReduction_.setMDSParameters(mds_Metric, mds_Init, mds_MaxIteration,
-                                         mds_Verbose, mds_Epsilon,
-                                         InputIsADistanceMatrix);
-    dimensionReduction_.setTSNEParameters(
+    this->setLLEParameters(lle_Regularization, lle_EigenSolver, lle_Tolerance,
+                           lle_MaxIteration, lle_Method, lle_HessianTolerance,
+                           lle_ModifiedTolerance, lle_NeighborsAlgorithm);
+    this->setMDSParameters(mds_Metric, mds_Init, mds_MaxIteration, mds_Verbose,
+                           mds_Epsilon, InputIsADistanceMatrix);
+    this->setTSNEParameters(
       tsne_Perplexity, tsne_Exaggeration, tsne_LearningRate, tsne_MaxIteration,
       tsne_MaxIterationProgress, tsne_GradientThreshold, tsne_Metric, tsne_Init,
       tsne_Verbose, tsne_Method, tsne_Angle);
-    dimensionReduction_.setISOParameters(iso_EigenSolver, iso_Tolerance,
-                                         iso_MaxIteration, iso_PathMethod,
-                                         iso_NeighborsAlgorithm);
-    dimensionReduction_.setPCAParameters(
+    this->setISOParameters(iso_EigenSolver, iso_Tolerance, iso_MaxIteration,
+                           iso_PathMethod, iso_NeighborsAlgorithm);
+    this->setPCAParameters(
       pca_Copy, pca_Whiten, pca_SVDSolver, pca_Tolerance, pca_MaxIteration);
-    dimensionReduction_.setOutputComponents(&outputData_);
-    const int errorCode = dimensionReduction_.execute();
+    this->setOutputComponents(&outputData_);
+    const int errorCode = this->execute();
 
     if(!errorCode) {
       if(KeepAllDataArrays)

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -76,30 +76,12 @@ int ttkDimensionReduction::RequestData(vtkInformation *request,
 
     outputData_.clear();
 
-    this->setInputModulePath(ModulePath);
-    this->setInputModuleName(ModuleName);
-    this->setInputFunctionName(FunctionName);
     this->setInputMatrixDimensions(numberOfRows, numberOfColumns);
     this->setInputMatrix(inputData.data());
     this->setInputMethod(Method);
     this->setInputNumberOfComponents(NumberOfComponents);
     this->setInputNumberOfNeighbors(NumberOfNeighbors);
     this->setInputIsDeterministic(IsDeterministic);
-    this->setSEParameters(
-      se_Affinity, se_Gamma, se_EigenSolver, InputIsADistanceMatrix);
-    this->setLLEParameters(lle_Regularization, lle_EigenSolver, lle_Tolerance,
-                           lle_MaxIteration, lle_Method, lle_HessianTolerance,
-                           lle_ModifiedTolerance, lle_NeighborsAlgorithm);
-    this->setMDSParameters(mds_Metric, mds_Init, mds_MaxIteration, mds_Verbose,
-                           mds_Epsilon, InputIsADistanceMatrix);
-    this->setTSNEParameters(
-      tsne_Perplexity, tsne_Exaggeration, tsne_LearningRate, tsne_MaxIteration,
-      tsne_MaxIterationProgress, tsne_GradientThreshold, tsne_Metric, tsne_Init,
-      tsne_Verbose, tsne_Method, tsne_Angle);
-    this->setISOParameters(iso_EigenSolver, iso_Tolerance, iso_MaxIteration,
-                           iso_PathMethod, iso_NeighborsAlgorithm);
-    this->setPCAParameters(
-      pca_Copy, pca_Whiten, pca_SVDSolver, pca_Tolerance, pca_MaxIteration);
     this->setOutputComponents(&outputData_);
     const int errorCode = this->execute();
 

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -59,7 +59,7 @@ int ttkDimensionReduction::RequestData(vtkInformation *request,
     const SimplexId numberOfColumns = ScalarFields.size();
 
 #ifndef TTK_ENABLE_KAMIKAZE
-    if(numberOfRows <= 0 or numberOfColumns <= 0) {
+    if(numberOfRows <= 0 || numberOfColumns <= 0) {
       this->printErr("input matrix has invalid dimensions");
       return -1;
     }

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -210,6 +210,8 @@ private:
   // default
   bool SelectFieldsWithRegexp{false};
   std::string RegexpString{".*"};
+  std::vector<std::string> ScalarFields{};
+
   int NumberOfComponents{2};
   int NumberOfNeighbors{5};
   int Method{2}; // MDS
@@ -219,60 +221,5 @@ private:
   // mds && se
   bool InputIsADistanceMatrix{false};
 
-  // se
-  std::string se_Affinity{"nearest_neighbors"};
-  float se_Gamma{1};
-  std::string se_EigenSolver{"auto"};
-
-  // lle
-  float lle_Regularization{1e-3};
-  std::string lle_EigenSolver{"auto"};
-  float lle_Tolerance{1e-3};
-  int lle_MaxIteration{300};
-  std::string lle_Method{"standard"};
-  float lle_HessianTolerance{1e-3};
-  float lle_ModifiedTolerance{1e-3};
-  std::string lle_NeighborsAlgorithm{"auto"};
-
-  // mds
-  bool mds_Metric{true};
-  int mds_Init{4};
-  int mds_MaxIteration{300};
-  int mds_Verbose{0};
-  float mds_Epsilon{0};
-
-  // tsne
-  float tsne_Perplexity{30};
-  float tsne_Exaggeration{12};
-  float tsne_LearningRate{200};
-  int tsne_MaxIteration{1000};
-  int tsne_MaxIterationProgress{300};
-  float tsne_GradientThreshold{1e-7};
-  std::string tsne_Metric{"euclidian"};
-  std::string tsne_Init{"random"};
-  int tsne_Verbose{0};
-  std::string tsne_Method{"barnes_hut"};
-  float tsne_Angle{0.5};
-
-  // iso
-  std::string iso_EigenSolver{"auto"};
-  float iso_Tolerance{1e-3};
-  int iso_MaxIteration{300};
-  std::string iso_PathMethod{"auto"};
-  std::string iso_NeighborsAlgorithm{"auto"};
-
-  // pca
-  bool pca_Copy{true};
-  bool pca_Whiten{false};
-  std::string pca_SVDSolver{"auto"};
-  float pca_Tolerance{0};
-  std::string pca_MaxIteration{"auto"};
-
-  // testing
-  std::string ModulePath{};
-  std::string ModuleName{};
-  std::string FunctionName{};
-
-  std::vector<std::string> ScalarFields{};
   std::vector<std::vector<double>> outputData_{};
 };

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -67,7 +67,14 @@ public:
   vtkGetMacro(KeepAllDataArrays, bool);
 
   // SE && MDS
-  vtkSetMacro(InputIsADistanceMatrix, bool);
+  void SetInputIsADistanceMatrix(const bool b) {
+    this->InputIsADistanceMatrix = b;
+    if(b) {
+      this->mds_Dissimilarity = "precomputed";
+      this->se_Affinity = "precomputed";
+    }
+    Modified();
+  }
   vtkGetMacro(InputIsADistanceMatrix, bool);
 
   // SE

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -213,8 +213,8 @@ private:
   int NumberOfComponents{2};
   int NumberOfNeighbors{5};
   int Method{2}; // MDS
-  int IsDeterministic;
-  bool KeepAllDataArrays;
+  int IsDeterministic{true};
+  bool KeepAllDataArrays{true};
 
   // mds && se
   bool InputIsADistanceMatrix{false};
@@ -269,11 +269,10 @@ private:
   std::string pca_MaxIteration{"auto"};
 
   // testing
-  std::string ModulePath;
-  std::string ModuleName;
-  std::string FunctionName;
-  ttk::DimensionReduction dimensionReduction_;
+  std::string ModulePath{};
+  std::string ModuleName{};
+  std::string FunctionName{};
 
-  std::vector<std::string> ScalarFields;
+  std::vector<std::string> ScalarFields{};
   std::vector<std::vector<double>> outputData_{};
 };

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -19,69 +19,20 @@
 /// \sa ttk::DimensionReduction
 #pragma once
 
-// VTK includes
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkIntArray.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
-#include <vtkTable.h>
-#include <vtkTableAlgorithm.h>
-
 // VTK Module
 #include <ttkDimensionReductionModule.h>
 
 // TTK includes
 #include <DimensionReduction.h>
-#include <ttkTriangulationAlgorithm.h>
+#include <ttkAlgorithm.h>
 
 class TTKDIMENSIONREDUCTION_EXPORT ttkDimensionReduction
-  : public vtkTableAlgorithm,
-    protected ttk::Wrapper {
+  : public ttkAlgorithm,
+    protected ttk::DimensionReduction {
+
 public:
-  enum Method {
-    SpectralEmbedding = 0,
-    LocallyLinearEmbedding,
-    MDS,
-    TSNE,
-    Isomap,
-    PCA
-  };
-
   static ttkDimensionReduction *New();
-  vtkTypeMacro(ttkDimensionReduction, vtkTableAlgorithm)
-
-    // default ttk setters
-    void SetDebugLevel(int debugLevel) {
-    setDebugLevel(debugLevel);
-    Modified();
-  }
-
-  void SetThreadNumber(int threadNumber) {
-    ThreadNumber = threadNumber;
-    SetThreads();
-  }
-
-  void SetThreads() {
-    if(!UseAllCores)
-      threadNumber_ = ThreadNumber;
-    else {
-      threadNumber_ = ttk::OsCall::getNumberOfCores();
-    }
-    Modified();
-  }
-
-  void SetUseAllCores(bool onOff) {
-    UseAllCores = onOff;
-    SetThreads();
-  }
-  // end of default ttk setters
+  vtkTypeMacro(ttkDimensionReduction, ttkAlgorithm);
 
   void SetScalarFields(std::string s) {
     ScalarFields.push_back(s);
@@ -246,96 +197,22 @@ public:
   vtkSetMacro(FunctionName, std::string);
   vtkGetMacro(FunctionName, std::string);
 
-  int FillInputPortInformation(int port, vtkInformation *info) override {
-    switch(port) {
-      case 0:
-        info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
-        break;
-    }
-
-    return 1;
-  }
-
-  int FillOutputPortInformation(int port, vtkInformation *info) override {
-    switch(port) {
-      case 0:
-        info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
-        break;
-    }
-
-    return 1;
-  }
-
 protected:
-  ttkDimensionReduction() {
-    NumberOfComponents = 2;
-    NumberOfNeighbors = 5;
-    Method = 2;
+  ttkDimensionReduction();
 
-    se_Affinity = "nearest_neighbors";
-    se_Gamma = 1;
-    se_EigenSolver = "auto";
-
-    lle_Regularization = 1e-3;
-    lle_EigenSolver = "auto";
-    lle_Tolerance = 1e-3;
-    lle_MaxIteration = 300;
-    lle_Method = "standard";
-    lle_HessianTolerance = 1e-3;
-    lle_ModifiedTolerance = 1e-3;
-    lle_NeighborsAlgorithm = "auto";
-
-    mds_Metric = true;
-    mds_Init = 4;
-    mds_MaxIteration = 300;
-    mds_Verbose = 0;
-    mds_Epsilon = 0;
-
-    tsne_Perplexity = 30;
-    tsne_Exaggeration = 12;
-    tsne_LearningRate = 200;
-    tsne_MaxIteration = 1000;
-    tsne_MaxIterationProgress = 300;
-    tsne_GradientThreshold = 1e-7;
-    tsne_Metric = "euclidean";
-    tsne_Init = "random";
-    tsne_Verbose = 0;
-    tsne_Method = "barnes_hut";
-    tsne_Angle = 0.5;
-
-    iso_EigenSolver = "auto";
-    iso_Tolerance = 1e-3;
-    iso_MaxIteration = 300;
-    iso_PathMethod = "auto";
-    iso_NeighborsAlgorithm = "auto";
-
-    pca_Copy = true;
-    pca_Whiten = false;
-    pca_SVDSolver = "auto";
-    pca_Tolerance = 0;
-    pca_MaxIteration = "auto";
-
-    UseAllCores = true;
-  }
-
-  ~ttkDimensionReduction() override {
-  }
-
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
 
 private:
-  int doIt(vtkTable *input, vtkTable *output);
-  bool needsToAbort() override;
-  int updateProgress(const float &progress) override;
-
   // default
   bool SelectFieldsWithRegexp{false};
   std::string RegexpString{".*"};
-  int NumberOfComponents;
-  int NumberOfNeighbors;
-  int Method;
+  int NumberOfComponents{2};
+  int NumberOfNeighbors{5};
+  int Method{2}; // MDS
   int IsDeterministic;
   bool KeepAllDataArrays;
 
@@ -343,60 +220,58 @@ private:
   bool InputIsADistanceMatrix{false};
 
   // se
-  std::string se_Affinity;
-  float se_Gamma;
-  std::string se_EigenSolver;
+  std::string se_Affinity{"nearest_neighbors"};
+  float se_Gamma{1};
+  std::string se_EigenSolver{"auto"};
 
   // lle
-  float lle_Regularization;
-  std::string lle_EigenSolver;
-  float lle_Tolerance;
-  int lle_MaxIteration;
-  std::string lle_Method;
-  float lle_HessianTolerance;
-  float lle_ModifiedTolerance;
-  std::string lle_NeighborsAlgorithm;
+  float lle_Regularization{1e-3};
+  std::string lle_EigenSolver{"auto"};
+  float lle_Tolerance{1e-3};
+  int lle_MaxIteration{300};
+  std::string lle_Method{"standard"};
+  float lle_HessianTolerance{1e-3};
+  float lle_ModifiedTolerance{1e-3};
+  std::string lle_NeighborsAlgorithm{"auto"};
 
   // mds
-  bool mds_Metric;
-  int mds_Init;
-  int mds_MaxIteration;
-  int mds_Verbose;
-  float mds_Epsilon;
+  bool mds_Metric{true};
+  int mds_Init{4};
+  int mds_MaxIteration{300};
+  int mds_Verbose{0};
+  float mds_Epsilon{0};
 
   // tsne
-  float tsne_Perplexity;
-  float tsne_Exaggeration;
-  float tsne_LearningRate;
-  int tsne_MaxIteration;
-  int tsne_MaxIterationProgress;
-  float tsne_GradientThreshold;
-  std::string tsne_Metric;
-  std::string tsne_Init;
-  int tsne_Verbose;
-  std::string tsne_Method;
-  float tsne_Angle;
+  float tsne_Perplexity{30};
+  float tsne_Exaggeration{12};
+  float tsne_LearningRate{200};
+  int tsne_MaxIteration{1000};
+  int tsne_MaxIterationProgress{300};
+  float tsne_GradientThreshold{1e-7};
+  std::string tsne_Metric{"euclidian"};
+  std::string tsne_Init{"random"};
+  int tsne_Verbose{0};
+  std::string tsne_Method{"barnes_hut"};
+  float tsne_Angle{0.5};
 
   // iso
-  std::string iso_EigenSolver;
-  float iso_Tolerance;
-  int iso_MaxIteration;
-  std::string iso_PathMethod;
-  std::string iso_NeighborsAlgorithm;
+  std::string iso_EigenSolver{"auto"};
+  float iso_Tolerance{1e-3};
+  int iso_MaxIteration{300};
+  std::string iso_PathMethod{"auto"};
+  std::string iso_NeighborsAlgorithm{"auto"};
 
   // pca
-  bool pca_Copy;
-  bool pca_Whiten;
-  std::string pca_SVDSolver;
-  float pca_Tolerance;
-  std::string pca_MaxIteration;
+  bool pca_Copy{true};
+  bool pca_Whiten{false};
+  std::string pca_SVDSolver{"auto"};
+  float pca_Tolerance{0};
+  std::string pca_MaxIteration{"auto"};
 
   // testing
   std::string ModulePath;
   std::string ModuleName;
   std::string FunctionName;
-  bool UseAllCores;
-  ttk::ThreadId ThreadNumber;
   ttk::DimensionReduction dimensionReduction_;
 
   std::vector<std::string> ScalarFields;

--- a/core/vtk/ttkDimensionReduction/vtk.module
+++ b/core/vtk/ttkDimensionReduction/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkDimensionReduction
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+ ttkAlgorithm

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -628,42 +628,6 @@
         </Documentation>
       </StringVectorProperty>
 
-      <IntVectorProperty
-        name="UseAllCores"
-        label="Use All Cores"
-        command="SetUseAllCores"
-        number_of_elements="1"
-        default_values="1" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Use all available cores.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-        name="ThreadNumber"
-        label="Thread Number"
-        command="SetThreadNumber"
-        number_of_elements="1"
-        default_values="1" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="1" max="100" />
-        <Documentation>
-          Thread number.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-        name="DebugLevel"
-        label="Debug Level"
-        command="SetDebugLevel"
-        number_of_elements="1"
-        default_values="3" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="0" max="100" />
-        <Documentation>
-          Debug level.
-        </Documentation>
-      </IntVectorProperty>
-
       <StringVectorProperty name="ModulePath"
         label="Module Path"
         command="SetModulePath"
@@ -713,6 +677,8 @@
           Set the random state.
         </Documentation>
       </IntVectorProperty>
+
+      ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="SelectFieldsWithRegexp" />
@@ -820,9 +786,6 @@
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="UseAllCores" />
-        <Property name="ThreadNumber" />
-        <Property name="DebugLevel" />
         <Property name="ModulePath" />
         <Property name="ModuleName" />
         <Property name="FunctionName" />


### PR DESCRIPTION
This PR migrates the DimensionReduction module to the new architecture.

For now, the current way of selecting input table arrays has been preserved. As a consequence, the ttk-data state files using DimensionReduction work without modifications.

Enjoy,
Pierre

