### PR TITLE
Bug fix: `make install` for ParaView plugins

### DIFF
--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -33,3 +33,22 @@ macro(ttk_register_pv_filter vtkModuleDir xmlFile)
     endif()
   endif()
 endmacro()
+
+function(ttk_set_paraview_rpath TARGET_NAME)
+  if(APPLE)
+    # On macOS,
+    # look into the subdirectory "TopologyToolKit"
+    # to find the actual plugins.
+    get_target_property(TEMP
+        ${TARGET_NAME} INSTALL_RPATH
+        )
+    set_target_properties(${TARGET_NAME}
+      PROPERTIES
+        INSTALL_RPATH "@loader_path/${TTK_PLUGIN_SUBDIR};${TEMP}"
+    )
+    get_target_property(TEMPTWO
+        ${TARGET_NAME} INSTALL_RPATH
+        )
+  endif(APPLE)
+endfunction(ttk_set_paraview_rpath TTK_NAME)
+

--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -46,9 +46,6 @@ function(ttk_set_paraview_rpath TARGET_NAME)
       PROPERTIES
         INSTALL_RPATH "@loader_path/${TTK_PLUGIN_SUBDIR};${TEMP}"
     )
-    get_target_property(TEMPTWO
-        ${TARGET_NAME} INSTALL_RPATH
-        )
   endif(APPLE)
 endfunction(ttk_set_paraview_rpath TTK_NAME)
 

--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -47,5 +47,5 @@ function(ttk_set_paraview_rpath TARGET_NAME)
         INSTALL_RPATH "@loader_path/${TTK_PLUGIN_SUBDIR};${TEMP}"
     )
   endif(APPLE)
-endfunction(ttk_set_paraview_rpath TTK_NAME)
+endfunction(ttk_set_paraview_rpath TARGET_NAME)
 

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -59,6 +59,17 @@ macro(ttk_add_vtk_module)
       )
   endif()
 
+  function(ttk_set_paraview_install_name TTK_NAME)
+    if(APPLE)
+      # On macOS,
+      # let the TopologyToolKit.so find this dependency in the subdirectory
+      set_target_properties (${TTK_NAME}
+        PROPERTIES
+          INSTALL_NAME_DIR "@rpath"
+      )
+    endif(APPLE)
+  endfunction(ttk_set_paraview_install_name)
+
   if(NOT "${TTK_INSTALL_PLUGIN_DIR}" STREQUAL "")
     ttk_set_paraview_install_name(${TTK_NAME})
     install(

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -60,11 +60,12 @@ macro(ttk_add_vtk_module)
   endif()
 
   if(NOT "${TTK_INSTALL_PLUGIN_DIR}" STREQUAL "")
+    ttk_set_paraview_install_name(${TTK_NAME})
     install(
       TARGETS
         ${TTK_NAME}
       DESTINATION
-        "${TTK_INSTALL_PLUGIN_DIR}/TopologyToolKit"
+        "${TTK_INSTALL_PLUGIN_DIR}/${TTK_PLUGIN_SUBDIR}"
       )
   endif()
 

--- a/config.cmake
+++ b/config.cmake
@@ -313,32 +313,10 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
-# Install rpath
-
+# ParaView plugins go to a subdirectory with this name
 set(TTK_PLUGIN_SUBDIR "TopologyToolKit")
 
-function(ttk_set_paraview_install_name TTK_NAME)
-  if(APPLE)
-    # On macOS,
-    # let the TopologyToolKit.so find this dependency in the subdirectory
-    set_target_properties (${TTK_NAME}
-      PROPERTIES
-        INSTALL_NAME_DIR "@rpath"
-    )
-  endif(APPLE)
-endfunction(ttk_set_paraview_install_name)
-
-function(ttk_set_paraview_rpath TARGET_NAME)
-  if(APPLE)
-    # On macOS,
-    # look into the subdirectory "TopologyToolKit"
-    # to find the actual plugins.
-    set_target_properties(${TARGET_NAME}
-      PROPERTIES
-        INSTALL_RPATH "@loader_path/${TTK_PLUGIN_SUBDIR}"
-    )
-  endif(APPLE)
-endfunction(ttk_set_paraview_rpath TTK_NAME)
+# Install rpath
 
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH TRUE)

--- a/config.cmake
+++ b/config.cmake
@@ -313,7 +313,32 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
-# Install rapth
+# Install rpath
+
+set(TTK_PLUGIN_SUBDIR "TopologyToolKit")
+
+function(ttk_set_paraview_install_name TTK_NAME)
+  if(APPLE)
+    # On macOS,
+    # let the TopologyToolKit.so find this dependency in the subdirectory
+    set_target_properties (${TTK_NAME}
+      PROPERTIES
+        INSTALL_NAME_DIR "@rpath"
+    )
+  endif(APPLE)
+endfunction(ttk_set_paraview_install_name)
+
+function(ttk_set_paraview_rpath TARGET_NAME)
+  if(APPLE)
+    # On macOS,
+    # look into the subdirectory "TopologyToolKit"
+    # to find the actual plugins.
+    set_target_properties(${TARGET_NAME}
+      PROPERTIES
+        INSTALL_RPATH "@loader_path/${TTK_PLUGIN_SUBDIR}"
+    )
+  endif(APPLE)
+endfunction(ttk_set_paraview_rpath TTK_NAME)
 
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH TRUE)

--- a/paraview/singlePlugin/CMakeLists.txt
+++ b/paraview/singlePlugin/CMakeLists.txt
@@ -17,6 +17,8 @@ paraview_add_plugin(TopologyToolKit
   )
 
 if(NOT "${TTK_INSTALL_PLUGIN_DIR}" STREQUAL "")
+  ttk_set_paraview_rpath(TopologyToolKit)
+
   install(
     TARGETS
       TopologyToolKit


### PR DESCRIPTION
- [X] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/dev/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.

- [X] Please provide a quick description of your contributions below:

When you issue a `make install` on macOS to install the TTK plugin for ParaView,
`TopologyToolKit.so` has failed to find shared libs in the subdirectory `TopologyToolKit`.
This is because CMake does not set rpaths properly for libraries in the
same project. Following CMake's documentation, this commit sets the
rpaths.

Perhaps an equivalent fix is needed on Linux (and on Windows.)

