### PR TITLE
[api-migration-hackathon] TopologicalCompression

### DIFF
--- a/CMake/topological_compression.xml
+++ b/CMake/topological_compression.xml
@@ -1,9 +1,11 @@
 <StringVectorProperty
-    name="ScalarField"
-    command="SetScalarField"
-    number_of_elements="1"
+    name="Scalar Field"
+    command="SetInputArrayToProcess"
+    element_types="0 0 0 0 2"
+    number_of_elements="5"
+    default_values="0"
     animateable="0"
-    label="Scalar Field">
+    >
   <ArrayListDomain
       name="array_list"
       default_values="0">

--- a/core/base/topologicalCompression/OtherCompression.h
+++ b/core/base/topologicalCompression/OtherCompression.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <TopologicalCompression.h>
+
 template <typename dataType>
 int ttk::TopologicalCompression::ComputeTotalSizeForOther() {
   // Should return the number of bytes to be written on the output file
@@ -33,63 +35,42 @@ int ttk::TopologicalCompression::compressForOther(int vertexNumber,
 
   // Code me
 
-  {
-    std::stringstream msg;
-    msg << "[TopologicalCompression] Other computed in " << t.getElapsedTime()
-        << " s. (" << threadNumber_ << " thread(s))." << std::endl;
-    dMsg(std::cout, msg.str(), timeMsg);
-    t.reStart();
-  }
+  this->printMsg(
+    "Other computed", 1.0, t.getElapsedTime(), this->threadNumber_);
+  t.reStart();
 
   // Code me
 
-  {
-    std::stringstream msg;
-    msg << "[TopologicalCompression] Scalar field compressed in "
-        << t.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
-        << std::endl;
-    dMsg(std::cout, msg.str(), timeMsg);
-  }
+  this->printMsg(
+    "Scalar field compressed", 1.0, t.getElapsedTime(), this->threadNumber_);
 
   return 0;
 }
 
 template <typename dataType>
 int ttk::TopologicalCompression::WriteOtherTopology(FILE *fm) {
-  std::cout << "[TopologicalCompression] Writing Other index / topology."
-            << std::endl;
-
+  this->printWrn("Writing Other index / topology.");
   // Code me
-
   return 0;
 }
 
 template <typename dataType>
 int ttk::TopologicalCompression::WriteOtherGeometry(FILE *fm) {
-  std::cout
-    << "[ttkTopologicalCompressionReader] Writing Other buffer / geometry."
-    << std::endl;
-
+  this->printWrn("Writing Other buffer / geometry.");
   // Code me
-
   return 0;
 }
 
 template <typename dataType>
 int ttk::TopologicalCompression::ReadOtherTopology(FILE *fm) {
-  std::cout
-    << "[ttkTopologicalCompressionReader] Reading Other index / topology."
-    << std::endl;
+  this->printWrn("Reading Other index / topology.");
   // Code me
-
   return 0;
 }
 
 template <typename dataType>
 int ttk::TopologicalCompression::ReadOtherGeometry(FILE *fm) {
-  std::cout
-    << "[ttkTopologicalCompressionReader] Reading Other buffer / geometry."
-    << std::endl;
+  this->printWrn("Reading Other buffer / geometry.");
   // Code me
   return 0;
 }

--- a/core/base/topologicalCompression/OtherCompression.h
+++ b/core/base/topologicalCompression/OtherCompression.h
@@ -7,8 +7,7 @@
 // ttkTopologicalCompressionWriter.cpp
 // OtherCompression.h
 
-#ifndef TTK_OTHERCOMPRESSION_H
-#define TTK_OTHERCOMPRESSION_H
+#pragma once
 
 template <typename dataType>
 int ttk::TopologicalCompression::ComputeTotalSizeForOther() {
@@ -94,5 +93,3 @@ int ttk::TopologicalCompression::ReadOtherGeometry(FILE *fm) {
   // Code me
   return 0;
 }
-
-#endif // TTK_OTHERCOMPRESSION_H

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -2,8 +2,7 @@
 // Created by max on 24/05/18.
 //
 
-#ifndef TTK_PERSISTENCEDIAGRAMCOMPRESSION_H
-#define TTK_PERSISTENCEDIAGRAMCOMPRESSION_H
+#pragma once
 
 template <typename dataType>
 int ttk::TopologicalCompression::ComputeTotalSizeForPersistenceDiagram(
@@ -1059,5 +1058,3 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
 
   return 0;
 }
-
-#endif // TTK_PERSISTENCEDIAGRAMCOMPRESSION_H

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <TopologicalCompression.h>
+
 template <typename dataType>
 int ttk::TopologicalCompression::ComputeTotalSizeForPersistenceDiagram(
   std::vector<std::tuple<double, int>> &mapping,
@@ -52,10 +54,10 @@ int ttk::TopologicalCompression::WritePersistenceTopology(FILE *fm) {
     return -1;
 
   numberOfBytesWritten += sizeof(int);
-  WriteInt(fm, numberOfVertices);
+  Write(fm, numberOfVertices);
 
   numberOfBytesWritten += sizeof(int);
-  WriteInt(fm, numberOfSegments);
+  Write(fm, numberOfSegments);
 
   numberOfBytesWritten += WriteCompactSegmentation(
     fm, getSegmentation(), numberOfVertices, numberOfSegments);

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -445,7 +445,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   topoIndices.push_back(std::make_tuple(maxValue, maxIndex));
   topoIndices.push_back(std::make_tuple(minValue, minIndex));
   double tolerance = 0.01 * tol * (maxValue - minValue);
-  double maxError = 0.01 * maximumError_ * (maxValue - minValue);
+  double maxError = 0.01 * MaximumError * (maxValue - minValue);
 
   this->printMsg(
     "Computed min/max", 1.0, t.getElapsedTime(), this->threadNumber_);
@@ -454,7 +454,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   bool sqDomain = false;
   bool sqRange = false;
 
-  const char *sq = sqMethod_.c_str();
+  const char *sq = SQMethod.c_str();
   int nbCrit = 0;
   std::vector<int> simplifiedConstraints;
   if(strcmp(sq, "") == 0 && !zfpOnly_) {
@@ -578,7 +578,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     t.reStart();
 
     // 2. Perform topological simplification with constraints.
-    if(useTopologicalSimplification_) {
+    if(UseTopologicalSimplification) {
       topologicalSimplification.setInputScalarFieldPointer(inputData);
       topologicalSimplification.setOutputScalarFieldPointer(outputData);
       topologicalSimplification.setInputOffsetScalarFieldPointer(
@@ -611,7 +611,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   } else if(zfpOnly_) {
     return 0;
   } else {
-    this->printErr("Unrecognized SQ option (" + sqMethod_ + ").");
+    this->printErr("Unrecognized SQ option (" + SQMethod + ").");
     return -3;
   }
 
@@ -626,7 +626,6 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   // ith rank = ith segment (from bottom)
   // 0: value
   // 1: critical point index or -1 if !critical
-  bool subdivide = !dontSubdivide_;
   auto l = (int)topoIndices.size();
   if(l < 1) {
     this->printMsg("Trivial subdivision performed.");
@@ -645,7 +644,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
 
       if(diff == 0)
         continue;
-      if(!subdivide || (diff < (dataType)maxError)) {
+      if(!Subdivide || (diff < (dataType)maxError)) {
         segments.push_back(std::make_tuple(v1, i1));
       } else {
         // Subdivide.

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -124,7 +124,7 @@ template <typename dataType, typename triangulationType>
 int ttk::TopologicalCompression::ReadPersistenceGeometry(
   FILE *fm, const triangulationType &triangulation) {
 
-  int sqMethod = sqMethodInt_;
+  int sqMethod = SQMethodInt;
   double zfpBitBudget = ZFPBitBudget;
   int *dataExtent = dataExtent_;
 

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -123,11 +123,9 @@ int ttk::TopologicalCompression::ReadPersistenceTopology(FILE *fm) {
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalCompression::ReadPersistenceGeometry(
   FILE *fm, const triangulationType &triangulation) {
-  using ttk::TopologicalCompression;
 
   int sqMethod = sqMethodInt_;
-  bool zfpOnly = zfpOnly_;
-  double zfpBitBudget = zfpBitBudget_;
+  double zfpBitBudget = ZFPBitBudget;
   int *dataExtent = dataExtent_;
 
   std::vector<std::tuple<double, int>> mappingsSortedPerValue;
@@ -137,7 +135,7 @@ int ttk::TopologicalCompression::ReadPersistenceGeometry(
   int nbConstraints = 0;
 
   int numberOfBytesRead = 0;
-  if(!zfpOnly) {
+  if(!ZFPOnly) {
     numberOfBytesRead
       += ReadPersistenceIndex(fm, mapping_, mappingsSortedPerValue,
                               criticalConstraints_, min, max, nbConstraints);
@@ -212,7 +210,7 @@ int ttk::TopologicalCompression::ReadPersistenceGeometry(
   if(sqMethod == 1 || sqMethod == 2)
     return 0;
 
-  if(zfpOnly)
+  if(ZFPOnly)
     return 0;
 
   // 2.b. (3.) Crop whatever doesn't fit in topological intervals.
@@ -460,7 +458,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   const char *sq = SQMethod.c_str();
   int nbCrit = 0;
   std::vector<int> simplifiedConstraints;
-  if(strcmp(sq, "") == 0 && !zfpOnly_) {
+  if(strcmp(sq, "") == 0 && !ZFPOnly) {
     // No SQ: perform topological control
 
     std::vector<std::tuple<SimplexId, SimplexId, dataType>> JTPairs;
@@ -610,7 +608,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   } else if(strcmp(sq, "d") == 0 || strcmp(sq, "D") == 0) {
     // Domain-based SQ: range quantization + later domain control
     sqDomain = true;
-  } else if(zfpOnly_) {
+  } else if(ZFPOnly) {
     return 0;
   } else {
     this->printErr("Unrecognized SQ option (" + SQMethod + ").");
@@ -882,7 +880,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
   }
 
   // 7. [ZFP]: max constraints, min constraints
-  if(!sqDomain && !sqRange && !zfpOnly_) {
+  if(!sqDomain && !sqRange && !ZFPOnly) {
     for(int i = 0; i < nbCrit; ++i) {
       SimplexId id = simplifiedConstraints[i];
       dataType val = inputData[id];
@@ -909,8 +907,8 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     }
 
     int nSegments = indexLast > -1 ? indexLast + 1 : (int)segments.size() - 1;
-    this->nbSegments = nSegments;
-    this->nbVertices = vertexNumber;
+    this->NbSegments = nSegments;
+    this->NbVertices = vertexNumber;
 
     this->printMsg("Assigned " + std::to_string(nSegments) + " segment(s).",
                    1.0, t1.getElapsedTime(), this->threadNumber_);

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -332,8 +332,7 @@ void ttk::TopologicalCompression::CropIntervals(
       double value = std::get<0>(tt);
       int sseg = std::get<1>(tt);
       if(seg != sseg) {
-        ttk::Debug d;
-        d.printErr("Decompression mismatch.");
+        this->printErr("Decompression mismatch.");
       }
 
       auto it2 = lower_bound(mappingsSortedPerValue.begin(),
@@ -370,14 +369,12 @@ void ttk::TopologicalCompression::CropIntervals(
         }
       }
     } else {
-      ttk::Debug d;
-      d.printErr("Error looking for topo index.");
+      this->printErr("Error looking for topo index.");
     }
   }
 
   if(numberOfMisses > 0) {
-    ttk::Debug d;
-    d.printWrn("Missed " + std::to_string(numberOfMisses) + " values.");
+    this->printWrn("Missed " + std::to_string(numberOfMisses) + " values.");
   }
 }
 

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -912,7 +912,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     this->nbSegments = nSegments;
     this->nbVertices = vertexNumber;
 
-    this->printMsg("Affected " + std::to_string(nSegments) + " segment(s).",
+    this->printMsg("Assigned " + std::to_string(nSegments) + " segment(s).",
                    1.0, t1.getElapsedTime(), this->threadNumber_);
   }
 

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -96,8 +96,7 @@ int ttk::TopologicalCompression::CompressWithZFP(FILE *file,
   // free(array);
 
   if(status != 0) {
-    ttk::Debug d;
-    d.printErr("Encountered a problem with ZFP.");
+    this->printErr("Encountered a problem with ZFP.");
   }
 
   return (int)zfpsize;

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -147,157 +147,19 @@ unsigned int ttk::TopologicalCompression::log2(int val) {
 
 // IO.
 
-bool ttk::TopologicalCompression::ReadBool(FILE *fm) {
-  bool b;
-  int ret = (int)std::fread(&b, sizeof(bool), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error reading boolean!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-  return b;
-}
-
-void ttk::TopologicalCompression::WriteBool(FILE *fm, bool b) {
-  int ret = (int)std::fwrite(&b, sizeof(bool), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error writing boolean!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-int ttk::TopologicalCompression::ReadInt(FILE *fm) {
-  int i;
-  int ret = (int)std::fread(&i, sizeof(int), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error reading integer!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-  return i;
-}
-
-void ttk::TopologicalCompression::WriteInt(FILE *fm, int i) {
-  int ret = (int)std::fwrite(&i, sizeof(int), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error writing integer!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-double ttk::TopologicalCompression::ReadDouble(FILE *fm) {
-  double d;
-  int ret = (int)std::fread(&d, sizeof(double), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug dbg;
-    msg << "[TopologicalCompression] Error reading double!" << std::endl;
-    dbg.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-  return d;
-}
-
-void ttk::TopologicalCompression::WriteDouble(FILE *fm, double d) {
-  int ret = (int)std::fwrite(&d, sizeof(double), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug dbg;
-    msg << "[TopologicalCompression] Error writing double!" << std::endl;
-    dbg.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-unsigned long ttk::TopologicalCompression::ReadUnsignedLong(FILE *fm) {
-  unsigned long ul;
-  int ret = (int)std::fread(&ul, sizeof(unsigned long), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error reading long!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-  return ul;
-}
-
-void ttk::TopologicalCompression::WriteUnsignedLong(FILE *fm,
-                                                    unsigned long ul) {
-  int ret = (int)std::fwrite(&ul, sizeof(unsigned long), 1, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error writing long!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-void ttk::TopologicalCompression::ReadUnsignedCharArray(FILE *fm,
-                                                        unsigned char *buffer,
-                                                        size_t length) {
-  int ret = (int)std::fread(buffer, sizeof(unsigned char), length, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error reading char array!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-void ttk::TopologicalCompression::WriteUnsignedCharArray(FILE *fm,
-                                                         unsigned char *buffer,
-                                                         size_t length) {
-  int ret = (int)std::fwrite(buffer, sizeof(unsigned char), length, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error writing char array!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-void ttk::TopologicalCompression::ReadCharArray(FILE *fm,
-                                                char *buffer,
-                                                size_t length) {
-  int ret = (int)std::fread(buffer, sizeof(char), length, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error reading char array!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
-void ttk::TopologicalCompression::WriteConstCharArray(FILE *fm,
-                                                      const char *buffer,
-                                                      size_t length) {
-  int ret = (int)std::fwrite(buffer, sizeof(char), length, fm);
-  if(!ret) {
-    std::stringstream msg;
-    ttk::Debug d;
-    msg << "[TopologicalCompression] Error writing char array!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), ttk::Debug::fatalMsg);
-  }
-}
-
 int ttk::TopologicalCompression::ReadCompactSegmentation(
   FILE *fm,
   std::vector<int> &segmentation,
   int &numberOfVertices,
   int &numberOfSegments) {
-  auto ReadInt = ttk::TopologicalCompression::ReadInt;
 
   int numberOfBytesRead = 0;
 
   numberOfBytesRead += sizeof(int);
-  numberOfVertices = ReadInt(fm);
+  numberOfVertices = Read<int>(fm);
 
   numberOfBytesRead += sizeof(int);
-  numberOfSegments = ReadInt(fm);
+  numberOfSegments = Read<int>(fm);
 
   unsigned int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
 
@@ -322,7 +184,7 @@ int ttk::TopologicalCompression::ReadCompactSegmentation(
 
     int compressedInt;
     numberOfBytesRead += sizeof(int);
-    compressedInt = ReadInt(fm);
+    compressedInt = Read<int>(fm);
 
     while(offset + numberOfBitsPerSegment <= 32) {
 
@@ -394,7 +256,6 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
   const std::vector<int> &segmentation,
   int numberOfVertices,
   int numberOfSegments) {
-  auto WriteInt = ttk::TopologicalCompression::WriteInt;
 
   int numberOfBytesWritten = 0;
 
@@ -443,7 +304,7 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
     // Test for overflow filling last part of current container.
     if(currentCell >= numberOfVertices) {
       numberOfBytesWritten += sizeof(int);
-      WriteInt(fm, compressedInt);
+      Write(fm, compressedInt);
       break;
     }
 
@@ -467,7 +328,7 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
 
     // Dump current container.
     numberOfBytesWritten += sizeof(int);
-    WriteInt(fm, compressedInt);
+    Write(fm, compressedInt);
   }
 
   return numberOfBytesWritten;
@@ -486,16 +347,16 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
   // 1.a. Read mapping.
   int mappingSize;
   numberOfBytesRead += sizeof(int);
-  mappingSize = ReadInt(fm);
+  mappingSize = Read<int>(fm);
 
   for(int i = 0; i < mappingSize; ++i) {
     int idv;
     numberOfBytesRead += sizeof(int);
-    idv = ReadInt(fm);
+    idv = Read<int>(fm);
 
     double value;
     numberOfBytesRead += sizeof(double);
-    value = ReadDouble(fm);
+    value = Read<double>(fm);
 
     mappings.push_back(std::make_tuple(value, idv));
     mappingsSortedPerValue.push_back(std::make_tuple(value, idv));
@@ -507,7 +368,7 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
 
   // 1.b. Read constraints.
   numberOfBytesRead += sizeof(int);
-  nbConstraints = ReadInt(fm);
+  nbConstraints = Read<int>(fm);
 
   for(int i = 0; i < nbConstraints; ++i) {
     int idVertex;
@@ -515,13 +376,13 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
     int vertexType;
 
     numberOfBytesRead += sizeof(int);
-    idVertex = ReadInt(fm);
+    idVertex = Read<int>(fm);
 
     numberOfBytesRead += sizeof(double);
-    value = ReadDouble(fm);
+    value = Read<double>(fm);
 
     numberOfBytesRead += sizeof(int);
-    vertexType = ReadInt(fm);
+    vertexType = Read<int>(fm);
 
     if(i == 0) {
       min = value;
@@ -548,23 +409,23 @@ int ttk::TopologicalCompression::WritePersistenceIndex(
   // Size.
   auto mappingSize = (int)mapping.size();
   numberOfBytesWritten += sizeof(int);
-  WriteInt(fm, mappingSize);
+  Write(fm, mappingSize);
 
   // Segmentation values for each particular index.
   for(int i = 0; i < mappingSize; ++i) {
     std::tuple<double, int> t = mapping[i];
     int idv = std::get<1>(t);
     numberOfBytesWritten += sizeof(int);
-    WriteInt(fm, idv);
+    Write(fm, idv);
 
     auto value = std::get<0>(t);
     numberOfBytesWritten += sizeof(double);
-    WriteDouble(fm, value);
+    Write(fm, value);
   }
 
   auto nbConstraints = (int)constraints.size();
   numberOfBytesWritten += sizeof(int);
-  WriteInt(fm, nbConstraints);
+  Write(fm, nbConstraints);
 
   for(int i = 0; i < nbConstraints; ++i) {
     std::tuple<int, double, int> t = constraints[i];
@@ -573,13 +434,13 @@ int ttk::TopologicalCompression::WritePersistenceIndex(
     int vertexType = std::get<2>(t);
 
     numberOfBytesWritten += sizeof(int);
-    WriteInt(fm, idVertex);
+    Write(fm, idVertex);
 
     numberOfBytesWritten += sizeof(double);
-    WriteDouble(fm, value);
+    Write(fm, value);
 
     numberOfBytesWritten += sizeof(int);
-    WriteInt(fm, vertexType);
+    Write(fm, vertexType);
   }
 
   return numberOfBytesWritten;

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -106,10 +106,7 @@ int ttk::TopologicalCompression::compressZFPInternal(double *array,
 
   if(status != 0) {
     ttk::Debug d;
-    std::stringstream msg;
-    msg << "[TopologicalCompression] Encountered a problem with ZFP."
-        << std::endl;
-    d.dMsg(std::cout, msg.str(), ttk::Debug::fatalMsg);
+    d.printErr("Encountered a problem with ZFP.");
   }
 
   return (int)zfpsize;

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -2,20 +2,11 @@
 
 // General.
 ttk::TopologicalCompression::TopologicalCompression() {
-  inputData_ = nullptr;
-  outputData_ = nullptr;
-  triangulation_ = nullptr;
-  sqMethod_ = "";
-  nbSegments = 0;
-  nbVertices = 0;
-  rawFileLength = 0;
+  this->setDebugMsgPrefix("TopologicalCompression");
 }
 
 const char *ttk::TopologicalCompression::magicBytes_{"TTKCompressedFileFormat"};
 const unsigned long ttk::TopologicalCompression::formatVersion_{1};
-
-ttk::TopologicalCompression::~TopologicalCompression() {
-}
 
 // Dependencies.
 

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -19,17 +19,7 @@ int ttk::TopologicalCompression::CompressWithZFP(FILE *file,
                                                  int ny,
                                                  int nz,
                                                  double rate) {
-  return ttk::TopologicalCompression::compressZFPInternal(
-    array.data(), nx, ny, nz, rate, decompress, file);
-}
 
-int ttk::TopologicalCompression::compressZFPInternal(double *array,
-                                                     int nx,
-                                                     int ny,
-                                                     int nz,
-                                                     double rate,
-                                                     bool decompress,
-                                                     FILE *file) {
   int status = 0; // return value: 0 = success
   zfp_type type; // array scalar type
   zfp_field *field; // array meta data
@@ -55,10 +45,11 @@ int ttk::TopologicalCompression::compressZFPInternal(double *array,
   type = zfp_type_double;
 
   if(is2D) {
-    field = zfp_field_2d(array, type, (unsigned int)n1, (unsigned int)n2);
+    field
+      = zfp_field_2d(array.data(), type, (unsigned int)n1, (unsigned int)n2);
   } else {
     field = zfp_field_3d(
-      array, type, (unsigned int)nx, (unsigned int)ny, (unsigned int)nz);
+      array.data(), type, (unsigned int)nx, (unsigned int)ny, (unsigned int)nz);
   }
 
   // allocate meta data for a compressed stream

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -9,9 +9,10 @@ ttk::TopologicalCompression::TopologicalCompression() {
   nbSegments = 0;
   nbVertices = 0;
   rawFileLength = 0;
-  magicBytes_ = "TTKCompressedFileFormat";
-  formatVersion_ = 1;
 }
+
+const char *ttk::TopologicalCompression::magicBytes_{"TTKCompressedFileFormat"};
+const unsigned long ttk::TopologicalCompression::formatVersion_{1};
 
 ttk::TopologicalCompression::~TopologicalCompression() {
 }

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -33,7 +33,7 @@ int ttk::TopologicalCompression::CompressWithZFP(FILE *file,
   bool is2D = nx == 1 || ny == 1 || nz == 1;
   if(is2D) {
     if(nx + ny == 2 || ny + nz == 2 || nx + nz == 2) {
-      fprintf(stderr, "One-dimensional arrays not supported.\n");
+      this->printErr("One-dimensional arrays not supported.");
       return 0;
     }
 
@@ -75,14 +75,14 @@ int ttk::TopologicalCompression::CompressWithZFP(FILE *file,
     // zfpsize = fread(buffer, 1, bufsize, stdin);
     zfpsize = fread(buffer.data(), 1, bufsize, file);
     if(!zfp_decompress(zfp, field)) {
-      fprintf(stderr, "decompression failed\n");
+      this->printErr("Decompression failed");
       status = 1;
     }
   } else {
     // compress array and output compressed stream
     zfpsize = zfp_compress(zfp, field);
     if(!zfpsize) {
-      fprintf(stderr, "compression failed\n");
+      this->printErr("Compression failed");
       status = 1;
     } else
       fwrite(buffer.data(), 1, zfpsize, file);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -53,7 +53,8 @@ namespace ttk {
     // Base code methods.
     TopologicalCompression();
 
-    template <class dataType, typename triangulationType>
+    template <class dataType,
+              typename triangulationType = AbstractTriangulation>
     int execute(dataType *inputData,
                 dataType *outputData,
                 const triangulationType &triangulation);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -310,16 +310,6 @@ namespace ttk {
 #endif
 
   private:
-#ifdef TTK_ENABLE_ZFP
-    static int compressZFPInternal(double *array,
-                                   int nx,
-                                   int ny,
-                                   int nz,
-                                   double rate,
-                                   bool decompress,
-                                   FILE *file);
-#endif
-
     // Internal read/write.
 
     template <typename dataType>

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -47,7 +47,7 @@ namespace ttk {
 
   enum class CompressionType { PersistenceDiagram = 0, Other = 1 };
 
-  class TopologicalCompression : public Debug {
+  class TopologicalCompression : virtual public Debug {
 
   public:
     // Base code methods.

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -139,7 +139,7 @@ namespace ttk {
       return compressionType_;
     }
     inline int getSQMethod() {
-      return sqMethodInt_;
+      return SQMethodInt;
     }
     inline int getDataScalarType() {
       return dataScalarType_;
@@ -379,7 +379,7 @@ namespace ttk {
     int compressionType_{};
     bool ZFPOnly{false};
     double ZFPBitBudget{};
-    int sqMethodInt_{};
+    int SQMethodInt{};
 
     double Tolerance{10};
     double MaximumError{10};
@@ -789,7 +789,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   ZFPOnly = Read<bool>(fm);
 
   // 0. SQ type
-  sqMethodInt_ = Read<int>(fm);
+  SQMethodInt = Read<int>(fm);
 
   // 1. DataType
   dataScalarType_ = Read<int>(fm);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -29,9 +29,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <stack>
-#include <string.h>
 
 #ifdef TTK_ENABLE_ZLIB
 #include <zlib.h>
@@ -41,10 +41,8 @@
 #ifndef __cplusplus
 #define __cplusplus 201112L
 #endif
-#include <limits.h>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <climits>
+#include <cstdio>
 #include <zfp.h>
 #include <zfp/macros.h>
 #endif
@@ -422,10 +420,10 @@ namespace ttk {
     char *fileName;
 
     // Char array that identifies the file format.
-    std::string magicBytes_;
+    static const char *magicBytes_;
     // Current version of the file format. To be incremented at every
     // breaking change to keep backward compatibility.
-    unsigned long formatVersion_;
+    static const unsigned long formatVersion_;
   };
 
   // End namespace ttk.
@@ -641,7 +639,7 @@ int ttk::TopologicalCompression::WriteMetaData(
   const std::string &dataArrayName) {
 
   // -4. Magic bytes
-  WriteConstCharArray(fp, magicBytes_.data(), magicBytes_.size());
+  WriteConstCharArray(fp, magicBytes_, std::strlen(magicBytes_));
 
   // -3. File format version
   WriteUnsignedLong(fp, formatVersion_);
@@ -860,12 +858,13 @@ template <typename T>
 int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
 
   // -4. Magic bytes
-  std::vector<char> mBytes(magicBytes_.size() + 1);
-  mBytes[magicBytes_.size()] = '\0'; // NULL-termination
-  ReadCharArray(fm, mBytes.data(), magicBytes_.size());
+  const auto magicBytesLen{std::strlen(magicBytes_)};
+  std::vector<char> mBytes(magicBytesLen + 1);
+  mBytes[magicBytesLen] = '\0'; // NULL-termination
+  ReadCharArray(fm, mBytes.data(), magicBytesLen);
 
   // To deal with pre-v1 file format (without scalar field array name)
-  bool hasMagicBytes = strcmp(mBytes.data(), magicBytes_.data()) == 0;
+  bool hasMagicBytes = strcmp(mBytes.data(), magicBytes_) == 0;
 
   if(!hasMagicBytes) {
     std::stringstream msg;

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -108,9 +108,10 @@ namespace ttk {
     inline void setFileName(char *fn) {
       fileName = fn;
     }
-    inline void setupTriangulation(Triangulation *triangulation) {
+    inline void
+      preconditionTriangulation(AbstractTriangulation *const triangulation) {
       triangulation_ = triangulation;
-      if(triangulation_)
+      if(triangulation != nullptr)
         triangulation_->preconditionVertexNeighbors();
     }
 
@@ -377,7 +378,7 @@ namespace ttk {
     // General.
     void *inputData_{};
     void *outputData_{};
-    Triangulation *triangulation_{};
+    AbstractTriangulation *triangulation_{};
     TopologicalSimplification topologicalSimplification{};
 
     // Parameters

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -631,7 +631,8 @@ int ttk::TopologicalCompression::WriteMetaData(
   Write(fp, zfpBitBudget);
 
   // 6. Length of array name
-  Write(fp, dataArrayName.size());
+  // (explicit call to unsigned long variant for MSVC compatibility)
+  Write<unsigned long>(fp, dataArrayName.size());
 
   // 7. Array name (as unsigned chars)
   WriteByteArray(fp, dataArrayName.c_str(), dataArrayName.size());

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -90,20 +90,20 @@ namespace ttk {
       compressionType_ = compressionType;
     }
     inline void setSQ(std::string sqMethod) {
-      sqMethod_ = sqMethod;
+      SQMethod = sqMethod;
     }
     inline void setZFPOnly(bool z) {
       zfpOnly_ = z;
     }
-    inline void setSubdivide(bool dontSubdivide) {
-      dontSubdivide_ = dontSubdivide;
+    inline void setSubdivide(bool b) {
+      Subdivide = b;
     }
     inline void setMaximumError(double maximumError) {
-      maximumError_ = maximumError;
+      MaximumError = maximumError;
     }
     inline void
       setUseTopologicalSimplification(bool useTopologicalSimplification) {
-      useTopologicalSimplification_ = useTopologicalSimplification;
+      UseTopologicalSimplification = useTopologicalSimplification;
     }
     inline void setFileName(char *fn) {
       fileName = fn;
@@ -150,7 +150,7 @@ namespace ttk {
       return dataOrigin_;
     }
     inline double getTolerance() {
-      return tolerance_;
+      return Tolerance;
     }
     inline double getZFPBitBudget() {
       return zfpBitBudget_;
@@ -374,17 +374,21 @@ namespace ttk {
     // Parameters
     int compressionType_{};
     bool zfpOnly_{};
+    double zfpBitBudget_{};
     int sqMethodInt_{};
-    std::string sqMethod_{""};
+
+    double Tolerance{10};
+    double MaximumError{10};
+    int CompressionType{0};
+    std::string SQMethod{};
+    bool Subdivide{false};
+    bool UseTopologicalSimplification{true};
+
     int dataScalarType_{};
     int dataExtent_[6];
     double dataSpacing_[3];
     double dataOrigin_[3];
-    double tolerance_{};
-    double maximumError_{};
-    double zfpBitBudget_{};
-    bool dontSubdivide_{};
-    bool useTopologicalSimplification_{};
+
     std::vector<char> dataArrayName_{};
 
     // Persistence compression.
@@ -797,7 +801,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
     dataOrigin_[i] = Read<double>(fm);
 
   // 4. Error tolerance (relative percentage)
-  tolerance_ = Read<double>(fm);
+  Tolerance = Read<double>(fm);
 
   // 5. Lossy compressor ratio
   zfpBitBudget_ = Read<double>(fm);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -528,7 +528,7 @@ int ttk::TopologicalCompression::WriteToFile(FILE *fp,
   // #endif
 
   if(status == 0) {
-    this->printMsg(" Geometry successfully written to buffer.");
+    this->printMsg("Geometry successfully written to buffer.");
   } else {
     this->printErr("Geometry was not successfully written to buffer.");
     fflush(fp);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -92,7 +92,7 @@ namespace ttk {
       SQMethod = sqMethod;
     }
     inline void setZFPOnly(bool z) {
-      zfpOnly_ = z;
+      ZFPOnly = z;
     }
     inline void setSubdivide(bool b) {
       Subdivide = b;
@@ -120,10 +120,10 @@ namespace ttk {
     }
 
     inline int getNbVertices() {
-      return nbVertices;
+      return NbVertices;
     }
     inline int getNbSegments() {
-      return nbSegments;
+      return NbSegments;
     }
     inline std::vector<int> &getSegmentation() {
       return segmentation_;
@@ -157,10 +157,10 @@ namespace ttk {
       return Tolerance;
     }
     inline double getZFPBitBudget() {
-      return zfpBitBudget_;
+      return ZFPBitBudget;
     }
     inline bool getZFPOnly() {
-      return zfpOnly_;
+      return ZFPOnly;
     }
 
     inline const std::vector<char> &getDataArrayName() const {
@@ -377,13 +377,13 @@ namespace ttk {
 
     // Parameters
     int compressionType_{};
-    bool zfpOnly_{};
-    double zfpBitBudget_{};
+    bool ZFPOnly{false};
+    double ZFPBitBudget{};
     int sqMethodInt_{};
 
     double Tolerance{10};
     double MaximumError{10};
-    int CompressionType{0};
+    int CompressionType{static_cast<int>(CompressionType::PersistenceDiagram)};
     std::string SQMethod{};
     bool Subdivide{false};
     bool UseTopologicalSimplification{true};
@@ -401,8 +401,8 @@ namespace ttk {
     std::vector<std::tuple<int, double, int>> criticalConstraints_{};
 
     // IO.
-    int nbVertices{0};
-    int nbSegments{0};
+    int NbVertices{0};
+    int NbSegments{0};
     int rawFileLength{0};
     std::vector<double> decompressedData_{};
     std::vector<int> decompressedOffsets_{};
@@ -481,7 +481,7 @@ int ttk::TopologicalCompression::WriteToFile(FILE *fp,
   int numberOfVertices = 1;
   for(int i = 0; i < 3; ++i)
     numberOfVertices *= (1 + dataExtent[2 * i + 1] - dataExtent[2 * i]);
-  nbVertices = numberOfVertices;
+  NbVertices = numberOfVertices;
 
   int totalSize = usePersistence
                     ? ComputeTotalSizeForPersistenceDiagram<double>(
@@ -649,7 +649,7 @@ int ttk::TopologicalCompression::ReadFromFile(
 
   this->printMsg("Successfully read metadata.");
 
-  if(zfpOnly_ && (zfpBitBudget_ > 64 || zfpBitBudget_ < 1)) {
+  if(ZFPOnly && (ZFPBitBudget > 64 || ZFPBitBudget < 1)) {
     this->printMsg("Wrong ZFP bit budget for ZFP-only use.");
     return -4;
   }
@@ -722,7 +722,7 @@ int ttk::TopologicalCompression::ReadFromFile(
   //#endif
 
   // Do read topology.
-  if(!(zfpOnly_)) {
+  if(!(ZFPOnly)) {
     if(compressionType_ == (int)ttk::CompressionType::PersistenceDiagram)
       ReadPersistenceTopology<double>(fm);
     else if(compressionType_ == (int)ttk::CompressionType::Other)
@@ -786,7 +786,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   compressionType_ = Read<int>(fm);
 
   // -1. ZFP only type.
-  zfpOnly_ = Read<bool>(fm);
+  ZFPOnly = Read<bool>(fm);
 
   // 0. SQ type
   sqMethodInt_ = Read<int>(fm);
@@ -809,7 +809,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   Tolerance = Read<double>(fm);
 
   // 5. Lossy compressor ratio
-  zfpBitBudget_ = Read<double>(fm);
+  ZFPBitBudget = Read<double>(fm);
 
   if(version == 0) {
     // Pre-v1 format has no scalar field array name

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -228,11 +228,11 @@ namespace ttk {
       }
     }
 
-    static int ReadCompactSegmentation(FILE *fm,
-                                       std::vector<int> &segmentation,
-                                       int &numberOfVertices,
-                                       int &numberOfSegments);
-    static int ReadPersistenceIndex(
+    int ReadCompactSegmentation(FILE *fm,
+                                std::vector<int> &segmentation,
+                                int &numberOfVertices,
+                                int &numberOfSegments);
+    int ReadPersistenceIndex(
       FILE *fm,
       std::vector<std::tuple<double, int>> &mappings,
       std::vector<std::tuple<double, int>> &mappingsSortedPerValue,
@@ -245,11 +245,11 @@ namespace ttk {
     template <typename dataType>
     int ReadFromFile(FILE *fm);
 
-    static int WriteCompactSegmentation(FILE *fm,
-                                        const std::vector<int> &segmentation,
-                                        int numberOfVertices,
-                                        int numberOfSegments);
-    static int WritePersistenceIndex(
+    int WriteCompactSegmentation(FILE *fm,
+                                 const std::vector<int> &segmentation,
+                                 int numberOfVertices,
+                                 int numberOfSegments);
+    int WritePersistenceIndex(
       FILE *fm,
       std::vector<std::tuple<double, int>> &mapping,
       std::vector<std::tuple<int, double, int>> &constraints);
@@ -280,7 +280,7 @@ namespace ttk {
                     const std::string &dataArrayName);
 
     template <typename dataType>
-    static void CropIntervals(
+    void CropIntervals(
       std::vector<std::tuple<dataType, int>> &mappings,
       std::vector<std::tuple<dataType, int>> &mappingsSortedPerValue,
       double min,
@@ -292,21 +292,21 @@ namespace ttk {
     // API management.
 
 #ifdef TTK_ENABLE_ZFP
-    static int CompressWithZFP(FILE *file,
-                               bool decompress,
-                               std::vector<double> &array,
-                               int nx,
-                               int ny,
-                               int nz,
-                               double rate);
+    int CompressWithZFP(FILE *file,
+                        bool decompress,
+                        std::vector<double> &array,
+                        int nx,
+                        int ny,
+                        int nz,
+                        double rate);
 #endif
 
 #ifdef TTK_ENABLE_ZLIB
-    static void CompressWithZlib(bool decompress,
-                                 Bytef *dest,
-                                 uLongf *destLen,
-                                 const Bytef *source,
-                                 uLong sourceLen);
+    void CompressWithZlib(bool decompress,
+                          Bytef *dest,
+                          uLongf *destLen,
+                          const Bytef *source,
+                          uLong sourceLen);
 #endif
 
   private:

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -14,14 +14,10 @@
 #pragma once
 
 // base code includes
-
-#include <DataTypes.h>
-#include <Debug.h>
 #include <FTMTreePP.h>
 #include <PersistenceDiagram.h>
 #include <TopologicalSimplification.h>
 #include <Triangulation.h>
-#include <Wrapper.h>
 
 // std
 
@@ -55,7 +51,7 @@ namespace ttk {
   public:
     // Base code methods.
     TopologicalCompression();
-    ~TopologicalCompression();
+
     template <class dataType>
     int execute(const double &tolerance);
 
@@ -83,75 +79,52 @@ namespace ttk {
                          const double &tol);
 
     // Getters and setters.
-    inline int setInputDataPointer(void *data) {
+    inline void setInputDataPointer(void *data) {
       inputData_ = data;
-      return 0;
     }
-
-    inline int setOutputDataPointer(void *data) {
+    inline void setOutputDataPointer(void *data) {
       outputData_ = data;
-      return 0;
     }
-
-    inline int setCompressionType(int compressionType) {
+    inline void setCompressionType(int compressionType) {
       compressionType_ = compressionType;
-      return 0;
     }
-
-    inline int setSQ(std::string sqMethod) {
+    inline void setSQ(std::string sqMethod) {
       sqMethod_ = sqMethod;
-      return 0;
     }
-
-    inline int setZFPOnly(bool z) {
+    inline void setZFPOnly(bool z) {
       zfpOnly_ = z;
-      return 0;
     }
-
-    inline int setSubdivide(bool dontSubdivide) {
+    inline void setSubdivide(bool dontSubdivide) {
       dontSubdivide_ = dontSubdivide;
-      return 0;
     }
-
-    inline int setMaximumError(double maximumError) {
+    inline void setMaximumError(double maximumError) {
       maximumError_ = maximumError;
-      return 0;
     }
-
-    inline int
+    inline void
       setUseTopologicalSimplification(bool useTopologicalSimplification) {
       useTopologicalSimplification_ = useTopologicalSimplification;
-      return 0;
     }
-
-    inline int setFileName(char *fn) {
+    inline void setFileName(char *fn) {
       fileName = fn;
-      return 0;
     }
-
-    inline int setupTriangulation(Triangulation *triangulation) {
+    inline void setupTriangulation(Triangulation *triangulation) {
       triangulation_ = triangulation;
       if(triangulation_)
         triangulation_->preconditionVertexNeighbors();
-      return 0;
     }
 
     inline int getNbVertices() {
       return nbVertices;
     }
-
     inline int getNbSegments() {
       return nbSegments;
     }
-
     inline std::vector<int> &getSegmentation() {
       return segmentation_;
     }
-
     inline std::vector<std::tuple<double, int>> &getMapping() {
       return mapping_;
     }
-
     inline std::vector<std::tuple<int, double, int>> &getCriticalConstraints() {
       return criticalConstraints_;
     }
@@ -159,35 +132,27 @@ namespace ttk {
     inline int getCompressionType() {
       return compressionType_;
     }
-
     inline int getSQMethod() {
       return sqMethodInt_;
     }
-
     inline int getDataScalarType() {
       return dataScalarType_;
     }
-
     inline int *getDataExtent() {
       return dataExtent_;
     }
-
     inline double *getDataSpacing() {
       return dataSpacing_;
     }
-
     inline double *getDataOrigin() {
       return dataOrigin_;
     }
-
     inline double getTolerance() {
       return tolerance_;
     }
-
     inline double getZFPBitBudget() {
       return zfpBitBudget_;
     }
-
     inline bool getZFPOnly() {
       return zfpOnly_;
     }
@@ -195,15 +160,12 @@ namespace ttk {
     inline const std::vector<char> &getDataArrayName() const {
       return dataArrayName_;
     }
-
     inline std::vector<double> &getDecompressedData() {
       return decompressedData_;
     }
-
     inline std::vector<int> &getDecompressedOffsets() {
       return decompressedOffsets_;
     }
-
     inline std::vector<int> &getCompressedOffsets() {
       return compressedOffsets_;
     }
@@ -382,41 +344,41 @@ namespace ttk {
 
   protected:
     // General.
-    void *inputData_;
-    void *outputData_;
-    Triangulation *triangulation_;
-    TopologicalSimplification topologicalSimplification;
+    void *inputData_{};
+    void *outputData_{};
+    Triangulation *triangulation_{};
+    TopologicalSimplification topologicalSimplification{};
 
     // Parameters
-    int compressionType_;
-    bool zfpOnly_;
-    int sqMethodInt_;
-    std::string sqMethod_;
-    int dataScalarType_;
+    int compressionType_{};
+    bool zfpOnly_{};
+    int sqMethodInt_{};
+    std::string sqMethod_{""};
+    int dataScalarType_{};
     int dataExtent_[6];
     double dataSpacing_[3];
     double dataOrigin_[3];
-    double tolerance_;
-    double maximumError_;
-    double zfpBitBudget_;
-    bool dontSubdivide_;
-    bool useTopologicalSimplification_;
+    double tolerance_{};
+    double maximumError_{};
+    double zfpBitBudget_{};
+    bool dontSubdivide_{};
+    bool useTopologicalSimplification_{};
     std::vector<char> dataArrayName_{};
 
     // Persistence compression.
-    std::vector<int> segmentation_;
-    std::vector<std::tuple<double, int>> mapping_;
-    std::vector<std::tuple<int, double, int>> criticalConstraints_;
+    std::vector<int> segmentation_{};
+    std::vector<std::tuple<double, int>> mapping_{};
+    std::vector<std::tuple<int, double, int>> criticalConstraints_{};
 
     // IO.
-    int nbVertices;
-    int nbSegments;
-    int rawFileLength;
-    std::vector<double> decompressedData_;
-    std::vector<int> decompressedOffsets_;
-    std::vector<int> compressedOffsets_;
-    int vertexNumberRead_;
-    char *fileName;
+    int nbVertices{0};
+    int nbSegments{0};
+    int rawFileLength{0};
+    std::vector<double> decompressedData_{};
+    std::vector<int> decompressedOffsets_{};
+    std::vector<int> compressedOffsets_{};
+    int vertexNumberRead_{};
+    char *fileName{};
 
     // Char array that identifies the file format.
     static const char *magicBytes_;
@@ -425,7 +387,6 @@ namespace ttk {
     static const unsigned long formatVersion_;
   };
 
-  // End namespace ttk.
 } // namespace ttk
 
 #include <OtherCompression.h>

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -54,7 +54,7 @@ namespace ttk {
     TopologicalCompression();
 
     template <class dataType>
-    int execute();
+    int execute(dataType *inputData, dataType *outputData);
 
     // Persistence compression methods.
     template <class dataType>
@@ -80,12 +80,6 @@ namespace ttk {
                          const double &tol);
 
     // Getters and setters.
-    inline void setInputDataPointer(void *data) {
-      inputData_ = data;
-    }
-    inline void setOutputDataPointer(void *data) {
-      outputData_ = data;
-    }
     inline void setCompressionType(int compressionType) {
       compressionType_ = compressionType;
     }
@@ -369,8 +363,6 @@ namespace ttk {
 
   protected:
     // General.
-    void *inputData_{};
-    void *outputData_{};
     AbstractTriangulation *triangulation_{};
     TopologicalSimplification topologicalSimplification{};
 
@@ -422,22 +414,21 @@ namespace ttk {
 #include <PersistenceDiagramCompression.h>
 
 template <class dataType>
-int ttk::TopologicalCompression::execute() {
+int ttk::TopologicalCompression::execute(dataType *inputData,
+                                         dataType *outputData) {
   this->printMsg("Starting compression...");
 
 // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!triangulation_)
     return -1;
-  if(!inputData_)
+  if(inputData == nullptr)
     return -2;
-  if(!outputData_)
+  if(outputData == nullptr)
     return -3;
 // if (tol < 0 || tol > 100) return -4;
 #endif
 
-  auto *outputData = (dataType *)outputData_;
-  auto *inputData = (dataType *)inputData_;
   int vertexNumber = triangulation_->getNumberOfVertices();
 
   int res = 0;

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -54,7 +54,7 @@ namespace ttk {
     TopologicalCompression();
 
     template <class dataType>
-    int execute(const double &tolerance);
+    int execute();
 
     // Persistence compression methods.
     template <class dataType>
@@ -100,6 +100,9 @@ namespace ttk {
     }
     inline void setMaximumError(double maximumError) {
       MaximumError = maximumError;
+    }
+    inline void setTolerance(const double data) {
+      Tolerance = data;
     }
     inline void
       setUseTopologicalSimplification(bool useTopologicalSimplification) {
@@ -419,7 +422,7 @@ namespace ttk {
 #include <PersistenceDiagramCompression.h>
 
 template <class dataType>
-int ttk::TopologicalCompression::execute(const double &tol) {
+int ttk::TopologicalCompression::execute() {
   this->printMsg("Starting compression...");
 
 // check the consistency of the variables -- to adapt
@@ -440,9 +443,9 @@ int ttk::TopologicalCompression::execute(const double &tol) {
   int res = 0;
   if(compressionType_ == (int)ttk::CompressionType::PersistenceDiagram)
     compressForPersistenceDiagram<dataType>(
-      vertexNumber, inputData, outputData, tol);
+      vertexNumber, inputData, outputData, Tolerance);
   else if(compressionType_ == (int)ttk::CompressionType::Other)
-    compressForOther<dataType>(vertexNumber, inputData, outputData, tol);
+    compressForOther<dataType>(vertexNumber, inputData, outputData, Tolerance);
 
   return res;
 }

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -11,8 +11,7 @@
 /// \sa ttk::Triangulation
 /// \sa vtkTopologicalCompression.cpp %for a usage example.
 
-#ifndef _TOPOLOGICALCOMPRESSION_H
-#define _TOPOLOGICALCOMPRESSION_H
+#pragma once
 
 // base code includes
 
@@ -927,5 +926,3 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
 
   return 0;
 }
-
-#endif // TOPOLOGICALCOMPRESSION_H

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -110,7 +110,7 @@ namespace ttk {
     template <typename dataType, typename idType>
     int execute() const;
 
-    inline int setupTriangulation(Triangulation *triangulation) {
+    inline int setupTriangulation(AbstractTriangulation *triangulation) {
       triangulation_ = triangulation;
       if(triangulation_) {
         vertexNumber_ = triangulation_->getNumberOfVertices();
@@ -165,7 +165,7 @@ namespace ttk {
     }
 
   protected:
-    Triangulation *triangulation_;
+    AbstractTriangulation *triangulation_;
     SimplexId vertexNumber_;
     SimplexId constraintNumber_;
     void *inputScalarFieldPointer_;

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -2,6 +2,7 @@
 
 #include <vtkInformation.h>
 
+#include <vtkImageData.h>
 #include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
 #include <vtkMultiBlockDataSet.h>

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -2,9 +2,11 @@
 
 #include <vtkInformation.h>
 
+#include <vtkDataArray.h>
 #include <vtkDirectory.h>
 #include <vtkFieldData.h>
 #include <vtkImageData.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkStdString.h>
 #include <vtkStringArray.h>
@@ -470,7 +472,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       topologicalCompressionWriter->SetFileName(
         (this->DatabasePath + "/" + rDataProductPath).data());
       topologicalCompressionWriter->SetInputData(inputData);
-      topologicalCompressionWriter->WriteData();
+      topologicalCompressionWriter->Write();
     }
 
     this->printMsg("Writing data product to disk", 1, t.getElapsedTime(),

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -444,8 +444,14 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
           "Cannot use Topological Compression without a vtkImageData");
         return 0;
       }
+
+      const auto inputData = vtkImageData::SafeDownCast(input);
+      const auto sf = this->GetInputArrayToProcess(0, inputData);
+
       vtkNew<ttkTopologicalCompressionWriter> topologicalCompressionWriter{};
-      topologicalCompressionWriter->SetScalarField(this->ScalarField);
+      topologicalCompressionWriter->SetInputArrayToProcess(
+        0, 0, 0, 0, sf->GetName());
+
       topologicalCompressionWriter->SetTolerance(this->Tolerance);
       topologicalCompressionWriter->SetMaximumError(this->MaximumError);
       topologicalCompressionWriter->SetZFPBitBudget(this->ZFPBitBudget);
@@ -455,13 +461,6 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
       topologicalCompressionWriter->SetSubdivide(this->Subdivide);
       topologicalCompressionWriter->SetUseTopologicalSimplification(
         this->UseTopologicalSimplification);
-
-      if(ScalarField.empty()) {
-        vtkErrorMacro("Need a scalar field for Topological Compression");
-        return 0;
-      }
-      const auto inputData = vtkImageData::SafeDownCast(input);
-      const auto sf = inputData->GetPointData()->GetArray(ScalarField.data());
 
       // Check that input scalar field is indeed scalar
       if(sf->GetNumberOfComponents() != 1) {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -45,8 +45,6 @@ public:
 
   int DeleteDatabase();
 
-  vtkGetMacro(ScalarField, std::string);
-  vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(Tolerance, double);
   vtkSetMacro(Tolerance, double);
   vtkGetMacro(MaximumError, double);
@@ -85,7 +83,6 @@ private:
   int Mode{0};
 
   // topological compression
-  std::string ScalarField{};
   double Tolerance{1.0};
   double MaximumError{};
   double ZFPBitBudget{0};

--- a/core/vtk/ttkTopologicalCompression/ttk.module
+++ b/core/vtk/ttkTopologicalCompression/ttk.module
@@ -6,4 +6,4 @@ HEADERS
   ttkTopologicalCompression.h
 DEPENDS
   topologicalCompression
-  ttkTriangulationAlgorithm
+  ttkAlgorithm

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -79,17 +79,10 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   // variable 'output' with the result of the computation.
   // if your wrapper produces an output of the same type of the input, you
   // should proceed in the same way.
-  vtkDataArray *inputScalarField = nullptr;
-
-  if(ScalarField.length()) {
-    inputScalarField = input->GetPointData()->GetArray(ScalarField.data());
-    this->printMsg("Starting computation on field '" + ScalarField + "'...");
-  } else {
-    inputScalarField = input->GetPointData()->GetArray(ScalarFieldId);
-  }
+  const auto inputScalarField = this->GetInputArrayToProcess(0, inputVector);
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(!inputScalarField) {
+  if(inputScalarField == nullptr) {
     this->printErr("Input scalar field pointer is NULL.");
     return -1;
   }

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -122,13 +122,12 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   outputOffsetField->SetName(ttk::OffsetScalarFieldName);
 
   // Call TopologicalCompression
-  switch(inputScalarField->GetDataType()) {
-    vtkTemplateMacro(this->execute(
+  ttkVtkTemplateMacro(
+    inputScalarField->GetDataType(), triangulation->getType(),
+    this->execute(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
-      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField))));
-    default:
-      break;
-  }
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField)),
+      *static_cast<TTK_TT *>(triangulation->getData())));
 
   for(SimplexId i = 0; i < vertexNumber; ++i)
     outputOffsetField->SetTuple1(i, this->compressedOffsets_[i]);

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -128,12 +128,11 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   outputOffsetField->SetNumberOfTuples(vertexNumber);
   outputOffsetField->SetName(ttk::OffsetScalarFieldName);
 
-  this->setInputDataPointer(ttkUtils::GetVoidPointer(inputScalarField));
-  this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputScalarField));
-
   // Call TopologicalCompression
   switch(inputScalarField->GetDataType()) {
-    vtkTemplateMacro(this->execute<VTK_TT>());
+    vtkTemplateMacro(this->execute(
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField))));
     default:
       break;
   }

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -1,60 +1,77 @@
 #include "ttkTopologicalCompression.h"
 
-using namespace std;
-using namespace ttk;
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
+#include <vtkInformation.h>
+#include <vtkIntArray.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkSignedCharArray.h>
+#include <vtkSmartPointer.h>
 
-vtkStandardNewMacro(ttkTopologicalCompression)
+vtkStandardNewMacro(ttkTopologicalCompression);
 
-  int ttkTopologicalCompression::doIt(std::vector<vtkDataSet *> &inputs,
-                                      std::vector<vtkDataSet *> &outputs) {
+ttkTopologicalCompression::ttkTopologicalCompression() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkTopologicalCompression::FillInputPortInformation(int port,
+                                                        vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkTopologicalCompression::FillOutputPortInformation(int port,
+                                                         vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
+}
+
+int ttkTopologicalCompression::RequestData(vtkInformation *request,
+                                           vtkInformationVector **inputVector,
+                                           vtkInformationVector *outputVector) {
+
+  auto input = vtkDataSet::GetData(inputVector[0]);
+  auto output = vtkDataSet::GetData(outputVector);
+
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(!inputs.size()) {
-    cerr << "[ttkTopologicalCompression] Error: not enough input information."
-         << endl;
+  if(input == nullptr) {
+    this->printErr("Input pointer is NULL.");
+    return -1;
+  }
+  if(input->GetNumberOfPoints() == 0) {
+    this->printErr("Input has no point.");
+    return -1;
+  }
+  if(input->GetPointData() == nullptr) {
+    this->printErr("Input has no point data.");
+    return -1;
+  }
+  if(output == nullptr) {
+    this->printErr("Output pointer is NULL.");
     return -1;
   }
 #endif
-
-  // Prepare IO
-  vtkDataSet *input1 = inputs[0];
-  vtkDataSet *output1 = outputs[0];
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!input1) {
-    cerr << "[ttkTopologicalCompression] Error: input pointer is NULL." << endl;
-    return -1;
-  }
-
-  if(!input1->GetNumberOfPoints()) {
-    cerr << "[ttkTopologicalCompression] Error: input has no point." << endl;
-    return -1;
-  }
-
-  if(!input1->GetPointData()) {
-    cerr << "[ttkTopologicalCompression] Error: input has no point data."
-         << endl;
-    return -1;
-  }
-
-  if(!output1) {
-    cerr << "[ttkTopologicalCompression] Error: output pointer is NULL."
-         << endl;
-    return -1;
-  }
-#endif
-
-  triangulation_.setWrapper(this);
-  topologicalCompression_.setWrapper(this);
 
   // Triangulate
-  triangulation_.setInputData(input1);
-  internalTriangulation_ = ttkTriangulation::getTriangulation(input1);
-  topologicalCompression_.setupTriangulation(internalTriangulation_);
-  Modified();
+  auto triangulation = ttkAlgorithm::GetTriangulation(input);
+  if(triangulation == nullptr) {
+    return 0;
+  }
+  this->preconditionTriangulation(triangulation);
 
   // use a pointer-base copy for the input data -- to adapt if your wrapper does
   // not produce an output of the type of the input.
-  output1->ShallowCopy(input1);
+  output->ShallowCopy(input);
 
   // in the following, the target scalar field of the input is replaced in the
   // variable 'output' with the result of the computation.
@@ -63,88 +80,73 @@ vtkStandardNewMacro(ttkTopologicalCompression)
   vtkDataArray *inputScalarField = nullptr;
 
   if(ScalarField.length()) {
-    inputScalarField = input1->GetPointData()->GetArray(ScalarField.data());
-    std::stringstream msg;
-    msg << "[ttkTopologicalCompression] Starting computation on field '"
-        << ScalarField << "'..." << std::endl;
-    dMsg(std::cout, msg.str(), infoMsg);
-  } else
-    inputScalarField = input1->GetPointData()->GetArray(ScalarFieldId);
+    inputScalarField = input->GetPointData()->GetArray(ScalarField.data());
+    this->printMsg("Starting computation on field '" + ScalarField + "'...");
+  } else {
+    inputScalarField = input->GetPointData()->GetArray(ScalarFieldId);
+  }
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!inputScalarField) {
-    cerr << "[ttkTopologicalCompression] Error: input scalar field pointer is "
-            "NULL."
-         << endl;
+    this->printErr("Input scalar field pointer is NULL.");
     return -1;
   }
 #endif
 
+  const auto vertexNumber = inputScalarField->GetNumberOfTuples();
+
   // allocate the memory for the output scalar field
-  if(!outputScalarField_) {
-    switch(inputScalarField->GetDataType()) {
-      case VTK_CHAR:
-        outputScalarField_
-          = vtkSmartPointer<vtkCharArray>::New(); // vtkCharArray::New();
-        break;
-      case VTK_DOUBLE:
-        outputScalarField_ = vtkSmartPointer<vtkDoubleArray>::New();
-        break;
-      case VTK_FLOAT:
-        outputScalarField_ = vtkSmartPointer<vtkFloatArray>::New();
-        break;
-      case VTK_INT:
-        outputScalarField_ = vtkSmartPointer<vtkIntArray>::New();
-        break;
-      case VTK_ID_TYPE:
-        outputScalarField_ = vtkSmartPointer<vtkIdTypeArray>::New();
-        break;
+  vtkSmartPointer<vtkDataArray> outputScalarField{};
 
-      default: {
-        std::stringstream msg;
-        msg << "[ttkTopologicalCompression] Unsupported data type :("
-            << std::endl;
-        dMsg(std::cerr, msg.str(), fatalMsg);
-      }
-        return -1;
-    }
+  switch(inputScalarField->GetDataType()) {
+    case VTK_CHAR:
+      outputScalarField = vtkSmartPointer<vtkSignedCharArray>::New();
+      break;
+    case VTK_DOUBLE:
+      outputScalarField = vtkSmartPointer<vtkDoubleArray>::New();
+      break;
+    case VTK_FLOAT:
+      outputScalarField = vtkSmartPointer<vtkFloatArray>::New();
+      break;
+    case VTK_INT:
+      outputScalarField = vtkSmartPointer<vtkIntArray>::New();
+      break;
+    case VTK_ID_TYPE:
+      outputScalarField = vtkSmartPointer<vtkIdTypeArray>::New();
+      break;
+    default:
+      this->printErr("Unsupported data type :(");
+      return -1;
   }
 
-  if(!outputOffsetField_) {
-    outputOffsetField_ = vtkSmartPointer<vtkIntArray>::New();
-  }
+  outputScalarField->SetNumberOfTuples(vertexNumber);
+  outputScalarField->SetName(inputScalarField->GetName());
 
-  SimplexId vertexNumber = (SimplexId)inputScalarField->GetNumberOfTuples();
-  outputOffsetField_->SetNumberOfTuples(vertexNumber);
-  outputOffsetField_->SetName(ttk::OffsetScalarFieldName);
+  vtkNew<vtkIntArray> outputOffsetField{};
+  outputOffsetField->SetNumberOfTuples(vertexNumber);
+  outputOffsetField->SetName(ttk::OffsetScalarFieldName);
 
-  outputScalarField_->SetNumberOfTuples(vertexNumber);
-  outputScalarField_->SetName(inputScalarField->GetName());
-
-  topologicalCompression_.setCompressionType(CompressionType);
-  topologicalCompression_.setInputDataPointer(
-    inputScalarField->GetVoidPointer(0));
-  topologicalCompression_.setSQ(SQMethod);
-  topologicalCompression_.setUseTopologicalSimplification(
-    UseTopologicalSimplification);
-  topologicalCompression_.setSubdivide(!Subdivide);
-  topologicalCompression_.setOutputDataPointer(
-    outputScalarField_->GetVoidPointer(0));
-  topologicalCompression_.setMaximumError(MaximumError);
+  this->setCompressionType(CompressionType);
+  this->setInputDataPointer(inputScalarField->GetVoidPointer(0));
+  this->setSQ(SQMethod);
+  this->setUseTopologicalSimplification(UseTopologicalSimplification);
+  this->setSubdivide(!Subdivide);
+  this->setOutputDataPointer(outputScalarField->GetVoidPointer(0));
+  this->setMaximumError(MaximumError);
 
   // Call TopologicalCompression
   switch(inputScalarField->GetDataType()) {
-    vtkTemplateMacro(topologicalCompression_.execute<VTK_TT>(Tolerance));
+    vtkTemplateMacro(this->execute<VTK_TT>(Tolerance));
     default:
       break;
   }
 
-  std::vector<int> voidOffsets = topologicalCompression_.getCompressedOffsets();
+  std::vector<int> voidOffsets = this->getCompressedOffsets();
   for(SimplexId i = 0; i < vertexNumber; ++i)
-    outputOffsetField_->SetTuple1(i, voidOffsets[i]);
+    outputOffsetField->SetTuple1(i, voidOffsets[i]);
 
-  output1->GetPointData()->AddArray(outputScalarField_);
-  output1->GetPointData()->AddArray(outputOffsetField_);
+  output->GetPointData()->AddArray(outputScalarField);
+  output->GetPointData()->AddArray(outputOffsetField);
 
   return 1;
 }

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -133,7 +133,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
 
   // Call TopologicalCompression
   switch(inputScalarField->GetDataType()) {
-    vtkTemplateMacro(this->execute<VTK_TT>(Tolerance));
+    vtkTemplateMacro(this->execute<VTK_TT>());
     default:
       break;
   }

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -128,13 +128,8 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   outputOffsetField->SetNumberOfTuples(vertexNumber);
   outputOffsetField->SetName(ttk::OffsetScalarFieldName);
 
-  this->setCompressionType(CompressionType);
   this->setInputDataPointer(ttkUtils::GetVoidPointer(inputScalarField));
-  this->setSQ(SQMethod);
-  this->setUseTopologicalSimplification(UseTopologicalSimplification);
-  this->setSubdivide(!Subdivide);
   this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputScalarField));
-  this->setMaximumError(MaximumError);
 
   // Call TopologicalCompression
   switch(inputScalarField->GetDataType()) {
@@ -143,9 +138,8 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
       break;
   }
 
-  std::vector<int> voidOffsets = this->getCompressedOffsets();
   for(SimplexId i = 0; i < vertexNumber; ++i)
-    outputOffsetField->SetTuple1(i, voidOffsets[i]);
+    outputOffsetField->SetTuple1(i, this->compressedOffsets_[i]);
 
   output->GetPointData()->AddArray(outputScalarField);
   output->GetPointData()->AddArray(outputOffsetField);

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -1,4 +1,6 @@
 #include "ttkTopologicalCompression.h"
+#include <ttkMacros.h>
+#include <ttkUtils.h>
 
 #include <vtkDataSet.h>
 #include <vtkDoubleArray.h>
@@ -127,11 +129,11 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   outputOffsetField->SetName(ttk::OffsetScalarFieldName);
 
   this->setCompressionType(CompressionType);
-  this->setInputDataPointer(inputScalarField->GetVoidPointer(0));
+  this->setInputDataPointer(ttkUtils::GetVoidPointer(inputScalarField));
   this->setSQ(SQMethod);
   this->setUseTopologicalSimplification(UseTopologicalSimplification);
   this->setSubdivide(!Subdivide);
-  this->setOutputDataPointer(outputScalarField->GetVoidPointer(0));
+  this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputScalarField));
   this->setMaximumError(MaximumError);
 
   // Call TopologicalCompression

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -18,60 +18,23 @@
 /// within a VTK pipeline.
 ///
 /// \sa ttk::TopologicalCompression
-#ifndef _VTK_TOPOLOGICALCOMPRESSION_H
-#define _VTK_TOPOLOGICALCOMPRESSION_H
+
+#pragma once
 
 // ttk code includes
 #include <TopologicalCompression.h>
-#include <ttkTriangulationAlgorithm.h>
-
-// VTK includes -- to adapt
-#include <vtkCellData.h>
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDataSetAlgorithm.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkIntArray.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
-#include <vtkUnstructuredGrid.h>
-#include <vtkXMLImageDataWriter.h>
+#include <ttkAlgorithm.h>
 
 // VTK Module
 #include <ttkTopologicalCompressionModule.h>
 
-// in this example, this wrapper takes a data-set on the input and produces a
-// data-set on the output - to adapt.
-// see the documentation of the vtkAlgorithm class to decide from which VTK
-// class your wrapper should inherit.
 class TTKTOPOLOGICALCOMPRESSION_EXPORT ttkTopologicalCompression
-  : public vtkDataSetAlgorithm,
-    protected ttk::Wrapper {
+  : public ttkAlgorithm,
+    protected ttk::TopologicalCompression {
 
 public:
   static ttkTopologicalCompression *New();
-
-  vtkTypeMacro(ttkTopologicalCompression, vtkDataSetAlgorithm);
-
-  void SetDebugLevel(int debugLevel) {
-    setDebugLevel(debugLevel);
-    Modified();
-  }
-
-  void SetThreadNumber(int threadNumber) {
-    ThreadNumber = threadNumber;
-    SetThreads();
-  }
-
-  void SetUseAllCores(bool onOff) {
-    UseAllCores = onOff;
-    SetThreads();
-  }
+  vtkTypeMacro(ttkTopologicalCompression, ttkAlgorithm);
 
   // Set/Get macros (arguments)
   vtkSetMacro(ScalarField, std::string);
@@ -114,37 +77,21 @@ public:
   }
 
 protected:
-  ttkTopologicalCompression() {
-    CompressionType = 0;
-    Tolerance = 10;
-    Subdivide = false;
-    MaximumError = 10;
-    UseTopologicalSimplification = true;
-    ScalarFieldId = 0;
-    outputScalarField_ = nullptr;
-    outputOffsetField_ = nullptr;
-    UseAllCores = true;
-  }
+  ttkTopologicalCompression();
 
-  ~ttkTopologicalCompression() override{};
-
-  TTK_SETUP();
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
 
 private:
-  double Tolerance;
-  double MaximumError;
-  int CompressionType;
-  std::string SQMethod;
-  bool Subdivide;
-  bool UseTopologicalSimplification;
-  std::string ScalarField;
-  int ScalarFieldId;
-
-  vtkSmartPointer<vtkDataArray> outputScalarField_;
-  vtkSmartPointer<vtkIntArray> outputOffsetField_;
-  ttkTriangulation triangulation_;
-  ttk::Triangulation *internalTriangulation_;
-  ttk::TopologicalCompression topologicalCompression_;
+  double Tolerance{10};
+  double MaximumError{10};
+  int CompressionType{0};
+  std::string SQMethod{};
+  bool Subdivide{false};
+  bool UseTopologicalSimplification{true};
+  std::string ScalarField{};
+  int ScalarFieldId{0};
 };
-
-#endif // _VTK_TOPOLOGICALCOMPRESSION_H

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -62,17 +62,12 @@ public:
   vtkGetMacro(UseTopologicalSimplification, bool);
 
   inline void SetSQMethodPV(int c) {
-    switch(c) {
-      case 1:
-        SetSQMethod("r");
-        break;
-      case 2:
-        SetSQMethod("d");
-        break;
-      case 0:
-      default:
-        SetSQMethod("");
-        break;
+    if(c == 1) {
+      SetSQMethod("r");
+    } else if(c == 2) {
+      SetSQMethod("d");
+    } else {
+      SetSQMethod("");
     }
   }
 

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -86,12 +86,6 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  double Tolerance{10};
-  double MaximumError{10};
-  int CompressionType{0};
-  std::string SQMethod{};
-  bool Subdivide{false};
-  bool UseTopologicalSimplification{true};
   std::string ScalarField{};
   int ScalarFieldId{0};
 };

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -11,6 +11,14 @@
 /// \param Input Input scalar field (vtkDataSet)
 /// \param Output Output scalar field (vtkDataSet)
 ///
+/// The input data array needs to be specified via the standard VTK call
+/// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
+/// \param idx 0 (FIXED: the first array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the input array)
+///
 /// This filter can be used as any other VTK filter (for instance, by using the
 /// sequence of calls SetInputData(), Update(), GetOutput()).
 ///
@@ -35,13 +43,6 @@ class TTKTOPOLOGICALCOMPRESSION_EXPORT ttkTopologicalCompression
 public:
   static ttkTopologicalCompression *New();
   vtkTypeMacro(ttkTopologicalCompression, ttkAlgorithm);
-
-  // Set/Get macros (arguments)
-  vtkSetMacro(ScalarField, std::string);
-  vtkGetMacro(ScalarField, std::string);
-
-  vtkSetMacro(ScalarFieldId, int);
-  vtkGetMacro(ScalarFieldId, int);
 
   vtkSetMacro(Tolerance, double);
   vtkGetMacro(Tolerance, double);
@@ -79,8 +80,4 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
-
-private:
-  std::string ScalarField{};
-  int ScalarFieldId{0};
 };

--- a/core/vtk/ttkTopologicalCompression/vtk.module
+++ b/core/vtk/ttkTopologicalCompression/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkTopologicalCompression
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+ ttkAlgorithm

--- a/core/vtk/ttkTopologicalCompressionReader/ttk.module
+++ b/core/vtk/ttkTopologicalCompressionReader/ttk.module
@@ -5,5 +5,5 @@ SOURCES
 HEADERS
   ttkTopologicalCompressionReader.h
 DEPENDS
-  ttkTriangulationAlgorithm
+  ttkAlgorithm
   topologicalCompression

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -134,7 +134,7 @@ int ttkTopologicalCompressionReader::RequestData(
   // decompressed->SetVoidArray(, vertexNumber, 0);
   mesh->GetPointData()->AddArray(decompressed);
 
-  if(SQMethod != 1 && SQMethod != 2 && !ZFPOnly) {
+  if(SQMethodInt != 1 && SQMethodInt != 2 && !ZFPOnly) {
     vtkNew<vtkIntArray> vertexOffset{};
     vertexOffset->SetNumberOfTuples(vertexNumber);
     vertexOffset->SetName(ttk::OffsetScalarFieldName);

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -115,7 +115,8 @@ int ttkTopologicalCompressionReader::RequestData(
   topologicalCompression.preconditionTriangulation(
     triangulation.getTriangulation());
 
-  const auto status = topologicalCompression.ReadFromFile<double>(fp);
+  const auto status = topologicalCompression.ReadFromFile<double>(
+    fp, *(triangulation.getTriangulation()));
   if(status != 0) {
     vtkWarningMacro("Failure when reading compressed TTK file");
   }

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -111,8 +111,24 @@ int ttkTopologicalCompressionReader::RequestData(
   auto triangulation = ttkAlgorithm::GetTriangulation(mesh);
   this->preconditionTriangulation(triangulation);
 
-  const auto status = this->ReadFromFile<double>(
-    fp, *static_cast<ttk::ImplicitTriangulation *>(triangulation->getData()));
+  int status{0};
+  switch(triangulation->getType()) {
+    case ttk::Triangulation::Type::EXPLICIT:
+      status = this->ReadFromFile<double>(
+        fp,
+        *static_cast<ttk::ExplicitTriangulation *>(triangulation->getData()));
+      break;
+    case ttk::Triangulation::Type::IMPLICIT:
+      status = this->ReadFromFile<double>(
+        fp,
+        *static_cast<ttk::ImplicitTriangulation *>(triangulation->getData()));
+      break;
+    case ttk::Triangulation::Type::PERIODIC:
+      status = this->ReadFromFile<double>(
+        fp,
+        *static_cast<ttk::PeriodicImplicitTriangulation *>(triangulation->getData()));
+      break;
+  }
   if(status != 0) {
     vtkWarningMacro("Failure when reading compressed TTK file");
   }

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -1,71 +1,65 @@
+#include <ttkMacros.h>
 #include <ttkTopologicalCompressionReader.h>
+#include <ttkUtils.h>
+
+#include <vtkDataObject.h>
+#include <vtkDataSet.h>
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkStreamingDemandDrivenPipeline.h>
 
 vtkStandardNewMacro(ttkTopologicalCompressionReader);
 
-/** Override **/
-
 ttkTopologicalCompressionReader::ttkTopologicalCompressionReader() {
-
-  FileName = nullptr;
-  ZFPOnly = false;
-  fp = nullptr;
-
-  DataScalarType = VTK_DOUBLE;
-  DataExtent[0] = 0;
-  DataExtent[1] = 0;
-  DataExtent[2] = 0;
-  DataExtent[3] = 0;
-  DataExtent[4] = 0;
-  DataExtent[5] = 0;
-  DataOrigin[0] = 0.0;
-  DataOrigin[1] = 0.0;
-  DataOrigin[2] = 0.0;
-  DataSpacing[0] = 1.0;
-  DataSpacing[1] = 1.0;
-  DataSpacing[2] = 1.0;
-
   SetNumberOfInputPorts(0);
   SetNumberOfOutputPorts(1);
+  this->setDebugMsgPrefix("TopologicalCompressionReader");
 }
 
 int ttkTopologicalCompressionReader::FillOutputPortInformation(
   int port, vtkInformation *info) {
-  info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkImageData");
-  return 1;
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkImageData");
+    return 1;
+  }
+  return 0;
 }
 
 int ttkTopologicalCompressionReader::RequestInformation(
   vtkInformation *request,
   vtkInformationVector **inputVector,
   vtkInformationVector *outputVector) {
+
   if(FileName == nullptr) {
     return 1;
   }
-  if(fp != nullptr) {
-    return 1;
-  }
-  fp = fopen(FileName, "rb"); // binary mode
+
+  FILE *fp = fopen(FileName, "rb"); // binary mode
   if(fp == nullptr) {
     return 1;
   }
 
   // Fill spacing, origin, extent, scalar type
   // L8 tolerance, ZFP factor
-  topologicalCompression.ReadMetaData<double>(fp);
-  DataScalarType = topologicalCompression.getDataScalarType();
+  this->ReadMetaData<double>(fp);
+  DataScalarType = this->getDataScalarType();
   for(int i = 0; i < 3; ++i) {
-    DataSpacing[i] = topologicalCompression.getDataSpacing()[i];
-    DataOrigin[i] = topologicalCompression.getDataOrigin()[i];
-    DataExtent[i] = topologicalCompression.getDataExtent()[i];
-    DataExtent[3 + i] = topologicalCompression.getDataExtent()[3 + i];
+    DataSpacing[i] = this->getDataSpacing()[i];
+    DataOrigin[i] = this->getDataOrigin()[i];
+    DataExtent[i] = this->getDataExtent()[i];
+    DataExtent[3 + i] = this->getDataExtent()[3 + i];
   }
 
   //  ReadMetaData(fp);
 
   vtkInformation *outInfo = outputVector->GetInformationObject(0);
-  outInfo->Set(vtkDataObject::SPACING(), DataSpacing, 3);
-  outInfo->Set(vtkDataObject::ORIGIN(), DataOrigin, 3);
-  outInfo->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), DataExtent, 6);
+  outInfo->Set(vtkDataObject::SPACING(), DataSpacing.data(), 3);
+  outInfo->Set(vtkDataObject::ORIGIN(), DataOrigin.data(), 3);
+  outInfo->Set(
+    vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), DataExtent.data(), 6);
 
   int numberOfVertices = 1;
   for(int i = 0; i < 3; ++i)
@@ -85,38 +79,40 @@ int ttkTopologicalCompressionReader::RequestData(
   vtkInformation *request,
   vtkInformationVector **inputVector,
   vtkInformationVector *outputVector) {
+
   // Initialize
   if(FileName == nullptr) {
     return 1;
   }
-  fp = fopen(FileName, "rb"); // binary mode
+  FILE *fp = fopen(FileName, "rb"); // binary mode
+
   if(fp == nullptr) {
     return 1;
   }
 
-  topologicalCompression.setFileName(FileName);
-  topologicalCompression.ReadMetaData<double>(fp);
-  DataScalarType = topologicalCompression.getDataScalarType();
+  this->setFileName(FileName);
+  this->ReadMetaData<double>(fp);
+  DataScalarType = this->getDataScalarType();
   for(int i = 0; i < 3; ++i) {
-    DataSpacing[i] = topologicalCompression.getDataSpacing()[i];
-    DataOrigin[i] = topologicalCompression.getDataOrigin()[i];
-    DataExtent[i] = topologicalCompression.getDataExtent()[i];
-    DataExtent[3 + i] = topologicalCompression.getDataExtent()[3 + i];
+    DataSpacing[i] = this->getDataSpacing()[i];
+    DataOrigin[i] = this->getDataOrigin()[i];
+    DataExtent[i] = this->getDataExtent()[i];
+    DataExtent[3 + i] = this->getDataExtent()[3 + i];
   }
   int nx = 1 + DataExtent[1] - DataExtent[0];
   int ny = 1 + DataExtent[3] - DataExtent[2];
   int nz = 1 + DataExtent[5] - DataExtent[4];
   int vertexNumber = nx * ny * nz;
-  ZFPOnly = topologicalCompression.getZFPOnly();
+  ZFPOnly = this->getZFPOnly();
 
-  BuildMesh();
+  vtkNew<vtkImageData> mesh{};
+  BuildMesh(mesh);
 
-  triangulation.setInputData(mesh);
-  topologicalCompression.preconditionTriangulation(
-    triangulation.getTriangulation());
+  auto triangulation = ttkAlgorithm::GetTriangulation(mesh);
+  this->preconditionTriangulation(triangulation);
 
-  const auto status = topologicalCompression.ReadFromFile<double>(
-    fp, *(triangulation.getTriangulation()));
+  const auto status = this->ReadFromFile<double>(
+    fp, *static_cast<ttk::ImplicitTriangulation *>(triangulation->getData()));
   if(status != 0) {
     vtkWarningMacro("Failure when reading compressed TTK file");
   }
@@ -124,27 +120,25 @@ int ttkTopologicalCompressionReader::RequestData(
   mesh->GetPointData()->RemoveArray(0);
   mesh->GetPointData()->SetNumberOfTuples(vertexNumber);
 
-  decompressed = vtkSmartPointer<vtkDoubleArray>::New();
+  vtkNew<vtkDoubleArray> decompressed{};
   decompressed->SetNumberOfTuples(vertexNumber);
-  auto name = topologicalCompression.getDataArrayName();
+  const auto &name = this->getDataArrayName();
   if(!name.empty()) {
     decompressed->SetName(name.data());
   } else {
     decompressed->SetName("Decompressed");
   }
-  std::vector<double> decompressdeData
-    = topologicalCompression.getDecompressedData();
+  const auto &decompressdeData = this->getDecompressedData();
   for(int i = 0; i < vertexNumber; ++i)
     decompressed->SetTuple1(i, decompressdeData[i]);
   // decompressed->SetVoidArray(, vertexNumber, 0);
   mesh->GetPointData()->AddArray(decompressed);
 
   if(SQMethod != 1 && SQMethod != 2 && !ZFPOnly) {
-    vertexOffset = vtkSmartPointer<vtkIntArray>::New();
+    vtkNew<vtkIntArray> vertexOffset{};
     vertexOffset->SetNumberOfTuples(vertexNumber);
     vertexOffset->SetName(ttk::OffsetScalarFieldName);
-    std::vector<int> voidOffsets
-      = topologicalCompression.getDecompressedOffsets();
+    const auto &voidOffsets = this->getDecompressedOffsets();
     for(size_t i = 0; i < voidOffsets.size(); ++i)
       vertexOffset->SetTuple1(i, voidOffsets[i]);
     //    vertexOffset->SetVoidArray(
@@ -152,40 +146,33 @@ int ttkTopologicalCompressionReader::RequestData(
     mesh->GetPointData()->AddArray(vertexOffset);
   }
 
-  {
-    ttk::Debug d;
-    std::stringstream msg;
-    msg << "[ttkCompressionReader] Read " << mesh->GetNumberOfPoints()
-        << " vertice(s)" << std::endl;
-    msg << "[ttkCompressionReader] Read " << mesh->GetNumberOfCells()
-        << " cell(s)" << std::endl;
-    d.dMsg(std::cout, msg.str(), ttk::Debug::infoMsg);
-  }
+  this->printMsg("Read " + std::to_string(mesh->GetNumberOfPoints())
+                 + " vertice(s), " + std::to_string(mesh->GetNumberOfCells())
+                 + " cell(s).");
 
   // get the info object
   vtkInformation *outInfo = outputVector->GetInformationObject(0);
   outInfo->Set(vtkStreamingDemandDrivenPipeline::UPDATE_NUMBER_OF_PIECES(), 1);
 
   // Set the output
-  vtkImageData *output
-    = vtkImageData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
+  auto output = vtkImageData::GetData(outputVector);
   output->ShallowCopy(mesh);
 
   return 1;
 }
 
-void ttkTopologicalCompressionReader::BuildMesh() {
+vtkImageData *ttkTopologicalCompressionReader::GetOutput() {
+  // copied from ParaView's vtkImageAlgorithm::GetOutput(int port)
+  return vtkImageData::SafeDownCast(this->GetOutputDataObject(0));
+}
+
+void ttkTopologicalCompressionReader::BuildMesh(vtkImageData *mesh) const {
   int nx = 1 + DataExtent[1] - DataExtent[0];
   int ny = 1 + DataExtent[3] - DataExtent[2];
   int nz = 1 + DataExtent[5] - DataExtent[4];
-  mesh = vtkSmartPointer<vtkImageData>::New();
   mesh->SetDimensions(nx, ny, nz);
   mesh->SetSpacing(DataSpacing[0], DataSpacing[1], DataSpacing[2]);
   mesh->SetOrigin(DataOrigin[0], DataOrigin[1], DataOrigin[2]);
   mesh->AllocateScalars(DataScalarType, 2);
   mesh->GetPointData()->SetNumberOfTuples(nx * ny * nz);
-
-  int numberOfVertices = 1;
-  for(int i = 0; i < 3; ++i)
-    numberOfVertices *= (1 + DataExtent[2 * i + 1] - DataExtent[2 * i]);
 }

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -112,7 +112,8 @@ int ttkTopologicalCompressionReader::RequestData(
   BuildMesh();
 
   triangulation.setInputData(mesh);
-  topologicalCompression.setupTriangulation(triangulation.getTriangulation());
+  topologicalCompression.preconditionTriangulation(
+    triangulation.getTriangulation());
 
   const auto status = topologicalCompression.ReadFromFile<double>(fp);
   if(status != 0) {

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -32,10 +32,6 @@ public:
   vtkSetMacro(DataScalarType, int);
   vtkGetMacro(DataScalarType, int);
 
-  void SetDebugLevel(const int val) {
-    this->setDebugLevel(val);
-  }
-
   // need this method to align with the vtkImageAlgorithm API
   vtkImageData *GetOutput();
 
@@ -62,6 +58,4 @@ private:
   std::array<int, 6> DataExtent{0, 0, 0, 0, 0, 0};
   std::array<double, 3> DataSpacing{1.0, 1.0, 1.0};
   std::array<double, 3> DataOrigin{0.0, 0.0, 0.0};
-  bool ZFPOnly{false};
-  int SQMethod;
 };

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -6,52 +6,25 @@
 /// \brief VTK-filter that wraps the topologicalCompressionWriter processing
 /// package.
 
-#ifndef _VTK_TOPOLOGICALCOMPRESSIONREADER_H
-#define _VTK_TOPOLOGICALCOMPRESSIONREADER_H
+#pragma once
 
 // TTK
 #include <TopologicalCompression.h>
-#include <ttkTriangulationAlgorithm.h>
-
-// VTK
-#include <vtkAlgorithm.h>
-#include <vtkCellData.h>
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDataObject.h>
-#include <vtkDataSet.h>
-#include <vtkDataSetAlgorithm.h>
-#include <vtkDemandDrivenPipeline.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkImageAlgorithm.h>
-#include <vtkImageData.h>
-#include <vtkInformation.h>
-#include <vtkIntArray.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkPoints.h>
-#include <vtkPolyData.h>
-#include <vtkSmartPointer.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
+#include <ttkAlgorithm.h>
 
 // VTK Module
 #include <ttkTopologicalCompressionReaderModule.h>
 
-// STD
-#include <fstream>
-#include <iostream>
-#include <limits.h>
-#include <string>
+class vtkImageData;
 
 class TTKTOPOLOGICALCOMPRESSIONREADER_EXPORT ttkTopologicalCompressionReader
-  : public vtkImageAlgorithm {
+  : public ttkAlgorithm,
+    protected ttk::TopologicalCompression {
 
 public:
   static ttkTopologicalCompressionReader *New();
 
-  vtkTypeMacro(ttkTopologicalCompressionReader, vtkAlgorithm);
+  vtkTypeMacro(ttkTopologicalCompressionReader, ttkAlgorithm);
 
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
@@ -60,13 +33,15 @@ public:
   vtkGetMacro(DataScalarType, int);
 
   void SetDebugLevel(const int val) {
-    this->topologicalCompression.setDebugLevel(val);
+    this->setDebugLevel(val);
   }
+
+  // need this method to align with the vtkImageAlgorithm API
+  vtkImageData *GetOutput();
 
 protected:
   // Regular ImageData reader management.
   ttkTopologicalCompressionReader();
-  ~ttkTopologicalCompressionReader() override = default;
   int FillOutputPortInformation(int, vtkInformation *) override;
   int RequestData(vtkInformation *,
                   vtkInformationVector **,
@@ -76,27 +51,17 @@ protected:
                                  vtkInformationVector *outputVector) override;
 
   // TTK management.
-  void BuildMesh();
+  void BuildMesh(vtkImageData *mesh) const;
 
 private:
   // General properties.
-  char *FileName;
-  FILE *fp;
+  char *FileName{};
 
   // Data properties.
   int DataScalarType;
-  int DataExtent[6];
-  double DataSpacing[3];
-  double DataOrigin[3];
-  bool ZFPOnly;
+  std::array<int, 6> DataExtent{0, 0, 0, 0, 0, 0};
+  std::array<double, 3> DataSpacing{1.0, 1.0, 1.0};
+  std::array<double, 3> DataOrigin{0.0, 0.0, 0.0};
+  bool ZFPOnly{false};
   int SQMethod;
-
-  // TTK object dependencies.
-  ttkTriangulation triangulation;
-  ttk::TopologicalCompression topologicalCompression;
-  vtkSmartPointer<vtkImageData> mesh;
-  vtkSmartPointer<vtkDoubleArray> decompressed;
-  vtkSmartPointer<vtkIntArray> vertexOffset;
 };
-
-#endif // _VTK_TOPOLOGICALCOMPRESSIONREADER_H

--- a/core/vtk/ttkTopologicalCompressionReader/vtk.module
+++ b/core/vtk/ttkTopologicalCompressionReader/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkTopologicalCompressionReader
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+ ttkAlgorithm

--- a/core/vtk/ttkTopologicalCompressionWriter/ttk.module
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttk.module
@@ -5,5 +5,5 @@ SOURCES
 HEADERS
   ttkTopologicalCompressionWriter.h
 DEPENDS
-  ttkTriangulationAlgorithm
+  ttkAlgorithm
   topologicalCompression

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -33,13 +33,6 @@ void ttkTopologicalCompressionWriter::PerformCompression(
   vtkDataArray *outputScalarField,
   const triangulationType &triangulation) {
 
-  this->setSQ(SQMethod);
-  this->setSubdivide(!Subdivide);
-  this->setUseTopologicalSimplification(UseTopologicalSimplification);
-  this->setZFPOnly(ZFPOnly);
-  this->setCompressionType(CompressionType);
-  this->setMaximumError(MaximumError);
-  this->setTolerance(Tolerance);
   switch(inputScalarField->GetDataType()) {
     vtkTemplateMacro(this->execute(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -1,4 +1,5 @@
 #include <ttkTopologicalCompressionWriter.h>
+#include <ttkUtils.h>
 
 vtkStandardNewMacro(ttkTopologicalCompressionWriter);
 
@@ -76,19 +77,18 @@ int ttkTopologicalCompressionWriter::AllocateOutput(
 
 void ttkTopologicalCompressionWriter::PerformCompression(
   vtkDataArray *inputScalarField) {
-  topologicalCompression.setInputDataPointer(
-    inputScalarField->GetVoidPointer(0));
   topologicalCompression.setSQ(SQMethod);
   topologicalCompression.setSubdivide(!Subdivide);
   topologicalCompression.setUseTopologicalSimplification(
     UseTopologicalSimplification);
   topologicalCompression.setZFPOnly(ZFPOnly);
   topologicalCompression.setCompressionType(CompressionType);
-  topologicalCompression.setOutputDataPointer(
-    outputScalarField->GetVoidPointer(0));
   topologicalCompression.setMaximumError(MaximumError);
+  topologicalCompression.setTolerance(Tolerance);
   switch(inputScalarField->GetDataType()) {
-    vtkTemplateMacro(topologicalCompression.execute<VTK_TT>(Tolerance));
+    vtkTemplateMacro(topologicalCompression.execute(
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField))));
     default: {
       std::stringstream msg;
       msg << "[ttkCompressionWriter] Unsupported data type." << std::endl;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -28,7 +28,8 @@ int ttkTopologicalCompressionWriter::FillInputPortInformation(
 
 void ttkTopologicalCompressionWriter::ComputeTriangulation(vtkImageData *vti) {
   triangulation.setInputData(vti);
-  topologicalCompression.setupTriangulation(triangulation.getTriangulation());
+  topologicalCompression.preconditionTriangulation(
+    triangulation.getTriangulation());
 }
 
 vtkDataArray *

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -88,7 +88,8 @@ void ttkTopologicalCompressionWriter::PerformCompression(
   switch(inputScalarField->GetDataType()) {
     vtkTemplateMacro(topologicalCompression.execute(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
-      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField))));
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField)),
+      *(triangulation.getTriangulation())));
     default: {
       std::stringstream msg;
       msg << "[ttkCompressionWriter] Unsupported data type." << std::endl;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -27,13 +27,6 @@ int ttkTopologicalCompressionWriter::FillInputPortInformation(
   return 0;
 }
 
-vtkDataArray *
-  ttkTopologicalCompressionWriter::GetInputScalarField(vtkImageData *vti) {
-  return ScalarField.length()
-           ? vti->GetPointData()->GetArray(ScalarField.data())
-           : vti->GetPointData()->GetArray(ScalarFieldId);
-}
-
 template <typename triangulationType>
 void ttkTopologicalCompressionWriter::PerformCompression(
   vtkDataArray *inputScalarField,
@@ -69,7 +62,10 @@ int ttkTopologicalCompressionWriter::Write() {
   vtkDataObject *input = GetInput();
   vtkImageData *vti = vtkImageData::SafeDownCast(input);
 
-  vtkDataArray *inputScalarField = GetInputScalarField(vti);
+  auto inputScalarField = this->GetInputArrayToProcess(0, input);
+  if(inputScalarField == nullptr) {
+    return 0;
+  }
 
   auto triangulation = ttkAlgorithm::GetTriangulation(vti);
   if(triangulation == nullptr) {

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -79,11 +79,6 @@ protected:
   ttkTopologicalCompressionWriter();
   virtual int FillInputPortInformation(int port, vtkInformation *info) override;
 
-  template <typename triangulationType>
-  void PerformCompression(vtkDataArray *inputScalarField,
-                          vtkDataArray *outputScalarField,
-                          const triangulationType &triangulation);
-
 private:
   // Writer parameters.
   char *FileName{};

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -29,12 +29,6 @@ public:
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
 
-  vtkSetMacro(ScalarField, std::string);
-  vtkGetMacro(ScalarField, std::string);
-
-  vtkSetMacro(ScalarFieldId, int);
-  vtkGetMacro(ScalarFieldId, int);
-
   vtkGetMacro(Tolerance, double);
   vtkSetMacro(Tolerance, double);
 
@@ -87,9 +81,6 @@ protected:
   vtkDataObject *GetInput();
   void SetInputData(vtkDataObject *input);
 
-  // TTK management.
-  vtkDataArray *GetInputScalarField(vtkImageData *vti);
-
   template <typename triangulationType>
   void PerformCompression(vtkDataArray *inputScalarField,
                           vtkDataArray *outputScalarField,
@@ -104,8 +95,6 @@ private:
     static_cast<int>(ttk::CompressionType::PersistenceDiagram)};
 
   // Compression results.
-  std::string ScalarField;
-  int ScalarFieldId;
   int *Segmentation;
   double Tolerance{1.0};
   double MaximumError;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -69,17 +69,15 @@ public:
     }
   }
 
-  // expose Write method for vtkWriter API compatibility (duck-typing)
+  // expose vtkWriter methods (duck-typing)
   int Write();
+  vtkDataObject *GetInput();
+  void SetInputData(vtkDataObject *input);
 
 protected:
   // Regular writer management.
   ttkTopologicalCompressionWriter();
   virtual int FillInputPortInformation(int port, vtkInformation *info) override;
-
-  // need those two methods to align with the vtkWriter API
-  vtkDataObject *GetInput();
-  void SetInputData(vtkDataObject *input);
 
   template <typename triangulationType>
   void PerformCompression(vtkDataArray *inputScalarField,
@@ -89,12 +87,4 @@ protected:
 private:
   // Writer parameters.
   char *FileName{};
-
-  // Whatever.
-  ttkTopologicalCompressionWriter(const ttkTopologicalCompressionWriter &);
-  void operator=(const ttkTopologicalCompressionWriter &);
-
-  // give ttkCinemaWriter access to ttkTopologicalCompressionWriter
-  // protected member functions
-  friend class ttkCinemaWriter;
 };

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -89,20 +89,6 @@ protected:
 private:
   // Writer parameters.
   char *FileName{};
-  double ZFPBitBudget{0};
-  bool ZFPOnly{false};
-  int CompressionType{
-    static_cast<int>(ttk::CompressionType::PersistenceDiagram)};
-
-  // Compression results.
-  int *Segmentation;
-  double Tolerance{1.0};
-  double MaximumError;
-  int NbSegments;
-  int NbVertices;
-  std::string SQMethod{};
-  bool Subdivide{false};
-  bool UseTopologicalSimplification{true};
 
   // Whatever.
   ttkTopologicalCompressionWriter(const ttkTopologicalCompressionWriter &);

--- a/core/vtk/ttkTopologicalCompressionWriter/vtk.module
+++ b/core/vtk/ttkTopologicalCompressionWriter/vtk.module
@@ -1,8 +1,4 @@
 NAME
  ttkTopologicalCompressionWriter
 DEPENDS
-  VTK::FiltersCore
-  VTK::IOParallelXML
-  VTK::IOLegacy
-PRIVATE_DEPENDS
-  VTK::CommonCore
+  ttkAlgorithm

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -78,7 +78,7 @@ NOTE:
             ${TOPOLOGICAL_COMPRESSION_WIDGETS}
 
             <PropertyGroup panel_widget="Line" label="Topological Compression" >
-              <Property name="ScalarField" />
+              <Property name="Scalar Field" />
               <Property name="CompressionType" />
               <Property name="Tolerance" />
               <Property name="Subdivide" />

--- a/paraview/TopologicalCompression/TopologicalCompression.xml
+++ b/paraview/TopologicalCompression/TopologicalCompression.xml
@@ -147,54 +147,7 @@
             <Property name="SQMethod" />
         </PropertyGroup>
 
-      <IntVectorProperty
-          name="UseAllCores"
-          label="Use All Cores"
-          command="SetUseAllCores"
-          number_of_elements="1"
-          default_values="1" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Use all available cores.
-        </Documentation>
-      </IntVectorProperty>
-
-        <IntVectorProperty
-                name="ThreadNumber"
-                label="Thread Number"
-                command="SetThreadNumber"
-                number_of_elements="1"
-                default_values="1" panel_visibility="advanced">
-            <IntRangeDomain name="range" min="1" max="100" />
-            <Hints>
-                <PropertyWidgetDecorator type="GenericDecorator"
-                                         mode="visibility"
-                                         property="UseAllCores"
-                                         value="0" />
-            </Hints>
-
-            <Documentation>
-                Thread number.
-            </Documentation>
-        </IntVectorProperty>
-
-      <IntVectorProperty
-          name="DebugLevel"
-          label="Debug Level"
-          command="SetDebugLevel"
-          number_of_elements="1"
-          default_values="3" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="0" max="100" />
-        <Documentation>
-          Debug level.
-        </Documentation>
-      </IntVectorProperty>
-
-      <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="UseAllCores" />
-        <Property name="ThreadNumber" />
-        <Property name="DebugLevel" />
-      </PropertyGroup>
+        ${DEBUG_WIDGETS}
 
       <Hints>
         <ShowInMenu category="TTK - Scalar Data" />

--- a/paraview/TopologicalCompression/TopologicalCompression.xml
+++ b/paraview/TopologicalCompression/TopologicalCompression.xml
@@ -34,11 +34,13 @@
         </InputProperty>
 
         <StringVectorProperty
-                name="ScalarField"
-                command="SetScalarField"
-                number_of_elements="1"
+                name="Scalar Field"
+                command="SetInputArrayToProcess"
+                element_types="0 0 0 0 2"
+                number_of_elements="5"
+                default_values="0"
                 animateable="0"
-                label="Scalar Field">
+                >
             <ArrayListDomain
                     name="array_list"
                     default_values="0">
@@ -134,7 +136,7 @@
         </IntVectorProperty>
 
         <PropertyGroup panel_widget="Line" label="Input">
-            <Property name="ScalarField" />
+            <Property name="Scalar Field" />
         </PropertyGroup>
 
         <PropertyGroup panel_widget="double_range"

--- a/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
+++ b/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
@@ -42,7 +42,7 @@
       ${TOPOLOGICAL_COMPRESSION_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input">
-        <Property name="ScalarField" />
+        <Property name="Scalar Field" />
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output">

--- a/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
+++ b/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
@@ -41,30 +41,6 @@
 
       ${TOPOLOGICAL_COMPRESSION_WIDGETS}
 
-      <IntVectorProperty
-              name="UseAllCores"
-              label="Use All Cores"
-              command="SetUseAllCores"
-              number_of_elements="1"
-              default_values="1" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Use all available cores.
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-              name="ThreadNumber"
-              label="Thread Number"
-              command="SetThreadNumber"
-              number_of_elements="1"
-              default_values="1" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="1" max="100" />
-        <Documentation>
-          Thread number.
-        </Documentation>
-      </IntVectorProperty>
-
       <PropertyGroup panel_widget="Line" label="Input">
         <Property name="ScalarField" />
       </PropertyGroup>
@@ -85,10 +61,7 @@
         <Property name="SQMethod" />
       </PropertyGroup>
 
-      <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="UseAllCores" />
-        <Property name="ThreadNumber" />
-      </PropertyGroup>
+      ${DEBUG_WIDGETS}
 
       <Hints>
         <Property name="Input" show="0"/>


### PR DESCRIPTION
This PR migrates the TopologicalCompression module to the new architecture:

- the new logging API replaces the old one (and the `std::cerr <<` and the `fprintf`),
- the triangulation-using methods have been templated,
- the new `GetInputArrayToProcess`, `SetInputArrayToProcess` method to access arrays has been used,
- TopologicalCompressionReader, TopologicalCompressionWriter and TopologicalSimplification have been updated to fix compatibility issues.

Since no ttk-data filter uses TopologicalCompression (excluding persistenceDrivenCompression that uses TopologicalCompressionReader), no need to update the state files.

Enjoy,
Pierre
