### PR TITLE
[api-migration-hackathon] Migrate HarmonicField to Get|SetInputArrayToProcess

### DIFF
--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -1,4 +1,6 @@
 #include <ttkHarmonicField.h>
+#include <ttkMacros.h>
+#include <ttkUtils.h>
 
 // VTK includes
 #include <vtkDoubleArray.h>
@@ -46,44 +48,6 @@ int ttkHarmonicField::FillOutputPortInformation(int port,
   return 0;
 }
 
-int ttkHarmonicField::getIdentifiers(vtkPointSet *input) {
-  auto vsfn = static_cast<const char *>(ttk::VertexScalarFieldName);
-
-  if(ForceConstraintIdentifiers && InputIdentifiersFieldName.length() != 0) {
-    identifiers_
-      = input->GetPointData()->GetArray(InputIdentifiersFieldName.data());
-  } else if(input->GetPointData()->GetArray(vsfn) != nullptr) {
-    identifiers_ = input->GetPointData()->GetArray(vsfn);
-  }
-
-  TTK_ABORT_KK(
-    identifiers_ == nullptr, "wrong vertex identifier scalar field", -1);
-  return 0;
-}
-
-int ttkHarmonicField::getConstraints(vtkPointSet *input) {
-  auto osfn = static_cast<const char *>(ttk::OffsetScalarFieldName);
-  auto pointData = input->GetPointData();
-
-  if(InputScalarFieldName.length() != 0) {
-    constraints_ = pointData->GetArray(InputScalarFieldName.data());
-  } else if(pointData->GetArray(osfn) != nullptr) {
-    constraints_ = pointData->GetArray(osfn);
-  }
-
-  TTK_ABORT_KK(constraints_ == nullptr, "wrong constraints scalar field", -1);
-
-  if(constraints_->IsA("vtkDoubleArray")) {
-    OutputScalarFieldType = FieldType::DOUBLE;
-  } else if(constraints_->IsA("vtkFloatArray")) {
-    OutputScalarFieldType = FieldType::FLOAT;
-  } else {
-    return -2;
-  }
-
-  return 0;
-}
-
 int ttkHarmonicField::RequestData(vtkInformation *request,
                                   vtkInformationVector **inputVector,
                                   vtkInformationVector *outputVector) {
@@ -93,34 +57,42 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
   auto output = vtkDataSet::GetData(outputVector);
   auto triangulation = ttkAlgorithm::GetTriangulation(domain);
 
-  TTK_ABORT_KK(triangulation == nullptr, "wrong triangulation", -1);
-
+  if(triangulation == nullptr) {
+    this->printErr("No triangulation");
+    return 0;
+  }
   this->preconditionTriangulation(*triangulation, UseCotanWeights);
 
-  int res = this->getIdentifiers(identifiers);
+  vtkDataArray *inputField = this->GetInputArrayToProcess(0, identifiers);
+  vtkDataArray *vertsid
+    = this->GetInputArrayInformation(1) && this->ForceConstraintIdentifiers
+        ? this->GetInputArrayToProcess(1, inputVector)
+        : identifiers->GetPointData()->GetArray(ttk::VertexScalarFieldName);
 
-  TTK_ABORT_KK(res != 0, "wrong identifiers", -2);
+  if(vertsid == nullptr || inputField == nullptr) {
+    this->printErr("Input fields are NULL");
+    return 0;
+  }
 
-  res += this->getConstraints(identifiers);
+  if(inputField->IsA("vtkDoubleArray")) {
+    OutputScalarFieldType = FieldType::DOUBLE;
+  } else if(inputField->IsA("vtkFloatArray")) {
+    OutputScalarFieldType = FieldType::FLOAT;
+  } else {
+    return -2;
+  }
 
-  TTK_ABORT_KK(res != 0, "wrong constraints", -2);
+  const auto nVerts = domain->GetNumberOfPoints();
+  const auto nSources = identifiers->GetNumberOfPoints();
 
-  const auto numberOfPointsInDomain = domain->GetNumberOfPoints();
-
-  TTK_ABORT_KK(numberOfPointsInDomain == 0, "domain has no points", -3);
-
-  const auto numberOfPointsInSources = identifiers->GetNumberOfPoints();
-
-  TTK_ABORT_KK(numberOfPointsInSources == 0, "sources has no points", -3);
-
-  vtkSmartPointer<vtkDataArray> harmonicScalarField{};
+  vtkSmartPointer<vtkDataArray> outputField{};
 
   switch(OutputScalarFieldType) {
     case FieldType::FLOAT:
-      harmonicScalarField = vtkSmartPointer<vtkFloatArray>::New();
+      outputField = vtkSmartPointer<vtkFloatArray>::New();
       break;
     case FieldType::DOUBLE:
-      harmonicScalarField = vtkSmartPointer<vtkDoubleArray>::New();
+      outputField = vtkSmartPointer<vtkDoubleArray>::New();
       break;
     default:
       this->printErr("Unknown scalar field type");
@@ -128,28 +100,28 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
       break;
   }
 
-  TTK_ABORT_KK(
-    harmonicScalarField == nullptr, "vtkArray allocation problem", -8);
+  TTK_ABORT_KK(outputField == nullptr, "vtkArray allocation problem", -8);
 
-  harmonicScalarField->SetNumberOfComponents(1);
-  harmonicScalarField->SetNumberOfTuples(numberOfPointsInDomain);
-  harmonicScalarField->SetName(OutputScalarFieldName.data());
+  outputField->SetNumberOfComponents(1);
+  outputField->SetNumberOfTuples(nVerts);
+  outputField->SetName(OutputScalarFieldName.data());
+  int res{};
 
   switch(OutputScalarFieldType) {
     case FieldType::FLOAT:
-      res += this->execute<float>(
-        *triangulation, numberOfPointsInSources,
-        static_cast<ttk::SimplexId *>(identifiers_->GetVoidPointer(0)),
-        static_cast<float *>(constraints_->GetVoidPointer(0)),
-        static_cast<float *>(harmonicScalarField->GetVoidPointer(0)),
+      res = this->execute<float>(
+        *triangulation, nSources,
+        static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(vertsid)),
+        static_cast<float *>(ttkUtils::GetVoidPointer(inputField)),
+        static_cast<float *>(ttkUtils::GetVoidPointer(outputField)),
         UseCotanWeights, SolvingMethod, LogAlpha);
       break;
     case FieldType::DOUBLE:
-      res += this->execute<double>(
-        *triangulation, numberOfPointsInSources,
-        static_cast<ttk::SimplexId *>(identifiers_->GetVoidPointer(0)),
-        static_cast<double *>(constraints_->GetVoidPointer(0)),
-        static_cast<double *>(harmonicScalarField->GetVoidPointer(0)),
+      res = this->execute<double>(
+        *triangulation, nSources,
+        static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(vertsid)),
+        static_cast<double *>(ttkUtils::GetVoidPointer(inputField)),
+        static_cast<double *>(ttkUtils::GetVoidPointer(outputField)),
         UseCotanWeights, SolvingMethod, LogAlpha);
       break;
     default:
@@ -161,7 +133,7 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
 
   // update result
   output->ShallowCopy(domain);
-  output->GetPointData()->AddArray(harmonicScalarField);
+  output->GetPointData()->AddArray(outputField);
 
   return 1;
 }

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -5,21 +5,10 @@
 // VTK includes
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkInformation.h>
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
 #include <vtkSmartPointer.h>
-
-#include <vtkInformation.h>
-
-#ifndef TTK_ENABLE_KAMIKAZE
-#define TTK_ABORT_KK(COND, MSG, RET) \
-  if(COND) {                         \
-    this->printErr(MSG);             \
-    return RET;                      \
-  }
-#else // TTK_ENABLE_KAMIKAZE
-#define TTK_ABORT_KK(COND, MSG, RET)
-#endif // TTK_ENABLE_KAMIKAZE
 
 vtkStandardNewMacro(ttkHarmonicField);
 
@@ -100,7 +89,10 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
       break;
   }
 
-  TTK_ABORT_KK(outputField == nullptr, "vtkArray allocation problem", -8);
+  if(outputField == nullptr) {
+    this->printErr("vtkArray allocation problem");
+    return 0;
+  }
 
   outputField->SetNumberOfComponents(1);
   outputField->SetNumberOfTuples(nVerts);
@@ -128,8 +120,11 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
       break;
   }
 
-  TTK_ABORT_KK(
-    res != 0, "HarmonicField execute() error code: " + std::to_string(res), -9);
+  if(res != 0) {
+    this->printErr("HarmonicField execute() error code: "
+                   + std::to_string(res));
+    return 0;
+  }
 
   // update result
   output->ShallowCopy(domain);

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.h
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.h
@@ -51,12 +51,6 @@ public:
 
   vtkTypeMacro(ttkHarmonicField, ttkAlgorithm);
 
-  vtkSetMacro(InputScalarFieldName, std::string);
-  vtkGetMacro(InputScalarFieldName, std::string);
-
-  vtkSetMacro(InputIdentifiersFieldName, std::string);
-  vtkGetMacro(InputIdentifiersFieldName, std::string);
-
   vtkSetMacro(OutputScalarFieldName, std::string);
   vtkGetMacro(OutputScalarFieldName, std::string);
 
@@ -91,11 +85,6 @@ public:
   vtkSetMacro(LogAlpha, double);
   vtkGetMacro(LogAlpha, double);
 
-  // get array of identifiers on the mesh
-  int getIdentifiers(vtkPointSet *input);
-  // get constraint values on identifiers
-  int getConstraints(vtkPointSet *input);
-
 protected:
   ttkHarmonicField();
   ~ttkHarmonicField() override = default;
@@ -107,16 +96,12 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  // user-defined input constraints (float) scalar field name
-  std::string InputScalarFieldName{};
   // output scalar field
   std::string OutputScalarFieldName{"OutputHarmonicField"};
   // let the user choose a different identifier scalar field
   bool ForceConstraintIdentifiers{false};
   // graph laplacian variant
   bool UseCotanWeights{true};
-  // user-defined input identifier (SimplexId) scalar field name
-  std::string InputIdentifiersFieldName{ttk::VertexScalarFieldName};
   // user-selected solving method
   SolvingMethodUserType SolvingMethod{SolvingMethodUserType::AUTO};
   // penalty value
@@ -125,9 +110,4 @@ private:
   // enum: float or double
   enum class FieldType { FLOAT, DOUBLE };
   FieldType OutputScalarFieldType{FieldType::FLOAT};
-
-  // points on the mesh where constraints_ are set
-  vtkDataArray *identifiers_{};
-  // scalar field constraint values on identifiers_
-  vtkDataArray *constraints_{};
 };

--- a/paraview/HarmonicField/HarmonicField.xml
+++ b/paraview/HarmonicField/HarmonicField.xml
@@ -19,7 +19,6 @@
 
       <InputProperty
           name="Domain"
-          label="Input Geometry"
           port_index="0"
           command="SetInputConnection">
         <ProxyGroupDomain name="groups">
@@ -37,7 +36,6 @@
       <InputProperty
           name="Constraints"
           port_index="1"
-          label="Input Constraints"
           command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
@@ -46,7 +44,7 @@
         <DataTypeDomain name="input_type">
           <DataType value="vtkPointSet"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
+        <InputArrayDomain name="input_scalars" number_of_components="1" >
           <Property name="Constraints" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>
@@ -55,21 +53,20 @@
       </InputProperty>
 
       <StringVectorProperty
-          name="InputConstraintFieldName"
-          command="SetInputScalarFieldName"
-          label="Constraint Values"
-          number_of_elements="1"
+          name="Scalar Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
           animateable="0"
           >
         <ArrayListDomain
             name="array_list"
+            input_domain_name="input_scalars"
             default_values="0"
             >
           <RequiredProperties>
-            <Property
-                name="Constraints"
-                function="Input"
-                />
+            <Property name="Constraints" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
         <Documentation>
@@ -91,15 +88,17 @@
       </IntVectorProperty>
 
       <StringVectorProperty
-          name="InputIdentifiersFieldName"
-          command="SetInputIdentifiersFieldName"
-          label="Constraint Identifiers"
-          number_of_elements="1"
+          name="Constraint Vertices Identifiers"
+          command="SetInputArrayToProcess"
+          number_of_elements="5"
+          element_types="0 0 0 0 2"
+          default_values="1"
           animateable="0"
           panel_visibility="advanced"
           >
         <ArrayListDomain
             name="array_list"
+            input_domain_name="input_scalars"
             default_values="0"
             >
           <RequiredProperties>
@@ -181,8 +180,9 @@
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="UseCotanWeights" />
         <Property name="SolvingMethod" />
-        <Property name="InputConstraintFieldName" />
+        <Property name="Scalar Field" />
         <Property name="ForceConstraintIdentifiers" />
+        <Property name="Constraint Vertices Identifiers" />
         <Property name="LogAlpha" />
       </PropertyGroup>
 


### PR DESCRIPTION
This PR migrates HarmonicField to the new `GetInputArrayToProcess`|`SetInputArrayToProcess` API.
Also, log handling was cleaned in HarmonicField and EigenField.

Companion ttk-data PR: https://github.com/topology-tool-kit/ttk-data/pull/42

Enjoy,
Pierre