### PR TITLE
Precondition caching for periodic triangulation

### DIFF
--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1199,102 +1199,57 @@ int PeriodicImplicitTriangulation::getTriangleEdgeInternal(
 #endif
 
   edgeId = -1;
+  const auto &p = triangleCoords_[triangleId];
+  const SimplexId wrapXRight = (p[0] / 2 == nbvoxels_[Di_]) ? -wrap_[0] : 0;
+  const SimplexId wrapYBottom = (p[1] == nbvoxels_[Dj_]) ? -wrap_[1] : 0;
+  const SimplexId id = triangleId % 2;
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-    const SimplexId id = triangleId % 2;
-
-    // F
-    if(triangleId < tsetshift_[0]) {
-      triangleToPosition(triangleId, 0, p);
-
-      if(id)
-        edgeId = getTriangleEdgeF_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeF_0(p, localEdgeId);
-    }
-    // H
-    else if(triangleId < tsetshift_[1]) {
-      triangleToPosition(triangleId, 1, p);
-
-      if(id)
-        edgeId = getTriangleEdgeH_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeH_0(p, localEdgeId);
-    }
-    // C
-    else if(triangleId < tsetshift_[2]) {
-      triangleToPosition(triangleId, 2, p);
-
-      if(id)
-        edgeId = getTriangleEdgeC_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeC_0(p, localEdgeId);
-    }
-    // D1
-    else if(triangleId < tsetshift_[3]) {
-      triangleToPosition(triangleId, 3, p);
-
-      if(id)
-        edgeId = getTriangleEdgeD1_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeD1_0(p, localEdgeId);
-    }
-    // D2
-    else if(triangleId < tsetshift_[4]) {
-      triangleToPosition(triangleId, 4, p);
-
-      if(id)
-        edgeId = getTriangleEdgeD2_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeD2_0(p, localEdgeId);
-    }
-    // D3
-    else if(triangleId < tsetshift_[5]) {
-      triangleToPosition(triangleId, 5, p);
-
-      if(id)
-        edgeId = getTriangleEdgeD3_1(p, localEdgeId);
-      else
-        edgeId = getTriangleEdgeD3_0(p, localEdgeId);
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-    const SimplexId id = triangleId % 2;
-    triangleToPosition2d(triangleId, p);
-
-    SimplexId wrapXRight = 0;
-    SimplexId wrapYBottom = 0;
-    if(p[0] / 2 == nbvoxels_[Di_])
-      wrapXRight = -wrap_[0];
-    if(p[1] == nbvoxels_[Dj_])
-      wrapYBottom = -wrap_[1];
-    if(id == 0) {
-      switch(localEdgeId) {
-        case 0:
-          edgeId = p[0] / 2 + p[1] * eshift_[0];
-          break;
-        case 1:
-          edgeId = esetshift_[0] + p[0] / 2 + p[1] * eshift_[2];
-          break;
-        case 2:
-          edgeId = esetshift_[1] + p[0] / 2 + p[1] * eshift_[4];
-          break;
+  switch(trianglePositions_[triangleId]) {
+    case TrianglePosition::F_3D:
+      edgeId = (id == 1) ? getTriangleEdgeF_1(p.data(), localEdgeId)
+                         : getTriangleEdgeF_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::H_3D:
+      edgeId = (id == 1) ? getTriangleEdgeH_1(p.data(), localEdgeId)
+                         : getTriangleEdgeH_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::C_3D:
+      edgeId = (id == 1) ? getTriangleEdgeC_1(p.data(), localEdgeId)
+                         : getTriangleEdgeC_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::D1_3D:
+      edgeId = (id == 1) ? getTriangleEdgeD1_1(p.data(), localEdgeId)
+                         : getTriangleEdgeD1_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::D2_3D:
+      edgeId = (id == 1) ? getTriangleEdgeD2_1(p.data(), localEdgeId)
+                         : getTriangleEdgeD2_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::D3_3D:
+      edgeId = (id == 1) ? getTriangleEdgeD3_1(p.data(), localEdgeId)
+                         : getTriangleEdgeD3_0(p.data(), localEdgeId);
+      break;
+    case TrianglePosition::TOP_2D:
+      if(localEdgeId == 0) {
+        edgeId = p[0] / 2 + p[1] * eshift_[0];
+      } else if(localEdgeId == 1) {
+        edgeId = esetshift_[0] + p[0] / 2 + p[1] * eshift_[2];
+      } else if(localEdgeId == 2) {
+        edgeId = esetshift_[1] + p[0] / 2 + p[1] * eshift_[4];
       }
-    } else {
-      switch(localEdgeId) {
-        case 0:
-          edgeId = p[0] / 2 + (p[1] + 1) * eshift_[0] + wrapYBottom;
-          break;
-        case 1:
-          edgeId
-            = esetshift_[0] + (p[0] + 1) / 2 + p[1] * eshift_[2] + wrapXRight;
-          break;
-        case 2:
-          edgeId = esetshift_[1] + p[0] / 2 + p[1] * eshift_[4];
-          break;
+      break;
+    case TrianglePosition::BOTTOM_2D:
+      if(localEdgeId == 0) {
+        edgeId = p[0] / 2 + (p[1] + 1) * eshift_[0] + wrapYBottom;
+      } else if(localEdgeId == 1) {
+        edgeId
+          = esetshift_[0] + (p[0] + 1) / 2 + p[1] * eshift_[2] + wrapXRight;
+      } else if(localEdgeId == 2) {
+        edgeId = esetshift_[1] + p[0] / 2 + p[1] * eshift_[4];
       }
-    }
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -181,6 +181,61 @@ int PeriodicImplicitTriangulation::setInputGrid(const float &xOrigin,
     cellNumber_ = edgeNumber_;
   }
 
+  // ensure preconditionned vertices and cells
+  this->preconditionVerticesInternal();
+  this->preconditionCellsInternal();
+
+  return 0;
+}
+
+int PeriodicImplicitTriangulation::preconditionVerticesInternal() {
+  if(this->dimensionality_ != 2 && this->dimensionality_ != 3) {
+    return 1;
+  }
+  if(dimensionality_ == 2) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < vertexNumber_; ++i) {
+      auto &p = vertexCoords_[i];
+      vertexToPosition2d(i, p.data());
+    }
+  } else if(dimensionality_ == 2) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < vertexNumber_; ++i) {
+      auto &p = vertexCoords_[i];
+      vertexToPosition(i, p.data());
+    }
+  }
+  return 0;
+}
+int PeriodicImplicitTriangulation::preconditionEdgesInternal() {
+  if(this->dimensionality_ != 2 && this->dimensionality_ != 3) {
+    return 1;
+  }
+  return 0;
+}
+int PeriodicImplicitTriangulation::preconditionTrianglesInternal() {
+  if(this->dimensionality_ != 2 && this->dimensionality_ != 3) {
+    return 1;
+  }
+  return 0;
+}
+int PeriodicImplicitTriangulation::preconditionTetrahedronsInternal() {
+  if(this->dimensionality_ != 3) {
+    return 1;
+  }
+  tetrahedronCoords_.resize(tetrahedronNumber_);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < tetrahedronNumber_; ++i) {
+    tetrahedronToPosition(i, tetrahedronCoords_[i].data());
+  }
+
   return 0;
 }
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -866,39 +866,23 @@ inline SimplexId PeriodicImplicitTriangulation::getEdgeTriangleNumberInternal(
     return -1;
 #endif
 
-  if(dimensionality_ == 3) {
-    // L
-    if(edgeId < esetshift_[0]) {
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+    case EdgePosition::H_3D:
+    case EdgePosition::P_3D:
+    case EdgePosition::D4_3D:
       return 6;
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      return 6;
-    }
-    // P
-    else if(edgeId < esetshift_[2]) {
-      return 6;
-    }
-    // D1
-    else if(edgeId < esetshift_[3]) {
+    case EdgePosition::D1_3D:
+    case EdgePosition::D2_3D:
+    case EdgePosition::D3_3D:
       return 4;
-    }
-    // D2
-    else if(edgeId < esetshift_[4]) {
-      return 4;
-    }
-    // D3
-    else if(edgeId < esetshift_[5]) {
-      return 4;
-    }
-    // D4
-    else if(edgeId < esetshift_[6])
-      return 6;
-  } else if(dimensionality_ == 2) {
-    return 2;
+    case EdgePosition::L_2D:
+    case EdgePosition::H_2D:
+    case EdgePosition::D1_2D:
+      return 2;
+    default:
+      return 0;
   }
-
-  return 0;
 }
 
 int PeriodicImplicitTriangulation::getEdgeTriangleInternal(

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -969,50 +969,41 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
 #endif
 
   linkId = -1;
+  const auto &p = edgeCoords_[edgeId];
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition(edgeId, 0, p);
-      linkId = getEdgeLinkL(p, localLinkId); // L
-    } else if(edgeId < esetshift_[1]) {
-      edgeToPosition(edgeId, 1, p);
-      linkId = getEdgeLinkH(p, localLinkId); // H
-    } else if(edgeId < esetshift_[2]) {
-      edgeToPosition(edgeId, 2, p);
-      linkId = getEdgeLinkP(p, localLinkId); // P
-    } else if(edgeId < esetshift_[3]) {
-      edgeToPosition(edgeId, 3, p);
-      linkId = getEdgeLinkD1(p, localLinkId); // D1
-    } else if(edgeId < esetshift_[4]) {
-      edgeToPosition(edgeId, 4, p);
-      linkId = getEdgeLinkD2(p, localLinkId); // D2
-    } else if(edgeId < esetshift_[5]) {
-      edgeToPosition(edgeId, 5, p);
-      linkId = getEdgeLinkD3(p, localLinkId); // D3
-    } else if(edgeId < esetshift_[6]) {
-      edgeToPosition(edgeId, 6, p);
-      linkId = getEdgeLinkD4(p, localLinkId); // D4
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition2d(edgeId, 0, p);
-      linkId = getEdgeLink2dL(p, localLinkId);
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition2d(edgeId, 1, p);
-      linkId = getEdgeLink2dH(p, localLinkId);
-    }
-    // D1
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition2d(edgeId, 2, p);
-      linkId = getEdgeLink2dD1(p, localLinkId);
-    }
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+      linkId = getEdgeLinkL(p.data(), localLinkId);
+      break;
+    case EdgePosition::H_3D:
+      linkId = getEdgeLinkH(p.data(), localLinkId);
+      break;
+    case EdgePosition::P_3D:
+      linkId = getEdgeLinkP(p.data(), localLinkId);
+      break;
+    case EdgePosition::D1_3D:
+      linkId = getEdgeLinkD1(p.data(), localLinkId);
+      break;
+    case EdgePosition::D2_3D:
+      linkId = getEdgeLinkD2(p.data(), localLinkId);
+      break;
+    case EdgePosition::D3_3D:
+      linkId = getEdgeLinkD3(p.data(), localLinkId);
+      break;
+    case EdgePosition::D4_3D:
+      linkId = getEdgeLinkD4(p.data(), localLinkId);
+      break;
+    case EdgePosition::L_2D:
+      linkId = getEdgeLink2dL(p.data(), localLinkId);
+      break;
+    case EdgePosition::H_2D:
+      linkId = getEdgeLink2dH(p.data(), localLinkId);
+      break;
+    case EdgePosition::D1_2D:
+      linkId = getEdgeLink2dD1(p.data(), localLinkId);
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -419,22 +419,15 @@ int PeriodicImplicitTriangulation::getVertexEdgeInternal(
   } else if(dimensionality_ == 2) {
     edgeId = getVertexEdge2d(p.data(), localEdgeId);
   } else if(dimensionality_ == 1) {
-    // ab
     if(vertexId > 0 and vertexId < nbvoxels_[Di_]) {
-      if(localEdgeId == 0)
-        edgeId = vertexId;
-      else
-        edgeId = vertexId - 1;
+      // ab
+      edgeId = localEdgeId == 0 ? vertexId : vertexId - 1;
     } else if(vertexId == 0) {
-      if(localEdgeId == 0)
-        edgeId = vertexId; // a
-      else
-        edgeId = 0;
+      // a
+      edgeId = localEdgeId == 0 ? vertexId : 0;
     } else {
-      if(localEdgeId == 0)
-        edgeId = 0;
-      else
-        edgeId = vertexId - 1; // b
+      // b
+      edgeId = localEdgeId == 0 ? 0 : vertexId - 1;
     }
   }
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1879,28 +1879,27 @@ int PeriodicImplicitTriangulation::getTetrahedronVertex(
   vertexId = -1;
 
   if(dimensionality_ == 3) {
-    SimplexId p[3];
-    tetrahedronToPosition(tetId, p);
+    const auto &p = tetrahedronCoords_[tetId];
     const SimplexId id = tetId % 6;
 
     switch(id) {
       case 0:
-        vertexId = getTetrahedronVertexABCG(p, localVertexId);
+        vertexId = getTetrahedronVertexABCG(p.data(), localVertexId);
         break;
       case 1:
-        vertexId = getTetrahedronVertexBCDG(p, localVertexId);
+        vertexId = getTetrahedronVertexBCDG(p.data(), localVertexId);
         break;
       case 2:
-        vertexId = getTetrahedronVertexABEG(p, localVertexId);
+        vertexId = getTetrahedronVertexABEG(p.data(), localVertexId);
         break;
       case 3:
-        vertexId = getTetrahedronVertexBEFG(p, localVertexId);
+        vertexId = getTetrahedronVertexBEFG(p.data(), localVertexId);
         break;
       case 4:
-        vertexId = getTetrahedronVertexBFGH(p, localVertexId);
+        vertexId = getTetrahedronVertexBFGH(p.data(), localVertexId);
         break;
       case 5:
-        vertexId = getTetrahedronVertexBDGH(p, localVertexId);
+        vertexId = getTetrahedronVertexBDGH(p.data(), localVertexId);
         break;
     }
   }
@@ -1920,28 +1919,27 @@ int PeriodicImplicitTriangulation::getTetrahedronEdge(const SimplexId &tetId,
   edgeId = -1;
 
   if(dimensionality_ == 3) {
-    SimplexId p[3];
-    tetrahedronToPosition(tetId, p);
+    const auto &p = tetrahedronCoords_[tetId];
     const SimplexId id = tetId % 6;
 
     switch(id) {
       case 0:
-        edgeId = getTetrahedronEdgeABCG(p, localEdgeId);
+        edgeId = getTetrahedronEdgeABCG(p.data(), localEdgeId);
         break;
       case 1:
-        edgeId = getTetrahedronEdgeBCDG(p, localEdgeId);
+        edgeId = getTetrahedronEdgeBCDG(p.data(), localEdgeId);
         break;
       case 2:
-        edgeId = getTetrahedronEdgeABEG(p, localEdgeId);
+        edgeId = getTetrahedronEdgeABEG(p.data(), localEdgeId);
         break;
       case 3:
-        edgeId = getTetrahedronEdgeBEFG(p, localEdgeId);
+        edgeId = getTetrahedronEdgeBEFG(p.data(), localEdgeId);
         break;
       case 4:
-        edgeId = getTetrahedronEdgeBFGH(p, localEdgeId);
+        edgeId = getTetrahedronEdgeBFGH(p.data(), localEdgeId);
         break;
       case 5:
-        edgeId = getTetrahedronEdgeBDGH(p, localEdgeId);
+        edgeId = getTetrahedronEdgeBDGH(p.data(), localEdgeId);
         break;
     }
   }
@@ -1975,28 +1973,27 @@ int PeriodicImplicitTriangulation::getTetrahedronTriangle(
   triangleId = -1;
 
   if(dimensionality_ == 3) {
-    SimplexId p[3];
-    tetrahedronToPosition(tetId, p);
+    const auto &p = tetrahedronCoords_[tetId];
     const SimplexId id = tetId % 6;
 
     switch(id) {
       case 0:
-        triangleId = getTetrahedronTriangleABCG(p, localTriangleId);
+        triangleId = getTetrahedronTriangleABCG(p.data(), localTriangleId);
         break;
       case 1:
-        triangleId = getTetrahedronTriangleBCDG(p, localTriangleId);
+        triangleId = getTetrahedronTriangleBCDG(p.data(), localTriangleId);
         break;
       case 2:
-        triangleId = getTetrahedronTriangleABEG(p, localTriangleId);
+        triangleId = getTetrahedronTriangleABEG(p.data(), localTriangleId);
         break;
       case 3:
-        triangleId = getTetrahedronTriangleBEFG(p, localTriangleId);
+        triangleId = getTetrahedronTriangleBEFG(p.data(), localTriangleId);
         break;
       case 4:
-        triangleId = getTetrahedronTriangleBFGH(p, localTriangleId);
+        triangleId = getTetrahedronTriangleBFGH(p.data(), localTriangleId);
         break;
       case 5:
-        triangleId = getTetrahedronTriangleBDGH(p, localTriangleId);
+        triangleId = getTetrahedronTriangleBDGH(p.data(), localTriangleId);
         break;
     }
   }
@@ -2043,28 +2040,33 @@ int PeriodicImplicitTriangulation::getTetrahedronNeighbor(
   neighborId = -1;
 
   if(dimensionality_ == 3) {
+    const auto &p = tetrahedronCoords_[tetId];
     const SimplexId id = tetId % 6;
-    SimplexId p[3];
-    tetrahedronToPosition(tetId, p);
 
     switch(id) {
       case 0:
-        neighborId = getTetrahedronNeighborABCG(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborABCG(tetId, p.data(), localNeighborId);
         break;
       case 1:
-        neighborId = getTetrahedronNeighborBCDG(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborBCDG(tetId, p.data(), localNeighborId);
         break;
       case 2:
-        neighborId = getTetrahedronNeighborABEG(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborABEG(tetId, p.data(), localNeighborId);
         break;
       case 3:
-        neighborId = getTetrahedronNeighborBEFG(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborBEFG(tetId, p.data(), localNeighborId);
         break;
       case 4:
-        neighborId = getTetrahedronNeighborBFGH(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborBFGH(tetId, p.data(), localNeighborId);
         break;
       case 5:
-        neighborId = getTetrahedronNeighborBDGH(tetId, p, localNeighborId);
+        neighborId
+          = getTetrahedronNeighborBDGH(tetId, p.data(), localNeighborId);
         break;
     }
   }

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -896,63 +896,41 @@ int PeriodicImplicitTriangulation::getEdgeTriangleInternal(
 #endif
 
   triangleId = -1;
+  const auto &p = edgeCoords_[edgeId];
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition(edgeId, 0, p);
-      triangleId = getEdgeTriangle3dL(p, localTriangleId);
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition(edgeId, 1, p);
-      triangleId = getEdgeTriangle3dH(p, localTriangleId);
-    }
-    // P
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition(edgeId, 2, p);
-      triangleId = getEdgeTriangle3dP(p, localTriangleId);
-    }
-    // D1
-    else if(edgeId < esetshift_[3]) {
-      edgeToPosition(edgeId, 3, p);
-      triangleId = getEdgeTriangle3dD1(p, localTriangleId);
-    }
-    // D2
-    else if(edgeId < esetshift_[4]) {
-      edgeToPosition(edgeId, 4, p);
-      triangleId = getEdgeTriangle3dD2(p, localTriangleId);
-    }
-    // D3
-    else if(edgeId < esetshift_[5]) {
-      edgeToPosition(edgeId, 5, p);
-      triangleId = getEdgeTriangle3dD3(p, localTriangleId);
-    }
-    // D4
-    else if(edgeId < esetshift_[6]) {
-      edgeToPosition(edgeId, 6, p);
-      triangleId = getEdgeTriangle3dD4(p, localTriangleId);
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition2d(edgeId, 0, p);
-      triangleId = getEdgeTriangle2dL(p, localTriangleId);
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition2d(edgeId, 1, p);
-      triangleId = getEdgeTriangle2dH(p, localTriangleId);
-    }
-    // D1
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition2d(edgeId, 2, p);
-      triangleId = getEdgeTriangle2dD1(p, localTriangleId);
-    }
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+      triangleId = getEdgeTriangle3dL(p.data(), localTriangleId);
+      break;
+    case EdgePosition::H_3D:
+      triangleId = getEdgeTriangle3dH(p.data(), localTriangleId);
+      break;
+    case EdgePosition::P_3D:
+      triangleId = getEdgeTriangle3dP(p.data(), localTriangleId);
+      break;
+    case EdgePosition::D1_3D:
+      triangleId = getEdgeTriangle3dD1(p.data(), localTriangleId);
+      break;
+    case EdgePosition::D2_3D:
+      triangleId = getEdgeTriangle3dD2(p.data(), localTriangleId);
+      break;
+    case EdgePosition::D3_3D:
+      triangleId = getEdgeTriangle3dD3(p.data(), localTriangleId);
+      break;
+    case EdgePosition::D4_3D:
+      triangleId = getEdgeTriangle3dD4(p.data(), localTriangleId);
+      break;
+    case EdgePosition::L_2D:
+      triangleId = getEdgeTriangle2dL(p.data(), localTriangleId);
+      break;
+    case EdgePosition::H_2D:
+      triangleId = getEdgeTriangle2dH(p.data(), localTriangleId);
+      break;
+    case EdgePosition::D1_2D:
+      triangleId = getEdgeTriangle2dD1(p.data(), localTriangleId);
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1138,77 +1138,50 @@ int PeriodicImplicitTriangulation::getTriangleVertexInternal(
 #endif
 
   vertexId = -1;
+  const auto &p = triangleCoords_[triangleId];
+  const SimplexId wrapXRight = (p[0] / 2 == nbvoxels_[Di_]) ? -wrap_[0] : 0;
+  const SimplexId wrapYBottom = (p[1] == nbvoxels_[Dj_]) ? -wrap_[1] : 0;
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-
-    // F
-    if(triangleId < tsetshift_[0]) {
-      triangleToPosition(triangleId, 0, p);
-      vertexId = getTriangleVertexF(p, localVertexId);
-    }
-    // H
-    else if(triangleId < tsetshift_[1]) {
-      triangleToPosition(triangleId, 1, p);
-      vertexId = getTriangleVertexH(p, localVertexId);
-    }
-    // C
-    else if(triangleId < tsetshift_[2]) {
-      triangleToPosition(triangleId, 2, p);
-      vertexId = getTriangleVertexC(p, localVertexId);
-    }
-    // D1
-    else if(triangleId < tsetshift_[3]) {
-      triangleToPosition(triangleId, 3, p);
-      vertexId = getTriangleVertexD1(p, localVertexId);
-    }
-    // D2
-    else if(triangleId < tsetshift_[4]) {
-      triangleToPosition(triangleId, 4, p);
-      vertexId = getTriangleVertexD2(p, localVertexId);
-    }
-    // D3
-    else if(triangleId < tsetshift_[5]) {
-      triangleToPosition(triangleId, 5, p);
-      vertexId = getTriangleVertexD3(p, localVertexId);
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-    triangleToPosition2d(triangleId, p);
-    const SimplexId id = triangleId % 2;
-
-    SimplexId wrapXRight = 0;
-    SimplexId wrapYBottom = 0;
-    if(p[0] / 2 == nbvoxels_[Di_])
-      wrapXRight = -wrap_[0];
-    if(p[1] == nbvoxels_[Dj_])
-      wrapYBottom = -wrap_[1];
-    if(id == 0) {
-      switch(localVertexId) {
-        case 0:
-          vertexId = p[0] / 2 + p[1] * vshift_[0];
-          break;
-        case 1:
-          vertexId = p[0] / 2 + p[1] * vshift_[0] + 1 + wrapXRight;
-          break;
-        case 2:
-          vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
-          break;
+  switch(trianglePositions_[triangleId]) {
+    case TrianglePosition::F_3D:
+      vertexId = getTriangleVertexF(p.data(), localVertexId);
+      break;
+    case TrianglePosition::H_3D:
+      vertexId = getTriangleVertexH(p.data(), localVertexId);
+      break;
+    case TrianglePosition::C_3D:
+      vertexId = getTriangleVertexC(p.data(), localVertexId);
+      break;
+    case TrianglePosition::D1_3D:
+      vertexId = getTriangleVertexD1(p.data(), localVertexId);
+      break;
+    case TrianglePosition::D2_3D:
+      vertexId = getTriangleVertexD2(p.data(), localVertexId);
+      break;
+    case TrianglePosition::D3_3D:
+      vertexId = getTriangleVertexD3(p.data(), localVertexId);
+      break;
+    case TrianglePosition::TOP_2D:
+      if(localVertexId == 0) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0];
+      } else if(localVertexId == 1) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0] + 1 + wrapXRight;
+      } else if(localVertexId == 2) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
       }
-    } else {
-      switch(localVertexId) {
-        case 0:
-          vertexId = p[0] / 2 + p[1] * vshift_[0] + 1 + wrapXRight;
-          break;
-        case 1:
-          vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + 1 + wrapXRight
-                     + wrapYBottom;
-          break;
-        case 2:
-          vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
-          break;
+      break;
+    case TrianglePosition::BOTTOM_2D:
+      if(localVertexId == 0) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0] + 1 + wrapXRight;
+      } else if(localVertexId == 1) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + 1 + wrapXRight
+                   + wrapYBottom;
+      } else if(localVertexId == 2) {
+        vertexId = p[0] / 2 + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
       }
-    }
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -770,259 +770,68 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
 #endif
 
   vertexId = -1;
+  const auto &p = edgeCoords_[edgeId];
+  const SimplexId wrapXRight = (p[0] == nbvoxels_[0] ? -wrap_[0] : 0);
+  const SimplexId wrapYBottom = (p[1] == nbvoxels_[1] ? -wrap_[1] : 0);
+  const SimplexId wrapZFront = (p[2] == nbvoxels_[2] ? -wrap_[2] : 0);
+  const auto a
+    = p[0] + (isAccelerated_ ? (p[1] << div_[0]) : (p[1] * vshift_[0]));
+  const auto b = a + (isAccelerated_ ? (p[2] << div_[1]) : (p[2] * vshift_[1]));
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-    SimplexId wrapXRight = 0;
-    SimplexId wrapYBottom = 0;
-    SimplexId wrapZFront = 0;
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition(edgeId, 0, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]);
-        else
-          vertexId
-            = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + 1 + wrapXRight;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1];
-        else
-          vertexId
-            = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + 1 + wrapXRight;
-      }
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition(edgeId, 1, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]);
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[0]
-                     + wrapYBottom;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1];
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
-                     + wrapYBottom;
-      }
-    }
-    // P
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition(edgeId, 2, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]);
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[1]
-                     + wrapZFront;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1];
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[1]
-                     + wrapZFront;
-      }
-    }
-    // D1
-    else if(edgeId < esetshift_[3]) {
-      edgeToPosition(edgeId, 3, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + 1 + wrapXRight;
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[0]
-                     + wrapYBottom;
-      } else {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + 1 + wrapXRight;
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
-                     + wrapYBottom;
-      }
-    }
-    // D2
-    else if(edgeId < esetshift_[4]) {
-      edgeToPosition(edgeId, 4, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]);
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[0]
-                     + vshift_[1] + wrapYBottom + wrapZFront;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1];
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
-                     + vshift_[1] + wrapYBottom + wrapZFront;
-      }
-    }
-    // D3
-    else if(edgeId < esetshift_[5]) {
-      edgeToPosition(edgeId, 5, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + 1 + wrapXRight;
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[1]
-                     + wrapZFront;
-
-      } else {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + 1 + wrapXRight;
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[1]
-                     + wrapZFront;
-      }
-    }
-    // D4
-    else if(edgeId < esetshift_[6]) {
-      edgeToPosition(edgeId, 6, p);
-      if(p[0] == nbvoxels_[0])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[1])
-        wrapYBottom = -wrap_[1];
-      if(p[2] == nbvoxels_[2])
-        wrapZFront = -wrap_[2];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + 1 + wrapXRight;
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + (p[2] << div_[1]) + vshift_[0]
-                     + vshift_[1] + wrapYBottom + wrapZFront;
-
-      } else {
-        if(localVertexId == 0)
-          vertexId
-            = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + 1 + wrapXRight;
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + p[2] * vshift_[1] + vshift_[0]
-                     + vshift_[1] + wrapYBottom + wrapZFront;
-      }
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-    SimplexId wrapXRight = 0;
-    SimplexId wrapYBottom = 0;
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition2d(edgeId, 0, p);
-      if(p[0] == nbvoxels_[Di_])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[Dj_])
-        wrapYBottom = -wrap_[1];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]);
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + 1 + wrapXRight;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0];
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + 1 + wrapXRight;
-      }
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition2d(edgeId, 1, p);
-      if(p[0] == nbvoxels_[Di_])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[Dj_])
-        wrapYBottom = -wrap_[1];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]);
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + vshift_[0] + wrapYBottom;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0];
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
-      }
-    }
-    // D1
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition2d(edgeId, 2, p);
-      if(p[0] == nbvoxels_[Di_])
-        wrapXRight = -wrap_[0];
-      if(p[1] == nbvoxels_[Dj_])
-        wrapYBottom = -wrap_[1];
-      if(isAccelerated_) {
-        if(localVertexId == 0)
-          vertexId = p[0] + (p[1] << div_[0]) + 1 + wrapXRight;
-        else
-          vertexId = p[0] + (p[1] << div_[0]) + vshift_[0] + wrapYBottom;
-      } else {
-        if(localVertexId == 0)
-          vertexId = p[0] + p[1] * vshift_[0] + 1 + wrapXRight;
-        else
-          vertexId = p[0] + p[1] * vshift_[0] + vshift_[0] + wrapYBottom;
-      }
-    }
-  } else if(dimensionality_ == 1) {
-    if(edgeId > 0 and edgeId < (edgeNumber_)) {
-      if(localVertexId == 0)
-        vertexId = edgeId;
-      else
-        vertexId = edgeId + 1;
-    } else if(edgeId == 0) {
-      if(localVertexId == 0)
-        vertexId = 0;
-      else
-        vertexId = 1;
-    } else {
-      if(localVertexId == 0)
-        vertexId = edgeId;
-      else
-        vertexId = 0;
-    }
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+      vertexId = b + (localVertexId == 0 ? 0 : (1 + wrapXRight));
+      break;
+    case EdgePosition::H_3D:
+      vertexId = b + (localVertexId == 0 ? 0 : (vshift_[0] + wrapYBottom));
+      break;
+    case EdgePosition::P_3D:
+      vertexId = b + (localVertexId == 0 ? 0 : (vshift_[1] + wrapZFront));
+      break;
+    case EdgePosition::D1_3D:
+      vertexId = b
+                 + (localVertexId == 0 ? (1 + wrapXRight)
+                                       : (vshift_[0] + wrapYBottom));
+      break;
+    case EdgePosition::D2_3D:
+      vertexId = b
+                 + (localVertexId == 0
+                      ? 0
+                      : (vshift_[0] + wrapYBottom + vshift_[1] + wrapZFront));
+      break;
+    case EdgePosition::D3_3D:
+      vertexId
+        = b
+          + (localVertexId == 0 ? (1 + wrapXRight) : (vshift_[1] + wrapZFront));
+      break;
+    case EdgePosition::D4_3D:
+      vertexId = b
+                 + (localVertexId == 0
+                      ? (1 + wrapXRight)
+                      : (vshift_[0] + wrapYBottom + vshift_[1] + wrapZFront));
+      break;
+    case EdgePosition::L_2D:
+      vertexId = a + (localVertexId == 0 ? 0 : (1 + wrapXRight));
+      break;
+    case EdgePosition::H_2D:
+      vertexId = a + (localVertexId == 0 ? 0 : (vshift_[0] + wrapYBottom));
+      break;
+    case EdgePosition::D1_2D:
+      vertexId = a
+                 + (localVertexId == 0 ? (1 + wrapXRight)
+                                       : (vshift_[0] + wrapYBottom));
+      break;
+    case EdgePosition::FIRST_EDGE_1D:
+      vertexId = localVertexId == 0 ? 0 : 1;
+      break;
+    case EdgePosition::LAST_EDGE_1D:
+      vertexId = localVertexId == 0 ? edgeId : 0;
+      break;
+    case EdgePosition::CENTER_1D:
+      vertexId = localVertexId == 0 ? edgeId : edgeId + 1;
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1036,36 +1036,22 @@ inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     return -1;
 #endif
 
-  if(dimensionality_ == 3) {
-    // L
-    if(edgeId < esetshift_[0]) {
-      return 6; // ABCG,ABEG,BCDG,BEFG,BFGH,BDGH
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      return 6; // ABCG,ABEG,BEFG,BFGH,BCDG,BDGH
-    }
-    // P
-    else if(edgeId < esetshift_[2]) {
-      return 6; // BDGH,ABCG,BCDG,ABEG,BEFG,BFGH
-    }
-    // D1
-    else if(edgeId < esetshift_[3]) {
-      return 4; // ABCG,BCDG,BEFG,BFGH
-    }
-    // D2
-    else if(edgeId < esetshift_[4]) {
-      return 4; // ABCG,ABEG,BDGH,BFGH
-    }
-    // D3
-    else if(edgeId < esetshift_[5]) {
-      return 4; // ABEG,BEFG,BCDG,BDGH
-    }
-    // D4
-    else if(edgeId < esetshift_[6])
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+    case EdgePosition::H_3D:
+    case EdgePosition::P_3D:
+    case EdgePosition::D4_3D:
       return 6;
-  } else if(dimensionality_ == 2) {
-    return 2;
+    case EdgePosition::D1_3D:
+    case EdgePosition::D2_3D:
+    case EdgePosition::D3_3D:
+      return 4;
+    case EdgePosition::L_2D:
+    case EdgePosition::H_2D:
+    case EdgePosition::D1_2D:
+      return 2;
+    default:
+      return 0;
   }
 
   return 0;
@@ -1079,51 +1065,42 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
 #endif
 
   starId = -1;
+  const auto &p = edgeCoords_[edgeId];
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition(edgeId, 0, p);
-      starId = getEdgeStarL(p, localStarId); // L
-    } else if(edgeId < esetshift_[1]) {
-      edgeToPosition(edgeId, 1, p);
-      starId = getEdgeStarH(p, localStarId); // H
-    } else if(edgeId < esetshift_[2]) {
-      edgeToPosition(edgeId, 2, p);
-      starId = getEdgeStarP(p, localStarId); // P
-    } else if(edgeId < esetshift_[3]) {
-      edgeToPosition(edgeId, 3, p);
-      starId = getEdgeStarD1(p, localStarId); // D1
-    } else if(edgeId < esetshift_[4]) {
-      edgeToPosition(edgeId, 4, p);
-      starId = getEdgeStarD2(p, localStarId); // D2
-    } else if(edgeId < esetshift_[5]) {
-      edgeToPosition(edgeId, 5, p);
-      starId = getEdgeStarD3(p, localStarId); // D3
-    } else if(edgeId < esetshift_[6]) {
-      edgeToPosition(edgeId, 6, p);
-      starId = p[2] * tetshift_[1] + p[1] * tetshift_[0] + p[0] * 6
-               + localStarId; // D4
-    }
-  } else if(dimensionality_ == 2) {
-    SimplexId p[2];
-
-    // L
-    if(edgeId < esetshift_[0]) {
-      edgeToPosition2d(edgeId, 0, p);
-      starId = getEdgeStar2dL(p, localStarId); // L
-    }
-    // H
-    else if(edgeId < esetshift_[1]) {
-      edgeToPosition2d(edgeId, 1, p);
-      starId = getEdgeStar2dH(p, localStarId); // L
-    }
-    // D1
-    else if(edgeId < esetshift_[2]) {
-      edgeToPosition2d(edgeId, 2, p);
-      starId = p[0] * 2 + p[1] * tshift_[0] + localStarId; // D1
-    }
+  switch(edgePositions_[edgeId]) {
+    case EdgePosition::L_3D:
+      starId = getEdgeStarL(p.data(), localStarId);
+      break;
+    case EdgePosition::H_3D:
+      starId = getEdgeStarH(p.data(), localStarId);
+      break;
+    case EdgePosition::P_3D:
+      starId = getEdgeStarP(p.data(), localStarId);
+      break;
+    case EdgePosition::D1_3D:
+      starId = getEdgeStarD1(p.data(), localStarId);
+      break;
+    case EdgePosition::D2_3D:
+      starId = getEdgeStarD2(p.data(), localStarId);
+      break;
+    case EdgePosition::D3_3D:
+      starId = getEdgeStarD3(p.data(), localStarId);
+      break;
+    case EdgePosition::D4_3D:
+      starId
+        = p[2] * tetshift_[1] + p[1] * tetshift_[0] + p[0] * 6 + localStarId;
+      break;
+    case EdgePosition::L_2D:
+      starId = getEdgeStar2dL(p.data(), localStarId);
+      break;
+    case EdgePosition::H_2D:
+      starId = getEdgeStar2dH(p.data(), localStarId);
+      break;
+    case EdgePosition::D1_2D:
+      starId = p[0] * 2 + p[1] * tshift_[0] + localStarId;
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -410,22 +410,6 @@ int PeriodicImplicitTriangulation::getVertexEdgeInternal(
   if(localEdgeId < 0 or localEdgeId >= getVertexEdgeNumberInternal(vertexId))
     return -1;
 #endif
-  //    e--------f
-  //   /|       /|
-  //  / |      / |
-  // a--g-----b--h
-  // | /      | /
-  // |/       |/
-  // c--------d
-  //
-  // Classement des "Edges" et dans cet ordre:
-  // L: largeur (type ab)
-  // H: hauteur (type ac)
-  // P: profondeur (type ae)
-  // D1: diagonale1 (type bc)
-  // D2: diagonale2 (type ag)
-  // D3: diagonale3 (type be)
-  // D4: diagonale4 (type bg)
 
   edgeId = -1;
   const auto &p = vertexCoords_[vertexId];
@@ -1312,22 +1296,6 @@ int PeriodicImplicitTriangulation::getTriangleVertexInternal(
   if(localVertexId < 0 or localVertexId >= 3)
     return -2;
 #endif
-
-  //    e--------f
-  //   /|       /|
-  //  / |      / |
-  // a--g-----b--h
-  // | /      | /
-  // |/       |/
-  // c--------d
-  //
-  // Classement des "Triangles" et dans cet ordre:
-  // F: face (type abc/bcd)
-  // C: cote (type abe/bef)
-  // H: haut (type acg/aeg)
-  // D1: diagonale1 (type bdg/beg)
-  // D2: diagonale2 (type abg/bgh)
-  // D3: diagonale3 (type bcg/bfg)
 
   vertexId = -1;
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1460,113 +1460,90 @@ int PeriodicImplicitTriangulation::getTriangleNeighbor(
 #endif
 
   neighborId = -1;
+  const auto &p = triangleCoords_[triangleId];
 
-  if(dimensionality_ == 2) {
-    SimplexId p[2];
-    triangleToPosition2d(triangleId, p);
-    const SimplexId id = triangleId % 2;
+  switch(trianglePositions_[triangleId]) {
+    case TrianglePosition::BOTTOM_2D:
 
-    if(id) {
       if(p[0] / 2 == nbvoxels_[Di_] and p[1] == nbvoxels_[Dj_]) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId - 1;
-            break;
-          case 1:
-            neighborId = triangleId + 1 - wrap_[0] * 2;
-            break;
-          case 2:
-            neighborId = triangleId + tshift_[0] - 1 - wrap_[1] * 2;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId + 1 - wrap_[0] * 2;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId + tshift_[0] - 1 - wrap_[1] * 2;
         }
+
       } else if(p[0] / 2 == nbvoxels_[Di_]) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId - 1;
-            break;
-          case 1:
-            neighborId = triangleId + 1 - wrap_[0] * 2;
-            break;
-          case 2:
-            neighborId = triangleId + tshift_[0] - 1;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId + 1 - wrap_[0] * 2;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId + tshift_[0] - 1;
         }
+
       } else if(p[1] == nbvoxels_[Dj_]) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId - 1;
-            break;
-          case 1:
-            neighborId = triangleId + 1;
-            break;
-          case 2:
-            neighborId = triangleId + tshift_[0] - 1 - wrap_[1] * 2;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId + tshift_[0] - 1 - wrap_[1] * 2;
         }
+
       } else {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId - 1;
-            break;
-          case 1:
-            neighborId = triangleId + 1;
-            break;
-          case 2:
-            neighborId = triangleId + tshift_[0] - 1;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId + tshift_[0] - 1;
         }
       }
-    } else {
+      break;
+
+    case TrianglePosition::TOP_2D:
+
       if(p[0] / 2 == 0 and p[1] == 0) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId + 1;
-            break;
-          case 1:
-            neighborId = triangleId - 1 + wrap_[0] * 2;
-            break;
-          case 2:
-            neighborId = triangleId - tshift_[0] + 1 + wrap_[1] * 2;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId - 1 + wrap_[0] * 2;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId - tshift_[0] + 1 + wrap_[1] * 2;
         }
+
       } else if(p[0] / 2 == 0) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId + 1;
-            break;
-          case 1:
-            neighborId = triangleId - 1 + wrap_[0] * 2;
-            break;
-          case 2:
-            neighborId = triangleId - tshift_[0] + 1;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId - 1 + wrap_[0] * 2;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId - tshift_[0] + 1;
         }
+
       } else if(p[1] == 0) {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId + 1;
-            break;
-          case 1:
-            neighborId = triangleId - 1;
-            break;
-          case 2:
-            neighborId = triangleId - tshift_[0] + 1 + wrap_[1] * 2;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId - tshift_[0] + 1 + wrap_[1] * 2;
         }
+
       } else {
-        switch(localNeighborId) {
-          case 0:
-            neighborId = triangleId + 1;
-            break;
-          case 1:
-            neighborId = triangleId - 1;
-            break;
-          case 2:
-            neighborId = triangleId - tshift_[0] + 1;
-            break;
+        if(localNeighborId == 0) {
+          neighborId = triangleId + 1;
+        } else if(localNeighborId == 1) {
+          neighborId = triangleId - 1;
+        } else if(localNeighborId == 2) {
+          neighborId = triangleId - tshift_[0] + 1;
         }
       }
-    }
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1310,40 +1310,29 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
 #endif
 
   linkId = -1;
+  const auto &p = triangleCoords_[triangleId];
 
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
-
-    // F
-    if(triangleId < tsetshift_[0]) {
-      triangleToPosition(triangleId, 0, p);
-      linkId = getTriangleLinkF(p, localLinkId);
-    }
-    // H
-    else if(triangleId < tsetshift_[1]) {
-      triangleToPosition(triangleId, 1, p);
-      linkId = getTriangleLinkH(p, localLinkId);
-    }
-    // C
-    else if(triangleId < tsetshift_[2]) {
-      triangleToPosition(triangleId, 2, p);
-      linkId = getTriangleLinkC(p, localLinkId);
-    }
-    // D1
-    else if(triangleId < tsetshift_[3]) {
-      triangleToPosition(triangleId, 3, p);
-      linkId = getTriangleLinkD1(p, localLinkId);
-    }
-    // D2
-    else if(triangleId < tsetshift_[4]) {
-      triangleToPosition(triangleId, 4, p);
-      linkId = getTriangleLinkD2(p, localLinkId);
-    }
-    // D3
-    else if(triangleId < tsetshift_[5]) {
-      triangleToPosition(triangleId, 5, p);
-      linkId = getTriangleLinkD3(p, localLinkId);
-    }
+  switch(trianglePositions_[triangleId]) {
+    case TrianglePosition::F_3D:
+      linkId = getTriangleLinkF(p.data(), localLinkId);
+      break;
+    case TrianglePosition::H_3D:
+      linkId = getTriangleLinkH(p.data(), localLinkId);
+      break;
+    case TrianglePosition::C_3D:
+      linkId = getTriangleLinkC(p.data(), localLinkId);
+      break;
+    case TrianglePosition::D1_3D:
+      linkId = getTriangleLinkD1(p.data(), localLinkId);
+      break;
+    case TrianglePosition::D2_3D:
+      linkId = getTriangleLinkD2(p.data(), localLinkId);
+      break;
+    case TrianglePosition::D3_3D:
+      linkId = getTriangleLinkD3(p.data(), localLinkId);
+      break;
+    default:
+      break;
   }
 
   return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -290,8 +290,7 @@ int PeriodicImplicitTriangulation::preconditionEdgesInternal() {
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < edgeNumber_; ++i) {
       const auto &p = edgeCoords_[i];
-      edgeVertexAccelerated_[i][0] = p[1] << div_[0];
-      edgeVertexAccelerated_[i][1] = p[2] << div_[1];
+      edgeVertexAccelerated_[i] = (p[1] << div_[0]) + (p[2] << div_[1]);
     }
   } else {
 #ifdef TTK_ENABLE_OPENMP
@@ -299,8 +298,7 @@ int PeriodicImplicitTriangulation::preconditionEdgesInternal() {
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < edgeNumber_; ++i) {
       const auto &p = edgeCoords_[i];
-      edgeVertexAccelerated_[i][0] = p[1] * vshift_[0];
-      edgeVertexAccelerated_[i][1] = p[2] * vshift_[1];
+      edgeVertexAccelerated_[i] = p[1] * vshift_[0] + p[2] * vshift_[1];
     }
   }
 
@@ -796,37 +794,36 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
   const SimplexId wrapXRight = (p[0] == nbvoxels_[0] ? -wrap_[0] : 0);
   const SimplexId wrapYBottom = (p[1] == nbvoxels_[1] ? -wrap_[1] : 0);
   const SimplexId wrapZFront = (p[2] == nbvoxels_[2] ? -wrap_[2] : 0);
-  const auto a = p[0] + edgeVertexAccelerated_[edgeId][0];
-  const auto b = a + edgeVertexAccelerated_[edgeId][1];
+  const auto a = p[0] + edgeVertexAccelerated_[edgeId];
 
   switch(edgePositions_[edgeId]) {
     case EdgePosition::L_3D:
-      vertexId = b + (localVertexId == 0 ? 0 : (1 + wrapXRight));
+      vertexId = a + (localVertexId == 0 ? 0 : (1 + wrapXRight));
       break;
     case EdgePosition::H_3D:
-      vertexId = b + (localVertexId == 0 ? 0 : (vshift_[0] + wrapYBottom));
+      vertexId = a + (localVertexId == 0 ? 0 : (vshift_[0] + wrapYBottom));
       break;
     case EdgePosition::P_3D:
-      vertexId = b + (localVertexId == 0 ? 0 : (vshift_[1] + wrapZFront));
+      vertexId = a + (localVertexId == 0 ? 0 : (vshift_[1] + wrapZFront));
       break;
     case EdgePosition::D1_3D:
-      vertexId = b
+      vertexId = a
                  + (localVertexId == 0 ? (1 + wrapXRight)
                                        : (vshift_[0] + wrapYBottom));
       break;
     case EdgePosition::D2_3D:
-      vertexId = b
+      vertexId = a
                  + (localVertexId == 0
                       ? 0
                       : (vshift_[0] + wrapYBottom + vshift_[1] + wrapZFront));
       break;
     case EdgePosition::D3_3D:
       vertexId
-        = b
+        = a
           + (localVertexId == 0 ? (1 + wrapXRight) : (vshift_[1] + wrapZFront));
       break;
     case EdgePosition::D4_3D:
-      vertexId = b
+      vertexId = a
                  + (localVertexId == 0
                       ? (1 + wrapXRight)
                       : (vshift_[0] + wrapYBottom + vshift_[1] + wrapZFront));

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1387,40 +1387,31 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
 #endif
 
   starId = -1;
-  if(dimensionality_ == 3) {
-    SimplexId p[3];
+  const auto &p = triangleCoords_[triangleId];
 
-    // F
-    if(triangleId < tsetshift_[0]) {
-      triangleToPosition(triangleId, 0, p);
-      starId = getTriangleStarF(p, localStarId);
-    }
-    // H
-    else if(triangleId < tsetshift_[1]) {
-      triangleToPosition(triangleId, 1, p);
-      starId = getTriangleStarH(p, localStarId);
-    }
-    // C
-    else if(triangleId < tsetshift_[2]) {
-      triangleToPosition(triangleId, 2, p);
-      starId = getTriangleStarC(p, localStarId);
-    }
-    // D1
-    else if(triangleId < tsetshift_[3]) {
-      triangleToPosition(triangleId, 3, p);
-      starId = getTriangleStarD1(p, localStarId);
-    }
-    // D2
-    else if(triangleId < tsetshift_[4]) {
-      triangleToPosition(triangleId, 4, p);
-      starId = getTriangleStarD2(p, localStarId);
-    }
-    // D3
-    else if(triangleId < tsetshift_[5]) {
-      triangleToPosition(triangleId, 5, p);
-      starId = getTriangleStarD3(p, localStarId);
-    }
+  switch(trianglePositions_[triangleId]) {
+    case TrianglePosition::F_3D:
+      starId = getTriangleStarF(p.data(), localStarId);
+      break;
+    case TrianglePosition::H_3D:
+      starId = getTriangleStarH(p.data(), localStarId);
+      break;
+    case TrianglePosition::C_3D:
+      starId = getTriangleStarC(p.data(), localStarId);
+      break;
+    case TrianglePosition::D1_3D:
+      starId = getTriangleStarD1(p.data(), localStarId);
+      break;
+    case TrianglePosition::D2_3D:
+      starId = getTriangleStarD2(p.data(), localStarId);
+      break;
+    case TrianglePosition::D3_3D:
+      starId = getTriangleStarD3(p.data(), localStarId);
+      break;
+    default:
+      break;
   }
+
   return 0;
 }
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -314,30 +314,27 @@ namespace ttk {
      * Compute the barycenter of the points of the given edge identifier.
      */
     virtual int getEdgeIncenter(SimplexId edgeId, float incenter[3]) const {
-      std::array<SimplexId, 2> vertexId;
-      for(int i = 0; i < (int)vertexId.size(); ++i) {
-        getEdgeVertexInternal(edgeId, i, vertexId[i]);
-      }
+      SimplexId v0{}, v1{};
+      getEdgeVertexInternal(edgeId, 0, v0);
+      getEdgeVertexInternal(edgeId, 1, v1);
 
-      std::array<std::array<float, 3>, vertexId.size()> p;
-      std::array<std::array<SimplexId, 3>, vertexId.size()> ind;
-      for(int i = 0; i < (int)vertexId.size(); ++i) {
-        for(int j = 0; j < 3; j++)
-          p[i][j] = 0;
-        getVertexPointInternal(vertexId[i], p[i][0], p[i][1], p[i][2]);
-        ind[i] = vertexToPositionNd(vertexId[i]);
-      }
+      std::array<float, 3> p0{}, p1{};
+      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
+      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
+
+      const auto &ind0 = vertexCoords_[v0];
+      const auto &ind1 = vertexCoords_[v1];
 
       for(int i = 0; i < dimensionality_; ++i) {
-        if(ind[1][i] == nbvoxels_[i]) {
-          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind[0][i] == nbvoxels_[i]) {
-          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
+        if(ind1[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind0[i] == nbvoxels_[i]) {
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
         }
       }
 
       for(int i = 0; i < 3; ++i) {
-        incenter[i] = 0.5f * (p[0][i] + p[1][i]);
+        incenter[i] = 0.5f * (p0[i] + p1[i]);
       }
 
       return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -305,11 +305,6 @@ namespace ttk {
       return 0;
     }
 
-    std::array<SimplexId, 3>
-      vertexToPositionNd(const SimplexId vertexId) const {
-      return vertexCoords_[vertexId];
-    }
-
     /**
      * Compute the barycenter of the points of the given edge identifier.
      */

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -391,41 +391,45 @@ namespace ttk {
      */
     virtual int getTetraIncenter(SimplexId tetraId, float incenter[3]) const {
 
-      std::array<SimplexId, 4> vertexId;
-      for(int i = 0; i < (int)vertexId.size(); ++i) {
-        vertexId[i] = -1;
-        getCellVertexInternal(tetraId, i, vertexId[i]);
-      }
+      SimplexId v0{}, v1{}, v2{}, v3{};
+      getCellVertexInternal(tetraId, 0, v0);
+      getCellVertexInternal(tetraId, 1, v1);
+      getCellVertexInternal(tetraId, 2, v2);
+      getCellVertexInternal(tetraId, 3, v3);
 
-      std::array<std::array<float, 3>, vertexId.size()> p;
-      std::array<std::array<SimplexId, 3>, vertexId.size()> ind;
-      for(int i = 0; i < (int)vertexId.size(); ++i) {
-        getVertexPointInternal(vertexId[i], p[i][0], p[i][1], p[i][2]);
-        ind[i] = vertexToPositionNd(vertexId[i]);
-      }
+      std::array<float, 3> p0{}, p1{}, p2{}, p3{};
+      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
+      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
+      getVertexPointInternal(v2, p2[0], p2[1], p2[2]);
+      getVertexPointInternal(v3, p3[0], p3[1], p3[2]);
+
+      const auto &ind0 = vertexCoords_[v0];
+      const auto &ind1 = vertexCoords_[v1];
+      const auto &ind2 = vertexCoords_[v2];
+      const auto &ind3 = vertexCoords_[v3];
 
       for(int i = 0; i < dimensionality_; ++i) {
-        if(ind[0][i] == nbvoxels_[i]) {
-          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
-          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
-          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind[1][i] == nbvoxels_[i]) {
-          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
-          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
-          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind[2][i] == nbvoxels_[i]) {
-          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
-          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
-          p[3][i] += (ind[3][i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind[3][i] == nbvoxels_[i]) {
-          p[0][i] += (ind[0][i] == 0) * dimensions_[i] * spacing_[i];
-          p[1][i] += (ind[1][i] == 0) * dimensions_[i] * spacing_[i];
-          p[2][i] += (ind[2][i] == 0) * dimensions_[i] * spacing_[i];
+        if(ind0[i] == nbvoxels_[i]) {
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind1[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind2[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind3[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
         }
       }
 
       for(int i = 0; i < 3; ++i) {
-        incenter[i] = 0.25f * (p[0][i] + p[1][i] + p[2][i] + p[3][i]);
+        incenter[i] = 0.25f * (p0[i] + p1[i] + p2[i] + p3[i]);
       }
       return 0;
     }

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -477,6 +477,69 @@ namespace ttk {
     // for every tetrahedron, its coordinates on the grid
     std::vector<std::array<SimplexId, 3>> tetrahedronCoords_{};
 
+    enum class EdgePosition : char {
+      //    e--------f
+      //   /|       /|
+      //  / |      / |
+      // a--------b  |
+      // |  g-----|--h
+      // | /      | /
+      // |/       |/
+      // c--------d
+
+      // length (ab)
+      L_3D,
+      // height (ac)
+      H_3D,
+      // depth (ae)
+      P_3D,
+      // diagonal1 (bc)
+      D1_3D,
+      // diagonal2 (ag)
+      D2_3D,
+      // diagonal3 (be)
+      D3_3D,
+      // diagonal4 (bg)
+      D4_3D,
+
+      // length (ab)
+      L_2D,
+      // height (ac)
+      H_2D,
+      // diagonal1 (bc)
+      D1_2D,
+
+      FIRST_EDGE_1D,
+      LAST_EDGE_1D,
+      CENTER_1D,
+    };
+
+    enum class TrianglePosition : char {
+      //    e--------f
+      //   /|       /|
+      //  / |      / |
+      // a--------b  |
+      // |  g-----|--h
+      // | /      | /
+      // |/       |/
+      // c--------d
+
+      F_3D, // face (abc, bcd)
+      C_3D, // side (abe, bef)
+      H_3D, // top (acg, aeg)
+      D1_3D, // diagonal1 (bdg, beg)
+      D2_3D, // diagonal2 (abg, bgh)
+      D3_3D, // diagonal3 (bcg, bfg)
+
+      TOP_2D, // abc
+      BOTTOM_2D, // bcd
+    };
+
+    // for every edge, its position on the grid
+    std::vector<EdgePosition> edgePositions_{};
+    // for every triangle, its position on the grid
+    std::vector<TrianglePosition> trianglePositions_{};
+
     // acceleration functions
     int checkAcceleration();
     bool isPowerOfTwo(unsigned long long int v, unsigned long long int &r);

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -290,6 +290,21 @@ namespace ttk {
                      const int &yDim,
                      const int &zDim);
 
+    int preconditionVerticesInternal();
+    int preconditionEdgesInternal() override;
+    int preconditionTrianglesInternal() override;
+    int preconditionTetrahedronsInternal();
+
+    inline int preconditionCellsInternal() {
+      if(dimensionality_ == 3) {
+        return this->preconditionTetrahedronsInternal();
+      } else if(dimensionality_ == 2 && !hasPreconditionedTriangles_) {
+        hasPreconditionedTriangles_ = true;
+        return this->preconditionTrianglesInternal();
+      }
+      return 0;
+    }
+
     std::array<SimplexId, 3>
       vertexToPositionNd(const SimplexId vertexId) const {
       std::array<SimplexId, 3> p{};
@@ -467,6 +482,15 @@ namespace ttk {
     bool isAccelerated_;
     SimplexId mod_[2];
     SimplexId div_[2];
+
+    // for  every vertex, its coordinates on the grid
+    std::vector<std::array<SimplexId, 3>> vertexCoords_{};
+    // for every edge, its coordinates on the grid
+    std::vector<std::array<SimplexId, 3>> edgeCoords_{};
+    // for every triangle, its coordinates on the grid
+    std::vector<std::array<SimplexId, 3>> triangleCoords_{};
+    // for every tetrahedron, its coordinates on the grid
+    std::vector<std::array<SimplexId, 3>> tetrahedronCoords_{};
 
     // acceleration functions
     int checkAcceleration();

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -307,15 +307,7 @@ namespace ttk {
 
     std::array<SimplexId, 3>
       vertexToPositionNd(const SimplexId vertexId) const {
-      std::array<SimplexId, 3> p{};
-      if(dimensionality_ == 1) {
-        p[0] = vertexId;
-      } else if(dimensionality_ == 2) {
-        vertexToPosition2d(vertexId, p.data());
-      } else if(dimensionality_ == 3) {
-        vertexToPosition(vertexId, p.data());
-      }
-      return p;
+      return vertexCoords_[vertexId];
     }
 
     /**

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -540,6 +540,9 @@ namespace ttk {
     // for every triangle, its position on the grid
     std::vector<TrianglePosition> trianglePositions_{};
 
+    // cache some edge vertex computation wrt acceleration
+    std::vector<std::array<SimplexId, 2>> edgeVertexAccelerated_{};
+
     // acceleration functions
     int checkAcceleration();
     bool isPowerOfTwo(unsigned long long int v, unsigned long long int &r);

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -460,8 +460,8 @@ namespace ttk {
     SimplexId tetrahedronNumber_; // number of tetrahedra
 
     // 2d helpers
-    SimplexId Di_;
-    SimplexId Dj_;
+    SimplexId Di_{};
+    SimplexId Dj_{};
 
     // acceleration variables
     bool isAccelerated_;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -541,7 +541,7 @@ namespace ttk {
     std::vector<TrianglePosition> trianglePositions_{};
 
     // cache some edge vertex computation wrt acceleration
-    std::vector<std::array<SimplexId, 2>> edgeVertexAccelerated_{};
+    std::vector<SimplexId> edgeVertexAccelerated_{};
 
     // acceleration functions
     int checkAcceleration();


### PR DESCRIPTION
This PR applies the changes made in #350 to the PeriodicImplicitTriangulation. Vertices, edges, triangles and tetrahedron "position" is cached at the precondition phase to fasten latter queries.

Enjoy,
Pierre
