### PR TITLE
PersistenceDiagramDistanceMatrix: Support rectangular matrices

### DIFF
--- a/core/base/persistenceDiagramDistanceMatrix/CMakeLists.txt
+++ b/core/base/persistenceDiagramDistanceMatrix/CMakeLists.txt
@@ -4,7 +4,7 @@ ttk_add_base_library(persistenceDiagramDistanceMatrix
   HEADERS
     PersistenceDiagramDistanceMatrix.h
   DEPENDS
-    common 
-    auction 
+    common
+    auction
     persistenceDiagram
   )

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -5,7 +5,7 @@
 using namespace ttk;
 
 std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
-  std::vector<std::vector<DiagramTuple>> &intermediateDiagrams) const {
+  const std::vector<Diagram> &intermediateDiagrams) const {
 
   Timer tm{};
 
@@ -21,9 +21,9 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     this->printMsg("Processing only SAD-MAX pairs");
   }
 
-  std::vector<std::vector<DiagramTuple>> inputDiagramsMin(nInputs);
-  std::vector<std::vector<DiagramTuple>> inputDiagramsSad(nInputs);
-  std::vector<std::vector<DiagramTuple>> inputDiagramsMax(nInputs);
+  std::vector<Diagram> inputDiagramsMin(nInputs);
+  std::vector<Diagram> inputDiagramsSad(nInputs);
+  std::vector<Diagram> inputDiagramsMax(nInputs);
 
   std::vector<BidderDiagram<double>> bidder_diagrams_min{};
   std::vector<BidderDiagram<double>> bidder_diagrams_sad{};
@@ -40,7 +40,7 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; i++) {
-    std::vector<DiagramTuple> &CTDiagram = intermediateDiagrams[i];
+    const Diagram &CTDiagram = intermediateDiagrams[i];
 
     for(size_t j = 0; j < CTDiagram.size(); ++j) {
       const DiagramTuple &t = CTDiagram[j];
@@ -223,7 +223,7 @@ void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
 
 void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   const size_t nInputs,
-  std::vector<std::vector<DiagramTuple>> &inputDiagrams,
+  std::vector<Diagram> &inputDiagrams,
   std::vector<BidderDiagram<double>> &bidder_diags) const {
 
   bidder_diags.resize(nInputs);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -5,11 +5,12 @@
 using namespace ttk;
 
 std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
-  const std::vector<Diagram> &intermediateDiagrams) const {
+  const std::vector<Diagram> &intermediateDiagrams,
+  const std::array<size_t, 2> &nInputs) const {
 
   Timer tm{};
 
-  const auto nInputs = intermediateDiagrams.size();
+  const auto nDiags = intermediateDiagrams.size();
 
   if(do_min_ && do_sad_ && do_max_) {
     this->printMsg("Processing all critical pairs types");
@@ -21,9 +22,9 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     this->printMsg("Processing only SAD-MAX pairs");
   }
 
-  std::vector<Diagram> inputDiagramsMin(nInputs);
-  std::vector<Diagram> inputDiagramsSad(nInputs);
-  std::vector<Diagram> inputDiagramsMax(nInputs);
+  std::vector<Diagram> inputDiagramsMin(nDiags);
+  std::vector<Diagram> inputDiagramsSad(nDiags);
+  std::vector<Diagram> inputDiagramsMax(nDiags);
 
   std::vector<BidderDiagram<double>> bidder_diagrams_min{};
   std::vector<BidderDiagram<double>> bidder_diagrams_sad{};
@@ -33,13 +34,13 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   std::vector<BidderDiagram<double>> current_bidder_diagrams_max{};
 
   // Store the persistence of the global min-max pair
-  std::vector<double> maxDiagPersistence(nInputs);
+  std::vector<double> maxDiagPersistence(nDiags);
 
   // Create diagrams for min, saddle and max persistence pairs
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nInputs; i++) {
+  for(size_t i = 0; i < nDiags; i++) {
     const Diagram &CTDiagram = intermediateDiagrams[i];
 
     for(size_t j = 0; j < CTDiagram.size(); ++j) {
@@ -73,13 +74,13 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   }
 
   if(this->do_min_) {
-    setBidderDiagrams(nInputs, inputDiagramsMin, bidder_diagrams_min);
+    setBidderDiagrams(nDiags, inputDiagramsMin, bidder_diagrams_min);
   }
   if(this->do_sad_) {
-    setBidderDiagrams(nInputs, inputDiagramsSad, bidder_diagrams_sad);
+    setBidderDiagrams(nDiags, inputDiagramsSad, bidder_diagrams_sad);
   }
   if(this->do_max_) {
-    setBidderDiagrams(nInputs, inputDiagramsMax, bidder_diagrams_max);
+    setBidderDiagrams(nDiags, inputDiagramsMax, bidder_diagrams_max);
   }
 
   switch(this->Constraint) {
@@ -110,7 +111,7 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
       break;
   }
 
-  std::vector<std::vector<double>> distMat(nInputs);
+  std::vector<std::vector<double>> distMat{};
   if(this->Constraint == ConstraintType::FULL_DIAGRAMS) {
     getDiagramsDistMat(nInputs, distMat, bidder_diagrams_min,
                        bidder_diagrams_sad, bidder_diagrams_max);

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -98,13 +98,13 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
     } break;
     case ConstraintType::RELATIVE_PERSISTENCE_PER_DIAG:
       this->printMsg(
-        "Use the "
+        "Using the "
         + std::to_string(static_cast<int>(100 * (1 - this->MinPersistence)))
         + "% most persistent pairs of every diagram");
       break;
     case ConstraintType::RELATIVE_PERSISTENCE_GLOBAL:
       this->printMsg(
-        "Use the "
+        "Using the "
         + std::to_string(static_cast<int>(100 * (1 - this->MinPersistence)))
         + "% most persistent pairs of all diagrams");
       break;

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -50,6 +50,8 @@ namespace ttk {
     float,
     float>;
 
+  using Diagram = std::vector<DiagramTuple>;
+
   class PersistenceDiagramDistanceMatrix : virtual public Debug {
 
   public:
@@ -57,8 +59,8 @@ namespace ttk {
       this->setDebugMsgPrefix("PersistenceDiagramDistanceMatrix");
     }
 
-    std::vector<std::vector<double>> execute(
-      std::vector<std::vector<DiagramTuple>> &intermediateDiagrams) const;
+    std::vector<std::vector<double>>
+      execute(const std::vector<Diagram> &intermediateDiagrams) const;
 
     inline void setWasserstein(const int data) {
       Wasserstein = data;
@@ -110,7 +112,7 @@ namespace ttk {
       const std::vector<BidderDiagram<double>> &diags_max) const;
     void
       setBidderDiagrams(const size_t nInputs,
-                        std::vector<std::vector<DiagramTuple>> &inputDiagrams,
+                        std::vector<Diagram> &inputDiagrams,
                         std::vector<BidderDiagram<double>> &bidder_diags) const;
     void enrichCurrentBidderDiagrams(
       const std::vector<BidderDiagram<double>> &bidder_diags,

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -105,7 +105,7 @@ namespace ttk {
     double computeDistance(const BidderDiagram<double> &D1,
                            const BidderDiagram<double> &D2) const;
     void getDiagramsDistMat(
-      const size_t nInputs,
+      const std::array<size_t, 2> &nInputs,
       std::vector<std::vector<double>> &distanceMatrix,
       const std::vector<BidderDiagram<double>> &diags_min,
       const std::vector<BidderDiagram<double>> &diags_sad,

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -60,7 +60,8 @@ namespace ttk {
     }
 
     std::vector<std::vector<double>>
-      execute(const std::vector<Diagram> &intermediateDiagrams) const;
+      execute(const std::vector<Diagram> &intermediateDiagrams,
+              const std::array<size_t, 2> &nInputs) const;
 
     inline void setWasserstein(const int data) {
       Wasserstein = data;

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -50,16 +50,30 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
   // Get input data
   std::vector<vtkUnstructuredGrid *> inputDiagrams;
 
-  auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+  auto nBlocks = inputVector[0]->GetNumberOfInformationObjects();
+  std::vector<vtkMultiBlockDataSet *> blocks(nBlocks);
 
-  if(blocks != nullptr) {
-    inputDiagrams.resize(blocks->GetNumberOfBlocks());
-    for(size_t i = 0; i < inputDiagrams.size(); ++i) {
-      inputDiagrams[i] = vtkUnstructuredGrid::SafeDownCast(blocks->GetBlock(i));
+  if(nBlocks > 2) {
+    this->printWrn("Only dealing with the first two MultiBlockDataSets");
+    nBlocks = 2;
+  }
+
+  // number of diagrams per input block
+  std::array<size_t, 2> nInputs{0, 0};
+
+  for(int i = 0; i < nBlocks; ++i) {
+    blocks[i] = vtkMultiBlockDataSet::GetData(inputVector[0], i);
+    if(blocks[i] != nullptr) {
+      nInputs[i] = blocks[i]->GetNumberOfBlocks();
+      for(size_t j = 0; j < nInputs[i]; ++j) {
+        inputDiagrams.emplace_back(
+          vtkUnstructuredGrid::SafeDownCast(blocks[i]->GetBlock(j)));
+      }
     }
   }
 
-  const int numInputs = inputDiagrams.size();
+  // total number of diagrams
+  const int nDiags = inputDiagrams.size();
 
   // Sanity check
   for(const auto vtu : inputDiagrams) {
@@ -72,10 +86,10 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
   // Set output
   auto diagramsDistTable = vtkTable::GetData(outputVector);
 
-  std::vector<ttk::Diagram> intermediateDiagrams(numInputs);
+  std::vector<ttk::Diagram> intermediateDiagrams(nDiags);
 
   double max_dimension_total = 0.0;
-  for(int i = 0; i < numInputs; i++) {
+  for(int i = 0; i < nDiags; i++) {
     double max_dimension
       = getPersistenceDiagram(intermediateDiagrams[i], inputDiagrams[i]);
     if(max_dimension_total < max_dimension) {
@@ -83,7 +97,7 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
     }
   }
 
-  const auto diagramsDistMat = this->execute(intermediateDiagrams);
+  const auto diagramsDistMat = this->execute(intermediateDiagrams, nInputs);
 
   // zero-padd column name to keep Row Data columns ordered
   const auto zeroPad
@@ -94,13 +108,15 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
         colName.append(zer).append(cur);
       };
 
+  const auto nTuples = nInputs[1] == 0 ? nInputs[0] : nInputs[1];
+
   // copy diagrams distance matrix to output
   for(size_t i = 0; i < diagramsDistMat.size(); ++i) {
     std::string name{"Diagram"};
     zeroPad(name, diagramsDistMat.size(), i);
 
     vtkNew<vtkDoubleArray> col{};
-    col->SetNumberOfTuples(numInputs);
+    col->SetNumberOfTuples(nTuples);
     col->SetName(name.c_str());
     for(size_t j = 0; j < diagramsDistMat[i].size(); ++j) {
       col->SetTuple1(j, diagramsDistMat[i][j]);
@@ -111,8 +127,8 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
   // aggregate input field data
   vtkNew<vtkFieldData> fd{};
   fd->CopyStructure(inputDiagrams[0]->GetFieldData());
-  fd->SetNumberOfTuples(inputDiagrams.size());
-  for(size_t i = 0; i < inputDiagrams.size(); ++i) {
+  fd->SetNumberOfTuples(nTuples);
+  for(size_t i = 0; i < nTuples; ++i) {
     fd->SetTuple(i, 0, inputDiagrams[i]->GetFieldData());
   }
 

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -25,6 +25,7 @@ int ttkPersistenceDiagramDistanceMatrix::FillInputPortInformation(
   int port, vtkInformation *info) {
   if(port == 0) {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+    info->Set(vtkAlgorithm::INPUT_IS_REPEATABLE(), 1);
     return 1;
   }
   return 0;

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -71,7 +71,7 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
   // Set output
   auto diagramsDistTable = vtkTable::GetData(outputVector);
 
-  std::vector<std::vector<ttk::DiagramTuple>> intermediateDiagrams(numInputs);
+  std::vector<ttk::Diagram> intermediateDiagrams(numInputs);
 
   double max_dimension_total = 0.0;
   for(int i = 0; i < numInputs; i++) {
@@ -124,8 +124,7 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
 }
 
 double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
-  std::vector<ttk::DiagramTuple> &diagram,
-  vtkUnstructuredGrid *CTPersistenceDiagram_) {
+  ttk::Diagram &diagram, vtkUnstructuredGrid *CTPersistenceDiagram_) {
 
   const auto pd = CTPersistenceDiagram_->GetPointData();
   const auto cd = CTPersistenceDiagram_->GetCellData();

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.h
@@ -126,7 +126,7 @@ protected:
   ttkPersistenceDiagramDistanceMatrix();
   ~ttkPersistenceDiagramDistanceMatrix() override = default;
 
-  double getPersistenceDiagram(std::vector<ttk::DiagramTuple> &diagram,
+  double getPersistenceDiagram(ttk::Diagram &diagram,
                                vtkUnstructuredGrid *CTPersistenceDiagram_);
 
   int FillInputPortInformation(int port, vtkInformation *info) override;

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -21,7 +21,9 @@
 
       <InputProperty
           name="Input"
-          command="SetInputConnection">
+          command="AddInputConnection"
+          clean_command="RemoveAllInputs"
+          multiple_input="1">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>


### PR DESCRIPTION
This PR adds the support of rectangular matrices alongside square matrices in the PersistenceDiagramDistanceMatrix module. Square matrices are still computed in a triangular fashion.

Enjoy,
Pierre

