### PR TITLE
[api-migration-hackathon] OBJWriter, OFFWriter, OFFReader

### DIFF
--- a/core/vtk/ttkOBJWriter/ttk.module
+++ b/core/vtk/ttkOBJWriter/ttk.module
@@ -4,3 +4,5 @@ SOURCES
   ttkOBJWriter.cpp
 HEADERS
   ttkOBJWriter.h
+DEPENDS
+  common

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
@@ -21,6 +21,7 @@ void ttkOBJWriter::PrintSelf(std::ostream &os, vtkIndent indent) {
 // {{{
 
 ttkOBJWriter::ttkOBJWriter() {
+  this->setDebugMsgPrefix("OBJWriter");
 }
 
 ttkOBJWriter::~ttkOBJWriter() {
@@ -47,8 +48,7 @@ void ttkOBJWriter::WriteData() {
     return;
 
   if(this->OpenFile() == -1) {
-    std::cerr << "[ttkOBJWriter] Could not open file `" << Filename << "' :("
-              << std::endl;
+    this->printErr("Could not open file `" + std::string{Filename} + "' :(");
     return;
   }
 

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
@@ -1,33 +1,19 @@
 #include <ttkOBJWriter.h>
 
 #include <vtkCell.h>
-#include <vtkCellData.h>
-#include <vtkCellType.h>
-#include <vtkDataObject.h>
-#include <vtkDoubleArray.h>
-#include <vtkIdList.h>
-#include <vtkInformation.h>
-#include <vtkInformationVector.h>
+#include <vtkDataSet.h>
 #include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
-#include <vtkUnstructuredGrid.h>
-
-#include <iostream>
-#include <sstream>
-
-using namespace std;
 
 vtkStandardNewMacro(ttkOBJWriter);
 
 // Public
 // {{{
 
-void ttkOBJWriter::PrintSelf(ostream &os, vtkIndent indent) {
+void ttkOBJWriter::PrintSelf(std::ostream &os, vtkIndent indent) {
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "File Name: " << (this->Filename ? this->Filename : "(none)")
-     << endl;
+     << std::endl;
 }
 
 // }}}
@@ -35,16 +21,14 @@ void ttkOBJWriter::PrintSelf(ostream &os, vtkIndent indent) {
 // {{{
 
 ttkOBJWriter::ttkOBJWriter() {
-  Filename = NULL;
 }
 
 ttkOBJWriter::~ttkOBJWriter() {
-  SetFilename(NULL);
 }
 
 int ttkOBJWriter::OpenFile() {
 
-  ofstream f(Filename, ios::out);
+  std::ofstream f(Filename, ios::out);
 
   if(!f.fail()) {
     Stream = std::move(f);
@@ -57,21 +41,21 @@ int ttkOBJWriter::OpenFile() {
 
 void ttkOBJWriter::WriteData() {
 
-  vtkDataSet *dataSet = vtkDataSet::SafeDownCast(this->GetInput());
+  auto dataSet = vtkDataSet::SafeDownCast(this->GetInput());
 
-  if(!dataSet)
+  if(dataSet == nullptr)
     return;
 
-  if(this->OpenFile()) {
-    cerr << "[ttkOBJWriter] Could not open file `" << Filename << "' :("
-         << endl;
+  if(this->OpenFile() == -1) {
+    std::cerr << "[ttkOBJWriter] Could not open file `" << Filename << "' :("
+              << std::endl;
     return;
   }
 
   double p[3];
   for(vtkIdType i = 0; i < dataSet->GetNumberOfPoints(); i++) {
     dataSet->GetPoint(i, p);
-    Stream << "v " << p[0] << " " << p[1] << " " << p[2] << " " << endl;
+    Stream << "v " << p[0] << " " << p[1] << " " << p[2] << " " << std::endl;
   }
 
   for(vtkIdType i = 0; i < dataSet->GetNumberOfCells(); i++) {
@@ -82,7 +66,7 @@ void ttkOBJWriter::WriteData() {
       Stream << c->GetPointId(j) + 1 << " ";
     }
 
-    Stream << endl;
+    Stream << std::endl;
   }
 }
 

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.h
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.h
@@ -11,11 +11,13 @@
 #include <vtkDataSetWriter.h>
 
 // VTK Module
+#include <Debug.h>
 #include <ttkOBJWriterModule.h>
 
 #include <fstream>
 
-class TTKOBJWRITER_EXPORT ttkOBJWriter : public vtkDataSetWriter {
+class TTKOBJWRITER_EXPORT ttkOBJWriter : public vtkDataSetWriter,
+                                         protected ttk::Debug {
 
 public:
   vtkTypeMacro(ttkOBJWriter, vtkDataSetWriter);

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.h
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.h
@@ -9,26 +9,23 @@
 #pragma once
 
 #include <vtkDataSetWriter.h>
-#include <vtkPoints.h>
-#include <vtkSmartPointer.h>
 
 // VTK Module
 #include <ttkOBJWriterModule.h>
 
-#include <iostream>
-#include <string>
-#include <vector>
+#include <fstream>
 
 class TTKOBJWRITER_EXPORT ttkOBJWriter : public vtkDataSetWriter {
 
 public:
   vtkTypeMacro(ttkOBJWriter, vtkDataSetWriter);
-  void PrintSelf(ostream &os, vtkIndent indent) override;
 
   static ttkOBJWriter *New();
 
+  void PrintSelf(std::ostream &os, vtkIndent indent) override;
+
   // Description:
-  // Specify file name of the .abc file.
+  // Specify file name of the .obj file.
   vtkSetStringMacro(Filename);
   vtkGetStringMacro(Filename);
 
@@ -39,7 +36,7 @@ protected:
   int OpenFile();
   virtual void WriteData() override;
 
-  char *Filename;
+  char *Filename{};
   std::ofstream Stream{};
 
 private:

--- a/core/vtk/ttkOFFReader/ttk.module
+++ b/core/vtk/ttkOFFReader/ttk.module
@@ -4,3 +4,5 @@ SOURCES
   ttkOFFReader.cpp
 HEADERS
   ttkOFFReader.h
+DEPENDS
+  common

--- a/core/vtk/ttkOFFReader/ttkOFFReader.h
+++ b/core/vtk/ttkOFFReader/ttkOFFReader.h
@@ -10,25 +10,28 @@
 
 #pragma once
 
-#include "vtkPoints.h"
-#include "vtkSmartPointer.h"
-#include "vtkUnstructuredGridAlgorithm.h"
-
 #include <ttkOFFReaderModule.h>
-#include <vtkDataSetReader.h>
+
+#include <vtkNew.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtkUnstructuredGridAlgorithm.h>
 
 #include <string>
 #include <vector>
 
+class vtkPoints;
+class vtkDoubleArray;
+
 class TTKOFFREADER_EXPORT ttkOFFReader : public vtkUnstructuredGridAlgorithm {
 public:
   vtkTypeMacro(ttkOFFReader, vtkUnstructuredGridAlgorithm);
-  void PrintSelf(ostream &os, vtkIndent indent) override;
 
   static ttkOFFReader *New();
 
+  void PrintSelf(std::ostream &os, vtkIndent indent) override;
+
   // Description:
-  // Specify file name of the .abc file.
+  // Specify file name of the .off file.
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
 
@@ -49,12 +52,12 @@ private:
   ttkOFFReader(const ttkOFFReader &) = delete;
   void operator=(const ttkOFFReader &) = delete;
 
-  char *FileName;
-  vtkIdType nbVerts_, nbCells_;
-  vtkIdType nbVertsData_, nbCellsData_;
+  char *FileName{};
+  vtkIdType nbVerts_{}, nbCells_{};
+  vtkIdType nbVertsData_{}, nbCellsData_{};
 
-  vtkSmartPointer<vtkUnstructuredGrid> mesh_;
-  vtkSmartPointer<vtkPoints> points_;
-  std::vector<vtkSmartPointer<vtkDoubleArray>> vertScalars_;
-  std::vector<vtkSmartPointer<vtkDoubleArray>> cellScalars_;
+  vtkNew<vtkUnstructuredGrid> mesh_{};
+  vtkNew<vtkPoints> points_{};
+  std::vector<vtkNew<vtkDoubleArray>> vertScalars_{};
+  std::vector<vtkNew<vtkDoubleArray>> cellScalars_{};
 };

--- a/core/vtk/ttkOFFReader/ttkOFFReader.h
+++ b/core/vtk/ttkOFFReader/ttkOFFReader.h
@@ -12,15 +12,7 @@
 
 #include <ttkOFFReaderModule.h>
 
-#include <vtkNew.h>
-#include <vtkUnstructuredGrid.h>
 #include <vtkUnstructuredGridAlgorithm.h>
-
-#include <string>
-#include <vector>
-
-class vtkPoints;
-class vtkDoubleArray;
 
 class TTKOFFREADER_EXPORT ttkOFFReader : public vtkUnstructuredGridAlgorithm {
 public:
@@ -43,21 +35,9 @@ protected:
                   vtkInformationVector **,
                   vtkInformationVector *) override;
 
-  int countVertsData(std::string line);
-  int countCellsData(std::string line);
-  int processLineVert(vtkIdType curLine, std::string &line);
-  int processLineCell(vtkIdType curLine, std::string &line);
-
 private:
   ttkOFFReader(const ttkOFFReader &) = delete;
   void operator=(const ttkOFFReader &) = delete;
 
   char *FileName{};
-  vtkIdType nbVerts_{}, nbCells_{};
-  vtkIdType nbVertsData_{}, nbCellsData_{};
-
-  vtkNew<vtkUnstructuredGrid> mesh_{};
-  vtkNew<vtkPoints> points_{};
-  std::vector<vtkNew<vtkDoubleArray>> vertScalars_{};
-  std::vector<vtkNew<vtkDoubleArray>> cellScalars_{};
 };

--- a/core/vtk/ttkOFFReader/ttkOFFReader.h
+++ b/core/vtk/ttkOFFReader/ttkOFFReader.h
@@ -10,11 +10,13 @@
 
 #pragma once
 
+#include <Debug.h>
 #include <ttkOFFReaderModule.h>
 
 #include <vtkUnstructuredGridAlgorithm.h>
 
-class TTKOFFREADER_EXPORT ttkOFFReader : public vtkUnstructuredGridAlgorithm {
+class TTKOFFREADER_EXPORT ttkOFFReader : public vtkUnstructuredGridAlgorithm,
+                                         protected ttk::Debug {
 public:
   vtkTypeMacro(ttkOFFReader, vtkUnstructuredGridAlgorithm);
 

--- a/core/vtk/ttkOFFWriter/ttk.module
+++ b/core/vtk/ttkOFFWriter/ttk.module
@@ -4,3 +4,5 @@ SOURCES
   ttkOFFWriter.cpp
 HEADERS
   ttkOFFWriter.h
+DEPENDS
+  common

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
@@ -24,6 +24,7 @@ void ttkOFFWriter::PrintSelf(std::ostream &os, vtkIndent indent) {
 // {{{
 
 ttkOFFWriter::ttkOFFWriter() {
+  this->setDebugMsgPrefix("OFFWriter");
 }
 
 ttkOFFWriter::~ttkOFFWriter() {
@@ -50,8 +51,7 @@ void ttkOFFWriter::WriteData() {
     return;
 
   if(this->OpenFile() == -1) {
-    std::cerr << "[ttkOFFWriter] Could not open file `" << FileName << "' :("
-              << std::endl;
+    this->printErr("Could not open file `" + std::string{FileName} + "' :(");
     return;
   }
 

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
@@ -2,32 +2,21 @@
 
 #include <vtkCell.h>
 #include <vtkCellData.h>
-#include <vtkCellType.h>
-#include <vtkDataObject.h>
-#include <vtkDoubleArray.h>
-#include <vtkIdList.h>
-#include <vtkInformation.h>
-#include <vtkInformationVector.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
-#include <vtkStreamingDemandDrivenPipeline.h>
-#include <vtkUnstructuredGrid.h>
-
-#include <iostream>
-#include <sstream>
-
-using namespace std;
 
 vtkStandardNewMacro(ttkOFFWriter);
 
 // Public
 // {{{
 
-void ttkOFFWriter::PrintSelf(ostream &os, vtkIndent indent) {
+void ttkOFFWriter::PrintSelf(std::ostream &os, vtkIndent indent) {
   this->Superclass::PrintSelf(os, indent);
 
   os << indent << "File Name: " << (this->Filename ? this->Filename : "(none)")
-     << endl;
+     << std::endl;
 }
 
 // }}}
@@ -35,16 +24,14 @@ void ttkOFFWriter::PrintSelf(ostream &os, vtkIndent indent) {
 // {{{
 
 ttkOFFWriter::ttkOFFWriter() {
-  Filename = NULL;
 }
 
 ttkOFFWriter::~ttkOFFWriter() {
-  SetFilename(NULL);
 }
 
 int ttkOFFWriter::OpenFile() {
 
-  ofstream f(Filename, ios::out);
+  std::ofstream f(Filename, ios::out);
 
   if(!f.fail()) {
     Stream = std::move(f);
@@ -62,15 +49,15 @@ void ttkOFFWriter::WriteData() {
   if(!dataSet)
     return;
 
-  if(this->OpenFile()) {
-    cerr << "[ttkOFFWriter] Could not open file `" << FileName << "' :("
-         << endl;
+  if(this->OpenFile() == -1) {
+    std::cerr << "[ttkOFFWriter] Could not open file `" << FileName << "' :("
+              << std::endl;
     return;
   }
 
-  Stream << "OFF" << endl;
+  Stream << "OFF" << std::endl;
   Stream << dataSet->GetNumberOfPoints() << " " << dataSet->GetNumberOfCells()
-         << " 0" << endl;
+         << " 0" << std::endl;
 
   double p[3];
   for(vtkIdType i = 0; i < dataSet->GetNumberOfPoints(); i++) {
@@ -86,7 +73,7 @@ void ttkOFFWriter::WriteData() {
       }
     }
 
-    Stream << endl;
+    Stream << std::endl;
   }
 
   for(vtkIdType i = 0; i < dataSet->GetNumberOfCells(); i++) {
@@ -106,7 +93,7 @@ void ttkOFFWriter::WriteData() {
       }
     }
 
-    Stream << endl;
+    Stream << std::endl;
   }
 }
 

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.h
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.h
@@ -9,25 +9,22 @@
 #pragma once
 
 #include <vtkDataSetWriter.h>
-#include <vtkPoints.h>
-#include <vtkSmartPointer.h>
 
 #include <ttkOFFWriterModule.h>
 
-#include <iostream>
-#include <string>
-#include <vector>
+#include <fstream>
 
 class TTKOFFWRITER_EXPORT ttkOFFWriter : public vtkDataSetWriter {
 
 public:
   vtkTypeMacro(ttkOFFWriter, vtkDataSetWriter);
-  void PrintSelf(ostream &os, vtkIndent indent) override;
 
   static ttkOFFWriter *New();
 
+  void PrintSelf(std::ostream &os, vtkIndent indent) override;
+
   // Description:
-  // Specify file name of the .abc file.
+  // Specify file name of the .off file.
   vtkSetStringMacro(Filename);
   vtkGetStringMacro(Filename);
 
@@ -38,7 +35,7 @@ protected:
   int OpenFile();
   virtual void WriteData() override;
 
-  char *Filename;
+  char *Filename{};
   std::ofstream Stream{};
 
 private:

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.h
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.h
@@ -10,11 +10,13 @@
 
 #include <vtkDataSetWriter.h>
 
+#include <Debug.h>
 #include <ttkOFFWriterModule.h>
 
 #include <fstream>
 
-class TTKOFFWRITER_EXPORT ttkOFFWriter : public vtkDataSetWriter {
+class TTKOFFWRITER_EXPORT ttkOFFWriter : public vtkDataSetWriter,
+                                         protected ttk::Debug {
 
 public:
   vtkTypeMacro(ttkOFFWriter, vtkDataSetWriter);


### PR DESCRIPTION
This PR migrates the OBJWriter, the OFFWriter and the OFFReader modules to the new log API (with a new dependency to the common library).

The modules were also cleaned: some class members have been demoted to local variables, some useless includes have been removed.

No change has been observed to the written OBJ and OFF files.

Enjoy,
Pierre