### PR TITLE
Remove persistenceDiagram dependency when unused

### DIFF
--- a/core/base/auction/Auction.h
+++ b/core/base/auction/Auction.h
@@ -25,7 +25,6 @@
 #include <AuctionActor.h>
 #include <Debug.h>
 #include <KDTree.h>
-#include <PersistenceDiagram.h>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -36,9 +35,9 @@
 namespace ttk {
   template <typename dataType>
   struct Compare {
-    constexpr bool operator()(std::pair<int, dataType> const &a,
-                              std::pair<int, dataType> const &b) const
-      noexcept {
+    constexpr bool
+      operator()(std::pair<int, dataType> const &a,
+                 std::pair<int, dataType> const &b) const noexcept {
       return a.second > b.second;
     }
   };

--- a/core/base/auction/AuctionActor.cpp
+++ b/core/base/auction/AuctionActor.cpp
@@ -1,1 +1,1 @@
-#include "AuctioActor.h"
+#include "AuctionActor.h"

--- a/core/base/auction/AuctionActor.h
+++ b/core/base/auction/AuctionActor.h
@@ -3,11 +3,11 @@
 
 #include <Debug.h>
 #include <KDTree.h>
-#include <PersistenceDiagram.h>
 #include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <queue>
 
 namespace ttk {
   template <typename dataType>

--- a/core/base/auction/CMakeLists.txt
+++ b/core/base/auction/CMakeLists.txt
@@ -1,5 +1,4 @@
 ttk_add_base_library(auction
-
   SOURCES Auction.cpp
   HEADERS Auction.h AuctionImpl.h AuctionActor.h
-  DEPENDS triangulation persistenceDiagram kdTree)
+  DEPENDS triangulation kdTree)

--- a/core/base/bottleneckDistance/BottleneckDistance.h
+++ b/core/base/bottleneckDistance/BottleneckDistance.h
@@ -25,7 +25,6 @@
 // base code includes
 #include <GabowTarjan.h>
 #include <Munkres.h>
-#include <PersistenceDiagram.h>
 #include <Triangulation.h>
 
 #include <functional>

--- a/core/base/bottleneckDistance/CMakeLists.txt
+++ b/core/base/bottleneckDistance/CMakeLists.txt
@@ -11,5 +11,4 @@ ttk_add_base_library(bottleneckDistance
     MatchingGraph.h
   DEPENDS
     triangulation
-    persistenceDiagram
     )

--- a/core/base/bottleneckDistance/Munkres.h
+++ b/core/base/bottleneckDistance/Munkres.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <Debug.h>
-#include <PersistenceDiagram.h>
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/core/base/persistenceDiagramClustering/CMakeLists.txt
+++ b/core/base/persistenceDiagramClustering/CMakeLists.txt
@@ -8,7 +8,5 @@ ttk_add_base_library(persistenceDiagramClustering
   DEPENDS
     common
     auction
-    persistenceDiagram
-    bottleneckDistance
     kdTree
   )

--- a/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
@@ -20,11 +20,10 @@
 #define BSaddle1 ttk::CriticalType::Saddle1
 #define BSaddle2 ttk::CriticalType::Saddle2
 
-#include <BottleneckDistance.h>
-//
-#include <stdlib.h> /* srand, rand */
+#include <cstdlib> /* srand, rand */
 //
 #include <cmath>
+#include <numeric>
 
 using namespace ttk;
 

--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -21,7 +21,10 @@
 //
 #include <array>
 #include <limits>
-//
+
+#ifdef _WIN32
+#include <ciso646>
+#endif
 
 #include <PDBarycenter.h>
 

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
@@ -33,8 +33,6 @@
 // base code includes
 #include <Wrapper.h>
 //
-#include <PersistenceDiagram.h>
-//
 #include <Auction.h>
 //
 #include <KDTree.h>

--- a/core/base/persistenceDiagramDistanceMatrix/CMakeLists.txt
+++ b/core/base/persistenceDiagramDistanceMatrix/CMakeLists.txt
@@ -6,5 +6,4 @@ ttk_add_base_library(persistenceDiagramDistanceMatrix
   DEPENDS
     common
     auction
-    persistenceDiagram
   )

--- a/core/base/topologicalCompression/CMakeLists.txt
+++ b/core/base/topologicalCompression/CMakeLists.txt
@@ -7,8 +7,8 @@ ttk_add_base_library(topologicalCompression
     OtherCompression.h
   DEPENDS
     triangulation
-    persistenceDiagram
     topologicalSimplification
+    ftmTreePP
   OPTIONAL_DEPENDS
     zfp::zfp
     ZLIB::ZLIB
@@ -21,4 +21,3 @@ endif()
 if(TTK_ENABLE_ZFP)
   target_compile_definitions(topologicalCompression PUBLIC TTK_ENABLE_ZFP)
 endif()
-

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -15,12 +15,10 @@
 
 // base code includes
 #include <FTMTreePP.h>
-#include <PersistenceDiagram.h>
 #include <TopologicalSimplification.h>
 #include <Triangulation.h>
 
 // std
-
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>

--- a/core/base/trackingFromPersistenceDiagrams/CMakeLists.txt
+++ b/core/base/trackingFromPersistenceDiagrams/CMakeLists.txt
@@ -4,5 +4,5 @@ ttk_add_base_library(trackingFromPersistenceDiagrams
   HEADERS
     TrackingFromPersistenceDiagrams.h
   DEPENDS
-    persistenceDiagram bottleneckDistance
+    bottleneckDistance
     )

--- a/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
+++ b/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
@@ -8,8 +8,9 @@
 
 // base code includes
 #include <BottleneckDistance.h>
-#include <PersistenceDiagram.h>
 #include <Wrapper.h>
+
+#include <set>
 
 namespace ttk {
 

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -129,7 +129,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField)),
       *static_cast<TTK_TT *>(triangulation->getData())));
 
-  for(SimplexId i = 0; i < vertexNumber; ++i)
+  for(ttk::SimplexId i = 0; i < vertexNumber; ++i)
     outputOffsetField->SetTuple1(i, this->compressedOffsets_[i]);
 
   output->GetPointData()->AddArray(outputScalarField);


### PR DESCRIPTION
Several TTK base modules declare persistenceDiagram as a dependency although they don't use it in practice.

This PR removes these unused dependencies. This should lead to faster build time, given that for the corresponding compilation units, the compiler doesn't have to parse the PersistenceDiagram header (and the included MorseSmaleComplex/DiscreteGradient headers).

No change has been observed in the ttk-data states that could have been impacted.

Enjoy,
Pierre