### PR TITLE
[api-migration-hackathon] WRLExporter

### DIFF
--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -1,19 +1,41 @@
-#include <ttkWRLExporter.h>
+// VTK includes
+#include <vtkActor.h>
+#include <vtkActorCollection.h>
+#include <vtkAssemblyPath.h>
+#include <vtkCamera.h>
+#include <vtkCellArray.h>
+#include <vtkCompositeDataGeometryFilter.h>
+#include <vtkDataArray.h>
+#include <vtkDataObject.h>
+#include <vtkGeometryFilter.h>
+#include <vtkLightCollection.h>
+#include <vtkMapper.h>
+#include <vtkMath.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPoints.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderer.h>
+#include <vtkRendererCollection.h>
+#include <vtkSmartPointer.h>
+#include <vtkTransform.h>
+#include <vtkUnsignedCharArray.h>
+#include <vtkVRMLExporter.h>
 
-using namespace std;
-using namespace ttk;
+// base code includes
+#include <Debug.h>
+
+#include <ttkWRLExporter.h>
 
 vtkPolyData *ttkWRLExporterPolyData_ = nullptr;
 
 // Over-ride the appropriate functions of the vtkVRMLExporter class.
 void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
 
-  {
-    ttk::Debug debugInfo;
-    stringstream msg;
-    msg << "[ttkWRLExporter] Using TTK fix for VRML export..." << endl;
-    debugInfo.dMsg(cout, msg.str(), 2);
-  }
+  ttk::Debug debugInfo;
+  debugInfo.setDebugMsgPrefix("WRLExporter");
+  debugInfo.printWrn("Using TTK fix for VRML export...");
 
   vtkSmartPointer<vtkPolyData> pd;
   vtkPointData *pntData;

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.h
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.h
@@ -6,37 +6,7 @@
 /// \brief TTK helper that fixes a few bugs in the texture support for the VRML
 /// export.
 
-#ifndef _TTK_WRL_EXPORTER_H
-#define _TTK_WRL_EXPORTER_H
+#pragma once
 
-// VTK includes
-#include <vtkActor.h>
-#include <vtkActorCollection.h>
-#include <vtkAssemblyPath.h>
-#include <vtkCamera.h>
-#include <vtkCellArray.h>
-#include <vtkCompositeDataGeometryFilter.h>
-#include <vtkDataArray.h>
-#include <vtkDataObject.h>
-#include <vtkGeometryFilter.h>
-#include <vtkLightCollection.h>
-#include <vtkMapper.h>
-#include <vtkMath.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkPoints.h>
-#include <vtkPolyDataMapper.h>
-#include <vtkRenderWindow.h>
-#include <vtkRenderer.h>
-#include <vtkRendererCollection.h>
-#include <vtkSmartPointer.h>
-#include <vtkTransform.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkVRMLExporter.h>
-
-// base code includes
-#include <Debug.h>
-
+class vtkPolyData;
 extern vtkPolyData *wrlExporterPolyData_;
-
-#endif // _TTK_WRL_EXPORTER_H


### PR DESCRIPTION
This PR migrates the WRLExporter module to the new log API.

No state in ttk-data should be impacted.

Enjoy,
Pierre