### PR TITLE
Harden linker flags

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -36,7 +36,7 @@ function(ttk_add_base_library library)
       endif()
     endforeach()
   endif()
- 
+
   ttk_set_compile_options(${library})
 
   install(TARGETS ${library}
@@ -130,6 +130,11 @@ function(ttk_set_compile_options library)
 
   # compilation flags
   target_compile_options(${library} PRIVATE ${TTK_COMPILER_FLAGS})
+
+  # linker flags
+  if(NOT MSVC)
+    target_link_options(${library} PRIVATE ${TTK_LINKER_FLAGS})
+  endif()
 
   if (TTK_ENABLE_KAMIKAZE)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_KAMIKAZE)

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -132,7 +132,7 @@ function(ttk_set_compile_options library)
   target_compile_options(${library} PRIVATE ${TTK_COMPILER_FLAGS})
 
   # linker flags
-  if(NOT MSVC)
+  if(TTK_LINKER_FLAGS)
     target_link_options(${library} PRIVATE ${TTK_LINKER_FLAGS})
   endif()
 

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -16,10 +16,12 @@ if (NOT MSVC) # GCC and Clang
   endif()
 
   # hardened linker flags for Clang and GCC
-  list(APPEND TTK_LINKER_FLAGS
-    -Wl,--as-needed
-    -Wl,--no-undefined
-    )
+  if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    list(APPEND TTK_LINKER_FLAGS
+      -Wl,--as-needed
+      -Wl,--no-undefined
+      )
+  endif()
 
 else() # MSVC
 

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -15,6 +15,12 @@ if (NOT MSVC) # GCC and Clang
     list(APPEND TTK_COMPILER_FLAGS -O0 -g -pg)
   endif()
 
+  # hardened linker flags for Clang and GCC
+  list(APPEND TTK_LINKER_FLAGS
+    -Wl,--as-needed
+    -Wl,--no-undefined
+    )
+
 else() # MSVC
 
   # warning flags

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -50,7 +50,7 @@ macro(ttk_add_vtk_module)
       vtk_module_definitions(${TTK_NAME} PRIVATE TTK_ENABLE_DOUBLE_TEMPLATING)
     endif()
 
-    if(NOT MSVC)
+    if(TTK_LINKER_FLAGS)
       vtk_module_link_options(${TTK_NAME} PRIVATE ${TTK_LINKER_FLAGS})
     endif()
 

--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -45,8 +45,13 @@ macro(ttk_add_vtk_module)
         ${TTK_DEPENDS}
       )
 
+
     if(TTK_ENABLE_DOUBLE_TEMPLATING)
       vtk_module_definitions(${TTK_NAME} PRIVATE TTK_ENABLE_DOUBLE_TEMPLATING)
+    endif()
+
+    if(NOT MSVC)
+      vtk_module_link_options(${TTK_NAME} PRIVATE ${TTK_LINKER_FLAGS})
     endif()
 
     install(

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -17,3 +17,4 @@ install(
   )
 
 target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_PREFIX}/share/scripts/ttk)
+target_link_libraries(dimensionReduction PRIVATE ${PYTHON_LIBRARY})


### PR DESCRIPTION
Since I began to play with explicit template instantiations (in particular in MorseSmaleComplex) to factor compile times and in order to eliminate `symbol lookup` run-time errors, this PR adds these two linker flags:

- `no-undefined` will return error at link time when symbols are missing, typically when the VTK layer calls a missing explicit template instantiation in the base layer,
- `as-needed` should reduce the linked library size by only linking to what is currently used.

At this moment, these flags are only applicable for GCC (ld.bfd and ld.gold) and Clang (ld.lld). I am not (yet) aware of similar flags for the MSVC linker, thus the `if(not MSVC)` everywhere.

Enjoy,
Pierre

