### PR TITLE
Add ttk prefix to paraview proxy names

### DIFF
--- a/paraview/ArrayEditor/ArrayEditor.xml
+++ b/paraview/ArrayEditor/ArrayEditor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="ArrayEditor" class="ttkArrayEditor" label="TTK ArrayEditor">
+        <SourceProxy name="ttkArrayEditor" class="ttkArrayEditor" label="TTK ArrayEditor">
             <Documentation long_help="TTK ArrayEditor" short_help="TTK ArrayEditor">This filter adds data arrays to a 'vtkDataObject' (called target) based on a string or point/cell/field data of an optional second 'vtkDataObject' (called source). This filter can also be used to directly edit an array (including renaming, type conversion, and reindexing).</Documentation>
             <!-- Inputs -->
             <InputProperty name="Target" port_index="0" command="SetInputConnection">

--- a/paraview/BarycentricSubdivision/BarycentricSubdivision.xml
+++ b/paraview/BarycentricSubdivision/BarycentricSubdivision.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="BarycentricSubdivision"
+     name="ttkBarycentricSubdivision"
      class="ttkBarycentricSubdivision"
      label="TTK BarycentricSubdivision">
      <Documentation

--- a/paraview/Blank/Blank.xml
+++ b/paraview/Blank/Blank.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="Blank"
+     name="ttkBlank"
      class="ttkBlank"
      label="TTK Blank">
      <Documentation

--- a/paraview/BlockAggregator/BlockAggregator.xml
+++ b/paraview/BlockAggregator/BlockAggregator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="BlockAggregator" class="ttkBlockAggregator" label="TTK BlockAggregator">
+        <SourceProxy name="ttkBlockAggregator" class="ttkBlockAggregator" label="TTK BlockAggregator">
             <Documentation long_help="ttkBlockAggregator" short_help="ttkBlockAggregator">
             This filter appends every input vtkDataObject as a block to an output vtkMultiBlockDataSet.
             </Documentation>

--- a/paraview/BottleneckDistance/BottleneckDistance.xml
+++ b/paraview/BottleneckDistance/BottleneckDistance.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-    name="BottleneckDistance"
+    name="ttkBottleneckDistance"
     class="ttkBottleneckDistance"
     label="TTK BottleneckDistance"
     >

--- a/paraview/CinemaImaging/CinemaImaging.xml
+++ b/paraview/CinemaImaging/CinemaImaging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="CinemaImaging" class="ttkCinemaImaging" label="TTK CinemaImaging">
+        <SourceProxy name="ttkCinemaImaging" class="ttkCinemaImaging" label="TTK CinemaImaging">
             <Documentation long_help="TTK CinemaImaging" short_help="TTK CinemaImaging">This filter takes images of a vtkDataObject (first input) from angles specified on a vtkPointSet (second input). Each image will be a block of a vtkMultiBlockDataSet where block order corresponds to point order. Each sample point can optionally have vtkDoubleArrays to override the default rendering parameters, i.e, the resolution, camera direction, clipping planes, and viewport height.</Documentation>
 
             <!-- Inputs -->

--- a/paraview/CinemaProductReader/CinemaProductReader.xml
+++ b/paraview/CinemaProductReader/CinemaProductReader.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="CinemaProductReader" class="ttkCinemaProductReader" label="TTK CinemaProductReader">
+        <SourceProxy name="ttkCinemaProductReader" class="ttkCinemaProductReader" label="TTK CinemaProductReader">
             <Documentation long_help="TTK CinemaProductReader" short_help="TTK CinemaProductReader">This filter reads the products that are referenced in a vtkTable. The results are stored in a vtkMultiBlockDataSet where each block corresponds to a row of the table with consistent ordering.</Documentation>
 
             <InputProperty name="Input" command="SetInputConnection">

--- a/paraview/CinemaQuery/CinemaQuery.xml
+++ b/paraview/CinemaQuery/CinemaQuery.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="CinemaQuery" class="ttkCinemaQuery" label="TTK CinemaQuery">
+        <SourceProxy name="ttkCinemaQuery" class="ttkCinemaQuery" label="TTK CinemaQuery">
             <Documentation long_help="TTK CinemaQuery" short_help="TTK CinemaQuery">This filter evaluates a SQL statement on multiple InputTables.</Documentation>
 
             <InputProperty clean_command="RemoveAllInputs" name="InputTable" command="AddInputConnection" multiple_input="1">

--- a/paraview/CinemaReader/CinemaReader.xml
+++ b/paraview/CinemaReader/CinemaReader.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="sources">
-        <SourceProxy name="CinemaReader" class="ttkCinemaReader" label="TTK CinemaReader">
+        <SourceProxy name="ttkCinemaReader" class="ttkCinemaReader" label="TTK CinemaReader">
             <Documentation long_help="TTK CinemaReader" short_help="TTK CinemaReader">
                 This source reads the content of a Cinema Spec D database by converting the corresponding data.csv file into a vtkTable.
             </Documentation>

--- a/paraview/CinemaWriter/CinemaWriter.xml
+++ b/paraview/CinemaWriter/CinemaWriter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="CinemaWriter" class="ttkCinemaWriter" label="TTK CinemaWriter">
+        <SourceProxy name="ttkCinemaWriter" class="ttkCinemaWriter" label="TTK CinemaWriter">
             <Documentation long_help="ttkCinemaWriter" short_help="ttkCinemaWriter">
 This filter stores a data product in a Cinema database, and then returns the unmodified input as output.
 

--- a/paraview/Compatibility/Compatibility.xml
+++ b/paraview/Compatibility/Compatibility.xml
@@ -1,0 +1,838 @@
+<ServerManagerConfiguration>
+    <ProxyGroup name="filters">
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkBlank" 
+            class="ttkBlank" 
+            name="Blank" 
+            label="TTK Blank (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkBlank instead of Blank.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkBlockAggregator" 
+            class="ttkBlockAggregator" 
+            name="BlockAggregator" 
+            label="TTK BlockAggregator (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkBlockAggregator instead of BlockAggregator.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkBottleneckDistance" 
+            class="ttkBottleneckDistance" 
+            name="BottleneckDistance" 
+            label="TTK BottleneckDistance (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkBottleneckDistance instead of BottleneckDistance.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkCinemaImaging" 
+            class="ttkCinemaImaging" 
+            name="CinemaImaging" 
+            label="TTK CinemaImaging (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkCinemaImaging instead of CinemaImaging.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkCinemaProductReader" 
+            class="ttkCinemaProductReader" 
+            name="CinemaProductReader" 
+            label="TTK CinemaProductReader (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkCinemaProductReader instead of CinemaProductReader.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkCinemaQuery" 
+            class="ttkCinemaQuery" 
+            name="CinemaQuery" 
+            label="TTK CinemaQuery (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkCinemaQuery instead of CinemaQuery.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkCinemaWriter" 
+            class="ttkCinemaWriter" 
+            name="CinemaWriter" 
+            label="TTK CinemaWriter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkCinemaWriter instead of CinemaWriter.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkComponentSize" 
+            class="ttkComponentSize" 
+            name="ComponentSize" 
+            label="TTK ComponentSize (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkComponentSize instead of ComponentSize.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkContinuousScatterPlot" 
+            class="ttkContinuousScatterPlot" 
+            name="ContinuousScatterPlot" 
+            label="TTK ContinuousScatterPlot (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkContinuousScatterPlot instead of ContinuousScatterPlot.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDataSetInterpolator" 
+            class="ttkDataSetInterpolator" 
+            name="DataSetInterpolator" 
+            label="TTK DataSetInterpolator (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDataSetInterpolator instead of DataSetInterpolator.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDataSetToTable" 
+            class="ttkDataSetToTable" 
+            name="DataSetToTable" 
+            label="TTK DataSetToTable (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDataSetToTable instead of DataSetToTable.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDepthImageBasedGeometryApproximation" 
+            class="ttkDepthImageBasedGeometryApproximation" 
+            name="DepthImageBasedGeometryApproximation" 
+            label="TTK DepthImageBasedGeometryApproximation (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDepthImageBasedGeometryApproximation instead of DepthImageBasedGeometryApproximation.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDimensionReduction" 
+            class="ttkDimensionReduction" 
+            name="DimensionReduction" 
+            label="TTK DimensionReduction (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDimensionReduction instead of DimensionReduction.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDiscreteGradient" 
+            class="ttkDiscreteGradient" 
+            name="DiscreteGradient" 
+            label="TTK DiscreteGradient (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDiscreteGradient instead of DiscreteGradient.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkDistanceField" 
+            class="ttkDistanceField" 
+            name="DistanceField" 
+            label="TTK DistanceField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkDistanceField instead of DistanceField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkEndFor" 
+            class="ttkEndFor" 
+            name="EndFor" 
+            label="TTK EndFor (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkEndFor instead of EndFor.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkftmtree" 
+            class="ttkFTMTree" 
+            name="ftmtree" 
+            label="TTK Merge and Contour Tree (FTM) (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkftmtree instead of ftmtree.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkFiber" 
+            class="ttkFiber" 
+            name="Fiber" 
+            label="TTK Fiber (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkFiber instead of Fiber.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkFiberSurface" 
+            class="ttkFiberSurface" 
+            name="FiberSurface" 
+            label="TTK FiberSurface (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkFiberSurface instead of FiberSurface.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkGeometrySmoother" 
+            class="ttkGeometrySmoother" 
+            name="GeometrySmoother" 
+            label="TTK GeometrySmoother (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkGeometrySmoother instead of GeometrySmoother.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIdentifierRandomizer" 
+            class="ttkIdentifierRandomizer" 
+            name="IdentifierRandomizer" 
+            label="TTK IdentifierRandomizer (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIdentifierRandomizer instead of IdentifierRandomizer.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIdentifiers" 
+            class="ttkIdentifiers" 
+            name="Identifiers" 
+            label="TTK Identifiers (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIdentifiers instead of Identifiers.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIdentifyByScalarField" 
+            class="ttkIdentifyByScalarField" 
+            name="IdentifyByScalarField" 
+            label="TTK IdentifyByScalarField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIdentifyByScalarField instead of IdentifyByScalarField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkImportEmbeddingFromTable" 
+            class="ttkImportEmbeddingFromTable" 
+            name="ImportEmbeddingFromTable" 
+            label="TTK ImportEmbeddingFromTable (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkImportEmbeddingFromTable instead of ImportEmbeddingFromTable.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIntegralLines" 
+            class="ttkIntegralLines" 
+            name="IntegralLines" 
+            label="TTK IntegralLines (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIntegralLines instead of IntegralLines.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkJacobiSet" 
+            class="ttkJacobiSet" 
+            name="JacobiSet" 
+            label="TTK JacobiSet (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkJacobiSet instead of JacobiSet.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkLDistance" 
+            class="ttkLDistance" 
+            name="LDistance" 
+            label="TTK LDistance (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkLDistance instead of LDistance.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMandatoryCriticalPoints" 
+            class="ttkMandatoryCriticalPoints" 
+            name="MandatoryCriticalPoints" 
+            label="TTK MandatoryCriticalPoints (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMandatoryCriticalPoints instead of MandatoryCriticalPoints.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkManifoldCheck" 
+            class="ttkManifoldCheck" 
+            name="ManifoldCheck" 
+            label="TTK ManifoldCheck (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkManifoldCheck instead of ManifoldCheck.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMeshGraph" 
+            class="ttkMeshGraph" 
+            name="MeshGraph" 
+            label="TTK MeshGraph (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMeshGraph instead of MeshGraph.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMeshSubdivision" 
+            class="ttkMeshSubdivision" 
+            name="MeshSubdivision" 
+            label="TTK MeshSubdivision (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMeshSubdivision instead of MeshSubdivision.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMorseSmaleComplex" 
+            class="ttkMorseSmaleComplex" 
+            name="MorseSmaleComplex" 
+            label="TTK MorseSmaleComplex (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMorseSmaleComplex instead of MorseSmaleComplex.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPersistenceCurve" 
+            class="ttkPersistenceCurve" 
+            name="PersistenceCurve" 
+            label="TTK PersistenceCurve (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPersistenceCurve instead of PersistenceCurve.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPersistenceDiagram" 
+            class="ttkPersistenceDiagram" 
+            name="PersistenceDiagram" 
+            label="TTK PersistenceDiagram (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPersistenceDiagram instead of PersistenceDiagram.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPlanarGraphLayout" 
+            class="ttkPlanarGraphLayout" 
+            name="PlanarGraphLayout" 
+            label="TTK PlanarGraphLayout (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPlanarGraphLayout instead of PlanarGraphLayout.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPointDataConverter" 
+            class="ttkPointDataConverter" 
+            name="PointDataConverter" 
+            label="TTK PointDataConverter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPointDataConverter instead of PointDataConverter.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPointDataSelector" 
+            class="ttkPointDataSelector" 
+            name="PointDataSelector" 
+            label="TTK PointDataSelector (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPointDataSelector instead of PointDataSelector.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPointMerger" 
+            class="ttkPointMerger" 
+            name="PointMerger" 
+            label="TTK PointMerger (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPointMerger instead of PointMerger.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkProjectionFromField" 
+            class="ttkProjectionFromField" 
+            name="ProjectionFromField" 
+            label="TTK ProjectionFromField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkProjectionFromField instead of ProjectionFromField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkRangePolygon" 
+            class="ttkRangePolygon" 
+            name="RangePolygon" 
+            label="TTK RangePolygon (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkRangePolygon instead of RangePolygon.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkReebSpace" 
+            class="ttkReebSpace" 
+            name="ReebSpace" 
+            label="TTK ReebSpace (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkReebSpace instead of ReebSpace.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkScalarFieldCriticalPoints" 
+            class="ttkScalarFieldCriticalPoints" 
+            name="ScalarFieldCriticalPoints" 
+            label="TTK ScalarFieldCriticalPoints (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkScalarFieldCriticalPoints instead of ScalarFieldCriticalPoints.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkScalarFieldNormalizer" 
+            class="ttkScalarFieldNormalizer" 
+            name="ScalarFieldNormalizer" 
+            label="TTK ScalarFieldNormalizer (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkScalarFieldNormalizer instead of ScalarFieldNormalizer.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkScalarFieldSmoother" 
+            class="ttkScalarFieldSmoother" 
+            name="ScalarFieldSmoother" 
+            label="TTK ScalarFieldSmoother (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkScalarFieldSmoother instead of ScalarFieldSmoother.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkSphereFromPoint" 
+            class="ttkSphereFromPoint" 
+            name="SphereFromPoint" 
+            label="TTK SphereFromPoint (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkSphereFromPoint instead of SphereFromPoint.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTableDataSelector" 
+            class="ttkTableDataSelector" 
+            name="TableDataSelector" 
+            label="TTK TableDataSelector (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTableDataSelector instead of TableDataSelector.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTextureMapFromField" 
+            class="ttkTextureMapFromField" 
+            name="TextureMapFromField" 
+            label="TTK TextureMapFromField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTextureMapFromField instead of TextureMapFromField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTopologicalCompression" 
+            class="ttkTopologicalCompression" 
+            name="TopologicalCompression" 
+            label="TTK TopologicalCompression (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTopologicalCompression instead of TopologicalCompression.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTopologicalSimplification" 
+            class="ttkTopologicalSimplification" 
+            name="TopologicalSimplification" 
+            label="TTK TopologicalSimplification (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTopologicalSimplification instead of TopologicalSimplification.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTrackingFromFields" 
+            class="ttkTrackingFromFields" 
+            name="TrackingFromFields" 
+            label="TTK TrackingFromFields (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTrackingFromFields instead of TrackingFromFields.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTrackingFromOverlap" 
+            class="ttkTrackingFromOverlap" 
+            name="TrackingFromOverlap" 
+            label="TTK TrackingFromOverlap (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTrackingFromOverlap instead of TrackingFromOverlap.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTrackingFromPersistenceDiagrams" 
+            class="ttkTrackingFromPersistenceDiagrams" 
+            name="TrackingFromPersistenceDiagrams" 
+            label="TTK TrackingFromPersistenceDiagrams (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTrackingFromPersistenceDiagrams instead of TrackingFromPersistenceDiagrams.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkTriangulationRequest" 
+            class="ttkTriangulationRequest" 
+            name="TriangulationRequest" 
+            label="TTK TriangulationRequest (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTriangulationRequest instead of TriangulationRequest.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkUncertainDataEstimator" 
+            class="ttkUncertainDataEstimator" 
+            name="UncertainDataEstimator" 
+            label="TTK UncertainDataEstimator (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkUncertainDataEstimator instead of UncertainDataEstimator.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkArrayEditor" 
+            class="ttkArrayEditor" 
+            name="ArrayEditor" 
+            label="TTK ArrayEditor (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkArrayEditor instead of ArrayEditor.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkBarycentricSubdivision" 
+            class="ttkBarycentricSubdivision" 
+            name="BarycentricSubdivision" 
+            label="TTK BarycentricSubdivision (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkBarycentricSubdivision instead of BarycentricSubdivision.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkContourAroundPoint" 
+            class="ttkContourAroundPoint" 
+            name="ContourAroundPoint" 
+            label="TTK ContourAroundPoint (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkContourAroundPoint instead of ContourAroundPoint.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkEigenField" 
+            class="ttkEigenField" 
+            name="EigenField" 
+            label="TTK EigenField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkEigenField instead of EigenField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkExtract" 
+            class="ttkExtract" 
+            name="Extract" 
+            label="TTK Extract (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkExtract instead of Extract.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkFTRGraph" 
+            class="ttkFTRGraph" 
+            name="FTRGraph" 
+            label="TTK Reeb graph (FTR) (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkFTRGraph instead of FTRGraph.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkForEach" 
+            class="ttkForEach" 
+            name="ForEach" 
+            label="TTK ForEach (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkForEach instead of ForEach.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkGridLayout" 
+            class="ttkGridLayout" 
+            name="GridLayout" 
+            label="TTK GridLayout (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkGridLayout instead of GridLayout.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkHarmonicField" 
+            class="ttkHarmonicField" 
+            name="HarmonicField" 
+            label="TTK HarmonicField (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkHarmonicField instead of HarmonicField.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkHelloWorld" 
+            class="ttkHelloWorld" 
+            name="HelloWorld" 
+            label="TTK HelloWorld (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkHelloWorld instead of HelloWorld.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkLDistanceMatrix" 
+            class="ttkLDistanceMatrix" 
+            name="LDistanceMatrix" 
+            label="TTK LDistanceMatrix (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkLDistanceMatrix instead of LDistanceMatrix.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMatrixToHeatMap" 
+            class="ttkMatrixToHeatMap" 
+            name="MatrixToHeatMap" 
+            label="TTK MatrixToHeatMap (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMatrixToHeatMap instead of MatrixToHeatMap.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkMorseSmaleQuadrangulation" 
+            class="ttkMorseSmaleQuadrangulation" 
+            name="MorseSmaleQuadrangulation" 
+            label="TTK MorseSmaleQuadrangulation (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkMorseSmaleQuadrangulation instead of MorseSmaleQuadrangulation.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPeriodicGrid" 
+            class="ttkPeriodicGrid" 
+            name="PeriodicGrid" 
+            label="TTK PeriodicGrid (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPeriodicGrid instead of PeriodicGrid.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPersistenceDiagramClustering" 
+            class="ttkPersistenceDiagramClustering" 
+            name="PersistenceDiagramClustering" 
+            label="TTK PersistenceDiagramClustering (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPersistenceDiagramClustering instead of PersistenceDiagramClustering.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPersistenceDiagramDistanceMatrix" 
+            class="ttkPersistenceDiagramDistanceMatrix" 
+            name="PersistenceDiagramDistanceMatrix" 
+            label="TTK PersistenceDiagramDistanceMatrix (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPersistenceDiagramDistanceMatrix instead of PersistenceDiagramDistanceMatrix.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkPointSetToCurve" 
+            class="ttkPointSetToCurve" 
+            name="PointSetToCurve" 
+            label="TTK PointSetToCurve (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkPointSetToCurve instead of PointSetToCurve.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkQuadrangulationSubdivision" 
+            class="ttkQuadrangulationSubdivision" 
+            name="QuadrangulationSubdivision" 
+            label="TTK QuadrangulationSubdivision (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkQuadrangulationSubdivision instead of QuadrangulationSubdivision.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkStringArrayConverter" 
+            class="ttkStringArrayConverter" 
+            name="StringArrayConverter" 
+            label="TTK StringArrayConverter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkStringArrayConverter instead of StringArrayConverter.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIcosphereFromObject" 
+            class="ttkIcosphereFromObject" 
+            name="IcosphereFromObject" 
+            label="TTK IcosphereFromObject (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIcosphereFromObject instead of IcosphereFromObject.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="filters" 
+            base_proxyname="ttkIcospheresFromPoints" 
+            class="ttkIcospheresFromPoints" 
+            name="IcospheresFromPoints" 
+            label="TTK IcospheresFromPoints (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIcospheresFromPoints instead of IcospheresFromPoints.
+            </Deprecated>
+        </SourceProxy>
+    </ProxyGroup>
+    <ProxyGroup name="sources">
+        <SourceProxy 
+            base_proxygroup="sources" 
+            base_proxyname="ttkCinemaReader" 
+            class="ttkCinemaReader" 
+            name="CinemaReader" 
+            label="TTK CinemaReader (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkCinemaReader instead of CinemaReader.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="sources" 
+            base_proxyname="ttkOFFReader" 
+            class="ttkOFFReader" 
+            name="OFFReader" 
+            label="TTK OFFReader (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkOFFReader instead of OFFReader.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="sources" 
+            base_proxyname="ttkTopologicalCompressionReader" 
+            class="ttkTopologicalCompressionReader" 
+            name="TopologicalCompressionReader" 
+            label="TTK TTKTopologicalCompressionReader (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTopologicalCompressionReader instead of TopologicalCompressionReader.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="sources" 
+            base_proxyname="ttkGaussianPointCloud" 
+            class="ttkGaussianPointCloud" 
+            name="GaussianPointCloud" 
+            label="TTK GaussianPointCloud (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkGaussianPointCloud instead of GaussianPointCloud.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="sources" 
+            base_proxyname="ttkIcosphere" 
+            class="ttkIcosphere" 
+            name="Icosphere" 
+            label="TTK Icosphere (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkIcosphere instead of Icosphere.
+            </Deprecated>
+        </SourceProxy>
+    </ProxyGroup>
+    <ProxyGroup name="writers">
+        <SourceProxy 
+            base_proxygroup="writers" 
+            base_proxyname="ttkOBJWriter" 
+            class="ttkOBJWriter" 
+            name="OBJWriter" 
+            label="TTK OBJWriter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkOBJWriter instead of OBJWriter.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="writers" 
+            base_proxyname="ttkOFFWriter" 
+            class="ttkOFFWriter" 
+            name="OFFWriter" 
+            label="TTK OFFWriter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkOFFWriter instead of OFFWriter.
+            </Deprecated>
+        </SourceProxy>
+        <SourceProxy 
+            base_proxygroup="writers" 
+            base_proxyname="ttkTopologicalCompressionWriter" 
+            class="ttkTopologicalCompressionWriter" 
+            name="TopologicalCompressionWriter" 
+            label="TTK TTKTopologicalCompressionWriter (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use ttkTopologicalCompressionWriter instead of TopologicalCompressionWriter.
+            </Deprecated>
+        </SourceProxy>
+    </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/Compatibility/TTKFilter.cmake
+++ b/paraview/Compatibility/TTKFilter.cmake
@@ -1,0 +1,1 @@
+list(APPEND TTK_XMLS "${CMAKE_CURRENT_LIST_DIR}/Compatibility.xml")

--- a/paraview/ComponentSize/ComponentSize.xml
+++ b/paraview/ComponentSize/ComponentSize.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ComponentSize"
+     name="ttkComponentSize"
      class="ttkComponentSize"
      label="TTK ComponentSize">
      <Documentation

--- a/paraview/ContinuousScatterPlot/ContinuousScatterPlot.xml
+++ b/paraview/ContinuousScatterPlot/ContinuousScatterPlot.xml
@@ -2,7 +2,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-      name="ContinuousScatterPlot"
+      name="ttkContinuousScatterPlot"
       class="ttkContinuousScatterPlot"
       label="TTK ContinuousScatterPlot">
       <Documentation

--- a/paraview/ContourAroundPoint/ContourAroundPoint.xml
+++ b/paraview/ContourAroundPoint/ContourAroundPoint.xml
@@ -1,5 +1,5 @@
 <ServerManagerConfiguration><ProxyGroup name="filters"><SourceProxy
-  name="ContourAroundPoint"
+  name="ttkContourAroundPoint"
   class="ttkContourAroundPoint"
   label="TTK ContourAroundPoint">
   <Documentation

--- a/paraview/DataSetInterpolator/DataSetInterpolator.xml
+++ b/paraview/DataSetInterpolator/DataSetInterpolator.xml
@@ -6,7 +6,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="DataSetInterpolator"
+      name="ttkDataSetInterpolator"
       class="ttkDataSetInterpolator"
       label="TTK DataSetInterpolator">
       <Documentation

--- a/paraview/DataSetToTable/DataSetToTable.xml
+++ b/paraview/DataSetToTable/DataSetToTable.xml
@@ -5,7 +5,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="DataSetToTable"
+      name="ttkDataSetToTable"
       class="ttkDataSetToTable"
       label="TTK DataSetToTable">
       <Documentation

--- a/paraview/DepthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.xml
+++ b/paraview/DepthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="DepthImageBasedGeometryApproximation" class="ttkDepthImageBasedGeometryApproximation" label="TTK DepthImageBasedGeometryApproximation">
+        <SourceProxy name="ttkDepthImageBasedGeometryApproximation" class="ttkDepthImageBasedGeometryApproximation" label="TTK DepthImageBasedGeometryApproximation">
             <Documentation long_help="TTK depthImageBasedGeometryApproximation" short_help="TTK depthImageBasedGeometryApproximation">This filter approximates the geometry that is depicted by a set of depth images.
 
                 Related publication:

--- a/paraview/DimensionReduction/DimensionReduction.xml
+++ b/paraview/DimensionReduction/DimensionReduction.xml
@@ -6,7 +6,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="DimensionReduction"
+      name="ttkDimensionReduction"
       class="ttkDimensionReduction"
       label="TTK DimensionReduction">
       <Documentation

--- a/paraview/DiscreteGradient/DiscreteGradient.xml
+++ b/paraview/DiscreteGradient/DiscreteGradient.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="DiscreteGradient"
+      name="ttkDiscreteGradient"
       class="ttkDiscreteGradient"
       label="TTK DiscreteGradient">
       <Documentation

--- a/paraview/DistanceField/DistanceField.xml
+++ b/paraview/DistanceField/DistanceField.xml
@@ -2,7 +2,7 @@
 
   <ProxyGroup name="filters">
     <SourceProxy
-      name="DistanceField"
+      name="ttkDistanceField"
       class="ttkDistanceField"
       label="TTK DistanceField">
       <Documentation

--- a/paraview/EigenField/EigenField.xml
+++ b/paraview/EigenField/EigenField.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="EigenField"
+        name="ttkEigenField"
         class="ttkEigenField"
         label="TTK EigenField">
       <Documentation

--- a/paraview/EndFor/EndFor.xml
+++ b/paraview/EndFor/EndFor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="EndFor" class="ttkEndFor" label="TTK EndFor">
+        <SourceProxy name="ttkEndFor" class="ttkEndFor" label="TTK EndFor">
             <Documentation long_help="TTK EndFor" short_help="TTK EndFor">This filter requests more data as long as the maximum number of elements is not reached. This filter works in conjunction with the ttkForEachRow filter.</Documentation>
 
             <InputProperty name="Data" port_index="0" command="SetInputConnection">

--- a/paraview/Extract/Extract.xml
+++ b/paraview/Extract/Extract.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="Extract" class="ttkExtract" label="TTK Extract">
+        <SourceProxy name="ttkExtract" class="ttkExtract" label="TTK Extract">
             <Documentation long_help="TTK Extract" short_help="TTK Extract">
 This filter uses a list of values to extract either blocks of a 'vtkMultiBlockDataSet' by interpreting the values as block indices, or the subset of a 'vtkDataObject' whose point/cell values are contained in that list.
             </Documentation>

--- a/paraview/FTMTree/FTMTree.xml
+++ b/paraview/FTMTree/FTMTree.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
         <SourceProxy
-            name="ftmtree"
+            name="ttkftmtree"
             class="ttkFTMTree"
             label="TTK Merge and Contour Tree (FTM)">
             <Documentation

--- a/paraview/FTRGraph/FTRGraph.xml
+++ b/paraview/FTRGraph/FTRGraph.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
      <SourceProxy
-        name="FTRGraph"
+        name="ttkFTRGraph"
         class="ttkFTRGraph"
         label="TTK Reeb graph (FTR)">
         <Documentation

--- a/paraview/Fiber/Fiber.xml
+++ b/paraview/Fiber/Fiber.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="Fiber"
+     name="ttkFiber"
      class="ttkFiber"
      label="TTK Fiber">
      <Documentation

--- a/paraview/FiberSurface/FiberSurface.xml
+++ b/paraview/FiberSurface/FiberSurface.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="FiberSurface"
+     name="ttkFiberSurface"
      class="ttkFiberSurface"
      label="TTK FiberSurface">
      <Documentation

--- a/paraview/ForEach/ForEach.xml
+++ b/paraview/ForEach/ForEach.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="ForEach" class="ttkForEach" label="TTK ForEach">
+        <SourceProxy name="ttkForEach" class="ttkForEach" label="TTK ForEach">
             <Documentation long_help="TTK ForEach" short_help="TTK ForEach">This filter works in conjunction with the ttkEndFor filter to iterate over blocks, rows, array values, and arrays.</Documentation>
 
             <InputProperty name="Input" command="SetInputConnection">

--- a/paraview/GaussianPointCloud/GaussianPointCloud.xml
+++ b/paraview/GaussianPointCloud/GaussianPointCloud.xml
@@ -1,6 +1,6 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="sources">
-        <SourceProxy name="GaussianPointCloud" class="ttkGaussianPointCloud" label="TTK GaussianPointCloud">
+        <SourceProxy name="ttkGaussianPointCloud" class="ttkGaussianPointCloud" label="TTK GaussianPointCloud">
             <Documentation long_help="TTK GaussianPointCloud" short_help="TTK
 GaussianPointCloud">
               This module generates a 1D, 2D or 3D point cloud by randomly

--- a/paraview/GeometrySmoother/GeometrySmoother.xml
+++ b/paraview/GeometrySmoother/GeometrySmoother.xml
@@ -6,7 +6,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="GeometrySmoother"
+      name="ttkGeometrySmoother"
       class="ttkGeometrySmoother"
       label="TTK GeometrySmoother">
       <Documentation

--- a/paraview/GridLayout/GridLayout.xml
+++ b/paraview/GridLayout/GridLayout.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="GridLayout" class="ttkGridLayout" label="TTK GridLayout">
+        <SourceProxy name="ttkGridLayout" class="ttkGridLayout" label="TTK GridLayout">
             <Documentation long_help="TTK GridLayout plugin." short_help="TTK GridLayout plugin.">This filter computes a grid layout for the blocks of a vtkMultiBlockDataSet.</Documentation>
 
             <InputProperty name="Input" command="SetInputConnection">

--- a/paraview/HarmonicField/HarmonicField.xml
+++ b/paraview/HarmonicField/HarmonicField.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="HarmonicField"
+        name="ttkHarmonicField"
         class="ttkHarmonicField"
         label="TTK HarmonicField">
       <Documentation

--- a/paraview/HelloWorld/HelloWorld.xml
+++ b/paraview/HelloWorld/HelloWorld.xml
@@ -8,7 +8,7 @@
 
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="HelloWorld" class="ttkHelloWorld" label="TTK HelloWorld">
+        <SourceProxy name="ttkHelloWorld" class="ttkHelloWorld" label="TTK HelloWorld">
            <Documentation long_help="HelloWorld Long" short_help="HelloWorld Short">
                This filter is a well documented ttk example filter that computes for each vertex of a vtkDataSet the average scalar value of itself and its neighbors.
            </Documentation>

--- a/paraview/Icosphere/Icosphere.xml
+++ b/paraview/Icosphere/Icosphere.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="sources">
-        <SourceProxy name="Icosphere" class="ttkIcosphere" label="TTK Icosphere">
+        <SourceProxy name="ttkIcosphere" class="ttkIcosphere" label="TTK Icosphere">
             <Documentation long_help="TTK filter that creates an Icosphere" short_help="TTK filter that creates an Icosphere">
                 This filter creates an Icosphere with a specified radius, center, and number of subdivisions. Alternatively, by providing an optional input, the filter will automatically determine the radius and center such that the resulting Icosphere encapsulates the input object. In this case, the entered radius parameter is used as a scaling factor.
             </Documentation>

--- a/paraview/IcosphereFromObject/IcosphereFromObject.xml
+++ b/paraview/IcosphereFromObject/IcosphereFromObject.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="IcosphereFromObject" class="ttkIcosphereFromObject" label="TTK IcosphereFromObject">
+        <SourceProxy name="ttkIcosphereFromObject" class="ttkIcosphereFromObject" label="TTK IcosphereFromObject">
             <Documentation long_help="TTK filter that creates an IcosphereFromObject" short_help="TTK filter that creates an IcosphereFromObject">
                 This filter creates an IcosphereFromObject with a specified radius, center, and number of subdivisions. Alternatively, by providing an optional input, the filter will automatically determine the radius and center such that the resulting IcosphereFromObject encapsulates the input object. In this case, the entered radius parameter is used as a scaling factor.
             </Documentation>

--- a/paraview/IcospheresFromPoints/IcospheresFromPoints.xml
+++ b/paraview/IcospheresFromPoints/IcospheresFromPoints.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="IcospheresFromPoints" class="ttkIcospheresFromPoints" label="TTK IcospheresFromPoints">
+        <SourceProxy name="ttkIcospheresFromPoints" class="ttkIcospheresFromPoints" label="TTK IcospheresFromPoints">
             <Documentation long_help="TTK filter that creates an IcospheresFromPoints" short_help="TTK filter that creates an IcospheresFromPoints">
                 This filter creates for every vertex of an input vtkPointSet an IcoSphere with a specified number of subdivisions and radius.
             </Documentation>

--- a/paraview/IdentifierRandomizer/IdentifierRandomizer.xml
+++ b/paraview/IdentifierRandomizer/IdentifierRandomizer.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="IdentifierRandomizer"
+     name="ttkIdentifierRandomizer"
      class="ttkIdentifierRandomizer"
      label="TTK IdentifierRandomizer">
      <Documentation

--- a/paraview/Identifiers/Identifiers.xml
+++ b/paraview/Identifiers/Identifiers.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="Identifiers"
+     name="ttkIdentifiers"
      class="ttkIdentifiers"
      label="TTK Identifiers">
      <Documentation

--- a/paraview/IdentifyByScalarField/IdentifyByScalarField.xml
+++ b/paraview/IdentifyByScalarField/IdentifyByScalarField.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="IdentifyByScalarField"
+     name="ttkIdentifyByScalarField"
      class="ttkIdentifyByScalarField"
      label="TTK IdentifyByScalarField">
      <Documentation

--- a/paraview/ImportEmbeddingFromTable/ImportEmbeddingFromTable.xml
+++ b/paraview/ImportEmbeddingFromTable/ImportEmbeddingFromTable.xml
@@ -6,7 +6,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-            name="ImportEmbeddingFromTable"
+            name="ttkImportEmbeddingFromTable"
             class="ttkImportEmbeddingFromTable"
             label="TTK ImportEmbeddingFromTable">
       <Documentation

--- a/paraview/IntegralLines/IntegralLines.xml
+++ b/paraview/IntegralLines/IntegralLines.xml
@@ -2,7 +2,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-      name="IntegralLines"
+      name="ttkIntegralLines"
       class="ttkIntegralLines"
       label="TTK IntegralLines">
       <Documentation

--- a/paraview/JacobiSet/JacobiSet.xml
+++ b/paraview/JacobiSet/JacobiSet.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="JacobiSet"
+     name="ttkJacobiSet"
      class="ttkJacobiSet"
      label="TTK JacobiSet">
      <Documentation

--- a/paraview/LDistance/LDistance.xml
+++ b/paraview/LDistance/LDistance.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="LDistance"
+     name="ttkLDistance"
      class="ttkLDistance"
      label="TTK LDistance">
 

--- a/paraview/LDistanceMatrix/LDistanceMatrix.xml
+++ b/paraview/LDistanceMatrix/LDistanceMatrix.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
    <SourceProxy
-     name="LDistanceMatrix"
+     name="ttkLDistanceMatrix"
      class="ttkLDistanceMatrix"
      label="TTK LDistanceMatrix">
      <Documentation

--- a/paraview/MandatoryCriticalPoints/MandatoryCriticalPoints.xml
+++ b/paraview/MandatoryCriticalPoints/MandatoryCriticalPoints.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="MandatoryCriticalPoints"
+     name="ttkMandatoryCriticalPoints"
      class="ttkMandatoryCriticalPoints"
      label="TTK MandatoryCriticalPoints">
      <Documentation

--- a/paraview/ManifoldCheck/ManifoldCheck.xml
+++ b/paraview/ManifoldCheck/ManifoldCheck.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ManifoldCheck"
+     name="ttkManifoldCheck"
      class="ttkManifoldCheck"
      label="TTK ManifoldCheck">
      <Documentation

--- a/paraview/MatrixToHeatMap/MatrixToHeatMap.xml
+++ b/paraview/MatrixToHeatMap/MatrixToHeatMap.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-      name="MatrixToHeatMap"
+      name="ttkMatrixToHeatMap"
       class="ttkMatrixToHeatMap"
       label="TTK MatrixToHeatMap">
 

--- a/paraview/MeshGraph/MeshGraph.xml
+++ b/paraview/MeshGraph/MeshGraph.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="MeshGraph" class="ttkMeshGraph" label="TTK MeshGraph">
+        <SourceProxy name="ttkMeshGraph" class="ttkMeshGraph" label="TTK MeshGraph">
             <Documentation long_help="TTK MeshGraph" short_help="TTK MeshGraph">This filter generates for each one dimensional cell (edge) of a 'vtkUnstructuredGrid' a two dimensional cell by mapping a size value to the width of the input cell. The output is a 'vtkUnstructuredGrid' consisting of a set of either quadratic quads or linear polygons.</Documentation>
 
             <InputProperty name="Input" command="SetInputConnection">

--- a/paraview/MeshSubdivision/MeshSubdivision.xml
+++ b/paraview/MeshSubdivision/MeshSubdivision.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="MeshSubdivision"
+     name="ttkMeshSubdivision"
      class="ttkMeshSubdivision"
      label="TTK MeshSubdivision">
      <Documentation

--- a/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
+++ b/paraview/MorseSmaleComplex/MorseSmaleComplex.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="MorseSmaleComplex"
+      name="ttkMorseSmaleComplex"
       class="ttkMorseSmaleComplex"
       label="TTK MorseSmaleComplex">
       <Documentation

--- a/paraview/MorseSmaleQuadrangulation/MorseSmaleQuadrangulation.xml
+++ b/paraview/MorseSmaleQuadrangulation/MorseSmaleQuadrangulation.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="MorseSmaleQuadrangulation"
+        name="ttkMorseSmaleQuadrangulation"
         class="ttkMorseSmaleQuadrangulation"
         label="TTK MorseSmaleQuadrangulation">
       <Documentation

--- a/paraview/OBJWriter/OBJWriter.xml
+++ b/paraview/OBJWriter/OBJWriter.xml
@@ -2,7 +2,7 @@
 
   <ProxyGroup name="writers">
     <!-- ================================================================== -->
-    <WriterProxy name="OBJWriter" class="ttkOBJWriter" label="OBJWriter">
+    <WriterProxy name="ttkOBJWriter" class="ttkOBJWriter" label="TTK OBJWriter">
         <Documentation
           long_help="Export a VTK Unstructured Grid into a Wavefront OBJ file."
           short_help="Write an .obj file.">

--- a/paraview/OFFReader/OFFReader.xml
+++ b/paraview/OFFReader/OFFReader.xml
@@ -2,7 +2,7 @@
 
    <ProxyGroup name="sources">
       <!-- ================================================================== -->
-      <SourceProxy name="OFFReader" class="ttkOFFReader" label="OFFReader">
+      <SourceProxy name="ttkOFFReader" class="ttkOFFReader" label="TTK OFFReader">
          <Documentation
             long_help="Import an Object File Format mesh into a VTK Unstructured Grid."
             short_help="Read an .off file.">

--- a/paraview/OFFWriter/OFFWriter.xml
+++ b/paraview/OFFWriter/OFFWriter.xml
@@ -2,7 +2,7 @@
 
   <ProxyGroup name="writers">
     <!-- ================================================================== -->
-    <WriterProxy name="OFFWriter" class="ttkOFFWriter" label="OFFWriter">
+    <WriterProxy name="ttkOFFWriter" class="ttkOFFWriter" label="TTK OFFWriter">
         <Documentation
           long_help="Export a VTK Unstructured Grid into an Object Filed Format mesh."
           short_help="Write an .off file.">

--- a/paraview/PeriodicGrid/PeriodicGrid.xml
+++ b/paraview/PeriodicGrid/PeriodicGrid.xml
@@ -8,7 +8,7 @@
 
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="PeriodicGrid" class="ttkPeriodicGrid" label="TTK PeriodicGrid">
+        <SourceProxy name="ttkPeriodicGrid" class="ttkPeriodicGrid" label="TTK PeriodicGrid">
            <Documentation long_help="PeriodicGrid Long" short_help="PeriodicGrid Short">
                This filter converts a regular grid (vtkImageData) into a
 periodic regular grid (vtkImageData), in all dimensions.

--- a/paraview/PersistenceCurve/PersistenceCurve.xml
+++ b/paraview/PersistenceCurve/PersistenceCurve.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="PersistenceCurve"
+      name="ttkPersistenceCurve"
       class="ttkPersistenceCurve"
       label="TTK PersistenceCurve">
       <Documentation

--- a/paraview/PersistenceDiagram/PersistenceDiagram.xml
+++ b/paraview/PersistenceDiagram/PersistenceDiagram.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="PersistenceDiagram"
+      name="ttkPersistenceDiagram"
       class="ttkPersistenceDiagram"
       label="TTK PersistenceDiagram">
       <Documentation

--- a/paraview/PersistenceDiagramClustering/PersistenceDiagramClustering.xml
+++ b/paraview/PersistenceDiagramClustering/PersistenceDiagramClustering.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="PersistenceDiagramClustering"
+     name="ttkPersistenceDiagramClustering"
      class="ttkPersistenceDiagramClustering"
      label="TTK PersistenceDiagramClustering">
      <Documentation

--- a/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
+++ b/paraview/PersistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="PersistenceDiagramDistanceMatrix"
+        name="ttkPersistenceDiagramDistanceMatrix"
         class="ttkPersistenceDiagramDistanceMatrix"
         label="TTK PersistenceDiagramDistanceMatrix">
       <Documentation

--- a/paraview/PlanarGraphLayout/PlanarGraphLayout.xml
+++ b/paraview/PlanarGraphLayout/PlanarGraphLayout.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="PlanarGraphLayout" class="ttkPlanarGraphLayout" label="TTK PlanarGraphLayout">
+        <SourceProxy name="ttkPlanarGraphLayout" class="ttkPlanarGraphLayout" label="TTK PlanarGraphLayout">
             <Documentation long_help="TTK PlanarGraphLayout" short_help="TTK PlanarGraphLayout">
 This filter computes a planar graph layout of a 'vtkUnstructuredGrid'. To improve the quality of the layout it is possible to pass additional field data to the algorithm:
 

--- a/paraview/PointDataConverter/PointDataConverter.xml
+++ b/paraview/PointDataConverter/PointDataConverter.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-    name="PointDataConverter"
+    name="ttkPointDataConverter"
     class="ttkPointDataConverter"
     label="TTK PointDataConverter">
       <Documentation

--- a/paraview/PointDataSelector/PointDataSelector.xml
+++ b/paraview/PointDataSelector/PointDataSelector.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="PointDataSelector"
+      name="ttkPointDataSelector"
       class="ttkPointDataSelector"
       label="TTK PointDataSelector">
       <Documentation

--- a/paraview/PointMerger/PointMerger.xml
+++ b/paraview/PointMerger/PointMerger.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="PointMerger"
+     name="ttkPointMerger"
      class="ttkPointMerger"
      label="TTK PointMerger">
      <Documentation

--- a/paraview/PointSetToCurve/PointSetToCurve.xml
+++ b/paraview/PointSetToCurve/PointSetToCurve.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="PointSetToCurve"
+        name="ttkPointSetToCurve"
         class="ttkPointSetToCurve"
         label="TTK PointSetToCurve">
       <Documentation

--- a/paraview/ProjectionFromField/ProjectionFromField.xml
+++ b/paraview/ProjectionFromField/ProjectionFromField.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ProjectionFromField"
+     name="ttkProjectionFromField"
      class="ttkProjectionFromField"
      label="TTK ProjectionFromField">
      <Documentation

--- a/paraview/QuadrangulationSubdivision/QuadrangulationSubdivision.xml
+++ b/paraview/QuadrangulationSubdivision/QuadrangulationSubdivision.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="QuadrangulationSubdivision"
+        name="ttkQuadrangulationSubdivision"
         class="ttkQuadrangulationSubdivision"
         label="TTK QuadrangulationSubdivision">
       <Documentation

--- a/paraview/RangePolygon/RangePolygon.xml
+++ b/paraview/RangePolygon/RangePolygon.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="RangePolygon"
+     name="ttkRangePolygon"
      class="ttkRangePolygon"
      label="TTK RangePolygon">
      <Documentation

--- a/paraview/ReebSpace/ReebSpace.xml
+++ b/paraview/ReebSpace/ReebSpace.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ReebSpace"
+     name="ttkReebSpace"
      class="ttkReebSpace"
      label="TTK ReebSpace">
      <Documentation

--- a/paraview/ScalarFieldCriticalPoints/ScalarFieldCriticalPoints.xml
+++ b/paraview/ScalarFieldCriticalPoints/ScalarFieldCriticalPoints.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ScalarFieldCriticalPoints"
+     name="ttkScalarFieldCriticalPoints"
      class="ttkScalarFieldCriticalPoints"
      label="TTK ScalarFieldCriticalPoints">
      <Documentation

--- a/paraview/ScalarFieldNormalizer/ScalarFieldNormalizer.xml
+++ b/paraview/ScalarFieldNormalizer/ScalarFieldNormalizer.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="ScalarFieldNormalizer"
+     name="ttkScalarFieldNormalizer"
      class="ttkScalarFieldNormalizer"
      label="TTK ScalarFieldNormalizer">
      <Documentation

--- a/paraview/ScalarFieldSmoother/ScalarFieldSmoother.xml
+++ b/paraview/ScalarFieldSmoother/ScalarFieldSmoother.xml
@@ -6,7 +6,7 @@
   that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="ScalarFieldSmoother"
+      name="ttkScalarFieldSmoother"
       class="ttkScalarFieldSmoother"
       label="TTK ScalarFieldSmoother">
       <Documentation

--- a/paraview/SphereFromPoint/SphereFromPoint.xml
+++ b/paraview/SphereFromPoint/SphereFromPoint.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="SphereFromPoint"
+     name="ttkSphereFromPoint"
      class="ttkSphereFromPoint"
      label="TTK SphereFromPoint">
      <Documentation

--- a/paraview/StringArrayConverter/StringArrayConverter.xml
+++ b/paraview/StringArrayConverter/StringArrayConverter.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy
-        name="StringArrayConverter"
+        name="ttkStringArrayConverter"
         class="ttkStringArrayConverter"
         label="TTK StringArrayConverter">
       <Documentation

--- a/paraview/TableDataSelector/TableDataSelector.xml
+++ b/paraview/TableDataSelector/TableDataSelector.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="TableDataSelector"
+      name="ttkTableDataSelector"
       class="ttkTableDataSelector"
       label="TTK TableDataSelector">
       <Documentation

--- a/paraview/TextureMapFromField/TextureMapFromField.xml
+++ b/paraview/TextureMapFromField/TextureMapFromField.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="TextureMapFromField"
+     name="ttkTextureMapFromField"
      class="ttkTextureMapFromField"
      label="TTK TextureMapFromField">
      <Documentation

--- a/paraview/TopologicalCompression/TopologicalCompression.xml
+++ b/paraview/TopologicalCompression/TopologicalCompression.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-        name="TopologicalCompression"
+        name="ttkTopologicalCompression"
         class="ttkTopologicalCompression"
         label="TTK TopologicalCompression">
 

--- a/paraview/TopologicalCompressionReader/TopologicalCompressionReader.xml
+++ b/paraview/TopologicalCompressionReader/TopologicalCompressionReader.xml
@@ -1,9 +1,9 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="sources">
     <SourceProxy
-        name="TopologicalCompressionReader"
+        name="ttkTopologicalCompressionReader"
         class="ttkTopologicalCompressionReader"
-        label="TTKTopologicalCompressionReader">
+        label="TTK TTKTopologicalCompressionReader">
       <Documentation
           long_help="TTK topologicalCompressionReader plugin."
           short_help="Read a .ttk file.">

--- a/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
+++ b/paraview/TopologicalCompressionWriter/TopologicalCompressionWriter.xml
@@ -1,9 +1,9 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="writers">
     <WriterProxy
-        name="TopologicalCompressionWriter"
+        name="ttkTopologicalCompressionWriter"
         class="ttkTopologicalCompressionWriter"
-        label="TTKTopologicalCompressionWriter">
+        label="TTK TTKTopologicalCompressionWriter">
 
       <Documentation
           long_help="TTK topologicalCompressionWriter plugin."

--- a/paraview/TopologicalSimplification/TopologicalSimplification.xml
+++ b/paraview/TopologicalSimplification/TopologicalSimplification.xml
@@ -1,7 +1,7 @@
 <ServerManagerConfiguration>
 	<ProxyGroup name="filters">
    <SourceProxy
-     name="TopologicalSimplification"
+     name="ttkTopologicalSimplification"
 		 class="ttkTopologicalSimplification"
 		 label="TTK TopologicalSimplification">
 		 <Documentation

--- a/paraview/TrackingFromFields/TrackingFromFields.xml
+++ b/paraview/TrackingFromFields/TrackingFromFields.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-    name="TrackingFromFields"
+    name="ttkTrackingFromFields"
     class="ttkTrackingFromFields"
     label="TTK TrackingFromFields">
       <Documentation

--- a/paraview/TrackingFromOverlap/TrackingFromOverlap.xml
+++ b/paraview/TrackingFromOverlap/TrackingFromOverlap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
-        <SourceProxy name="TrackingFromOverlap" class="ttkTrackingFromOverlap" label="TTK TrackingFromOverlap">
+        <SourceProxy name="ttkTrackingFromOverlap" class="ttkTrackingFromOverlap" label="TTK TrackingFromOverlap">
             <Documentation long_help="TTK TrackingFromOverlap" short_help="TTK TrackingFromOverlap">
 This filter identifies and tracks labled vtkPointSets across time (and optionally levels) based on spatial overlap, where two points overlap iff their corresponding coordinates are equal. This filter can be executed iteratively and can generate nested tracking graphs.
 

--- a/paraview/TrackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.xml
+++ b/paraview/TrackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-    name="TrackingFromPersistenceDiagrams"
+    name="ttkTrackingFromPersistenceDiagrams"
     class="ttkTrackingFromPersistenceDiagrams"
     label="TTK TrackingFromPersistenceDiagrams">
       <Documentation

--- a/paraview/TriangulationRequest/TriangulationRequest.xml
+++ b/paraview/TriangulationRequest/TriangulationRequest.xml
@@ -6,7 +6,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="TriangulationRequest"
+      name="ttkTriangulationRequest"
       class="ttkTriangulationRequest"
       label="TTK TriangulationRequest">
       <Documentation

--- a/paraview/UncertainDataEstimator/UncertainDataEstimator.xml
+++ b/paraview/UncertainDataEstimator/UncertainDataEstimator.xml
@@ -5,7 +5,7 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
    <SourceProxy
-     name="UncertainDataEstimator"
+     name="ttkUncertainDataEstimator"
      class="ttkUncertainDataEstimator"
      label="TTK UncertainDataEstimator">
      <Documentation

--- a/scripts/rename_plugins.py
+++ b/scripts/rename_plugins.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+CLASS_PREFIX = NAME_PREFIX = 'ttk'
+LABEL_PREFIX = 'TTK '
+
+PARAVIEW_XML_DIR = '../paraview'
+PARAVIEW_XML_OUTPUT = 'replace'  # 'replace', 'reformat', 'none'
+
+COMPATIBILITY_XML_FILE = '../paraview/Compatibility/Compatibility.xml'
+COMPATIBILITY_DEFINITION = '''
+        <SourceProxy base_proxygroup="{group}"
+                     base_proxyname="{proxy_name}"
+                     class="{proxy_class}"
+                     name="{proxy_name_old}"
+                     label="{label} (deprecated)">
+            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
+                Please update your state file to use {proxy_name} instead of {proxy_name_old}.
+            </Deprecated>
+        </SourceProxy> 
+'''
+
+STATE_FILE_DIR = '../../ttk-data/states'
+STATE_FILE_OUTPUT = 'replace'  # 'replace', 'reformat', 'none'
+
+
+def indent(elem, indentation=4 * ' ', level=0):
+    i = '\n' + level * indentation
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + indentation
+        for e in elem:
+            indent(e, indentation, level + 1)
+            if not e.tail or not e.tail.strip():
+                e.tail = i + indentation
+        if not e.tail or not e.tail.strip():
+            e.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+    if len(elem.attrib) > 3:
+        elem.attrib = {(i + indentation + k): v for k, v in elem.attrib.items()}
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    base_dir = os.path.abspath(os.path.join(script_dir, PARAVIEW_XML_DIR))
+
+    xml_files = Path(base_dir).rglob('*.xml')
+
+    filters_map = {}
+    compatiblity_root = ET.Element('ServerManagerConfiguration')
+
+    if COMPATIBILITY_XML_FILE:
+        compatiblity_file = os.path.realpath(os.path.join(script_dir, COMPATIBILITY_XML_FILE))
+        try:
+            e = ET.parse(compatiblity_file)
+            compatiblity_root = e.getroot()
+        except (ET.ParseError, FileNotFoundError):
+            pass
+    else:
+        compatiblity_file = None
+
+    for xml_file in xml_files:
+        if os.path.realpath(xml_file) == compatiblity_file:
+            continue
+        try:
+            e = ET.parse(xml_file)
+        except ET.ParseError:
+            continue
+        if PARAVIEW_XML_OUTPUT == 'replace':
+            with open(xml_file, 'r') as f:
+                contents = f.read()
+
+        for group in e.getroot().iter('ProxyGroup'):
+            group_name = group.get('name')
+            compatibility_group = compatiblity_root.find('./ProxyGroup[@name="{}"]'.format(group_name))
+            if compatibility_group is None:
+                compatibility_group = ET.SubElement(compatiblity_root, 'ProxyGroup', {'name': group_name})
+            for proxy in group:
+                proxy_name = proxy.get('name')
+                proxy_class = proxy.get('class')
+                proxy_label = proxy.get('label')
+
+                if not proxy_class.startswith(CLASS_PREFIX):
+                    print('Unexpected class name: ' + proxy_class)
+
+                if proxy_label is not None and not proxy_label.startswith(LABEL_PREFIX):
+                    proxy_label_old = proxy_label[:]
+                    proxy_label = LABEL_PREFIX + proxy_label
+
+                    if PARAVIEW_XML_OUTPUT == 'reformat':
+                        proxy.set('label', proxy_label)
+                    elif PARAVIEW_XML_OUTPUT == 'replace':
+                        contents = contents.replace('label="{}"'.format(proxy_label_old), 'label="{}"'.format(proxy_label))
+
+                    print('{}: Relabeled "{}" to "{}".'.format(xml_file.name, proxy_label_old, proxy_label))
+
+                if not proxy_name.startswith(NAME_PREFIX):
+                    proxy_name_old = proxy_name[:]
+                    proxy_name = NAME_PREFIX + proxy_name
+
+                    if PARAVIEW_XML_OUTPUT == 'reformat':
+                        proxy.set('name', proxy_name)
+                    elif PARAVIEW_XML_OUTPUT == 'replace':
+                        contents = contents.replace('name="{}"'.format(proxy_name_old), 'name="{}"'.format(proxy_name))
+
+                    compatibility_definition = COMPATIBILITY_DEFINITION.format(
+                        group=group_name, proxy_class=proxy_class, proxy_name=proxy_name, proxy_name_old=proxy_name_old, label=proxy_label)
+
+                    compatibility_group.append(ET.fromstring(compatibility_definition))
+
+                    print('{}: Renamed {} to {}.'.format(xml_file.name, proxy_name_old, proxy_name))
+
+                filters_map[proxy_name[len(NAME_PREFIX):]] = proxy_name
+        if PARAVIEW_XML_OUTPUT == 'reformat':
+            indent(e.getroot())
+            e.write(xml_file)
+        elif PARAVIEW_XML_OUTPUT == 'replace':
+            with open(xml_file, 'w') as f:
+                f.write(contents)
+
+    if COMPATIBILITY_XML_FILE:
+        indent(compatiblity_root)
+        compatiblity = ET.ElementTree(compatiblity_root)
+        compatiblity.write(os.path.join(script_dir, COMPATIBILITY_XML_FILE))
+
+
+    if len(sys.argv) > 1:
+        state_files = sys.argv[1:]
+        state_files = [Path(f) for f in state_files]
+    else:
+        state_dir = os.path.abspath(os.path.join(script_dir, STATE_FILE_DIR))
+        state_files = Path(state_dir).rglob('*.pvsm')
+
+    for state_file in state_files:
+        e = ET.parse(state_file)
+        if STATE_FILE_OUTPUT == 'replace':
+            with open(state_file, 'r') as f:
+                contents = f.read()
+
+        modified = False
+        for proxy in e.getroot().iter('Proxy'):
+            proxy_type = proxy.get('type')
+            if proxy_type in filters_map:
+                if STATE_FILE_OUTPUT == 'reformat':
+                    proxy.set('type', filters_map[proxy_type])
+                elif STATE_FILE_OUTPUT == 'replace':
+                    contents = contents.replace('type="{}"'.format(proxy_type), 'type="{}"'.format(filters_map[proxy_type]))
+                modified = True
+                print('{}: Renamed "{}" to "{}".'.format(state_file.name, proxy_type, filters_map[proxy_type]))
+
+        if modified:
+            if STATE_FILE_OUTPUT in ['reformat', 'replace']:
+                backup = state_file.with_suffix('.bak')
+                if backup.exists():
+                    print('Backup file {} already exists. Not writing file {}.'.format(backup, state_file))
+                    continue
+                state_file.rename(backup)
+
+            if STATE_FILE_OUTPUT == 'reformat':
+                e.write(state_file)
+            elif STATE_FILE_OUTPUT == 'replace':
+                with open(state_file, 'w') as f:
+                    f.write(contents)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR appends a `ttk` prefix to all ParaView proxy names (closes #454).

* The renaming has been done by the script `scripts/rename_plugins.py`.
This script can also convert arbitrary state files if called with a list of .pvsm files as command line parameter.
* There is a compatibility plugin (`paraview/Compatibility/Compatibility.xml`) generated, that allows old state files to still be loaded while displaying a warning message.

* I'm not sure if the compatibility plugin should be included in TTK by default, since for each "TTK Xyz" filter, an entry "TTK Xyz (deprecated)" will appear in the Ctrl+Space menu (but not in the main menus). Alternatively, the XML file `Compatibility.xml` could also be loaded as a plugin by the user directly without building a plugin.