### PR TITLE
Add Betti Number module

### DIFF
--- a/core/base/bettiNumbers/BettiNumbers.h
+++ b/core/base/bettiNumbers/BettiNumbers.h
@@ -1,0 +1,184 @@
+/// \ingroup base
+/// \class ttk::BettiNumbers
+/// \author Yoann Coudert--Osmont <ycoudert@ens-paris-saclay.fr>
+/// \date October 2019
+///
+/// \brief TTK bettiNumbers processing package.
+
+#pragma once
+
+// base code includes
+#include <Triangulation.h>
+#include <Wrapper.h>
+#include <UnionFind.h>
+
+namespace ttk {
+
+	namespace bettiNumbers {
+
+		class BettiNumbers : public Debug {
+
+		public:
+			BettiNumbers();
+
+			~BettiNumbers();
+
+			/// Execute the package.
+			/// \pre If this TTK package uses ttk::Triangulation for fast mesh
+			/// traversals, the function setupTriangulation() must be called on this
+			/// object prior to this function, in a clearly distinct pre-processing
+			/// steps. An error will be returned otherwise.
+			/// \note In such a case, it is recommended to exclude
+			/// setupTriangulation() from any time performance measurement.
+			/// \param argment Dummy integer argument.
+			/// \return Returns 0 upon success, negative values otherwise.
+			template <class dataType>
+			int execute(const int &argument) const;
+
+			/// Pass a pointer to an input array representing a scalarfield.
+			/// The expected format for the array is the following:
+			/// <vertex0-component0> <vertex0-component1> ... <vertex0-componentN>
+			/// <vertex1-component0> <vertex1-component1> ... <vertex1-componentN>
+			/// <vertexM-component0> <vertexM-component1> ... <vertexM-componentN>.
+			/// The array is expected to be correctly allocated.
+			/// \param data Pointer to the data array.
+			/// \return Returns 0 upon success, negative values otherwise.
+			/// \sa setVertexNumber() and setDimensionNumber().
+			inline int setInputDataPointer(void *data) {
+				inputData_ = data;
+				return 0;
+			}
+
+			/// Pass a pointer to an output array representing a scalar field.
+			/// The expected format for the array is the following:
+			/// <vertex0-component0> <vertex0-component1> ... <vertex0-componentN>
+			/// <vertex1-component0> <vertex1-component1> ... <vertex1-componentN>
+			/// <vertexM-component0> <vertexM-component1> ... <vertexM-componentN>.
+			/// The array is expected to be correctly allocated.
+			/// \param data Pointer to the data array.
+			/// \return Returns 0 upon success, negative values otherwise.
+			/// \sa setVertexNumber() and setDimensionNumber().
+			inline int setOutputDataPointer(void *data) {
+				outputData_ = data;
+				return 0;
+			}
+
+			// General documentation info:
+			//
+			/// Setup a (valid) triangulation object for this TTK base object.
+			///
+			/// \pre This function should be called prior to any usage of this TTK
+			/// object, in a clearly distinct pre-processing step that involves no
+			/// traversal or computation at all. An error will be returned otherwise.
+			///
+			/// \note It is recommended to exclude this pre-processing function from
+			/// any time performance measurement. Therefore, it is recommended to
+			/// call this function ONLY in the pre-processing steps of your program.
+			/// Note however, that your triangulation object must be valid when
+			/// calling this function (i.e. you should have filled it at this point,
+			/// see the setInput*() functions of ttk::Triangulation). See ttkBettiNumbers
+			/// for further examples.
+			///
+			/// \param triangulation Pointer to a valid triangulation.
+			/// \return Returns 0 upon success, negative values otherwise.
+			/// \sa ttk::Triangulation
+			inline int setupTriangulation(Triangulation *triangulation) {
+				triangulation_ = triangulation;
+				if(triangulation_) {
+					triangulation_->preprocessEdges();
+					triangulation_->preprocessTriangles();
+					triangulation_->preprocessCellTriangles();
+				}
+				return 0;
+			}
+
+		protected:
+			void *inputData_, *outputData_;
+			Triangulation *triangulation_;
+		};
+	} // namespace bettiNumbers
+} // namespace ttk
+
+// template functions
+template <class dataType>
+int ttk::bettiNumbers::BettiNumbers::execute(const int &argument) const {
+
+	Timer ti;
+	#ifndef TTK_ENABLE_KAMIKAZE
+	if(!triangulation_) return -1;
+	if(!inputData_) return -2;
+	if(!outputData_) return -3;
+	#endif
+
+	SimplexId vertexNumber = triangulation_->getNumberOfVertices();
+	dataType *outputData = (dataType *)outputData_;
+	dataType *inputData = (dataType *)inputData_;
+	for(SimplexId i = 0; i < vertexNumber; i++)
+		outputData[i] = inputData[i];
+
+	/**** B0 computation ****/
+	std::vector<UnionFind> uV(vertexNumber);
+	SimplexId edgeNumber = triangulation_->getNumberOfEdges();
+	for(SimplexId e = 0; e < edgeNumber; e++) {
+		SimplexId a, b;
+		triangulation_->getEdgeVertex(e, 0, a);
+		triangulation_->getEdgeVertex(e, 1, b);
+		makeUnion(&uV[a], &uV[b]);
+	}
+	int b0 = 0;
+	for(UnionFind &u : uV)
+		if(&u == u.find()) b0 ++;
+	/************************/
+
+	/**** B2 computation ****/
+	SimplexId triangleNumber = triangulation_->getNumberOfTriangles();
+	SimplexId cellNumber = triangulation_->getNumberOfCells();
+	std::vector<int> ncells(triangleNumber, 0);
+	for(SimplexId c = 0; c < cellNumber; c++) {
+		SimplexId nfaces = triangulation_->getCellTriangleNumber(c);
+		for(SimplexId i = 0; i < nfaces; i++) {
+			SimplexId t;
+			triangulation_->getCellTriangle(c, i, t);
+			ncells[t] ++;
+		}
+	}
+	std::vector<bool> surfaceVertex(vertexNumber, false);
+	for(UnionFind &u : uV) u.setParent(&u);
+	for(SimplexId t = 0; t < triangleNumber; t++) {
+		if(ncells[t] > 1) continue;
+		SimplexId v, v2=0;
+		for(SimplexId i = 0; i < 3; i++) {
+			triangulation_->getTriangleVertex(t, i, v);
+			surfaceVertex[v] = true;
+			if(i > 0) makeUnion(&uV[v], &uV[v2]);
+			v2 = v;
+		}
+	}
+	int b2 = -b0;
+	for(SimplexId v = 0; v < vertexNumber; v++)
+		if(surfaceVertex[v] && &uV[v] == uV[v].find()) b2 ++;
+	/************************/
+
+	/**** X computation ****/
+	int X = vertexNumber - edgeNumber + triangleNumber - cellNumber;
+
+	/**** B1 computation ****/
+	int b1 = b0 + b2 - X;
+
+	{
+		std::stringstream msg;
+		msg << "[BettiNumbers] Data-set (" << vertexNumber << " points, " << edgeNumber << " edges, "
+				<< triangleNumber << " triangles and " << cellNumber << " cells) processed in "
+				<< ti.getElapsedTime() << " s. (" << threadNumber_ << " thread(s))."
+				<< std::endl;
+		dMsg(std::cout, msg.str(), timeMsg);
+	}
+	std::cout << std::endl << "Hello World!" << std::endl;
+	std::cout << "B0 = " << b0 << std::endl;
+	std::cout << "B1 = " << b1 << std::endl;
+	std::cout << "B2 = " << b2 << std::endl;
+	std::cout << "X = " << X << std::endl;
+	std::cout << std::endl;
+
+	return 0;
+}

--- a/core/base/bettiNumbers/CMakeLists.txt
+++ b/core/base/bettiNumbers/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(bettiNumbers)
+
+find_package(TTKVTK REQUIRED)
+
+add_executable(betti main.cpp)
+
+target_link_libraries(betti
+  PUBLIC
+    ttk::vtk::ttkAll
+    )

--- a/core/base/bettiNumbers/main.cpp
+++ b/core/base/bettiNumbers/main.cpp
@@ -1,0 +1,158 @@
+/// \defgroup examples examples
+/// \author Yoann Coudert--Osmont <ycoudert@ens-paris-saclay.fr>
+/// 		with inspiration from a piece of Adrien's code to compute B1
+/// \date October 2019.
+///
+/// \brief A Program to compute the betti numbers and the euler caracteristic
+/// of the VTU file given in argument
+
+#include <CommandLineParser.h>
+#include <UnionFind.h>
+
+#include <ttkTriangulation.h>
+// #include <ttkBettiNumbers.h>
+
+#include <vtkXMLUnstructuredGridReader.h>
+#include <vtkSmartPointer.h>
+
+using namespace ttk;
+
+int main(int argc, char **argv) {
+
+	ttk::globalDebugLevel_ = 3;
+
+	CommandLineParser parser;
+	std::string inputFilePath;
+	parser.setArgument("i", &inputFilePath, "Path to input VTU file");
+	parser.parse(argc, argv);
+
+	vtkSmartPointer<vtkXMLUnstructuredGridReader> reader = vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
+	reader->SetFileName(inputFilePath.data());
+	reader->Update();
+
+	// vtkSmartPointer<ttkBettiNumbers> betti = vtkSmartPointer<ttkBettiNumbers>::New();
+	// betti->SetInputConnection(reader->GetOutputPort());
+	// betti->Update();
+
+	vtkUnstructuredGrid* ug = reader->GetOutput();
+	Triangulation triangulation;
+	vtkIdType np = ug->GetNumberOfPoints();
+	std::vector<float> points;
+	for(vtkIdType i = 0; i < np; i++) {
+		double* p = ug->GetPoint(i);
+		for(int j = 0; j < 3; j++) points.push_back(p[j]);
+	}
+	triangulation.setInputPoints(np, points.data());
+	vtkIdType nc = ug->GetNumberOfCells();
+	std::vector<LongSimplexId> cells;
+	for(vtkIdType i = 0; i < nc; i++) {
+		vtkCell* c = ug->GetCell(i);
+		cells.push_back(4);
+		for(int j = 0; j < 4; j++) cells.push_back(c->GetPointId(j));
+	}
+	triangulation.setInputPoints(np, points.data());
+	triangulation.setInputCells(nc, cells.data());
+
+	triangulation.preprocessCellTriangles();
+	triangulation.preprocessTriangles();
+	triangulation.preprocessTriangleEdges();
+	triangulation.preprocessEdges();
+
+	Timer ti;
+
+	/**** B0 computation ****/
+	SimplexId vertexNumber = triangulation.getNumberOfVertices();
+	std::vector<UnionFind> uV(vertexNumber);
+	SimplexId edgeNumber = triangulation.getNumberOfEdges();
+	for(SimplexId e = 0; e < edgeNumber; e++) {
+		SimplexId a, b;
+		triangulation.getEdgeVertex(e, 0, a);
+		triangulation.getEdgeVertex(e, 1, b);
+		makeUnion(&uV[a], &uV[b]);
+	}
+	int b0 = 0;
+	for(UnionFind &u : uV)
+		if(&u == u.find()) b0 ++;
+	/************************/
+
+	/**** B2 and B1 computation ****/
+
+	SimplexId triangleNumber = triangulation.getNumberOfTriangles();
+	SimplexId cellNumber = triangulation.getNumberOfCells();
+
+	// Computation of the number of cells to which the triangles belongs
+	std::vector<int> ncells(triangleNumber, 0);
+	for(SimplexId c = 0; c < cellNumber; c++) {
+		SimplexId nfaces = triangulation.getCellTriangleNumber(c);
+		for(SimplexId i = 0; i < nfaces; i++) {
+			SimplexId t;
+			triangulation.getCellTriangle(c, i, t);
+			ncells[t] ++;
+		}
+	}
+
+	// Computation of connected components on surfaces in the UnionFind u
+	// And computations of numbers of vertices, edges and triangles on surfaces
+	for(UnionFind &u : uV) u.setParent(&u);
+	std::vector<bool> surfaceVertex(vertexNumber, false);
+	std::vector<bool> surfaceEdge(edgeNumber, false);
+	int surfaceVertexNumber = 0;
+	int surfaceEdgeNumber = 0;
+	int surfaceTriangleNumber = 0;
+	for(SimplexId t = 0; t < triangleNumber; t++) {
+		if(ncells[t] > 1) continue;
+		// Then the triangle belongs to a surface
+		surfaceTriangleNumber ++;
+		// Treatment of vertices
+		SimplexId v, v2=0;
+		for(SimplexId i = 0; i < 3; i++) {
+			triangulation.getTriangleVertex(t, i, v);
+			if(!surfaceVertex[v]) {
+				surfaceVertex[v] = true;
+				surfaceVertexNumber ++;
+			}
+			if(i > 0) makeUnion(&uV[v], &uV[v2]);
+			v2 = v;
+		}
+		// Treatment of edges
+		SimplexId nedges = triangulation.getTriangleEdgeNumber(t);
+		for(SimplexId i = 0; i < nedges; i++) {
+			SimplexId e;
+			triangulation.getTriangleEdge(t, i, e);
+			if(!surfaceEdge[e]) {
+				surfaceEdge[e] = true;
+				surfaceEdgeNumber ++;
+			}
+		}
+	}
+
+	// B2 computation
+	int b2 = -b0;
+	for(SimplexId v = 0; v < vertexNumber; v++)
+		if(surfaceVertex[v] && &uV[v] == uV[v].find()) b2 ++;
+	
+	// B1 computation
+	int b1 = b0+b2 - (surfaceVertexNumber - surfaceEdgeNumber + surfaceTriangleNumber) / 2;
+	/************************/
+
+	/**** X computation ****/
+	int X = vertexNumber - edgeNumber + triangleNumber - cellNumber;
+
+	/**** B1 computation thanks to Euler ****/
+	int b1Bis = b0 + b2 - X;
+
+	cout << "[BettiNumbers] Data-set (" << vertexNumber << " points, " << edgeNumber << " edges, "
+			<< triangleNumber << " triangles and " << cellNumber << " cells) processed in "
+			<< ti.getElapsedTime() << " s. (" << 1 << " thread(s))."
+			<< std::endl;
+	std::cout << std::endl << "Hello World!" << std::endl;
+	std::cout << "B0 = " << b0 << std::endl;
+	std::cout << "B1 = " << b1 << "  (" << b1Bis << ")" << std::endl;
+	std::cout << "B2 = " << b2 << std::endl;
+	std::cout << "X = " << X << std::endl;
+	std::cout << std::endl;
+
+	return 0;
+}
+
+/// @}


### PR DESCRIPTION
Betti Numbers are common descriptors of objects' topology.
This contribution adds a module dedicated to their computations based on [1].

[1] Tamal K. Dey and Sumanta Guha. 1998. Computing homology groups of simplicial complexes in R3.
J. ACM 45, 2 (March 1998), 266–287. DOI:https://doi.org/10.1145/274787.274810