### PR TITLE
Move numberOfInput_ to inside PersDiagClustering::execute(), remove setter

### DIFF
--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -66,17 +66,6 @@ namespace ttk {
       std::vector<std::vector<diagramTuple>> &centroids,
       std::vector<std::vector<std::vector<matchingTuple>>> &all_matchings);
 
-    inline int setNumberOfInputs(int numberOfInputs) {
-      numberOfInputs_ = numberOfInputs;
-      // 			if(inputData_)
-      // 			free(inputData_);
-      // 			inputData_ = (void **) malloc(numberOfInputs*sizeof(void *));
-      // 			for(int i=0 ; i<numberOfInputs ; i++){
-      // 			inputData_[i] = NULL;
-      // 			}
-      return 0;
-    }
-
     template <class dataType>
     static dataType abs(const dataType var) {
       return (var >= 0) ? var : -var;
@@ -91,7 +80,6 @@ namespace ttk {
     bool Deterministic{true};
     int WassersteinMetric{2};
 
-    int numberOfInputs_{};
     bool UseProgressive{true};
 
     bool ForceUseOfAlgorithm{false};
@@ -119,6 +107,7 @@ namespace ttk {
     std::vector<std::vector<diagramTuple>> &final_centroids,
     std::vector<std::vector<std::vector<matchingTuple>>> &all_matchings) {
 
+    const int numberOfInputs_ = intermediateDiagrams.size();
     Timer tm;
     {
       printMsg("Clustering " + std::to_string(numberOfInputs_) + " diagrams in "

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -75,7 +75,6 @@ int ttkPersistenceDiagramClustering::RequestData(
     all_matchings_.resize(3);
 
     max_dimension_total_ = 0;
-    this->setNumberOfInputs(numInputs);
     for(int i = 0; i < numInputs; i++) {
       double max_dimension
         = getPersistenceDiagram(intermediateDiagrams_[i], input[i]);


### PR DESCRIPTION
Hello !
This numberOfInput_ class member is:
- obsolete: the code implies that it should necessarily be equal to intermediateDiagram.size()
- dangerous: the code segfaults if it is smaller
- preventing the execute() function from being reentrant: other class members are most likely set only once, or at least won't make the code explode if modified at any point

I suggest we remove it.

Other cleanings could be done (points_added_ and points_deleted_ are never used) but this isn't critical.