### PR TITLE
PersistenceDiagram: Fix diagrams not recomputing

### DIFF
--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -420,6 +420,11 @@ int ttkPersistenceDiagram::dispatch(
   return ret;
 }
 
+void ttkPersistenceDiagram::Modified() {
+  computeDiagram_ = true;
+  ttkAlgorithm::Modified();
+}
+
 int ttkPersistenceDiagram::RequestData(vtkInformation *request,
                                        vtkInformationVector **inputVector,
                                        vtkInformationVector *outputVector) {
@@ -498,10 +503,10 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
        outputCTPersistenceDiagram, inputScalars,
        (VTK_TT *)ttkUtils::GetVoidPointer(inputScalars),
        offsetField->GetDataType(), ttkUtils::GetVoidPointer(offsetField),
-       (TTK_TT *)(triangulation->getData()))))
+       (TTK_TT *)(triangulation->getData()))));
 
-    // something wrong in baseCode
-    if(status) {
+  // something wrong in baseCode
+  if(status) {
     std::stringstream msg;
     msg << "PersistenceDiagram::execute() error code : " << status;
     this->printErr(msg.str());

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -75,23 +75,16 @@ public:
 
   vtkTypeMacro(ttkPersistenceDiagram, ttkAlgorithm);
 
-  void SetForceInputOffsetScalarField(int data) {
-    ForceInputOffsetScalarField = data;
-    Modified();
-    computeDiagram_ = true;
-  }
+  vtkSetMacro(ForceInputOffsetScalarField, int);
   vtkGetMacro(ForceInputOffsetScalarField, int);
 
-  void SetComputeSaddleConnectors(int data) {
-    ComputeSaddleConnectors = data;
-    Modified();
-    computeDiagram_ = true;
-  }
+  vtkSetMacro(ComputeSaddleConnectors, int);
   vtkGetMacro(ComputeSaddleConnectors, int);
 
   void SetShowInsideDomain(int onOff) {
     ShowInsideDomain = onOff;
     Modified();
+    computeDiagram_ = false;
   }
   vtkGetMacro(ShowInsideDomain, int);
 
@@ -180,8 +173,8 @@ protected:
                   vtkInformationVector *outputVector) override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
-
   int FillOutputPortInformation(int port, vtkInformation *info) override;
+  void Modified() override;
 
 private:
   bool ForceInputOffsetScalarField{false};


### PR DESCRIPTION
The current PR fixes a bug in the PersistenceDiagram module in which changing the input scalar field does not trigger a recomputation. Incidentally, modifying the number of threads and the log level should also re-trigger the computation, contrary to the ShowInsideDomain option.

Enjoy,
Pierre 