### PR TITLE
Fix diagram size in input of diagrams diagonal is present or not

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -205,6 +205,10 @@ double ttkPersistenceDiagramClustering::getPersistenceDiagram(
       pairIdentifierScalars->SetTuple(pair_index, &index_of_pair);
   }
 
+  // If diagram has the diagonal (we assume it is last)
+  if(*pairIdentifierScalars->GetTuple(pairingsSize - 1) == -1)
+    pairingsSize -= 1;
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(pairingsSize < 1 || !vertexIdentifierScalars || !pairIdentifierScalars
      || !nodeTypeScalars || !persistenceScalars || !extremumIndexScalars
@@ -222,7 +226,7 @@ double ttkPersistenceDiagramClustering::getPersistenceDiagram(
   double max_dimension = 0;
 
   // skip diagonal cell (corresponding points already dealt with)
-  for(int i = 0; i < pairingsSize - 1; ++i) {
+  for(int i = 0; i < pairingsSize; ++i) {
 
     int vertexId1 = vertexIdentifierScalars->GetValue(2 * i);
     int vertexId2 = vertexIdentifierScalars->GetValue(2 * i + 1);

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -185,6 +185,10 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
       pairIdentifierScalars->SetTuple(pair_index, &index_of_pair);
   }
 
+  // If diagram has the diagonal (we assume it is last)
+  if(*pairIdentifierScalars->GetTuple(pairingsSize - 1) == -1)
+    pairingsSize -= 1;
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(pairingsSize < 1 || !vertexIdentifierScalars || !pairIdentifierScalars
      || !nodeTypeScalars || !persistenceScalars || !extremumIndexScalars
@@ -198,7 +202,7 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
   double max_dimension = 0;
 
   // skip diagonal cell (corresponding points already dealt with)
-  for(int i = 0; i < pairingsSize - 1; ++i) {
+  for(int i = 0; i < pairingsSize; ++i) {
 
     int vertexId1 = vertexIdentifierScalars->GetValue(2 * i);
     int vertexId2 = vertexIdentifierScalars->GetValue(2 * i + 1);


### PR DESCRIPTION
Fix a bug in persistence diagram inputs:
* Checks whether the diagonal (assumed to be the last cell, with `PairID == -1`) exists or not, and thus remove it or not from the input
* Fix the diagram size. Before the fix, the diagram pair of index `pairingsSize - 1` was never initialized, only created through the `vector::resize()`