### PR TITLE
[api-migration-hackathon] TopologicalSimplification

### DIFF
--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -297,18 +297,9 @@ int ttk::TopologicalCompression::PerformSimplification(
   for(int i = 0; i < vertexNumber; ++i)
     decompressedOffsets_[i] = 0;
 
-  topologicalSimplification.setInputScalarFieldPointer(inArray.data());
-  topologicalSimplification.setOutputScalarFieldPointer(array);
-  topologicalSimplification.setInputOffsetScalarFieldPointer(
-    inputOffsets.data());
-  topologicalSimplification.setOutputOffsetScalarFieldPointer(
-    decompressedOffsets_.data());
-  topologicalSimplification.setVertexIdentifierScalarFieldPointer(
-    critConstraints.data());
-  topologicalSimplification.setConstraintNumber(nbConstraints);
   status = topologicalSimplification.execute<double, int>(
     inArray.data(), array, critConstraints.data(), inputOffsets.data(),
-    decompressedOffsets_.data(), triangulation);
+    decompressedOffsets_.data(), nbConstraints, triangulation);
 
   return status;
 }
@@ -581,22 +572,13 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
 
     // 2. Perform topological simplification with constraints.
     if(UseTopologicalSimplification) {
-      topologicalSimplification.setInputScalarFieldPointer(inputData);
-      topologicalSimplification.setOutputScalarFieldPointer(outputData);
-      topologicalSimplification.setInputOffsetScalarFieldPointer(
-        inputOffsets.data());
       compressedOffsets_.resize(vertexNumber);
       for(int i = 0; i < vertexNumber; ++i)
         compressedOffsets_[i] = i;
-      topologicalSimplification.setOutputOffsetScalarFieldPointer(
-        compressedOffsets_.data());
-      topologicalSimplification.setVertexIdentifierScalarFieldPointer(
-        simplifiedConstraints.data());
-      topologicalSimplification.setConstraintNumber(nbCrit);
       int status = 0;
       status = topologicalSimplification.execute<dataType, SimplexId>(
         inputData, outputData, simplifiedConstraints.data(),
-        inputOffsets.data(), compressedOffsets_.data(), triangulation);
+        inputOffsets.data(), compressedOffsets_.data(), nbCrit, triangulation);
       if(status != 0) {
         return status;
       }

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -306,7 +306,9 @@ int ttk::TopologicalCompression::PerformSimplification(
   topologicalSimplification.setVertexIdentifierScalarFieldPointer(
     critConstraints.data());
   topologicalSimplification.setConstraintNumber(nbConstraints);
-  status = topologicalSimplification.execute<double, int>();
+  status = topologicalSimplification.execute<double, int>(
+    inArray.data(), array, critConstraints.data(), inputOffsets.data(),
+    decompressedOffsets_.data(), triangulation);
 
   return status;
 }
@@ -493,9 +495,9 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
         persistentSum2 += (p1 * p1);
         persistentSum1 += abs<dataType>(p1);
         int type1 = topologicalSimplification.getCriticalType(
-          cp1, inputData, inputOffsets.data());
+          cp1, inputData, inputOffsets.data(), triangulation);
         int type2 = topologicalSimplification.getCriticalType(
-          cp2, inputData, inputOffsets.data());
+          cp2, inputData, inputOffsets.data(), triangulation);
         if(type1 == 0) {
           // authorizedSaddles->push_back(cp1);
           topoIndices.push_back(std::make_tuple(idt1, cp1));
@@ -535,9 +537,9 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
         persistentSum1 += abs<dataType>(p1);
         // Saddle selection.
         int type1 = topologicalSimplification.getCriticalType(
-          cp1, inputData, inputOffsets.data());
+          cp1, inputData, inputOffsets.data(), triangulation);
         int type2 = topologicalSimplification.getCriticalType(
-          cp2, inputData, inputOffsets.data());
+          cp2, inputData, inputOffsets.data(), triangulation);
         if(type1 == 0) {
           // authorizedSaddles->push_back(cp1);
           topoIndices.push_back(std::make_tuple(idt1, cp1));
@@ -592,7 +594,9 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
         simplifiedConstraints.data());
       topologicalSimplification.setConstraintNumber(nbCrit);
       int status = 0;
-      status = topologicalSimplification.execute<dataType, SimplexId>();
+      status = topologicalSimplification.execute<dataType, SimplexId>(
+        inputData, outputData, simplifiedConstraints.data(),
+        inputOffsets.data(), compressedOffsets_.data(), triangulation);
       if(status != 0) {
         return status;
       }
@@ -885,7 +889,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
       SimplexId id = simplifiedConstraints[i];
       dataType val = inputData[id];
       int type = topologicalSimplification.getCriticalType(
-        id, inputData, inputOffsets.data());
+        id, inputData, inputOffsets.data(), triangulation);
       if(type == -1 // Local_minimum
          || type == 1 // Local_maximum
          || type == 0) {

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -112,7 +112,7 @@ namespace ttk {
       preconditionTriangulation(AbstractTriangulation *const triangulation) {
       if(triangulation != nullptr) {
         triangulation->preconditionVertexNeighbors();
-        topologicalSimplification.setupTriangulation(triangulation);
+        topologicalSimplification.preconditionTriangulation(triangulation);
         ftmTreePP.setupTriangulation(triangulation, false);
       }
     }

--- a/core/base/topologicalSimplification/TopologicalSimplification.cpp
+++ b/core/base/topologicalSimplification/TopologicalSimplification.cpp
@@ -1,17 +1,5 @@
 #include <TopologicalSimplification.h>
 
-using namespace std;
-using namespace ttk;
-
-TopologicalSimplification::TopologicalSimplification()
-  : triangulation_{}, vertexNumber_{}, constraintNumber_{},
-    inputScalarFieldPointer_{}, vertexIdentifierScalarFieldPointer_{},
-    inputOffsetScalarFieldPointer_{}, considerIdentifierAsBlackList_{},
-    addPerturbation_{}, outputScalarFieldPointer_{},
-    outputOffsetScalarFieldPointer_{} {
-  considerIdentifierAsBlackList_ = false;
-  addPerturbation_ = false;
-}
-
-TopologicalSimplification::~TopologicalSimplification() {
+ttk::TopologicalSimplification::TopologicalSimplification() {
+  this->setDebugMsgPrefix("TopologicalSimplification");
 }

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -340,13 +340,11 @@ int ttk::TopologicalSimplification::execute() const {
   getCriticalPoints<dataType>(
     scalars, offsets, authorizedMinima, authorizedMaxima, extrema);
 
-  {
-    std::stringstream msg;
-    msg << "[TopologicalSimplification] Maintaining " << constraintNumber_
-        << " constraints (" << authorizedMinima.size() << " minima and "
-        << authorizedMaxima.size() << " maxima)." << std::endl;
-    dMsg(std::cout, msg.str(), advancedInfoMsg);
-  }
+  this->printMsg("Maintaining " + std::to_string(constraintNumber_)
+                   + " constraints (" + std::to_string(authorizedMinima.size())
+                   + " minima and " + std::to_string(authorizedMaxima.size())
+                   + "maxima)",
+                 debug::Priority::DETAIL);
 
   // declare the tuple-comparison functor
   SweepCmp cmp;
@@ -355,12 +353,8 @@ int ttk::TopologicalSimplification::execute() const {
   int iteration{};
   for(SimplexId i = 0; i < vertexNumber_; ++i) {
 
-    {
-      std::stringstream msg;
-      msg << "[TopologicalSimplification] Starting simplifying iteration #" << i
-          << "..." << std::endl;
-      dMsg(std::cout, msg.str(), advancedInfoMsg);
-    }
+    this->printMsg("Starting simplifying iteration #" + std::to_string(i),
+                   debug::Priority::DETAIL);
 
     for(int j = 0; j < 2; ++j) {
 
@@ -444,12 +438,12 @@ int ttk::TopologicalSimplification::execute() const {
     if(minima.size() > authorizedMinima.size())
       needForMoreIterations = true;
 
-    {
-      std::stringstream msg;
-      msg << "[TopologicalSimplification] Current status: " << minima.size()
-          << " minima, " << maxima.size() << " maxima." << std::endl;
-      dMsg(std::cout, msg.str(), advancedInfoMsg);
-    }
+    this->printMsg(
+      std::vector<std::vector<std::string>>{
+        {"#Minima", std::to_string(minima.size())},
+        {"#Maxima", std::to_string(maxima.size())},
+      },
+      debug::Priority::DETAIL);
 
     if(!needForMoreIterations) {
       for(SimplexId k : minima) {
@@ -477,13 +471,8 @@ int ttk::TopologicalSimplification::execute() const {
       break;
   }
 
-  {
-    std::stringstream msg;
-    msg << "[TopologicalSimplification] Scalar field simplified"
-        << " in " << t.getElapsedTime() << " s. (" << threadNumber_
-        << " threads(s), " << iteration << " ite.)." << std::endl;
-    dMsg(std::cout, msg.str(), timeMsg);
-  }
+  this->printMsg(
+    "Simplified scalar field", 1.0, t.getElapsedTime(), this->threadNumber_);
 
   return 0;
 }

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -21,13 +21,12 @@
 ///
 /// \sa ttkTopologicalSimplification.cpp %for a usage example.
 
-#ifndef _TOPOLOGICALSIMPLIFICATION_H
-#define _TOPOLOGICALSIMPLIFICATION_H
+#pragma once
 
 // base code includes
-#include <Wrapper.h>
-
+#include <Debug.h>
 #include <Triangulation.h>
+
 #include <cmath>
 #include <set>
 #include <tuple>
@@ -35,20 +34,18 @@
 
 namespace ttk {
 
-  struct SweepCmp {
-  private:
-    bool isIncreasingOrder_;
+  class SweepCmp {
+    bool isIncreasingOrder_{};
 
   public:
-    SweepCmp() : isIncreasingOrder_{} {
+    SweepCmp() {
     }
 
     SweepCmp(bool isIncreasingOrder) : isIncreasingOrder_{isIncreasingOrder} {
     }
 
-    int setIsIncreasingOrder(bool isIncreasingOrder) {
+    inline void setIsIncreasingOrder(bool isIncreasingOrder) {
       isIncreasingOrder_ = isIncreasingOrder;
-      return 0;
     }
 
     template <typename dataType>
@@ -64,15 +61,12 @@ namespace ttk {
                 or (std::get<0>(v0) == std::get<0>(v1)
                     and std::get<1>(v0) > std::get<1>(v1)));
       }
-    };
+    }
   };
 
-  class TopologicalSimplification : public Debug {
-
+  class TopologicalSimplification : virtual public Debug {
   public:
     TopologicalSimplification();
-
-    ~TopologicalSimplification();
 
     template <typename dataType>
     bool isLowerThan(SimplexId a,
@@ -110,71 +104,62 @@ namespace ttk {
     template <typename dataType, typename idType>
     int execute() const;
 
-    inline int setupTriangulation(AbstractTriangulation *triangulation) {
+    inline int preconditionTriangulation(AbstractTriangulation *triangulation) {
       triangulation_ = triangulation;
-      if(triangulation_) {
-        vertexNumber_ = triangulation_->getNumberOfVertices();
-        triangulation_->preconditionVertexNeighbors();
+      if(triangulation) {
+        vertexNumber_ = triangulation->getNumberOfVertices();
+        triangulation->preconditionVertexNeighbors();
       }
       return 0;
     }
 
-    inline int setVertexNumber(SimplexId vertexNumber) {
+    inline void setVertexNumber(SimplexId vertexNumber) {
       vertexNumber_ = vertexNumber;
-      return 0;
     }
 
-    inline int setConstraintNumber(SimplexId constraintNumber) {
+    inline void setConstraintNumber(SimplexId constraintNumber) {
       constraintNumber_ = constraintNumber;
-      return 0;
     }
 
-    inline int setInputScalarFieldPointer(void *data) {
+    inline void setInputScalarFieldPointer(void *data) {
       inputScalarFieldPointer_ = data;
-      return 0;
     }
 
-    inline int setVertexIdentifierScalarFieldPointer(void *data) {
+    inline void setVertexIdentifierScalarFieldPointer(void *data) {
       vertexIdentifierScalarFieldPointer_ = data;
-      return 0;
     }
 
-    inline int setInputOffsetScalarFieldPointer(void *data) {
+    inline void setInputOffsetScalarFieldPointer(void *data) {
       inputOffsetScalarFieldPointer_ = data;
-      return 0;
     }
 
-    inline int setConsiderIdentifierAsBlackList(bool onOff) {
+    inline void setConsiderIdentifierAsBlackList(bool onOff) {
       considerIdentifierAsBlackList_ = onOff;
-      return 0;
     }
 
-    inline int setAddPerturbation(bool onOff) {
+    inline void setAddPerturbation(bool onOff) {
       addPerturbation_ = onOff;
-      return 0;
     }
 
-    inline int setOutputScalarFieldPointer(void *data) {
+    inline void setOutputScalarFieldPointer(void *data) {
       outputScalarFieldPointer_ = data;
-      return 0;
     }
 
-    inline int setOutputOffsetScalarFieldPointer(void *data) {
+    inline void setOutputOffsetScalarFieldPointer(void *data) {
       outputOffsetScalarFieldPointer_ = data;
-      return 0;
     }
 
   protected:
-    AbstractTriangulation *triangulation_;
-    SimplexId vertexNumber_;
-    SimplexId constraintNumber_;
-    void *inputScalarFieldPointer_;
-    void *vertexIdentifierScalarFieldPointer_;
-    void *inputOffsetScalarFieldPointer_;
-    bool considerIdentifierAsBlackList_;
-    bool addPerturbation_;
-    void *outputScalarFieldPointer_;
-    void *outputOffsetScalarFieldPointer_;
+    AbstractTriangulation *triangulation_{};
+    SimplexId vertexNumber_{};
+    SimplexId constraintNumber_{};
+    void *inputScalarFieldPointer_{};
+    void *vertexIdentifierScalarFieldPointer_{};
+    void *inputOffsetScalarFieldPointer_{};
+    bool considerIdentifierAsBlackList_{false};
+    bool addPerturbation_{false};
+    void *outputScalarFieldPointer_{};
+    void *outputOffsetScalarFieldPointer_{};
   };
 } // namespace ttk
 
@@ -502,4 +487,3 @@ int ttk::TopologicalSimplification::execute() const {
 
   return 0;
 }
-#endif // TOPOLOGICALSIMPLIFICATION_H

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -110,6 +110,7 @@ namespace ttk {
                 const idType *const identifiers,
                 const idType *const inputOffsets,
                 SimplexId *const offsets,
+                const SimplexId constraintNumber,
                 const triangulationType &triangulation) const;
 
     inline int preconditionTriangulation(AbstractTriangulation *triangulation) {
@@ -120,26 +121,6 @@ namespace ttk {
       return 0;
     }
 
-    inline void setVertexNumber(SimplexId vertexNumber) {
-      vertexNumber_ = vertexNumber;
-    }
-
-    inline void setConstraintNumber(SimplexId constraintNumber) {
-      constraintNumber_ = constraintNumber;
-    }
-
-    inline void setInputScalarFieldPointer(void *data) {
-      inputScalarFieldPointer_ = data;
-    }
-
-    inline void setVertexIdentifierScalarFieldPointer(void *data) {
-      vertexIdentifierScalarFieldPointer_ = data;
-    }
-
-    inline void setInputOffsetScalarFieldPointer(void *data) {
-      inputOffsetScalarFieldPointer_ = data;
-    }
-
     inline void setConsiderIdentifierAsBlackList(bool onOff) {
       considerIdentifierAsBlackList_ = onOff;
     }
@@ -148,24 +129,10 @@ namespace ttk {
       addPerturbation_ = onOff;
     }
 
-    inline void setOutputScalarFieldPointer(void *data) {
-      outputScalarFieldPointer_ = data;
-    }
-
-    inline void setOutputOffsetScalarFieldPointer(void *data) {
-      outputOffsetScalarFieldPointer_ = data;
-    }
-
   protected:
     SimplexId vertexNumber_{};
-    SimplexId constraintNumber_{};
-    void *inputScalarFieldPointer_{};
-    void *vertexIdentifierScalarFieldPointer_{};
-    void *inputOffsetScalarFieldPointer_{};
     bool considerIdentifierAsBlackList_{false};
     bool addPerturbation_{false};
-    void *outputScalarFieldPointer_{};
-    void *outputOffsetScalarFieldPointer_{};
   };
 } // namespace ttk
 
@@ -315,6 +282,7 @@ int ttk::TopologicalSimplification::execute(
   const idType *const identifiers,
   const idType *const inputOffsets,
   SimplexId *const offsets,
+  const SimplexId constraintNumber,
   const triangulationType &triangulation) const {
 
   Timer t;
@@ -333,7 +301,7 @@ int ttk::TopologicalSimplification::execute(
 
   // get the user extremum list
   std::vector<bool> extrema(vertexNumber_, false);
-  for(SimplexId k = 0; k < constraintNumber_; ++k) {
+  for(SimplexId k = 0; k < constraintNumber; ++k) {
     const SimplexId identifierId = identifiers[k];
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -349,7 +317,7 @@ int ttk::TopologicalSimplification::execute(
   getCriticalPoints(outputScalars, offsets, authorizedMinima, authorizedMaxima,
                     extrema, triangulation);
 
-  this->printMsg("Maintaining " + std::to_string(constraintNumber_)
+  this->printMsg("Maintaining " + std::to_string(constraintNumber)
                    + " constraints (" + std::to_string(authorizedMinima.size())
                    + " minima and " + std::to_string(authorizedMaxima.size())
                    + "maxima)",

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -252,6 +252,24 @@ vtkDataArray *
   return optionalArray;
 }
 
+vtkDataArray *ttkAlgorithm::GetOptionalArray(const bool &enforceArrayIndex,
+                                             const int &arrayIndex,
+                                             const std::string &arrayName,
+                                             vtkDataSet *const inputData,
+                                             const int &inputPort) {
+
+  vtkDataArray *optionalArray = nullptr;
+
+  if(enforceArrayIndex)
+    optionalArray = this->GetInputArrayToProcess(arrayIndex, inputData);
+
+  if(!optionalArray) {
+    this->SetInputArrayToProcess(arrayIndex, inputPort, 0, 0, arrayName.data());
+    optionalArray = this->GetInputArrayToProcess(arrayIndex, inputData);
+  }
+  return optionalArray;
+}
+
 ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
 
   this->printMsg("Requesting triangulation for '"

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -132,6 +132,11 @@ public:
                                  const std::string &arrayName,
                                  vtkInformationVector **inputVectors,
                                  const int &inputPort = 0);
+  vtkDataArray *GetOptionalArray(const bool &enforceArrayIndex,
+                                 const int &arrayIndex,
+                                 const std::string &arrayName,
+                                 vtkDataSet *const inputData,
+                                 const int &inputPort = 0);
 
   /**
    * This method retrieves the ttk::Triangulation of a vtkDataSet.

--- a/core/vtk/ttkTopologicalSimplification/ttk.module
+++ b/core/vtk/ttkTopologicalSimplification/ttk.module
@@ -6,4 +6,4 @@ HEADERS
   ttkTopologicalSimplification.h
 DEPENDS
   topologicalSimplification
-  ttkTriangulationAlgorithm
+  ttkAlgorithm

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -180,18 +180,6 @@ int ttkTopologicalSimplification::getOffsets(vtkDataSet *input) {
   return 0;
 }
 
-template <typename VTK_TT>
-int ttkTopologicalSimplification::dispatch() {
-  int ret = 0;
-  if(inputOffsets_->GetDataType() == VTK_INT) {
-    ret = topologicalSimplification_.execute<VTK_TT, int>();
-  }
-  if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
-    ret = topologicalSimplification_.execute<VTK_TT, vtkIdType>();
-  }
-  return ret;
-}
-
 int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
                                        vector<vtkDataSet *> &outputs) {
 
@@ -364,8 +352,15 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
   }
 #endif
 
-  switch(inputScalars_->GetDataType()) {
-    vtkTemplateMacro(ret = dispatch<VTK_TT>());
+  if(inputOffsets_->GetDataType() == VTK_INT) {
+    switch(inputScalars_->GetDataType()) {
+      vtkTemplateMacro(ret = topologicalSimplification_.execute<VTK_TT, int>());
+    }
+  } else if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
+    switch(inputScalars_->GetDataType()) {
+      vtkTemplateMacro(
+        ret = topologicalSimplification_.execute<VTK_TT, vtkIdType>());
+    }
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -325,25 +325,6 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
   }
 #endif
 
-  topologicalSimplification_.setVertexNumber(numberOfVertices);
-  topologicalSimplification_.setConstraintNumber(numberOfConstraints);
-  topologicalSimplification_.setInputScalarFieldPointer(
-    inputScalars_->GetVoidPointer(0));
-  topologicalSimplification_.setVertexIdentifierScalarFieldPointer(
-    identifiers_->GetVoidPointer(0));
-  topologicalSimplification_.setConsiderIdentifierAsBlackList(
-    ConsiderIdentifierAsBlackList);
-  topologicalSimplification_.setAddPerturbation(AddPerturbation);
-
-  topologicalSimplification_.setInputOffsetScalarFieldPointer(
-    inputOffsets_->GetVoidPointer(0));
-
-  topologicalSimplification_.setOutputScalarFieldPointer(
-    outputScalars->GetVoidPointer(0));
-
-  topologicalSimplification_.setOutputOffsetScalarFieldPointer(
-    outputOffsets->GetVoidPointer(0));
-
 #ifndef TTK_ENABLE_KAMIKAZE
   if(identifiers_->GetDataType() != inputOffsets_->GetDataType()) {
     cerr << "[ttkTopologicalSimplification] Error : type of identifiers and "
@@ -362,7 +343,7 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
           static_cast<int *>(ttkUtils::GetVoidPointer(identifiers_)),
           static_cast<int *>(ttkUtils::GetVoidPointer(inputOffsets_)),
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-          *triangulation_->getData()));
+          numberOfConstraints, *triangulation_->getData()));
     }
   } else if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
     switch(inputScalars_->GetDataType()) {
@@ -373,7 +354,7 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
           static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(identifiers_)),
           static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(inputOffsets_)),
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-          *triangulation_->getData()));
+          numberOfConstraints, *triangulation_->getData()));
     }
   }
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -58,7 +58,7 @@ int ttkTopologicalSimplification::getTriangulation(vtkDataSet *input) {
   triangulation_->setPeriodicBoundaryConditions(PeriodicBoundaryConditions);
   triangulation_->setWrapper(this);
   topologicalSimplification_.setWrapper(this);
-  topologicalSimplification_.setupTriangulation(triangulation_);
+  topologicalSimplification_.preconditionTriangulation(triangulation_);
   Modified();
   hasUpdatedMesh_ = true;
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -84,8 +84,12 @@ int ttkTopologicalSimplification::RequestData(
   }
 
   // constraint identifier field
+
+  // use the GetOptionalArray variant here to fix a segfault occuring
+  // when changing a threshold bound on the Threshold filter usually
+  // connected to the second input port
   const auto identifiers = this->GetOptionalArray(
-    ForceInputVertexScalarField, 1, ttk::VertexScalarFieldName, inputVector, 1);
+    ForceInputVertexScalarField, 1, ttk::VertexScalarFieldName, constraints);
 
   if(!identifiers) {
     this->printErr("Wrong vertex identifier scalar field.");

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -43,27 +43,26 @@ int ttkTopologicalSimplification::RequestData(
 
   int ret{};
 
+  // triangulation
+
   triangulation_ = ttkAlgorithm::GetTriangulation(domain);
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!triangulation_) {
     this->printErr("Input triangulation pointer is NULL.");
     return -1;
   }
-#endif
 
   this->preconditionTriangulation(triangulation_);
   Modified();
   hasUpdatedMesh_ = true;
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(triangulation_->isEmpty()) {
     this->printErr("Triangulation allocation problem.");
     return -1;
   }
-#endif
 
-#ifndef TTK_ENABLE_KAMIKAZE
+  // domain scalar field
+
   if(!domain) {
     this->printErr("Input pointer is NULL.");
     return -1;
@@ -73,16 +72,13 @@ int ttkTopologicalSimplification::RequestData(
     this->printErr("Input has no point.");
     return -1;
   }
-#endif
 
   const auto pointData = domain->GetPointData();
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!pointData) {
     this->printErr("Input has no point data.");
     return -1;
   }
-#endif
 
   if(ScalarField.length()) {
     inputScalars_ = pointData->GetArray(ScalarField.data());
@@ -92,12 +88,12 @@ int ttkTopologicalSimplification::RequestData(
       ScalarField = inputScalars_->GetName();
   }
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!inputScalars_) {
     this->printErr("Input scalar field pointer is null.");
     return -3;
   }
-#endif
+
+  // constraint identifier field
 
   if(ForceInputVertexScalarField && InputVertexScalarFieldName.length())
     identifiers_ = constraints->GetPointData()->GetArray(
@@ -106,12 +102,12 @@ int ttkTopologicalSimplification::RequestData(
     identifiers_
       = constraints->GetPointData()->GetArray(ttk::VertexScalarFieldName);
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!identifiers_) {
     this->printErr("Wrong vertex identifier scalar field.");
     return -1;
   }
-#endif
+
+  // domain offset field
 
   if(ForceInputOffsetScalarField && InputOffsetScalarFieldName.length()) {
     inputOffsets_
@@ -143,28 +139,22 @@ int ttkTopologicalSimplification::RequestData(
     inputOffsets_ = offsets_;
   }
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!inputOffsets_) {
     this->printErr("Wrong input offset scalar field.");
     return -1;
   }
-#endif
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(inputOffsets_->GetDataType() != VTK_INT
      and inputOffsets_->GetDataType() != VTK_ID_TYPE) {
     this->printErr("Input offset field type not supported.");
     return -1;
   }
-#endif
 
   const auto numberOfVertices = domain->GetNumberOfPoints();
-#ifndef TTK_ENABLE_KAMIKAZE
   if(numberOfVertices <= 0) {
     this->printErr("Domain has no points.");
     return -5;
   }
-#endif
 
   if(OutputOffsetScalarFieldName.length() <= 0)
     OutputOffsetScalarFieldName = ttk::OffsetScalarFieldName;
@@ -174,40 +164,30 @@ int ttkTopologicalSimplification::RequestData(
     outputOffsets->SetNumberOfComponents(1);
     outputOffsets->SetNumberOfTuples(numberOfVertices);
     outputOffsets->SetName(OutputOffsetScalarFieldName.data());
-  }
-#ifndef TTK_ENABLE_KAMIKAZE
-  else {
+  } else {
     this->printErr("ttkSimplexIdTypeArray allocation problem.");
     return -7;
   }
-#endif
 
   vtkSmartPointer<vtkDataArray> outputScalars{inputScalars_->NewInstance()};
   if(outputScalars) {
     outputScalars->SetNumberOfTuples(numberOfVertices);
     outputScalars->SetName(inputScalars_->GetName());
-  }
-#ifndef TTK_ENABLE_KAMIKAZE
-  else {
+  } else {
     this->printErr("vtkDataArray allocation problem.");
     return -9;
   }
-#endif
 
   const auto numberOfConstraints = constraints->GetNumberOfPoints();
-#ifndef TTK_ENABLE_KAMIKAZE
   if(numberOfConstraints <= 0) {
     this->printErr("Input has no constraints.");
     return -10;
   }
-#endif
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(identifiers_->GetDataType() != inputOffsets_->GetDataType()) {
     this->printErr("Type of identifiers and offsets are different.");
     return -11;
   }
-#endif
 
   if(inputOffsets_->GetDataType() == VTK_INT) {
     switch(inputScalars_->GetDataType()) {
@@ -232,14 +212,13 @@ int ttkTopologicalSimplification::RequestData(
           numberOfConstraints, *triangulation_->getData()));
     }
   }
-#ifndef TTK_ENABLE_KAMIKAZE
+
   // something wrong in baseCode
   if(ret) {
     this->printErr("TopologicalSimplification.execute() error code: "
                    + std::to_string(ret));
     return -12;
   }
-#endif
 
   output->ShallowCopy(domain);
   output->GetPointData()->AddArray(outputOffsets);

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -36,9 +36,7 @@ int ttkTopologicalSimplification::getTriangulation(vtkDataSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!triangulation_) {
-    cerr << "[ttkTopologicalSimplification] Error : input triangulation "
-            "pointer is NULL."
-         << endl;
+    this->printErr("Input triangulation pointer is NULL.");
     return -1;
   }
 #endif
@@ -49,9 +47,7 @@ int ttkTopologicalSimplification::getTriangulation(vtkDataSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangulation_->isEmpty()) {
-    cerr << "[ttkTopologicalSimplification] Error : ttkTriangulation "
-            "allocation problem."
-         << endl;
+    this->printErr("Triangulation allocation problem.");
     return -1;
   }
 #endif
@@ -62,14 +58,12 @@ int ttkTopologicalSimplification::getTriangulation(vtkDataSet *input) {
 int ttkTopologicalSimplification::getScalars(vtkDataSet *input) {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!input) {
-    cerr << "[ttkTopologicalSimplification] Error : input pointer is NULL."
-         << endl;
+    this->printErr("Input pointer is NULL.");
     return -1;
   }
 
   if(!input->GetNumberOfPoints()) {
-    cerr << "[ttkTopologicalSimplification] Error : input has no point."
-         << endl;
+    this->printErr("Input has no point.");
     return -1;
   }
 #endif
@@ -78,8 +72,7 @@ int ttkTopologicalSimplification::getScalars(vtkDataSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!pointData) {
-    cerr << "[ttkTopologicalSimplification] Error : input has no point data."
-         << endl;
+    this->printErr("Input has no point data.");
     return -1;
   }
 #endif
@@ -94,9 +87,7 @@ int ttkTopologicalSimplification::getScalars(vtkDataSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!inputScalars_) {
-    cerr << "[ttkTopologicalSimplification] Error : input scalar field pointer "
-            "is null."
-         << endl;
+    this->printErr("Input scalar field pointer is null.");
     return -3;
   }
 #endif
@@ -113,9 +104,7 @@ int ttkTopologicalSimplification::getIdentifiers(vtkPointSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!identifiers_) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong vertex identifier "
-            "scalar field."
-         << endl;
+    this->printErr("Wrong vertex identifier scalar field.");
     return -1;
   }
 #endif
@@ -155,9 +144,7 @@ int ttkTopologicalSimplification::getOffsets(vtkDataSet *input) {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!inputOffsets_) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong input offset scalar "
-            "field."
-         << endl;
+    this->printErr("Wrong input offset scalar field.");
     return -1;
   }
 #endif
@@ -181,8 +168,7 @@ int ttkTopologicalSimplification::RequestData(
   ret = getTriangulation(domain);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong triangulation."
-         << endl;
+    this->printErr("Wrong triangulation.");
     return -1;
   }
 #endif
@@ -190,7 +176,7 @@ int ttkTopologicalSimplification::RequestData(
   ret = getScalars(domain);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong scalars." << endl;
+    this->printErr("Wrong scalars.");
     return -2;
   }
 #endif
@@ -198,7 +184,7 @@ int ttkTopologicalSimplification::RequestData(
   ret = getIdentifiers(constraints);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong identifiers." << endl;
+    this->printErr("Wrong identifiers.");
     return -3;
   }
 #endif
@@ -206,16 +192,14 @@ int ttkTopologicalSimplification::RequestData(
   ret = getOffsets(domain);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {
-    cerr << "[ttkTopologicalSimplification] Error : wrong offsets." << endl;
+    this->printErr("Wrong offsets.");
     return -4;
   }
 #endif
 #ifndef TTK_ENABLE_KAMIKAZE
   if(inputOffsets_->GetDataType() != VTK_INT
      and inputOffsets_->GetDataType() != VTK_ID_TYPE) {
-    cerr << "[ttkTopologicalSimplification] Error : input offset field type "
-            "not supported."
-         << endl;
+    this->printErr("Input offset field type not supported.");
     return -1;
   }
 #endif
@@ -223,8 +207,7 @@ int ttkTopologicalSimplification::RequestData(
   const auto numberOfVertices = domain->GetNumberOfPoints();
 #ifndef TTK_ENABLE_KAMIKAZE
   if(numberOfVertices <= 0) {
-    cerr << "[ttkTopologicalSimplification] Error : domain has no points."
-         << endl;
+    this->printErr("Domain has no points.");
     return -5;
   }
 #endif
@@ -240,9 +223,7 @@ int ttkTopologicalSimplification::RequestData(
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   else {
-    cerr << "[ttkTopologicalSimplification] Error : ttkSimplexIdTypeArray "
-            "allocation problem."
-         << endl;
+    this->printErr("ttkSimplexIdTypeArray allocation problem.");
     return -7;
   }
 #endif
@@ -254,9 +235,7 @@ int ttkTopologicalSimplification::RequestData(
   }
 #ifndef TTK_ENABLE_KAMIKAZE
   else {
-    cerr << "[ttkTopologicalSimplification] Error : vtkDataArray allocation "
-            "problem."
-         << endl;
+    this->printErr("vtkDataArray allocation problem.");
     return -9;
   }
 #endif
@@ -264,17 +243,14 @@ int ttkTopologicalSimplification::RequestData(
   const auto numberOfConstraints = constraints->GetNumberOfPoints();
 #ifndef TTK_ENABLE_KAMIKAZE
   if(numberOfConstraints <= 0) {
-    cerr << "[ttkTopologicalSimplification] Error : input has no constraints."
-         << endl;
+    this->printErr("Input has no constraints.");
     return -10;
   }
 #endif
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(identifiers_->GetDataType() != inputOffsets_->GetDataType()) {
-    cerr << "[ttkTopologicalSimplification] Error : type of identifiers and "
-            "offsets are different."
-         << endl;
+    this->printErr("Type of identifiers and offsets are different.");
     return -11;
   }
 #endif
@@ -305,9 +281,8 @@ int ttkTopologicalSimplification::RequestData(
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode
   if(ret) {
-    cerr << "[ttkTopologicalSimplification] "
-            "TopologicalSimplification.execute() error code : "
-         << ret << endl;
+    this->printErr("TopologicalSimplification.execute() error code: "
+                   + std::to_string(ret));
     return -12;
   }
 #endif

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -1,4 +1,5 @@
 #include <ttkTopologicalSimplification.h>
+#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;
@@ -354,12 +355,25 @@ int ttkTopologicalSimplification::doIt(vector<vtkDataSet *> &inputs,
 
   if(inputOffsets_->GetDataType() == VTK_INT) {
     switch(inputScalars_->GetDataType()) {
-      vtkTemplateMacro(ret = topologicalSimplification_.execute<VTK_TT, int>());
+      vtkTemplateMacro(
+        ret = topologicalSimplification_.execute(
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars_)),
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
+          static_cast<int *>(ttkUtils::GetVoidPointer(identifiers_)),
+          static_cast<int *>(ttkUtils::GetVoidPointer(inputOffsets_)),
+          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
+          *triangulation_->getData()));
     }
   } else if(inputOffsets_->GetDataType() == VTK_ID_TYPE) {
     switch(inputScalars_->GetDataType()) {
       vtkTemplateMacro(
-        ret = topologicalSimplification_.execute<VTK_TT, vtkIdType>());
+        ret = topologicalSimplification_.execute(
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars_)),
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
+          static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(identifiers_)),
+          static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(inputOffsets_)),
+          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
+          *triangulation_->getData()));
     }
   }
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -46,8 +46,8 @@
 /// \sa ttkFTMTree
 /// \sa ttkIdentifiers
 /// \sa ttk::TopologicalSimplification
-#ifndef _TTK_TOPOLOGICALSIMPLIFICATION_H
-#define _TTK_TOPOLOGICALSIMPLIFICATION_H
+
+#pragma once
 
 // VTK includes -- to adapt
 #include <vtkCharArray.h>
@@ -61,6 +61,7 @@
 #include <vtkIntArray.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
+#include <vtkPointSet.h>
 #include <vtkShortArray.h>
 #include <vtkSmartPointer.h>
 #include <vtkUnsignedCharArray.h>
@@ -71,32 +72,15 @@
 
 // ttk code includes
 #include <TopologicalSimplification.h>
-#include <ttkTriangulationAlgorithm.h>
-
-#include <ttkTriangulation.h>
+#include <ttkAlgorithm.h>
 
 class TTKTOPOLOGICALSIMPLIFICATION_EXPORT ttkTopologicalSimplification
-  : public vtkDataSetAlgorithm,
-    protected ttk::Wrapper {
+  : public ttkAlgorithm,
+    protected ttk::TopologicalSimplification {
 
 public:
   static ttkTopologicalSimplification *New();
-  vtkTypeMacro(ttkTopologicalSimplification, vtkDataSetAlgorithm);
-
-  void SetDebugLevel(int debugLevel) {
-    setDebugLevel(debugLevel);
-    Modified();
-  }
-
-  void SetThreadNumber(int threadNumber) {
-    ThreadNumber = threadNumber;
-    SetThreads();
-  }
-
-  void SetUseAllCores(bool onOff) {
-    UseAllCores = onOff;
-    SetThreads();
-  }
+  vtkTypeMacro(ttkTopologicalSimplification, ttkAlgorithm);
 
   vtkSetMacro(ScalarField, std::string);
   vtkGetMacro(ScalarField, std::string);
@@ -122,9 +106,6 @@ public:
   vtkSetMacro(InputVertexScalarFieldName, std::string);
   vtkGetMacro(InputVertexScalarFieldName, std::string);
 
-  vtkSetMacro(PeriodicBoundaryConditions, int);
-  vtkGetMacro(PeriodicBoundaryConditions, int);
-
   int getTriangulation(vtkDataSet *input);
   int getScalars(vtkDataSet *input);
   int getIdentifiers(vtkPointSet *input);
@@ -133,32 +114,28 @@ public:
 protected:
   ttkTopologicalSimplification();
 
-  ~ttkTopologicalSimplification() override;
-
-  TTK_SETUP();
-
   int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
 
 private:
-  int ScalarFieldId;
-  int OffsetFieldId;
-  std::string ScalarField;
-  std::string InputOffsetScalarFieldName;
-  std::string OutputOffsetScalarFieldName;
-  bool ForceInputVertexScalarField;
-  std::string InputVertexScalarFieldName;
-  bool ForceInputOffsetScalarField;
-  bool PeriodicBoundaryConditions;
-  bool ConsiderIdentifierAsBlackList;
-  bool AddPerturbation;
-  bool hasUpdatedMesh_;
+  int ScalarFieldId{0};
+  int OffsetFieldId{-1};
+  std::string ScalarField{};
+  std::string InputOffsetScalarFieldName{ttk::OffsetScalarFieldName};
+  std::string OutputOffsetScalarFieldName{ttk::OffsetScalarFieldName};
+  bool ForceInputVertexScalarField{false};
+  std::string InputVertexScalarFieldName{ttk::VertexScalarFieldName};
+  bool ForceInputOffsetScalarField{false};
+  bool ConsiderIdentifierAsBlackList{false};
+  bool AddPerturbation{false};
+  bool hasUpdatedMesh_{false};
 
-  ttk::TopologicalSimplification topologicalSimplification_;
-  ttk::Triangulation *triangulation_;
-  vtkDataArray *identifiers_;
-  vtkDataArray *inputScalars_;
-  vtkDataArray *offsets_;
-  vtkDataArray *inputOffsets_;
+  ttk::Triangulation *triangulation_{};
+  vtkDataArray *identifiers_{};
+  vtkDataArray *inputScalars_{};
+  vtkSmartPointer<vtkDataArray> offsets_{};
+  vtkDataArray *inputOffsets_{};
 };
-
-#endif // _TTK_TOPOLOGICALSIMPLIFICATION_H

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -130,9 +130,6 @@ public:
   int getIdentifiers(vtkPointSet *input);
   int getOffsets(vtkDataSet *input);
 
-  template <typename VTK_TT>
-  int dispatch();
-
 protected:
   ttkTopologicalSimplification();
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -50,22 +50,7 @@
 #pragma once
 
 // VTK includes -- to adapt
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDataSetAlgorithm.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkIntArray.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkPointSet.h>
-#include <vtkShortArray.h>
 #include <vtkSmartPointer.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkUnsignedShortArray.h>
 
 // VTK Module
 #include <ttkTopologicalSimplificationModule.h>
@@ -73,6 +58,8 @@
 // ttk code includes
 #include <TopologicalSimplification.h>
 #include <ttkAlgorithm.h>
+
+class vtkDataArray;
 
 class TTKTOPOLOGICALSIMPLIFICATION_EXPORT ttkTopologicalSimplification
   : public ttkAlgorithm,
@@ -126,11 +113,6 @@ private:
   bool ForceInputOffsetScalarField{false};
   bool ConsiderIdentifierAsBlackList{false};
   bool AddPerturbation{false};
-  bool hasUpdatedMesh_{false};
 
-  ttk::Triangulation *triangulation_{};
-  vtkDataArray *identifiers_{};
-  vtkDataArray *inputScalars_{};
   vtkSmartPointer<vtkDataArray> offsets_{};
-  vtkDataArray *inputOffsets_{};
 };

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -69,9 +69,6 @@ public:
   static ttkTopologicalSimplification *New();
   vtkTypeMacro(ttkTopologicalSimplification, ttkAlgorithm);
 
-  vtkSetMacro(ScalarField, std::string);
-  vtkGetMacro(ScalarField, std::string);
-
   vtkSetMacro(ForceInputOffsetScalarField, bool);
   vtkGetMacro(ForceInputOffsetScalarField, bool);
 
@@ -81,17 +78,11 @@ public:
   vtkSetMacro(AddPerturbation, bool);
   vtkGetMacro(AddPerturbation, bool);
 
-  vtkSetMacro(InputOffsetScalarFieldName, std::string);
-  vtkGetMacro(InputOffsetScalarFieldName, std::string);
-
   vtkSetMacro(OutputOffsetScalarFieldName, std::string);
   vtkGetMacro(OutputOffsetScalarFieldName, std::string);
 
   vtkSetMacro(ForceInputVertexScalarField, bool);
   vtkGetMacro(ForceInputVertexScalarField, bool);
-
-  vtkSetMacro(InputVertexScalarFieldName, std::string);
-  vtkGetMacro(InputVertexScalarFieldName, std::string);
 
 protected:
   ttkTopologicalSimplification();
@@ -103,16 +94,10 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  int ScalarFieldId{0};
   int OffsetFieldId{-1};
-  std::string ScalarField{};
-  std::string InputOffsetScalarFieldName{ttk::OffsetScalarFieldName};
   std::string OutputOffsetScalarFieldName{ttk::OffsetScalarFieldName};
   bool ForceInputVertexScalarField{false};
-  std::string InputVertexScalarFieldName{ttk::VertexScalarFieldName};
   bool ForceInputOffsetScalarField{false};
   bool ConsiderIdentifierAsBlackList{false};
   bool AddPerturbation{false};
-
-  vtkSmartPointer<vtkDataArray> offsets_{};
 };

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -106,11 +106,6 @@ public:
   vtkSetMacro(InputVertexScalarFieldName, std::string);
   vtkGetMacro(InputVertexScalarFieldName, std::string);
 
-  int getTriangulation(vtkDataSet *input);
-  int getScalars(vtkDataSet *input);
-  int getIdentifiers(vtkPointSet *input);
-  int getOffsets(vtkDataSet *input);
-
 protected:
   ttkTopologicalSimplification();
 

--- a/core/vtk/ttkTopologicalSimplification/vtk.module
+++ b/core/vtk/ttkTopologicalSimplification/vtk.module
@@ -1,6 +1,4 @@
 NAME
  ttkTopologicalSimplification
 DEPENDS
-  VTK::FiltersCore
-PRIVATE_DEPENDS
-  VTK::CommonCore
+ ttkAlgorithm

--- a/paraview/TopologicalSimplification/TopologicalSimplification.xml
+++ b/paraview/TopologicalSimplification/TopologicalSimplification.xml
@@ -1,46 +1,46 @@
 <ServerManagerConfiguration>
-	<ProxyGroup name="filters">
-   <SourceProxy
-     name="ttkTopologicalSimplification"
-		 class="ttkTopologicalSimplification"
-		 label="TTK TopologicalSimplification">
-		 <Documentation
-			 long_help="TTK plugin for the topological simplification of scalar data."
-			 short_help="TTK plugin for the topological simplification of scalar
-data.">
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkTopologicalSimplification"
+        class="ttkTopologicalSimplification"
+        label="TTK TopologicalSimplification">
+      <Documentation
+          long_help="TTK plugin for the topological simplification of scalar data."
+          short_help="TTK plugin for the topological simplification of scalar
+                      data.">
 
-       Given an input scalar field and a list of critical points to remove,
-this plugin minimally edits the scalar field such that the listed critical
-points disappear. This procedure is useful to speedup subsequent topological
-data analysis when outlier critical points can be easily identified. It is
-also useful for data simplification.
+        Given an input scalar field and a list of critical points to remove,
+        this plugin minimally edits the scalar field such that the listed critical
+        points disappear. This procedure is useful to speedup subsequent topological
+        data analysis when outlier critical points can be easily identified. It is
+        also useful for data simplification.
 
-The list of critical points to remove must be associated with a point data
-scalar field that represent the vertex global identifiers in the input
-geometry.
+        The list of critical points to remove must be associated with a point data
+        scalar field that represent the vertex global identifiers in the input
+        geometry.
 
-Note that this plugin will also produce an output vertex offset scalar field
-that can be used for further topological data analysis tasks to disambiguate
-vertices on flat plateaus. For instance, this output vertex offset field
-can specified to the ContourForests, IntegralLines, or
-ScalarFieldCriticalPoints plugins.
+        Note that this plugin will also produce an output vertex offset scalar field
+        that can be used for further topological data analysis tasks to disambiguate
+        vertices on flat plateaus. For instance, this output vertex offset field
+        can specified to the ContourForests, IntegralLines, or
+        ScalarFieldCriticalPoints plugins.
 
-Also, this plugin can be given a specific input vertex offset.
+        Also, this plugin can be given a specific input vertex offset.
 
-Related publication:
-"Generalized Topological Simplification of Scalar Fields on Surfaces"
-Julien Tierny, Valerio Pascucci
-Proc. of IEEE VIS 2012.
-IEEE Transactions on Visualization and Computer Graphics, 2012.
+        Related publication:
+        "Generalized Topological Simplification of Scalar Fields on Surfaces"
+        Julien Tierny, Valerio Pascucci
+        Proc. of IEEE VIS 2012.
+        IEEE Transactions on Visualization and Computer Graphics, 2012.
 
-See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
+        See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
 
-		 </Documentation>
+      </Documentation>
 
-		 <InputProperty
-			 name="Domain"
-			 port_index="0"
-        command="SetInputConnection">
+      <InputProperty
+          name="Domain"
+          port_index="0"
+          command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>
@@ -56,10 +56,10 @@ See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
         </Documentation>
       </InputProperty>
 
-		 <InputProperty
-			 name="Constraints"
-			 port_index="1"
-        command="SetInputConnection">
+      <InputProperty
+          name="Constraints"
+          port_index="1"
+          command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>
@@ -71,21 +71,20 @@ See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
           <Property name="Constraints" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>
-					vtkPointSet that represent the constraints of the topological simplification.
+          vtkPointSet that represent the constraints of the topological simplification.
         </Documentation>
-			</InputProperty>
-
+      </InputProperty>
 
       <StringVectorProperty
-        name="ScalarField"
-        command="SetScalarField"
-        number_of_elements="1"
-        animateable="0"
-        label="Scalar Field"
-        >
+          name="ScalarField"
+          command="SetScalarField"
+          number_of_elements="1"
+          animateable="0"
+          label="Scalar Field"
+          >
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+            name="array_list"
+            default_values="0">
           <RequiredProperties>
             <Property name="Domain" function="Input" />
           </RequiredProperties>
@@ -96,41 +95,41 @@ See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
       </StringVectorProperty>
 
       <IntVectorProperty
-         name="ForceInputOffsetScalarField"
-         command="SetForceInputOffsetScalarField"
-         label="Force Input Offset Field"
-         number_of_elements="1"
-         panel_visibility="advanced"
-         default_values="0">
+          name="ForceInputOffsetScalarField"
+          command="SetForceInputOffsetScalarField"
+          label="Force Input Offset Field"
+          number_of_elements="1"
+          panel_visibility="advanced"
+          default_values="0">
         <BooleanDomain name="bool"/>
-         <Documentation>
+        <Documentation>
           Check this box to force the usage of a specific input scalar field
           as vertex offset (used to disambiguate flat plateaus).
-         </Documentation>
+        </Documentation>
       </IntVectorProperty>
 
-       <StringVectorProperty
-        name="InputOffsetScalarFieldName"
-        command="SetInputOffsetScalarFieldName"
-        label="Input Offset Field"
-        default_values="OutputOffsetScalarField"
-        number_of_elements="1"
-        animateable="0"
-        panel_visibility="advanced"
-        >
+      <StringVectorProperty
+          name="InputOffsetScalarFieldName"
+          command="SetInputOffsetScalarFieldName"
+          label="Input Offset Field"
+          default_values="OutputOffsetScalarField"
+          number_of_elements="1"
+          animateable="0"
+          panel_visibility="advanced"
+          >
         <ArrayListDomain
-          name="array_list"
-					default_values="0"
-                    >
+            name="array_list"
+            default_values="0"
+            >
           <RequiredProperties>
             <Property name="Domain" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="ForceInputOffsetScalarField"
-            value="1" />
+                                   mode="visibility"
+                                   property="ForceInputOffsetScalarField"
+                                   value="1" />
         </Hints>
         <Documentation>
           Select the input offset field (to disambiguate flat plateaus).
@@ -138,37 +137,37 @@ See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
       </StringVectorProperty>
 
       <IntVectorProperty name="ForceInputVertexScalarField"
-        label="Force Input Vertex ScalarField"
-        command="SetForceInputVertexScalarField"
-        number_of_elements="1"
-        default_values="0"
-        panel_visibility="advanced">
+                         label="Force Input Vertex ScalarField"
+                         command="SetForceInputVertexScalarField"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="advanced">
         <BooleanDomain name="bool"/>
         <Documentation>
         </Documentation>
       </IntVectorProperty>
 
       <StringVectorProperty
-        name="InputVertexScalarFieldName"
-        command="SetInputVertexScalarFieldName"
-        label="Vertex identifier field"
-        number_of_elements="1"
-        animateable="0"
-        panel_visibility="advanced"
-        >
-        <ArrayListDomain
-          name="array_list"
-          default_values="0"
+          name="InputVertexScalarFieldName"
+          command="SetInputVertexScalarFieldName"
+          label="Vertex identifier field"
+          number_of_elements="1"
+          animateable="0"
+          panel_visibility="advanced"
           >
+        <ArrayListDomain
+            name="array_list"
+            default_values="0"
+            >
           <RequiredProperties>
             <Property name="Constraints" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="ForceInputVertexScalarField"
-            value="1" />
+                                   mode="visibility"
+                                   property="ForceInputVertexScalarField"
+                                   value="1" />
         </Hints>
         <Documentation>
           Select the vertex identifier scalar field in the sources.
@@ -176,125 +175,63 @@ See also ScalarFieldCriticalPoints, IntegralLines, ContourForests, Identifiers.
       </StringVectorProperty>
 
       <IntVectorProperty
-        name="PeriodicBoundaryConditions"
-        command="SetPeriodicBoundaryConditions"
-        label="Periodic Boundary Conditions"
-        number_of_elements="1"
-        panel_visibility="advanced"
-        default_values="0">
+          name="ConsiderIdentifierAsBlackList"
+          command="SetConsiderIdentifierAsBlackList"
+          label="Remove selected extrema"
+          number_of_elements="1"
+          default_values="0">
         <BooleanDomain name="bool"/>
         <Documentation>
-          Check this box to use periodic boundary conditions for computation.
+          Check this box to remove the selected extrema (instead of
+          removing all non-selected extrema).
         </Documentation>
       </IntVectorProperty>
 
-     <IntVectorProperty
-         name="ConsiderIdentifierAsBlackList"
-         command="SetConsiderIdentifierAsBlackList"
-         label="Remove selected extrema"
-         number_of_elements="1"
-         default_values="0">
+      <IntVectorProperty
+          name="AddPerturbation"
+          command="SetAddPerturbation"
+          label="Numerical Perturbation"
+          number_of_elements="1"
+          default_values="0">
         <BooleanDomain name="bool"/>
-         <Documentation>
-          Check this box to remove the selected extrema (instead of
-removing all non-selected extrema).
-         </Documentation>
-			 </IntVectorProperty>
-
-    <IntVectorProperty
-         name="AddPerturbation"
-         command="SetAddPerturbation"
-         label="Numerical Perturbation"
-         number_of_elements="1"
-         default_values="0">
-        <BooleanDomain name="bool"/>
-				<Documentation>
+        <Documentation>
           Numerically perturb the output (to avoid the usage of an output
-offset field for flat plateau disambiguation).
-         </Documentation>
+          offset field for flat plateau disambiguation).
+        </Documentation>
       </IntVectorProperty>
 
-			<StringVectorProperty
-				name="OutputOffsetScalarFieldName"
-				command="SetOutputOffsetScalarFieldName"
-				label="Output Offset Scalar Field"
-				number_of_elements="1"
-                panel_visibility="advanced">
+      <StringVectorProperty
+          name="OutputOffsetScalarFieldName"
+          command="SetOutputOffsetScalarFieldName"
+          label="Output Offset Scalar Field"
+          number_of_elements="1"
+          panel_visibility="advanced">
         <Documentation>
           Select the name of the output offset field.
         </Documentation>
       </StringVectorProperty>
 
-      <IntVectorProperty
-         name="UseAllCores"
-         command="SetUseAllCores"
-         label="Use All Cores"
-         number_of_elements="1"
-         default_values="1" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-         <Documentation>
-          Use all available cores.
-         </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-         name="ThreadNumber"
-         command="SetThreadNumber"
-         label="Thread Number"
-         number_of_elements="1"
-         default_values="1" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="1" max="100" />
-        <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="UseAllCores"
-            value="0" />
-        </Hints>
-
-         <Documentation>
-          Thread number.
-         </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
-         name="DebugLevel"
-         command="SetDebugLevel"
-         label="Debug Level"
-         number_of_elements="1"
-         default_values="3" panel_visibility="advanced">
-        <IntRangeDomain name="range" min="0" max="100" />
-         <Documentation>
-           Debug level.
-         </Documentation>
-       </IntVectorProperty>
-
-
-      <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="UseAllCores" />
-        <Property name="ThreadNumber" />
-        <Property name="DebugLevel" />
-      </PropertyGroup>
+      ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
-	<Property name="ScalarField"/>
+        <Property name="ScalarField"/>
         <Property name="ForceInputVertexScalarField" />
         <Property name="InputVertexScalarFieldName" />
-	<Property name="ForceInputOffsetScalarField"/>
-	<Property name="InputOffsetScalarFieldName"/>
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="InputOffsetScalarFieldName"/>
         <Property name="ForceInputVertexScalarField" />
         <Property name="InputVertexScalarFieldName" />
-	<Property name="ConsiderIdentifierAsBlackList"/>
-        <Property name="PeriodicBoundaryConditions"/>
+        <Property name="ConsiderIdentifierAsBlackList"/>
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">
-	<Property name="OutputOffsetScalarFieldName"/>
-	<Property name="AddPerturbation"/>
+        <Property name="OutputOffsetScalarFieldName"/>
+        <Property name="AddPerturbation"/>
       </PropertyGroup>
 
       <Hints>
         <ShowInMenu category="TTK - Scalar Data" />
       </Hints>
-   </SourceProxy>
- </ProxyGroup>
+    </SourceProxy>
+  </ProxyGroup>
 </ServerManagerConfiguration>

--- a/paraview/TopologicalSimplification/TopologicalSimplification.xml
+++ b/paraview/TopologicalSimplification/TopologicalSimplification.xml
@@ -65,7 +65,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkDataSet"/>
+          <DataType value="vtkPointSet"/>
         </DataTypeDomain>
         <InputArrayDomain name="input_scalars" number_of_components="1">
           <Property name="Constraints" function="FieldDataSelection" />
@@ -76,11 +76,12 @@
       </InputProperty>
 
       <StringVectorProperty
-          name="ScalarField"
-          command="SetScalarField"
-          number_of_elements="1"
+          name="Scalar Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
           animateable="0"
-          label="Scalar Field"
           >
         <ArrayListDomain
             name="array_list"
@@ -109,11 +110,11 @@
       </IntVectorProperty>
 
       <StringVectorProperty
-          name="InputOffsetScalarFieldName"
-          command="SetInputOffsetScalarFieldName"
-          label="Input Offset Field"
-          default_values="OutputOffsetScalarField"
-          number_of_elements="1"
+          name="Input Offset Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="2"
           animateable="0"
           panel_visibility="advanced"
           >
@@ -148,10 +149,11 @@
       </IntVectorProperty>
 
       <StringVectorProperty
-          name="InputVertexScalarFieldName"
-          command="SetInputVertexScalarFieldName"
-          label="Vertex identifier field"
-          number_of_elements="1"
+          name="Vertex Identifier Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="1"
           animateable="0"
           panel_visibility="advanced"
           >
@@ -214,13 +216,11 @@
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="ScalarField"/>
+        <Property name="Scalar Field"/>
         <Property name="ForceInputVertexScalarField" />
-        <Property name="InputVertexScalarFieldName" />
+        <Property name="Vertex Identifier Field" />
         <Property name="ForceInputOffsetScalarField"/>
-        <Property name="InputOffsetScalarFieldName"/>
-        <Property name="ForceInputVertexScalarField" />
-        <Property name="InputVertexScalarFieldName" />
+        <Property name="Input Offset Field"/>
         <Property name="ConsiderIdentifierAsBlackList"/>
       </PropertyGroup>
 


### PR DESCRIPTION
This PR migrates the TopologicalSimplification module to the new API/architecture.

Note that the work on sorting offset field should arrive later, since it depends on the (pending) migration of the FTMTree and FTRGraph modules (ttk-data states break without a full support of this new feature).

Corresponding ttk-data PR: https://github.com/topology-tool-kit/ttk-data/pull/53

Enjoy,
Pierre
