### PR TITLE
MatrixToHeatMap: Parallelize filling the grid

### DIFF
--- a/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
+++ b/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
@@ -65,50 +65,68 @@ int ttkMatrixToHeatMap::RequestData(vtkInformation * /*request*/,
     this->printWrn("Distance matrix is not square");
   }
 
-  // generate heat map points
+  // grid points
   vtkNew<vtkPoints> points{};
-  for(size_t i = 0; i < nInputs + 1; ++i) {
-    for(size_t j = 0; j < nRows + 1; ++j) {
-      points->InsertNextPoint(i, j, 0.0);
-    }
-  }
-
-  // generate heat map cells
-  vtkNew<vtkCellArray> cells{};
-  for(size_t i = 0; i < nInputs; ++i) {
-    for(size_t j = 0; j < nRows; ++j) {
-      const auto nptline{static_cast<vtkIdType>(nRows + 1)};
-      const auto curr{static_cast<vtkIdType>(i * nptline + j)};
-      std::array<vtkIdType, 4> ptIds{
-        curr, curr + nptline, curr + nptline + 1, curr + 1};
-      cells->InsertNextCell(4, ptIds.data());
-    }
-  }
-
-  // copy distance matrix to heat map cell data
-  vtkNew<vtkDoubleArray> dist{};
-  vtkNew<vtkDoubleArray> prox{};
+  points->SetNumberOfPoints((nInputs + 1) * (nRows + 1));
+  // grid cells connectivity arrays
+  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+  offsets->SetNumberOfComponents(1);
+  offsets->SetNumberOfTuples(nInputs * nRows + 1);
+  connectivity->SetNumberOfComponents(1);
+  connectivity->SetNumberOfTuples(4 * nInputs * nRows);
+  // distance and proximity arrays
+  vtkNew<vtkDoubleArray> dist{}, prox{};
   dist->SetNumberOfComponents(1);
   dist->SetName("Distance");
+  dist->SetNumberOfTuples(nInputs * nRows);
   prox->SetNumberOfComponents(1);
   prox->SetName("Proximity");
+  prox->SetNumberOfTuples(nInputs * nRows);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nInputs + 1; ++i) {
+    for(size_t j = 0; j < nRows + 1; ++j) {
+      points->SetPoint(i * (nRows + 1) + j, i, j, 0.0);
+    }
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; ++i) {
     for(size_t j = 0; j < nRows; ++j) {
+      // build the cell connectivity and offsets array
+      const auto nptline{static_cast<vtkIdType>(nRows + 1)};
+      const auto curr{static_cast<vtkIdType>(i * nptline + j)};
+      const auto o = i * nRows + j;
+      connectivity->SetTuple1(4 * o + 0, curr);
+      connectivity->SetTuple1(4 * o + 1, curr + nptline);
+      connectivity->SetTuple1(4 * o + 2, curr + nptline + 1);
+      connectivity->SetTuple1(4 * o + 3, curr + 1);
+      offsets->SetTuple1(o, 4 * o);
+
+      // copy distance matrix to heat map cell data
       const auto val = input->GetColumnByName(ScalarFields[i].data())
                          ->GetVariantValue(j)
                          .ToDouble();
-      dist->InsertNextValue(val);
-      prox->InsertNextValue(std::exp(-val));
+      dist->SetTuple1(i * nRows + j, val);
+      prox->SetTuple1(i * nRows + j, std::exp(-val));
     }
   }
+  offsets->SetTuple1(nInputs * nRows, connectivity->GetNumberOfTuples());
 
+  // gather arrays to make the UnstructuredGrid
+  vtkNew<vtkCellArray> cells{};
+  cells->SetData(offsets, connectivity);
   output->SetPoints(points);
   output->SetCells(VTK_QUAD, cells);
   output->GetCellData()->AddArray(dist);
   output->GetCellData()->AddArray(prox);
 
   this->printMsg("Complete (#inputs: " + std::to_string(nInputs) + ")", 1.0,
-                 tm.getElapsedTime(), 1);
+                 tm.getElapsedTime(), this->threadNumber_);
 
   return 1;
 }


### PR DESCRIPTION
This PR parallelizes filling the output grid in the MatrixToHeatMap filter, leading to an at least x5 speedup with large input distance matrices.

Enjoy,
Pierre