### PR TITLE
Fix c++ example (and PersistenceCurve API)

### DIFF
--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -163,15 +163,17 @@ int ttkPersistenceCurve::dispatch(vtkTable *outputJTPersistenceCurve,
   std::vector<std::pair<VTK_TT, SimplexId>> MSCPlot{};
   std::vector<std::pair<VTK_TT, SimplexId>> CTPlot{};
 
+  this->setOutputJTPlot(&JTPlot);
+  this->setOutputSTPlot(&STPlot);
+  this->setOutputCTPlot(&CTPlot);
+
   if(inputOffsetsDataType == VTK_INT) {
-    ret = this->execute<VTK_TT, int, TTK_TT>(JTPlot, STPlot, MSCPlot, CTPlot,
-                                             inputScalars, (int *)inputOffsets,
-                                             triangulation);
+    ret = this->execute<VTK_TT, int, TTK_TT>(
+      MSCPlot, inputScalars, (int *)inputOffsets, triangulation);
   }
   if(inputOffsetsDataType == VTK_ID_TYPE) {
     ret = this->execute<VTK_TT, vtkIdType, TTK_TT>(
-      JTPlot, STPlot, MSCPlot, CTPlot, inputScalars, (vtkIdType *)inputOffsets,
-      triangulation);
+      MSCPlot, inputScalars, (vtkIdType *)inputOffsets, triangulation);
   }
 
   ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -190,22 +190,18 @@ int main(int argc, char **argv) {
   // 2. computing the persistence curve
   ttk::PersistenceCurve curve;
   std::vector<std::pair<float, ttk::SimplexId>> outputCurve;
-  curve.setupTriangulation(&triangulation);
-  curve.setInputScalars(height.data());
-  curve.setInputOffsets(offsets.data());
-  curve.setOutputCTPlot(&outputCurve);
-  curve.execute<float, ttk::SimplexId>();
+  curve.preconditionTriangulation(&triangulation);
+  curve.execute<float, ttk::SimplexId>(
+    outputCurve, height.data(), offsets.data(), &triangulation);
 
   // 3. computing the persitence diagram
   ttk::PersistenceDiagram diagram;
   std::vector<std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
                          ttk::CriticalType, float, ttk::SimplexId>>
     diagramOutput;
-  diagram.setupTriangulation(&triangulation);
-  diagram.setInputScalars(height.data());
-  diagram.setInputOffsets(offsets.data());
-  diagram.setOutputCTDiagram(&diagramOutput);
-  diagram.execute<float, ttk::SimplexId>();
+  diagram.preconditionTriangulation(&triangulation);
+  diagram.execute<float, ttk::SimplexId>(
+    diagramOutput, height.data(), offsets.data(), &triangulation);
 
   // 4. selecting the critical point pairs
   std::vector<float> simplifiedHeight = height;
@@ -222,15 +218,11 @@ int main(int argc, char **argv) {
 
   // 6. simplifying the input data to remove non-persistent pairs
   ttk::TopologicalSimplification simplification;
-  simplification.setupTriangulation(&triangulation);
-  simplification.setInputScalarFieldPointer(height.data());
-  simplification.setInputOffsetScalarFieldPointer(offsets.data());
-  simplification.setOutputOffsetScalarFieldPointer(simplifiedOffsets.data());
-  simplification.setOutputScalarFieldPointer(simplifiedHeight.data());
-  simplification.setConstraintNumber(authorizedCriticalPoints.size());
-  simplification.setVertexIdentifierScalarFieldPointer(
-    authorizedCriticalPoints.data());
-  simplification.execute<float, ttk::SimplexId>();
+  simplification.preconditionTriangulation(&triangulation);
+  simplification.execute<float, ttk::SimplexId>(
+    height.data(), simplifiedHeight.data(), authorizedCriticalPoints.data(),
+    offsets.data(), simplifiedOffsets.data(), authorizedCriticalPoints.size(),
+    triangulation);
 
   // assign the simplified values to the input mesh
   for(int i = 0; i < (int)simplifiedHeight.size(); i++) {
@@ -269,7 +261,7 @@ int main(int argc, char **argv) {
     triangulation.getNumberOfVertices(), -1),
     descendingSegmentation(triangulation.getNumberOfVertices(), -1),
     mscSegmentation(triangulation.getNumberOfVertices(), -1);
-  morseSmaleComplex.setupTriangulation(&triangulation);
+  morseSmaleComplex.preconditionTriangulation(&triangulation);
   morseSmaleComplex.setInputScalarField(simplifiedHeight.data());
   morseSmaleComplex.setInputOffsets(simplifiedOffsets.data());
   morseSmaleComplex.setOutputMorseComplexes(ascendingSegmentation.data(),
@@ -293,7 +285,7 @@ int main(int argc, char **argv) {
     &separatrices1_cells_separatrixFunctionDiffs,
     &separatrices1_cells_isOnBoundary);
 
-  morseSmaleComplex.execute<float, ttk::SimplexId>();
+  morseSmaleComplex.execute<float, ttk::SimplexId>(triangulation);
 
   // save the output
   save(pointSet, triangleSetCo, triangleSetOff, "output.off");

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -25,6 +25,7 @@
 #include <PersistenceDiagram.h>
 #include <TopologicalSimplification.h>
 
+#include <cassert>
 #include <iostream>
 
 int load(const std::string &inputPath,
@@ -37,17 +38,10 @@ int load(const std::string &inputPath,
   if(inputPath.empty())
     return -1;
 
-  ttk::Debug d;
-  d.setDebugLevel(ttk::globalDebugLevel_);
-
-  {
-    std::stringstream msg;
-    msg << "[main::load] Reading input mesh..." << std::endl;
-    // choose where to display this message (std::cout, std::cerr, a file)
-    // choose the priority of this message (1, nearly always displayed,
-    // higher values mean lower priorities)
-    d.dMsg(std::cout, msg.str(), d.timeMsg);
-  }
+  ttk::Debug dbg;
+  dbg.setDebugLevel(ttk::globalDebugLevel_);
+  dbg.setDebugMsgPrefix("main::load");
+  dbg.printMsg("Reading input mesh...");
 
   int vertexNumber = 0, triangleNumber = 0;
   std::string keyword;
@@ -55,19 +49,14 @@ int load(const std::string &inputPath,
   std::ifstream f(inputPath.data(), std::ios::in);
 
   if(!f) {
-    std::stringstream msg;
-    msg << "[main::load] Cannot open file `" << inputPath << "'!" << std::endl;
-    d.dMsg(std::cerr, msg.str(), d.fatalMsg);
+    dbg.printErr("Cannot read file `" + inputPath + "'!");
     return -1;
   }
 
   f >> keyword;
 
   if(keyword != "OFF") {
-    std::stringstream msg;
-    msg << "[main::load] Input OFF file `" << inputPath << "' seems invalid :("
-        << std::endl;
-    d.dMsg(std::cerr, msg.str(), d.fatalMsg);
+    dbg.printErr("Input OFF file `" + inputPath + "' seems invalid :(");
     return -2;
   }
 
@@ -103,12 +92,8 @@ int load(const std::string &inputPath,
 
   f.close();
 
-  {
-    std::stringstream msg;
-    msg << "[main::load]   done! (read " << vertexNumber << " vertices, "
-        << triangleNumber << " triangles)" << std::endl;
-    d.dMsg(std::cout, msg.str(), d.timeMsg);
-  }
+  dbg.printMsg("... done! (read " + std::to_string(vertexNumber) + " vertices, "
+               + std::to_string(triangleNumber) + " triangles)");
 
   return 0;
 }
@@ -119,18 +104,15 @@ int save(const std::vector<float> &pointSet,
          const std::string &outputPath) {
 
   // save the simplified terrain in some OFF file
-  ttk::Debug d;
-  d.setDebugLevel(ttk::globalDebugLevel_);
-
   std::string fileName(outputPath);
 
   std::ofstream f(fileName.data(), std::ios::out);
 
   if(!f) {
-    std::stringstream msg;
-    msg << "[main::save] Could not write output file `" << fileName << "'!"
-        << std::endl;
-    d.dMsg(std::cerr, msg.str(), d.fatalMsg);
+    ttk::Debug dbg;
+    dbg.setDebugLevel(ttk::globalDebugLevel_);
+    dbg.setDebugMsgPrefix("main::save");
+    dbg.printErr("Could not write output file `" + fileName + "'!");
     return -1;
   }
 


### PR DESCRIPTION
This PR fixes the c++ example by using the new API and the correct after-migration calls to the base layer modules.

The PersistenceCurve base layer API has been slightly rolled-back to allow the passing of optional arguments (JTPlot, STPlot and CTPlot). The new API is now more in line with how it is used in the c++ example.

Enjoy,
Pierre