### PR TITLE
Support sorted offset fields

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -20,7 +20,19 @@
 
 #include <queue>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#include <parallel/algorithm>
+#endif
+
 namespace ttk {
+
+#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
+#define PSORT                               \
+  omp_set_num_threads(this->threadNumber_); \
+  __gnu_parallel::sort
+#else
+#define PSORT std::sort
+#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
 
   /**
    * Utility class representing Ridge lines, Valley lines

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -8,6 +8,7 @@ ttk_add_base_library(common
         CommandLineParser.h
         Debug.h
         DataTypes.h
+        OrderDisambiguation.h
         Os.h
         ProgramBase.h
         Wrapper.h

--- a/core/base/common/OrderDisambiguation.h
+++ b/core/base/common/OrderDisambiguation.h
@@ -1,0 +1,69 @@
+#include <DataTypes.h>
+
+#include <algorithm>
+#include <vector>
+
+#if defined(__GNUC__) && !defined(__clang__)
+#include <parallel/algorithm>
+#endif
+
+namespace ttk {
+
+  /**
+   * @brief Sort vertices according to scalars disambiguated by offsets
+   *
+   * @param[in] nVerts number of vertices
+   * @param[in] scalars array of size nVerts, main vertex comparator
+   * @param[in] offsets array of size nVerts, disambiguate scalars on plateaux
+   * @param[out] order array of size nVerts, computed order of vertices
+   * @param[in] nThreads number of parallel threads
+   */
+  template <typename scalarType, typename idType>
+  void sortVertices(const size_t nVerts,
+                    const scalarType *const scalars,
+                    const idType *const offsets,
+                    SimplexId *const order,
+                    const int nThreads) {
+
+    // array of pre-sorted vertices
+    std::vector<SimplexId> sortedVertices(nVerts);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(nThreads)
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < sortedVertices.size(); ++i) {
+      sortedVertices[i] = i;
+    }
+
+#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
+#define PSORT                    \
+  omp_set_num_threads(nThreads); \
+  __gnu_parallel::sort
+#else
+#define PSORT std::sort
+#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
+
+    if(offsets != nullptr) {
+      PSORT(sortedVertices.begin(), sortedVertices.end(),
+            [&](const SimplexId a, const SimplexId b) {
+              return (scalars[a] < scalars[b])
+                     || (scalars[a] == scalars[b] && offsets[a] < offsets[b]);
+            });
+    } else {
+      PSORT(sortedVertices.begin(), sortedVertices.end(),
+            [&](const SimplexId a, const SimplexId b) {
+              return (scalars[a] < scalars[b])
+                     || (scalars[a] == scalars[b] && a < b);
+            });
+    }
+
+#undef PSORT
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(nThreads)
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < sortedVertices.size(); ++i) {
+      order[sortedVertices[i]] = i;
+    }
+  }
+} // namespace ttk

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -27,18 +27,7 @@
 #include <set>
 #include <utility>
 
-#if defined(__GNUC__) && !defined(__clang__)
-#include <parallel/algorithm>
-#endif
-
 namespace ttk {
-#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
-#define PSORT                               \
-  omp_set_num_threads(this->threadNumber_); \
-  __gnu_parallel::sort
-#else
-#define PSORT std::sort
-#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
 
   namespace dcg {
     /**
@@ -652,34 +641,6 @@ in the gradient.
                             const triangulationType &triangulation) const;
 
     private:
-      template <typename scalarType, typename offsetType>
-      void sortVertices(const SimplexId vertexNumber,
-                        std::vector<size_t> &vertsOrder,
-                        const scalarType *const scalarField,
-                        const offsetType *const offsetField) const {
-
-        std::vector<SimplexId> sortedVertices(vertexNumber);
-        vertsOrder.resize(vertexNumber);
-
-        // fill with numbers from 0 to vertexNumber - 1
-        std::iota(sortedVertices.begin(), sortedVertices.end(), 0);
-
-        // sort vertices in ascending order following scalarfield / offsets
-        PSORT(sortedVertices.begin(), sortedVertices.end(),
-              [&](const SimplexId a, const SimplexId b) {
-                return (scalarField[a] < scalarField[b])
-                       || (scalarField[a] == scalarField[b]
-                           && offsetField[a] < offsetField[b]);
-              });
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-        for(size_t i = 0; i < vertsOrder.size(); ++i) {
-          vertsOrder[sortedVertices[i]] = i;
-        }
-      }
-
       /**
        * Type alias for lower stars of a given cell
        */

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -397,7 +397,7 @@ function value.
        * Compute the initial gradient field of the input scalar function on the
 triangulation.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename idType, typename triangulationType>
       int buildGradient(const triangulationType &triangulation);
 
       /**

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -587,9 +587,10 @@ in the gradient.
        * Get the vertex id of with the maximum scalar field value on
        * the given cell. Compare offsets if scalar field is constant.
        */
-      template <typename triangulationType>
+      template <typename idType, typename triangulationType>
       SimplexId
         getCellGreaterVertex(const Cell c,
+                             const idType *const offsets,
                              const triangulationType &triangulation) const;
 
       /**
@@ -600,7 +601,7 @@ in the gradient.
        * outputCriticalPoints_points_
        * inputScalarField_
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int setCriticalPoints(const std::vector<Cell> &criticalPoints,
                             std::vector<size_t> &nCriticalPointsByDim,
                             const triangulationType &triangulation);
@@ -609,7 +610,7 @@ in the gradient.
        * Detect the critical points and build their geometric embedding.
        * The output data pointers are modified accordingly.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int setCriticalPoints(const triangulationType &triangulation);
 
       /**
@@ -655,9 +656,10 @@ in the gradient.
        * @return Lower star as 4 sets of cells (0-cells, 1-cells, 2-cells and
        * 3-cells)
        */
-      template <typename triangulationType>
+      template <typename idType, typename triangulationType>
       inline lowerStarType
         lowerStar(const SimplexId a,
+                  const idType *const offsets,
                   const triangulationType &triangulation) const;
 
       /**
@@ -700,8 +702,9 @@ in the gradient.
        * Grayscale Digital Images", V. Robins, P. J. Wood,
        * A. P. Sheppard
        */
-      template <typename triangulationType>
-      int processLowerStars(const triangulationType &triangulation);
+      template <typename idType, typename triangulationType>
+      int processLowerStars(const idType *const offsets,
+                            const triangulationType &triangulation);
 
       /**
        * Get the list of maxima candidates for simplification.
@@ -950,9 +953,6 @@ gradient, false otherwise.
       std::vector<SimplexId> outputCriticalPoints_points_manifoldSize_{};
 
       std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
-
-      // index of vertices sorted by ascending order
-      std::vector<size_t> vertsOrder_{};
     };
 
   } // namespace dcg

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -230,17 +230,8 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
     gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
   }
 
-  // copy offset to vertsOrder_ (avoid further templating)
-  vertsOrder_.resize(this->numberOfVertices_);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < vertsOrder_.size(); ++i) {
-    vertsOrder_[i] = offsets[i];
-  }
-
   // compute gradient pairs
-  processLowerStars(triangulation);
+  processLowerStars(offsets, triangulation);
 
   std::vector<std::vector<std::string>> rows{
     {"#Vertices", std::to_string(numberOfCells[0])},
@@ -259,7 +250,7 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   return 0;
 }
 
-template <typename dataType, typename triangulationType>
+template <typename dataType, typename idType, typename triangulationType>
 int DiscreteGradient::setCriticalPoints(
   const std::vector<Cell> &criticalPoints,
   std::vector<size_t> &nCriticalPointsByDim,
@@ -273,6 +264,7 @@ int DiscreteGradient::setCriticalPoints(
   }
 #endif
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
   auto *outputCriticalPoints_points_cellScalars
     = static_cast<std::vector<dataType> *>(
       outputCriticalPoints_points_cellScalars_);
@@ -323,7 +315,7 @@ int DiscreteGradient::setCriticalPoints(
       (*outputCriticalPoints_points_cellScalars)[i] = scalar;
     }
     outputCriticalPoints_points_isOnBoundary_[i] = isOnBoundary;
-    auto vertId = getCellGreaterVertex(cell, triangulation);
+    auto vertId = getCellGreaterVertex(cell, offsets, triangulation);
     outputCriticalPoints_points_PLVertexIdentifiers_[i] = vertId;
   }
 
@@ -338,14 +330,14 @@ int DiscreteGradient::setCriticalPoints(
   return 0;
 }
 
-template <typename dataType, typename triangulationType>
+template <typename dataType, typename idType, typename triangulationType>
 int DiscreteGradient::setCriticalPoints(
   const triangulationType &triangulation) {
 
   std::vector<Cell> criticalPoints;
   getCriticalPoints(criticalPoints, triangulation);
   std::vector<size_t> nCriticalPointsByDim{};
-  setCriticalPoints<dataType>(
+  setCriticalPoints<dataType, idType>(
     criticalPoints, nCriticalPointsByDim, triangulation);
 
   return 0;
@@ -1828,6 +1820,7 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
                                       bool detectCriticalPoints) {
 
   std::vector<std::pair<SimplexId, char>> criticalPoints{};
+  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
 
   if(detectCriticalPoints) {
 
@@ -1838,13 +1831,12 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
     criticalPoints.resize(criticalCells.size());
 
     // iterate over cells to get points (max vertex) and type
-    std::transform(
-      criticalCells.begin(), criticalCells.end(), criticalPoints.begin(),
-      [&](const Cell &c) {
-        const auto cellType = criticalTypeFromCellDimension(c.dim_);
-        const auto vertexId = getCellGreaterVertex(c, triangulation);
-        return std::make_pair(vertexId, static_cast<char>(cellType));
-      });
+    for(size_t i = 0; i < criticalCells.size(); ++i) {
+      const auto &c = criticalCells[i];
+      criticalPoints[i]
+        = {getCellGreaterVertex(c, offsets, triangulation),
+           static_cast<char>(criticalTypeFromCellDimension(c.dim_))};
+    }
 
     // print number of critical cells
     {
@@ -1944,9 +1936,10 @@ SimplexId DiscreteGradient::getNumberOfCells(
   return -1;
 }
 
-template <typename triangulationType>
+template <typename idType, typename triangulationType>
 inline DiscreteGradient::lowerStarType
   DiscreteGradient::lowerStar(const SimplexId a,
+                              const idType *const offsets,
                               const triangulationType &triangulation) const {
   lowerStarType res{};
 
@@ -1964,7 +1957,7 @@ inline DiscreteGradient::lowerStarType
     if(vertexId == a) {
       triangulation.getEdgeVertex(edgeId, 1, vertexId);
     }
-    if(vertsOrder_[vertexId] < vertsOrder_[a]) {
+    if(offsets[vertexId] < offsets[a]) {
       res[1].emplace_back(CellExt{1, edgeId, {vertexId}, {}});
     }
   }
@@ -1974,34 +1967,33 @@ inline DiscreteGradient::lowerStarType
     return res;
   }
 
-  const auto processTriangle
-    = [&](const SimplexId triangleId, const SimplexId v0, const SimplexId v1,
-          const SimplexId v2) {
-        std::array<SimplexId, 3> lowVerts{};
-        if(v0 == a) {
-          lowVerts[0] = v1;
-          lowVerts[1] = v2;
-        } else if(v1 == a) {
-          lowVerts[0] = v0;
-          lowVerts[1] = v2;
-        } else if(v2 == a) {
-          lowVerts[0] = v0;
-          lowVerts[1] = v1;
+  const auto processTriangle = [&](const SimplexId triangleId,
+                                   const SimplexId v0, const SimplexId v1,
+                                   const SimplexId v2) {
+    std::array<SimplexId, 3> lowVerts{};
+    if(v0 == a) {
+      lowVerts[0] = v1;
+      lowVerts[1] = v2;
+    } else if(v1 == a) {
+      lowVerts[0] = v0;
+      lowVerts[1] = v2;
+    } else if(v2 == a) {
+      lowVerts[0] = v0;
+      lowVerts[1] = v1;
+    }
+    if(offsets[a] > offsets[lowVerts[0]] && offsets[a] > offsets[lowVerts[1]]) {
+      uint8_t j{}, k{};
+      // store edges indices of current triangle
+      std::array<uint8_t, 3> faces{};
+      for(const auto &e : res[1]) {
+        if(e.lowVerts_[0] == lowVerts[0] || e.lowVerts_[0] == lowVerts[1]) {
+          faces[k++] = j;
         }
-        if(vertsOrder_[a] > vertsOrder_[lowVerts[0]]
-           && vertsOrder_[a] > vertsOrder_[lowVerts[1]]) {
-          uint8_t j{}, k{};
-          // store edges indices of current triangle
-          std::array<uint8_t, 3> faces{};
-          for(const auto &e : res[1]) {
-            if(e.lowVerts_[0] == lowVerts[0] || e.lowVerts_[0] == lowVerts[1]) {
-              faces[k++] = j;
-            }
-            j++;
-          }
-          res[2].emplace_back(CellExt{2, triangleId, lowVerts, faces});
-        }
-      };
+        j++;
+      }
+      res[2].emplace_back(CellExt{2, triangleId, lowVerts, faces});
+    }
+  };
 
   if(dimensionality_ == 2) {
     // store lower triangles
@@ -2065,9 +2057,9 @@ inline DiscreteGradient::lowerStarType
           lowVerts[1] = v1;
           lowVerts[2] = v2;
         }
-        if(vertsOrder_[a] > vertsOrder_[lowVerts[0]]
-           && vertsOrder_[a] > vertsOrder_[lowVerts[1]]
-           && vertsOrder_[a] > vertsOrder_[lowVerts[2]]) {
+        if(offsets[a] > offsets[lowVerts[0]]
+           && offsets[a] > offsets[lowVerts[1]]
+           && offsets[a] > offsets[lowVerts[2]]) {
           uint8_t j{}, k{};
           // store triangles indices of current tetra
           std::array<uint8_t, 3> faces{};
@@ -2155,9 +2147,9 @@ inline void DiscreteGradient::pairCells(
   beta.paired_ = true;
 }
 
-template <typename triangulationType>
+template <typename idType, typename triangulationType>
 int DiscreteGradient::processLowerStars(
-  const triangulationType &triangulation) {
+  const idType *const offsets, const triangulationType &triangulation) {
 
   /* Compute gradient */
 
@@ -2174,7 +2166,7 @@ int DiscreteGradient::processLowerStars(
         // there should be a shared facet between the two cells
         // compare the vertices not in the shared facet
         if(a.dim_ == 1) {
-          return vertsOrder_[a.lowVerts_[0]] > vertsOrder_[b.lowVerts_[0]];
+          return offsets[a.lowVerts_[0]] > offsets[b.lowVerts_[0]];
 
         } else if(a.dim_ == 2) {
           const auto &m0 = a.lowVerts_[0];
@@ -2183,13 +2175,13 @@ int DiscreteGradient::processLowerStars(
           const auto &n1 = b.lowVerts_[1];
 
           if(m0 == n0) {
-            return vertsOrder_[m1] > vertsOrder_[n1];
+            return offsets[m1] > offsets[n1];
           } else if(m0 == n1) {
-            return vertsOrder_[m1] > vertsOrder_[n0];
+            return offsets[m1] > offsets[n0];
           } else if(m1 == n0) {
-            return vertsOrder_[m0] > vertsOrder_[n1];
+            return offsets[m0] > offsets[n1];
           } else if(m1 == n1) {
-            return vertsOrder_[m0] > vertsOrder_[n0];
+            return offsets[m0] > offsets[n0];
           }
 
         } else if(a.dim_ == 3) {
@@ -2220,7 +2212,7 @@ int DiscreteGradient::processLowerStars(
             n = n2;
           }
 
-          return vertsOrder_[m] > vertsOrder_[n];
+          return offsets[m] > offsets[n];
         }
       } else {
         // the cell of greater dimension should contain the cell of
@@ -2269,7 +2261,7 @@ int DiscreteGradient::processLowerStars(
       }
     };
 
-    auto Lx = lowerStar(x, triangulation);
+    auto Lx = lowerStar(x, offsets, triangulation);
 
     // Lx[1] empty => x is a local minimum
 
@@ -2279,7 +2271,7 @@ int DiscreteGradient::processLowerStars(
       for(size_t i = 1; i < Lx[1].size(); ++i) {
         const auto &a = Lx[1][minId].lowVerts_[0];
         const auto &b = Lx[1][i].lowVerts_[0];
-        if(vertsOrder_[a] > vertsOrder_[b]) {
+        if(offsets[a] > offsets[b]) {
           // edge[i] < edge[0]
           minId = i;
         }
@@ -3182,9 +3174,11 @@ int DiscreteGradient::reverseDescendingPathOnWall(
   return 0;
 }
 
-template <typename triangulationType>
+template <typename idType, typename triangulationType>
 ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
-  const Cell c, const triangulationType &triangulation) const {
+  const Cell c,
+  const idType *const offsets,
+  const triangulationType &triangulation) const {
 
   auto cellDim = c.dim_;
   auto cellId = c.id_;
@@ -3200,7 +3194,7 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
     triangulation.getEdgeVertex(cellId, 0, v0);
     triangulation.getEdgeVertex(cellId, 1, v1);
 
-    if(vertsOrder_[v0] > vertsOrder_[v1]) {
+    if(offsets[v0] > offsets[v1]) {
       vertexId = v0;
     } else {
       vertexId = v1;
@@ -3212,10 +3206,9 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
     triangulation.getTriangleVertex(cellId, 0, v0);
     triangulation.getTriangleVertex(cellId, 1, v1);
     triangulation.getTriangleVertex(cellId, 2, v2);
-    if(vertsOrder_[v0] > vertsOrder_[v1] && vertsOrder_[v0] > vertsOrder_[v2]) {
+    if(offsets[v0] > offsets[v1] && offsets[v0] > offsets[v2]) {
       vertexId = v0;
-    } else if(vertsOrder_[v1] > vertsOrder_[v0]
-              && vertsOrder_[v1] > vertsOrder_[v2]) {
+    } else if(offsets[v1] > offsets[v0] && offsets[v1] > offsets[v2]) {
       vertexId = v1;
     } else {
       vertexId = v2;
@@ -3228,16 +3221,14 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
     triangulation.getCellVertex(cellId, 1, v1);
     triangulation.getCellVertex(cellId, 2, v2);
     triangulation.getCellVertex(cellId, 3, v3);
-    if(vertsOrder_[v0] > vertsOrder_[v1] && vertsOrder_[v0] > vertsOrder_[v2]
-       && vertsOrder_[v0] > vertsOrder_[v3]) {
+    if(offsets[v0] > offsets[v1] && offsets[v0] > offsets[v2]
+       && offsets[v0] > offsets[v3]) {
       vertexId = v0;
-    } else if(vertsOrder_[v1] > vertsOrder_[v0]
-              && vertsOrder_[v1] > vertsOrder_[v2]
-              && vertsOrder_[v1] > vertsOrder_[v3]) {
+    } else if(offsets[v1] > offsets[v0] && offsets[v1] > offsets[v2]
+              && offsets[v1] > offsets[v3]) {
       vertexId = v1;
-    } else if(vertsOrder_[v2] > vertsOrder_[v0]
-              && vertsOrder_[v2] > vertsOrder_[v1]
-              && vertsOrder_[v2] > vertsOrder_[v3]) {
+    } else if(offsets[v2] > offsets[v0] && offsets[v2] > offsets[v1]
+              && offsets[v2] > offsets[v3]) {
       vertexId = v2;
     } else {
       vertexId = v3;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -209,7 +209,6 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 
   const auto *const offsets = static_cast<const idType *>(inputOffsets_);
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
 
   const int numberOfDimensions = getNumberOfDimensions();
 
@@ -231,7 +230,14 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
     gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
   }
 
-  sortVertices(numberOfCells[0], vertsOrder_, scalars, offsets);
+  // copy offset to vertsOrder_ (avoid further templating)
+  vertsOrder_.resize(this->numberOfVertices_);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < vertsOrder_.size(); ++i) {
+    vertsOrder_[i] = offsets[i];
+  }
 
   // compute gradient pairs
   processLowerStars(triangulation);

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -204,7 +204,7 @@ dataType DiscreteGradient::getPersistence(
          - scalarMin(down, scalars, triangulation);
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename idType, typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -183,7 +183,7 @@ namespace ttk {
       /// them in a morse discret geometry compliant way.
       /// This is explained in the TTK report.
       /// Set the array to use here
-      void setVertexSoSoffsets(std::vector<SimplexId> *sos) {
+      void setVertexSoSoffsets(SimplexId *sos) {
         scalars_.setOffsets(sos);
       }
 

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -191,7 +191,6 @@ namespace ttk {
       const bool addMax = !params_.singleSweep;
 
       ScalarFieldCriticalPoints critPoints;
-      critPoints.setSosOffsets(scalars_.getVOffsets());
 
       TaskChunk leafChunkParams(scalars_.getSize());
       leafChunkParams.grainSize = 10000;
@@ -212,7 +211,8 @@ namespace ttk {
           for(idVertex v = lowerBound; v < upperBound; ++v) {
             std::tie(valences_.lower[v], valences_.upper[v])
               = critPoints.getNumberOfLowerUpperComponents<ScalarType>(
-                v, scalars_.getScalars(), mesh_.getTriangulation());
+                v, scalars_.getScalars(), scalars_.getOffsets(),
+                mesh_.getTriangulation());
 
             // leaf cases
             if(addMin && valences_.lower[v] == 0) {

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -210,9 +210,8 @@ namespace ttk {
           // each task uses its local forests
           for(idVertex v = lowerBound; v < upperBound; ++v) {
             std::tie(valences_.lower[v], valences_.upper[v])
-              = critPoints.getNumberOfLowerUpperComponents<ScalarType>(
-                v, scalars_.getScalars(), scalars_.getOffsets(),
-                mesh_.getTriangulation());
+              = critPoints.getNumberOfLowerUpperComponents(
+                v, scalars_.getOffsets(), mesh_.getTriangulation());
 
             // leaf cases
             if(addMin && valences_.lower[v] == 0) {

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -25,41 +25,26 @@ namespace ttk {
     template <typename ScalarType>
     class Scalars : virtual public Debug {
     private:
-      idVertex size_;
+      idVertex size_{nullVertex};
 
-      ScalarType *values_;
-      std::vector<SimplexId> *vOffsets_;
-      SimplexId *offsets_;
+      ScalarType *values_{};
+      const SimplexId *offsets_{};
 
-      bool externalOffsets_;
-
-      std::vector<Vert<ScalarType>> vertices_;
-      std::vector<idVertex> mirror_;
+      std::vector<Vert<ScalarType>> vertices_{};
+      std::vector<idVertex> mirror_{};
 
     public:
-      Scalars()
-        : size_(nullVertex), values_(nullptr), vOffsets_(nullptr),
-          offsets_(nullptr), externalOffsets_(false), vertices_(), mirror_() {
+      Scalars() {
       }
 
       // Heavy, prevent using it
       Scalars(const Scalars &o) = delete;
 
-      virtual ~Scalars() {
-        if(!externalOffsets_) {
-          delete[] offsets_;
-        }
-      }
-
       ScalarType *getScalars() {
         return values_;
       }
 
-      std::vector<SimplexId> *getVOffsets() {
-        return vOffsets_;
-      }
-
-      SimplexId *getOffsets() {
+      const SimplexId *getOffsets() const {
         return offsets_;
       }
 
@@ -87,33 +72,16 @@ namespace ttk {
         values_ = values;
       }
 
-      void setOffsets(std::vector<SimplexId> *sos) {
-        externalOffsets_ = sos;
-        vOffsets_ = sos;
-        if(vOffsets_) {
-          offsets_ = vOffsets_->data();
-        }
+      void setOffsets(const SimplexId *const sos) {
+        offsets_ = sos;
       }
 
       void alloc() {
-        if(!externalOffsets_) {
-          offsets_ = new SimplexId[size_];
-        }
         vertices_.resize(size_);
         mirror_.resize(size_);
       }
 
       void init() {
-        // Create offset array if not given by user
-        if(!externalOffsets_) {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for schedule(static, size_ / threadNumber_)
-#endif
-          for(SimplexId i = 0; i < size_; i++) {
-            offsets_[i] = i;
-          }
-        }
-
         // Copy everything in the main array
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(static, size_ / threadNumber_)

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -230,9 +230,8 @@ int ttk::JacobiSet::executeLegacy(
       // also, lots of things in there can be done out of the loop
 
       // in the loop
-      char type = threadedCriticalPoints[threadId].getCriticalType<double>(
-        pivotVertexId, threadedDistanceField[i].data(), sosOffsetsU_->data(),
-        (*edgeFanLinkEdgeLists_)[i]);
+      char type = threadedCriticalPoints[threadId].getCriticalType(
+        pivotVertexId, sosOffsetsU_->data(), (*edgeFanLinkEdgeLists_)[i]);
 
       if(type != -2) {
         // -2: regular vertex

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -164,7 +164,6 @@ int ttk::JacobiSet::executeLegacy(
   for(ThreadId i = 0; i < threadNumber_; i++) {
     threadedCriticalPoints[i].setDomainDimension(2);
     threadedCriticalPoints[i].setVertexNumber(vertexNumber_);
-    threadedCriticalPoints[i].setSosOffsets(sosOffsetsU_);
   }
 
   std::vector<std::vector<std::pair<SimplexId, char>>> threadedCriticalTypes(
@@ -232,7 +231,7 @@ int ttk::JacobiSet::executeLegacy(
 
       // in the loop
       char type = threadedCriticalPoints[threadId].getCriticalType<double>(
-        pivotVertexId, threadedDistanceField[i].data(),
+        pivotVertexId, threadedDistanceField[i].data(), sosOffsetsU_->data(),
         (*edgeFanLinkEdgeLists_)[i]);
 
       if(type != -2) {

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -75,7 +75,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
   discreteGradient_.setDebugLevel(debugLevel_);
   {
     Timer tmp;
-    discreteGradient_.buildGradient<dataType, idType>(triangulation);
+    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
 
     this->printMsg("Discrete gradient computed", 1.0, tmp.getElapsedTime(),
                    this->threadNumber_);

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -139,7 +139,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
 
   if(outputCriticalPoints_numberOfPoints_ and outputCriticalPoints_points_) {
     std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType>(
+    discreteGradient_.setCriticalPoints<dataType, idType>(
       criticalPoints, nCriticalPointsByDim, triangulation);
 
     discreteGradient_.fetchOutputCriticalPoints(

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -171,7 +171,7 @@ int ttk::MorseSmaleComplex3D::computePersistencePairs(
     discreteGradient_.setDebugLevel(debugLevel_);
     discreteGradient_.setThreadNumber(threadNumber_);
     discreteGradient_.setCollectPersistencePairs(false);
-    discreteGradient_.buildGradient<dataType, idType>(triangulation);
+    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
     discreteGradient_.reverseGradient<dataType, idType>(triangulation);
 
     // collect saddle-saddle connections
@@ -676,7 +676,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
   discreteGradient_.setDebugLevel(debugLevel_);
   {
     Timer tmp;
-    discreteGradient_.buildGradient<dataType, idType>(triangulation);
+    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
 
     this->printMsg("Discrete gradient computed", 1.0, tmp.getElapsedTime(),
                    this->threadNumber_);

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -164,6 +164,7 @@ int ttk::MorseSmaleComplex3D::computePersistencePairs(
   const triangulationType &triangulation) {
 
   const dataType *scalars = static_cast<const dataType *>(inputScalarField_);
+  const dataType *offsets = static_cast<const dataType *>(inputOffsets_);
 
   std::vector<std::array<dcg::Cell, 2>> dmt_pairs;
   {
@@ -183,9 +184,9 @@ int ttk::MorseSmaleComplex3D::computePersistencePairs(
   // transform DMT pairs into PL pairs
   for(const auto &pair : dmt_pairs) {
     const SimplexId v0
-      = discreteGradient_.getCellGreaterVertex(pair[0], triangulation);
+      = discreteGradient_.getCellGreaterVertex(pair[0], offsets, triangulation);
     const SimplexId v1
-      = discreteGradient_.getCellGreaterVertex(pair[1], triangulation);
+      = discreteGradient_.getCellGreaterVertex(pair[1], offsets, triangulation);
     const dataType persistence = scalars[v1] - scalars[v0];
 
     if(v0 != -1 and v1 != -1 and persistence >= 0) {
@@ -801,7 +802,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
 
   if(outputCriticalPoints_numberOfPoints_ and outputSeparatrices1_points_) {
     std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType>(
+    discreteGradient_.setCriticalPoints<dataType, idType>(
       criticalPoints, nCriticalPointsByDim, triangulation);
 
     discreteGradient_.fetchOutputCriticalPoints(

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
@@ -1,19 +1,5 @@
 #include <ScalarFieldCriticalPoints.h>
 
 ttk::ScalarFieldCriticalPoints::ScalarFieldCriticalPoints() {
-
-  dimension_ = 0;
-  vertexNumber_ = 0;
-  vertexLinkEdgeLists_ = NULL;
-  criticalPoints_ = NULL;
-  sosOffsets_ = NULL;
-
-  forceNonManifoldCheck = false;
-
-  setDebugMsgPrefix("ScalarFieldCriticalPoints");
-
-  //   threadNumber_ = 1;
-}
-
-ttk::ScalarFieldCriticalPoints::~ScalarFieldCriticalPoints() {
+  this->setDebugMsgPrefix("ScalarFieldCriticalPoints");
 }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -37,45 +37,23 @@ namespace ttk {
     /// Execute the package.
     /// \param argment Dummy integer argument.
     /// \return Returns 0 upon success, negative values otherwise.
-    template <class dataType,
-              typename idType,
-              class triangulationType = AbstractTriangulation>
-    int execute(const dataType *const scalarValues,
-                const idType *const offsets,
+    template <typename idType, class triangulationType = AbstractTriangulation>
+    int execute(const idType *const offsets,
                 const triangulationType *triangulation);
 
-    template <class dataType,
-              typename idType,
-              class triangulationType = AbstractTriangulation>
+    template <typename idType, class triangulationType = AbstractTriangulation>
     std::pair<SimplexId, SimplexId> getNumberOfLowerUpperComponents(
       const SimplexId vertexId,
-      const dataType *const scalarValues,
       const idType *const offsets,
       const triangulationType *triangulation) const;
 
-    template <class dataType,
-              typename idType,
-              class triangulationType = AbstractTriangulation>
-    char getCriticalType(const dataType *const scalarValues,
-                         const idType *const offsets,
-                         const triangulationType *triangulation,
-                         const SimplexId &vertexId) const {
-
-      return getCriticalType<dataType, triangulationType>(
-        vertexId, scalarValues, triangulation);
-    }
-
-    template <class dataType,
-              typename idType,
-              class triangulationType = AbstractTriangulation>
+    template <typename idType, class triangulationType = AbstractTriangulation>
     char getCriticalType(const SimplexId &vertexId,
-                         const dataType *const scalarValues,
                          const idType *const offsets,
                          const triangulationType *triangulation) const;
 
-    template <class dataType, typename idType>
+    template <typename idType>
     char getCriticalType(const SimplexId &vertexId,
-                         const dataType *const scalarValues,
                          const idType *const offsets,
                          const std::vector<std::pair<SimplexId, SimplexId>>
                            &vertexLinkEdgeList) const;
@@ -131,11 +109,9 @@ namespace ttk {
 } // namespace ttk
 
 // template functions
-template <class dataType, typename idType, class triangulationType>
+template <typename idType, class triangulationType>
 int ttk::ScalarFieldCriticalPoints::execute(
-  const dataType *const scalarValues,
-  const idType *const offsets,
-  const triangulationType *triangulation) {
+  const idType *const offsets, const triangulationType *triangulation) {
 
   // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -143,8 +119,6 @@ int ttk::ScalarFieldCriticalPoints::execute(
     return -1;
   if((!vertexNumber_) && ((!triangulation) || (triangulation->isEmpty())))
     return -2;
-  if(!scalarValues)
-    return -3;
   if((!vertexLinkEdgeLists_) && (!triangulation))
     return -4;
   if(!criticalPoints_)
@@ -168,7 +142,7 @@ int ttk::ScalarFieldCriticalPoints::execute(
 #endif
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
 
-      vertexTypes[i] = getCriticalType(i, scalarValues, offsets, triangulation);
+      vertexTypes[i] = getCriticalType(i, offsets, triangulation);
     }
   } else if(vertexLinkEdgeLists_) {
     // legacy implementation
@@ -177,8 +151,7 @@ int ttk::ScalarFieldCriticalPoints::execute(
 #endif
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
 
-      vertexTypes[i]
-        = getCriticalType(i, scalarValues, offsets, (*vertexLinkEdgeLists_)[i]);
+      vertexTypes[i] = getCriticalType(i, offsets, (*vertexLinkEdgeLists_)[i]);
     }
   }
 
@@ -269,11 +242,10 @@ int ttk::ScalarFieldCriticalPoints::execute(
   return 0;
 }
 
-template <class dataType, typename idType, class triangulationType>
+template <typename idType, class triangulationType>
 std::pair<ttk::SimplexId, ttk::SimplexId>
   ttk::ScalarFieldCriticalPoints::getNumberOfLowerUpperComponents(
     const SimplexId vertexId,
-    const dataType *const scalarValues,
     const idType *const offsets,
     const triangulationType *triangulation) const {
 
@@ -402,16 +374,15 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
   return std::make_pair(lowerList.size(), upperList.size());
 }
 
-template <class dataType, typename idType, class triangulationType>
+template <typename idType, class triangulationType>
 char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId &vertexId,
-  const dataType *const scalarValues,
   const idType *const offsets,
   const triangulationType *triangulation) const {
 
   SimplexId downValence, upValence;
-  std::tie(downValence, upValence) = getNumberOfLowerUpperComponents(
-    vertexId, scalarValues, offsets, triangulation);
+  std::tie(downValence, upValence)
+    = getNumberOfLowerUpperComponents(vertexId, offsets, triangulation);
 
   if(downValence == 0 && upValence == 1) {
     return (char)(CriticalType::Local_minimum);
@@ -453,10 +424,9 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
   return (char)(CriticalType::Regular);
 }
 
-template <class dataType, typename idType>
+template <typename idType>
 char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId &vertexId,
-  const dataType *const scalarValues,
   const idType *const offsets,
   const std::vector<std::pair<SimplexId, SimplexId>> &vertexLink) const {
 

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -34,23 +34,30 @@ namespace ttk {
   public:
     ScalarFieldCriticalPoints();
 
-    ~ScalarFieldCriticalPoints();
-
     /// Execute the package.
     /// \param argment Dummy integer argument.
     /// \return Returns 0 upon success, negative values otherwise.
-    template <class dataType, class triangulationType = AbstractTriangulation>
-    int execute(const dataType *scalarValues,
+    template <class dataType,
+              typename idType,
+              class triangulationType = AbstractTriangulation>
+    int execute(const dataType *const scalarValues,
+                const idType *const offsets,
                 const triangulationType *triangulation);
 
-    template <class dataType, class triangulationType = AbstractTriangulation>
+    template <class dataType,
+              typename idType,
+              class triangulationType = AbstractTriangulation>
     std::pair<SimplexId, SimplexId> getNumberOfLowerUpperComponents(
       const SimplexId vertexId,
-      const dataType *scalarValues,
+      const dataType *const scalarValues,
+      const idType *const offsets,
       const triangulationType *triangulation) const;
 
-    template <class dataType, class triangulationType = AbstractTriangulation>
-    char getCriticalType(const dataType *scalarValues,
+    template <class dataType,
+              typename idType,
+              class triangulationType = AbstractTriangulation>
+    char getCriticalType(const dataType *const scalarValues,
+                         const idType *const offsets,
                          const triangulationType *triangulation,
                          const SimplexId &vertexId) const {
 
@@ -58,51 +65,32 @@ namespace ttk {
         vertexId, scalarValues, triangulation);
     }
 
-    template <class dataType, class triangulationType = AbstractTriangulation>
+    template <class dataType,
+              typename idType,
+              class triangulationType = AbstractTriangulation>
     char getCriticalType(const SimplexId &vertexId,
-                         const dataType *scalarValues,
+                         const dataType *const scalarValues,
+                         const idType *const offsets,
                          const triangulationType *triangulation) const;
 
-    template <class dataType>
+    template <class dataType, typename idType>
     char getCriticalType(const SimplexId &vertexId,
-                         const dataType *scalarValues,
+                         const dataType *const scalarValues,
+                         const idType *const offsets,
                          const std::vector<std::pair<SimplexId, SimplexId>>
                            &vertexLinkEdgeList) const;
 
-    template <class dataType>
-    static bool isSosHigherThan(const SimplexId &offset0,
-                                const dataType &value0,
-                                const SimplexId &offset1,
-                                const dataType &value1) {
-
-      return ((value0 > value1) || ((value0 == value1) && (offset0 > offset1)));
-    }
-
-    template <class dataType>
-    static bool isSosLowerThan(const SimplexId &offset0,
-                               const dataType &value0,
-                               const SimplexId &offset1,
-                               const dataType &value1) {
-
-      return ((value0 < value1) || ((value0 == value1) && (offset0 < offset1)));
-    }
-
-    int setDomainDimension(const int &dimension) {
-
+    inline void setDomainDimension(const int &dimension) {
       dimension_ = dimension;
-
-      return 0;
     }
 
-    int setOutput(std::vector<std::pair<SimplexId, char>> *criticalPoints) {
-
+    inline void
+      setOutput(std::vector<std::pair<SimplexId, char>> *criticalPoints) {
       criticalPoints_ = criticalPoints;
-
-      return 0;
     }
 
-    int setupTriangulation(AbstractTriangulation *triangulation) {
-
+    inline void
+      preconditionTriangulation(AbstractTriangulation *triangulation) {
       // pre-condition functions
       if(triangulation) {
         triangulation->preconditionVertexNeighbors();
@@ -111,24 +99,12 @@ namespace ttk {
 
       setDomainDimension(triangulation->getDimensionality());
       setVertexNumber(triangulation->getNumberOfVertices());
-
-      return 0;
     }
 
-    int setSosOffsets(std::vector<SimplexId> *offsets) {
-
-      sosOffsets_ = offsets;
-
-      return 0;
-    }
-
-    int setVertexLinkEdgeLists(
+    inline void setVertexLinkEdgeLists(
       const std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
         *edgeList) {
-
       vertexLinkEdgeLists_ = edgeList;
-
-      return 0;
     }
 
     /// Set the number of vertices in the scalar field.
@@ -144,22 +120,22 @@ namespace ttk {
     }
 
   protected:
-    int dimension_;
-    SimplexId vertexNumber_;
+    int dimension_{};
+    SimplexId vertexNumber_{};
     const std::vector<std::vector<std::pair<SimplexId, SimplexId>>>
-      *vertexLinkEdgeLists_;
-    std::vector<std::pair<SimplexId, char>> *criticalPoints_;
-    std::vector<SimplexId> *sosOffsets_;
-    std::vector<SimplexId> localSosOffSets_;
+      *vertexLinkEdgeLists_{};
+    std::vector<std::pair<SimplexId, char>> *criticalPoints_{};
 
-    bool forceNonManifoldCheck;
+    bool forceNonManifoldCheck{false};
   };
 } // namespace ttk
 
 // template functions
-template <class dataType, class triangulationType>
+template <class dataType, typename idType, class triangulationType>
 int ttk::ScalarFieldCriticalPoints::execute(
-  const dataType *scalarValues, const triangulationType *triangulation) {
+  const dataType *const scalarValues,
+  const idType *const offsets,
+  const triangulationType *triangulation) {
 
   // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -180,22 +156,6 @@ int ttk::ScalarFieldCriticalPoints::execute(
     dimension_ = triangulation->getCellVertexNumber(0) - 1;
   }
 
-  if(!sosOffsets_) {
-    // let's use our own local copy
-    sosOffsets_ = &localSosOffSets_;
-  }
-  if((SimplexId)sosOffsets_->size() != vertexNumber_) {
-    Timer preProcess;
-    sosOffsets_->resize(vertexNumber_);
-    for(SimplexId i = 0; i < vertexNumber_; i++)
-      (*sosOffsets_)[i] = i;
-
-    printMsg("Preprocessed " + std::to_string(vertexNumber_) + " offsets.", 1,
-             preProcess.getElapsedTime(), 1);
-  }
-
-  printMsg(ttk::debug::Separator::L1);
-
   printMsg("Extracting critical points...");
 
   Timer t;
@@ -208,7 +168,7 @@ int ttk::ScalarFieldCriticalPoints::execute(
 #endif
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
 
-      vertexTypes[i] = getCriticalType(i, scalarValues, triangulation);
+      vertexTypes[i] = getCriticalType(i, scalarValues, offsets, triangulation);
     }
   } else if(vertexLinkEdgeLists_) {
     // legacy implementation
@@ -218,7 +178,7 @@ int ttk::ScalarFieldCriticalPoints::execute(
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
 
       vertexTypes[i]
-        = getCriticalType(i, scalarValues, (*vertexLinkEdgeLists_)[i]);
+        = getCriticalType(i, scalarValues, offsets, (*vertexLinkEdgeLists_)[i]);
     }
   }
 
@@ -309,11 +269,12 @@ int ttk::ScalarFieldCriticalPoints::execute(
   return 0;
 }
 
-template <class dataType, class triangulationType>
+template <class dataType, typename idType, class triangulationType>
 std::pair<ttk::SimplexId, ttk::SimplexId>
   ttk::ScalarFieldCriticalPoints::getNumberOfLowerUpperComponents(
     const SimplexId vertexId,
-    const dataType *scalarValues,
+    const dataType *const scalarValues,
+    const idType *const offsets,
     const triangulationType *triangulation) const {
 
   SimplexId neighborNumber = triangulation->getVertexNeighborNumber(vertexId);
@@ -323,18 +284,12 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
     SimplexId neighborId = 0;
     triangulation->getVertexNeighbor(vertexId, i, neighborId);
 
-    if(isSosLowerThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
-
+    if(offsets[neighborId] < offsets[vertexId]) {
       lowerNeighbors.push_back(neighborId);
     }
 
     // upper link
-    if(isSosHigherThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
-
+    if(offsets[neighborId] > offsets[vertexId]) {
       upperNeighbors.push_back(neighborId);
     }
   }
@@ -377,9 +332,7 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
       if(neighborId0 != vertexId) {
         // we are on the link
 
-        bool lower0 = isSosLowerThan<dataType>(
-          (*sosOffsets_)[neighborId0], scalarValues[neighborId0],
-          (*sosOffsets_)[vertexId], scalarValues[vertexId]);
+        bool lower0 = offsets[neighborId0] < offsets[vertexId];
 
         // connect it to everybody except himself and vertexId
         for(SimplexId k = j + 1; k < cellSize; k++) {
@@ -389,9 +342,7 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
 
           if((neighborId1 != neighborId0) && (neighborId1 != vertexId)) {
 
-            bool lower1 = isSosLowerThan<dataType>(
-              (*sosOffsets_)[neighborId1], scalarValues[neighborId1],
-              (*sosOffsets_)[vertexId], scalarValues[vertexId]);
+            bool lower1 = offsets[neighborId1] < offsets[vertexId];
 
             std::vector<SimplexId> *neighbors = &lowerNeighbors;
             std::vector<UnionFind *> *seeds = &lowerList;
@@ -451,15 +402,16 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
   return std::make_pair(lowerList.size(), upperList.size());
 }
 
-template <class dataType, class triangulationType>
+template <class dataType, typename idType, class triangulationType>
 char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId &vertexId,
-  const dataType *scalarValues,
+  const dataType *const scalarValues,
+  const idType *const offsets,
   const triangulationType *triangulation) const {
 
   SimplexId downValence, upValence;
-  std::tie(downValence, upValence) = getNumberOfLowerUpperComponents<dataType>(
-    vertexId, scalarValues, triangulation);
+  std::tie(downValence, upValence) = getNumberOfLowerUpperComponents(
+    vertexId, scalarValues, offsets, triangulation);
 
   if(downValence == 0 && upValence == 1) {
     return (char)(CriticalType::Local_minimum);
@@ -501,10 +453,11 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
   return (char)(CriticalType::Regular);
 }
 
-template <class dataType>
+template <class dataType, typename idType>
 char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId &vertexId,
-  const dataType *scalarValues,
+  const dataType *const scalarValues,
+  const idType *const offsets,
   const std::vector<std::pair<SimplexId, SimplexId>> &vertexLink) const {
 
   std::map<SimplexId, SimplexId> global2LowerLink, global2UpperLink;
@@ -518,9 +471,7 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
 
     // first vertex
     // lower link search
-    if(isSosLowerThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
+    if(offsets[neighborId] < offsets[vertexId]) {
 
       neighborIt = global2LowerLink.find(neighborId);
       if(neighborIt == global2LowerLink.end()) {
@@ -531,9 +482,7 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     }
 
     // upper link
-    if(isSosHigherThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
+    if(offsets[neighborId] > offsets[vertexId]) {
 
       neighborIt = global2UpperLink.find(neighborId);
       if(neighborIt == global2UpperLink.end()) {
@@ -547,9 +496,7 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     neighborId = vertexLink[i].second;
 
     // lower link search
-    if(isSosLowerThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
+    if(offsets[neighborId] < offsets[vertexId]) {
 
       neighborIt = global2LowerLink.find(neighborId);
       if(neighborIt == global2LowerLink.end()) {
@@ -560,9 +507,7 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     }
 
     // upper link
-    if(isSosHigherThan<dataType>(
-         (*sosOffsets_)[neighborId], scalarValues[neighborId],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId])) {
+    if(offsets[neighborId] > offsets[vertexId]) {
 
       neighborIt = global2UpperLink.find(neighborId);
       if(neighborIt == global2UpperLink.end()) {
@@ -611,12 +556,8 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     SimplexId neighborId1 = vertexLink[i].second;
 
     // process the lower link
-    if((isSosLowerThan<dataType>(
-         (*sosOffsets_)[neighborId0], scalarValues[neighborId0],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId]))
-       && (isSosLowerThan<dataType>(
-         (*sosOffsets_)[neighborId1], scalarValues[neighborId1],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId]))) {
+    if(offsets[neighborId0] < offsets[vertexId]
+       && offsets[neighborId1] < offsets[vertexId]) {
 
       // both vertices are lower, let's add that edge and update the UF
       std::map<SimplexId, SimplexId>::iterator n0It
@@ -630,12 +571,8 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     }
 
     // process the upper link
-    if((isSosHigherThan<dataType>(
-         (*sosOffsets_)[neighborId0], scalarValues[neighborId0],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId]))
-       && (isSosHigherThan<dataType>(
-         (*sosOffsets_)[neighborId1], scalarValues[neighborId1],
-         (*sosOffsets_)[vertexId], scalarValues[vertexId]))) {
+    if(offsets[neighborId0] > offsets[vertexId]
+       && offsets[neighborId1] > offsets[vertexId]) {
 
       // both vertices are lower, let's add that edge and update the UF
       std::map<SimplexId, SimplexId>::iterator n0It

--- a/core/base/topologicalCompression/OtherCompression.h
+++ b/core/base/topologicalCompression/OtherCompression.h
@@ -26,13 +26,15 @@ int ttk::TopologicalCompression::computeOther() {
   return 0;
 }
 
-template <typename dataType>
-int ttk::TopologicalCompression::compressForOther(int vertexNumber,
-                                                  dataType *inputData,
-                                                  dataType *outputData,
-                                                  const double &tol) {
-  ttk::Timer t;
+template <typename dataType, typename idType>
+int ttk::TopologicalCompression::compressForOther(
+  int vertexNumber,
+  const dataType *const inputData,
+  const idType *const inputOffsets,
+  dataType *outputData,
+  const double &tol) {
 
+  ttk::Timer t;
   // Code me
 
   this->printMsg(

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -44,8 +44,10 @@ namespace ttk {
     TopologicalCompression();
 
     template <class dataType,
+              typename idType,
               typename triangulationType = AbstractTriangulation>
-    int execute(dataType *inputData,
+    int execute(const dataType *const inputData,
+                const idType *const inputOffsets,
                 dataType *outputData,
                 const triangulationType &triangulation);
 
@@ -54,12 +56,13 @@ namespace ttk {
     int computePersistencePairs(
       std::vector<std::tuple<SimplexId, SimplexId, dataType>> &JTPairs,
       std::vector<std::tuple<SimplexId, SimplexId, dataType>> &STPairs,
-      dataType *inputScalars_,
-      SimplexId *inputOffsets,
+      const dataType *const inputScalars_,
+      const SimplexId *const inputOffsets,
       const triangulationType &triangulation);
-    template <typename dataType, typename triangulationType>
+    template <typename dataType, typename idType, typename triangulationType>
     int compressForPersistenceDiagram(int vertexNumber,
-                                      dataType *inputData,
+                                      const dataType *const inputData,
+                                      const idType *const inputOffset,
                                       dataType *outputData,
                                       const double &tol,
                                       const triangulationType &triangulation);
@@ -68,9 +71,10 @@ namespace ttk {
     template <typename dataType>
     int computeOther();
 
-    template <typename dataType>
+    template <typename dataType, typename idType>
     int compressForOther(int vertexNumber,
-                         dataType *inputData,
+                         const dataType *const inputData,
+                         const idType *const inputOffsets,
                          dataType *outputData,
                          const double &tol);
 
@@ -412,9 +416,10 @@ namespace ttk {
 #include <OtherCompression.h>
 #include <PersistenceDiagramCompression.h>
 
-template <class dataType, typename triangulationType>
+template <class dataType, typename idType, typename triangulationType>
 int ttk::TopologicalCompression::execute(
-  dataType *inputData,
+  const dataType *const inputData,
+  const idType *const inputOffsets,
   dataType *outputData,
   const triangulationType &triangulation) {
   this->printMsg("Starting compression...");
@@ -432,10 +437,11 @@ int ttk::TopologicalCompression::execute(
 
   int res = 0;
   if(compressionType_ == (int)ttk::CompressionType::PersistenceDiagram)
-    compressForPersistenceDiagram<dataType>(
-      vertexNumber, inputData, outputData, Tolerance, triangulation);
+    compressForPersistenceDiagram(vertexNumber, inputData, inputOffsets,
+                                  outputData, Tolerance, triangulation);
   else if(compressionType_ == (int)ttk::CompressionType::Other)
-    compressForOther<dataType>(vertexNumber, inputData, outputData, Tolerance);
+    compressForOther(
+      vertexNumber, inputData, inputOffsets, outputData, Tolerance);
 
   return res;
 }

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -66,27 +66,28 @@ namespace ttk {
 
     template <typename dataType, typename triangulationType>
     int getCriticalType(SimplexId vertexId,
-                        dataType *scalars,
-                        SimplexId *offsets,
+                        const dataType *const scalars,
+                        const SimplexId *const offsets,
                         const triangulationType &triangulation) const;
 
     template <typename dataType, typename triangulationType>
-    int getCriticalPoints(dataType *scalars,
-                          SimplexId *offsets,
+    int getCriticalPoints(const dataType *const scalars,
+                          const SimplexId *const offsets,
                           std::vector<SimplexId> &minList,
                           std::vector<SimplexId> &maxList,
                           const triangulationType &triangulation) const;
 
     template <typename dataType, typename triangulationType>
-    int getCriticalPoints(dataType *scalars,
-                          SimplexId *offsets,
+    int getCriticalPoints(const dataType *const scalars,
+                          const SimplexId *const offsets,
                           std::vector<SimplexId> &minList,
                           std::vector<SimplexId> &maxList,
                           std::vector<bool> &blackList,
                           const triangulationType &triangulation) const;
 
     template <typename dataType>
-    int addPerturbation(dataType *scalars, SimplexId *offsets) const;
+    int addPerturbation(dataType *const scalars,
+                        SimplexId *const offsets) const;
 
     template <typename dataType, typename idType, typename triangulationType>
     int execute(const dataType *const inputScalars,
@@ -126,8 +127,8 @@ namespace ttk {
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::getCriticalType(
   SimplexId vertex,
-  dataType *scalars,
-  SimplexId *offsets,
+  const dataType *const scalars,
+  const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
   bool isMinima{true};
@@ -156,8 +157,8 @@ int ttk::TopologicalSimplification::getCriticalType(
 
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::getCriticalPoints(
-  dataType *scalars,
-  SimplexId *offsets,
+  const dataType *const scalars,
+  const SimplexId *const offsets,
   std::vector<SimplexId> &minima,
   std::vector<SimplexId> &maxima,
   const triangulationType &triangulation) const {
@@ -181,8 +182,8 @@ int ttk::TopologicalSimplification::getCriticalPoints(
 
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::getCriticalPoints(
-  dataType *scalars,
-  SimplexId *offsets,
+  const dataType *const scalars,
+  const SimplexId *const offsets,
   std::vector<SimplexId> &minima,
   std::vector<SimplexId> &maxima,
   std::vector<bool> &extrema,
@@ -207,8 +208,8 @@ int ttk::TopologicalSimplification::getCriticalPoints(
 }
 
 template <typename dataType>
-int ttk::TopologicalSimplification::addPerturbation(dataType *scalars,
-                                                    SimplexId *offsets) const {
+int ttk::TopologicalSimplification::addPerturbation(
+  dataType *const scalars, SimplexId *const offsets) const {
   dataType epsilon{};
 
   if(std::is_same<dataType, double>::value)

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -53,13 +53,9 @@ namespace ttk {
       operator()(const std::tuple<dataType, SimplexId, SimplexId> &v0,
                  const std::tuple<dataType, SimplexId, SimplexId> &v1) const {
       if(isIncreasingOrder_) {
-        return (std::get<0>(v0) < std::get<0>(v1)
-                or (std::get<0>(v0) == std::get<0>(v1)
-                    and std::get<1>(v0) < std::get<1>(v1)));
+        return std::get<1>(v0) < std::get<1>(v1);
       } else {
-        return (std::get<0>(v0) > std::get<0>(v1)
-                or (std::get<0>(v0) == std::get<0>(v1)
-                    and std::get<1>(v0) > std::get<1>(v1)));
+        return std::get<1>(v0) > std::get<1>(v1);
       }
     }
   };
@@ -67,18 +63,6 @@ namespace ttk {
   class TopologicalSimplification : virtual public Debug {
   public:
     TopologicalSimplification();
-
-    template <typename dataType>
-    bool isLowerThan(SimplexId a,
-                     SimplexId b,
-                     dataType *scalars,
-                     SimplexId *offsets) const;
-
-    template <typename dataType>
-    bool isHigherThan(SimplexId a,
-                      SimplexId b,
-                      dataType *scalars,
-                      SimplexId *offsets) const;
 
     template <typename dataType, typename triangulationType>
     int getCriticalType(SimplexId vertexId,
@@ -139,24 +123,6 @@ namespace ttk {
 // if the package is a pure template typename, uncomment the following line
 // #include                  <TopologicalSimplification.cpp>
 
-template <typename dataType>
-bool ttk::TopologicalSimplification::isLowerThan(SimplexId a,
-                                                 SimplexId b,
-                                                 dataType *scalars,
-                                                 SimplexId *offsets) const {
-  return (scalars[a] < scalars[b]
-          or (scalars[a] == scalars[b] and offsets[a] < offsets[b]));
-}
-
-template <typename dataType>
-bool ttk::TopologicalSimplification::isHigherThan(SimplexId a,
-                                                  SimplexId b,
-                                                  dataType *scalars,
-                                                  SimplexId *offsets) const {
-  return (scalars[a] > scalars[b]
-          or (scalars[a] == scalars[b] and offsets[a] > offsets[b]));
-}
-
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::getCriticalType(
   SimplexId vertex,
@@ -171,9 +137,9 @@ int ttk::TopologicalSimplification::getCriticalType(
     SimplexId neighbor;
     triangulation.getVertexNeighbor(vertex, i, neighbor);
 
-    if(isLowerThan<dataType>(neighbor, vertex, scalars, offsets))
+    if(offsets[neighbor] < offsets[vertex])
       isMinima = false;
-    if(isHigherThan<dataType>(neighbor, vertex, scalars, offsets))
+    if(offsets[neighbor] > offsets[vertex])
       isMaxima = false;
     if(!isMinima and !isMaxima) {
       return 0;

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -247,25 +247,6 @@ int checkCellTypes(vtkDataSet *object) {
   return 1;
 }
 
-vtkDataArray *
-  ttkAlgorithm::GetOptionalArray(const bool &enforceArrayIndex,
-                                 const int &arrayIndex,
-                                 const std::string &arrayName,
-                                 vtkInformationVector **inputVectors,
-                                 const int &inputPort) {
-
-  vtkDataArray *optionalArray = nullptr;
-
-  if(enforceArrayIndex)
-    optionalArray = this->GetInputArrayToProcess(arrayIndex, inputVectors);
-
-  if(!optionalArray) {
-    this->SetInputArrayToProcess(arrayIndex, inputPort, 0, 0, arrayName.data());
-    optionalArray = this->GetInputArrayToProcess(arrayIndex, inputVectors);
-  }
-  return optionalArray;
-}
-
 vtkDataArray *ttkAlgorithm::GetOptionalArray(const bool &enforceArrayIndex,
                                              const int &arrayIndex,
                                              const std::string &arrayName,

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -282,6 +282,10 @@ vtkDataArray *ttkAlgorithm::GetOptionalArray(const bool &enforceArrayIndex,
   return optionalArray;
 }
 
+std::string ttkAlgorithm::OffsetFieldName(vtkDataArray *const sfArray) const {
+  return std::string{sfArray->GetName()} + "_Order";
+}
+
 vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
                                            const bool enforceArrayIndex,
                                            const int arrayIndex,
@@ -289,7 +293,7 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
                                            const int &inputPort) {
 
   // try to find a vtkDataArray with the name sfArrayName + "_Order"
-  const auto offsetFieldName = std::string{sfArray->GetName()} + "_Order";
+  const auto offsetFieldName = this->OffsetFieldName(sfArray);
   this->SetInputArrayToProcess(
     arrayIndex, inputPort, 0, 0, offsetFieldName.data());
   const auto inOrder = this->GetInputArrayToProcess(arrayIndex, inputVectors);

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -289,14 +289,14 @@ std::string ttkAlgorithm::OffsetFieldName(vtkDataArray *const sfArray) const {
 vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
                                            const bool enforceArrayIndex,
                                            const int arrayIndex,
-                                           vtkInformationVector **inputVectors,
+                                           vtkDataSet *const inputData,
                                            const int &inputPort) {
 
   // try to find a vtkDataArray with the name sfArrayName + "_Order"
   const auto offsetFieldName = this->OffsetFieldName(sfArray);
   this->SetInputArrayToProcess(
     arrayIndex, inputPort, 0, 0, offsetFieldName.data());
-  const auto inOrder = this->GetInputArrayToProcess(arrayIndex, inputVectors);
+  const auto inOrder = this->GetInputArrayToProcess(arrayIndex, inputData);
   if(inOrder != nullptr) {
     return inOrder;
   } else {
@@ -304,7 +304,7 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
     ttk::Timer tm{};
     vtkDataArray *inDisamb = nullptr;
     if(enforceArrayIndex) {
-      inDisamb = this->GetInputArrayToProcess(arrayIndex, inputVectors);
+      inDisamb = this->GetInputArrayToProcess(arrayIndex, inputData);
     }
 
     vtkSmartPointer<vtkDataArray> vertsOrder = ttkSimplexIdTypeArray::New();

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -297,6 +297,7 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
     return inOrder;
   } else {
     // if no array found, generate one
+    ttk::Timer tm{};
     vtkDataArray *inDisamb = nullptr;
     if(enforceArrayIndex) {
       inDisamb = this->GetInputArrayToProcess(arrayIndex, inputVectors);
@@ -327,6 +328,8 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
       CALL_SORT_VERTICES(vtkIdType, nullptr)
     }
 
+    this->printMsg("Generated a sorted offset field", 1.0, tm.getElapsedTime(),
+                   this->threadNumber_);
     return vertsOrder;
   }
 }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -4,6 +4,7 @@
 
 #include <OrderDisambiguation.h>
 #include <Triangulation.h>
+
 #include <vtkCellTypes.h>
 #include <vtkCommand.h>
 #include <vtkImageData.h>
@@ -11,6 +12,7 @@
 #include <vtkInformationIntegerKey.h>
 #include <vtkInformationVector.h>
 #include <vtkMultiBlockDataSet.h>
+#include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkTable.h>
 #include <vtkUnstructuredGrid.h>
@@ -298,6 +300,7 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
     arrayIndex, inputPort, 0, 0, offsetFieldName.data());
   const auto inOrder = this->GetInputArrayToProcess(arrayIndex, inputData);
   if(inOrder != nullptr) {
+    this->printMsg("Found existing sorted offset field");
     return inOrder;
   } else {
     // if no array found, generate one
@@ -322,15 +325,15 @@ vtkDataArray *ttkAlgorithm::GetOffsetField(vtkDataArray *const sfArray,
       this->threadNumber_));                                               \
   }
 
-    if(inDisamb == nullptr) {
-      CALL_SORT_VERTICES(int, nullptr)
-    } else if(inDisamb->GetDataType() == VTK_INT) {
+    if(inDisamb != nullptr && inDisamb->GetDataType() == VTK_INT) {
       CALL_SORT_VERTICES(int, ttkUtils::GetVoidPointer(inDisamb))
-    } else if(inDisamb->GetDataType() == VTK_ID_TYPE) {
+    } else if(inDisamb != nullptr && inDisamb->GetDataType() == VTK_ID_TYPE) {
       CALL_SORT_VERTICES(vtkIdType, ttkUtils::GetVoidPointer(inDisamb))
     } else {
-      CALL_SORT_VERTICES(vtkIdType, nullptr)
+      CALL_SORT_VERTICES(int, nullptr)
     }
+
+    inputData->GetPointData()->AddArray(vertsOrder);
 
     this->printMsg("Generated a sorted offset field", 1.0, tm.getElapsedTime(),
                    this->threadNumber_);

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -311,7 +311,8 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
                        + std::string(orderArray->GetName())
                        + "` is of incorrect type.");
         auto temp = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-        this->printErr(" -> use `ttkArrayEditor` to convert data type to `"+std::string(temp->GetDataTypeAsString())+"`.");
+        this->printErr(" -> use `ttkArrayEditor` to convert data type to `"
+                       + std::string(temp->GetDataTypeAsString()) + "`.");
         return nullptr;
       }
       default: {
@@ -375,7 +376,8 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       this->printMsg("Initializing order array.", 1, timer.getElapsedTime(),
                      this->threadNumber_);
 
-      this->printWrn("Run `ttkArrayPreconditioning` prior to this filter to improve performance during multiple executions.");
+      this->printWrn("Run `ttkArrayPreconditioning` prior to this filter to "
+                     "improve performance during multiple executions.");
 
       return newOrderArray;
     }
@@ -394,7 +396,8 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
         + "` for scalar array `" + std::string(scalarArray->GetName())
         + "` is of incorrect type.");
       auto temp = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
-      this->printErr(" -> use `ttkArrayEditor` to convert data type to `"+std::string(temp->GetDataTypeAsString())+"`.");
+      this->printErr(" -> use `ttkArrayEditor` to convert data type to `"
+                     + std::string(temp->GetDataTypeAsString()) + "`.");
       return nullptr;
     }
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -137,7 +137,7 @@ public:
    * Returns a string containing the name of the corresponding offset
    * field from a given scalar field
    */
-  std::string OffsetFieldName(vtkDataArray *const sfArray) const;
+  static std::string GetOrderArrayName(vtkDataArray *const array);
 
   /**
    * Retrieves an offset field from the given scalar field \p sfArray
@@ -147,11 +147,10 @@ public:
    * generated sorted offset field is then attached to the input
    * vtkDataset \p inputData.
    */
-  vtkDataArray *GetOffsetField(vtkDataArray *const sfArray,
-                               const bool enforceArrayIndex,
-                               const int arrayIndex,
-                               vtkDataSet *const inputData,
-                               const int &inputPort = 0);
+  vtkDataArray *GetOrderArray(vtkDataSet *const inputData,
+                              const int scalarArrayIdx,
+                              const int orderArrayIdx = 0,
+                              const bool enforceOrderArrayIdx = false);
 
   /**
    * This method retrieves the ttk::Triangulation of a vtkDataSet.

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -130,11 +130,6 @@ public:
   vtkDataArray *GetOptionalArray(const bool &enforceArrayIndex,
                                  const int &arrayIndex,
                                  const std::string &arrayName,
-                                 vtkInformationVector **inputVectors,
-                                 const int &inputPort = 0);
-  vtkDataArray *GetOptionalArray(const bool &enforceArrayIndex,
-                                 const int &arrayIndex,
-                                 const std::string &arrayName,
                                  vtkDataSet *const inputData,
                                  const int &inputPort = 0);
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -139,6 +139,12 @@ public:
                                  const int &inputPort = 0);
 
   /**
+   * Returns a string containing the name of the corresponding offset
+   * field from a given scalar field
+   */
+  std::string OffsetFieldName(vtkDataArray *const sfArray) const;
+
+  /**
    * Retrieves an offset field from the given scalar field named \p
    * sfArrayName or generates one, either disambiguated with the
    * implicit vertex identifier field, or with a user-provided offset

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -154,7 +154,7 @@ public:
   vtkDataArray *GetOffsetField(vtkDataArray *const sfArray,
                                const bool enforceArrayIndex,
                                const int arrayIndex,
-                               vtkInformationVector **inputVectors,
+                               vtkDataSet *const inputData,
                                const int &inputPort = 0);
 
   /**

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -139,6 +139,19 @@ public:
                                  const int &inputPort = 0);
 
   /**
+   * Retrieves an offset field from the given scalar field named \p
+   * sfArrayName or generates one, either disambiguated with the
+   * implicit vertex identifier field, or with a user-provided offset
+   * field through the \p enforceArrayIndex boolean parameter and the
+   * \p arrayIndex.
+   */
+  vtkDataArray *GetOffsetField(vtkDataArray *const sfArray,
+                               const bool enforceArrayIndex,
+                               const int arrayIndex,
+                               vtkInformationVector **inputVectors,
+                               const int &inputPort = 0);
+
+  /**
    * This method retrieves the ttk::Triangulation of a vtkDataSet.
    *
    * Note, this method initializes a triangulation if one does not exist

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -145,11 +145,12 @@ public:
   std::string OffsetFieldName(vtkDataArray *const sfArray) const;
 
   /**
-   * Retrieves an offset field from the given scalar field named \p
-   * sfArrayName or generates one, either disambiguated with the
-   * implicit vertex identifier field, or with a user-provided offset
-   * field through the \p enforceArrayIndex boolean parameter and the
-   * \p arrayIndex.
+   * Retrieves an offset field from the given scalar field \p sfArray
+   * or generates one, either disambiguated with the implicit vertex
+   * identifier field, or with a user-provided offset field through
+   * the \p enforceArrayIndex parameter and the \p arrayIndex. The
+   * generated sorted offset field is then attached to the input
+   * vtkDataset \p inputData.
    */
   vtkDataArray *GetOffsetField(vtkDataArray *const sfArray,
                                const bool enforceArrayIndex,

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -5,7 +5,7 @@
 #define TTK_COMMA ,
 
 #ifdef TTK_ENABLE_64BIT_IDS
-using ttkSimplexIdTypeArray = vtkIdTypeArray;
+using ttkSimplexIdTypeArray = vtkLongLongArray;
 #else
 using ttkSimplexIdTypeArray = vtkIntArray;
 #endif

--- a/core/vtk/ttkArrayPreconditioning/CMakeLists.txt
+++ b/core/vtk/ttkArrayPreconditioning/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkArrayPreconditioning/ttk.module
+++ b/core/vtk/ttkArrayPreconditioning/ttk.module
@@ -1,0 +1,8 @@
+NAME
+  ttkArrayPreconditioning
+SOURCES
+  ttkArrayPreconditioning.cpp
+HEADERS
+  ttkArrayPreconditioning.h
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -1,0 +1,92 @@
+#include <OrderDisambiguation.h>
+#include <ttkArrayPreconditioning.h>
+
+#include <vtkInformation.h>
+
+#include <vtkCommand.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkPointData.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+vtkStandardNewMacro(ttkArrayPreconditioning);
+
+ttkArrayPreconditioning::ttkArrayPreconditioning() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+  this->setDebugMsgPrefix("ArrayPreconditioning");
+
+  // ensure that modifying the selection re-triggers the filter
+  // (c.f. vtkPassSelectedArrays.cxx)
+  this->ArraySelection->AddObserver(
+    vtkCommand::ModifiedEvent, this, &ttkArrayPreconditioning::Modified);
+}
+
+int ttkArrayPreconditioning::FillInputPortInformation(int port,
+                                                      vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkArrayPreconditioning::FillOutputPortInformation(int port,
+                                                       vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
+}
+
+int ttkArrayPreconditioning::RequestData(vtkInformation *request,
+                                         vtkInformationVector **inputVector,
+                                         vtkInformationVector *outputVector) {
+
+  auto input = vtkDataSet::GetData(inputVector[0]);
+  auto output = vtkDataSet::GetData(outputVector);
+  ttk::Timer tm{};
+
+  if(input == nullptr || output == nullptr) {
+    return 0;
+  }
+
+  output->ShallowCopy(input);
+
+  auto pointData = input->GetPointData();
+  auto nVertices = input->GetNumberOfPoints();
+
+  for(int i = 0; i < pointData->GetNumberOfArrays(); ++i) {
+    auto scalarArray = pointData->GetArray(i);
+
+    if(scalarArray != nullptr && scalarArray->GetName() != nullptr
+       && ArraySelection->ArrayIsEnabled(scalarArray->GetName())) {
+
+      vtkNew<ttkSimplexIdTypeArray> orderArray{};
+      orderArray->SetName(this->GetOrderArrayName(scalarArray).data());
+      orderArray->SetNumberOfComponents(1);
+      orderArray->SetNumberOfTuples(nVertices);
+
+      switch(scalarArray->GetDataType()) {
+        vtkTemplateMacro(ttk::sortVertices(
+          nVertices,
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(scalarArray)),
+          static_cast<int *>(nullptr),
+          static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(orderArray)),
+          this->threadNumber_))
+      }
+
+      output->GetPointData()->AddArray(orderArray);
+      this->printMsg("Generated order array for scalar array `"
+                     + std::string{scalarArray->GetName()} + "'");
+    }
+  }
+
+  this->printMsg("Preconditioned selected scalar arrays", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_);
+
+  return 1;
+}

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
@@ -35,6 +35,12 @@ public:
   static ttkArrayPreconditioning *New();
   vtkTypeMacro(ttkArrayPreconditioning, ttkAlgorithm);
 
+  vtkSetMacro(SelectFieldsWithRegexp, bool);
+  vtkGetMacro(SelectFieldsWithRegexp, bool);
+
+  vtkSetMacro(RegexpString, std::string);
+  vtkGetMacro(RegexpString, std::string);
+
   // copy the vtkPassSelectedArray ("PassArrays" filter) API
   vtkDataArraySelection *GetPointDataArraySelection() {
     return this->ArraySelection;
@@ -50,4 +56,6 @@ protected:
 
 private:
   vtkNew<vtkDataArraySelection> ArraySelection{};
+  bool SelectFieldsWithRegexp{false};
+  std::string RegexpString{".*"};
 };

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
@@ -1,0 +1,53 @@
+/// \ingroup vtk
+/// \class ttkArrayPreconditioning
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date September 2020
+///
+/// \brief TTK VTK-filter to generate order fields.
+///
+/// This VTK filter generates order arrays from a selection of scalar
+/// field arrays.
+///
+/// \param Input vtkDataSet.
+/// \param Output vtkDataSet.
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::ttkArrayPreconditioning
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkArrayPreconditioningModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+
+#include <vtkDataArraySelection.h>
+#include <vtkNew.h>
+
+class TTKARRAYPRECONDITIONING_EXPORT ttkArrayPreconditioning
+  : public ttkAlgorithm {
+
+public:
+  static ttkArrayPreconditioning *New();
+  vtkTypeMacro(ttkArrayPreconditioning, ttkAlgorithm);
+
+  // copy the vtkPassSelectedArray ("PassArrays" filter) API
+  vtkDataArraySelection *GetPointDataArraySelection() {
+    return this->ArraySelection;
+  }
+
+protected:
+  ttkArrayPreconditioning();
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+private:
+  vtkNew<vtkDataArraySelection> ArraySelection{};
+};

--- a/core/vtk/ttkArrayPreconditioning/vtk.module
+++ b/core/vtk/ttkArrayPreconditioning/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkArrayPreconditioning
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1210,7 +1210,7 @@ int ttkContourForests::RequestData(vtkInformation *request,
     vertexSoSoffsets_.clear();
 
     const auto offsets = this->GetOffsetField(
-      vtkInputScalars_, ForceInputOffsetScalarField, 1, inputVector);
+      vtkInputScalars_, ForceInputOffsetScalarField, 1, input);
 
     if(offsets != nullptr) {
 

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1209,8 +1209,8 @@ int ttkContourForests::RequestData(vtkInformation *request,
 
     vertexSoSoffsets_.clear();
 
-    const auto offsets = this->GetOptionalArray(
-      ForceInputOffsetScalarField, 1, ttk::OffsetScalarFieldName, inputVector);
+    const auto offsets = this->GetOffsetField(
+      vtkInputScalars_, ForceInputOffsetScalarField, 1, inputVector);
 
     if(offsets != nullptr) {
 

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1209,8 +1209,8 @@ int ttkContourForests::RequestData(vtkInformation *request,
 
     vertexSoSoffsets_.clear();
 
-    const auto offsets = this->GetOffsetField(
-      vtkInputScalars_, ForceInputOffsetScalarField, 1, input);
+    const auto offsets
+      = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
 
     if(offsets != nullptr) {
 

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1213,7 +1213,10 @@ int ttkContourForests::RequestData(vtkInformation *request,
       vtkInputScalars_, ForceInputOffsetScalarField, 1, input);
 
     if(offsets != nullptr) {
-
+      if(segmentation_ != nullptr) {
+        // propagate offsets to output
+        segmentation_->GetPointData()->AddArray(offsets);
+      }
       if(offsets->GetNumberOfTuples() != numberOfVertices_) {
         this->printErr("Mesh and offset sizes do not match :(");
         this->printErr("Using default offset field instead...");

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1213,10 +1213,7 @@ int ttkContourForests::RequestData(vtkInformation *request,
       vtkInputScalars_, ForceInputOffsetScalarField, 1, input);
 
     if(offsets != nullptr) {
-      if(segmentation_ != nullptr) {
-        // propagate offsets to output
-        segmentation_->GetPointData()->AddArray(offsets);
-      }
+
       if(offsets->GetNumberOfTuples() != numberOfVertices_) {
         this->printErr("Mesh and offset sizes do not match :(");
         this->printErr("Using default offset field instead...");

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -49,8 +49,7 @@ int ttkDiscreteGradient::dispatch(vtkUnstructuredGrid *outputCriticalPoints,
   this->setOutputCriticalPoints(&criticalPoints_points_cellScalars);
 
   const int ret
-    = this->buildGradient<scalarType, offsetType, triangulationType>(
-      triangulation);
+    = this->buildGradient<offsetType, triangulationType>(triangulation);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -157,7 +157,7 @@ int ttkDiscreteGradient::RequestData(vtkInformation *request,
 
   const auto inputScalars = this->GetInputArrayToProcess(0, input);
   auto inputOffsets = ttkAlgorithm::GetOffsetField(
-    inputScalars, this->ForceInputOffsetScalarField, 1, inputVector);
+    inputScalars, this->ForceInputOffsetScalarField, 1, input);
 
   if(inputScalars == nullptr || inputOffsets == nullptr) {
     this->printErr("Input scalar arrays are NULL");

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -61,7 +61,7 @@ int ttkDiscreteGradient::dispatch(vtkUnstructuredGrid *outputCriticalPoints,
 
   // critical points
   {
-    this->setCriticalPoints<scalarType>(triangulation);
+    this->setCriticalPoints<scalarType, offsetType>(triangulation);
 
     vtkNew<vtkPoints> points{};
 

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -156,23 +156,8 @@ int ttkDiscreteGradient::RequestData(vtkInformation *request,
   this->preconditionTriangulation(triangulation);
 
   const auto inputScalars = this->GetInputArrayToProcess(0, input);
-  auto inputOffsets
-    = ttkAlgorithm::GetOptionalArray(this->ForceInputOffsetScalarField, 1,
-                                     ttk::OffsetScalarFieldName, inputVector);
-
-  vtkNew<ttkSimplexIdTypeArray> offsets{};
-
-  if(inputOffsets == nullptr) {
-    // build a new offset field
-    const SimplexId numberOfVertices = input->GetNumberOfPoints();
-    offsets->SetNumberOfComponents(1);
-    offsets->SetNumberOfTuples(numberOfVertices);
-    offsets->SetName(ttk::OffsetScalarFieldName);
-    for(SimplexId i = 0; i < numberOfVertices; ++i) {
-      offsets->SetTuple1(i, i);
-    }
-    inputOffsets = offsets;
-  }
+  auto inputOffsets = ttkAlgorithm::GetOffsetField(
+    inputScalars, this->ForceInputOffsetScalarField, 1, inputVector);
 
   if(inputScalars == nullptr || inputOffsets == nullptr) {
     this->printErr("Input scalar arrays are NULL");

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -156,8 +156,8 @@ int ttkDiscreteGradient::RequestData(vtkInformation *request,
   this->preconditionTriangulation(triangulation);
 
   const auto inputScalars = this->GetInputArrayToProcess(0, input);
-  auto inputOffsets = ttkAlgorithm::GetOffsetField(
-    inputScalars, this->ForceInputOffsetScalarField, 1, input);
+  auto inputOffsets = ttkAlgorithm::GetOrderArray(
+    input, 0, 1, this->ForceInputOffsetScalarField);
 
   if(inputScalars == nullptr || inputOffsets == nullptr) {
     this->printErr("Input scalar arrays are NULL");

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -71,6 +71,10 @@ int ttkFTMTree::RequestData(vtkInformation *request,
   if(!inputArray)
     return 0;
 
+  // force the computation of the offset field if it doesn't exist
+  const auto inputOffsets
+    = this->GetOffsetField(inputArray, ForceInputOffsetScalarField, 1, input);
+
   // Connected components
   if(input->IsA("vtkUnstructuredGrid")) {
     // This data set may have several connected components,
@@ -190,6 +194,7 @@ int ttkFTMTree::RequestData(vtkInformation *request,
       return 0;
 #endif
     }
+    outputSegmentation->GetPointData()->AddArray(inputOffsets);
   }
 
   UpdateProgress(1);

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -71,10 +71,6 @@ int ttkFTMTree::RequestData(vtkInformation *request,
   if(!inputArray)
     return 0;
 
-  // force the computation of the offset field if it doesn't exist
-  const auto inputOffsets
-    = this->GetOffsetField(inputArray, ForceInputOffsetScalarField, 1, input);
-
   // Connected components
   if(input->IsA("vtkUnstructuredGrid")) {
     // This data set may have several connected components,
@@ -194,7 +190,6 @@ int ttkFTMTree::RequestData(vtkInformation *request,
       return 0;
 #endif
     }
-    outputSegmentation->GetPointData()->AddArray(inputOffsets);
   }
 
   UpdateProgress(1);

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -140,7 +140,7 @@ int ttkFTMTree::RequestData(vtkInformation *request,
     return 0;
 #endif
   }
-  getOffsets(inputVector);
+  getOffsets();
 
   this->printMsg("Launching on field "
                  + std::string{inputScalars_[0]->GetName()});
@@ -421,13 +421,14 @@ int ttkFTMTree::addSampledSkeletonArc(const ttk::ftm::idSuperArc arcId,
   return 1;
 }
 
-int ttkFTMTree::getOffsets(vtkInformationVector **inputVector) {
+int ttkFTMTree::getOffsets() {
   // should be called after getScalars for inputScalars_ needs to be filled
 
   offsets_.resize(nbCC_);
   for(int cc = 0; cc < nbCC_; cc++) {
-    const auto offsets = this->GetOffsetField(
-      inputScalars_[cc], ForceInputOffsetScalarField, 1, inputVector);
+    const auto offsets
+      = this->GetOffsetField(inputScalars_[cc], ForceInputOffsetScalarField, 1,
+                             connected_components_[cc]);
 
     offsets_[cc].resize(connected_components_[cc]->GetNumberOfPoints());
 

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -426,9 +426,8 @@ int ttkFTMTree::getOffsets() {
 
   offsets_.resize(nbCC_);
   for(int cc = 0; cc < nbCC_; cc++) {
-    const auto offsets
-      = this->GetOffsetField(inputScalars_[cc], ForceInputOffsetScalarField, 1,
-                             connected_components_[cc]);
+    const auto offsets = this->GetOrderArray(
+      connected_components_[cc], 0, 1, ForceInputOffsetScalarField);
 
     offsets_[cc].resize(connected_components_[cc]->GetNumberOfPoints());
 

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -73,7 +73,7 @@ public:
 
   int preconditionTriangulation();
   int getScalars();
-  int getOffsets(vtkInformationVector **inputVector);
+  int getOffsets();
 
   int getSkeletonNodes(vtkUnstructuredGrid *outputSkeletonNodes);
 

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -73,7 +73,7 @@ public:
 
   int preconditionTriangulation();
   int getScalars();
-  int getOffsets();
+  int getOffsets(vtkInformationVector **inputVector);
 
   int getSkeletonNodes(vtkUnstructuredGrid *outputSkeletonNodes);
 

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -289,7 +289,6 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
   auto outputSkeletonNodes = vtkUnstructuredGrid::GetData(outputVector, 0);
   auto outputSkeletonArcs = vtkUnstructuredGrid::GetData(outputVector, 1);
   auto outputSegmentation = vtkDataSet::GetData(outputVector, 2);
-  outputSegmentation->ShallowCopy(mesh_);
 
   // Skeleton
   Graph graph;
@@ -356,6 +355,8 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
 
 int ttkFTRGraph::getSegmentation(const ttk::ftr::Graph &graph,
                                  vtkDataSet *outputSegmentation) {
+  outputSegmentation->ShallowCopy(mesh_);
+
   const idVertex numberOfVertices = mesh_->GetNumberOfPoints();
   ttk::ftr::VertData vertData(numberOfVertices);
 

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -319,7 +319,7 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
   }
 
   offsets_ = this->GetOffsetField(
-    inputScalars_, ForceInputOffsetScalarField, 1, inputVector);
+    inputScalars_, ForceInputOffsetScalarField, 1, mesh_);
 
   // compute graph
   ttkVtkTemplateMacro(inputScalars_->GetDataType(), triangulation_->getType(),

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -317,8 +317,7 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
     return -3;
   }
 
-  offsets_ = this->GetOffsetField(
-    inputScalars_, ForceInputOffsetScalarField, 1, mesh_);
+  offsets_ = this->GetOrderArray(mesh_, 0, 1, ForceInputOffsetScalarField);
 
   // compute graph
   ttkVtkTemplateMacro(inputScalars_->GetDataType(), triangulation_->getType(),

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -320,7 +320,6 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
 
   offsets_ = this->GetOffsetField(
     inputScalars_, ForceInputOffsetScalarField, 1, mesh_);
-  outputSegmentation->GetPointData()->AddArray(offsets_);
 
   // compute graph
   ttkVtkTemplateMacro(inputScalars_->GetDataType(), triangulation_->getType(),

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -320,6 +320,7 @@ int ttkFTRGraph::RequestData(vtkInformation *request,
 
   offsets_ = this->GetOffsetField(
     inputScalars_, ForceInputOffsetScalarField, 1, mesh_);
+  outputSegmentation->GetPointData()->AddArray(offsets_);
 
   // compute graph
   ttkVtkTemplateMacro(inputScalars_->GetDataType(), triangulation_->getType(),

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -115,5 +115,5 @@ private:
   vtkDataSet *mesh_{};
   ttk::Triangulation *triangulation_{};
   vtkDataArray *inputScalars_{};
-  std::vector<ttk::ftr::idVertex> offsets_{};
+  vtkDataArray *offsets_{};
 };

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -48,7 +48,7 @@ int ttkGeometrySmoother::RequestData(vtkInformation *request,
   this->preconditionTriangulation(triangulation);
 
   vtkDataArray *inputMaskField = ttkAlgorithm::GetOptionalArray(
-    ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, inputVector);
+    ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, inputPointSet);
 
   // This filter copies the input into a new data-set (smoothed)
   // let's use shallow copies, in order to only duplicate point positions

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -53,10 +53,8 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
   this->preconditionTriangulation(*triangulation, UseCotanWeights);
 
   vtkDataArray *inputField = this->GetInputArrayToProcess(0, identifiers);
-  vtkDataArray *vertsid
-    = this->GetInputArrayInformation(1) && this->ForceConstraintIdentifiers
-        ? this->GetInputArrayToProcess(1, inputVector)
-        : identifiers->GetPointData()->GetArray(ttk::VertexScalarFieldName);
+  vtkDataArray *vertsid = this->GetOptionalArray(
+    ForceConstraintIdentifiers, 1, ttk::VertexScalarFieldName, identifiers);
 
   if(vertsid == nullptr || inputField == nullptr) {
     this->printErr("Input fields are NULL");

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
@@ -95,6 +95,8 @@ int ttkHelloWorld::RequestData(vtkInformation *request,
   if(!inputDataSet)
     return 0;
 
+  inputDataSet->Print(std::cout);
+
   // Get input array that will be processed
   //
   // Note: VTK provides abstract functionality to handle array selections, but
@@ -152,6 +154,9 @@ int ttkHelloWorld::RequestData(vtkInformation *request,
     return 0;
   }
 
+  auto order = this->GetOrderArray(inputDataSet, 0, 0, false);
+  order->Print(std::cout);
+
   // Create an output array that has the same data type as the input array
   // Note: vtkSmartPointers are well documented
   //       (https://vtk.org/Wiki/VTK/Tutorials/SmartPointers)
@@ -194,6 +199,8 @@ int ttkHelloWorld::RequestData(vtkInformation *request,
 
   // add to the output point data the computed output array
   outputDataSet->GetPointData()->AddArray(outputArray);
+
+  inputDataSet->Print(std::cout);
 
   return 1;
 }

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -139,8 +139,8 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(domain);
   vtkDataArray *inputScalars = this->GetInputArrayToProcess(0, domain);
 
-  vtkDataArray *inputOffsets = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 1, domain);
+  vtkDataArray *inputOffsets
+    = this->GetOrderArray(domain, 0, 1, ForceInputOffsetScalarField);
 
   vtkDataArray *inputIdentifiers = this->GetOptionalArray(
     ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, seeds);

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -140,7 +140,7 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   vtkDataArray *inputScalars = this->GetInputArrayToProcess(0, domain);
 
   vtkDataArray *inputOffsets = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
+    inputScalars, ForceInputOffsetScalarField, 1, domain);
 
   vtkDataArray *inputIdentifiers = this->GetOptionalArray(
     ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, inputVector, 1);

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -143,7 +143,7 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
     inputScalars, ForceInputOffsetScalarField, 1, domain);
 
   vtkDataArray *inputIdentifiers = this->GetOptionalArray(
-    ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, inputVector, 1);
+    ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, seeds);
 
   const SimplexId numberOfPointsInDomain = domain->GetNumberOfPoints();
   const SimplexId numberOfPointsInSeeds = seeds->GetNumberOfPoints();

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -139,17 +139,8 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(domain);
   vtkDataArray *inputScalars = this->GetInputArrayToProcess(0, domain);
 
-  vtkDataArray *inputOffsets = this->GetOptionalArray(
-    ForceInputOffsetScalarField, 1, ttk::OffsetScalarFieldName, inputVector);
-  if(!inputOffsets) {
-    const SimplexId numberOfPoints = domain->GetNumberOfPoints();
-    inputOffsets = ttkSimplexIdTypeArray::New();
-    inputOffsets->SetNumberOfComponents(1);
-    inputOffsets->SetNumberOfTuples(numberOfPoints);
-    inputOffsets->SetName(ttk::OffsetScalarFieldName);
-    for(SimplexId i = 0; i < numberOfPoints; ++i)
-      inputOffsets->SetTuple1(i, i);
-  }
+  vtkDataArray *inputOffsets = this->GetOffsetField(
+    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
 
   vtkDataArray *inputIdentifiers = this->GetOptionalArray(
     ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, inputVector, 1);

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -67,10 +67,10 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   this->printMsg("V-component: `" + std::string{vComponent->GetName()} + "'");
 
   // point data
-  const auto offsetFieldU = this->GetOffsetField(
-    uComponent, ForceInputOffsetScalarField, 2, inputVector);
-  const auto offsetFieldV = this->GetOffsetField(
-    vComponent, ForceInputOffsetScalarField, 3, inputVector);
+  const auto offsetFieldU
+    = this->GetOffsetField(uComponent, ForceInputOffsetScalarField, 2, input);
+  const auto offsetFieldV
+    = this->GetOffsetField(vComponent, ForceInputOffsetScalarField, 3, input);
 
   if(offsetFieldU) {
     sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -67,27 +67,25 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   this->printMsg("V-component: `" + std::string{vComponent->GetName()} + "'");
 
   // point data
-  const auto offsetFieldU = this->GetOptionalArray(
-    ForceInputOffsetScalarField, 2, ttk::OffsetFieldUName, inputVector);
-  const auto offsetFieldV = this->GetOptionalArray(
-    ForceInputOffsetScalarField, 3, ttk::OffsetFieldVName, inputVector);
+  const auto offsetFieldU = this->GetOffsetField(
+    uComponent, ForceInputOffsetScalarField, 2, inputVector);
+  const auto offsetFieldV = this->GetOffsetField(
+    vComponent, ForceInputOffsetScalarField, 3, inputVector);
 
-  if(ForceInputOffsetScalarField) {
-    if(offsetFieldU) {
-      sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
-      for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
-        sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
-      }
-      this->setSosOffsetsU(&sosOffsetsU_);
+  if(offsetFieldU) {
+    sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
+    for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
+      sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
     }
+    this->setSosOffsetsU(&sosOffsetsU_);
+  }
 
-    if(offsetFieldV) {
-      sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
-      for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
-        sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
-      }
-      this->setSosOffsetsV(&sosOffsetsV_);
+  if(offsetFieldV) {
+    sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
+    for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
+      sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
     }
+    this->setSosOffsetsV(&sosOffsetsV_);
   }
 
   auto triangulation = ttkAlgorithm::GetTriangulation(input);

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -68,9 +68,9 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
 
   // point data
   const auto offsetFieldU
-    = this->GetOffsetField(uComponent, ForceInputOffsetScalarField, 2, input);
+    = this->GetOrderArray(input, 0, 2, ForceInputOffsetScalarField);
   const auto offsetFieldV
-    = this->GetOffsetField(vComponent, ForceInputOffsetScalarField, 3, input);
+    = this->GetOrderArray(input, 1, 3, ForceInputOffsetScalarField);
 
   if(offsetFieldU) {
     sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -495,8 +495,8 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
   }
 #endif
 
-  auto inputOffsets = ttkAlgorithm::GetOffsetField(
-    inputScalars, this->ForceInputOffsetScalarField, 1, input);
+  auto inputOffsets = ttkAlgorithm::GetOrderArray(
+    input, 0, 1, this->ForceInputOffsetScalarField);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(inputOffsets == nullptr) {

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -495,23 +495,8 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
   }
 #endif
 
-  auto inputOffsets
-    = ttkAlgorithm::GetOptionalArray(this->ForceInputOffsetScalarField, 1,
-                                     ttk::OffsetScalarFieldName, inputVector);
-
-  vtkNew<ttkSimplexIdTypeArray> offsets{};
-
-  if(inputOffsets == nullptr) {
-    // build a new offset field
-    const SimplexId numberOfVertices = input->GetNumberOfPoints();
-    offsets->SetNumberOfComponents(1);
-    offsets->SetNumberOfTuples(numberOfVertices);
-    offsets->SetName(ttk::OffsetScalarFieldName);
-    for(SimplexId i = 0; i < numberOfVertices; ++i) {
-      offsets->SetTuple1(i, i);
-    }
-    inputOffsets = offsets;
-  }
+  auto inputOffsets = ttkAlgorithm::GetOffsetField(
+    inputScalars, this->ForceInputOffsetScalarField, 1, inputVector);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(inputOffsets == nullptr) {
@@ -625,6 +610,8 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
     if(ComputeAscendingSegmentation and ComputeDescendingSegmentation
        and ComputeFinalSegmentation)
       pointData->AddArray(morseSmaleManifold);
+
+    pointData->AddArray(inputOffsets);
   }
 
   return !ret;

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -602,7 +602,7 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
       return -1;
     }
 #endif
-    pointData->AddArray(inputOffsets);
+
     if(ComputeDescendingSegmentation)
       pointData->AddArray(descendingManifold);
     if(ComputeAscendingSegmentation)

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -496,7 +496,7 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
 #endif
 
   auto inputOffsets = ttkAlgorithm::GetOffsetField(
-    inputScalars, this->ForceInputOffsetScalarField, 1, inputVector);
+    inputScalars, this->ForceInputOffsetScalarField, 1, input);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(inputOffsets == nullptr) {

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -602,7 +602,7 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
       return -1;
     }
 #endif
-
+    pointData->AddArray(inputOffsets);
     if(ComputeDescendingSegmentation)
       pointData->AddArray(descendingManifold);
     if(ComputeAscendingSegmentation)

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -254,8 +254,8 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
   }
 #endif
 
-  vtkDataArray *offsetField = ttkAlgorithm::GetOptionalArray(
-    ForceInputOffsetScalarField, 1, ttk::OffsetScalarFieldName, inputVector);
+  vtkDataArray *offsetField = this->GetOffsetField(
+    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
 
   if(!offsetField) {
     offsetField = pointData->GetArray(ttk::OffsetScalarFieldName);

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -257,20 +257,6 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
   vtkDataArray *offsetField = this->GetOffsetField(
     inputScalars, ForceInputOffsetScalarField, 1, inputVector);
 
-  if(!offsetField) {
-    offsetField = pointData->GetArray(ttk::OffsetScalarFieldName);
-  }
-
-  if(!offsetField) {
-    const SimplexId numberOfVertices = input->GetNumberOfPoints();
-
-    offsetField = ttkSimplexIdTypeArray::New();
-    offsetField->SetNumberOfComponents(1);
-    offsetField->SetNumberOfTuples(numberOfVertices);
-    offsetField->SetName(ttk::OffsetScalarFieldName);
-    for(SimplexId i = 0; i < numberOfVertices; ++i)
-      offsetField->SetTuple1(i, i);
-  }
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {
     this->printErr("Wrong input offsets");

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -254,8 +254,8 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
   }
 #endif
 
-  vtkDataArray *offsetField = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
+  vtkDataArray *offsetField
+    = this->GetOffsetField(inputScalars, ForceInputOffsetScalarField, 1, input);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -255,7 +255,7 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
 #endif
 
   vtkDataArray *offsetField
-    = this->GetOffsetField(inputScalars, ForceInputOffsetScalarField, 1, input);
+    = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -460,7 +460,7 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
 #endif
 
   vtkDataArray *offsetField
-    = this->GetOffsetField(inputScalars, ForceInputOffsetScalarField, 1, input);
+    = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -462,20 +462,6 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
   vtkDataArray *offsetField = this->GetOffsetField(
     inputScalars, ForceInputOffsetScalarField, 1, inputVector);
 
-  if(!offsetField) {
-    offsetField = pointData->GetArray(ttk::OffsetScalarFieldName);
-  }
-
-  if(!offsetField) {
-    const SimplexId numberOfVertices = input->GetNumberOfPoints();
-
-    offsetField = ttkSimplexIdTypeArray::New();
-    offsetField->SetNumberOfComponents(1);
-    offsetField->SetNumberOfTuples(numberOfVertices);
-    offsetField->SetName(ttk::OffsetScalarFieldName);
-    for(SimplexId i = 0; i < numberOfVertices; ++i)
-      offsetField->SetTuple1(i, i);
-  }
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {
     this->printErr("Wrong input offsets");

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -459,8 +459,8 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
   }
 #endif
 
-  vtkDataArray *offsetField = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
+  vtkDataArray *offsetField
+    = this->GetOffsetField(inputScalars, ForceInputOffsetScalarField, 1, input);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!offsetField) {

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -459,8 +459,8 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
   }
 #endif
 
-  vtkDataArray *offsetField = ttkAlgorithm::GetOptionalArray(
-    ForceInputOffsetScalarField, 1, ttk::OffsetScalarFieldName, inputVector);
+  vtkDataArray *offsetField = this->GetOffsetField(
+    inputScalars, ForceInputOffsetScalarField, 1, inputVector);
 
   if(!offsetField) {
     offsetField = pointData->GetArray(ttk::OffsetScalarFieldName);

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -91,10 +91,10 @@ int ttkReebSpace::RequestData(vtkInformation *request,
 
   const auto uComponent = this->GetInputArrayToProcess(0, inputVector);
   const auto vComponent = this->GetInputArrayToProcess(1, inputVector);
-  const auto offsetFieldU = this->GetOffsetField(
-    uComponent, ForceInputOffsetScalarField, 2, inputVector);
-  const auto offsetFieldV = this->GetOffsetField(
-    vComponent, ForceInputOffsetScalarField, 3, inputVector);
+  const auto offsetFieldU
+    = this->GetOffsetField(uComponent, ForceInputOffsetScalarField, 2, input);
+  const auto offsetFieldV
+    = this->GetOffsetField(vComponent, ForceInputOffsetScalarField, 3, input);
 
   // check data components
 

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -92,9 +92,9 @@ int ttkReebSpace::RequestData(vtkInformation *request,
   const auto uComponent = this->GetInputArrayToProcess(0, inputVector);
   const auto vComponent = this->GetInputArrayToProcess(1, inputVector);
   const auto offsetFieldU
-    = this->GetOffsetField(uComponent, ForceInputOffsetScalarField, 2, input);
+    = this->GetOrderArray(input, 0, 2, ForceInputOffsetScalarField);
   const auto offsetFieldV
-    = this->GetOffsetField(vComponent, ForceInputOffsetScalarField, 3, input);
+    = this->GetOrderArray(input, 1, 3, ForceInputOffsetScalarField);
 
   // check data components
 

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -589,6 +589,8 @@ int ttkReebSpace::RequestData(vtkInformation *request,
 
   // now take care of the 3 sheets
   sheet3->ShallowCopy(input);
+  sheet3->GetPointData()->AddArray(offsetFieldU);
+  sheet3->GetPointData()->AddArray(offsetFieldV);
   const auto vertex3sheets = this->get3sheetVertexSegmentation();
 
   vtkNew<ttkSimplexIdTypeArray> vertexNumberField{};

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -91,10 +91,10 @@ int ttkReebSpace::RequestData(vtkInformation *request,
 
   const auto uComponent = this->GetInputArrayToProcess(0, inputVector);
   const auto vComponent = this->GetInputArrayToProcess(1, inputVector);
-  const auto offsetFieldU = this->GetOptionalArray(
-    ForceInputOffsetScalarField, 2, ttk::OffsetFieldUName, inputVector);
-  const auto offsetFieldV = this->GetOptionalArray(
-    ForceInputOffsetScalarField, 3, ttk::OffsetFieldVName, inputVector);
+  const auto offsetFieldU = this->GetOffsetField(
+    uComponent, ForceInputOffsetScalarField, 2, inputVector);
+  const auto offsetFieldV = this->GetOffsetField(
+    vComponent, ForceInputOffsetScalarField, 3, inputVector);
 
   // check data components
 
@@ -102,18 +102,16 @@ int ttkReebSpace::RequestData(vtkInformation *request,
     return -1;
   }
 
-  if(ForceInputOffsetScalarField) {
-    if(offsetFieldU) {
-      sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
-      for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
-        sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
-      }
+  if(offsetFieldU) {
+    sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
+    for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
+      sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
     }
-    if(offsetFieldV) {
-      sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
-      for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
-        sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
-      }
+  }
+  if(offsetFieldV) {
+    sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
+    for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
+      sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
     }
   }
 

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -589,8 +589,6 @@ int ttkReebSpace::RequestData(vtkInformation *request,
 
   // now take care of the 3 sheets
   sheet3->ShallowCopy(input);
-  sheet3->GetPointData()->AddArray(offsetFieldU);
-  sheet3->GetPointData()->AddArray(offsetFieldV);
   const auto vertex3sheets = this->get3sheetVertexSegmentation();
 
   vtkNew<ttkSimplexIdTypeArray> vertexNumberField{};

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -70,8 +70,8 @@ int ttkScalarFieldCriticalPoints::RequestData(
   if(!inputScalarField)
     return 0;
 
-  vtkDataArray *offsetField = ttkAlgorithm::GetOptionalArray(
-    ForceInputOffsetScalarField, 1, ttk::OffsetScalarFieldName, inputVector);
+  vtkDataArray *offsetField = this->GetOffsetField(
+    inputScalarField, ForceInputOffsetScalarField, 1, inputVector);
 
   sosOffsets_.resize(inputScalarField->GetNumberOfTuples());
   for(SimplexId i = 0; i < inputScalarField->GetNumberOfTuples(); i++) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -72,7 +72,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
     return 0;
 
   vtkDataArray *offsetField = this->GetOffsetField(
-    inputScalarField, ForceInputOffsetScalarField, 1, inputVector);
+    inputScalarField, ForceInputOffsetScalarField, 1, input);
 
   // setting up the base layer
   this->preconditionTriangulation(triangulation);

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -71,8 +71,8 @@ int ttkScalarFieldCriticalPoints::RequestData(
   if(!inputScalarField)
     return 0;
 
-  vtkDataArray *offsetField = this->GetOffsetField(
-    inputScalarField, ForceInputOffsetScalarField, 1, input);
+  vtkDataArray *offsetField
+    = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
 
   // setting up the base layer
   this->preconditionTriangulation(triangulation);

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -84,17 +84,15 @@ int ttkScalarFieldCriticalPoints::RequestData(
 
   int status = 0;
   if(offsetField->GetDataType() == VTK_INT) {
-    ttkVtkTemplateMacro(
-      inputScalarField->GetDataType(), triangulation->getType(),
+    ttkTemplateMacro(
+      triangulation->getType(),
       (status = this->execute(
-         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalarField),
          static_cast<int *>(ttkUtils::GetVoidPointer(offsetField)),
          (TTK_TT *)triangulation->getData())));
   } else if(offsetField->GetDataType() == VTK_ID_TYPE) {
-    ttkVtkTemplateMacro(
-      inputScalarField->GetDataType(), triangulation->getType(),
+    ttkTemplateMacro(
+      triangulation->getType(),
       (status = this->execute(
-         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalarField),
          static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(offsetField)),
          (TTK_TT *)triangulation->getData())));
   } else {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -2,11 +2,12 @@
 
 #include <vtkInformation.h>
 
-#include <vtkCharArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
 #include <vtkIntArray.h>
+#include <vtkNew.h>
 #include <vtkPointData.h>
+#include <vtkSignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
 #include <ttkMacros.h>
@@ -73,18 +74,8 @@ int ttkScalarFieldCriticalPoints::RequestData(
   vtkDataArray *offsetField = this->GetOffsetField(
     inputScalarField, ForceInputOffsetScalarField, 1, inputVector);
 
-  sosOffsets_.resize(inputScalarField->GetNumberOfTuples());
-  for(SimplexId i = 0; i < inputScalarField->GetNumberOfTuples(); i++) {
-    SimplexId offset = i;
-    if(offsetField) {
-      offset = offsetField->GetTuple1(i);
-    }
-    sosOffsets_[i] = offset;
-  }
-
   // setting up the base layer
-  this->setupTriangulation(triangulation);
-  this->setSosOffsets(&sosOffsets_);
+  this->preconditionTriangulation(triangulation);
   this->setOutput(&criticalPoints_);
 
   printMsg("Starting computation...");
@@ -92,25 +83,37 @@ int ttkScalarFieldCriticalPoints::RequestData(
             {"  Offset Array", offsetField ? offsetField->GetName() : "None"}});
 
   int status = 0;
-  ttkVtkTemplateMacro(inputScalarField->GetDataType(), triangulation->getType(),
-                      (status = this->execute<VTK_TT, TTK_TT>(
-                         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalarField),
-                         (TTK_TT *)triangulation->getData())));
+  if(offsetField->GetDataType() == VTK_INT) {
+    ttkVtkTemplateMacro(
+      inputScalarField->GetDataType(), triangulation->getType(),
+      (status = this->execute(
+         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalarField),
+         static_cast<int *>(ttkUtils::GetVoidPointer(offsetField)),
+         (TTK_TT *)triangulation->getData())));
+  } else if(offsetField->GetDataType() == VTK_ID_TYPE) {
+    ttkVtkTemplateMacro(
+      inputScalarField->GetDataType(), triangulation->getType(),
+      (status = this->execute(
+         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalarField),
+         static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(offsetField)),
+         (TTK_TT *)triangulation->getData())));
+  } else {
+    this->printErr("Wrong offset field type");
+    return 0;
+  }
   if(status < 0)
     return 0;
 
   // allocate the output
-  vtkSmartPointer<vtkCharArray> vertexTypes
-    = vtkSmartPointer<vtkCharArray>::New();
-
+  vtkNew<vtkSignedCharArray> vertexTypes{};
   vertexTypes->SetNumberOfComponents(1);
   vertexTypes->SetNumberOfTuples(criticalPoints_.size());
   vertexTypes->SetName("CriticalType");
 
-  vtkSmartPointer<vtkPoints> pointSet = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> pointSet{};
   pointSet->SetNumberOfPoints(criticalPoints_.size());
   double p[3];
-  for(SimplexId i = 0; i < (SimplexId)criticalPoints_.size(); i++) {
+  for(size_t i = 0; i < criticalPoints_.size(); i++) {
     input->GetPoint(criticalPoints_[i].first, p);
     pointSet->SetPoint(i, p);
     vertexTypes->SetTuple1(i, (float)criticalPoints_[i].second);
@@ -119,8 +122,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
   output->GetPointData()->AddArray(vertexTypes);
 
   if(VertexBoundary) {
-    vtkSmartPointer<vtkCharArray> vertexBoundary
-      = vtkSmartPointer<vtkCharArray>::New();
+    vtkNew<vtkSignedCharArray> vertexBoundary{};
     vertexBoundary->SetNumberOfComponents(1);
     vertexBoundary->SetNumberOfTuples(criticalPoints_.size());
     vertexBoundary->SetName("IsOnBoundary");
@@ -128,9 +130,10 @@ int ttkScalarFieldCriticalPoints::RequestData(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId)criticalPoints_.size(); i++) {
+    for(size_t i = 0; i < criticalPoints_.size(); i++) {
       vertexBoundary->SetTuple1(
-        i, (char)triangulation->isVertexOnBoundary(criticalPoints_[i].first));
+        i, (signed char)triangulation->isVertexOnBoundary(
+             criticalPoints_[i].first));
     }
 
     output->GetPointData()->AddArray(vertexBoundary);
@@ -139,13 +142,12 @@ int ttkScalarFieldCriticalPoints::RequestData(
   }
 
   if(VertexIds) {
-    vtkSmartPointer<ttkSimplexIdTypeArray> vertexIds
-      = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+    vtkNew<ttkSimplexIdTypeArray> vertexIds{};
     vertexIds->SetNumberOfComponents(1);
     vertexIds->SetNumberOfTuples(criticalPoints_.size());
     vertexIds->SetName(ttk::VertexScalarFieldName);
 
-    for(SimplexId i = 0; i < (SimplexId)criticalPoints_.size(); i++) {
+    for(size_t i = 0; i < criticalPoints_.size(); i++) {
       vertexIds->SetTuple1(i, criticalPoints_[i].first);
     }
 
@@ -158,48 +160,17 @@ int ttkScalarFieldCriticalPoints::RequestData(
     for(SimplexId i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {
 
       vtkDataArray *scalarField = input->GetPointData()->GetArray(i);
-      vtkSmartPointer<vtkDataArray> scalarArray;
+      vtkSmartPointer<vtkDataArray> scalarArray{scalarField->NewInstance()};
 
-      auto copyToScalarArray = [&]() {
-        scalarArray->SetNumberOfComponents(
-          scalarField->GetNumberOfComponents());
-        scalarArray->SetNumberOfTuples(criticalPoints_.size());
-        scalarArray->SetName(scalarField->GetName());
-        std::vector<double> value(scalarField->GetNumberOfComponents());
-        for(SimplexId j = 0; j < (SimplexId)criticalPoints_.size(); j++) {
-          scalarField->GetTuple(criticalPoints_[j].first, value.data());
-          scalarArray->SetTuple(j, value.data());
-        }
-        output->GetPointData()->AddArray(scalarArray);
-      };
-
-      switch(scalarField->GetDataType()) {
-        case VTK_CHAR:
-          scalarArray = vtkSmartPointer<vtkCharArray>::New();
-          copyToScalarArray();
-          break;
-        case VTK_DOUBLE:
-          scalarArray = vtkSmartPointer<vtkDoubleArray>::New();
-          copyToScalarArray();
-          break;
-        case VTK_FLOAT:
-          scalarArray = vtkSmartPointer<vtkFloatArray>::New();
-          copyToScalarArray();
-          break;
-        case VTK_INT:
-          scalarArray = vtkSmartPointer<vtkIntArray>::New();
-          copyToScalarArray();
-          break;
-        case VTK_ID_TYPE:
-          scalarArray = vtkSmartPointer<vtkIdTypeArray>::New();
-          copyToScalarArray();
-          break;
-        default: {
-          printMsg("Unsupported data type for scalar attachment `"
-                     + std::string(scalarField->GetName()) + "' :(",
-                   ttk::debug::Priority::DETAIL);
-        } break;
+      scalarArray->SetNumberOfComponents(scalarField->GetNumberOfComponents());
+      scalarArray->SetNumberOfTuples(criticalPoints_.size());
+      scalarArray->SetName(scalarField->GetName());
+      std::vector<double> value(scalarField->GetNumberOfComponents());
+      for(size_t j = 0; j < criticalPoints_.size(); j++) {
+        scalarField->GetTuple(criticalPoints_[j].first, value.data());
+        scalarArray->SetTuple(j, value.data());
       }
+      output->GetPointData()->AddArray(scalarArray);
     }
   } else {
     for(SimplexId i = 0; i < input->GetPointData()->GetNumberOfArrays(); i++) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -102,5 +102,4 @@ private:
   std::vector<std::vector<std::pair<ttk::SimplexId, ttk::SimplexId>>>
     vertexLinkEdgeList_;
   std::vector<std::pair<ttk::SimplexId, char>> criticalPoints_;
-  std::vector<ttk::SimplexId> sosOffsets_;
 };

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -64,7 +64,7 @@ int ttkScalarFieldSmoother::RequestData(vtkInformation *request,
   }
 
   vtkDataArray *inputMaskField = ttkAlgorithm::GetOptionalArray(
-    ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, inputVector);
+    ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, input);
 
   // preparing the output
   vtkSmartPointer<vtkDataArray> outputArray

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -91,7 +91,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   const auto vertexNumber = inputScalarField->GetNumberOfTuples();
 
   const auto inputOffsets
-    = this->GetOffsetField(inputScalarField, false, 1, inputVector);
+    = this->GetOffsetField(inputScalarField, false, 1, input);
 
   // allocate the memory for the output scalar field
   vtkSmartPointer<vtkDataArray> outputScalarField{};

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -90,6 +90,9 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
 
   const auto vertexNumber = inputScalarField->GetNumberOfTuples();
 
+  const auto inputOffsets
+    = this->GetOffsetField(inputScalarField, false, 1, inputVector);
+
   // allocate the memory for the output scalar field
   vtkSmartPointer<vtkDataArray> outputScalarField{};
 
@@ -126,6 +129,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
     inputScalarField->GetDataType(), triangulation->getType(),
     this->execute(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
+      static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)),
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField)),
       *static_cast<TTK_TT *>(triangulation->getData())));
 

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -90,8 +90,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
 
   const auto vertexNumber = inputScalarField->GetNumberOfTuples();
 
-  const auto inputOffsets
-    = this->GetOffsetField(inputScalarField, false, 1, input);
+  const auto inputOffsets = this->GetOrderArray(input, 0, 1, false);
 
   // allocate the memory for the output scalar field
   vtkSmartPointer<vtkDataArray> outputScalarField{};
@@ -122,7 +121,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
 
   vtkNew<vtkIntArray> outputOffsetField{};
   outputOffsetField->SetNumberOfTuples(vertexNumber);
-  outputOffsetField->SetName(this->OffsetFieldName(inputScalarField).data());
+  outputOffsetField->SetName(this->GetOrderArrayName(inputScalarField).data());
 
   // Call TopologicalCompression
   ttkVtkTemplateMacro(

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -119,7 +119,7 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
 
   vtkNew<vtkIntArray> outputOffsetField{};
   outputOffsetField->SetNumberOfTuples(vertexNumber);
-  outputOffsetField->SetName(ttk::OffsetScalarFieldName);
+  outputOffsetField->SetName(this->OffsetFieldName(inputScalarField).data());
 
   // Call TopologicalCompression
   ttkVtkTemplateMacro(

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -140,7 +140,7 @@ int ttkTopologicalCompressionReader::RequestData(
   if(SQMethodInt != 1 && SQMethodInt != 2 && !ZFPOnly) {
     vtkNew<vtkIntArray> vertexOffset{};
     vertexOffset->SetNumberOfTuples(vertexNumber);
-    vertexOffset->SetName(ttk::OffsetScalarFieldName);
+    vertexOffset->SetName(this->OffsetFieldName(decompressed).data());
     const auto &voidOffsets = this->getDecompressedOffsets();
     for(size_t i = 0; i < voidOffsets.size(); ++i)
       vertexOffset->SetTuple1(i, voidOffsets[i]);

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -140,7 +140,7 @@ int ttkTopologicalCompressionReader::RequestData(
   if(SQMethodInt != 1 && SQMethodInt != 2 && !ZFPOnly) {
     vtkNew<vtkIntArray> vertexOffset{};
     vertexOffset->SetNumberOfTuples(vertexNumber);
-    vertexOffset->SetName(this->OffsetFieldName(decompressed).data());
+    vertexOffset->SetName(this->GetOrderArrayName(decompressed).data());
     const auto &voidOffsets = this->getDecompressedOffsets();
     for(size_t i = 0; i < voidOffsets.size(); ++i)
       vertexOffset->SetTuple1(i, voidOffsets[i]);

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -50,8 +50,8 @@ int ttkTopologicalCompressionWriter::Write() {
   }
   this->preconditionTriangulation(triangulation);
 
-  const auto inputOffsets = this->GetOffsetField(
-    inputScalarField, false, 1, vtkDataSet::SafeDownCast(input));
+  const auto inputOffsets
+    = this->GetOrderArray(vtkDataSet::SafeDownCast(input), 0, 1, false);
 
   vtkSmartPointer<vtkDataArray> outputScalarField;
 

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -50,8 +50,8 @@ int ttkTopologicalCompressionWriter::Write() {
   }
   this->preconditionTriangulation(triangulation);
 
-  const auto inputOffsets
-    = this->GetOffsetField(inputScalarField, false, 1, inputVector);
+  const auto inputOffsets = this->GetOffsetField(
+    inputScalarField, false, 1, vtkDataSet::SafeDownCast(input));
 
   vtkSmartPointer<vtkDataArray> outputScalarField;
 
@@ -85,6 +85,7 @@ int ttkTopologicalCompressionWriter::Write() {
     inputScalarField->GetDataType(), triangulation->getType(),
     this->execute(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
+      static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)),
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalarField)),
       *static_cast<TTK_TT *>(triangulation->getData())));
 

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -50,6 +50,9 @@ int ttkTopologicalCompressionWriter::Write() {
   }
   this->preconditionTriangulation(triangulation);
 
+  const auto inputOffsets
+    = this->GetOffsetField(inputScalarField, false, 1, inputVector);
+
   vtkSmartPointer<vtkDataArray> outputScalarField;
 
   switch(inputScalarField->GetDataType()) {

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -94,9 +94,8 @@ int ttkTopologicalSimplification::RequestData(
   }
 
   // domain offset field
-  const auto offsets = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 2, domain);
-
+  const auto offsets
+    = this->GetOrderArray(domain, 0, 2, ForceInputOffsetScalarField);
   if(!offsets) {
     this->printErr("Wrong input offset scalar field.");
     return -1;

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -5,6 +5,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
+#include <vtkSmartPointer.h>
 
 #include <ttkMacros.h>
 #include <ttkTopologicalSimplification.h>

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -85,10 +85,6 @@ int ttkTopologicalSimplification::RequestData(
   }
 
   // constraint identifier field
-
-  // use the GetOptionalArray variant here to fix a segfault occuring
-  // when changing a threshold bound on the Threshold filter usually
-  // connected to the second input port
   const auto identifiers = this->GetOptionalArray(
     ForceInputVertexScalarField, 1, ttk::VertexScalarFieldName, constraints);
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -99,7 +99,7 @@ int ttkTopologicalSimplification::RequestData(
 
   // domain offset field
   const auto offsets = this->GetOffsetField(
-    inputScalars, ForceInputOffsetScalarField, 2, inputVector);
+    inputScalars, ForceInputOffsetScalarField, 2, domain);
 
   if(!offsets) {
     this->printErr("Wrong input offset scalar field.");

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -78,9 +78,6 @@ public:
   vtkSetMacro(AddPerturbation, bool);
   vtkGetMacro(AddPerturbation, bool);
 
-  vtkSetMacro(OutputOffsetScalarFieldName, std::string);
-  vtkGetMacro(OutputOffsetScalarFieldName, std::string);
-
   vtkSetMacro(ForceInputVertexScalarField, bool);
   vtkGetMacro(ForceInputVertexScalarField, bool);
 
@@ -95,7 +92,6 @@ protected:
 
 private:
   int OffsetFieldId{-1};
-  std::string OutputOffsetScalarFieldName{ttk::OffsetScalarFieldName};
   bool ForceInputVertexScalarField{false};
   bool ForceInputOffsetScalarField{false};
   bool ConsiderIdentifierAsBlackList{false};

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -49,9 +49,6 @@
 
 #pragma once
 
-// VTK includes -- to adapt
-#include <vtkSmartPointer.h>
-
 // VTK Module
 #include <ttkTopologicalSimplificationModule.h>
 
@@ -91,7 +88,6 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  int OffsetFieldId{-1};
   bool ForceInputVertexScalarField{false};
   bool ForceInputOffsetScalarField{false};
   bool ConsiderIdentifierAsBlackList{false};

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
@@ -17,10 +17,10 @@
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
 #include <vtkIntArray.h>
+#include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPoints.h>
-#include <vtkNew.h>
 #include <vtkTable.h>
 #include <vtkUnstructuredGrid.h>
 

--- a/paraview/ArrayPreconditioning/ArrayPreconditioning.xml
+++ b/paraview/ArrayPreconditioning/ArrayPreconditioning.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ttkArrayPreconditioning"
+                 class="ttkArrayPreconditioning"
+                 label="TTK ArrayPreconditioning">
+      <Documentation
+          long_help="Array Preconditioning"
+          short_help="Array Preconditioning">
+        This filter preconditions a vtkDataSet by computing an input
+        order array for every selected scalar arrays.
+      </Documentation>
+
+      <InputProperty name="Input" command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources" />
+          <Group name="filters" />
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet" />
+        </DataTypeDomain>
+        <InputArrayDomain name="input_array"
+                          attribute_type="point"
+                          number_of_components="1" />
+        <Documentation>
+          A vtkDataSet that has at least one point data scalar array.
+        </Documentation>
+      </InputProperty>
+
+      <StringVectorProperty
+          name="PointDataArrays"
+          command="GetPointDataArraySelection"
+          number_of_elements_per_command="1"
+          repeat_command="1"
+          si_class="vtkSIDataArraySelectionProperty">
+          <ArrayListDomain name="array_list" input_domain_name="point_arrays">
+            <RequiredProperties>
+              <Property name="Input" function="Input" />
+            </RequiredProperties>
+          </ArrayListDomain>
+          <Documentation>
+            Select the point data arrays to pass through
+          </Documentation>
+          <Hints>
+            <ArraySelectionWidget icon_type="point"/>
+          </Hints>
+      </StringVectorProperty>
+
+      ${DEBUG_WIDGETS}
+
+      <PropertyGroup panel_widget="Line" label="Input Options">
+        <Property name="PointDataArrays" />
+      </PropertyGroup>
+
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/ArrayPreconditioning/ArrayPreconditioning.xml
+++ b/paraview/ArrayPreconditioning/ArrayPreconditioning.xml
@@ -28,29 +28,66 @@
         </Documentation>
       </InputProperty>
 
+      <IntVectorProperty
+          name="SelectFieldsWithRegexp"
+          label="Select Fields with a Regexp"
+          command="SetSelectFieldsWithRegexp"
+          panel_visibility="advanced"
+          number_of_elements="1"
+          default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Select input scalar fields matching a regular expression.
+        </Documentation>
+      </IntVectorProperty>
+
       <StringVectorProperty
           name="PointDataArrays"
           command="GetPointDataArraySelection"
           number_of_elements_per_command="1"
           repeat_command="1"
           si_class="vtkSIDataArraySelectionProperty">
-          <ArrayListDomain name="array_list" input_domain_name="point_arrays">
-            <RequiredProperties>
-              <Property name="Input" function="Input" />
-            </RequiredProperties>
-          </ArrayListDomain>
-          <Documentation>
-            Select the point data arrays to pass through
-          </Documentation>
-          <Hints>
-            <ArraySelectionWidget icon_type="point"/>
-          </Hints>
+        <ArrayListDomain name="array_list" input_domain_name="point_arrays">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the point data arrays to pass through
+        </Documentation>
+        <Hints>
+          <ArraySelectionWidget icon_type="point"/>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="0" />
+        </Hints>
+      </StringVectorProperty>
+
+      <StringVectorProperty
+          name="Regexp"
+          command="SetRegexpString"
+          number_of_elements="1"
+          default_values=".*"
+          panel_visibility="advanced">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="1" />
+        </Hints>
+        <Documentation>
+          This regexp will be used to filter the chosen fields. Only
+          matching ones will be selected.
+        </Documentation>
       </StringVectorProperty>
 
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input Options">
+        <Property name="SelectFieldsWithRegexp" />
         <Property name="PointDataArrays" />
+        <Property name="Regexp" />
       </PropertyGroup>
 
       <Hints>

--- a/paraview/ArrayPreconditioning/TTKFilter.cmake
+++ b/paraview/ArrayPreconditioning/TTKFilter.cmake
@@ -1,0 +1,1 @@
+ttk_register_pv_filter(ttkArrayPreconditioning ArrayPreconditioning.xml)

--- a/paraview/TopologicalSimplification/TopologicalSimplification.xml
+++ b/paraview/TopologicalSimplification/TopologicalSimplification.xml
@@ -202,17 +202,6 @@
         </Documentation>
       </IntVectorProperty>
 
-      <StringVectorProperty
-          name="OutputOffsetScalarFieldName"
-          command="SetOutputOffsetScalarFieldName"
-          label="Output Offset Scalar Field"
-          number_of_elements="1"
-          panel_visibility="advanced">
-        <Documentation>
-          Select the name of the output offset field.
-        </Documentation>
-      </StringVectorProperty>
-
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
@@ -225,7 +214,6 @@
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">
-        <Property name="OutputOffsetScalarFieldName"/>
         <Property name="AddPerturbation"/>
       </PropertyGroup>
 

--- a/paraview/patch/data/Example1.pvsm
+++ b/paraview/patch/data/Example1.pvsm
@@ -27111,7 +27111,7 @@
         <Domain name="bool" id="18001.With boundary mask.bool"/>
       </Property>
       <Property name="With predefined offset" id="18001.With predefined offset" number_of_elements="1">
-        <Element index="0" value="1"/>
+        <Element index="0" value="0"/>
         <Domain name="bool" id="18001.With predefined offset.bool"/>
       </Property>
       <Property name="With vertex identifiers" id="18001.With vertex identifiers" number_of_elements="1">

--- a/paraview/patch/data/Example3.pvsm
+++ b/paraview/patch/data/Example3.pvsm
@@ -57538,7 +57538,7 @@
         <Domain name="bool" id="9534.With boundary mask.bool"/>
       </Property>
       <Property name="With predefined offset" id="9534.With predefined offset" number_of_elements="1">
-        <Element index="0" value="1"/>
+        <Element index="0" value="0"/>
         <Domain name="bool" id="9534.With predefined offset.bool"/>
       </Property>
       <Property name="With vertex identifiers" id="9534.With vertex identifiers" number_of_elements="1">
@@ -57599,7 +57599,7 @@
         <Domain name="bool" id="10734.With boundary mask.bool"/>
       </Property>
       <Property name="With predefined offset" id="10734.With predefined offset" number_of_elements="1">
-        <Element index="0" value="1"/>
+        <Element index="0" value="0"/>
         <Domain name="bool" id="10734.With predefined offset.bool"/>
       </Property>
       <Property name="With vertex identifiers" id="10734.With vertex identifiers" number_of_elements="1">


### PR DESCRIPTION
This PR add the support of sorted offset fields. Sorted offset fields are now associated with scalar fields and stored in vtkDataSets as vtkDataArrays with the name $ScalarFieldName + "_Order". These offset fields are created when needed or fetched if already existing.

The creating step sorts the vertices using the scalar field values and the implicit vertex order or a pre-existing offset field.

The new vtkDataArrays are attached to the input of the current filter (see core/vtk/ttkAlgorithm/ttkAlgorithm.cpp). The sorting process is located in core/base/common/OrderDisambiguation.h.

Several modules have been ported to take fully advantage of sorted offsets: DiscreteGradient, MorseSmaleComplex, ScalarFieldCriticalPoints, TopologicalSimplification. The other should be ready in a few days.

Enjoy,
Pierre

