### PR TITLE
Fix access to BottleneckDistance result

### DIFF
--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.h
@@ -98,7 +98,9 @@ public:
   vtkSetMacro(Spacing, double);
   vtkGetMacro(Spacing, double);
 
-  vtkGetMacro(result, double);
+  double Getresult() {
+    return this->distance_;
+  }
 
   // Override input types.
   int FillInputPortInformation(int port, vtkInformation *info) override {
@@ -196,7 +198,6 @@ protected:
     PVAlgorithm = -1;
 
     // outputs
-    result = -1.;
     CTPersistenceDiagram1_ = vtkSmartPointer<vtkUnstructuredGrid>::New();
     CTPersistenceDiagram2_ = vtkSmartPointer<vtkUnstructuredGrid>::New();
     CTPersistenceDiagram3_ = vtkSmartPointer<vtkUnstructuredGrid>::New();
@@ -224,7 +225,6 @@ private:
   bool UsePersistenceMetric;
   bool UseGeometricSpacing;
   int PVAlgorithm;
-  double result;
 
   vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram1_;
   vtkSmartPointer<vtkUnstructuredGrid> CTPersistenceDiagram2_;


### PR DESCRIPTION
This PR should fix #477 by giving access to the distance value through the `Getresult()` method in the VTK layer.

The `result` member of the VTK class was not connected to the distance value, which is stored inside the `distance_` member of the base class.

To get access to this value without modifying the current API, the `result` member has been removed, and the `Getresult()` method has been updated to give access to the `distance_` member.

Enjoy,
Pierre