### PR TITLE
[Order-based SoS] Module migrations

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -228,7 +228,7 @@ namespace ttk {
      * Set the input offset field associated on the points of the data set
      * (if none, identifiers are used instead).
      */
-    inline int setInputOffsets(const void *const data) {
+    inline int setInputOffsets(const SimplexId *const data) {
       inputOffsets_ = data;
       discreteGradient_.setInputOffsets(inputOffsets_);
       return 0;
@@ -378,7 +378,7 @@ namespace ttk {
      * outputSeparatrices1_cells_
      * inputScalarField_
      */
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int setSeparatrices1(
       const std::vector<Separatrix> &separatrices,
       const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -429,7 +429,7 @@ namespace ttk {
     dcg::DiscreteGradient discreteGradient_{};
 
     const void *inputScalarField_{};
-    const void *inputOffsets_{};
+    const SimplexId *inputOffsets_{};
 
     SimplexId *outputCriticalPoints_numberOfPoints_{};
     std::vector<float> *outputCriticalPoints_points_{};
@@ -535,7 +535,7 @@ int ttk::AbstractMorseSmaleComplex::getDescendingSeparatrices1(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
   const std::vector<Separatrix> &separatrices,
   const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -566,7 +566,7 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto offsets = static_cast<const idType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
   auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
     outputSeparatrices1_cells_separatrixFunctionMaxima_);
   auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -378,7 +378,7 @@ namespace ttk {
      * outputSeparatrices1_cells_
      * inputScalarField_
      */
-    template <typename dataType, typename triangulationType>
+    template <typename dataType, typename idType, typename triangulationType>
     int setSeparatrices1(
       const std::vector<Separatrix> &separatrices,
       const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -535,7 +535,7 @@ int ttk::AbstractMorseSmaleComplex::getDescendingSeparatrices1(
   return 0;
 }
 
-template <typename dataType, typename triangulationType>
+template <typename dataType, typename idType, typename triangulationType>
 int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
   const std::vector<Separatrix> &separatrices,
   const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -566,6 +566,7 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto offsets = static_cast<const idType *>(inputOffsets_);
   auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
     outputSeparatrices1_cells_separatrixFunctionMaxima_);
   auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
@@ -662,11 +663,15 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 
     // compute separatrix function diff
     const auto sepFuncMax
-      = std::max(discreteGradient_.scalarMax(src, scalars, triangulation),
-                 discreteGradient_.scalarMax(dst, scalars, triangulation));
+      = std::max(scalars[discreteGradient_.getCellGreaterVertex(
+                   src, offsets, triangulation)],
+                 scalars[discreteGradient_.getCellGreaterVertex(
+                   dst, offsets, triangulation)]);
     const auto sepFuncMin
-      = std::min(discreteGradient_.scalarMin(src, scalars, triangulation),
-                 discreteGradient_.scalarMin(dst, scalars, triangulation));
+      = std::min(scalars[discreteGradient_.getCellLowerVertex(
+                   src, offsets, triangulation)],
+                 scalars[discreteGradient_.getCellLowerVertex(
+                   dst, offsets, triangulation)]);
     const auto sepFuncDiff = sepFuncMax - sepFuncMin;
 
     // get boundary condition

--- a/core/base/common/OrderDisambiguation.h
+++ b/core/base/common/OrderDisambiguation.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <DataTypes.h>
 
 #include <algorithm>

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -38,12 +38,11 @@ ContourForests::~ContourForests() {
 // {
 
 idPartition ContourForests::vertex2partition(const SimplexId &v) {
-  const SimplexId &position = scalars_->mirrorVertices[v];
+  const SimplexId &position = scalars_->sosOffsets[v];
   idPartition partition = 0;
-  while(
-    partition < parallelParams_.nbInterfaces
-    && scalars_->mirrorVertices[parallelData_.interfaces[partition].getSeed()]
-         <= position) {
+  while(partition < parallelParams_.nbInterfaces
+        && scalars_->sosOffsets[parallelData_.interfaces[partition].getSeed()]
+             <= position) {
     ++partition;
   }
 
@@ -266,7 +265,7 @@ void ContourForests::stitchTree(const char treetype) {
       if(otherPartition < parallelParams_.nbInterfaces) {
         const SimplexId &nextSeed
           = parallelData_.interfaces[otherPartition].getSeed();
-        crossNextInterface = isEqLower(nextSeed, stitchVertex);
+        crossNextInterface = isLower(nextSeed, stitchVertex);
       }
       otherTree->treeData_.superArcs.emplace_back(
         curTreeStitchNodeId, otherTreeStitchNodeId, true, crossNextInterface, i,

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -153,13 +153,12 @@ namespace ttk {
         const SimplexId &start
           = (i == 0)
               ? 0
-              : scalars_
-                  ->mirrorVertices[parallelData_.interfaces[i - 1].getSeed()];
+              : scalars_->sosOffsets[parallelData_.interfaces[i - 1].getSeed()];
 
         const SimplexId &end
           = (i == parallelParams_.nbInterfaces)
               ? scalars_->size
-              : scalars_->mirrorVertices[parallelData_.interfaces[i].getSeed()];
+              : scalars_->sosOffsets[parallelData_.interfaces[i].getSeed()];
 
         return std::make_tuple(start, end);
       }
@@ -169,14 +168,12 @@ namespace ttk {
         const SimplexId &start
           = (i == parallelParams_.nbInterfaces)
               ? scalars_->size - 1
-              : scalars_->mirrorVertices[parallelData_.interfaces[i].getSeed()]
-                  - 1;
+              : scalars_->sosOffsets[parallelData_.interfaces[i].getSeed()] - 1;
 
         const SimplexId &end
           = (i == 0)
               ? -1
-              : scalars_
-                    ->mirrorVertices[parallelData_.interfaces[i - 1].getSeed()]
+              : scalars_->sosOffsets[parallelData_.interfaces[i - 1].getSeed()]
                   - 1;
 
         return std::make_tuple(start, end);
@@ -187,13 +184,12 @@ namespace ttk {
         const SimplexId &seed0
           = (i == 0)
               ? -1
-              : scalars_
-                  ->mirrorVertices[parallelData_.interfaces[i - 1].getSeed()];
+              : scalars_->sosOffsets[parallelData_.interfaces[i - 1].getSeed()];
 
         const SimplexId &seed1
           = (i == parallelParams_.nbInterfaces)
               ? nullVertex
-              : scalars_->mirrorVertices[parallelData_.interfaces[i].getSeed()];
+              : scalars_->sosOffsets[parallelData_.interfaces[i].getSeed()];
 
         return std::make_tuple(seed0, seed1);
       }

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -44,7 +44,6 @@ namespace ttk {
       initTreeType();
       initNbScalars(mesh);
       initNbPartitions();
-      initSoS();
 
       this->printMsg(std::vector<std::vector<std::string>>{
         {"#Threads", std::to_string(parallelParams_.nbThreads)},
@@ -548,9 +547,9 @@ namespace ttk {
 
         for(idInterface i = 0; i < parallelParams_.nbInterfaces; i++) {
           const bool side0
-            = isEqHigher(v0, parallelData_.interfaces[i].getSeed());
+            = isHigher(v0, parallelData_.interfaces[i].getSeed());
           const bool side1
-            = isEqHigher(v1, parallelData_.interfaces[i].getSeed());
+            = isHigher(v1, parallelData_.interfaces[i].getSeed());
 
           if(side0 != side1) {
             // edge cross this interface, add both extrema in it

--- a/core/base/contourForestsTree/ContourForestsTree.cpp
+++ b/core/base/contourForestsTree/ContourForestsTree.cpp
@@ -224,12 +224,12 @@ int ContourForestsTree::combine(const SimplexId &seed0,
 
       // If the created arc cross tha above or below interface, keep this info
       if(s0 != nullVertex) {
-        overlapB = (isEqHigher(currentNode->getVertexId(), s0)
-                    != isEqHigher(parentNode->getVertexId(), s0));
+        overlapB = (isHigher(currentNode->getVertexId(), s0)
+                    != isHigher(parentNode->getVertexId(), s0));
       }
       if(s1 != nullVertex) {
-        overlapA = (isEqHigher(currentNode->getVertexId(), s1)
-                    != isEqHigher(parentNode->getVertexId(), s1));
+        overlapA = (isHigher(currentNode->getVertexId(), s1)
+                    != isHigher(parentNode->getVertexId(), s1));
       }
 
       idSuperArc createdArc;

--- a/core/base/contourForestsTree/DeprecatedStructures.h
+++ b/core/base/contourForestsTree/DeprecatedStructures.h
@@ -32,25 +32,16 @@ namespace ttk {
 
     // Scalar related containers (global)
     struct Scalars {
-      SimplexId size;
-      void *values;
-      std::vector<SimplexId> sosOffsets;
-      std::vector<SimplexId> sortedVertices, mirrorVertices;
-
-      // Need vertices to be sorted : use mirrorVertices.
+      SimplexId size{};
+      void *values{};
+      const SimplexId *sosOffsets{};
+      std::vector<SimplexId> sortedVertices{};
 
       bool isLower(const SimplexId &a, const SimplexId &b) const {
-        return mirrorVertices[a] < mirrorVertices[b];
+        return sosOffsets[a] < sosOffsets[b];
       }
-      bool isEqLower(const SimplexId &a, const SimplexId &b) const {
-        return mirrorVertices[a] <= mirrorVertices[b];
-      }
-
       bool isHigher(const SimplexId &a, const SimplexId &b) const {
-        return mirrorVertices[a] > mirrorVertices[b];
-      }
-      bool isEqHigher(const SimplexId &a, const SimplexId &b) const {
-        return mirrorVertices[a] >= mirrorVertices[b];
+        return sosOffsets[a] > sosOffsets[b];
       }
     };
 

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -75,15 +75,6 @@ namespace ttk {
         scalars_->size = tri->getNumberOfVertices();
       }
 
-      /// \brief init Simulation of Simplicity datastructure if not set
-      void initSoS(void) {
-        std::vector<SimplexId> &sosVect = scalars_->sosOffsets;
-        if(!sosVect.size()) {
-          sosVect.resize(scalars_->size);
-          iota(sosVect.begin(), sosVect.end(), 0);
-        }
-      }
-
       /// \brief init the type of the current tree froms params
       void initTreeType(void) {
         treeData_.treeType = params_->treeType;
@@ -175,7 +166,7 @@ namespace ttk {
       // offset
       // .....................{
 
-      inline void setVertexSoSoffsets(const std::vector<SimplexId> &offsets) {
+      inline void setVertexSoSoffsets(const SimplexId *const offsets) {
         scalars_->sosOffsets = offsets;
       }
 
@@ -647,21 +638,11 @@ namespace ttk {
       // Strict
 
       inline bool isLower(const SimplexId &a, const SimplexId &b) const {
-        return scalars_->mirrorVertices[a] < scalars_->mirrorVertices[b];
+        return scalars_->isLower(a, b);
       }
 
       inline bool isHigher(const SimplexId &a, const SimplexId &b) const {
-        return scalars_->mirrorVertices[a] > scalars_->mirrorVertices[b];
-      }
-
-      // Large
-
-      inline bool isEqLower(const SimplexId &a, const SimplexId &b) const {
-        return scalars_->mirrorVertices[a] <= scalars_->mirrorVertices[b];
-      }
-
-      inline bool isEqHigher(const SimplexId &a, const SimplexId &b) const {
-        return scalars_->mirrorVertices[a] >= scalars_->mirrorVertices[b];
+        return scalars_->isHigher(a, b);
       }
 
       //}

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -356,30 +356,13 @@ saddle-connectors.
       }
 
       /**
-       * Return the scalar value of the point in the cell which has the highest
-function value.
-       */
-      template <typename dataType, typename triangulationType>
-      dataType scalarMax(const Cell &cell,
-                         const dataType *const scalars,
-                         const triangulationType &triangulation) const;
-
-      /**
-       * Return the scalar value of the point in the cell which has the lowest
-function value.
-       */
-      template <typename dataType, typename triangulationType>
-      dataType scalarMin(const Cell &cell,
-                         const dataType *const scalars,
-                         const triangulationType &triangulation) const;
-
-      /**
        * Compute the difference of function values of a pair of cells.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       dataType getPersistence(const Cell &up,
                               const Cell &down,
-                              const dataType *scalars,
+                              const dataType *const scalars,
+                              const idType *const offsets,
                               const triangulationType &triangulation) const;
 
       /**
@@ -754,7 +737,7 @@ in the gradient.
 (2-saddle,...,1-saddle) vpaths
        * to the simplification process.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int initializeSaddleSaddleConnections1(
         const std::vector<char> &isRemovableSaddle1,
         const std::vector<char> &isRemovableSaddle2,
@@ -779,7 +762,7 @@ in the gradient.
        * Core of the simplification process, modify the gradient and
        * reverse the selected (2-saddle,...,1-saddle) vpaths to simplify.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int processSaddleSaddleConnections1(
         const int iterationThreshold,
         const std::vector<char> &isPL,
@@ -802,7 +785,7 @@ in the gradient.
        * High-level function that manages the global simplification of
 (2-saddle,...,1-saddle) vpaths.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int simplifySaddleSaddleConnections1(
         const std::vector<std::pair<SimplexId, char>> &criticalPoints,
         const std::vector<char> &isPL,
@@ -817,7 +800,7 @@ in the gradient.
 (1-saddle,...,2-saddle) vpaths
        * to the simplification process.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int initializeSaddleSaddleConnections2(
         const std::vector<char> &isRemovableSaddle1,
         const std::vector<char> &isRemovableSaddle2,
@@ -842,7 +825,7 @@ in the gradient.
        * Core of the simplification process, modify the gradient and
        * reverse the selected (1-saddle,...,2-saddle) vpaths to simplify.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int processSaddleSaddleConnections2(
         const int iterationThreshold,
         const std::vector<char> &isPL,
@@ -865,7 +848,7 @@ in the gradient.
        * High-level function that manages the global simplification of
 (1-saddle,...,2-saddle) vpaths.
        */
-      template <typename dataType, typename triangulationType>
+      template <typename dataType, typename idType, typename triangulationType>
       int simplifySaddleSaddleConnections2(
         const std::vector<std::pair<SimplexId, char>> &criticalPoints,
         const std::vector<char> &isPL,

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -358,34 +358,33 @@ saddle-connectors.
       /**
        * Compute the difference of function values of a pair of cells.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       dataType getPersistence(const Cell &up,
                               const Cell &down,
                               const dataType *const scalars,
-                              const idType *const offsets,
+                              const SimplexId *const offsets,
                               const triangulationType &triangulation) const;
 
       /**
        * Compute the initial gradient field of the input scalar function on the
 triangulation.
        */
-      template <typename idType, typename triangulationType>
+      template <typename triangulationType>
       int buildGradient(const triangulationType &triangulation);
 
       /**
        * Automatic detection of the PL critical points and simplification
 according to them.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int reverseGradient(const triangulationType &triangulation,
                           const bool detectCriticalPoints = true);
 
       /**
        * Set the input scalar function.
        */
-      inline int setInputScalarField(const void *const data) {
+      inline void setInputScalarField(const void *const data) {
         inputScalarField_ = data;
-        return 0;
       }
 
       /**
@@ -422,9 +421,8 @@ according to them.
       /**
        * Set the input offset function.
        */
-      inline int setInputOffsets(const void *const data) {
+      inline void setInputOffsets(const SimplexId *const data) {
         inputOffsets_ = data;
-        return 0;
       }
 
       /**
@@ -570,20 +568,20 @@ in the gradient.
        * Get the vertex id of with the maximum scalar field value on
        * the given cell.
        */
-      template <typename idType, typename triangulationType>
+      template <typename triangulationType>
       SimplexId
         getCellGreaterVertex(const Cell c,
-                             const idType *const offsets,
+                             const SimplexId *const offsets,
                              const triangulationType &triangulation) const;
 
       /**
        * Get the vertex id of with the minimum scalar field value on
        * the given cell.
        */
-      template <typename idType, typename triangulationType>
+      template <typename triangulationType>
       SimplexId
         getCellLowerVertex(const Cell c,
-                           const idType *const offsets,
+                           const SimplexId *const offsets,
                            const triangulationType &triangulation) const;
 
       /**
@@ -594,7 +592,7 @@ in the gradient.
        * outputCriticalPoints_points_
        * inputScalarField_
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int setCriticalPoints(const std::vector<Cell> &criticalPoints,
                             std::vector<size_t> &nCriticalPointsByDim,
                             const triangulationType &triangulation);
@@ -603,7 +601,7 @@ in the gradient.
        * Detect the critical points and build their geometric embedding.
        * The output data pointers are modified accordingly.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int setCriticalPoints(const triangulationType &triangulation);
 
       /**
@@ -649,10 +647,10 @@ in the gradient.
        * @return Lower star as 4 sets of cells (0-cells, 1-cells, 2-cells and
        * 3-cells)
        */
-      template <typename idType, typename triangulationType>
+      template <typename triangulationType>
       inline lowerStarType
         lowerStar(const SimplexId a,
-                  const idType *const offsets,
+                  const SimplexId *const offsets,
                   const triangulationType &triangulation) const;
 
       /**
@@ -695,8 +693,8 @@ in the gradient.
        * Grayscale Digital Images", V. Robins, P. J. Wood,
        * A. P. Sheppard
        */
-      template <typename idType, typename triangulationType>
-      int processLowerStars(const idType *const offsets,
+      template <typename triangulationType>
+      int processLowerStars(const SimplexId *const offsets,
                             const triangulationType &triangulation);
 
       /**
@@ -737,7 +735,7 @@ in the gradient.
 (2-saddle,...,1-saddle) vpaths
        * to the simplification process.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int initializeSaddleSaddleConnections1(
         const std::vector<char> &isRemovableSaddle1,
         const std::vector<char> &isRemovableSaddle2,
@@ -762,7 +760,7 @@ in the gradient.
        * Core of the simplification process, modify the gradient and
        * reverse the selected (2-saddle,...,1-saddle) vpaths to simplify.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int processSaddleSaddleConnections1(
         const int iterationThreshold,
         const std::vector<char> &isPL,
@@ -785,7 +783,7 @@ in the gradient.
        * High-level function that manages the global simplification of
 (2-saddle,...,1-saddle) vpaths.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int simplifySaddleSaddleConnections1(
         const std::vector<std::pair<SimplexId, char>> &criticalPoints,
         const std::vector<char> &isPL,
@@ -800,7 +798,7 @@ in the gradient.
 (1-saddle,...,2-saddle) vpaths
        * to the simplification process.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int initializeSaddleSaddleConnections2(
         const std::vector<char> &isRemovableSaddle1,
         const std::vector<char> &isRemovableSaddle2,
@@ -825,7 +823,7 @@ in the gradient.
        * Core of the simplification process, modify the gradient and
        * reverse the selected (1-saddle,...,2-saddle) vpaths to simplify.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int processSaddleSaddleConnections2(
         const int iterationThreshold,
         const std::vector<char> &isPL,
@@ -848,7 +846,7 @@ in the gradient.
        * High-level function that manages the global simplification of
 (1-saddle,...,2-saddle) vpaths.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int simplifySaddleSaddleConnections2(
         const std::vector<std::pair<SimplexId, char>> &criticalPoints,
         const std::vector<char> &isPL,
@@ -869,7 +867,7 @@ in the gradient.
        * Process the saddle connectors by increasing value of persistence until
 a given threshold is met.
        */
-      template <typename dataType, typename idType, typename triangulationType>
+      template <typename dataType, typename triangulationType>
       int filterSaddleConnectors(const bool allowBoundary,
                                  const triangulationType &triangulation);
 
@@ -934,7 +932,7 @@ gradient, false otherwise.
       std::vector<SimplexId> dmt2Saddle2PL_{};
 
       const void *inputScalarField_{};
-      const void *inputOffsets_{};
+      const SimplexId *inputOffsets_{};
 
       SimplexId outputCriticalPoints_numberOfPoints_{};
       std::vector<float> outputCriticalPoints_points_{};

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -585,13 +585,23 @@ in the gradient.
 
       /**
        * Get the vertex id of with the maximum scalar field value on
-       * the given cell. Compare offsets if scalar field is constant.
+       * the given cell.
        */
       template <typename idType, typename triangulationType>
       SimplexId
         getCellGreaterVertex(const Cell c,
                              const idType *const offsets,
                              const triangulationType &triangulation) const;
+
+      /**
+       * Get the vertex id of with the minimum scalar field value on
+       * the given cell.
+       */
+      template <typename idType, typename triangulationType>
+      SimplexId
+        getCellLowerVertex(const Cell c,
+                           const idType *const offsets,
+                           const triangulationType &triangulation) const;
 
       /**
        * Build the geometric embedding of the given STL vector of cells.

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1629,7 +1629,7 @@ int DiscreteGradient::filterSaddleConnectors(
   contourTree_.setVertexSoSoffsets(offsets);
   contourTree_.setThreadNumber(threadNumber_);
   contourTree_.setSegmentation(false);
-  contourTree_.build<dataType, SimplexId>(&triangulation);
+  contourTree_.build<dataType>(&triangulation);
   ftm::FTMTree_MT *tree = contourTree_.getTree(ftm::TreeType::Contour);
 
   const SimplexId numberOfNodes = tree->getNumberOfNodes();

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -25,23 +25,23 @@ using ttk::dcg::SaddleSaddleVPathComparator;
 using ttk::dcg::VisitedMask;
 using ttk::dcg::VPath;
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 dataType DiscreteGradient::getPersistence(
   const Cell &up,
   const Cell &down,
   const dataType *const scalars,
-  const idType *const offsets,
+  const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
   return scalars[getCellGreaterVertex(up, offsets, triangulation)]
          - scalars[getCellLowerVertex(down, offsets, triangulation)];
 }
 
-template <typename idType, typename triangulationType>
+template <typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   const int numberOfDimensions = getNumberOfDimensions();
 
@@ -83,7 +83,7 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::setCriticalPoints(
   const std::vector<Cell> &criticalPoints,
   std::vector<size_t> &nCriticalPointsByDim,
@@ -97,7 +97,7 @@ int DiscreteGradient::setCriticalPoints(
   }
 #endif
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
   auto *outputCriticalPoints_points_cellScalars
     = static_cast<std::vector<dataType> *>(
       outputCriticalPoints_points_cellScalars_);
@@ -164,14 +164,14 @@ int DiscreteGradient::setCriticalPoints(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::setCriticalPoints(
   const triangulationType &triangulation) {
 
   std::vector<Cell> criticalPoints;
   getCriticalPoints(criticalPoints, triangulation);
   std::vector<size_t> nCriticalPointsByDim{};
-  setCriticalPoints<dataType, idType>(
+  setCriticalPoints<dataType>(
     criticalPoints, nCriticalPointsByDim, triangulation);
 
   return 0;
@@ -393,7 +393,7 @@ int DiscreteGradient::getRemovableSaddles2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::initializeSaddleSaddleConnections1(
   const std::vector<char> &isRemovableSaddle1,
   const std::vector<char> &isRemovableSaddle2,
@@ -406,7 +406,7 @@ int DiscreteGradient::initializeSaddleSaddleConnections1(
   Timer t;
 
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   const int maximumDim = dimensionality_;
   const int saddle2Dim = maximumDim - 1;
@@ -549,7 +549,7 @@ int DiscreteGradient::orderSaddleSaddleConnections1(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::processSaddleSaddleConnections1(
   const int iterationThreshold,
   const std::vector<char> &isPL,
@@ -570,7 +570,7 @@ int DiscreteGradient::processSaddleSaddleConnections1(
   Timer t;
 
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   const SimplexId numberOfEdges = triangulation.getNumberOfEdges();
   const SimplexId numberOfTriangles = triangulation.getNumberOfTriangles();
@@ -936,7 +936,7 @@ int DiscreteGradient::processSaddleSaddleConnections1(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::simplifySaddleSaddleConnections1(
   const std::vector<std::pair<SimplexId, char>> &criticalPoints,
   const std::vector<char> &isPL,
@@ -965,7 +965,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections1(
   std::vector<CriticalPoint> dmt_criticalPoints;
   std::vector<SimplexId> saddle1Index;
   std::vector<SimplexId> saddle2Index;
-  initializeSaddleSaddleConnections1<dataType, idType>(
+  initializeSaddleSaddleConnections1<dataType>(
     isRemovableSaddle1, isRemovableSaddle2, allowBruteForce, vpaths,
     dmt_criticalPoints, saddle1Index, saddle2Index, triangulation);
 
@@ -977,7 +977,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections1(
   orderSaddleSaddleConnections1<dataType>(vpaths, dmt_criticalPoints, S);
 
   // Part 3 : process the vpaths
-  processSaddleSaddleConnections1<dataType, idType>(
+  processSaddleSaddleConnections1<dataType>(
     iterationThreshold, isPL, allowBoundary, allowBruteForce,
     returnSaddleConnectors, S, pl2dmt_saddle1, pl2dmt_saddle2,
     isRemovableSaddle1, isRemovableSaddle2, vpaths, dmt_criticalPoints,
@@ -989,7 +989,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections1(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::initializeSaddleSaddleConnections2(
   const std::vector<char> &isRemovableSaddle1,
   const std::vector<char> &isRemovableSaddle2,
@@ -1002,7 +1002,7 @@ int DiscreteGradient::initializeSaddleSaddleConnections2(
   Timer t;
 
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   const int maximumDim = dimensionality_;
   const int saddle2Dim = maximumDim - 1;
@@ -1144,7 +1144,7 @@ int DiscreteGradient::orderSaddleSaddleConnections2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::processSaddleSaddleConnections2(
   const int iterationThreshold,
   const std::vector<char> &isPL,
@@ -1168,7 +1168,7 @@ int DiscreteGradient::processSaddleSaddleConnections2(
                  + std::to_string(this->SaddleConnectorsPersistenceThreshold));
 
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   const SimplexId numberOfEdges = triangulation.getNumberOfEdges();
   const SimplexId numberOfTriangles = triangulation.getNumberOfTriangles();
@@ -1531,7 +1531,7 @@ int DiscreteGradient::processSaddleSaddleConnections2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::simplifySaddleSaddleConnections2(
   const std::vector<std::pair<SimplexId, char>> &criticalPoints,
   const std::vector<char> &isPL,
@@ -1560,7 +1560,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections2(
   std::vector<CriticalPoint> dmt_criticalPoints;
   std::vector<SimplexId> saddle1Index;
   std::vector<SimplexId> saddle2Index;
-  initializeSaddleSaddleConnections2<dataType, idType>(
+  initializeSaddleSaddleConnections2<dataType>(
     isRemovableSaddle1, isRemovableSaddle2, allowBruteForce, vpaths,
     dmt_criticalPoints, saddle1Index, saddle2Index, triangulation);
 
@@ -1572,7 +1572,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections2(
   orderSaddleSaddleConnections2<dataType>(vpaths, dmt_criticalPoints, S);
 
   // Part 3 : process the vpaths
-  processSaddleSaddleConnections2<dataType, idType>(
+  processSaddleSaddleConnections2<dataType>(
     iterationThreshold, isPL, allowBoundary, allowBruteForce,
     returnSaddleConnectors, S, pl2dmt_saddle1, pl2dmt_saddle2,
     isRemovableSaddle1, isRemovableSaddle2, vpaths, dmt_criticalPoints,
@@ -1584,7 +1584,7 @@ int DiscreteGradient::simplifySaddleSaddleConnections2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::filterSaddleConnectors(
   const bool allowBoundary, const triangulationType &triangulation) {
 
@@ -1620,8 +1620,8 @@ int DiscreteGradient::filterSaddleConnectors(
 
   std::vector<std::pair<SimplexId, char>> cpset;
 
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const offsets = inputOffsets_;
 
   contourTree_.setDebugLevel(debugLevel_);
   contourTree_.setVertexScalars(scalars);
@@ -1643,22 +1643,22 @@ int DiscreteGradient::filterSaddleConnectors(
   std::vector<char> isPL;
   getCriticalPointMap(cpset, isPL);
 
-  simplifySaddleSaddleConnections1<dataType, idType>(
+  simplifySaddleSaddleConnections1<dataType>(
     cpset, isPL, IterationThreshold, allowBoundary, allowBruteForce,
     returnSaddleConnectors, triangulation);
-  simplifySaddleSaddleConnections2<dataType, idType>(
+  simplifySaddleSaddleConnections2<dataType>(
     cpset, isPL, IterationThreshold, allowBoundary, allowBruteForce,
     returnSaddleConnectors, triangulation);
 
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
                                       bool detectCriticalPoints) {
 
   std::vector<std::pair<SimplexId, char>> criticalPoints{};
-  const auto *const offsets = static_cast<const idType *>(inputOffsets_);
+  const auto *const offsets = inputOffsets_;
 
   if(detectCriticalPoints) {
 
@@ -1716,16 +1716,16 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
   std::fill(dmt1Saddle2PL_.begin(), dmt1Saddle2PL_.end(), -1);
 
   if(dimensionality_ == 3) {
-    simplifySaddleSaddleConnections1<dataType, idType>(
+    simplifySaddleSaddleConnections1<dataType>(
       criticalPoints, isPL, IterationThreshold, allowBoundary, allowBruteForce,
       returnSaddleConnectors, triangulation);
-    simplifySaddleSaddleConnections2<dataType, idType>(
+    simplifySaddleSaddleConnections2<dataType>(
       criticalPoints, isPL, IterationThreshold, allowBoundary, allowBruteForce,
       returnSaddleConnectors, triangulation);
   }
 
   if(dimensionality_ == 3 and ReturnSaddleConnectors) {
-    filterSaddleConnectors<dataType, idType>(allowBoundary, triangulation);
+    filterSaddleConnectors<dataType>(allowBoundary, triangulation);
   }
 
   this->printMsg(
@@ -1774,10 +1774,10 @@ SimplexId DiscreteGradient::getNumberOfCells(
   return -1;
 }
 
-template <typename idType, typename triangulationType>
+template <typename triangulationType>
 inline DiscreteGradient::lowerStarType
   DiscreteGradient::lowerStar(const SimplexId a,
-                              const idType *const offsets,
+                              const SimplexId *const offsets,
                               const triangulationType &triangulation) const {
   lowerStarType res{};
 
@@ -1985,9 +1985,9 @@ inline void DiscreteGradient::pairCells(
   beta.paired_ = true;
 }
 
-template <typename idType, typename triangulationType>
+template <typename triangulationType>
 int DiscreteGradient::processLowerStars(
-  const idType *const offsets, const triangulationType &triangulation) {
+  const SimplexId *const offsets, const triangulationType &triangulation) {
 
   /* Compute gradient */
 
@@ -3012,10 +3012,10 @@ int DiscreteGradient::reverseDescendingPathOnWall(
   return 0;
 }
 
-template <typename idType, typename triangulationType>
+template <typename triangulationType>
 ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
   const Cell c,
-  const idType *const offsets,
+  const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
   auto cellDim = c.dim_;
@@ -3075,10 +3075,10 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
   return vertexId;
 }
 
-template <typename idType, typename triangulationType>
+template <typename triangulationType>
 ttk::SimplexId DiscreteGradient::getCellLowerVertex(
   const Cell c,
-  const idType *const offsets,
+  const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
   auto cellDim = c.dim_;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -3237,6 +3237,69 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
   return vertexId;
 }
 
+template <typename idType, typename triangulationType>
+ttk::SimplexId DiscreteGradient::getCellLowerVertex(
+  const Cell c,
+  const idType *const offsets,
+  const triangulationType &triangulation) const {
+
+  auto cellDim = c.dim_;
+  auto cellId = c.id_;
+
+  SimplexId vertexId = -1;
+  if(cellDim == 0) {
+    vertexId = cellId;
+  }
+
+  else if(cellDim == 1) {
+    SimplexId v0;
+    SimplexId v1;
+    triangulation.getEdgeVertex(cellId, 0, v0);
+    triangulation.getEdgeVertex(cellId, 1, v1);
+
+    if(offsets[v0] < offsets[v1]) {
+      vertexId = v0;
+    } else {
+      vertexId = v1;
+    }
+  }
+
+  else if(cellDim == 2) {
+    SimplexId v0{}, v1{}, v2{};
+    triangulation.getTriangleVertex(cellId, 0, v0);
+    triangulation.getTriangleVertex(cellId, 1, v1);
+    triangulation.getTriangleVertex(cellId, 2, v2);
+    if(offsets[v0] < offsets[v1] && offsets[v0] < offsets[v2]) {
+      vertexId = v0;
+    } else if(offsets[v1] < offsets[v0] && offsets[v1] < offsets[v2]) {
+      vertexId = v1;
+    } else {
+      vertexId = v2;
+    }
+  }
+
+  else if(cellDim == 3) {
+    SimplexId v0{}, v1{}, v2{}, v3{};
+    triangulation.getCellVertex(cellId, 0, v0);
+    triangulation.getCellVertex(cellId, 1, v1);
+    triangulation.getCellVertex(cellId, 2, v2);
+    triangulation.getCellVertex(cellId, 3, v3);
+    if(offsets[v0] < offsets[v1] && offsets[v0] < offsets[v2]
+       && offsets[v0] < offsets[v3]) {
+      vertexId = v0;
+    } else if(offsets[v1] < offsets[v0] && offsets[v1] < offsets[v2]
+              && offsets[v1] < offsets[v3]) {
+      vertexId = v1;
+    } else if(offsets[v2] < offsets[v0] && offsets[v2] < offsets[v1]
+              && offsets[v2] < offsets[v3]) {
+      vertexId = v2;
+    } else {
+      vertexId = v3;
+    }
+  }
+  return vertexId;
+}
+
 template <typename triangulationType>
 int DiscreteGradient::setGradientGlyphs(
   SimplexId &numberOfPoints,

--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -234,8 +234,8 @@ SimplexId ArcRegion::findBelow(SimplexId v,
   const bool chkOther = vert2treeOther.size() > 0;
 
   for(const auto &reg : segmentsIn_) {
-    if(s->isEqLower(*reg.segmentBegin, v)
-       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isLower(*reg.segmentBegin, v)
+       && s->isHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldBeg = reg.segmentBegin;
@@ -312,8 +312,8 @@ tuple<SimplexId, ArcRegion> ArcRegion::splitBack(SimplexId v,
   for(decltype(segmentsIn_)::iterator it = segmentsIn_.begin();
       it != segmentsIn_.end(); ++it) {
     auto &reg = *it;
-    if(s->isEqLower(*reg.segmentBegin, v)
-       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isLower(*reg.segmentBegin, v)
+       && s->isHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldBeg = reg.segmentBegin;
@@ -367,8 +367,8 @@ tuple<SimplexId, ArcRegion> ArcRegion::splitFront(SimplexId v,
   for(decltype(segmentsIn_)::iterator it = segmentsIn_.begin();
       it != segmentsIn_.end(); ++it) {
     auto &reg = *it;
-    if(s->isEqLower(*reg.segmentBegin, v)
-       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isLower(*reg.segmentBegin, v)
+       && s->isHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldEnd = reg.segmentEnd;

--- a/core/base/ftmTree/FTMStructures.h
+++ b/core/base/ftmTree/FTMStructures.h
@@ -43,86 +43,19 @@ namespace ttk {
 
     // Scalar related containers (global)
     struct Scalars {
-      SimplexId size;
-      void *values;
-      void *offsets;
+      SimplexId size{};
+      void *values{};
+      const SimplexId *offsets{};
 
-      std::shared_ptr<std::vector<SimplexId>> sortedVertices, mirrorVertices;
-
-      // Need vertices to be sorted : use mirrorVertices.
+      // [0] -> vertex id of the global miminum
+      // [size-1] -> vertex id of the global maximum
+      std::vector<SimplexId> sortedVertices{};
 
       bool isLower(SimplexId a, SimplexId b) const {
-        return (*mirrorVertices)[a] < (*mirrorVertices)[b];
+        return offsets[a] < offsets[b];
       }
-      bool isEqLower(SimplexId a, SimplexId b) const {
-        return (*mirrorVertices)[a] <= (*mirrorVertices)[b];
-      }
-
       bool isHigher(SimplexId a, SimplexId b) const {
-        return (*mirrorVertices)[a] > (*mirrorVertices)[b];
-      }
-      bool isEqHigher(SimplexId a, SimplexId b) const {
-        return (*mirrorVertices)[a] >= (*mirrorVertices)[b];
-      }
-
-      Scalars()
-        : size(0), values(nullptr), offsets(nullptr), sortedVertices(nullptr),
-          mirrorVertices(nullptr) {
-      }
-
-      // Heavy
-      Scalars(const Scalars &o)
-        : size(o.size), values(o.values), offsets(o.offsets),
-          sortedVertices(o.sortedVertices), mirrorVertices(o.mirrorVertices) {
-        std::cout << "copy in depth, bad perfs" << std::endl;
-      }
-
-      // Sort
-      template <typename type>
-      void qsort(type arr[],
-                 const long int begin,
-                 const long int stop,
-                 std::function<bool(type, type)> comp) const {
-        if(begin >= stop)
-          return;
-
-#ifdef TTK_ENABLE_OPENMP
-        static const long int MINSIZE = 10;
-#endif
-
-        long int left = begin - 1;
-        long int right = stop + 1;
-        const type pivot = arr[begin];
-
-        while(1) {
-          while(comp(pivot, arr[--right]))
-            ;
-          while(++left <= stop && !comp(pivot, arr[left]))
-            ;
-
-          if(left < right)
-            swap_el<type>(arr, left, right);
-          else
-            break;
-        }
-
-        swap_el<type>(arr, begin, right);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp task untied if(right - begin > MINSIZE)
-#endif
-        qsort(arr, begin, right - 1, comp);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp task untied if(stop - right > MINSIZE)
-#endif
-        qsort(arr, right + 1, stop, comp);
-      }
-
-    private:
-      template <typename type>
-      static void swap_el(type arr[], const size_t a, const size_t b) {
-        const type tmp = arr[a];
-        arr[a] = arr[b];
-        arr[b] = tmp;
+        return offsets[a] > offsets[b];
       }
     };
 

--- a/core/base/ftmTree/FTMTree.h
+++ b/core/base/ftmTree/FTMTree.h
@@ -45,7 +45,7 @@ namespace ttk {
 
       // Initialize structures then build tree
       // Need triangulation, scalars and all params set before call
-      template <typename scalarType, typename idType, class triangulationType>
+      template <typename scalarType, class triangulationType>
       void build(const triangulationType *mesh);
     };
 

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -182,7 +182,7 @@ void FTMTree_MT::buildSegmentation() {
       const SimplexId lowerBound = chunkId * chunkSize;
       const SimplexId upperBound = min(nbVert, (chunkId + 1) * chunkSize);
       for(SimplexId i = lowerBound; i < upperBound; ++i) {
-        const auto vert = (*scalars_->sortedVertices)[i];
+        const auto vert = scalars_->sortedVertices[i];
         if(isCorrespondingArc(vert)) {
           idSuperArc sa = getCorrespondingSuperArcId(vert);
           SimplexId vertToAdd;
@@ -380,9 +380,9 @@ tuple<SimplexId, SimplexId>
 
   if(isST()) {
     begin = 0;
-    stop = (*scalars_->mirrorVertices)[trunkVerts[0]];
+    stop = scalars_->offsets[trunkVerts[0]];
   } else {
-    begin = (*scalars_->mirrorVertices)[trunkVerts[0]];
+    begin = scalars_->offsets[trunkVerts[0]];
     stop = scalars_->size;
   }
 
@@ -884,13 +884,12 @@ SimplexId FTMTree_MT::trunkCTSegmentation(const vector<SimplexId> &trunkVerts,
       if(lowerBound != upperBound) {
         const SimplexId pos = isST() ? upperBound - 1 : lowerBound;
         lastVertInRange
-          = getVertInRange(trunkVerts, (*scalars_->sortedVertices)[pos], 0);
+          = getVertInRange(trunkVerts, scalars_->sortedVertices[pos], 0);
       }
       for(SimplexId v = lowerBound; v < upperBound; ++v) {
         const SimplexId s
-          = isST()
-              ? (*scalars_->sortedVertices)[lowerBound + upperBound - 1 - v]
-              : (*scalars_->sortedVertices)[v];
+          = isST() ? scalars_->sortedVertices[lowerBound + upperBound - 1 - v]
+                   : scalars_->sortedVertices[v];
         if(isCorrespondingNull(s)) {
           const idNode oldVertInRange = lastVertInRange;
           lastVertInRange = getVertInRange(trunkVerts, s, lastVertInRange);
@@ -977,9 +976,8 @@ SimplexId FTMTree_MT::trunkSegmentation(const vector<SimplexId> &trunkVerts,
         = min(stop, (begin + (chunkId + 1) * chunkSize));
       for(SimplexId v = lowerBound; v < upperBound; ++v) {
         const SimplexId s
-          = isST()
-              ? (*scalars_->sortedVertices)[lowerBound + upperBound - 1 - v]
-              : (*scalars_->sortedVertices)[v];
+          = isST() ? scalars_->sortedVertices[lowerBound + upperBound - 1 - v]
+                   : scalars_->sortedVertices[v];
         if(isCorrespondingNull(s)) {
           const idNode oldVertInRange = lastVertInRange;
           lastVertInRange = getVertInRange(trunkVerts, s, lastVertInRange);

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -130,20 +130,6 @@ namespace ttk {
         scalars_->size = triangulation->getNumberOfVertices();
       }
 
-      /// \brief init Simulation of Simplicity datastructure if not set
-      template <typename idType>
-      void initSoS(void) {
-        if(scalars_->offsets == nullptr) {
-          scalars_->offsets = new idType[scalars_->size];
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for
-#endif
-          for(SimplexId i = 0; i < scalars_->size; i++) {
-            ((idType *)scalars_->offsets)[i] = i;
-          }
-        }
-      }
-
       void initComp(void) {
         if(isST()) {
           comp_.vertLower
@@ -171,7 +157,6 @@ namespace ttk {
       }
 
       /// \brief if sortedVertices_ is null, define and fill it
-      /// Also fill the mirror vector
       template <typename scalarType, typename idType>
       void sortInput(void);
 
@@ -371,9 +356,8 @@ namespace ttk {
       }
 
       // offset
-      template <typename idType>
-      inline void setVertexSoSoffsets(idType *sos) {
-        scalars_->offsets = (void *)sos;
+      inline void setVertexSoSoffsets(const SimplexId *const sos) {
+        scalars_->offsets = sos;
       }
 
       // arcs
@@ -658,44 +642,12 @@ namespace ttk {
       // -----------------
       // Compare using the scalar array : only for sort step
 
-      template <typename scalarType, typename idType>
       inline bool isLower(SimplexId a, SimplexId b) const {
-        return ((scalarType *)scalars_->values)[a]
-                 < ((scalarType *)scalars_->values)[b]
-               || (((scalarType *)scalars_->values)[a]
-                     == ((scalarType *)scalars_->values)[b]
-                   && ((idType *)scalars_->offsets)[a]
-                        < ((idType *)scalars_->offsets)[b]);
+        return scalars_->offsets[a] < scalars_->offsets[b];
       }
 
-      template <typename scalarType, typename idType>
       inline bool isHigher(SimplexId a, SimplexId b) const {
-        return ((scalarType *)scalars_->values)[a]
-                 > ((scalarType *)scalars_->values)[b]
-               || (((scalarType *)scalars_->values)[a]
-                     == ((scalarType *)scalars_->values)[b]
-                   && ((idType *)scalars_->offsets)[a]
-                        > ((idType *)scalars_->offsets)[b]);
-      }
-
-      template <typename scalarType, typename idType>
-      inline bool isEqLower(SimplexId a, SimplexId b) const {
-        return ((scalarType *)scalars_->values)[a]
-                 < ((scalarType *)scalars_->values)[b]
-               || (((scalarType *)scalars_->values)[a]
-                     == ((scalarType *)scalars_->values)[b]
-                   && ((idType *)scalars_->offsets)[a]
-                        <= ((idType *)scalars_->offsets)[b]);
-      }
-
-      template <typename scalarType, typename idType>
-      inline bool isEqHigher(SimplexId a, SimplexId b) const {
-        return ((scalarType *)scalars_->values)[a]
-                 > ((scalarType *)scalars_->values)[b]
-               || (((scalarType *)scalars_->values)[a]
-                     == ((scalarType *)scalars_->values)[b]
-                   && ((idType *)scalars_->offsets)[a]
-                        >= ((idType *)scalars_->offsets)[b]);
+        return scalars_->offsets[a] > scalars_->offsets[b];
       }
 
       template <typename type>

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -157,7 +157,7 @@ namespace ttk {
       }
 
       /// \brief if sortedVertices_ is null, define and fill it
-      template <typename scalarType, typename idType>
+      template <typename scalarType>
       void sortInput(void);
 
       /// \brief clear local data for new computation

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -513,7 +513,7 @@ namespace ttk {
 
     // ------------------------------------------------------------------------
 
-    template <typename scalarType, typename idType>
+    template <typename scalarType>
     void ftm::FTMTree_MT::sortInput(void) {
 
       const auto nbVertices = scalars_->size;

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -434,8 +434,8 @@ namespace ttk {
       // Root (close last arc)
       // if several CC still the backbone is only in one.
       // But the root may not be the max node of the whole dataset: TODO
-      const idNode rootNode = makeNode(
-        (*scalars_->sortedVertices)[(isJT()) ? scalars_->size - 1 : 0]);
+      const idNode rootNode
+        = makeNode(scalars_->sortedVertices[(isJT()) ? scalars_->size - 1 : 0]);
       closeSuperArc(lastArc, rootNode);
       getSuperArc(lastArc)->setLastVisited(getNode(rootNode)->getVertexId());
 
@@ -515,55 +515,15 @@ namespace ttk {
 
     template <typename scalarType, typename idType>
     void ftm::FTMTree_MT::sortInput(void) {
-      const auto &nbVertices = scalars_->size;
 
-      auto *sortedVect = scalars_->sortedVertices.get();
-      if(sortedVect == nullptr) {
-        sortedVect = new std::vector<SimplexId>(0);
-        scalars_->sortedVertices.reset(sortedVect);
-      } else {
-        sortedVect->clear();
-      }
-
-      auto indirect_sort = [&](const size_t &a, const size_t &b) {
-        return isLower<scalarType, idType>(a, b);
-      };
-
-      sortedVect->resize(nbVertices, 0);
-      std::iota(sortedVect->begin(), sortedVect->end(), SimplexId{0});
-
-      // #pragma omp parallel
-      // #pragma omp single
-      //    scalars_->qsort<SimplexId>(sortedVect->data(), 0, scalars_->size -1,
-      //    indirect_sort);
-
-#ifdef TTK_ENABLE_OPENMP
-#ifdef __clang__
-      std::cout << "Caution, outside GCC, sequential sort" << std::endl;
-      std::sort(sortedVect->begin(), sortedVect->end(), indirect_sort);
-#else
-      __gnu_parallel::sort(
-        sortedVect->begin(), sortedVect->end(), indirect_sort);
-#endif
-#else
-      std::sort(sortedVect->begin(), sortedVect->end(), indirect_sort);
-#endif
-
-      auto *mirrorVert = scalars_->mirrorVertices.get();
-      if(mirrorVert == nullptr) {
-        mirrorVert = new std::vector<SimplexId>(0);
-        scalars_->mirrorVertices.reset(mirrorVert);
-      } else {
-        mirrorVert->clear();
-      }
-
-      scalars_->mirrorVertices->resize(nbVertices);
+      const auto nbVertices = scalars_->size;
+      scalars_->sortedVertices.resize(nbVertices);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for
 #endif
       for(SimplexId i = 0; i < nbVertices; i++) {
-        (*scalars_->mirrorVertices)[(*sortedVect)[i]] = i;
+        scalars_->sortedVertices[scalars_->offsets[i]] = i;
       }
     }
 

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -27,7 +27,7 @@
 // PROCESS
 // -------
 
-template <typename scalarType, typename idType, class triangulationType>
+template <typename scalarType, class triangulationType>
 void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
   // -----
   // INPUT
@@ -119,7 +119,7 @@ void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
   // for fast comparison
   // and regions / segmentation
   Timer sortTime;
-  sortInput<scalarType, idType>();
+  sortInput<scalarType>();
   printTime(sortTime, "sort step", -1, 3);
 
   // -----

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -119,7 +119,6 @@ void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
   // for fast comparison
   // and regions / segmentation
   Timer sortTime;
-  initSoS<idType>();
   sortInput<scalarType, idType>();
   printTime(sortTime, "sort step", -1, 3);
 

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -73,7 +73,6 @@ namespace ttk {
 #endif
 
       Timer timeSort;
-      scalars_.sort();
       this->printMsg(
         "sort time: ", 1.0, timeSort.getElapsedTime(), this->threadNumber_);
 

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -142,43 +142,17 @@ int ttk::IntegralLines::execute(const triangulationType *triangulation) const {
       SimplexId vnext{-1};
       float fnext = std::numeric_limits<float>::min();
       SimplexId neighborNumber = triangulation->getVertexNeighborNumber(v);
-      bool isLocalMax = true;
-      bool isLocalMin = true;
       for(SimplexId k = 0; k < neighborNumber; ++k) {
         SimplexId n;
         triangulation->getVertexNeighbor(v, k, n);
 
-        if(scalars[n] <= scalars[v])
-          isLocalMax = false;
-        if(scalars[n] >= scalars[v])
-          isLocalMin = false;
-
         if((direction_ == static_cast<int>(Direction::Forward))
-           xor (scalars[n] < scalars[v])) {
+           xor (offsets[n] < offsets[v])) {
           const float f = getGradient<dataType, triangulationType>(
             triangulation, v, n, scalars);
           if(f > fnext) {
             vnext = n;
             fnext = f;
-          }
-        }
-      }
-
-      if(vnext == -1 and !isLocalMax and !isLocalMin) {
-        idType onext = -1;
-        for(SimplexId k = 0; k < neighborNumber; ++k) {
-          SimplexId n;
-          triangulation->getVertexNeighbor(v, k, n);
-
-          if(scalars[n] == scalars[v]) {
-            const idType o = offsets[n];
-            if((direction_ == static_cast<int>(Direction::Forward))
-               xor (o < offsets[v])) {
-              if(o > onext) {
-                vnext = n;
-                onext = o;
-              }
-            }
           }
         }
       }
@@ -234,43 +208,17 @@ int ttk::IntegralLines::execute(Compare cmp,
       SimplexId vnext{-1};
       float fnext = std::numeric_limits<float>::min();
       SimplexId neighborNumber = triangulation->getVertexNeighborNumber(v);
-      bool isLocalMax = true;
-      bool isLocalMin = true;
       for(SimplexId k = 0; k < neighborNumber; ++k) {
         SimplexId n;
         triangulation->getVertexNeighbor(v, k, n);
 
-        if(scalars[n] <= scalars[v])
-          isLocalMax = false;
-        if(scalars[n] >= scalars[v])
-          isLocalMin = false;
-
         if((direction_ == static_cast<int>(Direction::Forward))
-           xor (scalars[n] < scalars[v])) {
+           xor (offsets[n] < offsets[v])) {
           const float f
             = getGradient<dataType, triangulationType>(v, n, scalars);
           if(f > fnext) {
             vnext = n;
             fnext = f;
-          }
-        }
-      }
-
-      if(vnext == -1 and !isLocalMax and !isLocalMin) {
-        SimplexId onext = -1;
-        for(SimplexId k = 0; k < neighborNumber; ++k) {
-          SimplexId n;
-          triangulation->getVertexNeighbor(v, k, n);
-
-          if(scalars[n] == scalars[v]) {
-            const SimplexId o = offsets[n];
-            if((direction_ == static_cast<int>(Direction::Forward))
-               xor (o < offsets[v])) {
-              if(o > onext) {
-                vnext = n;
-                onext = o;
-              }
-            }
           }
         }
       }

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -51,29 +51,24 @@ namespace ttk {
     }
 
     template <typename dataType,
-              typename idType,
               class triangulationType = ttk::AbstractTriangulation>
     int execute(const triangulationType *) const;
 
     template <typename dataType,
-              typename idType,
               class Compare,
               class triangulationType = ttk::AbstractTriangulation>
     int execute(Compare, const triangulationType *) const;
 
-    inline int setVertexNumber(const SimplexId &vertexNumber) {
+    inline void setVertexNumber(const SimplexId &vertexNumber) {
       vertexNumber_ = vertexNumber;
-      return 0;
     }
 
-    inline int setSeedNumber(const SimplexId &seedNumber) {
+    inline void setSeedNumber(const SimplexId &seedNumber) {
       seedNumber_ = seedNumber;
-      return 0;
     }
 
-    inline int setDirection(int direction) {
+    inline void setDirection(int direction) {
       direction_ = direction;
-      return 0;
     }
 
     int preconditionTriangulation(
@@ -81,25 +76,21 @@ namespace ttk {
       return triangulation->preconditionVertexNeighbors();
     }
 
-    inline int setInputScalarField(void *data) {
+    inline void setInputScalarField(void *data) {
       inputScalarField_ = data;
-      return 0;
     }
 
-    inline int setInputOffsets(void *data) {
+    inline void setInputOffsets(const SimplexId *const data) {
       inputOffsets_ = data;
-      return 0;
     }
 
-    inline int setVertexIdentifierScalarField(void *data) {
+    inline void setVertexIdentifierScalarField(void *data) {
       vertexIdentifierScalarField_ = data;
-      return 0;
     }
 
-    inline int
+    inline void
       setOutputTrajectories(std::vector<std::vector<SimplexId>> *trajectories) {
       outputTrajectories_ = trajectories;
-      return 0;
     }
 
   protected:
@@ -107,15 +98,15 @@ namespace ttk {
     SimplexId seedNumber_;
     int direction_;
     void *inputScalarField_;
-    void *inputOffsets_;
+    const SimplexId *inputOffsets_;
     void *vertexIdentifierScalarField_;
     std::vector<std::vector<SimplexId>> *outputTrajectories_;
   };
 } // namespace ttk
 
-template <typename dataType, typename idType, class triangulationType>
+template <typename dataType, class triangulationType>
 int ttk::IntegralLines::execute(const triangulationType *triangulation) const {
-  idType *offsets = static_cast<idType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
   SimplexId *identifiers
     = static_cast<SimplexId *>(vertexIdentifierScalarField_);
   dataType *scalars = static_cast<dataType *>(inputScalarField_);
@@ -175,13 +166,10 @@ int ttk::IntegralLines::execute(const triangulationType *triangulation) const {
   return 0;
 }
 
-template <typename dataType,
-          typename idType,
-          class Compare,
-          class triangulationType>
+template <typename dataType, class Compare, class triangulationType>
 int ttk::IntegralLines::execute(Compare cmp,
                                 const triangulationType *triangulation) const {
-  idType *offsets = static_cast<idType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
   SimplexId *identifiers
     = static_cast<SimplexId *>(vertexIdentifierScalarField_);
   dataType *scalars = static_cast<dataType *>(inputScalarField_);

--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -73,14 +73,14 @@ namespace ttk {
 
     inline void setSosOffsets(std::vector<SimplexId> *sosOffsets) {
       // legacy API
-      setSosOffsetsU(sosOffsets);
+      setSosOffsetsU(sosOffsets->data());
     }
 
-    inline void setSosOffsetsU(std::vector<SimplexId> *sosOffsets) {
+    inline void setSosOffsetsU(const SimplexId *const sosOffsets) {
       sosOffsetsU_ = sosOffsets;
     }
 
-    inline void setSosOffsetsV(std::vector<SimplexId> *sosOffsets) {
+    inline void setSosOffsetsV(const SimplexId *const sosOffsets) {
       sosOffsetsV_ = sosOffsets;
     }
 
@@ -117,8 +117,7 @@ namespace ttk {
       *edgeFanLinkEdgeLists_{};
     // for each edge, the one skeleton of its triangle fan
     const std::vector<std::vector<SimplexId>> *edgeFans_{};
-    std::vector<SimplexId> *sosOffsetsU_{}, *sosOffsetsV_{};
-    std::vector<SimplexId> localSosOffsetsU_{}, localSosOffsetsV_{};
+    const SimplexId *sosOffsetsU_{}, *sosOffsetsV_{};
   };
 } // namespace ttk
 

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -22,34 +22,6 @@ int ttk::JacobiSet::execute(std::vector<std::pair<SimplexId, char>> &jacobiSet,
     return -3;
 #endif
 
-  SimplexId vertexNumber = triangulation.getNumberOfVertices();
-
-  if(!sosOffsetsU_) {
-    // let's use our own local copy
-    sosOffsetsU_ = &localSosOffsetsU_;
-  }
-
-  if(vertexNumber != (SimplexId)sosOffsetsU_->size()) {
-
-    sosOffsetsU_->resize(vertexNumber);
-    for(SimplexId i = 0; i < vertexNumber; i++) {
-      (*sosOffsetsU_)[i] = i;
-    }
-  }
-
-  if(!sosOffsetsV_) {
-    // let's use our own local copy
-    sosOffsetsV_ = &localSosOffsetsV_;
-  }
-
-  if(vertexNumber != (SimplexId)sosOffsetsV_->size()) {
-
-    sosOffsetsV_->resize(vertexNumber);
-    for(SimplexId i = 0; i < vertexNumber; i++) {
-      (*sosOffsetsV_)[i] = vertexNumber - i;
-    }
-  }
-
   jacobiSet.clear();
 
   SimplexId edgeNumber = triangulation.getNumberOfEdges();
@@ -231,7 +203,7 @@ int ttk::JacobiSet::executeLegacy(
 
       // in the loop
       char type = threadedCriticalPoints[threadId].getCriticalType(
-        pivotVertexId, sosOffsetsU_->data(), (*edgeFanLinkEdgeLists_)[i]);
+        pivotVertexId, sosOffsetsU_, (*edgeFanLinkEdgeLists_)[i]);
 
       if(type != -2) {
         // -2: regular vertex
@@ -386,14 +358,14 @@ char ttk::JacobiSet::getCriticalType(const SimplexId &edgeId,
             // degenerate
             // compute the distance field out of the offset positions
             double offsetProjectedPivotVertex[2];
-            offsetProjectedPivotVertex[0] = (*sosOffsetsU_)[vertexId0];
+            offsetProjectedPivotVertex[0] = sosOffsetsU_[vertexId0];
             offsetProjectedPivotVertex[1]
-              = (*sosOffsetsV_)[vertexId0] * (*sosOffsetsV_)[vertexId0];
+              = sosOffsetsV_[vertexId0] * sosOffsetsV_[vertexId0];
 
             double offsetProjectedOtherVertex[2];
-            offsetProjectedOtherVertex[0] = (*sosOffsetsU_)[vertexId1];
+            offsetProjectedOtherVertex[0] = sosOffsetsU_[vertexId1];
             offsetProjectedOtherVertex[1]
-              = (*sosOffsetsV_)[vertexId1] * (*sosOffsetsV_)[vertexId1];
+              = sosOffsetsV_[vertexId1] * sosOffsetsV_[vertexId1];
 
             double offsetRangeEdge[2];
             offsetRangeEdge[0]
@@ -405,9 +377,9 @@ char ttk::JacobiSet::getCriticalType(const SimplexId &edgeId,
             offsetRangeNormal[0] = -offsetRangeEdge[1];
             offsetRangeNormal[1] = offsetRangeEdge[0];
 
-            projectedVertex[0] = (*sosOffsetsU_)[vertexId];
+            projectedVertex[0] = sosOffsetsU_[vertexId];
             projectedVertex[1]
-              = (*sosOffsetsV_)[vertexId] * (*sosOffsetsV_)[vertexId];
+              = sosOffsetsV_[vertexId] * sosOffsetsV_[vertexId];
 
             vertexRangeEdge[0]
               = projectedVertex[0] - offsetProjectedPivotVertex[0];

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -303,7 +303,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int setInputOffsets(void *const data) {
+    inline int setInputOffsets(const SimplexId *const data) {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!abstractMorseSmaleComplex_) {
         return -1;
@@ -417,15 +417,15 @@ namespace ttk {
       return 0;
     }
 
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int execute(const triangulationType &triangulation) {
       switch(dimensionality_) {
         case 2:
-          morseSmaleComplex2D_.execute<dataType, idType>(triangulation);
+          morseSmaleComplex2D_.execute<dataType>(triangulation);
           break;
 
         case 3:
-          morseSmaleComplex3D_.execute<dataType, idType>(triangulation);
+          morseSmaleComplex3D_.execute<dataType>(triangulation);
           break;
       }
       return 0;

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -31,7 +31,7 @@ namespace ttk {
     /**
      * Main function for computing the whole Morse-Smale complex.
      */
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int execute(const triangulationType &triangulation);
 
     /**
@@ -47,7 +47,7 @@ namespace ttk {
   };
 } // namespace ttk
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!inputScalarField_) {
@@ -75,7 +75,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
   discreteGradient_.setDebugLevel(debugLevel_);
   {
     Timer tmp;
-    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
+    discreteGradient_.buildGradient<triangulationType>(triangulation);
 
     this->printMsg("Discrete gradient computed", 1.0, tmp.getElapsedTime(),
                    this->threadNumber_);
@@ -91,7 +91,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
     std::vector<std::vector<dcg::Cell>> separatricesGeometry;
     getDescendingSeparatrices1(
       criticalPoints, separatrices, separatricesGeometry, triangulation);
-    setSeparatrices1<dataType, idType>(
+    setSeparatrices1<dataType>(
       separatrices, separatricesGeometry, triangulation);
 
     this->printMsg("Descending 1-separatrices computed", 1.0,
@@ -104,7 +104,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
     std::vector<std::vector<dcg::Cell>> separatricesGeometry;
     getAscendingSeparatrices1(
       criticalPoints, separatrices, separatricesGeometry, triangulation);
-    setSeparatrices1<dataType, idType>(
+    setSeparatrices1<dataType>(
       separatrices, separatricesGeometry, triangulation);
 
     this->printMsg("Ascending 1-separatrices computed", 1.0,
@@ -139,7 +139,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
 
   if(outputCriticalPoints_numberOfPoints_ and outputCriticalPoints_points_) {
     std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType, idType>(
+    discreteGradient_.setCriticalPoints<dataType>(
       criticalPoints, nCriticalPointsByDim, triangulation);
 
     discreteGradient_.fetchOutputCriticalPoints(

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -91,7 +91,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
     std::vector<std::vector<dcg::Cell>> separatricesGeometry;
     getDescendingSeparatrices1(
       criticalPoints, separatrices, separatricesGeometry, triangulation);
-    setSeparatrices1<dataType>(
+    setSeparatrices1<dataType, idType>(
       separatrices, separatricesGeometry, triangulation);
 
     this->printMsg("Descending 1-separatrices computed", 1.0,
@@ -104,7 +104,7 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
     std::vector<std::vector<dcg::Cell>> separatricesGeometry;
     getAscendingSeparatrices1(
       criticalPoints, separatrices, separatricesGeometry, triangulation);
-    setSeparatrices1<dataType>(
+    setSeparatrices1<dataType, idType>(
       separatrices, separatricesGeometry, triangulation);
 
     this->printMsg("Ascending 1-separatrices computed", 1.0,

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -33,14 +33,14 @@ namespace ttk {
     /**
      * Main function for computing the whole Morse-Smale complex.
      */
-    template <typename dataType, typename idtype, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int execute(const triangulationType &triangulation);
 
     /**
      * Compute the (saddle1, saddle2) pairs not detected by the
      * contour tree.
      */
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int computePersistencePairs(
       std::vector<std::tuple<SimplexId, SimplexId, dataType>>
         &pl_saddleSaddlePairs,
@@ -95,7 +95,7 @@ namespace ttk {
      * outputSeparatrices2_cells_
      * inputScalarField_
      */
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int setDescendingSeparatrices2(
       const std::vector<Separatrix> &separatrices,
       const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -141,7 +141,7 @@ namespace ttk {
      * outputSeparatrices2_cells_
      * inputScalarField_
      */
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int setAscendingSeparatrices2(
       const std::vector<Separatrix> &separatrices,
       const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -158,7 +158,7 @@ namespace ttk {
   };
 } // namespace ttk
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
   const std::vector<Separatrix> &separatrices,
   const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -188,7 +188,7 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto offsets = static_cast<const idType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
   auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
     outputSeparatrices2_cells_separatrixFunctionMaxima_);
   auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
@@ -402,7 +402,7 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
   const std::vector<Separatrix> &separatrices,
   const std::vector<std::vector<dcg::Cell>> &separatricesGeometry,
@@ -432,7 +432,7 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto offsets = static_cast<const idType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
   auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
     outputSeparatrices2_cells_separatrixFunctionMaxima_);
   auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
@@ -612,7 +612,7 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!inputScalarField_) {
@@ -640,14 +640,14 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
   discreteGradient_.setDebugLevel(debugLevel_);
   {
     Timer tmp;
-    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
+    discreteGradient_.buildGradient<triangulationType>(triangulation);
 
     this->printMsg("Discrete gradient computed", 1.0, tmp.getElapsedTime(),
                    this->threadNumber_);
   }
 
   if(ReturnSaddleConnectors) {
-    discreteGradient_.reverseGradient<dataType, idType>(triangulation);
+    discreteGradient_.reverseGradient<dataType>(triangulation);
   }
 
   std::vector<dcg::Cell> criticalPoints;
@@ -699,7 +699,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
     Timer tmp{};
 
     flattenSeparatricesVectors(separatrices1, separatricesGeometry1);
-    setSeparatrices1<dataType, idType>(
+    setSeparatrices1<dataType>(
       separatrices1[0], separatricesGeometry1[0], triangulation);
 
     this->printMsg(
@@ -715,7 +715,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
     getDescendingSeparatrices2(criticalPoints, separatrices,
                                separatricesGeometry, separatricesSaddles,
                                triangulation);
-    setDescendingSeparatrices2<dataType, idType>(
+    setDescendingSeparatrices2<dataType>(
       separatrices, separatricesGeometry, separatricesSaddles, triangulation);
 
     this->printMsg("Descending 2-separatrices computed", 1.0,
@@ -730,7 +730,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
     getAscendingSeparatrices2(criticalPoints, separatrices,
                               separatricesGeometry, separatricesSaddles,
                               triangulation);
-    setAscendingSeparatrices2<dataType, idType>(
+    setAscendingSeparatrices2<dataType>(
       separatrices, separatricesGeometry, separatricesSaddles, triangulation);
 
     this->printMsg("Ascending 2-separatrices computed", 1.0,
@@ -765,7 +765,7 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
 
   if(outputCriticalPoints_numberOfPoints_ and outputSeparatrices1_points_) {
     std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType, idType>(
+    discreteGradient_.setCriticalPoints<dataType>(
       criticalPoints, nCriticalPointsByDim, triangulation);
 
     discreteGradient_.fetchOutputCriticalPoints(
@@ -792,13 +792,13 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::MorseSmaleComplex3D::computePersistencePairs(
   std::vector<std::tuple<SimplexId, SimplexId, dataType>> &pl_saddleSaddlePairs,
   const triangulationType &triangulation) {
 
   const dataType *scalars = static_cast<const dataType *>(inputScalarField_);
-  const dataType *offsets = static_cast<const dataType *>(inputOffsets_);
+  const auto offsets = inputOffsets_;
 
   std::vector<std::array<dcg::Cell, 2>> dmt_pairs;
   {
@@ -806,13 +806,13 @@ int ttk::MorseSmaleComplex3D::computePersistencePairs(
     discreteGradient_.setDebugLevel(debugLevel_);
     discreteGradient_.setThreadNumber(threadNumber_);
     discreteGradient_.setCollectPersistencePairs(false);
-    discreteGradient_.buildGradient<idType, triangulationType>(triangulation);
-    discreteGradient_.reverseGradient<dataType, idType>(triangulation);
+    discreteGradient_.buildGradient<triangulationType>(triangulation);
+    discreteGradient_.reverseGradient<dataType>(triangulation);
 
     // collect saddle-saddle connections
     discreteGradient_.setCollectPersistencePairs(true);
     discreteGradient_.setOutputPersistencePairs(&dmt_pairs);
-    discreteGradient_.reverseGradient<dataType, idType>(triangulation, false);
+    discreteGradient_.reverseGradient<dataType>(triangulation, false);
   }
 
   // transform DMT pairs into PL pairs

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -152,7 +152,7 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
       pl_saddleSaddlePairs;
     morseSmaleComplex_.setInputScalarField(inputScalars);
     morseSmaleComplex_.setInputOffsets(inputOffsets);
-    morseSmaleComplex_.computePersistencePairs<scalarType, SimplexId>(
+    morseSmaleComplex_.computePersistencePairs<scalarType>(
       pl_saddleSaddlePairs, *triangulation);
 
     // sort the saddle-saddle pairs by persistence value and compute curve

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -124,7 +124,7 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
   contourTree_.setVertexSoSoffsets(inputOffsets);
   contourTree_.setSegmentation(false);
   contourTree_.setThreadNumber(threadNumber_);
-  contourTree_.build<scalarType, SimplexId>(triangulation);
+  contourTree_.build<scalarType>(triangulation);
 
   // get persistence pairs
   std::vector<std::tuple<SimplexId, SimplexId, scalarType>> JTPairs;

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -44,10 +44,9 @@ namespace ttk {
       std::vector<std::pair<scalarType, SimplexId>> &plot) const;
 
     template <typename scalarType,
-              typename idType,
               class triangulationType = ttk::AbstractTriangulation>
     int execute(const scalarType *inputScalars,
-                const idType *inputOffsets,
+                const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
 
     inline void preconditionTriangulation(Triangulation *triangulation) {
@@ -104,9 +103,9 @@ int ttk::PersistenceCurve::computePersistencePlot(
   return 0;
 }
 
-template <typename scalarType, typename idType, class triangulationType>
+template <typename scalarType, class triangulationType>
 int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
-                                   const idType *inputOffsets,
+                                   const SimplexId *inputOffsets,
                                    const triangulationType *triangulation) {
 
   printMsg(ttk::debug::Separator::L1);
@@ -120,17 +119,12 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
   auto CTPlot = static_cast<plotType *>(CTPlot_);
   auto MSCPlot = static_cast<plotType *>(MSCPlot_);
 
-  const SimplexId numberOfVertices = triangulation->getNumberOfVertices();
-  // convert offsets into a valid format for contour tree
-  std::vector<SimplexId> voffsets(numberOfVertices);
-  std::copy(inputOffsets, inputOffsets + numberOfVertices, voffsets.begin());
-
   contourTree_.setVertexScalars(inputScalars);
   contourTree_.setTreeType(ftm::TreeType::Join_Split);
-  contourTree_.setVertexSoSoffsets(voffsets.data());
+  contourTree_.setVertexSoSoffsets(inputOffsets);
   contourTree_.setSegmentation(false);
   contourTree_.setThreadNumber(threadNumber_);
-  contourTree_.build<scalarType, idType>(triangulation);
+  contourTree_.build<scalarType, SimplexId>(triangulation);
 
   // get persistence pairs
   std::vector<std::tuple<SimplexId, SimplexId, scalarType>> JTPairs;
@@ -158,7 +152,7 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
       pl_saddleSaddlePairs;
     morseSmaleComplex_.setInputScalarField(inputScalars);
     morseSmaleComplex_.setInputOffsets(inputOffsets);
-    morseSmaleComplex_.computePersistencePairs<scalarType, idType>(
+    morseSmaleComplex_.computePersistencePairs<scalarType, SimplexId>(
       pl_saddleSaddlePairs, *triangulation);
 
     // sort the saddle-saddle pairs by persistence value and compute curve

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -55,14 +55,15 @@ namespace ttk {
                                   const SimplexId vertexId) const;
 
     template <typename scalarType>
-    int sortPersistenceDiagram(std::vector<std::tuple<ttk::SimplexId,
-                                                      ttk::CriticalType,
-                                                      ttk::SimplexId,
-                                                      ttk::CriticalType,
-                                                      scalarType,
-                                                      ttk::SimplexId>> &diagram,
-                               const scalarType *scalars,
-                               SimplexId *offsets) const;
+    void
+      sortPersistenceDiagram(std::vector<std::tuple<ttk::SimplexId,
+                                                    ttk::CriticalType,
+                                                    ttk::SimplexId,
+                                                    ttk::CriticalType,
+                                                    scalarType,
+                                                    ttk::SimplexId>> &diagram,
+                             const scalarType *scalars,
+                             SimplexId *offsets) const;
 
     template <typename scalarType>
     int computeCTPersistenceDiagram(
@@ -116,8 +117,7 @@ namespace ttk {
 } // namespace ttk
 
 template <typename scalarType>
-int ttk::PersistenceDiagram::sortPersistenceDiagram(
-
+void ttk::PersistenceDiagram::sortPersistenceDiagram(
   std::vector<std::tuple<ttk::SimplexId,
                          ttk::CriticalType,
                          ttk::SimplexId,
@@ -126,28 +126,17 @@ int ttk::PersistenceDiagram::sortPersistenceDiagram(
                          ttk::SimplexId>> &diagram,
   const scalarType *scalars,
   SimplexId *offsets) const {
+
   auto cmp
-    = [scalars, offsets](
+    = [offsets](
         const std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
                          ttk::CriticalType, scalarType, ttk::SimplexId> &a,
         const std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
                          ttk::CriticalType, scalarType, ttk::SimplexId> &b) {
-        const ttk::SimplexId idA = std::get<0>(a);
-        const ttk::SimplexId idB = std::get<0>(b);
-        const ttk::SimplexId va = offsets[idA];
-        const ttk::SimplexId vb = offsets[idB];
-        const scalarType sa = scalars[idA];
-        const scalarType sb = scalars[idB];
-
-        if(sa != sb)
-          return sa < sb;
-        else
-          return va < vb;
+        return offsets[std::get<0>(a)] < offsets[std::get<0>(b)];
       };
 
   std::sort(diagram.begin(), diagram.end(), cmp);
-
-  return 0;
 }
 
 template <typename scalarType>
@@ -212,14 +201,11 @@ int ttk::PersistenceDiagram::execute(
   std::vector<ttk::SimplexId> voffsets(numberOfVertices);
   std::copy(inputOffsets, inputOffsets + numberOfVertices, voffsets.begin());
 
-  // TODO: Change the following to migrated code when FTM module is migrated
-  // get contour tree
   contourTree_.setVertexScalars(inputScalars);
   contourTree_.setTreeType(ftm::TreeType::Join_Split);
   contourTree_.setVertexSoSoffsets(voffsets.data());
   contourTree_.setSegmentation(false);
   contourTree_.build<scalarType, idType>(triangulation);
-  // !!!
 
   // get persistence pairs
   std::vector<std::tuple<ttk::SimplexId, ttk::SimplexId, scalarType>> JTPairs;
@@ -261,12 +247,10 @@ int ttk::PersistenceDiagram::execute(
     pl_saddleSaddlePairs;
   const int dimensionality = triangulation->getDimensionality();
   if(dimensionality == 3 and ComputeSaddleConnectors) {
-    // TODO: Change the following to migrated code when FTM module is migrated
     morseSmaleComplex_.setInputScalarField(inputScalars);
     morseSmaleComplex_.setInputOffsets(inputOffsets);
     morseSmaleComplex_.computePersistencePairs<scalarType, idType>(
       pl_saddleSaddlePairs, *triangulation);
-    // !!!
   }
 
   // get persistence diagrams

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -62,8 +62,8 @@ namespace ttk {
                                                     ttk::CriticalType,
                                                     scalarType,
                                                     ttk::SimplexId>> &diagram,
-                             const scalarType *scalars,
-                             SimplexId *offsets) const;
+                             const scalarType *const scalars,
+                             const SimplexId *const offsets) const;
 
     template <typename scalarType>
     int computeCTPersistenceDiagram(
@@ -78,7 +78,7 @@ namespace ttk {
                              ttk::SimplexId>> &diagram,
       const scalarType *scalars) const;
 
-    template <typename scalarType, typename idType, class triangulationType>
+    template <typename scalarType, class triangulationType>
     int execute(std::vector<std::tuple<ttk::SimplexId,
                                        ttk::CriticalType,
                                        ttk::SimplexId,
@@ -86,7 +86,7 @@ namespace ttk {
                                        scalarType,
                                        ttk::SimplexId>> &CTDiagram,
                 const scalarType *inputScalars,
-                const idType *inputOffsets,
+                const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
 
     inline void
@@ -124,8 +124,8 @@ void ttk::PersistenceDiagram::sortPersistenceDiagram(
                          ttk::CriticalType,
                          scalarType,
                          ttk::SimplexId>> &diagram,
-  const scalarType *scalars,
-  SimplexId *offsets) const {
+  const scalarType *const scalars,
+  const SimplexId *const offsets) const {
 
   auto cmp
     = [offsets](
@@ -182,7 +182,7 @@ int ttk::PersistenceDiagram::computeCTPersistenceDiagram(
   return 0;
 }
 
-template <typename scalarType, typename idType, class triangulationType>
+template <typename scalarType, class triangulationType>
 int ttk::PersistenceDiagram::execute(
   std::vector<std::tuple<ttk::SimplexId,
                          ttk::CriticalType,
@@ -191,21 +191,16 @@ int ttk::PersistenceDiagram::execute(
                          scalarType,
                          ttk::SimplexId>> &CTDiagram,
   const scalarType *inputScalars,
-  const idType *inputOffsets,
+  const SimplexId *inputOffsets,
   const triangulationType *triangulation) {
 
   printMsg(ttk::debug::Separator::L1);
 
-  const ttk::SimplexId numberOfVertices = triangulation->getNumberOfVertices();
-  // convert offsets into a valid format for contour forests
-  std::vector<ttk::SimplexId> voffsets(numberOfVertices);
-  std::copy(inputOffsets, inputOffsets + numberOfVertices, voffsets.begin());
-
   contourTree_.setVertexScalars(inputScalars);
   contourTree_.setTreeType(ftm::TreeType::Join_Split);
-  contourTree_.setVertexSoSoffsets(voffsets.data());
+  contourTree_.setVertexSoSoffsets(inputOffsets);
   contourTree_.setSegmentation(false);
-  contourTree_.build<scalarType, idType>(triangulation);
+  contourTree_.build<scalarType, SimplexId>(triangulation);
 
   // get persistence pairs
   std::vector<std::tuple<ttk::SimplexId, ttk::SimplexId, scalarType>> JTPairs;
@@ -249,7 +244,7 @@ int ttk::PersistenceDiagram::execute(
   if(dimensionality == 3 and ComputeSaddleConnectors) {
     morseSmaleComplex_.setInputScalarField(inputScalars);
     morseSmaleComplex_.setInputOffsets(inputOffsets);
-    morseSmaleComplex_.computePersistencePairs<scalarType, idType>(
+    morseSmaleComplex_.computePersistencePairs<scalarType, SimplexId>(
       pl_saddleSaddlePairs, *triangulation);
   }
 
@@ -280,7 +275,7 @@ int ttk::PersistenceDiagram::execute(
   }
 
   // finally sort the diagram
-  sortPersistenceDiagram(CTDiagram, inputScalars, voffsets.data());
+  sortPersistenceDiagram(CTDiagram, inputScalars, inputOffsets);
 
   printMsg(ttk::debug::Separator::L1);
 

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -200,7 +200,7 @@ int ttk::PersistenceDiagram::execute(
   contourTree_.setTreeType(ftm::TreeType::Join_Split);
   contourTree_.setVertexSoSoffsets(inputOffsets);
   contourTree_.setSegmentation(false);
-  contourTree_.build<scalarType, SimplexId>(triangulation);
+  contourTree_.build<scalarType>(triangulation);
 
   // get persistence pairs
   std::vector<std::tuple<ttk::SimplexId, ttk::SimplexId, scalarType>> JTPairs;

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -244,7 +244,7 @@ int ttk::PersistenceDiagram::execute(
   if(dimensionality == 3 and ComputeSaddleConnectors) {
     morseSmaleComplex_.setInputScalarField(inputScalars);
     morseSmaleComplex_.setInputOffsets(inputOffsets);
-    morseSmaleComplex_.computePersistencePairs<scalarType, SimplexId>(
+    morseSmaleComplex_.computePersistencePairs<scalarType>(
       pl_saddleSaddlePairs, *triangulation);
   }
 

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -209,11 +209,11 @@ namespace ttk {
       return false;
     }
 
-    inline void setSosOffsetsU(std::vector<SimplexId> *sosOffsetsU) {
+    inline void setSosOffsetsU(const SimplexId *const sosOffsetsU) {
       sosOffsetsU_ = sosOffsetsU;
     }
 
-    inline void setSosOffsetsV(std::vector<SimplexId> *sosOffsetsV) {
+    inline void setSosOffsetsV(const SimplexId *const sosOffsetsV) {
       sosOffsetsV_ = sosOffsetsV;
     }
 
@@ -401,7 +401,7 @@ namespace ttk {
     SimplexId vertexNumber_{0}, edgeNumber_{0}, tetNumber_{0};
     double totalArea_{-1}, totalVolume_{-1}, totalHyperVolume_{-1};
 
-    std::vector<SimplexId> *sosOffsetsU_{}, *sosOffsetsV_{};
+    const SimplexId *sosOffsetsU_{}, *sosOffsetsV_{};
 
     bool hasConnectedSheets_{false}, expand3sheets_{true},
       withRangeDrivenOctree_{true};

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
@@ -3,3 +3,191 @@
 ttk::ScalarFieldCriticalPoints::ScalarFieldCriticalPoints() {
   this->setDebugMsgPrefix("ScalarFieldCriticalPoints");
 }
+
+char ttk::ScalarFieldCriticalPoints::getCriticalType(
+  const SimplexId &vertexId,
+  const SimplexId *const offsets,
+  const std::vector<std::pair<SimplexId, SimplexId>> &vertexLink) const {
+
+  std::map<SimplexId, SimplexId> global2LowerLink, global2UpperLink;
+  std::map<SimplexId, SimplexId>::iterator neighborIt;
+
+  SimplexId lowerCount = 0, upperCount = 0;
+
+  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
+
+    SimplexId neighborId = vertexLink[i].first;
+
+    // first vertex
+    // lower link search
+    if(offsets[neighborId] < offsets[vertexId]) {
+
+      neighborIt = global2LowerLink.find(neighborId);
+      if(neighborIt == global2LowerLink.end()) {
+        // not in there, add it
+        global2LowerLink[neighborId] = lowerCount;
+        lowerCount++;
+      }
+    }
+
+    // upper link
+    if(offsets[neighborId] > offsets[vertexId]) {
+
+      neighborIt = global2UpperLink.find(neighborId);
+      if(neighborIt == global2UpperLink.end()) {
+        // not in there, add it
+        global2UpperLink[neighborId] = upperCount;
+        upperCount++;
+      }
+    }
+
+    // second vertex
+    neighborId = vertexLink[i].second;
+
+    // lower link search
+    if(offsets[neighborId] < offsets[vertexId]) {
+
+      neighborIt = global2LowerLink.find(neighborId);
+      if(neighborIt == global2LowerLink.end()) {
+        // not in there, add it
+        global2LowerLink[neighborId] = lowerCount;
+        lowerCount++;
+      }
+    }
+
+    // upper link
+    if(offsets[neighborId] > offsets[vertexId]) {
+
+      neighborIt = global2UpperLink.find(neighborId);
+      if(neighborIt == global2UpperLink.end()) {
+        // not in there, add it
+        global2UpperLink[neighborId] = upperCount;
+        upperCount++;
+      }
+    }
+  }
+
+  if(debugLevel_ >= (int)(debug::Priority::VERBOSE)) {
+    printMsg("Vertex #" + std::to_string(vertexId) + " lower link ("
+               + std::to_string(lowerCount) + " vertices)",
+             debug::Priority::VERBOSE);
+    printMsg("Vertex #" + std::to_string(vertexId) + " upper link ("
+               + std::to_string(upperCount) + " vertices)",
+             debug::Priority::VERBOSE);
+  }
+
+  if(!lowerCount) {
+    // minimum
+    return (char)(CriticalType::Local_minimum);
+  }
+  if(!upperCount) {
+    // maximum
+    return (char)(CriticalType::Local_maximum);
+  }
+
+  // so far 40% of the computation, that's ok.
+
+  // now enumerate the connected components of the lower and upper links
+  // NOTE: a breadth first search might be faster than a UF
+  // if so, one would need the one-skeleton data structure, not the edge list
+  std::vector<UnionFind> lowerSeeds(lowerCount);
+  std::vector<UnionFind> upperSeeds(upperCount);
+  std::vector<UnionFind *> lowerList(lowerCount);
+  std::vector<UnionFind *> upperList(upperCount);
+  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
+    lowerList[i] = &(lowerSeeds[i]);
+  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
+    upperList[i] = &(upperSeeds[i]);
+
+  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
+
+    SimplexId neighborId0 = vertexLink[i].first;
+    SimplexId neighborId1 = vertexLink[i].second;
+
+    // process the lower link
+    if(offsets[neighborId0] < offsets[vertexId]
+       && offsets[neighborId1] < offsets[vertexId]) {
+
+      // both vertices are lower, let's add that edge and update the UF
+      std::map<SimplexId, SimplexId>::iterator n0It
+        = global2LowerLink.find(neighborId0);
+      std::map<SimplexId, SimplexId>::iterator n1It
+        = global2LowerLink.find(neighborId1);
+
+      lowerList[n0It->second]
+        = makeUnion(lowerList[n0It->second], lowerList[n1It->second]);
+      lowerList[n1It->second] = lowerList[n0It->second];
+    }
+
+    // process the upper link
+    if(offsets[neighborId0] > offsets[vertexId]
+       && offsets[neighborId1] > offsets[vertexId]) {
+
+      // both vertices are lower, let's add that edge and update the UF
+      std::map<SimplexId, SimplexId>::iterator n0It
+        = global2UpperLink.find(neighborId0);
+      std::map<SimplexId, SimplexId>::iterator n1It
+        = global2UpperLink.find(neighborId1);
+
+      upperList[n0It->second]
+        = makeUnion(upperList[n0It->second], upperList[n1It->second]);
+      upperList[n1It->second] = upperList[n0It->second];
+    }
+  }
+
+  // let's remove duplicates
+  std::vector<UnionFind *>::iterator it;
+  // update the UFs if necessary
+  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
+    lowerList[i] = lowerList[i]->find();
+  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
+    upperList[i] = upperList[i]->find();
+
+  sort(lowerList.begin(), lowerList.end());
+  it = unique(lowerList.begin(), lowerList.end());
+  lowerList.resize(distance(lowerList.begin(), it));
+
+  sort(upperList.begin(), upperList.end());
+  it = unique(upperList.begin(), upperList.end());
+  upperList.resize(distance(upperList.begin(), it));
+
+  if(debugLevel_ >= (int)(debug::Priority::VERBOSE)) {
+    printMsg("Vertex #" + std::to_string(vertexId)
+               + ": lowerLink-#CC=" + std::to_string(lowerList.size())
+               + " upperLink-#CC=" + std::to_string(upperList.size()),
+             debug::Priority::VERBOSE);
+  }
+
+  if((lowerList.size() == 1) && (upperList.size() == 1))
+    // regular point
+    return (char)(CriticalType::Regular);
+  else {
+    // saddles
+    if(dimension_ == 2) {
+      if((lowerList.size() > 2) || (upperList.size() > 2)) {
+        // monkey saddle
+        return (char)(CriticalType::Degenerate);
+      } else {
+        // regular saddle
+        return (char)(CriticalType::Saddle1);
+        // NOTE: you may have multi-saddles on the boundary in that
+        // configuration
+        // to make this computation 100% correct, one would need to disambiguate
+        // boundary from interior vertices
+      }
+    } else if(dimension_ == 3) {
+      if((lowerList.size() == 2) && (upperList.size() == 1)) {
+        return (char)(CriticalType::Saddle1);
+      } else if((lowerList.size() == 1) && (upperList.size() == 2)) {
+        return (char)(CriticalType::Saddle2);
+      } else {
+        // monkey saddle
+        return (char)(CriticalType::Degenerate);
+        // NOTE: we may have a similar effect in 3D (TODO)
+      }
+    }
+  }
+
+  // -2: regular points
+  return (char)(CriticalType::Regular);
+}

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -37,24 +37,23 @@ namespace ttk {
     /// Execute the package.
     /// \param argment Dummy integer argument.
     /// \return Returns 0 upon success, negative values otherwise.
-    template <typename idType, class triangulationType = AbstractTriangulation>
-    int execute(const idType *const offsets,
+    template <class triangulationType = AbstractTriangulation>
+    int execute(const SimplexId *const offsets,
                 const triangulationType *triangulation);
 
-    template <typename idType, class triangulationType = AbstractTriangulation>
+    template <class triangulationType = AbstractTriangulation>
     std::pair<SimplexId, SimplexId> getNumberOfLowerUpperComponents(
       const SimplexId vertexId,
-      const idType *const offsets,
+      const SimplexId *const offsets,
       const triangulationType *triangulation) const;
 
-    template <typename idType, class triangulationType = AbstractTriangulation>
+    template <class triangulationType = AbstractTriangulation>
     char getCriticalType(const SimplexId &vertexId,
-                         const idType *const offsets,
+                         const SimplexId *const offsets,
                          const triangulationType *triangulation) const;
 
-    template <typename idType>
     char getCriticalType(const SimplexId &vertexId,
-                         const idType *const offsets,
+                         const SimplexId *const offsets,
                          const std::vector<std::pair<SimplexId, SimplexId>>
                            &vertexLinkEdgeList) const;
 
@@ -109,9 +108,9 @@ namespace ttk {
 } // namespace ttk
 
 // template functions
-template <typename idType, class triangulationType>
+template <class triangulationType>
 int ttk::ScalarFieldCriticalPoints::execute(
-  const idType *const offsets, const triangulationType *triangulation) {
+  const SimplexId *const offsets, const triangulationType *triangulation) {
 
   // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -242,11 +241,11 @@ int ttk::ScalarFieldCriticalPoints::execute(
   return 0;
 }
 
-template <typename idType, class triangulationType>
+template <class triangulationType>
 std::pair<ttk::SimplexId, ttk::SimplexId>
   ttk::ScalarFieldCriticalPoints::getNumberOfLowerUpperComponents(
     const SimplexId vertexId,
-    const idType *const offsets,
+    const SimplexId *const offsets,
     const triangulationType *triangulation) const {
 
   SimplexId neighborNumber = triangulation->getVertexNeighborNumber(vertexId);
@@ -374,10 +373,10 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
   return std::make_pair(lowerList.size(), upperList.size());
 }
 
-template <typename idType, class triangulationType>
+template <class triangulationType>
 char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId &vertexId,
-  const idType *const offsets,
+  const SimplexId *const offsets,
   const triangulationType *triangulation) const {
 
   SimplexId downValence, upValence;
@@ -414,195 +413,6 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
         return (char)(CriticalType::Saddle2);
       } else {
         // monkey saddle, saddle + extremum
-        return (char)(CriticalType::Degenerate);
-        // NOTE: we may have a similar effect in 3D (TODO)
-      }
-    }
-  }
-
-  // -2: regular points
-  return (char)(CriticalType::Regular);
-}
-
-template <typename idType>
-char ttk::ScalarFieldCriticalPoints::getCriticalType(
-  const SimplexId &vertexId,
-  const idType *const offsets,
-  const std::vector<std::pair<SimplexId, SimplexId>> &vertexLink) const {
-
-  std::map<SimplexId, SimplexId> global2LowerLink, global2UpperLink;
-  std::map<SimplexId, SimplexId>::iterator neighborIt;
-
-  SimplexId lowerCount = 0, upperCount = 0;
-
-  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
-
-    SimplexId neighborId = vertexLink[i].first;
-
-    // first vertex
-    // lower link search
-    if(offsets[neighborId] < offsets[vertexId]) {
-
-      neighborIt = global2LowerLink.find(neighborId);
-      if(neighborIt == global2LowerLink.end()) {
-        // not in there, add it
-        global2LowerLink[neighborId] = lowerCount;
-        lowerCount++;
-      }
-    }
-
-    // upper link
-    if(offsets[neighborId] > offsets[vertexId]) {
-
-      neighborIt = global2UpperLink.find(neighborId);
-      if(neighborIt == global2UpperLink.end()) {
-        // not in there, add it
-        global2UpperLink[neighborId] = upperCount;
-        upperCount++;
-      }
-    }
-
-    // second vertex
-    neighborId = vertexLink[i].second;
-
-    // lower link search
-    if(offsets[neighborId] < offsets[vertexId]) {
-
-      neighborIt = global2LowerLink.find(neighborId);
-      if(neighborIt == global2LowerLink.end()) {
-        // not in there, add it
-        global2LowerLink[neighborId] = lowerCount;
-        lowerCount++;
-      }
-    }
-
-    // upper link
-    if(offsets[neighborId] > offsets[vertexId]) {
-
-      neighborIt = global2UpperLink.find(neighborId);
-      if(neighborIt == global2UpperLink.end()) {
-        // not in there, add it
-        global2UpperLink[neighborId] = upperCount;
-        upperCount++;
-      }
-    }
-  }
-
-  if(debugLevel_ >= (int)(debug::Priority::VERBOSE)) {
-    printMsg("Vertex #" + std::to_string(vertexId) + " lower link ("
-               + std::to_string(lowerCount) + " vertices)",
-             debug::Priority::VERBOSE);
-    printMsg("Vertex #" + std::to_string(vertexId) + " upper link ("
-               + std::to_string(upperCount) + " vertices)",
-             debug::Priority::VERBOSE);
-  }
-
-  if(!lowerCount) {
-    // minimum
-    return (char)(CriticalType::Local_minimum);
-  }
-  if(!upperCount) {
-    // maximum
-    return (char)(CriticalType::Local_maximum);
-  }
-
-  // so far 40% of the computation, that's ok.
-
-  // now enumerate the connected components of the lower and upper links
-  // NOTE: a breadth first search might be faster than a UF
-  // if so, one would need the one-skeleton data structure, not the edge list
-  std::vector<UnionFind> lowerSeeds(lowerCount);
-  std::vector<UnionFind> upperSeeds(upperCount);
-  std::vector<UnionFind *> lowerList(lowerCount);
-  std::vector<UnionFind *> upperList(upperCount);
-  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
-    lowerList[i] = &(lowerSeeds[i]);
-  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
-    upperList[i] = &(upperSeeds[i]);
-
-  for(SimplexId i = 0; i < (SimplexId)vertexLink.size(); i++) {
-
-    SimplexId neighborId0 = vertexLink[i].first;
-    SimplexId neighborId1 = vertexLink[i].second;
-
-    // process the lower link
-    if(offsets[neighborId0] < offsets[vertexId]
-       && offsets[neighborId1] < offsets[vertexId]) {
-
-      // both vertices are lower, let's add that edge and update the UF
-      std::map<SimplexId, SimplexId>::iterator n0It
-        = global2LowerLink.find(neighborId0);
-      std::map<SimplexId, SimplexId>::iterator n1It
-        = global2LowerLink.find(neighborId1);
-
-      lowerList[n0It->second]
-        = makeUnion(lowerList[n0It->second], lowerList[n1It->second]);
-      lowerList[n1It->second] = lowerList[n0It->second];
-    }
-
-    // process the upper link
-    if(offsets[neighborId0] > offsets[vertexId]
-       && offsets[neighborId1] > offsets[vertexId]) {
-
-      // both vertices are lower, let's add that edge and update the UF
-      std::map<SimplexId, SimplexId>::iterator n0It
-        = global2UpperLink.find(neighborId0);
-      std::map<SimplexId, SimplexId>::iterator n1It
-        = global2UpperLink.find(neighborId1);
-
-      upperList[n0It->second]
-        = makeUnion(upperList[n0It->second], upperList[n1It->second]);
-      upperList[n1It->second] = upperList[n0It->second];
-    }
-  }
-
-  // let's remove duplicates
-  std::vector<UnionFind *>::iterator it;
-  // update the UFs if necessary
-  for(SimplexId i = 0; i < (SimplexId)lowerList.size(); i++)
-    lowerList[i] = lowerList[i]->find();
-  for(SimplexId i = 0; i < (SimplexId)upperList.size(); i++)
-    upperList[i] = upperList[i]->find();
-
-  sort(lowerList.begin(), lowerList.end());
-  it = unique(lowerList.begin(), lowerList.end());
-  lowerList.resize(distance(lowerList.begin(), it));
-
-  sort(upperList.begin(), upperList.end());
-  it = unique(upperList.begin(), upperList.end());
-  upperList.resize(distance(upperList.begin(), it));
-
-  if(debugLevel_ >= (int)(debug::Priority::VERBOSE)) {
-    printMsg("Vertex #" + std::to_string(vertexId)
-               + ": lowerLink-#CC=" + std::to_string(lowerList.size())
-               + " upperLink-#CC=" + std::to_string(upperList.size()),
-             debug::Priority::VERBOSE);
-  }
-
-  if((lowerList.size() == 1) && (upperList.size() == 1))
-    // regular point
-    return (char)(CriticalType::Regular);
-  else {
-    // saddles
-    if(dimension_ == 2) {
-      if((lowerList.size() > 2) || (upperList.size() > 2)) {
-        // monkey saddle
-        return (char)(CriticalType::Degenerate);
-      } else {
-        // regular saddle
-        return (char)(CriticalType::Saddle1);
-        // NOTE: you may have multi-saddles on the boundary in that
-        // configuration
-        // to make this computation 100% correct, one would need to disambiguate
-        // boundary from interior vertices
-      }
-    } else if(dimension_ == 3) {
-      if((lowerList.size() == 2) && (upperList.size() == 1)) {
-        return (char)(CriticalType::Saddle1);
-      } else if((lowerList.size() == 1) && (upperList.size() == 2)) {
-        return (char)(CriticalType::Saddle2);
-      } else {
-        // monkey saddle
         return (char)(CriticalType::Degenerate);
         // NOTE: we may have a similar effect in 3D (TODO)
       }

--- a/core/base/topologicalCompression/OtherCompression.h
+++ b/core/base/topologicalCompression/OtherCompression.h
@@ -26,11 +26,11 @@ int ttk::TopologicalCompression::computeOther() {
   return 0;
 }
 
-template <typename dataType, typename idType>
+template <typename dataType>
 int ttk::TopologicalCompression::compressForOther(
   int vertexNumber,
   const dataType *const inputData,
-  const idType *const inputOffsets,
+  const SimplexId *const inputOffsets,
   dataType *outputData,
   const double &tol) {
 

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -390,7 +390,7 @@ int ttk::TopologicalCompression::computePersistencePairs(
   ftmTreePP.setTreeType(ftm::TreeType::Join_Split);
   ftmTreePP.setVertexSoSoffsets(voffsets.data());
   ftmTreePP.setThreadNumber(threadNumber_);
-  ftmTreePP.build<dataType, SimplexId>(&triangulation);
+  ftmTreePP.build<dataType>(&triangulation);
   ftmTreePP.setSegmentation(false);
   ftmTreePP.computePersistencePairs<dataType>(JTPairs, true);
   ftmTreePP.computePersistencePairs<dataType>(STPairs, false);

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -398,11 +398,11 @@ int ttk::TopologicalCompression::computePersistencePairs(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::TopologicalCompression::compressForPersistenceDiagram(
   int vertexNumber,
   const dataType *const inputData,
-  const idType *const inputOffsets,
+  const SimplexId *const inputOffsets,
   dataType *outputData,
   const double &tol,
   const triangulationType &triangulation) {

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -299,7 +299,7 @@ int ttk::TopologicalCompression::PerformSimplification(
   sortVertices(vertexNumber, array, inputOffsets.data(), vertsOrder.data(),
                this->threadNumber_);
 
-  status = topologicalSimplification.execute<double, int>(
+  status = topologicalSimplification.execute<double>(
     inArray.data(), array, critConstraints.data(), vertsOrder.data(),
     decompressedOffsets_.data(), nbConstraints, triangulation);
 
@@ -573,7 +573,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     if(UseTopologicalSimplification) {
       compressedOffsets_.resize(vertexNumber);
       int status = 0;
-      status = topologicalSimplification.execute<dataType, SimplexId>(
+      status = topologicalSimplification.execute<dataType>(
         inputData, outputData, simplifiedConstraints.data(), inputOffsets,
         compressedOffsets_.data(), nbCrit, triangulation);
       if(status != 0) {

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -44,10 +44,9 @@ namespace ttk {
     TopologicalCompression();
 
     template <class dataType,
-              typename idType,
               typename triangulationType = AbstractTriangulation>
     int execute(const dataType *const inputData,
-                const idType *const inputOffsets,
+                const SimplexId *const inputOffsets,
                 dataType *outputData,
                 const triangulationType &triangulation);
 
@@ -59,10 +58,10 @@ namespace ttk {
       const dataType *const inputScalars_,
       const SimplexId *const inputOffsets,
       const triangulationType &triangulation);
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int compressForPersistenceDiagram(int vertexNumber,
                                       const dataType *const inputData,
-                                      const idType *const inputOffset,
+                                      const SimplexId *const inputOffset,
                                       dataType *outputData,
                                       const double &tol,
                                       const triangulationType &triangulation);
@@ -71,10 +70,10 @@ namespace ttk {
     template <typename dataType>
     int computeOther();
 
-    template <typename dataType, typename idType>
+    template <typename dataType>
     int compressForOther(int vertexNumber,
                          const dataType *const inputData,
-                         const idType *const inputOffsets,
+                         const SimplexId *const inputOffsets,
                          dataType *outputData,
                          const double &tol);
 
@@ -416,10 +415,10 @@ namespace ttk {
 #include <OtherCompression.h>
 #include <PersistenceDiagramCompression.h>
 
-template <class dataType, typename idType, typename triangulationType>
+template <class dataType, typename triangulationType>
 int ttk::TopologicalCompression::execute(
   const dataType *const inputData,
-  const idType *const inputOffsets,
+  const SimplexId *const inputOffsets,
   dataType *outputData,
   const triangulationType &triangulation) {
   this->printMsg("Starting compression...");

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -351,7 +351,7 @@ int ttk::TopologicalSimplification::execute(
       } while(!sweepFront.empty());
 
       // save offsets and rearrange outputScalars
-      SimplexId offset = (isIncreasingOrder ? 0 : vertexNumber_ + 1);
+      SimplexId offset = (isIncreasingOrder ? 0 : vertexNumber_);
 
       for(SimplexId k = 0; k < vertexNumber_; ++k) {
 

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -89,11 +89,11 @@ namespace ttk {
     int addPerturbation(dataType *const scalars,
                         SimplexId *const offsets) const;
 
-    template <typename dataType, typename idType, typename triangulationType>
+    template <typename dataType, typename triangulationType>
     int execute(const dataType *const inputScalars,
                 dataType *const outputScalars,
-                const idType *const identifiers,
-                const idType *const inputOffsets,
+                const SimplexId *const identifiers,
+                const SimplexId *const inputOffsets,
                 SimplexId *const offsets,
                 const SimplexId constraintNumber,
                 const triangulationType &triangulation) const;
@@ -242,12 +242,12 @@ int ttk::TopologicalSimplification::addPerturbation(
   return 0;
 }
 
-template <typename dataType, typename idType, typename triangulationType>
+template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::execute(
   const dataType *const inputScalars,
   dataType *const outputScalars,
-  const idType *const identifiers,
-  const idType *const inputOffsets,
+  const SimplexId *const identifiers,
+  const SimplexId *const inputOffsets,
   SimplexId *const offsets,
   const SimplexId constraintNumber,
   const triangulationType &triangulation) const {

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -63,14 +63,14 @@ namespace ttk {
       inputData_ = is;
     }
 
-    inline void setInputOffsets(void *io) {
+    inline void setInputOffsets(std::vector<SimplexId *> &io) {
       inputOffsets_ = io;
     }
 
   protected:
     int numberOfInputs_{0};
     std::vector<void *> inputData_{};
-    void *inputOffsets_{};
+    std::vector<SimplexId *> inputOffsets_{};
   };
 } // namespace ttk
 
@@ -96,9 +96,8 @@ int ttk::TrackingFromFields::performDiagramComputation(
       CTDiagram;
 
     // persistenceDiagram.setOutputCTDiagram(&CTDiagram);
-    persistenceDiagram.execute<dataType, int, triangulationType>(
-      CTDiagram, (dataType *)(inputData_[i]), (int *)(inputOffsets_),
-      triangulation);
+    persistenceDiagram.execute<dataType, triangulationType>(
+      CTDiagram, (dataType *)(inputData_[i]), inputOffsets_[i], triangulation);
 
     // Copy diagram into augmented diagram.
     persistenceDiagrams[i] = std::vector<diagramTuple>(CTDiagram.size());

--- a/core/vtk/ttkContourForests/ttkContourForests.cpp
+++ b/core/vtk/ttkContourForests/ttkContourForests.cpp
@@ -1074,9 +1074,8 @@ void ttkContourForests::getTree() {
   // sequential params
   this->preconditionTriangulation(triangulation_);
   this->setVertexScalars(ttkUtils::GetVoidPointer(vtkInputScalars_));
-  if(!vertexSoSoffsets_.empty()) {
-    this->setVertexSoSoffsets(vertexSoSoffsets_);
-  }
+  this->setVertexSoSoffsets(vertexSoSoffsets_);
+
   this->setTreeType(treeType_);
   // parallel params
   this->setLessPartition(lessPartition_);
@@ -1205,32 +1204,16 @@ int ttkContourForests::RequestData(vtkInformation *request,
   deltaScalar_ = (scalarMax - scalarMin);
 
   // offsets
-  if(varyingMesh_ || varyingDataValues_ || !vertexSoSoffsets_.size()) {
-
-    vertexSoSoffsets_.clear();
+  if(varyingMesh_ || varyingDataValues_ || vertexSoSoffsets_ == nullptr) {
 
     const auto offsets
       = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
 
     if(offsets != nullptr) {
-
-      if(offsets->GetNumberOfTuples() != numberOfVertices_) {
-        this->printErr("Mesh and offset sizes do not match :(");
-        this->printErr("Using default offset field instead...");
-      } else {
-        vertexSoSoffsets_.resize(offsets->GetNumberOfTuples());
-        for(SimplexId i = 0; i < (SimplexId)vertexSoSoffsets_.size(); ++i) {
-          vertexSoSoffsets_[i] = offsets->GetTuple1(i);
-        }
-      }
+      vertexSoSoffsets_
+        = static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsets));
     }
 
-    if(vertexSoSoffsets_.empty()) {
-      vertexSoSoffsets_.resize(numberOfVertices_);
-      for(SimplexId i = 0; i < (SimplexId)vertexSoSoffsets_.size(); ++i) {
-        vertexSoSoffsets_[i] = i;
-      }
-    }
     toUpdateVertexSoSoffsets_ = false;
   }
 
@@ -1240,7 +1223,6 @@ int ttkContourForests::RequestData(vtkInformation *request,
       std::vector<std::vector<std::string>>{
         {"#Tuples", std::to_string(vertexScalars_.size())},
         {"#Vertices", std::to_string(numberOfVertices_)},
-        {"#Offsets", std::to_string(vertexSoSoffsets_.size())},
         {"Min", std::to_string(scalarMin)},
         {"Max", std::to_string(scalarMax)},
       },

--- a/core/vtk/ttkContourForests/ttkContourForests.h
+++ b/core/vtk/ttkContourForests/ttkContourForests.h
@@ -170,7 +170,7 @@ private:
   double deltaScalar_{};
   ttk::SimplexId numberOfVertices_{};
   ttk::Triangulation *triangulation_{};
-  std::vector<ttk::SimplexId> vertexSoSoffsets_{};
+  ttk::SimplexId *vertexSoSoffsets_{};
   std::vector<ttk::SimplexId> criticalPoints_{};
   std::vector<double> vertexScalars_{};
 

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -38,7 +38,7 @@ int ttkDiscreteGradient::FillOutputPortInformation(int port,
   return 0;
 }
 
-template <typename scalarType, typename offsetType, typename triangulationType>
+template <typename scalarType, typename triangulationType>
 int ttkDiscreteGradient::dispatch(vtkUnstructuredGrid *outputCriticalPoints,
                                   vtkDataArray *const inputScalars,
                                   vtkDataArray *const inputOffsets,
@@ -48,8 +48,7 @@ int ttkDiscreteGradient::dispatch(vtkUnstructuredGrid *outputCriticalPoints,
   std::vector<scalarType> criticalPoints_points_cellScalars;
   this->setOutputCriticalPoints(&criticalPoints_points_cellScalars);
 
-  const int ret
-    = this->buildGradient<offsetType, triangulationType>(triangulation);
+  const int ret = this->buildGradient<triangulationType>(triangulation);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {
@@ -61,7 +60,7 @@ int ttkDiscreteGradient::dispatch(vtkUnstructuredGrid *outputCriticalPoints,
 
   // critical points
   {
-    this->setCriticalPoints<scalarType, offsetType>(triangulation);
+    this->setCriticalPoints<scalarType>(triangulation);
 
     vtkNew<vtkPoints> points{};
 
@@ -176,10 +175,11 @@ int ttkDiscreteGradient::RequestData(vtkInformation *request,
 
   // baseCode processing
   this->setInputScalarField(ttkUtils::GetVoidPointer(inputScalars));
-  this->setInputOffsets(ttkUtils::GetVoidPointer(inputOffsets));
+  this->setInputOffsets(
+    static_cast<SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)));
 
   ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                      (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
+                      (ret = dispatch<VTK_TT, TTK_TT>(
                          outputCriticalPoints, inputScalars, inputOffsets,
                          *static_cast<TTK_TT *>(triangulation->getData()))));
 

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -178,17 +178,10 @@ int ttkDiscreteGradient::RequestData(vtkInformation *request,
   this->setInputScalarField(ttkUtils::GetVoidPointer(inputScalars));
   this->setInputOffsets(ttkUtils::GetVoidPointer(inputOffsets));
 
-  if(inputOffsets->GetDataType() == VTK_INT) {
-    ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                        (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
-                           outputCriticalPoints, inputScalars, inputOffsets,
-                           *static_cast<TTK_TT *>(triangulation->getData()))))
-  } else if(inputOffsets->GetDataType() == VTK_ID_TYPE) {
-    ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                        (ret = dispatch<VTK_TT, LongSimplexId, TTK_TT>(
-                           outputCriticalPoints, inputScalars, inputOffsets,
-                           *static_cast<TTK_TT *>(triangulation->getData()))))
-  }
+  ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
+                      (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
+                         outputCriticalPoints, inputScalars, inputOffsets,
+                         *static_cast<TTK_TT *>(triangulation->getData()))));
 
   if(ret != 0) {
     return -1;

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -74,9 +74,7 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  template <typename scalarType,
-            typename offsetType,
-            typename triangulationType>
+  template <typename scalarType, typename triangulationType>
   int dispatch(vtkUnstructuredGrid *outputCriticalPoints,
                vtkDataArray *const inputScalars,
                vtkDataArray *const inputOffsets,

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -156,10 +156,10 @@ int ttkFTMTree::RequestData(vtkInformation *request,
     ftmTree_[cc].tree.setSegmentation(GetWithSegmentation());
     ftmTree_[cc].tree.setNormalizeIds(GetWithNormalize());
 
-    ttkVtkTemplateMacro(
-      inputArray->GetDataType(), triangulation_[cc]->getType(),
-      (ftmTree_[cc].tree.build<VTK_TT, ttk::SimplexId, TTK_TT>(
-        (TTK_TT *)triangulation_[cc]->getData())));
+    ttkVtkTemplateMacro(inputArray->GetDataType(),
+                        triangulation_[cc]->getType(),
+                        (ftmTree_[cc].tree.build<VTK_TT, TTK_TT>(
+                          (TTK_TT *)triangulation_[cc]->getData())));
 
     ftmTree_[cc].offset = acc_nbNodes;
     acc_nbNodes += ftmTree_[cc].tree.getTree(GetTreeType())->getNumberOfNodes();

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -116,19 +116,6 @@ int ttkIntegralLines::getTrajectories(vtkDataSet *input,
   return 0;
 }
 
-template <typename VTK_TT, typename TTK_TT>
-int ttkIntegralLines::dispatch(int inputOffsetsDataType,
-                               const TTK_TT *triangulation) {
-  int ret = 0;
-  if(inputOffsetsDataType == VTK_INT) {
-    ret = this->execute<VTK_TT, int, TTK_TT>(triangulation);
-  }
-  if(inputOffsetsDataType == VTK_ID_TYPE) {
-    ret = this->execute<VTK_TT, vtkIdType, TTK_TT>(triangulation);
-  }
-  return ret;
-}
-
 int ttkIntegralLines::RequestData(vtkInformation *request,
                                   vtkInformationVector **inputVector,
                                   vtkInformationVector *outputVector) {
@@ -196,13 +183,12 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   this->preconditionTriangulation(triangulation);
 
   int status = 0;
-  ttkVtkTemplateMacro(
-    inputScalars->GetDataType(), triangulation->getType(),
-    (status = this->dispatch<VTK_TT, TTK_TT>(
-       inputOffsets->GetDataType(), (TTK_TT *)(triangulation->getData()))))
+  ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
+                      (status = this->execute<VTK_TT, SimplexId, TTK_TT>(
+                         static_cast<TTK_TT *>(triangulation->getData()))));
 #ifndef TTK_ENABLE_KAMIKAZE
-    // something wrong in baseCode
-    if(status) {
+  // something wrong in baseCode
+  if(status) {
     std::stringstream msg;
     msg << "IntegralLines.execute() error code : " << status;
     this->printErr(msg.str());

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -175,7 +175,8 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   this->setSeedNumber(numberOfPointsInSeeds);
   this->setDirection(Direction);
   this->setInputScalarField(inputScalars->GetVoidPointer(0));
-  this->setInputOffsets(inputOffsets->GetVoidPointer(0));
+  this->setInputOffsets(
+    static_cast<SimplexId *>(inputOffsets->GetVoidPointer(0)));
 
   this->setVertexIdentifierScalarField(inputIdentifiers->GetVoidPointer(0));
   this->setOutputTrajectories(&trajectories);
@@ -184,7 +185,7 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
 
   int status = 0;
   ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                      (status = this->execute<VTK_TT, SimplexId, TTK_TT>(
+                      (status = this->execute<VTK_TT, TTK_TT>(
                          static_cast<TTK_TT *>(triangulation->getData()))));
 #ifndef TTK_ENABLE_KAMIKAZE
   // something wrong in baseCode

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.h
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.h
@@ -89,9 +89,6 @@ public:
                       std::vector<std::vector<ttk::SimplexId>> &trajectories,
                       vtkUnstructuredGrid *output);
 
-  template <typename VTK_TT, typename TTK_TT>
-  int dispatch(int, const TTK_TT *);
-
 protected:
   ttkIntegralLines();
   ~ttkIntegralLines() override;

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -72,21 +72,10 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   const auto offsetFieldV
     = this->GetOrderArray(input, 1, 3, ForceInputOffsetScalarField);
 
-  if(offsetFieldU) {
-    sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
-    for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
-      sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
-    }
-    this->setSosOffsetsU(&sosOffsetsU_);
-  }
-
-  if(offsetFieldV) {
-    sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
-    for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
-      sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
-    }
-    this->setSosOffsetsV(&sosOffsetsV_);
-  }
+  this->setSosOffsetsU(
+    static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(offsetFieldU)));
+  this->setSosOffsetsV(
+    static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(offsetFieldV)));
 
   auto triangulation = ttkAlgorithm::GetTriangulation(input);
   if(triangulation == nullptr)

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.h
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.h
@@ -96,5 +96,4 @@ private:
   // for each edge, the one skeleton of its triangle fan
   std::vector<std::vector<ttk::SimplexId>> edgeFans_{};
   std::vector<std::pair<ttk::SimplexId, char>> jacobiSet_{};
-  std::vector<ttk::SimplexId> sosOffsetsU_{}, sosOffsetsV_{};
 };

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -44,7 +44,7 @@ int ttkMorseSmaleComplex::FillOutputPortInformation(int port,
   return 0;
 }
 
-template <typename scalarType, typename offsetType, typename triangulationType>
+template <typename scalarType, typename triangulationType>
 int ttkMorseSmaleComplex::dispatch(
   vtkDataArray *const inputScalars,
   vtkDataArray *const inputOffsets,
@@ -129,8 +129,7 @@ int ttkMorseSmaleComplex::dispatch(
     &separatrices2_cells_separatrixFunctionDiffs,
     &separatrices2_cells_isOnBoundary);
 
-  const int ret
-    = this->execute<scalarType, offsetType, triangulationType>(triangulation);
+  const int ret = this->execute<scalarType, triangulationType>(triangulation);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret != 0) {
@@ -557,7 +556,8 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
     SaddleConnectorsPersistenceThreshold);
 
   this->setInputScalarField(ttkUtils::GetVoidPointer(inputScalars));
-  this->setInputOffsets(ttkUtils::GetVoidPointer(inputOffsets));
+  this->setInputOffsets(
+    static_cast<SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)));
 
   void *ascendingManifoldPtr = nullptr;
   void *descendingManifoldPtr = nullptr;
@@ -577,7 +577,7 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
 
   ttkVtkTemplateMacro(
     inputScalars->GetDataType(), triangulation->getType(),
-    (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
+    (ret = dispatch<VTK_TT, TTK_TT>(
        inputScalars, inputOffsets, outputCriticalPoints, outputSeparatrices1,
        outputSeparatrices2, *static_cast<TTK_TT *>(triangulation->getData()))));
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -574,19 +574,12 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
     ascendingManifoldPtr, descendingManifoldPtr, morseSmaleManifoldPtr);
 
   int ret{};
-  if(inputOffsets->GetDataType() == VTK_INT) {
-    ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                        (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
-                           inputScalars, inputOffsets, outputCriticalPoints,
-                           outputSeparatrices1, outputSeparatrices2,
-                           *static_cast<TTK_TT *>(triangulation->getData()))))
-  } else if(inputOffsets->GetDataType() == VTK_ID_TYPE) {
-    ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                        (ret = dispatch<VTK_TT, ttk::LongSimplexId, TTK_TT>(
-                           inputScalars, inputOffsets, outputCriticalPoints,
-                           outputSeparatrices1, outputSeparatrices2,
-                           *static_cast<TTK_TT *>(triangulation->getData()))))
-  }
+
+  ttkVtkTemplateMacro(
+    inputScalars->GetDataType(), triangulation->getType(),
+    (ret = dispatch<VTK_TT, SimplexId, TTK_TT>(
+       inputScalars, inputOffsets, outputCriticalPoints, outputSeparatrices1,
+       outputSeparatrices2, *static_cast<TTK_TT *>(triangulation->getData()))));
 
   if(ret != 0) {
     return -1;

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -111,9 +111,7 @@ public:
   vtkGetMacro(SaddleConnectorsPersistenceThreshold, double);
 
 protected:
-  template <typename scalarType,
-            typename offsetType,
-            typename triangulationType>
+  template <typename scalarType, typename triangulationType>
   int dispatch(vtkDataArray *const inputScalars,
                vtkDataArray *const inputOffsets,
                vtkUnstructuredGrid *const outputCriticalPoints,

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -168,7 +168,7 @@ int ttkPersistenceCurve::dispatch(vtkTable *outputJTPersistenceCurve,
   this->setOutputCTPlot(&CTPlot);
   this->setOutputMSCPlot(&MSCPlot);
 
-  ret = this->execute<VTK_TT, SimplexId, TTK_TT>(
+  ret = this->execute<VTK_TT, TTK_TT>(
     inputScalars, (SimplexId *)inputOffsets, triangulation);
 
   ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -168,14 +168,8 @@ int ttkPersistenceCurve::dispatch(vtkTable *outputJTPersistenceCurve,
   this->setOutputCTPlot(&CTPlot);
   this->setOutputMSCPlot(&MSCPlot);
 
-  if(inputOffsetsDataType == VTK_INT) {
-    ret = this->execute<VTK_TT, int, TTK_TT>(
-      inputScalars, (int *)inputOffsets, triangulation);
-  }
-  if(inputOffsetsDataType == VTK_ID_TYPE) {
-    ret = this->execute<VTK_TT, vtkIdType, TTK_TT>(
-      inputScalars, (vtkIdType *)inputOffsets, triangulation);
-  }
+  ret = this->execute<VTK_TT, SimplexId, TTK_TT>(
+    inputScalars, (SimplexId *)inputOffsets, triangulation);
 
   ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(
     outputJTPersistenceCurve, TreeType::Join, JTPlot);

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -228,14 +228,6 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
   vtkTable *outputSTPersistenceCurve = vtkTable::GetData(outputVector, 2);
   vtkTable *outputCTPersistenceCurve = vtkTable::GetData(outputVector, 3);
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  vtkPointData *pointData = input->GetPointData();
-  if(!pointData) {
-    cerr << "[ttkPersistenceCurve] Error : input has no point data." << endl;
-    return -1;
-  }
-#endif
-
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!triangulation) {
@@ -277,9 +269,10 @@ int ttkPersistenceCurve::RequestData(vtkInformation *request,
        outputSTPersistenceCurve, outputCTPersistenceCurve,
        (VTK_TT *)ttkUtils::GetVoidPointer(inputScalars),
        offsetField->GetDataType(), ttkUtils::GetVoidPointer(offsetField),
-       (TTK_TT *)(triangulation->getData()))))
-    // something wrong in baseCode
-    if(status) {
+       (TTK_TT *)(triangulation->getData()))));
+
+  // something wrong in baseCode
+  if(status) {
     std::stringstream msg;
     msg << "PersistenceCurve::execute() error code : " << status;
     this->printErr(msg.str());

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -386,7 +386,7 @@ int ttkPersistenceDiagram::dispatch(
   vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
 
   if(computeDiagram_) {
-    ret = this->execute<VTK_TT, SimplexId, TTK_TT>(
+    ret = this->execute<VTK_TT, TTK_TT>(
       *CTDiagram, inputScalars, (SimplexId *)inputOffsets, triangulation);
 #ifndef TTK_ENABLE_KAMIKAZE
     if(ret) {

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -386,12 +386,8 @@ int ttkPersistenceDiagram::dispatch(
   vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
 
   if(computeDiagram_) {
-    if(inputOffsetsDataType == VTK_INT)
-      ret = this->execute<VTK_TT, int, TTK_TT>(
-        *CTDiagram, inputScalars, (int *)inputOffsets, triangulation);
-    if(inputOffsetsDataType == VTK_ID_TYPE)
-      ret = this->execute<VTK_TT, vtkIdType, TTK_TT>(
-        *CTDiagram, inputScalars, (vtkIdType *)inputOffsets, triangulation);
+    ret = this->execute<VTK_TT, SimplexId, TTK_TT>(
+      *CTDiagram, inputScalars, (SimplexId *)inputOffsets, triangulation);
 #ifndef TTK_ENABLE_KAMIKAZE
     if(ret) {
       std::stringstream msg;

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -433,14 +433,6 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
   vtkUnstructuredGrid *outputCTPersistenceDiagram
     = vtkUnstructuredGrid::GetData(outputVector, 0);
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  vtkPointData *pointData = input->GetPointData();
-  if(!pointData) {
-    this->printErr("Input has no point data.");
-    return 0;
-  }
-#endif
-
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!triangulation) {

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -102,19 +102,6 @@ int ttkReebSpace::RequestData(vtkInformation *request,
     return -1;
   }
 
-  if(offsetFieldU) {
-    sosOffsetsU_.resize(offsetFieldU->GetNumberOfTuples());
-    for(vtkIdType i = 0; i < offsetFieldU->GetNumberOfTuples(); i++) {
-      sosOffsetsU_[i] = offsetFieldU->GetTuple1(i);
-    }
-  }
-  if(offsetFieldV) {
-    sosOffsetsV_.resize(offsetFieldV->GetNumberOfTuples());
-    for(vtkIdType i = 0; i < offsetFieldV->GetNumberOfTuples(); i++) {
-      sosOffsetsV_[i] = offsetFieldV->GetTuple1(i);
-    }
-  }
-
   this->printMsg("U-component: `" + std::string{uComponent->GetName()} + "'");
   this->printMsg("V-component: `" + std::string{vComponent->GetName()} + "'");
 
@@ -124,8 +111,10 @@ int ttkReebSpace::RequestData(vtkInformation *request,
   }
   this->preconditionTriangulation(triangulation);
 
-  this->setSosOffsetsU(&sosOffsetsU_);
-  this->setSosOffsetsV(&sosOffsetsV_);
+  this->setSosOffsetsU(
+    static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(offsetFieldU)));
+  this->setSosOffsetsV(
+    static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(offsetFieldV)));
 
 #ifndef TTK_ENABLE_DOUBLE_TEMPLATING
   if(uComponent->GetDataType() != vComponent->GetDataType()) {

--- a/core/vtk/ttkReebSpace/ttkReebSpace.h
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.h
@@ -194,6 +194,4 @@ private:
   bool UseOctreeAcceleration{true};
   int SimplificationCriterion{1};
   double SimplificationThreshold{0.0};
-
-  std::vector<ttk::SimplexId> sosOffsetsU_{}, sosOffsetsV_{};
 };

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -83,22 +83,12 @@ int ttkScalarFieldCriticalPoints::RequestData(
             {"  Offset Array", offsetField ? offsetField->GetName() : "None"}});
 
   int status = 0;
-  if(offsetField->GetDataType() == VTK_INT) {
-    ttkTemplateMacro(
-      triangulation->getType(),
-      (status = this->execute(
-         static_cast<int *>(ttkUtils::GetVoidPointer(offsetField)),
-         (TTK_TT *)triangulation->getData())));
-  } else if(offsetField->GetDataType() == VTK_ID_TYPE) {
-    ttkTemplateMacro(
-      triangulation->getType(),
-      (status = this->execute(
-         static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(offsetField)),
-         (TTK_TT *)triangulation->getData())));
-  } else {
-    this->printErr("Wrong offset field type");
-    return 0;
-  }
+  ttkTemplateMacro(
+    triangulation->getType(),
+    (status = this->execute(
+       static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsetField)),
+       (TTK_TT *)triangulation->getData())));
+
   if(status < 0)
     return 0;
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -138,28 +138,15 @@ int ttkTopologicalSimplification::RequestData(
   }
 
   int ret{};
-  if(offsets->GetDataType() == VTK_INT) {
-    switch(inputScalars->GetDataType()) {
-      vtkTemplateMacro(
-        ret = this->execute(
-          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
-          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
-          static_cast<int *>(ttkUtils::GetVoidPointer(identifiers)),
-          static_cast<int *>(ttkUtils::GetVoidPointer(offsets)),
-          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-          numberOfConstraints, *triangulation->getData()));
-    }
-  } else if(offsets->GetDataType() == VTK_ID_TYPE) {
-    switch(inputScalars->GetDataType()) {
-      vtkTemplateMacro(
-        ret = this->execute(
-          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
-          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
-          static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(identifiers)),
-          static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(offsets)),
-          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-          numberOfConstraints, *triangulation->getData()));
-    }
+  switch(inputScalars->GetDataType()) {
+    vtkTemplateMacro(
+      ret = this->execute(
+        static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
+        static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
+        static_cast<int *>(ttkUtils::GetVoidPointer(identifiers)),
+        static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsets)),
+        static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
+        numberOfConstraints, *triangulation->getData()));
   }
 
   // something wrong in baseCode

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
@@ -149,9 +149,17 @@ int ttkTrackingFromFields::RequestData(vtkInformation *request,
   for(int i = 0; i < numberOfInputFields; ++i) {
     vtkDataArray *currentScalarField = pointData->GetArray(i);
     if(currentScalarField == nullptr
-       || firstScalarField->GetDataType()
-            != currentScalarField->GetDataType()) {
-      this->printErr("Inconsistent field data type or size");
+       || currentScalarField->GetName() == nullptr) {
+      continue;
+    }
+    std::string sfname{currentScalarField->GetName()};
+    if(sfname.rfind("_Order") == (sfname.size() - 6)) {
+      continue;
+    }
+    if(firstScalarField->GetDataType() != currentScalarField->GetDataType()) {
+      this->printErr("Inconsistent field data type or size between fields `"
+                     + std::string{firstScalarField->GetName()} + "' and `"
+                     + sfname + "'");
       return -1;
     }
     inputScalarFieldsRaw.push_back(currentScalarField);
@@ -165,6 +173,7 @@ int ttkTrackingFromFields::RequestData(vtkInformation *request,
                 s1.begin(), s1.end(), s2.begin(), s2.end());
             });
 
+  numberOfInputFields = inputScalarFieldsRaw.size();
   int end = EndTimestep <= 0 ? numberOfInputFields
                              : std::min(numberOfInputFields, EndTimestep);
   for(int i = StartTimestep; i < end; i += Sampling) {

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
@@ -128,21 +128,21 @@ int ttkTrackingFromFields::RequestData(vtkInformation *request,
   }
 
   // 0. get data
-  unsigned long fieldNumber = inputScalarFields.size();
+  int fieldNumber = inputScalarFields.size();
   std::vector<void *> inputFields(fieldNumber);
-  for(int i = 0; i < (int)fieldNumber; ++i)
+  for(int i = 0; i < fieldNumber; ++i)
     inputFields[i] = ttkUtils::GetVoidPointer(inputScalarFields[i]);
   this->setInputScalars(inputFields);
 
   // 0'. get offsets
-  auto numberOfVertices = (int)input->GetNumberOfPoints();
-  vtkIdTypeArray *offsets_ = vtkIdTypeArray::New();
-  offsets_->SetNumberOfComponents(1);
-  offsets_->SetNumberOfTuples(numberOfVertices);
-  offsets_->SetName("OffsetScalarField");
-  for(int i = 0; i < numberOfVertices; ++i)
-    offsets_->SetTuple1(i, i);
-  this->setInputOffsets(ttkUtils::GetVoidPointer(offsets_));
+  std::vector<SimplexId *> inputOrders(fieldNumber);
+  for(int i = 0; i < fieldNumber; ++i) {
+    auto orderArray
+      = this->GetOffsetField(inputScalarFields[i], false, 0, input);
+    inputOrders[i]
+      = static_cast<SimplexId *>(ttkUtils::GetVoidPointer(orderArray));
+  }
+  this->setInputOffsets(inputOrders);
 
   int status = 0;
   if(useTTKMethod) {

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
@@ -137,8 +137,8 @@ int ttkTrackingFromFields::RequestData(vtkInformation *request,
   // 0'. get offsets
   std::vector<SimplexId *> inputOrders(fieldNumber);
   for(int i = 0; i < fieldNumber; ++i) {
-    auto orderArray
-      = this->GetOffsetField(inputScalarFields[i], false, 0, input);
+    this->SetInputArrayToProcess(0, 0, 0, 0, inputScalarFields[i]->GetName());
+    auto orderArray = this->GetOrderArray(input, 0, 0, false);
     inputOrders[i]
       = static_cast<SimplexId *>(ttkUtils::GetVoidPointer(orderArray));
   }

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.h
@@ -1,37 +1,12 @@
 #pragma once
 
-#include <tuple>
-
-#include <ttkAlgorithm.h>
-// #include <ttkUtils.h>
-
-#include <vtkCellData.h>
-#include <vtkCellType.h>
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
 #include <vtkDataSet.h>
-#include <vtkDataSetAlgorithm.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkInformationVector.h>
-#include <vtkIntArray.h>
-#include <vtkNew.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkPoints.h>
-#include <vtkTable.h>
 #include <vtkUnstructuredGrid.h>
 
-#include <ttkTrackingFromPersistenceDiagrams.h>
-
 // VTK Module
-#include <ttkTrackingFromFieldsModule.h>
-#include <ttkTrackingFromPersistenceDiagramsModule.h>
-
 #include <TrackingFromFields.h>
-#include <TrackingFromPersistenceDiagrams.h>
+#include <ttkAlgorithm.h>
+#include <ttkTrackingFromFieldsModule.h>
 
 #include <algorithm>
 #include <string>
@@ -96,15 +71,10 @@ public:
   vtkGetMacro(PostProcThresh, double);
 
 protected:
-  ttkTrackingFromFields() {
-    SetNumberOfInputPorts(1);
-    SetNumberOfOutputPorts(1);
-  }
+  ttkTrackingFromFields();
 
-  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
-
-  virtual int FillOutputPortInformation(int port,
-                                        vtkInformation *info) override;
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
@@ -133,98 +103,9 @@ private:
   int PVAlgorithm{-1};
   std::string WassersteinMetric{"2"};
 
-  // ttk::Triangulation *internalTriangulation_;
-  // ttkTriangulation triangulation_;
-  ttk::TrackingFromFields trackingF_;
-  ttk::TrackingFromPersistenceDiagrams tracking_;
-
   template <class dataType, class triangulationType>
   int trackWithPersistenceMatching(vtkDataSet *input,
                                    vtkUnstructuredGrid *output,
                                    unsigned long fieldNumber,
                                    const triangulationType *triangulation);
 };
-
-// (*) Persistence-driven approach
-template <class dataType, class triangulationType>
-int ttkTrackingFromFields::trackWithPersistenceMatching(
-  vtkDataSet *input,
-  vtkUnstructuredGrid *output,
-  unsigned long fieldNumber,
-  const triangulationType *triangulation) {
-
-  using trackingTuple = ttk::trackingTuple;
-
-  // 1. get persistence diagrams.
-  std::vector<std::vector<diagramTuple>> persistenceDiagrams(
-    fieldNumber, std::vector<diagramTuple>());
-
-  this->performDiagramComputation<dataType, triangulationType>(
-    (int)fieldNumber, persistenceDiagrams, triangulation);
-
-  // 2. call feature tracking with threshold.
-  std::vector<std::vector<matchingTuple>> outputMatchings(
-    fieldNumber - 1, std::vector<matchingTuple>());
-
-  double spacing = Spacing;
-  std::string algorithm = DistanceAlgorithm;
-  double alpha = Alpha;
-  double tolerance = Tolerance;
-  bool is3D = true; // Is3D;
-  std::string wasserstein = WassersteinMetric;
-
-  tracking_.setThreadNumber(this->threadNumber_);
-  tracking_.performMatchings<dataType>(
-    (int)fieldNumber, persistenceDiagrams, outputMatchings,
-    algorithm, // Not from paraview, from enclosing tracking plugin
-    wasserstein, tolerance, is3D,
-    alpha, // Blending
-    PX, PY, PZ, PS, PE // Coefficients
-  );
-
-  vtkNew<vtkPoints> points{};
-  vtkNew<vtkUnstructuredGrid> persistenceDiagram{};
-
-  vtkNew<vtkDoubleArray> persistenceScalars{};
-  vtkNew<vtkDoubleArray> valueScalars{};
-  vtkNew<vtkIntArray> matchingIdScalars{};
-  vtkNew<vtkIntArray> lengthScalars{};
-  vtkNew<vtkIntArray> timeScalars{};
-  vtkNew<vtkIntArray> componentIds{};
-  vtkNew<vtkIntArray> pointTypeScalars{};
-
-  persistenceScalars->SetName("Cost");
-  valueScalars->SetName("Scalar");
-  matchingIdScalars->SetName("MatchingIdentifier");
-  lengthScalars->SetName("ComponentLength");
-  timeScalars->SetName("TimeStep");
-  componentIds->SetName("ConnectedComponentId");
-  pointTypeScalars->SetName("CriticalType");
-
-  // (+ vertex id)
-  std::vector<trackingTuple> trackingsBase;
-  tracking_.performTracking<dataType>(
-    persistenceDiagrams, outputMatchings, trackingsBase);
-
-  std::vector<std::set<int>> trackingTupleToMerged(
-    trackingsBase.size(), std::set<int>());
-
-  if(DoPostProc) {
-    tracking_.performPostProcess<dataType>(persistenceDiagrams, trackingsBase,
-                                           trackingTupleToMerged,
-                                           PostProcThresh);
-  }
-
-  bool useGeometricSpacing = UseGeometricSpacing;
-
-  // Build mesh.
-  ttkTrackingFromPersistenceDiagrams::buildMesh<dataType>(
-    trackingsBase, outputMatchings, persistenceDiagrams, useGeometricSpacing,
-    spacing, DoPostProc, trackingTupleToMerged, points, persistenceDiagram,
-    persistenceScalars, valueScalars, matchingIdScalars, lengthScalars,
-    timeScalars, componentIds, pointTypeScalars);
-
-  output->ShallowCopy(persistenceDiagram);
-
-  return 1;
-}

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -192,8 +192,7 @@ int main(int argc, char **argv) {
   std::vector<std::pair<float, ttk::SimplexId>> outputCurve;
   curve.preconditionTriangulation(&triangulation);
   curve.setOutputCTPlot(&outputCurve);
-  curve.execute<float, ttk::SimplexId>(
-    height.data(), offsets.data(), &triangulation);
+  curve.execute<float>(height.data(), offsets.data(), &triangulation);
 
   // 3. computing the persitence diagram
   ttk::PersistenceDiagram diagram;
@@ -201,7 +200,7 @@ int main(int argc, char **argv) {
                          ttk::CriticalType, float, ttk::SimplexId>>
     diagramOutput;
   diagram.preconditionTriangulation(&triangulation);
-  diagram.execute<float, ttk::SimplexId>(
+  diagram.execute<float>(
     diagramOutput, height.data(), offsets.data(), &triangulation);
 
   // 4. selecting the critical point pairs
@@ -220,10 +219,10 @@ int main(int argc, char **argv) {
   // 6. simplifying the input data to remove non-persistent pairs
   ttk::TopologicalSimplification simplification;
   simplification.preconditionTriangulation(&triangulation);
-  simplification.execute<float, ttk::SimplexId>(
-    height.data(), simplifiedHeight.data(), authorizedCriticalPoints.data(),
-    offsets.data(), simplifiedOffsets.data(), authorizedCriticalPoints.size(),
-    triangulation);
+  simplification.execute<float>(height.data(), simplifiedHeight.data(),
+                                authorizedCriticalPoints.data(), offsets.data(),
+                                simplifiedOffsets.data(),
+                                authorizedCriticalPoints.size(), triangulation);
 
   // assign the simplified values to the input mesh
   for(int i = 0; i < (int)simplifiedHeight.size(); i++) {

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
     &separatrices1_cells_separatrixFunctionDiffs,
     &separatrices1_cells_isOnBoundary);
 
-  morseSmaleComplex.execute<float, ttk::SimplexId>(triangulation);
+  morseSmaleComplex.execute<float>(triangulation);
 
   // save the output
   save(pointSet, triangleSetCo, triangleSetOff, "output.off");


### PR DESCRIPTION
This PR replaces the use of offset fields with order fields in the following filter:
* ContourForests
* DiscreteGradient & MorseSmaleComplex
* FTMTree
* FTRGraph
* IntegralLines
* PersistenceDiagram
* PersistenceCurve
* ScalarFieldCriticalPoints
* TopologicalCompression
* TopologicalSimplification
* TrackingFromFields

In particular, the offset sorting routines in ContourForests, FTMTree and FTRGraph have been remove.

A bug in the order field generated by TopologicalSimplification has also been fixed (wrong initial value).

Due to the fixed type of the order arrays (a buffer of SimplexId), some now unecessary copies/conversions have been remove, particularly in JacobiSet and ReebSpace. In the VTK layer, tests of the offset field type around `vtkTemplateMacro` calls have been removed, leading to a reduction of generated code (and improved build times). Base code has been de-templatized over the offset type, particularly in DiscreteGradient and MorseSmaleComplex.

The base layer C++ example has been updated to the new API calls.

No change has been observed in the ttk-data states.

Enjoy,
Pierre 