### PR TITLE
Order arrays preconditioning for users of the base layer API

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -227,6 +227,13 @@ namespace ttk {
     /**
      * Set the input offset field associated on the points of the data set
      * (if none, identifiers are used instead).
+     *
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p data buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
      */
     inline int setInputOffsets(const SimplexId *const data) {
       inputOffsets_ = data;

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -20,10 +20,10 @@
 /// and local scope, time and memory measurements, etc.
 /// Each ttk class should inheritate from it.
 
-#ifndef _DEBUG_H
-#define _DEBUG_H
+#pragma once
 
 #include <BaseClass.h>
+
 #include <algorithm>
 #include <cerrno>
 #include <fstream>
@@ -491,5 +491,6 @@ namespace ttk {
   class DebugMemory : public Memory {};
 } // namespace ttk
 
-#endif
+#include <OrderDisambiguation.h>
+
 /// @}

--- a/core/base/common/OrderDisambiguation.h
+++ b/core/base/common/OrderDisambiguation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <DataTypes.h>
+#include <Debug.h>
 
 #include <algorithm>
 #include <vector>
@@ -67,5 +68,23 @@ namespace ttk {
     for(size_t i = 0; i < sortedVertices.size(); ++i) {
       order[sortedVertices[i]] = i;
     }
+  }
+
+  /**
+   * @brief Precondition an order array to be consumed by the base layer API
+   *
+   * @param[in] nVerts number of vertices
+   * @param[in] scalars pointer to scalar field buffer of size @p nVerts
+   * @param[out] order pointer to pre-allocated order buffer of size @p nVerts
+   * @param[in] nThreads number of threads to be used
+   */
+  template <typename scalarType>
+  inline void preconditionOrderArray(const size_t nVerts,
+                                     const scalarType *const scalars,
+                                     SimplexId *const order,
+                                     const int nThreads
+                                     = ttk::globalThreadNumber_) {
+    ttk::sortVertices(
+      nVerts, scalars, static_cast<int *>(nullptr), order, nThreads);
   }
 } // namespace ttk

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -166,6 +166,14 @@ namespace ttk {
       // offset
       // .....................{
 
+      /**
+       * @pre For this function to behave correctly in the absence of
+       * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+       * called to fill the @p offsets buffer prior to any
+       * computation (the VTK wrapper already includes a mecanism to
+       * automatically generate such a preconditioned buffer).
+       * @see examples/c++/main.cpp for an example use.
+       */
       inline void setVertexSoSoffsets(const SimplexId *const offsets) {
         scalars_->sosOffsets = offsets;
       }

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -420,6 +420,13 @@ according to them.
 
       /**
        * Set the input offset function.
+       *
+       * @pre For this function to behave correctly in the absence of
+       * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+       * called to fill the @p data buffer prior to any
+       * computation (the VTK wrapper already includes a mecanism to
+       * automatically generate such a preconditioned buffer).
+       * @see examples/c++/main.cpp for an example use.
        */
       inline void setInputOffsets(const SimplexId *const data) {
         inputOffsets_ = data;

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -356,6 +356,14 @@ namespace ttk {
       }
 
       // offset
+      /**
+       * @pre For this function to behave correctly in the absence of
+       * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+       * called to fill the @p sos buffer prior to any
+       * computation (the VTK wrapper already includes a mecanism to
+       * automatically generate such a preconditioned buffer).
+       * @see examples/c++/main.cpp for an example use.
+       */
       inline void setVertexSoSoffsets(const SimplexId *const sos) {
         scalars_->offsets = sos;
       }

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -66,6 +66,14 @@ namespace ttk {
         values_ = values;
       }
 
+      /**
+       * @pre For this function to behave correctly in the absence of
+       * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+       * called to fill the @p sos buffer prior to any
+       * computation (the VTK wrapper already includes a mecanism to
+       * automatically generate such a preconditioned buffer).
+       * @see examples/c++/main.cpp for an example use.
+       */
       void setOffsets(const SimplexId *const sos) {
         offsets_ = sos;
       }

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -80,6 +80,14 @@ namespace ttk {
       inputScalarField_ = data;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p data buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setInputOffsets(const SimplexId *const data) {
       inputOffsets_ = data;
     }

--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -76,10 +76,26 @@ namespace ttk {
       setSosOffsetsU(sosOffsets->data());
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p sosOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setSosOffsetsU(const SimplexId *const sosOffsets) {
       sosOffsetsU_ = sosOffsets;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p sosOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setSosOffsetsV(const SimplexId *const sosOffsets) {
       sosOffsetsV_ = sosOffsets;
     }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -303,6 +303,14 @@ namespace ttk {
       return 0;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p data buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline int setInputOffsets(const SimplexId *const data) {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!abstractMorseSmaleComplex_) {

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -43,6 +43,14 @@ namespace ttk {
       const std::vector<std::tuple<SimplexId, SimplexId, scalarType>> &pairs,
       std::vector<std::pair<scalarType, SimplexId>> &plot) const;
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p inputOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     template <typename scalarType,
               class triangulationType = ttk::AbstractTriangulation>
     int execute(const scalarType *inputScalars,

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -78,6 +78,14 @@ namespace ttk {
                              ttk::SimplexId>> &diagram,
       const scalarType *scalars) const;
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p inputOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     template <typename scalarType, class triangulationType>
     int execute(std::vector<std::tuple<ttk::SimplexId,
                                        ttk::CriticalType,

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -209,10 +209,26 @@ namespace ttk {
       return false;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p sosOffsetsU buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setSosOffsetsU(const SimplexId *const sosOffsetsU) {
       sosOffsetsU_ = sosOffsetsU;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p sosOffsetsV buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setSosOffsetsV(const SimplexId *const sosOffsetsV) {
       sosOffsetsV_ = sosOffsetsV;
     }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -34,9 +34,18 @@ namespace ttk {
   public:
     ScalarFieldCriticalPoints();
 
-    /// Execute the package.
-    /// \param argment Dummy integer argument.
-    /// \return Returns 0 upon success, negative values otherwise.
+    /**
+     * Execute the package.
+     * \param argment Dummy integer argument.
+     * \return Returns 0 upon success, negative values otherwise.
+     *
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p offsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     template <class triangulationType = AbstractTriangulation>
     int execute(const SimplexId *const offsets,
                 const triangulationType *triangulation);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -43,6 +43,14 @@ namespace ttk {
     // Base code methods.
     TopologicalCompression();
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p inputOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     template <class dataType,
               typename triangulationType = AbstractTriangulation>
     int execute(const dataType *const inputData,

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -89,6 +89,14 @@ namespace ttk {
     int addPerturbation(dataType *const scalars,
                         SimplexId *const offsets) const;
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p inputOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     template <typename dataType, typename triangulationType>
     int execute(const dataType *const inputScalars,
                 dataType *const outputScalars,

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -63,6 +63,14 @@ namespace ttk {
       inputData_ = is;
     }
 
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill every buffer in the @p io vector prior to any
+     * computation (the VTK wrapper already includes a mecanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
     inline void setInputOffsets(std::vector<SimplexId *> &io) {
       inputOffsets_ = io;
     }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -358,10 +358,9 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       newOrderArray->SetNumberOfTuples(nVertices);
 
       switch(scalarArray->GetDataType()) {
-        vtkTemplateMacro(ttk::sortVertices(
+        vtkTemplateMacro(ttk::preconditionOrderArray(
           nVertices,
           static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(scalarArray)),
-          static_cast<int *>(nullptr),
           static_cast<ttk::SimplexId *>(
             ttkUtils::GetVoidPointer(newOrderArray)),
           this->threadNumber_));


### PR DESCRIPTION
This PR introduces a new function, `preconditionOrderArray`, in `core/base/common/OrderBaseDisambiguation.h` that wraps the `sortedVertices` function. This new functions is for users of the base layer API that don't use the automatic mechanisms available in the VTK layer (`GetOrderArray` and `ArrayPreconditioning`).

Doxygen comments that warn to use this function to precondition order arrays before executing base layer modules have been introduced above the relevant methods. 

The C++ example has been fixed to use this new method.

Enjoy,
Pierre