### PR TITLE
ParaView 5.8.0 patches for generating binary packages

### DIFF
--- a/paraview/patch/main.yml
+++ b/paraview/patch/main.yml
@@ -1,0 +1,186 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branch-ignore:
+      - '*'
+    tags:
+      - 'v*'
+      - 'dev*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build-linux:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt update
+        # ParaView dependencies
+        sudo apt install -y \
+          qt5-default \
+          qttools5-dev \
+          qtxmlpatterns5-dev-tools \
+          libqt5x11extras5-dev \
+          libqt5svg5-dev \
+          dpkg-dev
+
+    - name: Build patched ParaView & create package
+      run: |
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DVTK_ENABLE_OSPRAY=OFF \
+          $GITHUB_WORKSPACE
+        make -j$(nproc)
+        cpack -G DEB
+
+    - name: Update package informations
+      run: |
+        cd build
+        # unpack deb package to access control file
+        mkdir tmp
+        dpkg-deb -x ttk-paraview.deb tmp
+        dpkg-deb --control ttk-paraview.deb tmp/DEBIAN
+        # modify control file, remove libgcc-s1 dependency
+        sed 's/libgcc-s1[^,]*, //g' -i tmp/DEBIAN/control
+        # build updated deb package
+        dpkg -b tmp ttk-paraview.deb.new
+        # replace old package with new
+        mv ttk-paraview.deb.new ttk-paraview.deb
+
+    - name: Upload .deb package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview-${{ matrix.os }}.deb
+        path: build/ttk-paraview.deb
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install macOS dependencies
+      run: |
+        brew cask install xquartz
+        brew install wget python libomp mesa glew boost qt ninja
+
+    - name: Build patched ParaView & create package
+      run: |
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DVTK_ENABLE_OSPRAY=OFF \
+          -DQt5_DIR=$(brew --prefix qt)/lib/cmake/Qt5 \
+          -GNinja \
+          $GITHUB_WORKSPACE
+        ninja
+        cpack -G productbuild
+
+    - name: Upload .pgk package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview.pkg
+        path: build/ttk-paraview.pkg
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install qt with conda
+      shell: bash
+      run: |
+        conda install -c anaconda qt
+
+    - name: Configure & build ParaView
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DVTK_ENABLE_OSPRAY=OFF -GNinja ..
+        ninja
+        cpack -G NSIS64
+
+    - name: Upload .exe installer
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview.exe
+        path: build/ttk-paraview.exe
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-macos, build-windows]
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Fetch all uploaded artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Upload Ubuntu Bionic .deb as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk-paraview-ubuntu-18.04.deb/ttk-paraview.deb
+        asset_name: ttk-paraview-ubuntu-18.04.deb
+        asset_content_type: application/vnd.debian.binary-package
+
+    - name: Upload Ubuntu Focal .deb as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk-paraview-ubuntu-20.04.deb/ttk-paraview.deb
+        asset_name: ttk-paraview-ubuntu-20.04.deb
+        asset_content_type: application/vnd.debian.binary-package
+
+    - name: Upload .pkg as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk-paraview.pkg/ttk-paraview.pkg
+        asset_name: ttk-paraview.pkg
+        asset_content_type: application/x-newton-compatible-pkg
+
+    - name: Upload .exe as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk-paraview.exe/ttk-paraview.exe
+        asset_name: ttk-paraview.exe
+        asset_content_type: application/vnd.microsoft.portable-executable

--- a/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
+++ b/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
@@ -1,0 +1,26 @@
+diff --git c/CMakeLists.txt w/CMakeLists.txt
+index 792bfff6..3870fbb5 100644
+--- c/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -803,3 +803,21 @@ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
+ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example3.vti
+   DESTINATION share/paraview-5.8/examples/
+   COMPONENT development)
++
++#-----------------------------------------------------------------------------
++# Generate a .deb package
++set(CPACK_PACKAGE_NAME "TTK-ParaView")
++set(CPACK_PACKAGE_FILE_NAME "ttk-paraview")
++set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ParaView built with TTK patches")
++set(CPACK_PACKAGE_CONTACT "Julien Tierny <julien.tierny@sorbonne-universite.fr>")
++set(CPACK_PACKAGE_VENDOR "LIP6 - Sorbonne Université")
++set(CPACK_PACKAGE_HOMEPAGE_URL "https://topology-tool-kit.github.io/")
++set(CPACK_DEBIAN_PACKAGE_DEPENDS
++  "qt5-default, qttools5-dev, libqt5x11extras5-dev, qtxmlpatterns5-dev-tools, libqt5svg5-dev, libxt-dev"
++  )
++set(CPACK_PACKAGE_VERSION_MAJOR ${PARAVIEW_VERSION_MAJOR})
++set(CPACK_PACKAGE_VERSION_MINOR ${PARAVIEW_VERSION_MINOR})
++set(CPACK_PACKAGE_VERSION_PATCH ${PARAVIEW_VERSION_PATCH})
++# autogenerate dependency information
++set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
++include(CPack)

--- a/paraview/patch/paraview-5.8.0-build-options-CMakeLists.txt.patch
+++ b/paraview/patch/paraview-5.8.0-build-options-CMakeLists.txt.patch
@@ -1,0 +1,41 @@
+diff --git a/CMake/ParaViewOptions.cmake b/CMake/ParaViewOptions.cmake
+index 5e402e9f..c8a0b5f2 100644
+--- a/CMake/ParaViewOptions.cmake
++++ b/CMake/ParaViewOptions.cmake
+@@ -99,7 +99,7 @@ option(PARAVIEW_USE_MPI "Enable MPI support for parallel computing" OFF)
+ option(PARAVIEW_USE_CUDA "Support CUDA compilation" OFF)
+ option(PARAVIEW_USE_VTKM "Enable VTK-m accelerated algorithms" "${PARAVIEW_ENABLE_NONESSENTIAL}")
+ 
+-vtk_deprecated_setting(python_default PARAVIEW_USE_PYTHON PARAVIEW_ENABLE_PYTHON OFF)
++vtk_deprecated_setting(python_default PARAVIEW_USE_PYTHON PARAVIEW_ENABLE_PYTHON ON)
+ option(PARAVIEW_USE_PYTHON "Enable/Disable Python scripting support" "${python_default}")
+ 
+ # Currently, we're making `PARAVIEW_USE_QT` available only when doing CANONICAL
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0f9ad4a2..792bfff6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,8 +52,8 @@ endif ()
+ get_property(generator_is_multi_config GLOBAL
+   PROPERTY GENERATOR_IS_MULTI_CONFIG)
+ if (NOT CMAKE_BUILD_TYPE AND NOT generator_is_multi_config)
+-  message(STATUS "Setting build type to 'Debug' as none was specified.")
+-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
++  message(STATUS "Setting build type to 'Release' as none was specified.")
++  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+   # Set the possible values of build type for cmake-gui
+   set_property(CACHE CMAKE_BUILD_TYPE
+     PROPERTY
+diff --git a/VTK/CMake/vtkWrapSettings.cmake b/VTK/CMake/vtkWrapSettings.cmake
+index 3faaefe0..0e5ff996 100644
+--- a/VTK/CMake/vtkWrapSettings.cmake
++++ b/VTK/CMake/vtkWrapSettings.cmake
+@@ -2,7 +2,7 @@
+ 
+ # Add the option for build the Python wrapping to VTK.
+ option(VTK_WRAP_PYTHON "Should VTK Python wrapping be built?" OFF)
+-set(VTK_PYTHON_VERSION 2 CACHE STRING
++set(VTK_PYTHON_VERSION 3 CACHE STRING
+   "Python version to use")
+ set_property(CACHE VTK_PYTHON_VERSION
+   PROPERTY

--- a/paraview/patch/paraview-5.8.0-numpy_interface-warning.patch
+++ b/paraview/patch/paraview-5.8.0-numpy_interface-warning.patch
@@ -1,0 +1,13 @@
+diff --git a/VTK/Wrapping/Python/vtkmodules/numpy_interface/algorithms.py b/VTK/Wrapping/Python/vtkmodules/numpy_interface/algorithms.py
+index 51e2ea7d..2a5e888f 100644
+--- a/VTK/Wrapping/Python/vtkmodules/numpy_interface/algorithms.py
++++ b/VTK/Wrapping/Python/vtkmodules/numpy_interface/algorithms.py
+@@ -206,7 +206,7 @@ def _global_func(impl, array, axis, controller):
+                 return dsa.NoneArray;
+ 
+             if res is dsa.NoneArray:
+-                if max_dims is 1:
++                if max_dims == 1:
+                     # Weird trick to make the array look like a scalar
+                     max_dims = ()
+                 res = numpy.empty(max_dims)

--- a/paraview/patch/paraview-examples-5.8-CMakeLists.txt.patch
+++ b/paraview/patch/paraview-examples-5.8-CMakeLists.txt.patch
@@ -9,12 +9,12 @@
 +# Install TTK example data
 +install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example1.vti
 +  DESTINATION share/paraview-5.8/examples/
-+  COMPONENT Development)
++  COMPONENT development)
 +
 +install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
 +  DESTINATION share/paraview-5.8/examples/
-+  COMPONENT Development)
++  COMPONENT development)
 +
 +install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example3.vti
 +  DESTINATION share/paraview-5.8/examples/
-+  COMPONENT Development)
++  COMPONENT development)

--- a/paraview/patch/patch-paraview-5.8.0.sh
+++ b/paraview/patch/patch-paraview-5.8.0.sh
@@ -87,6 +87,10 @@ $PATCH_BIN Qt/ApplicationComponents/pqExampleVisualizationsDialog.cxx \
 $PATCH_BIN Remoting/Core/vtkPVFileInformation.cxx \
   < "${PATCH_DIR}/paraview-5.8.0-vtkPVFileInformation.cxx.patch"
 
+## CPack variables for packaging meta-data
+$PATCH_BIN -p1 \
+  < "${PATCH_DIR}/paraview-5.8.0-CPack-CMakeLists.txt.patch"
+
 echo "Finished patching."
 
 cd "$PATCH_DIR" || exit 4

--- a/paraview/patch/patch-paraview-5.8.0.sh
+++ b/paraview/patch/patch-paraview-5.8.0.sh
@@ -90,6 +90,10 @@ $PATCH_BIN Remoting/Core/vtkPVFileInformation.cxx \
 ## CPack variables for packaging meta-data
 $PATCH_BIN -p1 \
   < "${PATCH_DIR}/paraview-5.8.0-CPack-CMakeLists.txt.patch"
+$PATCH_BIN -p1 \
+  < "${PATCH_DIR}/paraview-5.8.0-build-options-CMakeLists.txt.patch"
+$PATCH_BIN -p1 \
+  < "${PATCH_DIR}/paraview-5.8.0-numpy_interface-warning.patch"
 mkdir -p .github/workflows/
 cp ${PATCH_DIR}/main.yml .github/workflows
 

--- a/paraview/patch/patch-paraview-5.8.0.sh
+++ b/paraview/patch/patch-paraview-5.8.0.sh
@@ -90,6 +90,8 @@ $PATCH_BIN Remoting/Core/vtkPVFileInformation.cxx \
 ## CPack variables for packaging meta-data
 $PATCH_BIN -p1 \
   < "${PATCH_DIR}/paraview-5.8.0-CPack-CMakeLists.txt.patch"
+mkdir -p .github/workflows/
+cp ${PATCH_DIR}/main.yml .github/workflows
 
 echo "Finished patching."
 


### PR DESCRIPTION
This PR adds patches to the `paraview/patch` folder that enable the creation of binary packages for the following targets:
- Ubuntu 18.04 (bionic)
- Ubuntu 20.04 (focal)
- Windows Server 2019
- macOS 10.15 (Catalina).

c.f. https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners for a description of the available virtual environments.

From the ParaView 5.8.0 sources, the TTK patching process should set the relevant build options, the packaging meta-data and set the Github Action CI file.

Packages should be automatically created when the patched ParaView sources are pushed to Github with tags that match the patterns `v*` or `dev*`. A Github release should be automatically created with links to the generated packages.

Enjoy,
Pierre