### PR TITLE
Missing vtkVersion includes

### DIFF
--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -104,7 +104,9 @@ void addValuePass(vtkDataSet *object,
     size_t nComponents = field->GetNumberOfComponents();
     for(size_t c = 0; c < nComponents; c++) {
       auto valuePass = vtkSmartPointer<vtkValuePass>::New();
+#if VTK_MAJOR_VERSION < 8 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION < 90)
       valuePass->SetRenderingMode(vtkValuePass::FLOATING_POINT);
+#endif
       valuePass->SetInputArrayToProcess(fieldType == 0
                                           ? VTK_SCALAR_MODE_USE_POINT_FIELD_DATA
                                           : VTK_SCALAR_MODE_USE_CELL_FIELD_DATA,

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -1,5 +1,6 @@
 #include <ttkCinemaQuery.h>
 
+#include <vtkVersion.h>
 #include <vtkInformation.h>
 
 #include <vtkDelimitedTextReader.h>

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -3,7 +3,7 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
-// #include <vtkVersion.h>
+#include <vtkVersion.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
 

--- a/core/vtk/ttkTriangulationAlgorithm/macro.h
+++ b/core/vtk/ttkTriangulationAlgorithm/macro.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vtkVersion.h>
 #include <vtkIdTypeArray.h>
 #include <vtkImageData.h>
 #include <vtkInformationVector.h>


### PR DESCRIPTION
This PR adds missing vtkVersion.h includes in places that use `VTK_MAJOR_VERSION` macros.
This has caused build errors for me using ParaView 5.8.0.
I'm not sure if this will not break elsewhere, since in one place this include was commented out, and there is a comment about this in config.cmake: https://github.com/topology-tool-kit/ttk/blob/dev/config.cmake#L38

Also removes the use of the deprecated `vtkValuePass::SetRenderingMode` in ttkCinemaImaging, which fails to build when VTK was configured with `VTK_LEGACY_REMOVE=ON`.