### PR TITLE
Remove linking against all VTK_LIBRARIES

### DIFF
--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -41,7 +41,6 @@ macro(ttk_add_vtk_module)
 
     vtk_module_link(${TTK_NAME}
       PUBLIC
-        ${VTK_LIBRARIES}
         ${TTK_DEPENDS}
       )
 

--- a/core/vtk/ttkCinemaImaging/vtk.module
+++ b/core/vtk/ttkCinemaImaging/vtk.module
@@ -3,3 +3,5 @@ NAME
 DEPENDS
   ttkAlgorithm
   VTK::RenderingOpenGL2
+PRIVATE_DEPENDS
+  VTK::FiltersGeometry

--- a/core/vtk/ttkCinemaProductReader/vtk.module
+++ b/core/vtk/ttkCinemaProductReader/vtk.module
@@ -3,3 +3,7 @@ NAME
 DEPENDS
   ttkAlgorithm
   ttkTopologicalCompressionReader
+PRIVATE_DEPENDS
+  VTK::IOImage
+  VTK::IOLegacy
+  VTK::IOXML

--- a/core/vtk/ttkCinemaProductReader/vtk.module
+++ b/core/vtk/ttkCinemaProductReader/vtk.module
@@ -3,7 +3,6 @@ NAME
 DEPENDS
   ttkAlgorithm
   ttkTopologicalCompressionReader
-PRIVATE_DEPENDS
   VTK::IOImage
   VTK::IOLegacy
   VTK::IOXML

--- a/core/vtk/ttkCinemaQuery/vtk.module
+++ b/core/vtk/ttkCinemaQuery/vtk.module
@@ -2,3 +2,5 @@ NAME
   ttkCinemaQuery
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::IOInfovis

--- a/core/vtk/ttkCinemaReader/vtk.module
+++ b/core/vtk/ttkCinemaReader/vtk.module
@@ -2,3 +2,5 @@ NAME
   ttkCinemaReader
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::IOInfovis

--- a/core/vtk/ttkCinemaWriter/vtk.module
+++ b/core/vtk/ttkCinemaWriter/vtk.module
@@ -3,3 +3,7 @@ NAME
 DEPENDS
   ttkAlgorithm
   ttkTopologicalCompressionWriter
+PRIVATE_DEPENDS
+  VTK::CommonSystem
+  VTK::IOInfovis
+  VTK::IOImage

--- a/core/vtk/ttkContourForests/vtk.module
+++ b/core/vtk/ttkContourForests/vtk.module
@@ -2,3 +2,5 @@ NAME
  ttkContourForests
 DEPENDS
  ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersSources

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.h
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.h
@@ -44,6 +44,28 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 
+/* Note on including VTK modules 
+ * 
+ * Each VTK module that you include a header from needs to be specified in this
+ * module's vtk.module file, either in the DEPENDS or PRIVATE_DEPENDS (if the
+ * header is included in the cpp file only) sections. 
+ * 
+ * In order to find the corresponding module, check its location within the VTK
+ * source code. The VTK module name is composed of the path to the header. You
+ * can also find the module name within the vtk.module file located in the same
+ * directory as the header file.
+ * 
+ * For example, vtkSphereSource.h is located in directory VTK/Filters/Sources/,
+ * so its corresponding VTK module is called VTK::FiltersSources. In this case,
+ * the vtk.module file would need to be extended to
+ *
+ * NAME
+ *   ttkHelloWorld
+ * DEPENDS
+ *   ttkAlgorithm
+ *   VTK::FiltersSources
+ */
+
 // TTK Base Includes
 #include <HelloWorld.h>
 

--- a/core/vtk/ttkMeshGraph/vtk.module
+++ b/core/vtk/ttkMeshGraph/vtk.module
@@ -2,3 +2,5 @@ NAME
   ttkMeshGraph
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersGeneral

--- a/core/vtk/ttkProgramBase/vtk.module
+++ b/core/vtk/ttkProgramBase/vtk.module
@@ -4,3 +4,4 @@ DEPENDS
   VTK::FiltersCore
 PRIVATE_DEPENDS
   VTK::CommonCore
+  VTK::IOXML

--- a/core/vtk/ttkProgramBase/vtk.module
+++ b/core/vtk/ttkProgramBase/vtk.module
@@ -2,6 +2,6 @@ NAME
  ttkProgramBase
 DEPENDS
   VTK::FiltersCore
+  VTK::IOXML
 PRIVATE_DEPENDS
   VTK::CommonCore
-  VTK::IOXML

--- a/core/vtk/ttkRangePolygon/vtk.module
+++ b/core/vtk/ttkRangePolygon/vtk.module
@@ -2,3 +2,6 @@ NAME
   ttkRangePolygon
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersGeneral
+  VTK::FiltersGeometry

--- a/core/vtk/ttkSphereFromPoint/vtk.module
+++ b/core/vtk/ttkSphereFromPoint/vtk.module
@@ -2,3 +2,5 @@ NAME
   ttkSphereFromPoint
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersSources

--- a/core/vtk/ttkUserInterfaceBase/vtk.module
+++ b/core/vtk/ttkUserInterfaceBase/vtk.module
@@ -5,3 +5,7 @@ DEPENDS
   VTK::RenderingOpenGL2
 PRIVATE_DEPENDS
   VTK::CommonCore
+  VTK::InteractionStyle
+  VTK::IOExport
+  VTK::IOImage
+  VTK::FiltersGeometry

--- a/core/vtk/ttkUserInterfaceBase/vtk.module
+++ b/core/vtk/ttkUserInterfaceBase/vtk.module
@@ -2,10 +2,10 @@ NAME
  ttkUserInterfaceBase
 DEPENDS
   VTK::FiltersCore
-  VTK::RenderingOpenGL2
-PRIVATE_DEPENDS
-  VTK::CommonCore
+  VTK::FiltersGeometry
   VTK::InteractionStyle
   VTK::IOExport
   VTK::IOImage
-  VTK::FiltersGeometry
+  VTK::RenderingOpenGL2
+PRIVATE_DEPENDS
+  VTK::CommonCore

--- a/core/vtk/ttkWRLExporter/vtk.module
+++ b/core/vtk/ttkWRLExporter/vtk.module
@@ -6,3 +6,4 @@ DEPENDS
   VTK::IOExport
 PRIVATE_DEPENDS
   VTK::CommonCore
+  VTK::FiltersGeometry

--- a/standalone/ContinuousScatterPlot/CMakeLists.txt
+++ b/standalone/ContinuousScatterPlot/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkContinuousScatterPlot)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkContinuousScatterPlot
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ContourAroundPoint/CMakeLists.txt
+++ b/standalone/ContourAroundPoint/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkContourAroundPoint)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkContourAroundPoint
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ContourForests/CMakeLists.txt
+++ b/standalone/ContourForests/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkContourForests)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkContourForests
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/FTMTree/CMakeLists.txt
+++ b/standalone/FTMTree/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkFTMTree)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkFTMTree
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/FTRGraph/CMakeLists.txt
+++ b/standalone/FTRGraph/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkFTRGraph)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkFTRGraph
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/HelloWorld/CMakeLists.txt
+++ b/standalone/HelloWorld/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkHelloWorld)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkHelloWorld
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/JacobiSet/CMakeLists.txt
+++ b/standalone/JacobiSet/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkJacobiSet)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkJacobiSet
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/LDistance/CMakeLists.txt
+++ b/standalone/LDistance/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkLDistance)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkLDistance
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/MandatoryCriticalPoints/CMakeLists.txt
+++ b/standalone/MandatoryCriticalPoints/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkMandatoryCriticalPoints)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkMandatoryCriticalPoints
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ManifoldCheck/CMakeLists.txt
+++ b/standalone/ManifoldCheck/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkManifoldCheck)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkManifoldCheck
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/MeshSubdivision/CMakeLists.txt
+++ b/standalone/MeshSubdivision/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkMeshSubdivision)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkMeshSubdivision
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/MorseSmaleComplex/CMakeLists.txt
+++ b/standalone/MorseSmaleComplex/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkMorseSmaleComplex)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkMorseSmaleComplex
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/PersistenceDiagram/CMakeLists.txt
+++ b/standalone/PersistenceDiagram/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkPersistenceDiagram)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkPersistenceDiagram
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/PointMerger/CMakeLists.txt
+++ b/standalone/PointMerger/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkPointMerger)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkPointMerger
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ReebSpace/CMakeLists.txt
+++ b/standalone/ReebSpace/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkReebSpace)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkReebSpace
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ScalarFieldCriticalPoints/CMakeLists.txt
+++ b/standalone/ScalarFieldCriticalPoints/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkScalarFieldCriticalPoints)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkScalarFieldCriticalPoints
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/ScalarFieldSmoother/CMakeLists.txt
+++ b/standalone/ScalarFieldSmoother/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET ttkScalarFieldSmoother)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkScalarFieldSmoother
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES

--- a/standalone/UncertainDataEstimator/CMakeLists.txt
+++ b/standalone/UncertainDataEstimator/CMakeLists.txt
@@ -7,6 +7,9 @@ if(TARGET ttkUncertainDataEstimator)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkUncertainDataEstimator
+      VTK::IOImage
+      VTK::IOLegacy
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES


### PR DESCRIPTION
This PR removes linking against ${VTK_LIBRARIES} in the `ttk_add_vtk_module` macro and adds all missing VTK module dependencies.

This way, the VTK modules only link the VTK libraries that are actually needed. Linking all VTK libraries broke building TTK in the ParaView superbuild for me (the TTK modules were linked against vtkWrappingTools, which is not contained in the binary distribution).