### PR TITLE
Remove deprecated writers declarations in Compatibility.xml

### DIFF
--- a/paraview/Compatibility/Compatibility.xml
+++ b/paraview/Compatibility/Compatibility.xml
@@ -803,36 +803,4 @@
             </Deprecated>
         </SourceProxy>
     </ProxyGroup>
-    <ProxyGroup name="writers">
-        <SourceProxy
-            base_proxygroup="writers"
-            base_proxyname="ttkOBJWriter"
-            class="ttkOBJWriter"
-            name="OBJWriter"
-            label="TTK OBJWriter (deprecated)">
-            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
-                Please update your state file to use ttkOBJWriter instead of OBJWriter.
-            </Deprecated>
-        </SourceProxy>
-        <SourceProxy
-            base_proxygroup="writers"
-            base_proxyname="ttkOFFWriter"
-            class="ttkOFFWriter"
-            name="OFFWriter"
-            label="TTK OFFWriter (deprecated)">
-            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
-                Please update your state file to use ttkOFFWriter instead of OFFWriter.
-            </Deprecated>
-        </SourceProxy>
-        <SourceProxy
-            base_proxygroup="writers"
-            base_proxyname="ttkTopologicalCompressionWriter"
-            class="ttkTopologicalCompressionWriter"
-            name="TopologicalCompressionWriter"
-            label="TTK TopologicalCompressionWriter (deprecated)">
-            <Deprecated deprecated_in="5.8" to_remove_in="5.9">
-                Please update your state file to use ttkTopologicalCompressionWriter instead of TopologicalCompressionWriter.
-            </Deprecated>
-        </SourceProxy>
-    </ProxyGroup>
 </ServerManagerConfiguration>


### PR DESCRIPTION
Since #467, TTK writers (OBJ, OFF and TopologicalCompression) fail and return the following VTK warning:

`vtkSMProxy.cxx:892   WARN| vtkSMSourceProxy (0x563eca7fd750): Proxy (writers, OBJWriter)  has been deprecated in ParaView 5.8 and will be removed by ParaView 5.9. Please update your state file to use ttkOBJWriter instead of OBJWriter.`

This PR removes the writers declarations in `paraview/Compatibility/Compatibility.xml` that shadow the real writers. This should be sufficient to make them work again.

I don't think that any state file in ttk-data uses directly those writers, so no modifications needed there.

Enjoy,
Pierre