### PR TITLE
Reduce PersistenceDiagram overhead

### DIFF
--- a/core/base/ftmTree/FTMAtomicUF.h
+++ b/core/base/ftmTree/FTMAtomicUF.h
@@ -26,19 +26,18 @@ namespace ttk {
 
     class AtomicUF {
     private:
-      unsigned rank_;
-      AtomicUF *parent_;
+      unsigned rank_{};
+      AtomicUF *parent_{};
       SharedData data_;
 
     public:
       inline explicit AtomicUF(SimplexId extrema = nullVertex)
-        : rank_(0), data_(extrema) {
-        parent_ = this;
+        : data_(extrema) {
       }
 
       // heavy recursif
       inline AtomicUF *find() {
-        if(parent_ == this)
+        if(parent_ == nullptr)
           return this;
         else {
           decltype(parent_) tmp = parent_->find();
@@ -139,13 +138,6 @@ namespace ttk {
 #pragma omp atomic write
 #endif
         parent_ = parent;
-      }
-
-      inline void resetParent() {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp atomic write
-#endif
-        parent_ = this;
       }
 
       static inline AtomicUF *makeUnion(AtomicUF *uf0, AtomicUF *uf1) {

--- a/core/base/ftmTree/FTMAtomicUF.h
+++ b/core/base/ftmTree/FTMAtomicUF.h
@@ -141,6 +141,13 @@ namespace ttk {
         parent_ = parent;
       }
 
+      inline void resetParent() {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp atomic write
+#endif
+        parent_ = this;
+      }
+
       static inline AtomicUF *makeUnion(AtomicUF *uf0, AtomicUF *uf1) {
         uf0 = uf0->find();
         uf1 = uf1->find();

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -131,6 +131,7 @@ namespace ttk {
     FTMAtomicVector<type> &operator=(const FTMAtomicVector<type> &other) {
       std::vector<type>::operator=(other);
       nextId = other.nextId;
+      return *this;
     }
 
     // ---------

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -118,7 +118,6 @@ void ttk::ftm::FTMTreePP::computePersistencePairs(
 
   for(idNode nid = 0; nid < nbNodes; ++nid) {
     nodesUF_[nid] = AtomicUF{tree->getNode(nid)->getVertexId()};
-    nodesUF_[nid].resetParent();
   }
 
   computePairs<scalarType>(tree, pairs);

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -25,7 +25,7 @@ namespace ttk {
      */
     class FTMTreePP : public FTMTree {
     private:
-      std::vector<AtomicUF *> nodesUF_;
+      std::vector<AtomicUF> nodesUF_;
 
     public:
       FTMTreePP();
@@ -50,21 +50,21 @@ namespace ttk {
       void addPendingNode(const idNode parentNode, const idNode toAdd) {
         // Trick, we use the arc list to maintaint nodes
         // coming to this UF.
-        nodesUF_[parentNode]->find()->addArcToClose(toAdd);
+        nodesUF_[parentNode].find()->addArcToClose(toAdd);
       }
 
       idNode countPendingNode(const idNode current) {
-        return nodesUF_[current]->find()->getOpenedArcs().size();
+        return nodesUF_[current].find()->getOpenedArcs().size();
       }
 
       template <typename scalarType>
       SimplexId getMostPersistVert(const idNode current,
                                    ftm::FTMTree_MT *tree) {
         SimplexId minVert = tree->getNode(current)->getVertexId();
-        AtomicUF *uf = nodesUF_[current]->find();
+        AtomicUF *uf = nodesUF_[current].find();
 
         for(const auto nodeid : uf->getOpenedArcs()) {
-          const SimplexId vtmp = nodesUF_[nodeid]->find()->getExtrema();
+          const SimplexId vtmp = nodesUF_[nodeid].find()->getExtrema();
           if(tree->compLower(vtmp, minVert)) {
             minVert = vtmp;
           }
@@ -74,7 +74,7 @@ namespace ttk {
       }
 
       void clearPendingNodes(const idNode current) {
-        nodesUF_[current]->find()->clearOpenedArcs();
+        nodesUF_[current].find()->clearOpenedArcs();
       }
 
       template <typename scalarType>
@@ -83,13 +83,13 @@ namespace ttk {
         std::vector<std::tuple<SimplexId, SimplexId, scalarType>> &pairs,
         ftm::FTMTree_MT *tree,
         const SimplexId mp) {
-        AtomicUF *uf = nodesUF_[current]->find();
+        AtomicUF *uf = nodesUF_[current].find();
         const SimplexId curVert = tree->getNode(current)->getVertexId();
         const scalarType curVal = getValue<scalarType>(curVert);
 
         for(const auto nodeid : uf->getOpenedArcs()) {
-          const SimplexId tmpVert = nodesUF_[nodeid]->find()->getExtrema();
-          AtomicUF::makeUnion(uf, nodesUF_[nodeid]);
+          const SimplexId tmpVert = nodesUF_[nodeid].find()->getExtrema();
+          AtomicUF::makeUnion(uf, &nodesUF_[nodeid]);
           if(tmpVert != mp) {
             const scalarType tmpVal = getValue<scalarType>(tmpVert);
             if(scalars_->isLower(tmpVert, curVert)) {
@@ -110,25 +110,19 @@ void ttk::ftm::FTMTreePP::computePersistencePairs(
   const bool jt) {
   ftm::FTMTree_MT *tree = jt ? getJoinTree() : getSplitTree();
 
-  nodesUF_.clear();
   pairs.clear();
-  nodesUF_.resize(tree->getNumberOfNodes(), nullptr);
   pairs.reserve(tree->getNumberOfLeaves());
 
   const auto nbNodes = tree->getNumberOfNodes();
+  nodesUF_.resize(nbNodes);
+
   for(idNode nid = 0; nid < nbNodes; ++nid) {
-    nodesUF_[nid] = new AtomicUF(tree->getNode(nid)->getVertexId());
+    nodesUF_[nid] = AtomicUF{tree->getNode(nid)->getVertexId()};
+    nodesUF_[nid].resetParent();
   }
 
   computePairs<scalarType>(tree, pairs);
-
   sortPairs<scalarType>(tree, pairs);
-
-  // destruct
-  for(AtomicUF *uf : nodesUF_) {
-    delete uf;
-    uf = nullptr;
-  }
 }
 
 template <typename scalarType>
@@ -168,7 +162,7 @@ void ttk::ftm::FTMTreePP::computePairs(
       const SimplexId mostPersist
         = getMostPersistVert<scalarType>(parentNode, tree);
       createPairs<scalarType>(parentNode, pairs, tree, mostPersist);
-      nodesUF_[parentNode]->find()->setExtrema(mostPersist);
+      nodesUF_[parentNode].find()->setExtrema(mostPersist);
       toSee.push(parentNode);
     }
   }

--- a/core/base/persistenceDiagram/PersistenceDiagram.cpp
+++ b/core/base/persistenceDiagram/PersistenceDiagram.cpp
@@ -9,9 +9,6 @@ PersistenceDiagram::PersistenceDiagram() {
   setDebugMsgPrefix("PersistenceDiagram");
 }
 
-PersistenceDiagram::~PersistenceDiagram() {
-}
-
 CriticalType PersistenceDiagram::getNodeType(FTMTree_MT *tree,
                                              TreeType treeType,
                                              const SimplexId vertexId) const {
@@ -41,4 +38,14 @@ CriticalType PersistenceDiagram::getNodeType(FTMTree_MT *tree,
     else
       return CriticalType::Local_maximum;
   }
+}
+
+void ttk::PersistenceDiagram::sortPersistenceDiagram(
+  std::vector<PersistencePair> &diagram, const SimplexId *const offsets) const {
+
+  auto cmp = [offsets](const PersistencePair &a, const PersistencePair &b) {
+    return offsets[std::get<0>(a)] < offsets[std::get<0>(b)];
+  };
+
+  std::sort(diagram.begin(), diagram.end(), cmp);
 }

--- a/core/base/persistenceDiagram/PersistenceDiagram.cpp
+++ b/core/base/persistenceDiagram/PersistenceDiagram.cpp
@@ -44,7 +44,7 @@ void ttk::PersistenceDiagram::sortPersistenceDiagram(
   std::vector<PersistencePair> &diagram, const SimplexId *const offsets) const {
 
   auto cmp = [offsets](const PersistencePair &a, const PersistencePair &b) {
-    return offsets[std::get<0>(a)] < offsets[std::get<0>(b)];
+    return offsets[a.birth] < offsets[b.birth];
   };
 
   std::sort(diagram.begin(), diagram.end(), cmp);

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -37,6 +37,23 @@
 namespace ttk {
 
   /**
+   * @brief Persistence pair type (with persistence in double)
+   */
+  using PersistencePair = std::tuple<
+    /** first (lower) vertex id */
+    ttk::SimplexId,
+    /** first vertex type */
+    ttk::CriticalType,
+    /** second (higher) vertex id */
+    ttk::SimplexId,
+    /** second vertex type */
+    ttk::CriticalType,
+    /** persistence value (scalars[second] - scalars[first]) */
+    double,
+    /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
+    ttk::SimplexId>;
+
+  /**
    * Compute the persistence diagram of a function on a triangulation.
    * TTK assumes that the input dataset is made of only one connected component.
    */

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -115,11 +115,6 @@ namespace ttk {
                 const triangulationType *triangulation);
 
     inline void
-      setDMTPairs(std::vector<std::tuple<dcg::Cell, dcg::Cell>> *data) {
-      dmt_pairs = data;
-    }
-
-    inline void
       preconditionTriangulation(AbstractTriangulation *triangulation) {
       if(triangulation) {
         triangulation->preconditionBoundaryVertices();
@@ -133,8 +128,6 @@ namespace ttk {
     }
 
   protected:
-    std::vector<std::tuple<dcg::Cell, dcg::Cell>> *dmt_pairs;
-
     bool ComputeSaddleConnectors{false};
     ftm::FTMTreePP contourTree_{};
     MorseSmaleComplex3D morseSmaleComplex_{};

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -61,7 +61,6 @@ namespace ttk {
 
   public:
     PersistenceDiagram();
-    ~PersistenceDiagram();
 
     inline void setComputeSaddleConnectors(bool state) {
       ComputeSaddleConnectors = state;
@@ -71,28 +70,15 @@ namespace ttk {
                                   ftm::TreeType treeType,
                                   const SimplexId vertexId) const;
 
-    template <typename scalarType>
-    void
-      sortPersistenceDiagram(std::vector<std::tuple<ttk::SimplexId,
-                                                    ttk::CriticalType,
-                                                    ttk::SimplexId,
-                                                    ttk::CriticalType,
-                                                    scalarType,
-                                                    ttk::SimplexId>> &diagram,
-                             const scalarType *const scalars,
-                             const SimplexId *const offsets) const;
+    void sortPersistenceDiagram(std::vector<PersistencePair> &diagram,
+                                const SimplexId *const offsets) const;
 
     template <typename scalarType>
     int computeCTPersistenceDiagram(
       ftm::FTMTreePP &tree,
       const std::vector<
         std::tuple<ttk::SimplexId, ttk::SimplexId, scalarType, bool>> &pairs,
-      std::vector<std::tuple<ttk::SimplexId,
-                             ttk::CriticalType,
-                             ttk::SimplexId,
-                             ttk::CriticalType,
-                             scalarType,
-                             ttk::SimplexId>> &diagram,
+      std::vector<PersistencePair> &diagram,
       const scalarType *scalars) const;
 
     /**
@@ -104,12 +90,7 @@ namespace ttk {
      * @see examples/c++/main.cpp for an example use.
      */
     template <typename scalarType, class triangulationType>
-    int execute(std::vector<std::tuple<ttk::SimplexId,
-                                       ttk::CriticalType,
-                                       ttk::SimplexId,
-                                       ttk::CriticalType,
-                                       scalarType,
-                                       ttk::SimplexId>> &CTDiagram,
+    int execute(std::vector<PersistencePair> &CTDiagram,
                 const scalarType *inputScalars,
                 const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
@@ -135,40 +116,13 @@ namespace ttk {
 } // namespace ttk
 
 template <typename scalarType>
-void ttk::PersistenceDiagram::sortPersistenceDiagram(
-  std::vector<std::tuple<ttk::SimplexId,
-                         ttk::CriticalType,
-                         ttk::SimplexId,
-                         ttk::CriticalType,
-                         scalarType,
-                         ttk::SimplexId>> &diagram,
-  const scalarType *const scalars,
-  const SimplexId *const offsets) const {
-
-  auto cmp
-    = [offsets](
-        const std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
-                         ttk::CriticalType, scalarType, ttk::SimplexId> &a,
-        const std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
-                         ttk::CriticalType, scalarType, ttk::SimplexId> &b) {
-        return offsets[std::get<0>(a)] < offsets[std::get<0>(b)];
-      };
-
-  std::sort(diagram.begin(), diagram.end(), cmp);
-}
-
-template <typename scalarType>
 int ttk::PersistenceDiagram::computeCTPersistenceDiagram(
   ftm::FTMTreePP &tree,
   const std::vector<
     std::tuple<ttk::SimplexId, ttk::SimplexId, scalarType, bool>> &pairs,
-  std::vector<std::tuple<ttk::SimplexId,
-                         ttk::CriticalType,
-                         ttk::SimplexId,
-                         ttk::CriticalType,
-                         scalarType,
-                         ttk::SimplexId>> &diagram,
+  std::vector<PersistencePair> &diagram,
   const scalarType *scalars) const {
+
   const ttk::SimplexId numberOfPairs = pairs.size();
   diagram.resize(numberOfPairs);
   for(ttk::SimplexId i = 0; i < numberOfPairs; ++i) {
@@ -201,16 +155,10 @@ int ttk::PersistenceDiagram::computeCTPersistenceDiagram(
 }
 
 template <typename scalarType, class triangulationType>
-int ttk::PersistenceDiagram::execute(
-  std::vector<std::tuple<ttk::SimplexId,
-                         ttk::CriticalType,
-                         ttk::SimplexId,
-                         ttk::CriticalType,
-                         scalarType,
-                         ttk::SimplexId>> &CTDiagram,
-  const scalarType *inputScalars,
-  const SimplexId *inputOffsets,
-  const triangulationType *triangulation) {
+int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
+                                     const scalarType *inputScalars,
+                                     const SimplexId *inputOffsets,
+                                     const triangulationType *triangulation) {
 
   printMsg(ttk::debug::Separator::L1);
 
@@ -293,7 +241,7 @@ int ttk::PersistenceDiagram::execute(
   }
 
   // finally sort the diagram
-  sortPersistenceDiagram(CTDiagram, inputScalars, inputOffsets);
+  sortPersistenceDiagram(CTDiagram, inputOffsets);
 
   printMsg(ttk::debug::Separator::L1);
 

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -114,9 +114,11 @@ namespace ttk {
         contourTree_.setDebugLevel(debugLevel_);
         contourTree_.setThreadNumber(threadNumber_);
         contourTree_.preconditionTriangulation(triangulation);
-        morseSmaleComplex_.setDebugLevel(debugLevel_);
-        morseSmaleComplex_.setThreadNumber(threadNumber_);
-        morseSmaleComplex_.preconditionTriangulation(triangulation);
+        if(this->ComputeSaddleConnectors) {
+          morseSmaleComplex_.setDebugLevel(debugLevel_);
+          morseSmaleComplex_.setThreadNumber(threadNumber_);
+          morseSmaleComplex_.preconditionTriangulation(triangulation);
+        }
       }
     }
 

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -100,7 +100,7 @@ int ttk::TrackingFromFields::performDiagramComputation(
     // persistenceDiagram.setInputScalars(inputData_[i]);
     // persistenceDiagram.setInputOffsets(inputOffsets_);
     persistenceDiagram.setComputeSaddleConnectors(false);
-    std::vector<std::tuple<int, CriticalType, int, CriticalType, dataType, int>>
+    std::vector<std::tuple<int, CriticalType, int, CriticalType, double, int>>
       CTDiagram;
 
     // persistenceDiagram.setOutputCTDiagram(&CTDiagram);

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -100,8 +100,7 @@ int ttk::TrackingFromFields::performDiagramComputation(
     // persistenceDiagram.setInputScalars(inputData_[i]);
     // persistenceDiagram.setInputOffsets(inputOffsets_);
     persistenceDiagram.setComputeSaddleConnectors(false);
-    std::vector<std::tuple<int, CriticalType, int, CriticalType, double, int>>
-      CTDiagram;
+    std::vector<PersistencePair> CTDiagram{};
 
     // persistenceDiagram.setOutputCTDiagram(&CTDiagram);
     persistenceDiagram.execute<dataType, triangulationType>(
@@ -114,17 +113,16 @@ int ttk::TrackingFromFields::performDiagramComputation(
       float p[3];
       float q[3];
       auto currentTuple = CTDiagram[j];
-      const int a = std::get<0>(currentTuple);
-      const int b = std::get<2>(currentTuple);
+      const int a = currentTuple.birth;
+      const int b = currentTuple.death;
       triangulation->getVertexPoint(a, p[0], p[1], p[2]);
       triangulation->getVertexPoint(b, q[0], q[1], q[2]);
       const double sa = ((double *)inputData_[i])[a];
       const double sb = ((double *)inputData_[i])[b];
-      diagramTuple dt
-        = std::make_tuple(std::get<0>(currentTuple), std::get<1>(currentTuple),
-                          std::get<2>(currentTuple), std::get<3>(currentTuple),
-                          std::get<4>(currentTuple), std::get<5>(currentTuple),
-                          sa, p[0], p[1], p[2], sb, q[0], q[1], q[2]);
+      diagramTuple dt = std::make_tuple(
+        currentTuple.birth, currentTuple.birthType, currentTuple.death,
+        currentTuple.deathType, currentTuple.persistence, currentTuple.pairType,
+        sa, p[0], p[1], p[2], sb, q[0], q[1], q[2]);
 
       persistenceDiagrams[i][j] = dt;
     }

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -4,11 +4,10 @@
 
 using namespace std;
 using namespace ttk;
-using namespace dcg;
 
-vtkStandardNewMacro(ttkPersistenceDiagram)
+vtkStandardNewMacro(ttkPersistenceDiagram);
 
-  ttkPersistenceDiagram::ttkPersistenceDiagram() {
+ttkPersistenceDiagram::ttkPersistenceDiagram() {
   SetNumberOfInputPorts(1);
   SetNumberOfOutputPorts(1);
 }
@@ -464,9 +463,6 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *request,
 
   if(this->GetMTime() < inputScalars->GetMTime())
     computeDiagram_ = true;
-
-  vector<tuple<Cell, Cell>> dmt_pairs_temp;
-  setDMTPairs(&dmt_pairs_temp);
 
   scalarDataType = inputScalars->GetDataType();
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -115,10 +115,10 @@ int ttkPersistenceDiagram::setPersistenceDiagram(
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < diagram.size(); ++i) {
-    const auto a = std::get<0>(diagram[i]);
-    const auto b = std::get<2>(diagram[i]);
-    const auto ta = std::get<1>(diagram[i]);
-    const auto tb = std::get<3>(diagram[i]);
+    const auto a = diagram[i].birth;
+    const auto b = diagram[i].death;
+    const auto ta = diagram[i].birthType;
+    const auto tb = diagram[i].deathType;
     // inputScalarsArray->GetTuple is not thread safe...
     const auto sa = inputScalars[a];
     const auto sb = inputScalars[b];
@@ -158,11 +158,11 @@ int ttkPersistenceDiagram::setPersistenceDiagram(
 
     // cell data
     pairIdentifierScalars->SetTuple1(i, i);
-    persistenceScalars->SetTuple1(i, std::get<4>(diagram[i]));
+    persistenceScalars->SetTuple1(i, diagram[i].persistence);
     if(i == 0) {
       extremumIndexScalars->SetTuple1(i, -1);
     } else {
-      const auto type = std::get<5>(diagram[i]);
+      const auto type = diagram[i].pairType;
       if(type == 0) {
         extremumIndexScalars->SetTuple1(i, minIndex);
       } else if(type == 1) {
@@ -186,7 +186,7 @@ int ttkPersistenceDiagram::setPersistenceDiagram(
     pairIdentifierScalars->InsertTuple1(diagram.size(), -1);
     extremumIndexScalars->InsertTuple1(diagram.size(), -1);
     // persistence of min-max pair
-    const auto maxPersistence = std::get<4>(diagram[0]);
+    const auto maxPersistence = diagram[0].persistence;
     persistenceScalars->InsertTuple1(diagram.size(), 2 * maxPersistence);
   }
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -217,7 +217,7 @@ int ttkPersistenceDiagram::dispatch(
   const triangulationType *triangulation) {
 
   int status{};
-  if(this->computeDiagram_) {
+  if(this->computeDiagram_ || CTDiagram_.empty()) {
     CTDiagram_.clear();
     status = this->execute(CTDiagram_, inputScalars, inputOrder, triangulation);
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -37,6 +37,11 @@ int ttkPersistenceDiagram::FillOutputPortInformation(int port,
   return 0;
 }
 
+void ttkPersistenceDiagram::Modified() {
+  computeDiagram_ = true;
+  ttkAlgorithm::Modified();
+}
+
 template <typename scalarType, typename triangulationType>
 int ttkPersistenceDiagram::setPersistenceDiagram(
   vtkUnstructuredGrid *outputCTPersistenceDiagram,
@@ -228,11 +233,6 @@ int ttkPersistenceDiagram::dispatch(
                         inputScalarsArray, inputScalars, triangulation);
 
   return 1;
-}
-
-void ttkPersistenceDiagram::Modified() {
-  computeDiagram_ = true;
-  ttkAlgorithm::Modified();
 }
 
 int ttkPersistenceDiagram::RequestData(vtkInformation *request,

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -1,3 +1,10 @@
+#include <vtkCellData.h>
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkInformation.h>
+#include <vtkPointData.h>
+
 #include <ttkMacros.h>
 #include <ttkPersistenceDiagram.h>
 #include <ttkUtils.h>

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -2,9 +2,6 @@
 #include <ttkPersistenceDiagram.h>
 #include <ttkUtils.h>
 
-using namespace std;
-using namespace ttk;
-
 vtkStandardNewMacro(ttkPersistenceDiagram);
 
 ttkPersistenceDiagram::ttkPersistenceDiagram() {
@@ -29,19 +26,18 @@ int ttkPersistenceDiagram::FillInputPortInformation(int port,
 
 int ttkPersistenceDiagram::FillOutputPortInformation(int port,
                                                      vtkInformation *info) {
-  switch(port) {
-    case 0:
-      info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
-      break;
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    return 1;
   }
-  return 1;
+  return 0;
 }
 
 template <typename VTK_TT>
 int ttkPersistenceDiagram::deleteDiagram() {
-  using tuple_t = tuple<SimplexId, CriticalType, SimplexId, CriticalType,
-                        VTK_TT, SimplexId>;
-  vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
+  using tuple_t = std::tuple<SimplexId, ttk::CriticalType, SimplexId,
+                             ttk::CriticalType, VTK_TT, SimplexId>;
+  std::vector<tuple_t> *CTDiagram = (std::vector<tuple_t> *)CTDiagram_;
   delete CTDiagram;
   return 0;
 }
@@ -51,16 +47,16 @@ template <typename scalarType,
           class triangulationType>
 int ttkPersistenceDiagram::setPersistenceDiagramInfo(
   ttk::SimplexId id,
-  vtkSmartPointer<vtkSimplexArray> vertexIdentifierScalars,
-  vtkSmartPointer<vtkIntArray> nodeTypeScalars,
-  vtkSmartPointer<vtkFloatArray> coordsScalars,
+  vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
+  vtkNew<vtkIntArray> &nodeTypeScalars,
+  vtkNew<vtkFloatArray> &coordsScalars,
   const std::vector<std::tuple<ttk::SimplexId,
                                ttk::CriticalType,
                                ttk::SimplexId,
                                ttk::CriticalType,
                                scalarType,
                                ttk::SimplexId>> &diagram,
-  vtkSmartPointer<vtkPoints> points,
+  vtkNew<vtkPoints> &points,
   vtkIdType ids[3],
   vtkDataArray *inputScalars,
   const triangulationType *triangulation) {
@@ -108,38 +104,31 @@ int ttkPersistenceDiagram::getPersistenceDiagram(
                                ttk::SimplexId>> &diagram,
   vtkDataArray *inputScalars,
   const triangulationType *triangulation) {
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> points{};
 
-  vtkSmartPointer<vtkUnstructuredGrid> persistenceDiagram
-    = vtkSmartPointer<vtkUnstructuredGrid>::New();
+  vtkNew<vtkUnstructuredGrid> persistenceDiagram{};
 
-  vtkSmartPointer<ttkSimplexIdTypeArray> vertexIdentifierScalars
-    = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> vertexIdentifierScalars{};
   vertexIdentifierScalars->SetNumberOfComponents(1);
   vertexIdentifierScalars->SetName(ttk::VertexScalarFieldName);
 
-  vtkSmartPointer<vtkIntArray> nodeTypeScalars
-    = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> nodeTypeScalars{};
   nodeTypeScalars->SetNumberOfComponents(1);
   nodeTypeScalars->SetName("CriticalType");
 
-  vtkSmartPointer<ttkSimplexIdTypeArray> pairIdentifierScalars
-    = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> pairIdentifierScalars{};
   pairIdentifierScalars->SetNumberOfComponents(1);
   pairIdentifierScalars->SetName("PairIdentifier");
 
-  vtkSmartPointer<vtkDoubleArray> persistenceScalars
-    = vtkSmartPointer<vtkDoubleArray>::New();
+  vtkNew<vtkDoubleArray> persistenceScalars{};
   persistenceScalars->SetNumberOfComponents(1);
   persistenceScalars->SetName("Persistence");
 
-  vtkSmartPointer<vtkIntArray> extremumIndexScalars
-    = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> extremumIndexScalars{};
   extremumIndexScalars->SetNumberOfComponents(1);
   extremumIndexScalars->SetName("PairType");
 
-  vtkSmartPointer<vtkFloatArray> coordsScalars
-    = vtkSmartPointer<vtkFloatArray>::New();
+  vtkNew<vtkFloatArray> coordsScalars{};
   coordsScalars->SetNumberOfComponents(3);
   coordsScalars->SetName("Coordinates");
 
@@ -212,8 +201,8 @@ template <typename scalarType,
           class triangulationType>
 int ttkPersistenceDiagram::setPersistenceDiagramInfoInsideDomain(
   ttk::SimplexId id,
-  vtkSmartPointer<vtkSimplexArray> vertexIdentifierScalars,
-  vtkSmartPointer<vtkIntArray> nodeTypeScalars,
+  vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
+  vtkNew<vtkIntArray> &nodeTypeScalars,
   vtkDataArray *birthScalars,
   vtkDataArray *deathScalars,
   const std::vector<std::tuple<ttk::SimplexId,
@@ -222,7 +211,7 @@ int ttkPersistenceDiagram::setPersistenceDiagramInfoInsideDomain(
                                ttk::CriticalType,
                                scalarType,
                                ttk::SimplexId>> &diagram,
-  vtkSmartPointer<vtkPoints> points,
+  vtkNew<vtkPoints> &points,
   vtkIdType ids[3],
   vtkDataArray *inputScalars,
   const triangulationType *triangulation) {
@@ -266,33 +255,27 @@ int ttkPersistenceDiagram::getPersistenceDiagramInsideDomain(
                                ttk::SimplexId>> &diagram,
   vtkDataArray *inputScalars,
   const triangulationType *triangulation) {
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> points{};
 
-  vtkSmartPointer<vtkUnstructuredGrid> persistenceDiagram
-    = vtkSmartPointer<vtkUnstructuredGrid>::New();
+  vtkNew<vtkUnstructuredGrid> persistenceDiagram{};
 
-  vtkSmartPointer<ttkSimplexIdTypeArray> vertexIdentifierScalars
-    = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> vertexIdentifierScalars{};
   vertexIdentifierScalars->SetNumberOfComponents(1);
   vertexIdentifierScalars->SetName(ttk::VertexScalarFieldName);
 
-  vtkSmartPointer<vtkIntArray> nodeTypeScalars
-    = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> nodeTypeScalars{};
   nodeTypeScalars->SetNumberOfComponents(1);
   nodeTypeScalars->SetName("CriticalType");
 
-  vtkSmartPointer<ttkSimplexIdTypeArray> pairIdentifierScalars
-    = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> pairIdentifierScalars{};
   pairIdentifierScalars->SetNumberOfComponents(1);
   pairIdentifierScalars->SetName("PairIdentifier");
 
-  vtkSmartPointer<vtkDoubleArray> persistenceScalars
-    = vtkSmartPointer<vtkDoubleArray>::New();
+  vtkNew<vtkDoubleArray> persistenceScalars{};
   persistenceScalars->SetNumberOfComponents(1);
   persistenceScalars->SetName("Persistence");
 
-  vtkSmartPointer<vtkIntArray> extremumIndexScalars
-    = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> extremumIndexScalars{};
   extremumIndexScalars->SetNumberOfComponents(1);
   extremumIndexScalars->SetName("PairType");
 
@@ -370,19 +353,19 @@ int ttkPersistenceDiagram::dispatch(
 
   int ret = 0;
 
-  using tuple_t = tuple<SimplexId, CriticalType, SimplexId, CriticalType,
-                        VTK_TT, SimplexId>;
+  using tuple_t = std::tuple<SimplexId, ttk::CriticalType, SimplexId,
+                             ttk::CriticalType, VTK_TT, SimplexId>;
 
   if(CTDiagram_ && computeDiagram_) {
-    vector<tuple_t> *tmpDiagram = (vector<tuple_t> *)CTDiagram_;
+    std::vector<tuple_t> *tmpDiagram = (std::vector<tuple_t> *)CTDiagram_;
     delete tmpDiagram;
-    CTDiagram_ = new vector<tuple_t>();
+    CTDiagram_ = new std::vector<tuple_t>();
   } else if(!CTDiagram_) {
-    CTDiagram_ = new vector<tuple_t>();
+    CTDiagram_ = new std::vector<tuple_t>();
     computeDiagram_ = true;
   }
 
-  vector<tuple_t> *CTDiagram = (vector<tuple_t> *)CTDiagram_;
+  std::vector<tuple_t> *CTDiagram = (std::vector<tuple_t> *)CTDiagram_;
 
   if(computeDiagram_) {
     ret = this->execute<VTK_TT, TTK_TT>(
@@ -399,11 +382,11 @@ int ttkPersistenceDiagram::dispatch(
 
   if(ShowInsideDomain)
     ret = getPersistenceDiagramInsideDomain<VTK_TT>(
-      outputCTPersistenceDiagram, ftm::TreeType::Contour, *CTDiagram,
+      outputCTPersistenceDiagram, ttk::ftm::TreeType::Contour, *CTDiagram,
       inputScalarDataArray, triangulation);
   else
     ret = getPersistenceDiagram<VTK_TT>(outputCTPersistenceDiagram,
-                                        ftm::TreeType::Contour, *CTDiagram,
+                                        ttk::ftm::TreeType::Contour, *CTDiagram,
                                         inputScalarDataArray, triangulation);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret) {

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -88,27 +88,8 @@ public:
   }
   vtkGetMacro(ShowInsideDomain, int);
 
-  template <typename scalarType,
-            typename vtkSimplexArray,
-            class triangulationType>
-  int setPersistenceDiagramInfo(
-    ttk::SimplexId id,
-    vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
-    vtkNew<vtkIntArray> &nodeTypeScalars,
-    vtkNew<vtkFloatArray> &coordsScalars,
-    const std::vector<std::tuple<ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 scalarType,
-                                 ttk::SimplexId>> &diagram,
-    vtkNew<vtkPoints> &points,
-    vtkIdType ids[3],
-    vtkDataArray *inputScalars,
-    const triangulationType *triangulation);
-
   template <typename scalarType, class triangulationType>
-  int getPersistenceDiagram(
+  int setPersistenceDiagram(
     vtkUnstructuredGrid *outputCTPersistenceDiagram,
     ttk::ftm::TreeType treeType,
     const std::vector<std::tuple<ttk::SimplexId,
@@ -120,28 +101,8 @@ public:
     vtkDataArray *inputScalars,
     const triangulationType *triangulation);
 
-  template <typename scalarType,
-            typename vtkSimplexArray,
-            class triangulationType>
-  int setPersistenceDiagramInfoInsideDomain(
-    ttk::SimplexId id,
-    vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
-    vtkNew<vtkIntArray> &nodeTypeScalars,
-    vtkDataArray *birthScalars,
-    vtkDataArray *deathScalars,
-    const std::vector<std::tuple<ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 scalarType,
-                                 ttk::SimplexId>> &diagram,
-    vtkNew<vtkPoints> &points,
-    vtkIdType ids[3],
-    vtkDataArray *inputScalars,
-    const triangulationType *triangulation);
-
   template <typename scalarType, class triangulationType>
-  int getPersistenceDiagramInsideDomain(
+  int setPersistenceDiagramInsideDomain(
     vtkUnstructuredGrid *outputCTPersistenceDiagram,
     ttk::ftm::TreeType treeType,
     const std::vector<std::tuple<ttk::SimplexId,

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -88,29 +88,18 @@ public:
   }
   vtkGetMacro(ShowInsideDomain, int);
 
-  template <typename scalarType, class triangulationType>
-  int setPersistenceDiagram(
-    vtkUnstructuredGrid *outputCTPersistenceDiagram,
-    ttk::ftm::TreeType treeType,
-    const std::vector<std::tuple<ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 scalarType,
-                                 ttk::SimplexId>> &diagram,
-    vtkDataArray *inputScalars,
-    const triangulationType *triangulation);
+  template <class triangulationType>
+  int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
+                            ttk::ftm::TreeType treeType,
+                            const std::vector<ttk::PersistencePair> &diagram,
+                            vtkDataArray *inputScalars,
+                            const triangulationType *triangulation);
 
-  template <typename scalarType, class triangulationType>
+  template <class triangulationType>
   int setPersistenceDiagramInsideDomain(
     vtkUnstructuredGrid *outputCTPersistenceDiagram,
     ttk::ftm::TreeType treeType,
-    const std::vector<std::tuple<ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 scalarType,
-                                 ttk::SimplexId>> &diagram,
+    const std::vector<ttk::PersistencePair> &diagram,
     vtkDataArray *inputScalars,
     const triangulationType *triangulation);
 
@@ -122,12 +111,8 @@ public:
                const void *inputOffsets,
                const TTK_TT *triangulation);
 
-  template <typename VTK_TT>
-  int deleteDiagram();
-
 protected:
   ttkPersistenceDiagram();
-  ~ttkPersistenceDiagram() override;
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
@@ -142,7 +127,7 @@ private:
   int ShowInsideDomain{false};
 
   bool computeDiagram_{true};
-  void *CTDiagram_{nullptr};
+  std::vector<ttk::PersistencePair> CTDiagram_{};
   int scalarDataType{0};
 };
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -54,8 +54,8 @@
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
+#include <vtkNew.h>
 #include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 #include <vtkUnstructuredGrid.h>
 
@@ -93,16 +93,16 @@ public:
             class triangulationType>
   int setPersistenceDiagramInfo(
     ttk::SimplexId id,
-    vtkSmartPointer<vtkSimplexArray> vertexIdentifierScalars,
-    vtkSmartPointer<vtkIntArray> nodeTypeScalars,
-    vtkSmartPointer<vtkFloatArray> coordsScalars,
+    vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
+    vtkNew<vtkIntArray> &nodeTypeScalars,
+    vtkNew<vtkFloatArray> &coordsScalars,
     const std::vector<std::tuple<ttk::SimplexId,
                                  ttk::CriticalType,
                                  ttk::SimplexId,
                                  ttk::CriticalType,
                                  scalarType,
                                  ttk::SimplexId>> &diagram,
-    vtkSmartPointer<vtkPoints> points,
+    vtkNew<vtkPoints> &points,
     vtkIdType ids[3],
     vtkDataArray *inputScalars,
     const triangulationType *triangulation);
@@ -125,8 +125,8 @@ public:
             class triangulationType>
   int setPersistenceDiagramInfoInsideDomain(
     ttk::SimplexId id,
-    vtkSmartPointer<vtkSimplexArray> vertexIdentifierScalars,
-    vtkSmartPointer<vtkIntArray> nodeTypeScalars,
+    vtkNew<vtkSimplexArray> &vertexIdentifierScalars,
+    vtkNew<vtkIntArray> &nodeTypeScalars,
     vtkDataArray *birthScalars,
     vtkDataArray *deathScalars,
     const std::vector<std::tuple<ttk::SimplexId,
@@ -135,7 +135,7 @@ public:
                                  ttk::CriticalType,
                                  scalarType,
                                  ttk::SimplexId>> &diagram,
-    vtkSmartPointer<vtkPoints> points,
+    vtkNew<vtkPoints> &points,
     vtkIdType ids[3],
     vtkDataArray *inputScalars,
     const triangulationType *triangulation);

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -97,10 +97,11 @@ private:
                const SimplexId *const inputOrder,
                const triangulationType *triangulation);
 
-  template <class triangulationType>
+  template <typename scalarType, typename triangulationType>
   int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
                             const std::vector<ttk::PersistencePair> &diagram,
-                            vtkDataArray *inputScalars,
+                            vtkDataArray *inputScalarsArray,
+                            const scalarType *const inputScalars,
                             const triangulationType *triangulation) const;
 
   bool ForceInputOffsetScalarField{false};

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -42,21 +42,12 @@
 /// \sa ttkScalarFieldCriticalPoints
 /// \sa ttkTopologicalSimplification
 /// \sa ttk::PersistenceDiagram
-#ifndef _TTK_PERSISTENCEDIAGRAM_H
-#define _TTK_PERSISTENCEDIAGRAM_H
+
 #pragma once
 
 // VTK includes
-#include <vtkCellData.h>
 #include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDoubleArray.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkInformationVector.h>
 #include <vtkNew.h>
-#include <vtkPointData.h>
-#include <vtkTable.h>
 #include <vtkUnstructuredGrid.h>
 
 // VTK Module
@@ -130,5 +121,3 @@ private:
   std::vector<ttk::PersistencePair> CTDiagram_{};
   int scalarDataType{0};
 };
-
-#endif // _TTK_PERSISTENCEDIAGRAM_H

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -90,6 +90,13 @@ protected:
   void Modified() override;
 
 private:
+  template <typename scalarType, typename triangulationType>
+  int dispatch(vtkUnstructuredGrid *outputCTPersistenceDiagram,
+               vtkDataArray *const inputScalarsArray,
+               const scalarType *const inputScalars,
+               const SimplexId *const inputOrder,
+               const triangulationType *triangulation);
+
   template <class triangulationType>
   int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
                             const std::vector<ttk::PersistencePair> &diagram,

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -47,7 +47,6 @@
 
 // VTK includes
 #include <vtkDataArray.h>
-#include <vtkNew.h>
 #include <vtkUnstructuredGrid.h>
 
 // VTK Module
@@ -79,21 +78,6 @@ public:
   }
   vtkGetMacro(ShowInsideDomain, int);
 
-  template <class triangulationType>
-  int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
-                            ttk::ftm::TreeType treeType,
-                            const std::vector<ttk::PersistencePair> &diagram,
-                            vtkDataArray *inputScalars,
-                            const triangulationType *triangulation);
-
-  template <class triangulationType>
-  int setPersistenceDiagramInsideDomain(
-    vtkUnstructuredGrid *outputCTPersistenceDiagram,
-    ttk::ftm::TreeType treeType,
-    const std::vector<ttk::PersistencePair> &diagram,
-    vtkDataArray *inputScalars,
-    const triangulationType *triangulation);
-
 protected:
   ttkPersistenceDiagram();
 
@@ -106,10 +90,15 @@ protected:
   void Modified() override;
 
 private:
+  template <class triangulationType>
+  int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
+                            const std::vector<ttk::PersistencePair> &diagram,
+                            vtkDataArray *inputScalars,
+                            const triangulationType *triangulation) const;
+
   bool ForceInputOffsetScalarField{false};
   int ShowInsideDomain{false};
 
   bool computeDiagram_{true};
   std::vector<ttk::PersistencePair> CTDiagram_{};
-  int scalarDataType{0};
 };

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -94,14 +94,6 @@ public:
     vtkDataArray *inputScalars,
     const triangulationType *triangulation);
 
-  template <typename VTK_TT, typename TTK_TT>
-  int dispatch(vtkUnstructuredGrid *outputCTPersistenceDiagram,
-               vtkDataArray *inputScalarDataArray,
-               const VTK_TT *inputScalars,
-               int inputOffsetsDataType,
-               const void *inputOffsets,
-               const TTK_TT *triangulation);
-
 protected:
   ttkPersistenceDiagram();
 

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -199,22 +199,18 @@ int main(int argc, char **argv) {
 
   // 3. computing the persitence diagram
   ttk::PersistenceDiagram diagram;
-  std::vector<std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,
-                         ttk::CriticalType, float, ttk::SimplexId>>
-    diagramOutput;
+  std::vector<ttk::PersistencePair> diagramOutput;
   diagram.preconditionTriangulation(&triangulation);
-  diagram.execute<float>(
-    diagramOutput, height.data(), order.data(), &triangulation);
+  diagram.execute(diagramOutput, height.data(), order.data(), &triangulation);
 
   // 4. selecting the critical point pairs
   std::vector<float> simplifiedHeight = height;
   std::vector<ttk::SimplexId> authorizedCriticalPoints, simplifiedOrder = order;
   for(int i = 0; i < (int)diagramOutput.size(); i++) {
-    double persistence = std::get<4>(diagramOutput[i]);
-    if(persistence > 0.05) {
+    if(diagramOutput[i].persistence > 0.05) {
       // 5. selecting the most persistent pairs
-      authorizedCriticalPoints.push_back(std::get<0>(diagramOutput[i]));
-      authorizedCriticalPoints.push_back(std::get<2>(diagramOutput[i]));
+      authorizedCriticalPoints.push_back(diagramOutput[i].birth);
+      authorizedCriticalPoints.push_back(diagramOutput[i].death);
     }
   }
 


### PR DESCRIPTION
This PR reduce some overhead in the PersistenceDiagram module. For instance, the duration of the `RequestData` method on the `ctBones.vti` has dropped from 12s to 7s.

The modifications include:
* the triangulation precondition for the MorseSmaleComplex is not executed by default
* a PersistencePair struct has been introduced to replace the un-documented, templated tuple that held the pairs data.
* the persistence pair has been set to double, since in the VTK layer it is stored in a vtkDoubleArray. This helps to avoid storing templated vectors of persistence pairs on the heap (one less indirection)
* the methods generating the VTK structures for an embed and a non-embed diagram have been merged together
* filling the VTK arrays is now done in parallel
* a vector of pointers in FTMTreePP has been changed into a vector of the pointed structs to reduce indirections

No change has been observed on the ttk-data states.

Enjoy,
Pierre