### PR TITLE
turned ttkUtils into class

### DIFF
--- a/core/vtk/ttkAlgorithm/ttk.module
+++ b/core/vtk/ttkAlgorithm/ttk.module
@@ -2,6 +2,7 @@ NAME
   ttkAlgorithm
 SOURCES
   ttkAlgorithm.cpp
+  ttkUtils.cpp
 HEADERS
   ttkAlgorithm.h
   ttkUtils.h

--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -1,0 +1,308 @@
+#include <ttkUtils.h>
+
+#include <limits>
+#include <vtkStringArray.h>
+
+#include <vtkAbstractArray.h>
+#include <vtkCellArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkFieldData.h>
+#include <vtkPoints.h>
+#include <vtkSmartPointer.h>
+
+int ttkUtils::replaceVariable(const std::string &iString,
+                              vtkFieldData *fieldData,
+                              std::string &oString,
+                              std::string &errorMsg) {
+  std::string varName = iString;
+  int varIndex = -1;
+  bool varIndexDefined = false;
+
+  // Check if varIndex is specified
+  size_t indexDelimiter0 = iString.find("[");
+  size_t indexDelimiter1 = iString.find("]");
+  if(indexDelimiter0 != std::string::npos
+     && indexDelimiter1 != std::string::npos) {
+    if(indexDelimiter0 > indexDelimiter1
+       || iString.find("[", indexDelimiter0 + 1) != std::string::npos
+       || iString.find("}", indexDelimiter1 + 1) != std::string::npos) {
+      errorMsg = "Invalid Syntax:\n" + iString;
+      return 0;
+    }
+
+    varName = iString.substr(0, indexDelimiter0);
+    varIndex = stoi(iString.substr(
+      indexDelimiter0 + 1, indexDelimiter1 - indexDelimiter0 - 1));
+    varIndexDefined = true;
+  }
+
+  // Search in candidates
+  auto column = fieldData->GetAbstractArray(varName.data());
+  if(column == nullptr) {
+    errorMsg = "FieldData does not contain array '" + varName + "'";
+    return 0;
+  }
+
+  size_t n = column->GetNumberOfTuples();
+  size_t m = column->GetNumberOfComponents();
+  int s = n * m;
+
+  if(!varIndexDefined) {
+    if(s > 0) {
+      oString = column->GetVariantValue(0).ToString();
+      for(int i = 1; i < s; i++)
+        oString += "," + column->GetVariantValue(i).ToString();
+    }
+  } else {
+    if(varIndex < 0 || varIndex >= s) {
+      errorMsg = "Index " + std::to_string(varIndex) + "/" + std::to_string(s)
+                 + " for FieldData Array '" + varName + "' out of range";
+      return 0;
+    }
+    oString = column->GetVariantValue(varIndex).ToString();
+  }
+
+  return 1;
+};
+
+int ttkUtils::replaceVariables(const std::string &iString,
+                               vtkFieldData *fieldData,
+                               std::string &oString,
+                               std::string &errorMsg) {
+  oString = iString;
+
+  while(oString.find("{") != std::string::npos
+        && oString.find("}") != std::string::npos) {
+    size_t o = oString.find("{");
+    size_t c = oString.find("}");
+    // {...{....{...}...}..}
+    // |            |
+    // o            c
+
+    size_t oNext = oString.find("{", o + 1);
+    while(oNext != std::string::npos && oNext < c) {
+      o = oNext;
+      oNext = oString.find("{", o + 1);
+    }
+
+    // {...{....{var}...}..}
+    //          |   |
+    //          o   c
+    std::string var = oString.substr(o + 1, c - 1 - o);
+
+    std::string rVar;
+    if(!replaceVariable(var, fieldData, rVar, errorMsg))
+      return 0;
+
+    oString = oString.substr(0, o) + rVar
+              + oString.substr(c + 1, oString.length() - c - 1);
+  }
+
+  if(oString.find("{") != std::string::npos
+     || oString.find("}") != std::string::npos) {
+    errorMsg = "Invalid Syntax:\n" + iString;
+    return 0;
+  }
+
+  return 1;
+};
+
+int ttkUtils::stringListToVector(const std::string &iString,
+                                 std::vector<std::string> &v) {
+  // ...,...,....,
+  //     |  |
+  //     i  j
+  size_t i = 0;
+  size_t j = iString.find(",");
+  while(j != std::string::npos) {
+    v.push_back(iString.substr(i, j - i));
+    i = j + 1;
+    j = iString.find(",", i);
+  }
+  if(iString.length() > i)
+    v.push_back(iString.substr(i, iString.length() - i));
+
+  return 1;
+};
+
+int ttkUtils::stringListToDoubleVector(const std::string &iString,
+                                       std::vector<double> &v) {
+  std::vector<std::string> stringVector;
+  if(!ttkUtils::stringListToVector(iString, stringVector))
+    return 0;
+
+  size_t n = stringVector.size();
+  v.resize(n);
+  // try {
+  for(size_t i = 0; i < n; i++)
+    v[i] = stod(stringVector[i]);
+  // } catch(std::invalid_argument &e) {
+  //   return 0;
+  // }
+
+  return 1;
+};
+
+vtkSmartPointer<vtkAbstractArray> ttkUtils::csvToVtkArray(std::string line) {
+  size_t firstComma = line.find(",", 0);
+
+  if(firstComma == std::string::npos)
+    return nullptr;
+
+  std::string arrayName = line.substr(0, firstComma);
+
+  std::vector<std::string> valuesAsString;
+  stringListToVector(
+    line.substr(firstComma + 1, std::string::npos), valuesAsString);
+  size_t nValues = valuesAsString.size();
+  if(nValues < 1)
+    return nullptr;
+
+  // Check if all elements are numbers
+  bool isNumeric = true;
+  {
+    for(size_t i = 0; i < nValues; i++) {
+      if(valuesAsString[i].size() > 0 && !isdigit(valuesAsString[i][0])) {
+        isNumeric = false;
+        break;
+      }
+    }
+  }
+
+  if(isNumeric) {
+    auto array = vtkSmartPointer<vtkDoubleArray>::New();
+    array->SetName(arrayName.data());
+    array->SetNumberOfComponents(1);
+    array->SetNumberOfTuples(nValues);
+    auto arrayData = reinterpret_cast<double *>(GetVoidPointer(array));
+    // try {
+    for(size_t i = 0; i < nValues; i++)
+      arrayData[i] = std::stod(valuesAsString[i]);
+    // } catch(std::invalid_argument &e) {
+    //   // return nullptr;
+    // }
+    return array;
+  } else {
+    auto array = vtkSmartPointer<vtkStringArray>::New();
+    array->SetName(arrayName.data());
+    array->SetNumberOfValues(nValues);
+    for(size_t i = 0; i < nValues; i++)
+      array->SetValue(i, valuesAsString[i]);
+    return array;
+  }
+};
+
+vtkSmartPointer<vtkDoubleArray> ttkUtils::csvToDoubleArray(std::string line) {
+  size_t firstComma = line.find(",", 0);
+
+  if(firstComma == std::string::npos)
+    return nullptr;
+
+  std::string arrayName = line.substr(0, firstComma);
+  std::string valuesAsString = line.substr(firstComma + 1, std::string::npos);
+
+  std::vector<double> values;
+  ttkUtils::stringListToDoubleVector(valuesAsString, values);
+  size_t n = values.size();
+
+  auto array = vtkSmartPointer<vtkDoubleArray>::New();
+  array->SetName(arrayName.data());
+  array->SetNumberOfComponents(1);
+  array->SetNumberOfTuples(n);
+  auto arrayData = reinterpret_cast<double *>(GetVoidPointer(array));
+  for(size_t i = 0; i < n; i++)
+    arrayData[i] = values[i];
+
+  return array;
+};
+
+/// Retrieve pointer to the internal data
+/// This method is a workaround to emulate
+/// the old GetVoidPointer in vtkDataArray
+void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
+  void *outPtr = nullptr;
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) { outPtr = aosArray->GetVoidPointer(start); });
+  }
+  return outPtr;
+};
+
+void *ttkUtils::GetVoidPointer(vtkPoints *points, vtkIdType start) {
+  return GetVoidPointer(points->GetData(), start);
+};
+
+void *ttkUtils::WriteVoidPointer(vtkDataArray *array,
+                                 vtkIdType valueIdx,
+                                 vtkIdType numValues) {
+  void *outPtr = nullptr;
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(auto *aosArray
+                     = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+                     if(aosArray) {
+                       outPtr = aosArray->WriteVoidPointer(valueIdx, numValues);
+                     });
+  }
+  return outPtr;
+};
+
+void *ttkUtils::WritePointer(vtkDataArray *array,
+                             vtkIdType valueIdx,
+                             vtkIdType numValues) {
+  void *outPtr = nullptr;
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) { outPtr = aosArray->WritePointer(valueIdx, numValues); });
+  }
+  return outPtr;
+};
+
+void ttkUtils::SetVoidArray(vtkDataArray *array,
+                            void *data,
+                            vtkIdType size,
+                            int save) {
+  switch(array->GetDataType()) {
+    vtkTemplateMacro(
+      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
+      if(aosArray) { aosArray->SetVoidArray(data, size, save); } else {
+        std::cerr << "SetVoidArray on incompatible vtkDataArray:" << endl;
+        array->Print(std::cerr);
+      });
+  }
+};
+
+[[deprecated]] void ttkUtils::FillCellArrayFromSingle(vtkIdType const *cells,
+                                                      vtkIdType ncells,
+                                                      vtkCellArray *cellArray) {
+  size_t curPos = 0;
+  vtkNew<vtkIdList> verts;
+  for(vtkIdType cid = 0; cid < ncells; cid++) {
+    const vtkIdType nbVerts = cells[curPos];
+    verts->SetNumberOfIds(nbVerts);
+    curPos++;
+    for(vtkIdType v = 0; v < nbVerts; v++) {
+      verts->SetId(v, cells[curPos]);
+      curPos++;
+    }
+    cellArray->InsertNextCell(verts);
+  }
+};
+
+void ttkUtils::FillCellArrayFromDual(vtkIdType const *cells_co,
+                                     vtkIdType const *cells_off,
+                                     vtkIdType ncells,
+                                     vtkCellArray *cellArray) {
+  size_t curPos = 0;
+  vtkNew<vtkIdList> verts;
+  for(vtkIdType cid = 0; cid < ncells; cid++) {
+    const vtkIdType nbVerts = cells_off[cid + 1] - cells_off[cid];
+    verts->SetNumberOfIds(nbVerts);
+    for(vtkIdType v = 0; v < nbVerts; v++) {
+      verts->SetId(v, cells_co[curPos]);
+      curPos++;
+    }
+    cellArray->InsertNextCell(verts);
+  }
+};

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -7,353 +7,67 @@
 
 #pragma once
 
-#include <vtkAbstractArray.h>
-#include <vtkCellArray.h>
-#include <vtkDoubleArray.h>
-#include <vtkFieldData.h>
-#include <vtkPoints.h>
-#include <vtkSmartPointer.h>
+#include <string>
+#include <vector>
 
-namespace ttkUtils {
-  int replaceVariable(const std::string &iString,
-                      vtkFieldData *fieldData,
-                      std::string &oString,
-                      std::string &errorMsg);
+#include <vtkType.h>
 
-  int replaceVariables(const std::string &iString,
-                       vtkFieldData *fieldData,
-                       std::string &oString,
-                       std::string &errorMsg);
+class vtkFieldData;
+class vtkDataArray;
+class vtkDoubleArray;
+class vtkPoints;
+class vtkAbstractArray;
+class vtkCellArray;
 
-  int stringListToVector(const std::string &iString,
-                         std::vector<std::string> &v);
+template <typename T>
+class vtkSmartPointer;
 
-  int stringListToDoubleVector(const std::string &iString,
-                               std::vector<double> &v);
+class ttkUtils {
+private:
+  ttkUtils(){};
 
-  vtkSmartPointer<vtkAbstractArray> csvToVtkArray(std::string line);
+public:
+  static int replaceVariable(const std::string &iString,
+                             vtkFieldData *fieldData,
+                             std::string &oString,
+                             std::string &errorMsg);
 
-  vtkSmartPointer<vtkDoubleArray> csvToDoubleArray(std::string line);
+  static int replaceVariables(const std::string &iString,
+                              vtkFieldData *fieldData,
+                              std::string &oString,
+                              std::string &errorMsg);
+
+  static int stringListToVector(const std::string &iString,
+                                std::vector<std::string> &v);
+
+  static int stringListToDoubleVector(const std::string &iString,
+                                      std::vector<double> &v);
+
+  static vtkSmartPointer<vtkAbstractArray> csvToVtkArray(std::string line);
+
+  static vtkSmartPointer<vtkDoubleArray> csvToDoubleArray(std::string line);
 
   // Emultate old VTK functions
+  static void *GetVoidPointer(vtkDataArray *array, vtkIdType start = 0);
+  static void *GetVoidPointer(vtkPoints *points, vtkIdType start = 0);
 
-  void *GetVoidPointer(vtkDataArray *array, vtkIdType start = 0);
-  void *GetVoidPointer(vtkPoints *points, vtkIdType start = 0);
-
-  void *
+  static void *
     WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
-  void *WritePointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
+  static void *
+    WritePointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
 
-  void SetVoidArray(vtkDataArray *array, void *data, vtkIdType size, int save);
+  static void
+    SetVoidArray(vtkDataArray *array, void *data, vtkIdType size, int save);
 
   // Fill Cell array using a pointer with the old memory layout
   // DEPRECTAED
-  void FillCellArrayFromSingle(vtkIdType const *cells,
-                               vtkIdType ncells,
-                               vtkCellArray *cellArray);
+  static void FillCellArrayFromSingle(vtkIdType const *cells,
+                                      vtkIdType ncells,
+                                      vtkCellArray *cellArray);
 
   // Fill Cell array using a pointer with the new memory layout
-  void FillCellArrayFromDual(vtkIdType const *cells_co,
-                             vtkIdType const *cells_off,
-                             vtkIdType ncells,
-                             vtkCellArray *cellArray);
-}; // namespace ttkUtils
-
-#include <limits>
-#include <vtkStringArray.h>
-
-int ttkUtils::replaceVariable(const std::string &iString,
-                              vtkFieldData *fieldData,
-                              std::string &oString,
-                              std::string &errorMsg) {
-  std::string varName = iString;
-  int varIndex = -1;
-  bool varIndexDefined = false;
-
-  // Check if varIndex is specified
-  size_t indexDelimiter0 = iString.find("[");
-  size_t indexDelimiter1 = iString.find("]");
-  if(indexDelimiter0 != std::string::npos
-     && indexDelimiter1 != std::string::npos) {
-    if(indexDelimiter0 > indexDelimiter1
-       || iString.find("[", indexDelimiter0 + 1) != std::string::npos
-       || iString.find("}", indexDelimiter1 + 1) != std::string::npos) {
-      errorMsg = "Invalid Syntax:\n" + iString;
-      return 0;
-    }
-
-    varName = iString.substr(0, indexDelimiter0);
-    varIndex = stoi(iString.substr(
-      indexDelimiter0 + 1, indexDelimiter1 - indexDelimiter0 - 1));
-    varIndexDefined = true;
-  }
-
-  // Search in candidates
-  auto column = fieldData->GetAbstractArray(varName.data());
-  if(column == nullptr) {
-    errorMsg = "FieldData does not contain array '" + varName + "'";
-    return 0;
-  }
-
-  size_t n = column->GetNumberOfTuples();
-  size_t m = column->GetNumberOfComponents();
-  int s = n * m;
-
-  if(!varIndexDefined) {
-    if(s > 0) {
-      oString = column->GetVariantValue(0).ToString();
-      for(int i = 1; i < s; i++)
-        oString += "," + column->GetVariantValue(i).ToString();
-    }
-  } else {
-    if(varIndex < 0 || varIndex >= s) {
-      errorMsg = "Index " + std::to_string(varIndex) + "/" + std::to_string(s)
-                 + " for FieldData Array '" + varName + "' out of range";
-      return 0;
-    }
-    oString = column->GetVariantValue(varIndex).ToString();
-  }
-
-  return 1;
-}
-
-int ttkUtils::replaceVariables(const std::string &iString,
-                               vtkFieldData *fieldData,
-                               std::string &oString,
-                               std::string &errorMsg) {
-  oString = iString;
-
-  while(oString.find("{") != std::string::npos
-        && oString.find("}") != std::string::npos) {
-    size_t o = oString.find("{");
-    size_t c = oString.find("}");
-    // {...{....{...}...}..}
-    // |            |
-    // o            c
-
-    size_t oNext = oString.find("{", o + 1);
-    while(oNext != std::string::npos && oNext < c) {
-      o = oNext;
-      oNext = oString.find("{", o + 1);
-    }
-
-    // {...{....{var}...}..}
-    //          |   |
-    //          o   c
-    std::string var = oString.substr(o + 1, c - 1 - o);
-
-    std::string rVar;
-    if(!replaceVariable(var, fieldData, rVar, errorMsg))
-      return 0;
-
-    oString = oString.substr(0, o) + rVar
-              + oString.substr(c + 1, oString.length() - c - 1);
-  }
-
-  if(oString.find("{") != std::string::npos
-     || oString.find("}") != std::string::npos) {
-    errorMsg = "Invalid Syntax:\n" + iString;
-    return 0;
-  }
-
-  return 1;
-}
-
-int ttkUtils::stringListToVector(const std::string &iString,
-                                 std::vector<std::string> &v) {
-  // ...,...,....,
-  //     |  |
-  //     i  j
-  size_t i = 0;
-  size_t j = iString.find(",");
-  while(j != std::string::npos) {
-    v.push_back(iString.substr(i, j - i));
-    i = j + 1;
-    j = iString.find(",", i);
-  }
-  if(iString.length() > i)
-    v.push_back(iString.substr(i, iString.length() - i));
-
-  return 1;
-}
-
-int ttkUtils::stringListToDoubleVector(const std::string &iString,
-                                       std::vector<double> &v) {
-  std::vector<std::string> stringVector;
-  if(!ttkUtils::stringListToVector(iString, stringVector))
-    return 0;
-
-  size_t n = stringVector.size();
-  v.resize(n);
-  // try {
-  for(size_t i = 0; i < n; i++)
-    v[i] = stod(stringVector[i]);
-  // } catch(std::invalid_argument &e) {
-  //   return 0;
-  // }
-
-  return 1;
-}
-
-vtkSmartPointer<vtkAbstractArray> ttkUtils::csvToVtkArray(std::string line) {
-  size_t firstComma = line.find(",", 0);
-
-  if(firstComma == std::string::npos)
-    return nullptr;
-
-  std::string arrayName = line.substr(0, firstComma);
-
-  std::vector<std::string> valuesAsString;
-  stringListToVector(
-    line.substr(firstComma + 1, std::string::npos), valuesAsString);
-  size_t nValues = valuesAsString.size();
-  if(nValues < 1)
-    return nullptr;
-
-  // Check if all elements are numbers
-  bool isNumeric = true;
-  {
-    for(size_t i = 0; i < nValues; i++) {
-      if(valuesAsString[i].size() > 0 && !isdigit(valuesAsString[i][0])) {
-        isNumeric = false;
-        break;
-      }
-    }
-  }
-
-  if(isNumeric) {
-    auto array = vtkSmartPointer<vtkDoubleArray>::New();
-    array->SetName(arrayName.data());
-    array->SetNumberOfComponents(1);
-    array->SetNumberOfTuples(nValues);
-    auto arrayData = reinterpret_cast<double *>(GetVoidPointer(array));
-    // try {
-    for(size_t i = 0; i < nValues; i++)
-      arrayData[i] = std::stod(valuesAsString[i]);
-    // } catch(std::invalid_argument &e) {
-    //   // return nullptr;
-    // }
-    return array;
-  } else {
-    auto array = vtkSmartPointer<vtkStringArray>::New();
-    array->SetName(arrayName.data());
-    array->SetNumberOfValues(nValues);
-    for(size_t i = 0; i < nValues; i++)
-      array->SetValue(i, valuesAsString[i]);
-    return array;
-  }
-}
-
-vtkSmartPointer<vtkDoubleArray> ttkUtils::csvToDoubleArray(std::string line) {
-  size_t firstComma = line.find(",", 0);
-
-  if(firstComma == std::string::npos)
-    return nullptr;
-
-  std::string arrayName = line.substr(0, firstComma);
-  std::string valuesAsString = line.substr(firstComma + 1, std::string::npos);
-
-  std::vector<double> values;
-  ttkUtils::stringListToDoubleVector(valuesAsString, values);
-  size_t n = values.size();
-
-  auto array = vtkSmartPointer<vtkDoubleArray>::New();
-  array->SetName(arrayName.data());
-  array->SetNumberOfComponents(1);
-  array->SetNumberOfTuples(n);
-  auto arrayData = reinterpret_cast<double *>(GetVoidPointer(array));
-  for(size_t i = 0; i < n; i++)
-    arrayData[i] = values[i];
-
-  return array;
-}
-
-/// Retrieve pointer to the internal data
-/// This method is a workaround to emulate
-/// the old GetVoidPointer in vtkDataArray
-void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
-  void *outPtr = nullptr;
-  switch(array->GetDataType()) {
-    vtkTemplateMacro(
-      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-      if(aosArray) { outPtr = aosArray->GetVoidPointer(start); });
-  }
-  return outPtr;
-}
-void *ttkUtils::GetVoidPointer(vtkPoints *points, vtkIdType start) {
-  return GetVoidPointer(points->GetData(), start);
-}
-
-void *ttkUtils::WriteVoidPointer(vtkDataArray *array,
-                                 vtkIdType valueIdx,
-                                 vtkIdType numValues) {
-  void *outPtr = nullptr;
-  switch(array->GetDataType()) {
-    vtkTemplateMacro(auto *aosArray
-                     = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-                     if(aosArray) {
-                       outPtr = aosArray->WriteVoidPointer(valueIdx, numValues);
-                     });
-  }
-  return outPtr;
-}
-
-void *ttkUtils::WritePointer(vtkDataArray *array,
-                             vtkIdType valueIdx,
-                             vtkIdType numValues) {
-  void *outPtr = nullptr;
-  switch(array->GetDataType()) {
-    vtkTemplateMacro(
-      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-      if(aosArray) { outPtr = aosArray->WritePointer(valueIdx, numValues); });
-  }
-  return outPtr;
-}
-
-void ttkUtils::SetVoidArray(vtkDataArray *array,
-                            void *data,
-                            vtkIdType size,
-                            int save) {
-  switch(array->GetDataType()) {
-    vtkTemplateMacro(
-      auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
-      if(aosArray) { aosArray->SetVoidArray(data, size, save); } else {
-        std::cerr << "SetVoidArray on incompatible vtkDataArray:" << endl;
-        array->Print(std::cerr);
-      });
-  }
-}
-
-[[deprecated]] void ttkUtils::FillCellArrayFromSingle(vtkIdType const *cells,
-                                                      vtkIdType ncells,
-                                                      vtkCellArray *cellArray) {
-  size_t curPos = 0;
-  vtkNew<vtkIdList> verts;
-  for(vtkIdType cid = 0; cid < ncells; cid++) {
-    const vtkIdType nbVerts = cells[curPos];
-    verts->SetNumberOfIds(nbVerts);
-    curPos++;
-    for(vtkIdType v = 0; v < nbVerts; v++) {
-      verts->SetId(v, cells[curPos]);
-      curPos++;
-    }
-    cellArray->InsertNextCell(verts);
-  }
-}
-
-void ttkUtils::FillCellArrayFromDual(vtkIdType const *cells_co,
-                                     vtkIdType const *cells_off,
-                                     vtkIdType ncells,
-                                     vtkCellArray *cellArray) {
-  size_t curPos = 0;
-  vtkNew<vtkIdList> verts;
-  for(vtkIdType cid = 0; cid < ncells; cid++) {
-    const vtkIdType nbVerts = cells_off[cid + 1] - cells_off[cid];
-    verts->SetNumberOfIds(nbVerts);
-    for(vtkIdType v = 0; v < nbVerts; v++) {
-      verts->SetId(v, cells_co[curPos]);
-      curPos++;
-    }
-    cellArray->InsertNextCell(verts);
-  }
-}
+  static void FillCellArrayFromDual(vtkIdType const *cells_co,
+                                    vtkIdType const *cells_off,
+                                    vtkIdType ncells,
+                                    vtkCellArray *cellArray);
+};

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+// VTK Module
+#include <ttkAlgorithmModule.h>
+
 #include <string>
 #include <vector>
 
@@ -22,7 +25,7 @@ class vtkCellArray;
 template <typename T>
 class vtkSmartPointer;
 
-class ttkUtils {
+class TTKALGORITHM_EXPORT ttkUtils {
 private:
   ttkUtils(){};
 

--- a/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
+++ b/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
@@ -1,6 +1,7 @@
 #include <ttkArrayEditor.h>
 
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 
 #include <vtkAbstractArray.h>
 #include <vtkDataArray.h>

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -1,14 +1,13 @@
 #include <ttkCinemaQuery.h>
 
-#include <vtkVersion.h>
 #include <vtkInformation.h>
 
 #include <vtkDelimitedTextReader.h>
 #include <vtkFieldData.h>
 #include <vtkInformationVector.h>
+#include <vtkObjectFactory.h>
 #include <vtkSmartPointer.h>
 #include <vtkTable.h>
-#include <vtkVersionMacros.h>
 
 #include <ttkUtils.h>
 
@@ -167,10 +166,6 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
   // ===========================================================================
   // Process Result
   {
-#if VTK_MAJOR_VERSION < 7
-    this->printErr("This filter requires at least VTK 7.0");
-    return 0;
-#else
     if(csvNRows < 1 || status != 1) {
       csvResult << "NULL";
       for(int i = 0; i < csvNColumns; i++)
@@ -209,7 +204,6 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
 
     this->printMsg("Converting SQL result to VTK table", 1,
                    conversionTimer.getElapsedTime());
-#endif
   }
 
   // print stats

--- a/core/vtk/ttkCinemaReader/ttkCinemaReader.cpp
+++ b/core/vtk/ttkCinemaReader/ttkCinemaReader.cpp
@@ -1,6 +1,7 @@
 #include <ttkCinemaReader.h>
 
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 
 #include <vtkDelimitedTextReader.h>
 #include <vtkFieldData.h>

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -3,9 +3,9 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
-#include <vtkVersion.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
+#include <vtkVersion.h>
 
 #include <vtkCellData.h>
 #include <vtkDataSet.h>

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -1,6 +1,7 @@
 #include <ttkDimensionReduction.h>
 #include <ttkUtils.h>
 
+#include <vtkDoubleArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>

--- a/core/vtk/ttkDistanceField/ttkDistanceField.cpp
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.cpp
@@ -1,3 +1,4 @@
+#include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -4,6 +4,7 @@
 
 #include <vtkDataObject.h>
 #include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
 #include <vtkInformation.h>
 #include <vtkObjectFactory.h>

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -4,6 +4,7 @@
 
 #include <vtkDataObject.h>
 #include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>

--- a/core/vtk/ttkTriangulationAlgorithm/macro.h
+++ b/core/vtk/ttkTriangulationAlgorithm/macro.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <vtkVersion.h>
 #include <vtkIdTypeArray.h>
 #include <vtkImageData.h>
 #include <vtkInformationVector.h>
 #include <vtkIntArray.h>
 #include <vtkPolyData.h>
 #include <vtkUnstructuredGrid.h>
+#include <vtkVersion.h>
 
 #define TTK_COMMA ,
 


### PR DESCRIPTION
Hi everyone,
I'm working on modules that have several classes in the vtk component which all require ttkUtils functionality. However, due to a reason I forgot we had to add the content of the ttkUtils.cpp into the ttkUtils.h file. So in my scenario I get "duplicate definition" errors.

I created this PR to separate the implementation from the header again. This also required me to adjust some includes in other modules. If I remember correctly the old version caused linking errors on some platforms. So we have to make sure that everything works (not only the statefiles) before we merge this in.

Best
Jonas