### PR TITLE
Make setThreadNumber virtual (and other fixes)

### DIFF
--- a/core/base/TTKBaseConfig.cmake.in
+++ b/core/base/TTKBaseConfig.cmake.in
@@ -13,5 +13,14 @@ if (@TTK_ENABLE_OPENMP@)
   find_dependency(OpenMP REQUIRED)
 endif()
 
+if (@TTK_ENABLE_ZFP@ AND NOT @TTK_ENABLE_SHARED_BASE_LIBRARIES@)
+  set(ZFP_DIR "@ZFP_DIR@" CACHE PATH "Use TTK ZFP dir" FORCE)
+  find_dependency(ZFP REQUIRED @ZFP_DIR@)
+endif()
+
+if (@TTK_ENABLE_ZLIB@ AND NOT @TTK_ENABLE_SHARED_BASE_LIBRARIES@)
+  find_dependency(ZLIB REQUIRED)
+endif()
+
 # Include the actual targets for TTK Base
 include("${CMAKE_CURRENT_LIST_DIR}/TTKBaseTargets.cmake")

--- a/core/base/auction/Auction.h
+++ b/core/base/auction/Auction.h
@@ -1,6 +1,4 @@
-
-#ifndef _AUCTION_H
-#define _AUCTION_H
+#pragma once
 
 #ifndef matchingTuple
 #define matchingTuple std::tuple<ttk::SimplexId, ttk::SimplexId, dataType>
@@ -35,11 +33,13 @@
 namespace ttk {
   template <typename dataType>
   struct Compare {
+    // clang-format off
     constexpr bool
       operator()(std::pair<int, dataType> const &a,
                  std::pair<int, dataType> const &b) const noexcept {
       return a.second > b.second;
     }
+    // clang-format on
   };
 
   template <typename dataType>
@@ -360,5 +360,3 @@ namespace ttk {
 } // namespace ttk
 
 #include <AuctionImpl.h>
-
-#endif

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -30,7 +30,7 @@ namespace ttk {
       return threadNumber_;
     };
 
-    int setThreadNumber(const int threadNumber) {
+    virtual int setThreadNumber(const int threadNumber) {
       threadNumber_ = threadNumber;
       return 0;
     }

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -12,6 +12,11 @@
 #include <omp.h>
 #endif
 
+#ifdef _WIN32
+// enable the `and` and `or` keywords on MSVC
+#include <ciso646>
+#endif // _WIN32
+
 #include <DataTypes.h>
 
 namespace ttk {

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -36,7 +36,9 @@ namespace ttk {
 #ifdef _WIN32
     directoryPath = _getcwd(NULL, 0);
 #else
-    directoryPath = getcwd(NULL, PATH_MAX);
+    std::vector<char> cwdName(PATH_MAX);
+    getcwd(cwdName.data(), cwdName.size());
+    directoryPath = std::string{cwdName.data()};
 #endif
     directoryPath += "/";
 

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -12,7 +12,6 @@
 
 #include <windows.h>
 
-#include <ciso646>
 #include <cwchar>
 #include <direct.h>
 #include <stdint.h>

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -130,12 +130,13 @@ namespace ttk {
       // Getters & Setters
       // {
 
-      inline void setThreadNumber(const unsigned short nbThread) {
+      inline int setThreadNumber(const int nbThread) {
         if(nbThread) {
           parallelParams_.nbThreads = nbThread;
         } else {
           parallelParams_.nbThreads = OsCall::getNumberOfCores();
         }
+        return 0;
       }
 
       inline void setPartitionNum(int p) {

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -1234,7 +1234,7 @@ AlignmentTree *ttk::ContourTreeAlignment::traceAlignmentTree(BinaryTree *t1,
   if(t2 == NULL)
     return traceNullAlignment(t1, true);
 
-  auto id = [this](BinaryTree *t) { return t == NULL ? 0 : t->id; };
+  auto id = [](BinaryTree *t) { return t == NULL ? 0 : t->id; };
 
   if(memT[t1->id][t2->id] == editCost(t1, t2) + memF[t1->id][t2->id]) {
 
@@ -1381,7 +1381,7 @@ std::vector<AlignmentTree *> ttk::ContourTreeAlignment::traceAlignmentForest(
       res.push_back(traceNullAlignment(t1->child2, true));
   }
 
-  auto id = [this](BinaryTree *t) { return t == NULL ? 0 : t->id; };
+  auto id = [](BinaryTree *t) { return t == NULL ? 0 : t->id; };
 
   if(memF[t1->id][t2->id]
      == memT[id(t1->child1)][id(t2->child1)]

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -70,8 +70,6 @@ struct AlignmentEdge {
   std::vector<std::pair<int, int>> arcRefs;
 };
 
-using namespace std;
-
 namespace ttk {
 
   class ContourTreeAlignment : virtual public Debug {
@@ -115,20 +113,20 @@ namespace ttk {
 
     /// The actual iterated n-tree-alignment algorithm
     template <class scalarType>
-    int execute(const vector<void *> &scalarsVP,
-                const vector<int *> &regionSizes,
-                const vector<int *> &segmentationIds,
-                const vector<long long *> &topologies,
-                const vector<size_t> &nVertices,
-                const vector<size_t> &nEdges,
+    int execute(const std::vector<void *> &scalarsVP,
+                const std::vector<int *> &regionSizes,
+                const std::vector<int *> &segmentationIds,
+                const std::vector<long long *> &topologies,
+                const std::vector<size_t> &nVertices,
+                const std::vector<size_t> &nEdges,
 
-                vector<float> &outputVertices,
-                vector<long long> &outputFrequencies,
-                vector<long long> &outputVertexIds,
-                vector<long long> &outputBranchIds,
-                vector<long long> &outputSegmentationIds,
-                vector<long long> &outputArcIds,
-                vector<int> &outputEdges,
+                std::vector<float> &outputVertices,
+                std::vector<long long> &outputFrequencies,
+                std::vector<long long> &outputVertexIds,
+                std::vector<long long> &outputBranchIds,
+                std::vector<long long> &outputSegmentationIds,
+                std::vector<long long> &outputArcIds,
+                std::vector<int> &outputEdges,
                 int seed);
 
     /// functions for aligning single trees in iteration
@@ -225,26 +223,27 @@ namespace ttk {
 } // namespace ttk
 
 template <class scalarType>
-int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
-                                       const vector<int *> &regionSizes,
-                                       const vector<int *> &segmentationIds,
-                                       const vector<long long *> &topologies,
-                                       const vector<size_t> &nVertices,
-                                       const vector<size_t> &nEdges,
-                                       vector<float> &outputVertices,
-                                       vector<long long> &outputFrequencies,
-                                       vector<long long> &outputVertexIds,
-                                       vector<long long> &outputBranchIds,
-                                       vector<long long> &outputSegmentationIds,
-                                       vector<long long> &outputArcIds,
-                                       vector<int> &outputEdges,
-                                       int seed) {
+int ttk::ContourTreeAlignment::execute(
+  const std::vector<void *> &scalarsVP,
+  const std::vector<int *> &regionSizes,
+  const std::vector<int *> &segmentationIds,
+  const std::vector<long long *> &topologies,
+  const std::vector<size_t> &nVertices,
+  const std::vector<size_t> &nEdges,
+  std::vector<float> &outputVertices,
+  std::vector<long long> &outputFrequencies,
+  std::vector<long long> &outputVertexIds,
+  std::vector<long long> &outputBranchIds,
+  std::vector<long long> &outputSegmentationIds,
+  std::vector<long long> &outputArcIds,
+  std::vector<int> &outputEdges,
+  int seed) {
 
   Timer timer;
 
   size_t nTrees = nVertices.size();
 
-  vector<float *> scalars(nTrees);
+  std::vector<float *> scalars(nTrees);
   for(size_t t = 0; t < nTrees; t++) {
     scalars[t] = (float *)((scalarType *)scalarsVP[t]);
   }

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -304,7 +304,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
   contourtrees = std::vector<ContourTree *>();
   nodes = std::vector<AlignmentNode *>();
   arcs = std::vector<AlignmentEdge *>();
-  int bestRootIdx;
+  int bestRootIdx{};
 
   this->printMsg(ttk::debug::Separator::L1);
   this->printMsg("Shuffling input trees. Used seed: " + std::to_string(seed), 0,
@@ -317,7 +317,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
   }
   std::srand(seed);
   if(alignmenttreeType != lastMatchedValue)
-    std::random_shuffle(permutation.begin(), permutation.end());
+    std::shuffle(permutation.begin(), permutation.end(), std::random_device{});
 
   this->printMsg(
     "Shuffling input trees. Used seed: " + std::to_string(seed), 1);

--- a/core/base/contourTreeAlignment/contourtree.cpp
+++ b/core/base/contourTreeAlignment/contourtree.cpp
@@ -135,7 +135,7 @@ Tree *ContourTree::computeRootedTree(CTNode *node, CTEdge *parent, int &id) {
     t->volume = 0.0001;
   } else {
     t->scalardistanceParent = parent->scalardistance;
-    t->volume = t->scalardistanceParent * (float)parent->area;
+    t->volume = t->scalardistanceParent * parent->area;
   }
 
   return t;
@@ -216,8 +216,8 @@ BinaryTree *
     t->volume = 10000;
   } else {
     t->scalardistanceParent = parent->scalardistance;
-    t->area = (float)parent->area;
-    t->volume = t->scalardistanceParent * (float)parent->area;
+    t->area = parent->area;
+    t->volume = t->scalardistanceParent * parent->area;
   }
 
   return t;

--- a/core/base/contourTreeAlignment/contourtree.h
+++ b/core/base/contourTreeAlignment/contourtree.h
@@ -113,7 +113,6 @@ private:
   std::vector<CTEdge *> arcs;
 
   bool binary;
-  float threshold;
 
   Tree *computeRootedTree(CTNode *node, CTEdge *parent, int &id);
   BinaryTree *computeRootedTree_binary(CTNode *node, CTEdge *parent, int &id);

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -1025,7 +1025,9 @@ namespace ttk {
 #endif
           for(SimplexId i = 0; i < cellNumber; i++) {
             if(offset[i + 1] - offset[i] - 1 != cellDimension) {
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic write
+#endif // TTK_ENABLE_OPENMP
               error = true;
             }
           }

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -44,9 +44,8 @@ namespace ttk {
 
     template <typename Type>
     std::string DynamicGraph<Type>::print(void) {
-      using namespace std;
 
-      stringstream res;
+      std::stringstream res;
 
       for(const auto &node : nodes_) {
         if(1 or node.parent_) {
@@ -59,7 +58,7 @@ namespace ttk {
           res << " root: " << findRoot(&node) - &nodes_[0];
           res << " weight: " << (float)node.weight_;
           res << " cArc: " << node.corArc_;
-          res << endl;
+          res << std::endl;
         }
       }
       return res.str();
@@ -68,9 +67,8 @@ namespace ttk {
     template <typename Type>
     std::string DynamicGraph<Type>::print(
       std::function<std::string(std::size_t)> printFunction) {
-      using namespace std;
 
-      stringstream res;
+      std::stringstream res;
 
       for(const auto &node : nodes_) {
         if(node.parent_) {
@@ -89,8 +87,8 @@ namespace ttk {
 
     template <typename Type>
     std::string DynamicGraph<Type>::printNbCC(void) {
-      using namespace std;
-      stringstream res;
+
+      std::stringstream res;
       std::vector<DynGraphNode<Type> *> roots;
       roots.reserve(nodes_.size());
       for(const auto &n : nodes_) {

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -156,10 +156,11 @@ namespace ttk {
 
       /// The nuber of threads to be used during the computation
       /// of the reeb graph
-      void setThreadNumber(const idThread nb) {
+      int setThreadNumber(const int nb) override {
         params_.threadNumber = nb;
         // Security, but do not rely on this one
         threadNumber_ = nb;
+        return 0;
       }
 
       /// Control the verbosity of the base code

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -15,10 +15,6 @@
 // base code includes
 #include <AbstractTriangulation.h>
 
-#ifdef _WIN32
-#include <ciso646>
-#endif
-
 namespace ttk {
 
   class ImplicitTriangulation final : public AbstractTriangulation {

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -32,1179 +32,1089 @@
 
 #include <SSCPropagation.h>
 
-
 namespace ttk {
 
-  std::string toFixed(const float& number, const int precision = 2){
-      std::stringstream vFraction;
-      vFraction << std::fixed << std::setprecision(precision) << number;
-      return vFraction.str();
+  std::string toFixed(const float &number, const int precision = 2) {
+    std::stringstream vFraction;
+    vFraction << std::fixed << std::setprecision(precision) << number;
+    return vFraction.str();
   };
 
-  template<typename IT>
-  std::string toFixed(const IT& number0, const IT& number1, const int precision = 2){
-      return toFixed( ((float)number0)/((float)number1), precision );
+  template <typename IT>
+  std::string
+    toFixed(const IT &number0, const IT &number1, const int precision = 2) {
+    return toFixed(((float)number0) / ((float)number1), precision);
   };
 
   class LocalizedTopologicalSimplification : virtual public Debug {
 
-    public:
-      LocalizedTopologicalSimplification() {
-        this->setDebugMsgPrefix("LTS");
-      };
-      ~LocalizedTopologicalSimplification(){};
+  public:
+    LocalizedTopologicalSimplification() {
+      this->setDebugMsgPrefix("LTS");
+    };
+    ~LocalizedTopologicalSimplification(){};
 
-      int preconditionTriangulation(
-        ttk::AbstractTriangulation *triangulation) const {
-        return triangulation->preconditionVertexNeighbors();
-      };
+    int preconditionTriangulation(
+      ttk::AbstractTriangulation *triangulation) const {
+      return triangulation->preconditionVertexNeighbors();
+    };
 
-      template<typename IT>
-      int allocateMemory(
-          std::vector<IT>& segmentation,
-          std::vector<IT>& queueMask,
-          std::vector<IT>& localOrder,
-          std::vector<SSCPropagation<IT>*>& propagationMask,
-          std::vector<std::tuple<IT,IT,IT>>& sortedIndices,
+    template <typename IT>
+    int allocateMemory(std::vector<IT> &segmentation,
+                       std::vector<IT> &queueMask,
+                       std::vector<IT> &localOrder,
+                       std::vector<SSCPropagation<IT> *> &propagationMask,
+                       std::vector<std::tuple<IT, IT, IT>> &sortedIndices,
 
-          const IT& nVertices
-      ) const {
-          ttk::Timer timer;
+                       const IT &nVertices) const {
+      ttk::Timer timer;
 
-          // -------------------------------------------------------------
-          // allocate and init memory
-          // -------------------------------------------------------------
-          this->printMsg(
-              "Allocating Memory",
-              0,0,this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
+      // -------------------------------------------------------------
+      // allocate and init memory
+      // -------------------------------------------------------------
+      this->printMsg("Allocating Memory", 0, 0, this->threadNumber_,
+                     debug::LineMode::REPLACE);
 
-          segmentation.resize(nVertices);
-          queueMask.resize(nVertices);
-          localOrder.resize(nVertices);
-          propagationMask.resize(nVertices);
-          sortedIndices.resize(nVertices);
+      segmentation.resize(nVertices);
+      queueMask.resize(nVertices);
+      localOrder.resize(nVertices);
+      propagationMask.resize(nVertices);
+      sortedIndices.resize(nVertices);
 
-          this->printMsg(
-              "Allocating Memory",
-              1,timer.getElapsedTime(),this->threadNumber_
-          );
+      this->printMsg(
+        "Allocating Memory", 1, timer.getElapsedTime(), this->threadNumber_);
 
-          return 1;
-      };
+      return 1;
+    };
 
-      template<typename IT>
-      int initializeMemory(
-          IT* segmentation,
-          IT* queueMask,
-          IT* localOrder,
-          SSCPropagation<IT>** propagationMask,
+    template <typename IT>
+    int initializeMemory(IT *segmentation,
+                         IT *queueMask,
+                         IT *localOrder,
+                         SSCPropagation<IT> **propagationMask,
 
-          const IT& nVertices
-      ) const {
-          ttk::Timer timer;
+                         const IT &nVertices) const {
+      ttk::Timer timer;
 
-          // -------------------------------------------------------------
-          // allocate and init memory
-          // -------------------------------------------------------------
-          this->printMsg(
-              "Initializing Memory",
-              0,0,this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
+      // -------------------------------------------------------------
+      // allocate and init memory
+      // -------------------------------------------------------------
+      this->printMsg("Initializing Memory", 0, 0, this->threadNumber_,
+                     debug::LineMode::REPLACE);
 
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT i=0; i<nVertices; i++){
-              segmentation[i] = -1;
-              queueMask[i] = -1;
-              localOrder[i] = -1;
-              propagationMask[i] = nullptr;
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT i = 0; i < nVertices; i++) {
+        segmentation[i] = -1;
+        queueMask[i] = -1;
+        localOrder[i] = -1;
+        propagationMask[i] = nullptr;
+      }
+
+      this->printMsg(
+        "Initializing Memory", 1, timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    };
+
+    template <typename IT, class TT>
+    int initializePropagations(
+      std::vector<SSCPropagation<IT>> &propagations,
+      IT *authorizationMask, // assumes preservation mask is initialized as -1
+      IT *maximaBuffer,
+
+      const IT *authorizedExtremaIndices,
+      const IT &nAuthorizedExtremaIndices,
+      const IT *inputOrder,
+      const TT *triangulation) const {
+
+      ttk::Timer timer;
+      this->printMsg("Initializing Propagations", 0, 0, this->threadNumber_,
+                     debug::LineMode::REPLACE);
+
+      const IT nVertices = triangulation->getNumberOfVertices();
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT i = 0; i < nAuthorizedExtremaIndices; i++)
+        authorizationMask[authorizedExtremaIndices[i]] = -2;
+
+      IT writeIndex = 0;
+// find discareded maxima
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT v = 0; v < nVertices; v++) {
+
+        // if v needs to be preserved then skip
+        if(authorizationMask[v] == -2)
+          continue;
+
+        // check if v has larger neighbors
+        bool hasLargerNeighbor = false;
+        const IT &vOrder = inputOrder[v];
+        const IT nNeighbors = triangulation->getVertexNeighborNumber(v);
+        for(IT n = 0; n < nNeighbors; n++) {
+          IT u;
+          triangulation->getVertexNeighbor(v, n, u);
+          if(vOrder < inputOrder[u]) {
+            hasLargerNeighbor = true;
+            break;
+          }
+        }
+
+        // if v has larger neighbors then v can not be maximum
+        if(hasLargerNeighbor)
+          continue;
+
+        // get local write index for this thread
+        IT localWriteIndex = 0;
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp atomic capture
+#endif // TTK_ENABLE_OPENMP
+        localWriteIndex = writeIndex++;
+
+// atomic write to prevent cache line conflicts
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp atomic write
+#endif // TTK_ENABLE_OPENMP
+        maximaBuffer[localWriteIndex] = v;
+      }
+
+      // init propagations
+      propagations.resize(writeIndex);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < writeIndex; p++) {
+        propagations[p].criticalPoints.push_back(maximaBuffer[p]);
+      }
+
+      this->printMsg("Initializing Propagations (" + std::to_string(writeIndex)
+                       + "|" + std::to_string(nVertices) + ")",
+                     1, timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    };
+
+    /// This is a simple superlevel set propagation procedure that just absorbs
+    /// the largest neighbor of the current set until the propagation encounters
+    /// a saddle. To gain additional speedup this procedure does NOT compute a
+    /// list of visited critical points and does not check for an early escape.
+    template <typename IT, typename TT>
+    int computeSimplePropagation(
+      SSCPropagation<IT> &propagation,
+      SSCPropagation<IT> **propagationMask,
+      IT *segmentation, // used here to also store registered larger vertices
+      IT *queueMask, // used to mark vertices that have already been added to
+                     // the queue by this thread
+
+      const TT *triangulation,
+      const IT *orderField) const {
+
+      // pointer used to compare against representative
+      auto *currentPropagation = &propagation;
+
+      // frequently used propagation members
+      IT &extremumIndex = currentPropagation->criticalPoints[0];
+      auto *queue = &currentPropagation->queue;
+
+      // add extremumIndex to queue
+      queue->emplace(orderField[extremumIndex], extremumIndex);
+
+      IT queueMaskLabel = extremumIndex;
+      queueMask[extremumIndex] = queueMaskLabel;
+      IT segmentId = extremumIndex;
+
+      // grow segment until prop reaches a saddle and then decide if prop should
+      // continue
+      IT v = -1;
+      while(!queue->empty()) {
+        v = std::get<1>(queue->top());
+        queue->pop();
+
+        // continue if this thread has already seen this vertex
+        if(propagationMask[v] != nullptr)
+          continue;
+
+        const IT &orderV = orderField[v];
+
+        // add neighbors to queue AND check if v is a saddle
+        bool isSaddle = false;
+        const IT nNeighbors = triangulation->getVertexNeighborNumber(v);
+
+        IT numberOfLargerNeighbors = 0;
+        IT numberOfLargerNeighborsThisThreadVisited = 0;
+        for(IT n = 0; n < nNeighbors; n++) {
+          IT u;
+          triangulation->getVertexNeighbor(v, n, u);
+
+          const IT &orderU = orderField[u];
+
+          // if larger neighbor
+          if(orderU > orderV) {
+            numberOfLargerNeighbors++;
+
+            auto uPropagation = propagationMask[u];
+            if(uPropagation == nullptr
+               || currentPropagation != uPropagation->find())
+              isSaddle = true;
+            else
+              numberOfLargerNeighborsThisThreadVisited++;
+          } else if(queueMask[u] != queueMaskLabel) {
+            queue->emplace(orderU, u);
+            queueMask[u] = queueMaskLabel;
+          }
+        }
+
+        // if v is a saddle we have to check if the current thread is the last
+        // visitor
+        if(isSaddle) {
+          currentPropagation->lastEncounteredCriticalPoint = v;
+
+          IT numberOfRegisteredLargerVertices = 0;
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp atomic capture
+#endif // TTK_ENABLE_OPENMP
+          {
+            segmentation[v] -= numberOfLargerNeighborsThisThreadVisited;
+            numberOfRegisteredLargerVertices = segmentation[v];
           }
 
-          this->printMsg(
-              "Initializing Memory",
-              1,timer.getElapsedTime(),this->threadNumber_
-          );
+          // if this thread did not register the last remaining larger vertices
+          // then terminate propagation
+          if(numberOfRegisteredLargerVertices != -numberOfLargerNeighbors - 1)
+            return 1;
 
-          return 1;
-      };
+          // merge propagations
+          for(IT n = 0; n < nNeighbors; n++) {
+            IT u;
+            triangulation->getVertexNeighbor(v, n, u);
 
-      template<typename IT, class TT>
-      int initializePropagations(
-          std::vector<SSCPropagation<IT>>& propagations,
-          IT* authorizationMask, // assumes preservation mask is initialized as -1
-          IT* maximaBuffer,
-
-          const IT* authorizedExtremaIndices,
-          const IT& nAuthorizedExtremaIndices,
-          const IT* inputOrder,
-          const TT* triangulation
-      ) const {
-
-          ttk::Timer timer;
-          this->printMsg(
-              "Initializing Propagations",
-              0,0,this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          const IT nVertices = triangulation->getNumberOfVertices();
-
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT i=0; i<nAuthorizedExtremaIndices; i++)
-              authorizationMask[authorizedExtremaIndices[i]]=-2;
-
-          IT writeIndex=0;
-          // find discareded maxima
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT v=0; v<nVertices; v++){
-
-              // if v needs to be preserved then skip
-              if(authorizationMask[v]==-2)
-                continue;
-
-              // check if v has larger neighbors
-              bool hasLargerNeighbor = false;
-              const IT& vOrder = inputOrder[v];
-              const IT nNeighbors = triangulation->getVertexNeighborNumber( v );
-              for(IT n=0; n<nNeighbors; n++){
-                  IT u;
-                  triangulation->getVertexNeighbor(v,n,u);
-                  if( vOrder<inputOrder[u] ){
-                      hasLargerNeighbor = true;
-                      break;
-                  }
+            if(propagationMask[u] != nullptr) {
+              auto uPropagation = propagationMask[u]->find();
+              if(uPropagation != currentPropagation) {
+                currentPropagation = SSCPropagation<IT>::unify(
+                  currentPropagation, uPropagation, orderField);
               }
-
-              // if v has larger neighbors then v can not be maximum
-              if(hasLargerNeighbor)
-                  continue;
-
-              // get local write index for this thread
-              IT localWriteIndex = 0;
-              #pragma omp atomic capture
-              localWriteIndex = writeIndex++;
-
-              // atomic write to prevent cache line conflicts
-              #pragma omp atomic write
-              maximaBuffer[localWriteIndex] = v;
+            }
           }
 
-          // init propagations
-          propagations.resize(writeIndex);
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT p=0; p<writeIndex; p++){
-            propagations[p].criticalPoints.push_back( maximaBuffer[p] );
+          queue = &currentPropagation->queue;
+          segmentId = v;
+          queueMaskLabel = currentPropagation->criticalPoints[0];
+        }
+
+        // mark vertex as visited and continue
+        propagationMask[v] = currentPropagation;
+        segmentation[v] = segmentId;
+        currentPropagation->segmentSize++;
+      }
+
+      this->printErr(
+        "Simple propagations should never reach global minimum/maximum.");
+
+      return 0;
+    };
+
+    template <typename IT, class TT>
+    int computeSimplePropagations(std::vector<SSCPropagation<IT>> &propagations,
+                                  SSCPropagation<IT> **propagationMask,
+                                  IT *segmentation,
+                                  IT *queueMask,
+
+                                  const TT *triangulation,
+                                  const IT *inputOrder) const {
+      ttk::Timer timer;
+
+      const IT nPropagations = propagations.size();
+      this->printMsg(
+        "Computing Propagations (" + std::to_string(nPropagations) + ")", 0, 0,
+        this->threadNumber_, debug::LineMode::REPLACE);
+
+      int status = 1;
+// compute propagations
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic, 1) num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < nPropagations; p++) {
+        int localStatus = this->computeSimplePropagation<IT, TT>(
+          propagations[p], propagationMask, segmentation, queueMask,
+
+          triangulation, inputOrder);
+
+        if(!localStatus)
+          status = 0;
+      }
+
+      if(!status)
+        return 0;
+
+      this->printMsg(
+        "Computing Propagations (" + std::to_string(nPropagations) + ")", 1,
+        timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    }
+
+    template <typename IT>
+    int finalizePropagations(
+      std::vector<SSCPropagation<IT> *> &parentPropagations,
+      std::vector<SSCPropagation<IT>> &propagations,
+
+      const IT nVertices) const {
+      ttk::Timer timer;
+
+      const IT nPropagations = propagations.size();
+
+      this->printMsg(
+        "Finalizing Propagations (" + std::to_string(nPropagations) + ")", 0,
+        timer.getElapsedTime(), this->threadNumber_, debug::LineMode::REPLACE);
+
+      IT nSegmentVertices = 0;
+      IT nParentPropagations = 0;
+      parentPropagations.clear();
+      parentPropagations.resize(nPropagations);
+      for(IT p = 0; p < nPropagations; p++) {
+        auto *propagation = &propagations[p];
+        if(propagation->parent == propagation) {
+          nSegmentVertices = nSegmentVertices + propagation->segmentSize;
+          parentPropagations[nParentPropagations++] = propagation;
+        }
+      }
+      parentPropagations.resize(nParentPropagations);
+
+      std::stringstream pFraction, vFraction;
+      pFraction << std::fixed << std::setprecision(2)
+                << ((float)nParentPropagations / (float)nPropagations);
+      vFraction << std::fixed << std::setprecision(2)
+                << ((float)nSegmentVertices / (float)nVertices);
+
+      this->printMsg("Finalizing Propagations ("
+                       + std::to_string(nParentPropagations) + "|"
+                       + toFixed(nParentPropagations, nPropagations) + "|"
+                       + toFixed(nSegmentVertices, nVertices) + ")",
+                     1, timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    };
+
+    template <typename IT, class TT>
+    int computeSegment(IT *segmentation,
+                       SSCPropagation<IT> *propagation,
+
+                       const TT *triangulation) const {
+
+      const IT &extremumIndex = propagation->criticalPoints[0];
+
+      // collect segment
+      auto &segment = propagation->segment;
+
+      segment.resize(propagation->segmentSize);
+      IT segmentIndex = 0;
+      {
+        std::vector<IT> queue(propagation->segmentSize);
+        IT queueIndex = 0;
+
+        // init queue
+        {
+          queue[queueIndex++] = extremumIndex;
+          segmentation[extremumIndex] = -1000;
+        }
+
+        // flood fill by starting from extremum
+        while(queueIndex > 0) {
+          const IT v = queue[--queueIndex];
+
+          segment[segmentIndex++] = v;
+
+          IT nNeighbors = triangulation->getVertexNeighborNumber(v);
+          for(IT n = 0; n < nNeighbors; n++) {
+            IT u;
+            triangulation->getVertexNeighbor(v, n, u);
+            if(segmentation[u] >= 0) {
+              segmentation[u] = -999; // mark as visited
+              queue[queueIndex++] = u; // add to queue
+            }
           }
+        }
+      }
 
-          this->printMsg(
-              "Initializing Propagations ("+std::to_string(writeIndex)+"|"+std::to_string(nVertices)+")",
-              1,timer.getElapsedTime(),this->threadNumber_
-          );
+      if(segmentIndex != propagation->segmentSize) {
+        this->printErr("Segment size incorrect: " + std::to_string(segmentIndex)
+                       + " " + std::to_string(propagation->segmentSize));
+        return 0;
+      }
 
-          return 1;
-      };
+      for(auto idx : propagation->segment)
+        segmentation[idx] = extremumIndex;
 
-      /// This is a simple superlevel set propagation procedure that just absorbs
-      /// the largest neighbor of the current set until the propagation encounters
-      /// a saddle. To gain additional speedup this procedure does NOT compute a
-      /// list of visited critical points and does not check for an early escape.
-      template<typename IT, typename TT>
-      int computeSimplePropagation(
-          SSCPropagation<IT>& propagation,
-          SSCPropagation<IT>** propagationMask,
-          IT* segmentation, // used here to also store registered larger vertices
-          IT* queueMask, // used to mark vertices that have already been added to the queue by this thread
+      return 1;
+    };
 
-          const TT* triangulation,
-          const IT* orderField
-      ) const {
+    template <typename IT, class TT>
+    int computeSegments(IT *segmentation,
+                        std::vector<SSCPropagation<IT> *> &propagations,
 
-          // pointer used to compare against representative
-          auto* currentPropagation = &propagation;
+                        const TT *triangulation) const {
 
-          // frequently used propagation members
-          IT& extremumIndex = currentPropagation->criticalPoints[0];
-          auto* queue = &currentPropagation->queue;
+      const IT nPropagations = propagations.size();
+      const IT nVertices = triangulation->getNumberOfVertices();
 
-          // add extremumIndex to queue
-          queue->emplace(orderField[extremumIndex],extremumIndex);
+      ttk::Timer timer;
+      this->printMsg(
+        "Computing segments (" + std::to_string(nPropagations) + ")", 0, 0,
+        this->threadNumber_, debug::LineMode::REPLACE);
 
-          IT queueMaskLabel = extremumIndex;
-          queueMask[extremumIndex] = queueMaskLabel;
-          IT segmentId = extremumIndex;
+      int status = 1;
 
-          // grow segment until prop reaches a saddle and then decide if prop should continue
-          IT v = -1;
-          while(!queue->empty()){
-              v = std::get<1>(queue->top());
-              queue->pop();
+// compute segments in parallel
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < nPropagations; p++) {
+        int localStatus
+          = this->computeSegment<IT, TT>(segmentation, propagations[p],
 
-              // continue if this thread has already seen this vertex
-              if(propagationMask[v]!=nullptr)
-                  continue;
+                                         triangulation);
+        if(!localStatus)
+          status = 0;
+      }
+      if(!status)
+        return 0;
 
-              const IT& orderV = orderField[v];
+      // print status
+      if(this->debugLevel_ < 4) {
+        this->printMsg(
+          "Computing segments (" + std::to_string(nPropagations) + ")", 1,
+          timer.getElapsedTime(), this->threadNumber_);
+      } else {
 
-              // add neighbors to queue AND check if v is a saddle
-              bool isSaddle = false;
-              const IT nNeighbors = triangulation->getVertexNeighborNumber( v );
+        IT min = propagations[0]->segmentSize;
+        IT max = min;
+        IT avg = 0;
 
-              IT numberOfLargerNeighbors = 0;
-              IT numberOfLargerNeighborsThisThreadVisited = 0;
-              for(IT n=0; n<nNeighbors; n++){
-                  IT u;
-                  triangulation->getVertexNeighbor(v,n,u);
+        for(IT p = 0; p < nPropagations; p++) {
+          const auto propagation = propagations[p];
+          if(min > propagation->segmentSize)
+            min = propagation->segmentSize;
+          if(max < propagation->segmentSize)
+            max = propagation->segmentSize;
+          avg += propagation->segmentSize;
+        }
 
-                  const IT& orderU = orderField[u];
+        avg /= nPropagations;
 
-                  // if larger neighbor
-                  if( orderU>orderV ){
-                      numberOfLargerNeighbors++;
+        this->printMsg("Computing segments (" + std::to_string(nPropagations)
+                         + "|" + toFixed(min, nVertices) + "|"
+                         + toFixed(avg, nVertices) + "|"
+                         + toFixed(max, nVertices) + ")",
+                       1, timer.getElapsedTime(), this->threadNumber_);
+      }
 
-                      auto uPropagation = propagationMask[u];
-                      if(uPropagation==nullptr || currentPropagation!=uPropagation->find())
-                          isSaddle = true;
-                      else
-                          numberOfLargerNeighborsThisThreadVisited++;
-                  } else if(queueMask[u] != queueMaskLabel) {
-                      queue->emplace(orderU,u);
-                      queueMask[u] = queueMaskLabel;
-                  }
-              }
+      return 1;
+    };
 
-              // if v is a saddle we have to check if the current thread is the last visitor
-              if(isSaddle){
-                  currentPropagation->lastEncounteredCriticalPoint = v;
+    template <typename IT, class TT>
+    int computeLocalOrderOfSegmentIteration(
+      IT *localOrder,
+      IT *localVertexSequence,
 
-                  IT numberOfRegisteredLargerVertices=0;
-                  #pragma omp atomic capture
-                  {
-                      segmentation[v] -= numberOfLargerNeighborsThisThreadVisited;
-                      numberOfRegisteredLargerVertices = segmentation[v];
-                  }
+      const bool &performSuperlevelSetPropagation,
+      const TT *triangulation,
+      const IT *segmentation,
+      const IT &segmentId,
+      const std::vector<IT> &boundary,
+      const std::vector<IT> &segment,
+      const IT &saddleIdx) const {
+      // init priority queue
+      std::priority_queue<std::pair<IT, IT>, std::vector<std::pair<IT, IT>>>
+        queue;
 
-                  // if this thread did not register the last remaining larger vertices then terminate propagation
-                  if(numberOfRegisteredLargerVertices != -numberOfLargerNeighbors-1)
-                      return 1;
+      IT nSegmentVertices = segment.size();
 
-                  // merge propagations
-                  for(IT n=0; n<nNeighbors; n++){
-                      IT u;
-                      triangulation->getVertexNeighbor(v,n,u);
+      if(performSuperlevelSetPropagation) {
+        // add saddle to queue
+        queue.emplace(std::numeric_limits<IT>::max(), saddleIdx);
+      } else {
+        // invert order
+        IT offset = -nSegmentVertices - 1; // ensures that inverted order < 0
+        for(IT i = 0; i < nSegmentVertices; i++)
+          localOrder[segment[i]] = offset - localOrder[segment[i]];
 
-                      if(propagationMask[u]!=nullptr){
-                          auto uPropagation = propagationMask[u]->find();
-                          if(uPropagation!=currentPropagation){
-                              currentPropagation = SSCPropagation<IT>::unify(
-                                  currentPropagation,
-                                  uPropagation,
-                                  orderField
-                              );
-                          }
-                      }
-                  }
+        // add all boundary vertices to queue
+        for(const auto &v : boundary) {
+          queue.emplace(localOrder[v], v);
+          localOrder[v] = 0;
+        }
 
-                  queue = &currentPropagation->queue;
-                  segmentId = v;
-                  queueMaskLabel = currentPropagation->criticalPoints[0];
-              }
+        // also add saddle to queue
+        queue.emplace(std::numeric_limits<IT>::min(), saddleIdx);
+      }
 
-              // mark vertex as visited and continue
-              propagationMask[v] = currentPropagation;
-              segmentation[v] = segmentId;
-              currentPropagation->segmentSize++;
+      IT q = 0;
+      while(!queue.empty()) {
+        IT v = std::get<1>(queue.top());
+        queue.pop();
+
+        localVertexSequence[q++] = v;
+
+        IT nNeighbors = triangulation->getVertexNeighborNumber(v);
+        for(IT n = 0; n < nNeighbors; n++) {
+          IT u;
+          triangulation->getVertexNeighbor(v, n, u);
+
+          // if u is in segment and has not already been added to the queue
+          if(segmentation[u] == segmentId && localOrder[u] < 0) {
+            queue.emplace(localOrder[u], u);
+            localOrder[u] = 0;
           }
+        }
+      }
 
-          this->printErr("Simple propagations should never reach global minimum/maximum.");
+      if(performSuperlevelSetPropagation) {
+        // skip first idx as it correponds to saddle
+        for(IT i = 1; i <= nSegmentVertices; i++)
+          localOrder[localVertexSequence[i]] = -i;
+      } else {
+        IT order = -nSegmentVertices;
+        // skip last idx as it correponds to saddle
+        for(IT i = 0; i < nSegmentVertices; i++)
+          localOrder[localVertexSequence[i]] = order++;
+      }
 
+      return 1;
+    };
+
+    template <typename IT, class TT>
+    int computeLocalOrderOfSegment(IT *localOrder,
+
+                                   const SSCPropagation<IT> *propagation,
+                                   const TT *triangulation,
+                                   const IT *segmentation,
+                                   const IT *inputOrder) const {
+      // quick espace for small segments
+      if(propagation->segmentSize == 1) {
+        localOrder[propagation->segment[0]] = -2;
+        return 1;
+      }
+
+      // init local order by input order
+      // Note: force orders to be smaller than 0 for in situ updates in
+      // propagation procedures
+      IT nVertices = triangulation->getNumberOfVertices();
+      for(const auto &v : propagation->segment)
+        localOrder[v] = inputOrder[v] - nVertices;
+
+      const IT &extremumIndex = propagation->criticalPoints[0];
+      const IT &saddleIndex = propagation->lastEncounteredCriticalPoint;
+
+      // vector to record boundary
+      std::vector<IT> boundary;
+
+      // make enough room for segment + saddle
+      std::vector<IT> localVertexSequence(propagation->segmentSize + 1);
+
+      int status = 1;
+      bool containsResidualExtrema = true;
+      bool performSuperlevelSetPropagation = true;
+      while(containsResidualExtrema) {
+        propagation->nIterations++;
+
+        if(propagation->nIterations > 20) {
+          this->printErr("Unable to converge within 20 iterations!");
           return 0;
-      };
+        }
 
-      template<typename IT, class TT>
-      int computeSimplePropagations(
-          std::vector<SSCPropagation<IT>>& propagations,
-          SSCPropagation<IT>** propagationMask,
-          IT* segmentation,
-          IT* queueMask,
+        // execute superlevel set propagation
+        status = this->computeLocalOrderOfSegmentIteration<IT, TT>(
+          localOrder, localVertexSequence.data(),
 
-          const TT* triangulation,
-          const IT* inputOrder
-      ) const {
-          ttk::Timer timer;
+          performSuperlevelSetPropagation, triangulation, segmentation,
+          extremumIndex, boundary, propagation->segment, saddleIndex);
+        if(!status)
+          return 0;
 
-          const IT nPropagations = propagations.size();
-          this->printMsg(
-              "Computing Propagations ("+std::to_string(nPropagations)+")",
-              0, 0, this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
+        performSuperlevelSetPropagation = !performSuperlevelSetPropagation;
 
-          int status = 1;
-          // compute propagations
-          #pragma omp parallel for schedule(dynamic,1) num_threads(this->threadNumber_)
-          for(IT p=0; p<nPropagations; p++){
-              int localStatus = this->computeSimplePropagation<IT,TT>(
-                  propagations[p],
-                  propagationMask,
-                  segmentation,
-                  queueMask,
+        IT boundaryWriteIdx = 0;
+        IT nResidualMaxima = 0;
+        IT nResidualMinima = 0;
 
-                  triangulation,
-                  inputOrder
-              );
+        for(const auto &v : propagation->segment) {
+          bool isOnSegmentBoundary = false;
+          bool hasSmallerNeighbor = false;
+          bool hasLargerNeighbor = false;
 
-              if(!localStatus)
-                  status = 0;
+          const auto &vOrder = localOrder[v];
+
+          IT nNeighbors = triangulation->getVertexNeighborNumber(v);
+          for(IT n = 0; n < nNeighbors; n++) {
+            IT u;
+            triangulation->getVertexNeighbor(v, n, u);
+
+            if(u == saddleIndex) {
+              hasLargerNeighbor = true;
+              continue;
+            }
+
+            // if u is not inside segment -> v is on segment boundary
+            if(segmentation[u] != extremumIndex) {
+              isOnSegmentBoundary = true;
+            } else {
+              if(localOrder[u] > vOrder)
+                hasLargerNeighbor = true;
+              else
+                hasSmallerNeighbor = true;
+            }
           }
 
-          if(!status) return 0;
+          if(!hasLargerNeighbor)
+            nResidualMaxima++;
 
-          this->printMsg(
-              "Computing Propagations ("+std::to_string(nPropagations)+")",
-              1, timer.getElapsedTime(), this->threadNumber_
-          );
+          if(isOnSegmentBoundary) {
+            localVertexSequence[boundaryWriteIdx++] = v;
+          } else if(!hasSmallerNeighbor) {
+            nResidualMinima++;
+          }
+        }
 
-          return 1;
+        containsResidualExtrema = nResidualMinima > 0 || nResidualMaxima > 0;
+
+        if(containsResidualExtrema && boundary.size() == 0) {
+          boundary.resize(boundaryWriteIdx);
+          for(IT i = 0; i < boundaryWriteIdx; i++) {
+            boundary[i] = localVertexSequence[i];
+          }
+        }
       }
 
-      template<typename IT>
-      int finalizePropagations(
-          std::vector<SSCPropagation<IT>*>& parentPropagations,
-          std::vector<SSCPropagation<IT>>& propagations,
-
-          const IT nVertices
-      ) const {
-          ttk::Timer timer;
-
-          const IT nPropagations = propagations.size();
-
-          this->printMsg(
-              "Finalizing Propagations ("+std::to_string(nPropagations)+")",
-              0, timer.getElapsedTime(), this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          IT nSegmentVertices = 0;
-          IT nParentPropagations=0;
-          parentPropagations.clear();
-          parentPropagations.resize(nPropagations);
-          for(IT p=0; p<nPropagations; p++){
-              auto* propagation = &propagations[p];
-              if(propagation->parent == propagation){
-                  nSegmentVertices = nSegmentVertices + propagation->segmentSize;
-                  parentPropagations[nParentPropagations++] = propagation;
-              }
-          }
-          parentPropagations.resize(nParentPropagations);
-
-          std::stringstream pFraction, vFraction;
-          pFraction << std::fixed << std::setprecision(2) << ((float)nParentPropagations/(float)nPropagations);
-          vFraction << std::fixed << std::setprecision(2) << ((float)nSegmentVertices/(float)nVertices);
-
-          this->printMsg(
-              "Finalizing Propagations ("
-              +std::to_string(nParentPropagations)
-              +"|"+toFixed(nParentPropagations,nPropagations)
-              +"|"+toFixed(nSegmentVertices,nVertices)
-              +")",
-              1, timer.getElapsedTime(), this->threadNumber_
-          );
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int computeSegment(
-          IT* segmentation,
-          SSCPropagation<IT>* propagation,
-
-          const TT* triangulation
-      ) const {
-
-          const IT& extremumIndex = propagation->criticalPoints[0];
-
-          // collect segment
-          auto& segment = propagation->segment;
-
-          segment.resize(propagation->segmentSize);
-          IT segmentIndex = 0;
-          {
-              std::vector<IT> queue(propagation->segmentSize);
-              IT queueIndex = 0;
-
-              // init queue
-              {
-                  queue[queueIndex++] = extremumIndex;
-                  segmentation[extremumIndex] = -1000;
-              }
-
-              // flood fill by starting from extremum
-              while(queueIndex>0){
-                  const IT v = queue[--queueIndex];
-
-                  segment[segmentIndex++] = v;
-
-                  IT nNeighbors = triangulation->getVertexNeighborNumber(v);
-                  for(IT n=0; n<nNeighbors; n++){
-                      IT u;
-                      triangulation->getVertexNeighbor(v,n,u);
-                      if(segmentation[u]>=0){
-                          segmentation[u] = -999; // mark as visited
-                          queue[queueIndex++]=u; // add to queue
-                      }
-                  }
-              }
-          }
-
-          if(segmentIndex!=propagation->segmentSize){
-              this->printErr("Segment size incorrect: "+std::to_string(segmentIndex)+ " "+std::to_string(propagation->segmentSize));
-              return 0;
-          }
-
-          for(auto idx : propagation->segment)
-            segmentation[idx] = extremumIndex;
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int computeSegments(
-          IT* segmentation,
-          std::vector<SSCPropagation<IT>*>& propagations,
-
-          const TT* triangulation
-      ) const {
-
-          const IT nPropagations = propagations.size();
-          const IT nVertices = triangulation->getNumberOfVertices();
-
-          ttk::Timer timer;
-          this->printMsg(
-              "Computing segments ("+std::to_string(nPropagations)+")",
-              0, 0, this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          int status = 1;
-
-          // compute segments in parallel
-          #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
-          for(IT p=0; p<nPropagations; p++){
-              int localStatus = this->computeSegment<IT,TT>(
-                  segmentation,
-                  propagations[p],
-
-                  triangulation
-              );
-              if(!localStatus)
-                  status = 0;
-          }
-          if(!status) return 0;
-
-          // print status
-          if(this->debugLevel_<4){
-              this->printMsg(
-                  "Computing segments ("+std::to_string(nPropagations)+")",
-                  1, timer.getElapsedTime(), this->threadNumber_
-              );
-          } else {
-
-              IT min = propagations[0]->segmentSize;
-              IT max = min;
-              IT avg = 0;
-
-              for(IT p=0; p<nPropagations; p++){
-                  const auto propagation = propagations[p];
-                  if(min>propagation->segmentSize)
-                      min=propagation->segmentSize;
-                  if(max<propagation->segmentSize)
-                      max=propagation->segmentSize;
-                  avg += propagation->segmentSize;
-              }
-
-              avg /= nPropagations;
-
-              this->printMsg(
-                  "Computing segments ("+std::to_string(nPropagations)
-                      + "|" + toFixed(min,nVertices)
-                      + "|" + toFixed(avg,nVertices)
-                      + "|" + toFixed(max,nVertices)
-                  +")",
-                  1, timer.getElapsedTime(), this->threadNumber_
-              );
-          }
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int computeLocalOrderOfSegmentIteration(
-          IT* localOrder,
-          IT* localVertexSequence,
-
-          const bool& performSuperlevelSetPropagation,
-          const TT* triangulation,
-          const IT* segmentation,
-          const IT& segmentId,
-          const std::vector<IT>& boundary,
-          const std::vector<IT>& segment,
-          const IT& saddleIdx
-      ) const {
-          // init priority queue
-          std::priority_queue<
-              std::pair<IT,IT>,
-              std::vector<std::pair<IT,IT>>
-          > queue;
-
-          IT nSegmentVertices = segment.size();
-
-          if(performSuperlevelSetPropagation){
-            // add saddle to queue
-            queue.emplace( std::numeric_limits<IT>::max(), saddleIdx );
-          } else {
-            // invert order
-            IT offset = -nSegmentVertices-1; // ensures that inverted order < 0
-            for(IT i=0; i<nSegmentVertices; i++)
-              localOrder[ segment[i] ] = offset-localOrder[ segment[i] ];
-
-            // add all boundary vertices to queue
-            for(const auto& v: boundary){
-              queue.emplace( localOrder[v], v );
-              localOrder[v] = 0;
-            }
-
-            // also add saddle to queue
-            queue.emplace( std::numeric_limits<IT>::min(), saddleIdx );
-          }
-
-          IT q=0;
-          while(!queue.empty()){
-              IT v = std::get<1>(queue.top());
-              queue.pop();
-
-              localVertexSequence[q++] = v;
-
-              IT nNeighbors = triangulation->getVertexNeighborNumber( v );
-              for(IT n=0; n<nNeighbors; n++){
-                  IT u;
-                  triangulation->getVertexNeighbor(v,n,u);
-
-                  // if u is in segment and has not already been added to the queue
-                  if(segmentation[u]==segmentId && localOrder[u]<0){
-                      queue.emplace( localOrder[u], u );
-                      localOrder[u] = 0;
-                  }
-              }
-          }
-
-          if(performSuperlevelSetPropagation){
-            // skip first idx as it correponds to saddle
-            for(IT i=1; i<=nSegmentVertices; i++)
-                localOrder[ localVertexSequence[i] ] = -i;
-          } else {
-            IT order = -nSegmentVertices;
-            // skip last idx as it correponds to saddle
-            for(IT i=0; i<nSegmentVertices; i++)
-                localOrder[ localVertexSequence[i] ] = order++;
-          }
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int computeLocalOrderOfSegment(
-          IT* localOrder,
-
-          const SSCPropagation<IT>* propagation,
-          const TT* triangulation,
-          const IT* segmentation,
-          const IT* inputOrder
-      ) const {
-          // quick espace for small segments
-          if(propagation->segmentSize==1){
-              localOrder[ propagation->segment[0] ] = -2;
-              return 1;
-          }
-
-          // init local order by input order
-          // Note: force orders to be smaller than 0 for in situ updates in propagation procedures
-          IT nVertices = triangulation->getNumberOfVertices();
-          for(const auto& v: propagation->segment)
-            localOrder[v] = inputOrder[v] - nVertices;
-
-          const IT& extremumIndex = propagation->criticalPoints[0];
-          const IT& saddleIndex = propagation->lastEncounteredCriticalPoint;
-
-          // vector to record boundary
-          std::vector<IT> boundary;
-
-          // make enough room for segment + saddle
-          std::vector<IT> localVertexSequence(propagation->segmentSize+1);
-
-          int status = 1;
-          bool containsResidualExtrema = true;
-          bool performSuperlevelSetPropagation = true;
-          while(containsResidualExtrema){
-            propagation->nIterations++;
-
-            if(propagation->nIterations>20){
-              this->printErr("Unable to converge within 20 iterations!");
-              return 0;
-            }
-
-            // execute superlevel set propagation
-            status = this->computeLocalOrderOfSegmentIteration<IT,TT>(
-                localOrder,
-                localVertexSequence.data(),
-
-                performSuperlevelSetPropagation,
-                triangulation,
-                segmentation,
-                extremumIndex,
-                boundary,
-                propagation->segment,
-                saddleIndex
-            );
-            if(!status)
-                return 0;
-
-            performSuperlevelSetPropagation = !performSuperlevelSetPropagation;
-
-            IT boundaryWriteIdx = 0;
-            IT nResidualMaxima = 0;
-            IT nResidualMinima = 0;
-
-            for(const auto& v: propagation->segment){
-              bool isOnSegmentBoundary = false;
-              bool hasSmallerNeighbor = false;
-              bool hasLargerNeighbor = false;
-
-              const auto& vOrder = localOrder[v];
-
-              IT nNeighbors = triangulation->getVertexNeighborNumber( v );
-              for(IT n=0; n<nNeighbors; n++){
-                IT u;
-                triangulation->getVertexNeighbor(v,n,u);
-
-                if(u==saddleIndex){
-                  hasLargerNeighbor = true;
-                  continue;
-                }
-
-                // if u is not inside segment -> v is on segment boundary
-                if(segmentation[u]!=extremumIndex){
-                    isOnSegmentBoundary = true;
-                } else {
-                  if(localOrder[u]>vOrder)
-                    hasLargerNeighbor = true;
-                  else
-                    hasSmallerNeighbor = true;
-                }
-              }
-
-              if(!hasLargerNeighbor)
-                  nResidualMaxima++;
-
-              if(isOnSegmentBoundary){
-                  localVertexSequence[boundaryWriteIdx++] = v;
-              } else if(!hasSmallerNeighbor){
-                  nResidualMinima++;
-              }
-            }
-
-            containsResidualExtrema = nResidualMinima>0 || nResidualMaxima>0;
-
-            if(containsResidualExtrema && boundary.size()==0){
-              boundary.resize( boundaryWriteIdx );
-              for(IT i=0; i<boundaryWriteIdx; i++){
-                boundary[i] = localVertexSequence[i];
-              }
-            }
-          }
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int computeLocalOrderOfSegments(
-          IT* localOrder,
-
-          const TT* triangulation,
-          const IT* segmentation,
-          const IT* inputOrder,
-          const std::vector<SSCPropagation<IT>*>& propagations
-      ) const {
-          ttk::Timer timer;
-
-          const IT nPropagations = propagations.size();
-          this->printMsg(
-              "Computing Local Order of Segments ("+std::to_string(nPropagations)+")",
-              0, 0, this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          int status = 1;
-          #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
-          for(IT p=0; p<nPropagations; p++){
-              int localStatus = this->computeLocalOrderOfSegment<IT>(
-                  localOrder,
-
-                  propagations[p],
-                  triangulation,
-                  segmentation,
-                  inputOrder
-              );
-              if(!localStatus)
-                  status = 0;
-          }
-          if(!status)
-              return 0;
-
-          // enforce that saddles have the highest local order
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT p=0; p<nPropagations; p++){
-            localOrder[ propagations[p]->lastEncounteredCriticalPoint ] = std::numeric_limits<IT>::max();
-          }
-
-          if(this->debugLevel_<4){
-              this->printMsg( "Computing Local Order of Segments ("+std::to_string(nPropagations)+")",
-                  1, timer.getElapsedTime(), this->threadNumber_
-              );
-          } else {
-              IT min = propagations[0]->nIterations;
-              IT max = min;
-              IT avg = 0;
-
-              for(IT p=0; p<nPropagations; p++){
-                  const auto propagation = propagations[p];
-                  if(min>propagation->nIterations)
-                      min=propagation->nIterations;
-                  if(max<propagation->nIterations)
-                      max=propagation->nIterations;
-                  avg += propagation->nIterations;
-              }
-
-              avg /= nPropagations;
-
-              this->printMsg(
-                  "Computing Local Order of Segments ("+std::to_string(nPropagations)
-                      + "|" + std::to_string(min)
-                      + "|" + std::to_string(avg)
-                      + "|" + std::to_string(max)
-                  +")",
-                  1, timer.getElapsedTime(), this->threadNumber_
-              );
-          }
-
-          return 1;
-      };
-
-      template<typename IT>
-      int flattenOrder(
-          IT* outputOrder,
-
-          const std::vector<SSCPropagation<IT>*>& parentPropagations,
-          const IT& nVertices
-      ) const {
-          ttk::Timer timer;
-          this->printMsg("Flattening Order Field",0,0,this->threadNumber_,debug::LineMode::REPLACE);
-
-          const IT nParentPropagations = parentPropagations.size();
-
-          // flatten segemnt to order of last encountered saddles
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT p=0; p<nParentPropagations; p++){
-              const auto* propagation = parentPropagations[p];
-              const auto& order = outputOrder[propagation->lastEncounteredCriticalPoint];
-              for(const auto& v : propagation->segment)
-                  outputOrder[v] = order;
-          }
-
-          this->printMsg("Flattening Order Field",1,timer.getElapsedTime(),this->threadNumber_);
-
-          return 1;
-      };
-
-      template<typename DT, typename IT>
-      int flattenScalars(
-          DT* outputScalars,
-
-          const std::vector<SSCPropagation<IT>>& propagationsMin,
-          const std::vector<SSCPropagation<IT>>& propagationsMax,
-          const DT* inputScalars,
-          const IT& nVertices
-      ) const {
-          ttk::Timer timer;
-          this->printMsg("Flattening Scalar Field",0,0,this->threadNumber_,debug::LineMode::REPLACE);
-
-          #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
-          for(IT v=0; v<nVertices; v++)
-            outputScalars[v] = inputScalars[v];
-
-          std::vector<const std::vector<SSCPropagation<IT>>*> propagationsPair={
-            &propagationsMin,
-            &propagationsMax
-          };
-
-          for(const auto propagations : propagationsPair){
-            const IT nPropagations = propagations->size();
-
-            // flatten scalars to saddle value
-            #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
-            for(IT p=0; p<nPropagations; p++){
-                const auto& propagation = (*propagations)[p];
-                if(propagation.parent!=&propagation)
-                  continue;
-
-                const auto& saddleScalar = outputScalars[propagation.lastEncounteredCriticalPoint];
-                for(const auto& v : propagation.segment)
-                    outputScalars[v] = saddleScalar;
-            }
-          }
-
-          this->printMsg("Flattening Scalar Field",1,timer.getElapsedTime(),this->threadNumber_);
-
-          return 1;
-      };
-
-      template<typename DT,typename IT>
-      int computeGlobalOrder(
-          IT* outputOrder,
-          std::vector<std::tuple<DT,IT,IT>>& sortedIndices,
-
-          const DT* rank1,
-          const IT* rank2
-      ) const {
-          ttk::Timer timer;
-
-          const IT nVertices = sortedIndices.size();
-
-          // init tuples
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT i=0; i<nVertices; i++){
-              auto& t = sortedIndices[i];
-              std::get<0>(t) = rank1[i];
-              std::get<1>(t) = rank2[i];
-              std::get<2>(t) = i;
-          }
-
-          this->printMsg(
-              "Computing Global Order",
-              0.2, timer.getElapsedTime(), this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          #ifdef TTK_ENABLE_OPENMP
-              #ifdef __clang__
-                  this->printWrn("Caution, outside GCC, sequential sort");
-                  std::sort(sortedIndices.begin(), sortedIndices.end());
-              #else
-                  omp_set_num_threads(this->threadNumber_);
-                  __gnu_parallel::sort(sortedIndices.begin(), sortedIndices.end());
-                  omp_set_num_threads(1);
-              #endif
-          #else
-              this->printWrn("Caution, outside GCC, sequential sort");
-              std::sort(sortedIndices.begin(), sortedIndices.end());
-          #endif
-
-          this->printMsg(
-              "Computing Global Order",
-              0.8, timer.getElapsedTime(), this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT i=0; i<nVertices; i++)
-              outputOrder[std::get<2>(sortedIndices[i])] = i;
-
-          this->printMsg(
-              "Computing Global Order",
-              1,
-              timer.getElapsedTime(),
-              this->threadNumber_
-          );
-
-          return 1;
-      };
-
-      template<typename DT, typename IT>
-      int computeNumericalPerturbation(
-          DT* outputScalars,
-          const std::vector<std::tuple<IT,IT,IT>>& sortedIndices
-      ) const {
-          ttk::Timer timer;
-          this->printMsg(
-              "Applying numerical perturbation",
-              0,0,this->threadNumber_,
-              debug::LineMode::REPLACE
-          );
-
-          const IT nVertices = sortedIndices.size();
-          for(IT i=1; i<nVertices; i++){
-            const IT& v0 = std::get<2>(sortedIndices[i-1]);
-            const IT& v1 = std::get<2>(sortedIndices[i]);
-            if(outputScalars[v0]>=outputScalars[v1])
-              outputScalars[v1] = boost::math::float_next(outputScalars[v0]);
-          }
-
-          this->printMsg(
-              "Applying numerical perturbation",
-              1,timer.getElapsedTime(),this->threadNumber_
-          );
-
-          return 1;
-      };
-
-      template<typename IT, class TT>
-      int detectAndRemoveUnauthorizedMaxima(
-          IT* outputOrder,
-          IT* segmentation,
-          IT* queueMask,
-          IT* localOrder,
-          SSCPropagation<IT>** propagationMask,
-          std::vector<SSCPropagation<IT>>& propagations,
-          std::vector<std::tuple<IT,IT,IT>>& sortedIndices,
-
-          const TT* triangulation,
-          const IT* authorizedExtremaIndices,
-          const IT& nAuthorizedExtremaIndices
-      ) const {
-          const IT nVertices = triangulation->getNumberOfVertices();
-
-          int status = 0;
-
-          // init propagations
-          status = this->initializeMemory<IT>(
-              segmentation,
-              queueMask,
-              localOrder,
-              propagationMask,
-
-              nVertices
-          );
-          if(!status) return 0;
-
-          // init propagations
-          status = this->initializePropagations<IT,TT>(
-              propagations,
-              queueMask, // use as authorization mask (will be overriden by subsequent procedures)
-              localOrder, // use as maxima buffer (will be overriden by subsequent procedures)
-
-              authorizedExtremaIndices,
-              nAuthorizedExtremaIndices,
-              outputOrder,
-              triangulation
-          );
-          if(!status) return 0;
-
-          // compute propagations
-          status = this->computeSimplePropagations<IT>(
-              propagations,
-              propagationMask,
-              segmentation,
-              queueMask,
-
-              triangulation,
-              outputOrder
-          );
-          if(!status) return 0;
-
-          // finalize master propagations
-          std::vector<SSCPropagation<IT>*> parentPropagations;
-          status = this->finalizePropagations<IT>(
-              parentPropagations,
-              propagations,
-
-              nVertices
-          );
-          if(!status) return 0;
-
-          // compute segments
-          status = this->computeSegments<IT,TT>(
-              segmentation,
-              parentPropagations,
-
-              triangulation
-          );
-          if(!status) return 0;
-
-          // compute local order of segments
-          status = this->computeLocalOrderOfSegments<IT,TT>(
-              localOrder,
-
-              triangulation,
-              segmentation,
-              outputOrder,
-              parentPropagations
-          );
-          if(!status) return 0;
-
-          // flatten order
-          status = this->flattenOrder<IT>(
-              outputOrder,
-
-              parentPropagations,
-              nVertices
-          );
-          if(!status) return 0;
-
-          // compute global offsets
-          status = this->computeGlobalOrder<IT,IT>(
-              outputOrder,
-              sortedIndices,
-
-              outputOrder,
-              localOrder
-          );
-          if(!status) return 0;
-
-          return 1;
-      };
-
-      template<typename IT>
-      int invertArray(
-          IT* outputOrder,
-
-          const IT* inputOrder,
-          const IT& nVertices
-      ) const {
-          ttk::Timer timer;
-          this->printMsg("Inverting Array",0,0,this->threadNumber_,debug::LineMode::REPLACE);
-
-          #pragma omp parallel for num_threads(this->threadNumber_)
-          for(IT v=0; v<nVertices; v++)
-              outputOrder[v] = nVertices - inputOrder[v];
-
-          this->printMsg("Inverting Array",1,timer.getElapsedTime(),this->threadNumber_);
-
-          return 1;
+      return 1;
+    };
+
+    template <typename IT, class TT>
+    int computeLocalOrderOfSegments(
+      IT *localOrder,
+
+      const TT *triangulation,
+      const IT *segmentation,
+      const IT *inputOrder,
+      const std::vector<SSCPropagation<IT> *> &propagations) const {
+      ttk::Timer timer;
+
+      const IT nPropagations = propagations.size();
+      this->printMsg("Computing Local Order of Segments ("
+                       + std::to_string(nPropagations) + ")",
+                     0, 0, this->threadNumber_, debug::LineMode::REPLACE);
+
+      int status = 1;
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < nPropagations; p++) {
+        int localStatus = this->computeLocalOrderOfSegment<IT>(
+          localOrder,
+
+          propagations[p], triangulation, segmentation, inputOrder);
+        if(!localStatus)
+          status = 0;
+      }
+      if(!status)
+        return 0;
+
+// enforce that saddles have the highest local order
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < nPropagations; p++) {
+        localOrder[propagations[p]->lastEncounteredCriticalPoint]
+          = std::numeric_limits<IT>::max();
       }
 
-      template<typename DT, typename IT, class TT>
-      int removeUnauthorizedExtrema(
-          DT* outputScalars,
-          IT* outputOrder,
+      if(this->debugLevel_ < 4) {
+        this->printMsg("Computing Local Order of Segments ("
+                         + std::to_string(nPropagations) + ")",
+                       1, timer.getElapsedTime(), this->threadNumber_);
+      } else {
+        IT min = propagations[0]->nIterations;
+        IT max = min;
+        IT avg = 0;
 
-          const TT* triangulation,
-          const DT* inputScalars,
-          const IT* inputOrder,
-          const IT* authorizedExtremaIndices,
-          const IT& nAuthorizedExtremaIndices,
-          const bool& addPerturbation
-      ) const {
-          ttk::Timer globalTimer;
+        for(IT p = 0; p < nPropagations; p++) {
+          const auto propagation = propagations[p];
+          if(min > propagation->nIterations)
+            min = propagation->nIterations;
+          if(max < propagation->nIterations)
+            max = propagation->nIterations;
+          avg += propagation->nIterations;
+        }
 
-          IT nVertices = triangulation->getNumberOfVertices();
+        avg /= nPropagations;
 
-          // Allocating Memory
-          int status = 0;
-          std::vector<IT> segmentation;
-          std::vector<IT> queueMask;
-          std::vector<IT> localOrder;
-          std::vector<SSCPropagation<IT>*> propagationMask;
-          std::vector<SSCPropagation<IT>> propagationsMax;
-          std::vector<SSCPropagation<IT>> propagationsMin;
-          std::vector<std::tuple<IT,IT,IT>> sortedIndices;
+        this->printMsg("Computing Local Order of Segments ("
+                         + std::to_string(nPropagations) + "|"
+                         + std::to_string(min) + "|" + std::to_string(avg) + "|"
+                         + std::to_string(max) + ")",
+                       1, timer.getElapsedTime(), this->threadNumber_);
+      }
 
-          this->allocateMemory<IT>(
-            segmentation,
-            queueMask,
-            localOrder,
-            propagationMask,
-            sortedIndices,
+      return 1;
+    };
 
-            nVertices
-          );
+    template <typename IT>
+    int
+      flattenOrder(IT *outputOrder,
 
-          {
-            this->printMsg("----------- [Removing unauthorized minima]", ttk::debug::Separator::L2);
+                   const std::vector<SSCPropagation<IT> *> &parentPropagations,
+                   const IT &nVertices) const {
+      ttk::Timer timer;
+      this->printMsg("Flattening Order Field", 0, 0, this->threadNumber_,
+                     debug::LineMode::REPLACE);
 
-            // init output order as input order
-            status = this->invertArray(
-              outputOrder,
+      const IT nParentPropagations = parentPropagations.size();
 
-              inputOrder,
-              nVertices
-            );
-            if(!status) return 0;
+// flatten segemnt to order of last encountered saddles
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT p = 0; p < nParentPropagations; p++) {
+        const auto *propagation = parentPropagations[p];
+        const auto &order
+          = outputOrder[propagation->lastEncounteredCriticalPoint];
+        for(const auto &v : propagation->segment)
+          outputOrder[v] = order;
+      }
 
-            status = this->detectAndRemoveUnauthorizedMaxima<IT,TT>(
-                outputOrder,
-                segmentation.data(),
-                queueMask.data(),
-                localOrder.data(),
-                propagationMask.data(),
-                propagationsMin,
-                sortedIndices,
+      this->printMsg("Flattening Order Field", 1, timer.getElapsedTime(),
+                     this->threadNumber_);
 
-                triangulation,
-                authorizedExtremaIndices,
-                nAuthorizedExtremaIndices
-            );
-            if(!status) return 0;
-          }
+      return 1;
+    };
 
-          // Maxima
-          {
-              this->printMsg("----------- [Removing unauthorized maxima]", ttk::debug::Separator::L2);
+    template <typename DT, typename IT>
+    int flattenScalars(DT *outputScalars,
 
-              // invert outputOrder
-              status = this->invertArray(
-                outputOrder,
+                       const std::vector<SSCPropagation<IT>> &propagationsMin,
+                       const std::vector<SSCPropagation<IT>> &propagationsMax,
+                       const DT *inputScalars,
+                       const IT &nVertices) const {
+      ttk::Timer timer;
+      this->printMsg("Flattening Scalar Field", 0, 0, this->threadNumber_,
+                     debug::LineMode::REPLACE);
 
-                outputOrder,
-                nVertices
-              );
-              if(!status) return 0;
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT v = 0; v < nVertices; v++)
+        outputScalars[v] = inputScalars[v];
 
-              status = this->detectAndRemoveUnauthorizedMaxima<IT,TT>(
-                  outputOrder,
-                  segmentation.data(),
-                  queueMask.data(),
-                  localOrder.data(),
-                  propagationMask.data(),
-                  propagationsMax,
-                  sortedIndices,
+      std::vector<const std::vector<SSCPropagation<IT>> *> propagationsPair
+        = {&propagationsMin, &propagationsMax};
 
-                  triangulation,
-                  authorizedExtremaIndices,
-                  nAuthorizedExtremaIndices
-              );
-              if(!status) return 0;
-          }
+      for(const auto propagations : propagationsPair) {
+        const IT nPropagations = propagations->size();
 
-          status = this->flattenScalars<DT,IT>(
-              outputScalars,
+// flatten scalars to saddle value
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+        for(IT p = 0; p < nPropagations; p++) {
+          const auto &propagation = (*propagations)[p];
+          if(propagation.parent != &propagation)
+            continue;
 
-              propagationsMin,
-              propagationsMax,
-              inputScalars,
-              nVertices
-          );
-          if(!status) return 0;
+          const auto &saddleScalar
+            = outputScalars[propagation.lastEncounteredCriticalPoint];
+          for(const auto &v : propagation.segment)
+            outputScalars[v] = saddleScalar;
+        }
+      }
 
+      this->printMsg("Flattening Scalar Field", 1, timer.getElapsedTime(),
+                     this->threadNumber_);
 
-          // optionally add perturbation
-          if(addPerturbation){
-              this->printMsg(debug::Separator::L2);
-              status = this->computeNumericalPerturbation<DT,IT>(
-                  outputScalars,
+      return 1;
+    };
 
-                  sortedIndices
-              );
-              if(!status) return 0;
-          }
+    template <typename DT, typename IT>
+    int computeGlobalOrder(IT *outputOrder,
+                           std::vector<std::tuple<DT, IT, IT>> &sortedIndices,
 
-          this->printMsg(debug::Separator::L2);
-          this->printMsg("Complete", 1, globalTimer.getElapsedTime(), this->threadNumber_);
+                           const DT *rank1,
+                           const IT *rank2) const {
+      ttk::Timer timer;
 
-          this->printMsg(debug::Separator::L1);
+      const IT nVertices = sortedIndices.size();
 
-          return 1;
+// init tuples
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT i = 0; i < nVertices; i++) {
+        auto &t = sortedIndices[i];
+        std::get<0>(t) = rank1[i];
+        std::get<1>(t) = rank2[i];
+        std::get<2>(t) = i;
+      }
+
+      this->printMsg("Computing Global Order", 0.2, timer.getElapsedTime(),
+                     this->threadNumber_, debug::LineMode::REPLACE);
+
+#ifdef TTK_ENABLE_OPENMP
+#ifdef __clang__
+      this->printWrn("Caution, outside GCC, sequential sort");
+      std::sort(sortedIndices.begin(), sortedIndices.end());
+#else
+      omp_set_num_threads(this->threadNumber_);
+      __gnu_parallel::sort(sortedIndices.begin(), sortedIndices.end());
+      omp_set_num_threads(1);
+#endif
+#else
+      this->printWrn("Caution, outside GCC, sequential sort");
+      std::sort(sortedIndices.begin(), sortedIndices.end());
+#endif
+
+      this->printMsg("Computing Global Order", 0.8, timer.getElapsedTime(),
+                     this->threadNumber_, debug::LineMode::REPLACE);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT i = 0; i < nVertices; i++)
+        outputOrder[std::get<2>(sortedIndices[i])] = i;
+
+      this->printMsg("Computing Global Order", 1, timer.getElapsedTime(),
+                     this->threadNumber_);
+
+      return 1;
+    };
+
+    template <typename DT, typename IT>
+    int computeNumericalPerturbation(
+      DT *outputScalars,
+      const std::vector<std::tuple<IT, IT, IT>> &sortedIndices) const {
+      ttk::Timer timer;
+      this->printMsg("Applying numerical perturbation", 0, 0,
+                     this->threadNumber_, debug::LineMode::REPLACE);
+
+      const IT nVertices = sortedIndices.size();
+      for(IT i = 1; i < nVertices; i++) {
+        const IT &v0 = std::get<2>(sortedIndices[i - 1]);
+        const IT &v1 = std::get<2>(sortedIndices[i]);
+        if(outputScalars[v0] >= outputScalars[v1])
+          outputScalars[v1] = boost::math::float_next(outputScalars[v0]);
+      }
+
+      this->printMsg("Applying numerical perturbation", 1,
+                     timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    };
+
+    template <typename IT, class TT>
+    int detectAndRemoveUnauthorizedMaxima(
+      IT *outputOrder,
+      IT *segmentation,
+      IT *queueMask,
+      IT *localOrder,
+      SSCPropagation<IT> **propagationMask,
+      std::vector<SSCPropagation<IT>> &propagations,
+      std::vector<std::tuple<IT, IT, IT>> &sortedIndices,
+
+      const TT *triangulation,
+      const IT *authorizedExtremaIndices,
+      const IT &nAuthorizedExtremaIndices) const {
+      const IT nVertices = triangulation->getNumberOfVertices();
+
+      int status = 0;
+
+      // init propagations
+      status = this->initializeMemory<IT>(segmentation, queueMask, localOrder,
+                                          propagationMask,
+
+                                          nVertices);
+      if(!status)
+        return 0;
+
+      // init propagations
+      status = this->initializePropagations<IT, TT>(
+        propagations,
+        queueMask, // use as authorization mask (will be overriden by subsequent
+                   // procedures)
+        localOrder, // use as maxima buffer (will be overriden by subsequent
+                    // procedures)
+
+        authorizedExtremaIndices, nAuthorizedExtremaIndices, outputOrder,
+        triangulation);
+      if(!status)
+        return 0;
+
+      // compute propagations
+      status = this->computeSimplePropagations<IT>(
+        propagations, propagationMask, segmentation, queueMask,
+
+        triangulation, outputOrder);
+      if(!status)
+        return 0;
+
+      // finalize master propagations
+      std::vector<SSCPropagation<IT> *> parentPropagations;
+      status = this->finalizePropagations<IT>(parentPropagations, propagations,
+
+                                              nVertices);
+      if(!status)
+        return 0;
+
+      // compute segments
+      status = this->computeSegments<IT, TT>(segmentation, parentPropagations,
+
+                                             triangulation);
+      if(!status)
+        return 0;
+
+      // compute local order of segments
+      status = this->computeLocalOrderOfSegments<IT, TT>(
+        localOrder,
+
+        triangulation, segmentation, outputOrder, parentPropagations);
+      if(!status)
+        return 0;
+
+      // flatten order
+      status = this->flattenOrder<IT>(outputOrder,
+
+                                      parentPropagations, nVertices);
+      if(!status)
+        return 0;
+
+      // compute global offsets
+      status = this->computeGlobalOrder<IT, IT>(outputOrder, sortedIndices,
+
+                                                outputOrder, localOrder);
+      if(!status)
+        return 0;
+
+      return 1;
+    };
+
+    template <typename IT>
+    int invertArray(IT *outputOrder,
+
+                    const IT *inputOrder,
+                    const IT &nVertices) const {
+      ttk::Timer timer;
+      this->printMsg(
+        "Inverting Array", 0, 0, this->threadNumber_, debug::LineMode::REPLACE);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+      for(IT v = 0; v < nVertices; v++)
+        outputOrder[v] = nVertices - inputOrder[v];
+
+      this->printMsg(
+        "Inverting Array", 1, timer.getElapsedTime(), this->threadNumber_);
+
+      return 1;
+    }
+
+    template <typename DT, typename IT, class TT>
+    int removeUnauthorizedExtrema(DT *outputScalars,
+                                  IT *outputOrder,
+
+                                  const TT *triangulation,
+                                  const DT *inputScalars,
+                                  const IT *inputOrder,
+                                  const IT *authorizedExtremaIndices,
+                                  const IT &nAuthorizedExtremaIndices,
+                                  const bool &addPerturbation) const {
+      ttk::Timer globalTimer;
+
+      IT nVertices = triangulation->getNumberOfVertices();
+
+      // Allocating Memory
+      int status = 0;
+      std::vector<IT> segmentation;
+      std::vector<IT> queueMask;
+      std::vector<IT> localOrder;
+      std::vector<SSCPropagation<IT> *> propagationMask;
+      std::vector<SSCPropagation<IT>> propagationsMax;
+      std::vector<SSCPropagation<IT>> propagationsMin;
+      std::vector<std::tuple<IT, IT, IT>> sortedIndices;
+
+      this->allocateMemory<IT>(segmentation, queueMask, localOrder,
+                               propagationMask, sortedIndices,
+
+                               nVertices);
+
+      {
+        this->printMsg("----------- [Removing unauthorized minima]",
+                       ttk::debug::Separator::L2);
+
+        // init output order as input order
+        status = this->invertArray(outputOrder,
+
+                                   inputOrder, nVertices);
+        if(!status)
+          return 0;
+
+        status = this->detectAndRemoveUnauthorizedMaxima<IT, TT>(
+          outputOrder, segmentation.data(), queueMask.data(), localOrder.data(),
+          propagationMask.data(), propagationsMin, sortedIndices,
+
+          triangulation, authorizedExtremaIndices, nAuthorizedExtremaIndices);
+        if(!status)
+          return 0;
+      }
+
+      // Maxima
+      {
+        this->printMsg("----------- [Removing unauthorized maxima]",
+                       ttk::debug::Separator::L2);
+
+        // invert outputOrder
+        status = this->invertArray(outputOrder,
+
+                                   outputOrder, nVertices);
+        if(!status)
+          return 0;
+
+        status = this->detectAndRemoveUnauthorizedMaxima<IT, TT>(
+          outputOrder, segmentation.data(), queueMask.data(), localOrder.data(),
+          propagationMask.data(), propagationsMax, sortedIndices,
+
+          triangulation, authorizedExtremaIndices, nAuthorizedExtremaIndices);
+        if(!status)
+          return 0;
+      }
+
+      status = this->flattenScalars<DT, IT>(outputScalars,
+
+                                            propagationsMin, propagationsMax,
+                                            inputScalars, nVertices);
+      if(!status)
+        return 0;
+
+      // optionally add perturbation
+      if(addPerturbation) {
+        this->printMsg(debug::Separator::L2);
+        status = this->computeNumericalPerturbation<DT, IT>(outputScalars,
+
+                                                            sortedIndices);
+        if(!status)
+          return 0;
+      }
+
+      this->printMsg(debug::Separator::L2);
+      this->printMsg(
+        "Complete", 1, globalTimer.getElapsedTime(), this->threadNumber_);
+
+      this->printMsg(debug::Separator::L1);
+
+      return 1;
     };
 
   }; // class
-} // namespace
+} // namespace ttk

--- a/core/base/localizedTopologicalSimplification/SSCPropagation.h
+++ b/core/base/localizedTopologicalSimplification/SSCPropagation.h
@@ -1,62 +1,63 @@
 #pragma once
 
-#include <vector>
 #include <boost/heap/fibonacci_heap.hpp>
+#include <vector>
 
 namespace ttk {
 
-    /// Superlevel Set Component Propagation
-    template<typename IT>
-    struct SSCPropagation {
+  /// Superlevel Set Component Propagation
+  template <typename IT>
+  struct SSCPropagation {
 
-        // union find members
-        SSCPropagation<IT>* parent{this};
+    // union find members
+    SSCPropagation<IT> *parent{this};
 
-        // propagation data
-        std::vector<IT> criticalPoints;
-        boost::heap::fibonacci_heap< std::pair<IT,IT> > queue;
-        IT segmentSize{0};
-        std::vector<IT> segment;
-        IT lastEncounteredCriticalPoint{-1};
+    // propagation data
+    std::vector<IT> criticalPoints;
+    boost::heap::fibonacci_heap<std::pair<IT, IT>> queue;
+    IT segmentSize{0};
+    std::vector<IT> segment;
+    IT lastEncounteredCriticalPoint{-1};
 
-        mutable IT nIterations{0};
+    mutable IT nIterations{0};
 
-        inline SSCPropagation *find(){
-            if(this->parent == this)
-                return this;
-            else {
-                auto tmp = this->parent->find();
-                #pragma omp atomic write
-                this->parent = tmp;
-                return this->parent;
-            }
-        }
+    inline SSCPropagation *find() {
+      if(this->parent == this)
+        return this;
+      else {
+        auto tmp = this->parent->find();
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp atomic write
+#endif // TTK_ENABLE_OPENMP
+        this->parent = tmp;
+        return this->parent;
+      }
+    }
 
-        static inline SSCPropagation<IT>* unify(
-            SSCPropagation<IT>* p0,
-            SSCPropagation<IT>* p1,
-            const IT* orderField
-        ){
-            SSCPropagation<IT>* parent = p0;
-            SSCPropagation<IT>* child  = p1;
+    static inline SSCPropagation<IT> *unify(SSCPropagation<IT> *p0,
+                                            SSCPropagation<IT> *p1,
+                                            const IT *orderField) {
+      SSCPropagation<IT> *parent = p0;
+      SSCPropagation<IT> *child = p1;
 
-            // determine parent and child based on persistence
-            if(orderField[parent->criticalPoints[0]] < orderField[child->criticalPoints[0]]) {
-                SSCPropagation<IT>* temp = parent;
-                parent = child;
-                child = temp;
-            }
+      // determine parent and child based on persistence
+      if(orderField[parent->criticalPoints[0]]
+         < orderField[child->criticalPoints[0]]) {
+        SSCPropagation<IT> *temp = parent;
+        parent = child;
+        child = temp;
+      }
 
-            // update union find tree
-            // #pragma omp atomic write
-            child->parent = parent;
+      // update union find tree
+      // #pragma omp atomic write
+      child->parent = parent;
 
-            parent->segmentSize += child->segmentSize;
+      parent->segmentSize += child->segmentSize;
 
-            // merge f. heaps
-            parent->queue.merge(child->queue);
+      // merge f. heaps
+      parent->queue.merge(child->queue);
 
-            return parent;
-        }
-    };
+      return parent;
+    }
+  };
 } // namespace ttk

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -286,7 +286,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int setWrapper(const Wrapper *const wrapper) {
+    inline int setWrapper(const Wrapper *wrapper) {
       Debug::setWrapper(wrapper);
       morseSmaleComplex2D_.setWrapper(wrapper);
       morseSmaleComplex3D_.setWrapper(wrapper);

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -280,7 +280,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int setThreadNumber(const int &threadNumber) {
+    inline int setThreadNumber(const int threadNumber) {
       morseSmaleComplex2D_.setThreadNumber(threadNumber);
       morseSmaleComplex3D_.setThreadNumber(threadNumber);
       return 0;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -16,10 +16,6 @@
 // base code includes
 #include <AbstractTriangulation.h>
 
-#ifdef _WIN32
-#include <ciso646>
-#endif
-
 #include <array>
 
 namespace ttk {

--- a/core/base/persistenceDiagramClustering/PDBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.h
@@ -150,10 +150,6 @@ namespace ttk {
       wasserstein_ = wasserstein;
     }
 
-    inline void setThreadNumber(const int &threadNumber) {
-      threadNumber_ = threadNumber;
-    }
-
     inline void setUseProgressive(const bool use_progressive) {
       use_progressive_ = use_progressive;
     }
@@ -247,7 +243,6 @@ namespace ttk {
     BNodeType nt2_;
     dataType cost_;
     int numberOfInputs_;
-    int threadNumber_;
     bool use_progressive_;
     double time_limit_;
     double epsilon_min_;

--- a/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenterImpl.h
@@ -58,8 +58,7 @@ void PDBarycenter<dataType>::runMatching(
   int actual_distance) {
   Timer time_matchings;
 #ifdef TTK_ENABLE_OPENMP
-  omp_set_num_threads(threadNumber_);
-#pragma omp parallel for schedule(dynamic, 1)
+#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1)
 #endif
 
   for(int i = 0; i < numberOfInputs_; i++) {
@@ -135,8 +134,7 @@ void PDBarycenter<dataType>::runMatchingAuction(
   std::vector<std::vector<matchingTuple>> *all_matchings,
   bool use_kdt) {
 #ifdef TTK_ENABLE_OPENMP
-  omp_set_num_threads(threadNumber_);
-#pragma omp parallel for schedule(dynamic, 1)
+#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1)
 #endif
   for(int i = 0; i < numberOfInputs_; i++) {
     Auction<dataType> auction = Auction<dataType>(

--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -22,10 +22,6 @@
 #include <array>
 #include <limits>
 
-#ifdef _WIN32
-#include <ciso646>
-#endif
-
 #include <PDBarycenter.h>
 
 using namespace std;

--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -173,10 +173,6 @@ namespace ttk {
       wasserstein_ = wasserstein;
     }
 
-    inline void setThreadNumber(const int &threadNumber) {
-      threadNumber_ = threadNumber;
-    }
-
     inline void setUseProgressive(const bool use_progressive) {
       use_progressive_ = use_progressive;
     }
@@ -291,7 +287,6 @@ namespace ttk {
 
     int k_;
     int numberOfInputs_;
-    int threadNumber_;
     bool use_progressive_;
     bool use_accelerated_;
     bool use_kmeanspp_;

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
@@ -99,10 +99,6 @@ namespace ttk {
       wasserstein_ = (wasserstein == "inf") ? -1 : stoi(wasserstein);
     }
 
-    inline void setThreadNumber(const int &ThreadNumber) {
-      threadNumber_ = ThreadNumber;
-    }
-
     inline void setUseProgressive(const bool use_progressive) {
       if(use_progressive)
         epsilon_decreases_ = true;
@@ -150,7 +146,6 @@ namespace ttk {
     int method_;
     int wasserstein_;
     int numberOfInputs_;
-    int threadNumber_;
     bool use_progressive_;
     double alpha_;
     double lambda_;

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -348,7 +348,6 @@ int TwoSkeleton::buildTriangleList(
             triangleNumber++;
 
             if(triangleList) {
-              triangleList->size();
               triangleList->push_back(triangle);
             }
             if(triangleStars) {

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -300,7 +300,7 @@ int ttk::TopologicalSimplification::execute(
   this->printMsg("Maintaining " + std::to_string(constraintNumber)
                    + " constraints (" + std::to_string(authorizedMinima.size())
                    + " minima and " + std::to_string(authorizedMaxima.size())
-                   + "maxima)",
+                   + " maxima)",
                  debug::Priority::DETAIL);
 
   // declare the tuple-comparison functor

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -9,7 +9,6 @@
 #include <BottleneckDistance.h>
 #include <PersistenceDiagram.h>
 #include <Triangulation.h>
-using namespace std;
 
 namespace ttk {
 

--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -26,8 +26,6 @@
 #include <map>
 #include <unordered_map>
 
-using namespace std;
-
 using topologyType = unsigned char;
 using idType = long long int;
 
@@ -60,8 +58,8 @@ struct Node {
   Node() = default;
 };
 
-using Edges = vector<idType>; // [index0, index1, overlap, branch,...]
-using Nodes = vector<Node>;
+using Edges = std::vector<idType>; // [index0, index1, overlap, branch,...]
+using Nodes = std::vector<Node>;
 
 struct CoordinateComparator {
   const float *coordinates;
@@ -90,7 +88,7 @@ namespace ttk {
     // This function sorts points based on their x, y, and then z coordinate
     int sortCoordinates(const float *pointCoordinates,
                         const size_t nPoints,
-                        vector<size_t> &sortedIndicies) const {
+                        std::vector<size_t> &sortedIndicies) const {
       printMsg("Sorting coordinates ... ", debug::Priority::PERFORMANCE);
       Timer t;
 
@@ -100,15 +98,15 @@ namespace ttk {
       CoordinateComparator c = CoordinateComparator(pointCoordinates);
       sort(sortedIndicies.begin(), sortedIndicies.end(), c);
 
-      stringstream msg;
+      std::stringstream msg;
       msg << "done (" << t.getElapsedTime() << " s).";
       printMsg(msg.str(), debug::Priority::PERFORMANCE);
 
       return 1;
     }
 
-    int computeBranches(vector<Edges> &timeEdgesMap,
-                        vector<Nodes> &timeNodesMap) const {
+    int computeBranches(std::vector<Edges> &timeEdgesMap,
+                        std::vector<Nodes> &timeNodesMap) const {
       printMsg("Computing branches  ... ", debug::Priority::PERFORMANCE);
       Timer tm;
 
@@ -198,7 +196,7 @@ namespace ttk {
         }
       }
 
-      stringstream msg;
+      std::stringstream msg;
       msg << "done (" << tm.getElapsedTime() << " s).";
       printMsg(msg.str(), debug::Priority::PERFORMANCE);
 
@@ -210,7 +208,7 @@ namespace ttk {
     template <typename labelType>
     int computeLabelIndexMap(const labelType *pointLabels,
                              const size_t nPoints,
-                             map<labelType, size_t> &labelIndexMap) const;
+                             std::map<labelType, size_t> &labelIndexMap) const;
 
     // This function computes all nodes and their properties based on a labeled
     // point set
@@ -242,7 +240,7 @@ template <typename labelType>
 int ttk::TrackingFromOverlap::computeLabelIndexMap(
   const labelType *pointLabels,
   const size_t nPoints,
-  map<labelType, size_t> &labelIndexMap) const {
+  std::map<labelType, size_t> &labelIndexMap) const {
   for(size_t i = 0; i < nPoints; i++)
     labelIndexMap[pointLabels[i]] = 0;
   size_t i = 0;
@@ -263,7 +261,7 @@ int ttk::TrackingFromOverlap::computeNodes(const float *pointCoordinates,
 
   Timer t;
 
-  map<labelType, size_t> labelIndexMap;
+  std::map<labelType, size_t> labelIndexMap;
   this->computeLabelIndexMap(pointLabels, nPoints, labelIndexMap);
 
   size_t nNodes = labelIndexMap.size();
@@ -289,7 +287,7 @@ int ttk::TrackingFromOverlap::computeNodes(const float *pointCoordinates,
 
   // Print Status
   {
-    stringstream msg;
+    std::stringstream msg;
     msg << "done (#" << nNodes << " in " << t.getElapsedTime() << " s).";
     printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }
@@ -312,16 +310,16 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   // -------------------------------------------------------------------------
   // Compute labelIndexMaps
   // -------------------------------------------------------------------------
-  map<labelType, size_t> labelIndexMap0;
-  map<labelType, size_t> labelIndexMap1;
+  std::map<labelType, size_t> labelIndexMap0;
+  std::map<labelType, size_t> labelIndexMap1;
   this->computeLabelIndexMap<labelType>(pointLabels0, nPoints0, labelIndexMap0);
   this->computeLabelIndexMap<labelType>(pointLabels1, nPoints1, labelIndexMap1);
 
   // -------------------------------------------------------------------------
   // Sort coordinates
   // -------------------------------------------------------------------------
-  vector<size_t> sortedIndicies0;
-  vector<size_t> sortedIndicies1;
+  std::vector<size_t> sortedIndicies0;
+  std::vector<size_t> sortedIndicies1;
   this->sortCoordinates(pointCoordinates0, nPoints0, sortedIndicies0);
   this->sortCoordinates(pointCoordinates1, nPoints1, sortedIndicies1);
 
@@ -357,7 +355,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   size_t j = 0; // iterator for 1
 
   size_t nEdges = 0;
-  unordered_map<size_t, unordered_map<size_t, size_t>> edgesMap;
+  std::unordered_map<size_t, std::unordered_map<size_t, size_t>> edgesMap;
   // Iterate over both point sets synchronously using comparison function
   while(i < nPoints0 && j < nPoints1) {
     size_t pointIndex0 = sortedIndicies0[i];
@@ -378,7 +376,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
 
       // If map does not exist then create it
       if(edges0 == edgesMap.end()) {
-        edgesMap[nodeIndex0] = unordered_map<size_t, size_t>();
+        edgesMap[nodeIndex0] = std::unordered_map<size_t, size_t>();
         edges0 = edgesMap.find(nodeIndex0);
       }
 
@@ -422,7 +420,7 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
 
   // Print Status
   {
-    stringstream msg;
+    std::stringstream msg;
     msg << "done (#" << nEdges << " in " << t.getElapsedTime() << " s).";
     printMsg(msg.str(), debug::Priority::PERFORMANCE);
   }

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2435,7 +2435,7 @@ namespace ttk {
     }
 
     /// Tune the number of active threads (default: number of logical cores)
-    inline int setThreadNumber(const ThreadId &threadNumber) {
+    inline int setThreadNumber(const ThreadId threadNumber) {
       explicitTriangulation_.setThreadNumber(threadNumber);
       implicitTriangulation_.setThreadNumber(threadNumber);
       periodicImplicitTriangulation_.setThreadNumber(threadNumber);

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -163,7 +163,7 @@ int ttkCinemaImaging::RequestData(vtkInformation *request,
   double camFocus[3];
   std::copy(this->CamFocus, this->CamFocus + 3, camFocus);
   double camNearFar[2];
-  std::copy(this->CamNearFar, this->CamNearFar + 3, camNearFar);
+  std::copy(this->CamNearFar, this->CamNearFar + 2, camNearFar);
   double camHeight = this->GetCamHeight();
   double camDir[3];
   double camUp[3] = {0, 0, 1};

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -246,7 +246,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     boost::interprocess::file_lock flock(csvPath.data());
     try {
       // flock.lock();
-    } catch(boost::interprocess::interprocess_exception &e) {
+    } catch(boost::interprocess::interprocess_exception &) {
       this->printErr("Unable to initialize write lock.");
       return 0;
     }

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
@@ -47,7 +47,6 @@ int ttkContourTreeAlignment::FillOutputPortInformation(int port,
 int ttkContourTreeAlignment::RequestData(vtkInformation *request,
                                          vtkInformationVector **inputVector,
                                          vtkInformationVector *outputVector) {
-  Timer t;
 
   //==================================================================================================================
   // Print status

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -295,7 +295,9 @@ int testPointDataArray(std::vector<int> &oIndex_to_mIndex_map,
                        const std::vector<dataType> pivotValues,
                        const size_t &threadNumber) {
   const size_t nPivotValues = pivotValues.size();
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber)
+#endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nPoints; i++) {
     bool hasToBeMarked = false;
     const dataType &v = inputPointDataArray[i];
@@ -319,7 +321,9 @@ int testCellDataArray(std::vector<int> &oIndex_to_mIndex_map,
                       const size_t &threadNumber) {
   const size_t nPivotValues = pivotValues.size();
 
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber)
+#endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nCells; i++) {
     const dataType &v = inputCellDataArray[i];
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -65,11 +65,11 @@ public:
 
   vtkTypeMacro(ttkPersistenceDiagram, ttkAlgorithm);
 
-  vtkSetMacro(ForceInputOffsetScalarField, int);
-  vtkGetMacro(ForceInputOffsetScalarField, int);
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
 
-  vtkSetMacro(ComputeSaddleConnectors, int);
-  vtkGetMacro(ComputeSaddleConnectors, int);
+  vtkSetMacro(ComputeSaddleConnectors, bool);
+  vtkGetMacro(ComputeSaddleConnectors, bool);
 
   void SetShowInsideDomain(int onOff) {
     ShowInsideDomain = onOff;

--- a/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
+++ b/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
@@ -18,10 +18,6 @@
 
 #include <limits>
 
-#ifdef _WIN32
-#include <ciso646>
-#endif // _WIN32
-
 vtkStandardNewMacro(ttkPointDataConverter);
 
 ttkPointDataConverter::ttkPointDataConverter() {

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -55,10 +55,10 @@ class TTKTRACKINGFROMOVERLAP_EXPORT ttkTrackingFromOverlap
 
 public:
   static ttkTrackingFromOverlap *New();
-  vtkTypeMacro(ttkTrackingFromOverlap, ttkAlgorithm)
+  vtkTypeMacro(ttkTrackingFromOverlap, ttkAlgorithm);
 
-    vtkSetMacro(LabelFieldName, string);
-  vtkGetMacro(LabelFieldName, string);
+  vtkSetMacro(LabelFieldName, std::string);
+  vtkGetMacro(LabelFieldName, std::string);
 
 protected:
   ttkTrackingFromOverlap() {
@@ -69,7 +69,6 @@ protected:
     SetNumberOfInputPorts(1);
     SetNumberOfOutputPorts(1);
   }
-  ~ttkTrackingFromOverlap() override{};
 
   bool UseAllCores;
   int ThreadNumber;
@@ -121,12 +120,12 @@ protected:
 
 private:
   int LabelDataType;
-  string LabelFieldName;
+  std::string LabelFieldName;
 
   vtkSmartPointer<vtkMultiBlockDataSet> previousIterationData;
 
   // Containers for nodes and edges
-  vector<vector<Nodes>> levelTimeNodesMap; // N
-  vector<vector<Edges>> levelTimeEdgesTMap; // E_T
-  vector<vector<Edges>> timeLevelEdgesNMap; // E_N
+  std::vector<std::vector<Nodes>> levelTimeNodesMap; // N
+  std::vector<std::vector<Edges>> levelTimeEdgesTMap; // E_T
+  std::vector<std::vector<Edges>> timeLevelEdgesNMap; // E_N
 };


### PR DESCRIPTION
This PR fixes, among others, a bug introduced during the migration: base modules that redefined the `setThreadNumber` method (MorseSmaleComplex, FTRGraph, ContourForests, Triangulation...) were locked at the maximum number of threads, since `ttkAlgorithm` was calling the `BaseClass` method and not the derived ones. The `BaseClass::setThreadNumber` method has been thusly made virtual (this change also triggers a compiler warning if the derived methods don't respect the base method signature).

Other fixes provided by this PR include:
* some MSVC compiler warning fixes
* disabling clang-format on a sensitive section in `Auction.h`
* reducing the usage of the `use namespace` directive in headers (to avoid side effects)
* adding missing `TTK_ENABLE_OPENMP` guards around OpenMP pragmas (especially in LocalizedTopologicalSimplification, which has been clang-formatted for the occasion)
* a global include of the `ciso646` header that allows MSVC to support the `and` and `or` keywords
* a memory leak fix in the `getcwd` call in a ununsed method of `BaseClass`
* the handling of the ZFP and zlib dependencies for the base libraries has also been resurrected in `TTKBaseConfig.cmake` but only when the base libraries are statically compiled.

No change has been observed in the ttk-data states.

Enjoy,
Pierre
