### PR TITLE
MorseSmaleComplex: Parallelize filling the VTK arrays

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -325,7 +325,8 @@ namespace ttk {
       SimplexId *const separatrices2_numberOfPoints,
       std::vector<float> *const separatrices2_points,
       SimplexId *const separatrices2_numberOfCells,
-      std::vector<SimplexId> *const separatrices2_cells,
+      std::vector<SimplexId> *const separatrices2_cells_offsets,
+      std::vector<SimplexId> *const separatrices2_cells_connectivity,
       std::vector<SimplexId> *const separatrices2_cells_sourceIds,
       std::vector<SimplexId> *const separatrices2_cells_separatrixIds,
       std::vector<char> *const separatrices2_cells_separatrixTypes,
@@ -336,7 +337,9 @@ namespace ttk {
       outputSeparatrices2_numberOfPoints_ = separatrices2_numberOfPoints;
       outputSeparatrices2_points_ = separatrices2_points;
       outputSeparatrices2_numberOfCells_ = separatrices2_numberOfCells;
-      outputSeparatrices2_cells_ = separatrices2_cells;
+      outputSeparatrices2_cells_offsets_ = separatrices2_cells_offsets;
+      outputSeparatrices2_cells_connectivity_
+        = separatrices2_cells_connectivity;
       outputSeparatrices2_cells_sourceIds_ = separatrices2_cells_sourceIds;
       outputSeparatrices2_cells_separatrixIds_
         = separatrices2_cells_separatrixIds;
@@ -466,7 +469,8 @@ namespace ttk {
     SimplexId *outputSeparatrices2_numberOfPoints_{};
     std::vector<float> *outputSeparatrices2_points_{};
     SimplexId *outputSeparatrices2_numberOfCells_{};
-    std::vector<SimplexId> *outputSeparatrices2_cells_{};
+    std::vector<SimplexId> *outputSeparatrices2_cells_offsets_{};
+    std::vector<SimplexId> *outputSeparatrices2_cells_connectivity_{};
     std::vector<SimplexId> *outputSeparatrices2_cells_sourceIds_{};
     std::vector<SimplexId> *outputSeparatrices2_cells_separatrixIds_{};
     std::vector<char> *outputSeparatrices2_cells_separatrixTypes_{};

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -282,7 +282,7 @@ namespace ttk {
       std::vector<char> *const separatrices1_points_cellDimensions,
       std::vector<SimplexId> *const separatrices1_points_cellIds,
       SimplexId *const separatrices1_numberOfCells,
-      std::vector<SimplexId> *const separatrices1_cells,
+      std::vector<SimplexId> *const separatrices1_cells_connectivity,
       std::vector<SimplexId> *const separatrices1_cells_sourceIds,
       std::vector<SimplexId> *const separatrices1_cells_destinationIds,
       std::vector<SimplexId> *const separatrices1_cells_separatrixIds,
@@ -299,7 +299,8 @@ namespace ttk {
         = separatrices1_points_cellDimensions;
       outputSeparatrices1_points_cellIds_ = separatrices1_points_cellIds;
       outputSeparatrices1_numberOfCells_ = separatrices1_numberOfCells;
-      outputSeparatrices1_cells_ = separatrices1_cells;
+      outputSeparatrices1_cells_connectivity_
+        = separatrices1_cells_connectivity;
       outputSeparatrices1_cells_sourceIds_ = separatrices1_cells_sourceIds;
       outputSeparatrices1_cells_destinationIds_
         = separatrices1_cells_destinationIds;
@@ -456,7 +457,7 @@ namespace ttk {
     std::vector<char> *outputSeparatrices1_points_cellDimensions_{};
     std::vector<SimplexId> *outputSeparatrices1_points_cellIds_{};
     SimplexId *outputSeparatrices1_numberOfCells_{};
-    std::vector<SimplexId> *outputSeparatrices1_cells_{};
+    std::vector<SimplexId> *outputSeparatrices1_cells_connectivity_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_sourceIds_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_destinationIds_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_separatrixIds_{};
@@ -565,7 +566,7 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
     this->printErr("1-separatrices pointer to numberOfCells is null.");
     return -1;
   }
-  if(outputSeparatrices1_cells_ == nullptr) {
+  if(outputSeparatrices1_cells_connectivity_ == nullptr) {
     this->printErr("1-separatrices pointer to cells is null.");
     return -1;
   }
@@ -629,8 +630,8 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
   // resize arrays
   outputSeparatrices1_points_->resize(3 * npoints);
   auto &points = *outputSeparatrices1_points_;
-  outputSeparatrices1_cells_->resize(3 * ncells);
-  auto &cells = *outputSeparatrices1_cells_;
+  outputSeparatrices1_cells_connectivity_->resize(2 * ncells);
+  auto &cellsConn = *outputSeparatrices1_cells_connectivity_;
   if(outputSeparatrices1_points_smoothingMask_ != nullptr)
     outputSeparatrices1_points_smoothingMask_->resize(npoints);
   if(outputSeparatrices1_points_cellDimensions_ != nullptr)
@@ -722,9 +723,8 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
       // index of current cell in cell data arrays
       const auto l = geomCellsBegId[i] + j - 1;
 
-      cells[3 * l + 0] = 2;
-      cells[3 * l + 1] = k - 1;
-      cells[3 * l + 2] = k;
+      cellsConn[2 * l + 0] = k - 1;
+      cellsConn[2 * l + 1] = k;
 
       if(outputSeparatrices1_cells_sourceIds_ != nullptr)
         (*outputSeparatrices1_cells_sourceIds_)[l] = src.id_;

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -385,7 +385,8 @@ namespace ttk {
       SimplexId *const separatrices2_numberOfPoints,
       std::vector<float> *const separatrices2_points,
       SimplexId *const separatrices2_numberOfCells,
-      std::vector<SimplexId> *const separatrices2_cells,
+      std::vector<SimplexId> *const separatrices2_cells_offsets,
+      std::vector<SimplexId> *const separatrices2_cells_connectivity,
       std::vector<SimplexId> *const separatrices2_cells_sourceIds,
       std::vector<SimplexId> *const separatrices2_cells_separatrixIds,
       std::vector<char> *const separatrices2_cells_separatrixTypes,
@@ -400,9 +401,9 @@ namespace ttk {
 #endif
       abstractMorseSmaleComplex_->setOutputSeparatrices2(
         separatrices2_numberOfPoints, separatrices2_points,
-        separatrices2_numberOfCells, separatrices2_cells,
-        separatrices2_cells_sourceIds, separatrices2_cells_separatrixIds,
-        separatrices2_cells_separatrixTypes,
+        separatrices2_numberOfCells, separatrices2_cells_offsets,
+        separatrices2_cells_connectivity, separatrices2_cells_sourceIds,
+        separatrices2_cells_separatrixIds, separatrices2_cells_separatrixTypes,
         separatrices2_cells_separatrixFunctionMaxima,
         separatrices2_cells_separatrixFunctionMinima,
         separatrices2_cells_separatrixFunctionDiffs,

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -153,46 +153,55 @@ int ttkMorseSmaleComplex::dispatch(
       return -1;
     }
 #endif
+    points->SetNumberOfPoints(criticalPoints_numberOfPoints);
 
     cellDimensions->SetNumberOfComponents(1);
     cellDimensions->SetName("CellDimension");
+    cellDimensions->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
     cellIds->SetNumberOfComponents(1);
     cellIds->SetName("CellId");
+    cellIds->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
     cellScalars->SetNumberOfComponents(1);
     cellScalars->SetName(inputScalars->GetName());
+    cellScalars->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
     isOnBoundary->SetNumberOfComponents(1);
     isOnBoundary->SetName("IsOnBoundary");
+    isOnBoundary->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
     PLVertexIdentifiers->SetNumberOfComponents(1);
     PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
+    PLVertexIdentifiers->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
     manifoldSizeScalars->SetNumberOfComponents(1);
     manifoldSizeScalars->SetName("ManifoldSize");
+    manifoldSizeScalars->SetNumberOfTuples(criticalPoints_numberOfPoints);
 
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
-      points->InsertNextPoint(criticalPoints_points[3 * i],
-                              criticalPoints_points[3 * i + 1],
-                              criticalPoints_points[3 * i + 2]);
+      points->SetPoint(i, criticalPoints_points[3 * i],
+                       criticalPoints_points[3 * i + 1],
+                       criticalPoints_points[3 * i + 2]);
 
-      cellDimensions->InsertNextTuple1(criticalPoints_points_cellDimensions[i]);
-      cellIds->InsertNextTuple1(criticalPoints_points_cellIds[i]);
+      cellDimensions->SetTuple1(i, criticalPoints_points_cellDimensions[i]);
+      cellIds->SetTuple1(i, criticalPoints_points_cellIds[i]);
+      cellScalars->SetTuple1(i, criticalPoints_points_cellScalars[i]);
+      isOnBoundary->SetTuple1(i, criticalPoints_points_isOnBoundary[i]);
+      PLVertexIdentifiers->SetTuple1(
+        i, criticalPoints_points_PLVertexIdentifiers[i]);
 
-      cellScalars->InsertNextTuple1(criticalPoints_points_cellScalars[i]);
-
-      isOnBoundary->InsertNextTuple1(criticalPoints_points_isOnBoundary[i]);
-
-      PLVertexIdentifiers->InsertNextTuple1(
-        criticalPoints_points_PLVertexIdentifiers[i]);
-
-      if(ComputeAscendingSegmentation and ComputeDescendingSegmentation)
-        manifoldSizeScalars->InsertNextTuple1(
-          criticalPoints_points_manifoldSize[i]);
-      else
-        manifoldSizeScalars->InsertNextTuple1(-1);
+      if(ComputeAscendingSegmentation and ComputeDescendingSegmentation) {
+        manifoldSizeScalars->SetTuple1(
+          i, criticalPoints_points_manifoldSize[i]);
+      } else {
+        manifoldSizeScalars->SetTuple1(i, -1);
+      }
     }
+
     outputCriticalPoints->SetPoints(points);
 
     auto pointData = outputCriticalPoints->GetPointData();
@@ -240,80 +249,99 @@ int ttkMorseSmaleComplex::dispatch(
       return -1;
     }
 #endif
+    points->SetNumberOfPoints(separatrices1_numberOfPoints);
+
     smoothingMask->SetNumberOfComponents(1);
     smoothingMask->SetName(ttk::MaskScalarFieldName);
+    smoothingMask->SetNumberOfTuples(separatrices1_numberOfPoints);
 
     cellDimensions->SetNumberOfComponents(1);
     cellDimensions->SetName("CellDimension");
+    cellDimensions->SetNumberOfTuples(separatrices1_numberOfPoints);
 
     cellIds->SetNumberOfComponents(1);
     cellIds->SetName("CellId");
+    cellIds->SetNumberOfTuples(separatrices1_numberOfPoints);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
+      points->SetPoint(i, separatrices1_points[3 * i],
+                       separatrices1_points[3 * i + 1],
+                       separatrices1_points[3 * i + 2]);
+
+      smoothingMask->SetTuple1(i, separatrices1_points_smoothingMask[i]);
+      cellDimensions->SetTuple1(i, separatrices1_points_cellDimensions[i]);
+      cellIds->SetTuple1(i, separatrices1_points_cellIds[i]);
+    }
 
     sourceIds->SetNumberOfComponents(1);
     sourceIds->SetName("SourceId");
+    sourceIds->SetNumberOfTuples(separatrices1_numberOfCells);
 
     destinationIds->SetNumberOfComponents(1);
     destinationIds->SetName("DestinationId");
+    destinationIds->SetNumberOfTuples(separatrices1_numberOfCells);
 
     separatrixIds->SetNumberOfComponents(1);
     separatrixIds->SetName("SeparatrixId");
+    separatrixIds->SetNumberOfTuples(separatrices1_numberOfCells);
 
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
+    separatrixTypes->SetNumberOfTuples(separatrices1_numberOfCells);
 
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
+    separatrixFunctionMaxima->SetNumberOfTuples(separatrices1_numberOfCells);
 
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
+    separatrixFunctionMinima->SetNumberOfTuples(separatrices1_numberOfCells);
 
     separatrixFunctionDiffs->SetNumberOfComponents(1);
     separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
+    separatrixFunctionDiffs->SetNumberOfTuples(separatrices1_numberOfCells);
 
     isOnBoundary->SetNumberOfComponents(1);
     isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
+    isOnBoundary->SetNumberOfTuples(separatrices1_numberOfCells);
 
-    for(SimplexId i = 0; i < separatrices1_numberOfPoints; ++i) {
-      points->InsertNextPoint(separatrices1_points[3 * i],
-                              separatrices1_points[3 * i + 1],
-                              separatrices1_points[3 * i + 2]);
+    vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+    offsets->SetNumberOfComponents(1);
+    offsets->SetNumberOfTuples(separatrices1_numberOfCells + 1);
+    connectivity->SetNumberOfComponents(1);
+    connectivity->SetNumberOfTuples(2 * separatrices1_numberOfCells);
 
-      smoothingMask->InsertNextTuple1(separatrices1_points_smoothingMask[i]);
-      cellDimensions->InsertNextTuple1(separatrices1_points_cellDimensions[i]);
-      cellIds->InsertNextTuple1(separatrices1_points_cellIds[i]);
-    }
-    outputSeparatrices1->SetPoints(points);
-
-    outputSeparatrices1->Allocate(separatrices1_numberOfCells);
-    SimplexId ptr{};
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
-      vtkIdType line[2];
-      line[0] = separatrices1_cells[ptr + 1];
-      line[1] = separatrices1_cells[ptr + 2];
+      connectivity->SetTuple1(2 * i, separatrices1_cells[3 * i + 1]);
+      connectivity->SetTuple1(2 * i + 1, separatrices1_cells[3 * i + 2]);
+      offsets->SetTuple1(i, 2 * i);
 
-      outputSeparatrices1->InsertNextCell(VTK_LINE, 2, line);
-
-      sourceIds->InsertNextTuple1(separatrices1_cells_sourceIds[i]);
-
-      destinationIds->InsertNextTuple1(separatrices1_cells_destinationIds[i]);
-
-      separatrixIds->InsertNextTuple1(separatrices1_cells_separatrixIds[i]);
-
-      separatrixTypes->InsertNextTuple1(separatrices1_cells_separatrixTypes[i]);
-
-      separatrixFunctionMaxima->InsertNextTuple1(
-        separatrices1_cells_separatrixFunctionMaxima[i]);
-
-      separatrixFunctionMinima->InsertNextTuple1(
-        separatrices1_cells_separatrixFunctionMinima[i]);
-
-      separatrixFunctionDiffs->InsertNextTuple1(
-        separatrices1_cells_separatrixFunctionDiffs[i]);
-
-      isOnBoundary->InsertNextTuple1(separatrices1_cells_isOnBoundary[i]);
-
-      ptr += (separatrices1_cells[ptr] + 1);
+      sourceIds->SetTuple1(i, separatrices1_cells_sourceIds[i]);
+      destinationIds->SetTuple1(i, separatrices1_cells_destinationIds[i]);
+      separatrixIds->SetTuple1(i, separatrices1_cells_separatrixIds[i]);
+      separatrixTypes->SetTuple1(i, separatrices1_cells_separatrixTypes[i]);
+      separatrixFunctionMaxima->SetTuple1(
+        i, separatrices1_cells_separatrixFunctionMaxima[i]);
+      separatrixFunctionMinima->SetTuple1(
+        i, separatrices1_cells_separatrixFunctionMinima[i]);
+      separatrixFunctionDiffs->SetTuple1(
+        i, separatrices1_cells_separatrixFunctionDiffs[i]);
+      isOnBoundary->SetTuple1(i, separatrices1_cells_isOnBoundary[i]);
     }
+
+    offsets->SetTuple1(
+      separatrices1_numberOfCells, connectivity->GetNumberOfTuples());
+
+    vtkNew<vtkCellArray> cells{};
+    cells->SetData(offsets, connectivity);
+    outputSeparatrices1->SetPoints(points);
+    outputSeparatrices1->SetCells(VTK_LINE, cells);
 
     auto pointData = outputSeparatrices1->GetPointData();
     auto cellData = outputSeparatrices1->GetCellData();
@@ -363,34 +391,46 @@ int ttkMorseSmaleComplex::dispatch(
       return -1;
     }
 #endif
+    points->SetNumberOfPoints(separatrices2_numberOfPoints);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
+      points->SetPoint(i, separatrices2_points[3 * i],
+                       separatrices2_points[3 * i + 1],
+                       separatrices2_points[3 * i + 2]);
+    }
+
+    outputSeparatrices2->SetPoints(points);
 
     sourceIds->SetNumberOfComponents(1);
     sourceIds->SetName("SourceId");
+    sourceIds->SetNumberOfTuples(separatrices2_numberOfCells);
 
     separatrixIds->SetNumberOfComponents(1);
     separatrixIds->SetName("SeparatrixId");
+    separatrixIds->SetNumberOfTuples(separatrices2_numberOfCells);
 
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
+    separatrixTypes->SetNumberOfTuples(separatrices2_numberOfCells);
 
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
+    separatrixFunctionMaxima->SetNumberOfTuples(separatrices2_numberOfCells);
 
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
+    separatrixFunctionMinima->SetNumberOfTuples(separatrices2_numberOfCells);
 
     separatrixFunctionDiffs->SetNumberOfComponents(1);
     separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
+    separatrixFunctionDiffs->SetNumberOfTuples(separatrices2_numberOfCells);
 
     isOnBoundary->SetNumberOfComponents(1);
     isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-
-    for(SimplexId i = 0; i < separatrices2_numberOfPoints; ++i) {
-      points->InsertNextPoint(separatrices2_points[3 * i],
-                              separatrices2_points[3 * i + 1],
-                              separatrices2_points[3 * i + 2]);
-    }
-    outputSeparatrices2->SetPoints(points);
+    isOnBoundary->SetNumberOfTuples(separatrices2_numberOfCells);
 
     outputSeparatrices2->Allocate(separatrices2_numberOfCells);
     SimplexId ptr{};
@@ -412,22 +452,23 @@ int ttkMorseSmaleComplex::dispatch(
 
         outputSeparatrices2->InsertNextCell(VTK_POLYGON, vertexNumber, ids);
       }
-
-      sourceIds->InsertNextTuple1(separatrices2_cells_sourceIds[i]);
-      separatrixIds->InsertNextTuple1(separatrices2_cells_separatrixIds[i]);
-
-      separatrixTypes->InsertNextTuple1(separatrices2_cells_separatrixTypes[i]);
-      separatrixFunctionMaxima->InsertNextTuple1(
-        separatrices2_cells_separatrixFunctionMaxima[i]);
-
-      separatrixFunctionMinima->InsertNextTuple1(
-        separatrices2_cells_separatrixFunctionMinima[i]);
-
-      separatrixFunctionDiffs->InsertNextTuple1(
-        separatrices2_cells_separatrixFunctionDiffs[i]);
-      isOnBoundary->InsertNextTuple1(separatrices2_cells_isOnBoundary[i]);
-
       ptr += (separatrices2_cells[ptr] + 1);
+    }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
+      sourceIds->SetTuple1(i, separatrices2_cells_sourceIds[i]);
+      separatrixIds->SetTuple1(i, separatrices2_cells_separatrixIds[i]);
+      separatrixTypes->SetTuple1(i, separatrices2_cells_separatrixTypes[i]);
+      separatrixFunctionMaxima->SetTuple1(
+        i, separatrices2_cells_separatrixFunctionMaxima[i]);
+      separatrixFunctionMinima->SetTuple1(
+        i, separatrices2_cells_separatrixFunctionMinima[i]);
+      separatrixFunctionDiffs->SetTuple1(
+        i, separatrices2_cells_separatrixFunctionDiffs[i]);
+      isOnBoundary->SetTuple1(i, separatrices2_cells_isOnBoundary[i]);
     }
 
     auto cellData = outputSeparatrices2->GetCellData();

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -71,7 +71,7 @@ int ttkMorseSmaleComplex::dispatch(
   std::vector<char> separatrices1_points_cellDimensions;
   std::vector<SimplexId> separatrices1_points_cellIds;
   SimplexId separatrices1_numberOfCells{};
-  std::vector<SimplexId> separatrices1_cells;
+  std::vector<SimplexId> separatrices1_cells_connectivity;
   std::vector<SimplexId> separatrices1_cells_sourceIds;
   std::vector<SimplexId> separatrices1_cells_destinationIds;
   std::vector<SimplexId> separatrices1_cells_separatrixIds;
@@ -111,7 +111,7 @@ int ttkMorseSmaleComplex::dispatch(
     &separatrices1_numberOfPoints, &separatrices1_points,
     &separatrices1_points_smoothingMask, &separatrices1_points_cellDimensions,
     &separatrices1_points_cellIds, &separatrices1_numberOfCells,
-    &separatrices1_cells, &separatrices1_cells_sourceIds,
+    &separatrices1_cells_connectivity, &separatrices1_cells_sourceIds,
     &separatrices1_cells_destinationIds, &separatrices1_cells_separatrixIds,
     &separatrices1_cells_separatrixTypes,
     &separatrices1_cells_separatrixFunctionMaxima,
@@ -320,8 +320,10 @@ int ttkMorseSmaleComplex::dispatch(
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < separatrices1_numberOfCells; ++i) {
-      connectivity->SetTuple1(2 * i, separatrices1_cells[3 * i + 1]);
-      connectivity->SetTuple1(2 * i + 1, separatrices1_cells[3 * i + 2]);
+      connectivity->SetTuple1(
+        2 * i + 0, separatrices1_cells_connectivity[2 * i + 0]);
+      connectivity->SetTuple1(
+        2 * i + 1, separatrices1_cells_connectivity[2 * i + 1]);
       offsets->SetTuple1(i, 2 * i);
 
       sourceIds->SetTuple1(i, separatrices1_cells_sourceIds[i]);

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -13,8 +13,6 @@
 #include <vtkSignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
-using namespace std;
-
 vtkStandardNewMacro(ttkMorseSmaleComplex);
 
 ttkMorseSmaleComplex::ttkMorseSmaleComplex() {
@@ -57,43 +55,43 @@ int ttkMorseSmaleComplex::dispatch(
 
   // critical points
   SimplexId criticalPoints_numberOfPoints{};
-  vector<float> criticalPoints_points;
-  vector<char> criticalPoints_points_cellDimensions;
-  vector<scalarType> criticalPoints_points_cellScalars;
-  vector<SimplexId> criticalPoints_points_cellIds;
-  vector<char> criticalPoints_points_isOnBoundary;
-  vector<SimplexId> criticalPoints_points_PLVertexIdentifiers;
-  vector<SimplexId> criticalPoints_points_manifoldSize;
+  std::vector<float> criticalPoints_points;
+  std::vector<char> criticalPoints_points_cellDimensions;
+  std::vector<scalarType> criticalPoints_points_cellScalars;
+  std::vector<SimplexId> criticalPoints_points_cellIds;
+  std::vector<char> criticalPoints_points_isOnBoundary;
+  std::vector<SimplexId> criticalPoints_points_PLVertexIdentifiers;
+  std::vector<SimplexId> criticalPoints_points_manifoldSize;
 
   // 1-separatrices
   SimplexId separatrices1_numberOfPoints{};
-  vector<float> separatrices1_points;
-  vector<char> separatrices1_points_smoothingMask;
-  vector<char> separatrices1_points_cellDimensions;
-  vector<SimplexId> separatrices1_points_cellIds;
+  std::vector<float> separatrices1_points;
+  std::vector<char> separatrices1_points_smoothingMask;
+  std::vector<char> separatrices1_points_cellDimensions;
+  std::vector<SimplexId> separatrices1_points_cellIds;
   SimplexId separatrices1_numberOfCells{};
-  vector<SimplexId> separatrices1_cells;
-  vector<SimplexId> separatrices1_cells_sourceIds;
-  vector<SimplexId> separatrices1_cells_destinationIds;
-  vector<SimplexId> separatrices1_cells_separatrixIds;
-  vector<char> separatrices1_cells_separatrixTypes;
-  vector<char> separatrices1_cells_isOnBoundary;
-  vector<scalarType> separatrices1_cells_separatrixFunctionMaxima;
-  vector<scalarType> separatrices1_cells_separatrixFunctionMinima;
-  vector<scalarType> separatrices1_cells_separatrixFunctionDiffs;
+  std::vector<SimplexId> separatrices1_cells;
+  std::vector<SimplexId> separatrices1_cells_sourceIds;
+  std::vector<SimplexId> separatrices1_cells_destinationIds;
+  std::vector<SimplexId> separatrices1_cells_separatrixIds;
+  std::vector<char> separatrices1_cells_separatrixTypes;
+  std::vector<char> separatrices1_cells_isOnBoundary;
+  std::vector<scalarType> separatrices1_cells_separatrixFunctionMaxima;
+  std::vector<scalarType> separatrices1_cells_separatrixFunctionMinima;
+  std::vector<scalarType> separatrices1_cells_separatrixFunctionDiffs;
 
   // 2-separatrices
   SimplexId separatrices2_numberOfPoints{};
-  vector<float> separatrices2_points;
+  std::vector<float> separatrices2_points;
   SimplexId separatrices2_numberOfCells{};
-  vector<SimplexId> separatrices2_cells;
-  vector<SimplexId> separatrices2_cells_sourceIds;
-  vector<SimplexId> separatrices2_cells_separatrixIds;
-  vector<char> separatrices2_cells_separatrixTypes;
-  vector<char> separatrices2_cells_isOnBoundary;
-  vector<scalarType> separatrices2_cells_separatrixFunctionMaxima;
-  vector<scalarType> separatrices2_cells_separatrixFunctionMinima;
-  vector<scalarType> separatrices2_cells_separatrixFunctionDiffs;
+  std::vector<SimplexId> separatrices2_cells;
+  std::vector<SimplexId> separatrices2_cells_sourceIds;
+  std::vector<SimplexId> separatrices2_cells_separatrixIds;
+  std::vector<char> separatrices2_cells_separatrixTypes;
+  std::vector<char> separatrices2_cells_isOnBoundary;
+  std::vector<scalarType> separatrices2_cells_separatrixFunctionMaxima;
+  std::vector<scalarType> separatrices2_cells_separatrixFunctionMinima;
+  std::vector<scalarType> separatrices2_cells_separatrixFunctionDiffs;
 
   if(ComputeCriticalPoints) {
     this->setOutputCriticalPoints(


### PR DESCRIPTION
This PR reduces the overhead in the MorseSmaleComplex filter by parallelizing the last step i.e. the filling of the VTK arrays.

To do so, VTK arrays are pre-allocated with the correct size and filled in parallel using `SetTuple` instead of `InsertNextTuple`.

To manage the cells of the vtkUnstructuredGrids underlying the 1-separatrices and the 2-separatrices representations, the interleaved layout (npoints, pt0id, pt1id...) has been dropped in favor of the new offset/connectivity arrays (1-separatrices don't need to fill an offset array in the base layer since the produced cells are all VTK_LINES with two vertices).

As a result, this step has been reduced from 60s to 5s for a full MorseSmaleComplex (incl. 2-separatrices) of the ctBones.vti dataset. For reference, the base layer computation takes approximately 90s.

No change has been observed in the concerned ttk-data state files.

In a next step, I will try to avoid those now parallel copies promoting the temporary vectors filled in the base layer to class member and using `ttkUtils::SetVoidArray` to reference them in the VTK arrays. This should reduce the memory footprint of the filter (especially with the 2-separatrices).

Enjoy,
Pierre

