### PR TITLE
PersistenceDiagram/Curve: Shunt the MorseSmaleComplex dependency

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -578,7 +578,6 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto offsets = inputOffsets_;
   auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
     outputSeparatrices1_cells_separatrixFunctionMaxima_);
   auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
@@ -674,16 +673,12 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
       = saddleConnector ? 1 : std::min(dst.dim_, dimensionality - 1);
 
     // compute separatrix function diff
-    const auto sepFuncMax
-      = std::max(scalars[discreteGradient_.getCellGreaterVertex(
-                   src, offsets, triangulation)],
-                 scalars[discreteGradient_.getCellGreaterVertex(
-                   dst, offsets, triangulation)]);
-    const auto sepFuncMin
-      = std::min(scalars[discreteGradient_.getCellLowerVertex(
-                   src, offsets, triangulation)],
-                 scalars[discreteGradient_.getCellLowerVertex(
-                   dst, offsets, triangulation)]);
+    const auto sepFuncMax = std::max(
+      scalars[discreteGradient_.getCellGreaterVertex(src, triangulation)],
+      scalars[discreteGradient_.getCellGreaterVertex(dst, triangulation)]);
+    const auto sepFuncMin = std::min(
+      scalars[discreteGradient_.getCellLowerVertex(src, triangulation)],
+      scalars[discreteGradient_.getCellLowerVertex(dst, triangulation)]);
     const auto sepFuncDiff = sepFuncMax - sepFuncMin;
 
     // get boundary condition

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -588,7 +588,6 @@ in the gradient.
       template <typename triangulationType>
       SimplexId
         getCellGreaterVertex(const Cell c,
-                             const SimplexId *const offsets,
                              const triangulationType &triangulation) const;
 
       /**
@@ -598,7 +597,6 @@ in the gradient.
       template <typename triangulationType>
       SimplexId
         getCellLowerVertex(const Cell c,
-                           const SimplexId *const offsets,
                            const triangulationType &triangulation) const;
 
       /**

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -381,6 +381,16 @@ according to them.
                           const bool detectCriticalPoints = true);
 
       /**
+       * Compute the (saddle1, saddle2) pairs not detected by the
+       * contour tree.
+       */
+      template <typename dataType, typename triangulationType>
+      void computeSaddleSaddlePersistencePairs(
+        std::vector<std::tuple<SimplexId, SimplexId, dataType>>
+          &pl_saddleSaddlePairs,
+        const triangulationType &triangulation);
+
+      /**
        * Set the input scalar function.
        */
       inline void setInputScalarField(const void *const data) {

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -33,8 +33,8 @@ dataType DiscreteGradient::getPersistence(
   const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
-  return scalars[getCellGreaterVertex(up, offsets, triangulation)]
-         - scalars[getCellLowerVertex(down, offsets, triangulation)];
+  return scalars[getCellGreaterVertex(up, triangulation)]
+         - scalars[getCellLowerVertex(down, triangulation)];
 }
 
 template <typename triangulationType>
@@ -97,7 +97,6 @@ int DiscreteGradient::setCriticalPoints(
   }
 #endif
   const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto *const offsets = inputOffsets_;
   auto *outputCriticalPoints_points_cellScalars
     = static_cast<std::vector<dataType> *>(
       outputCriticalPoints_points_cellScalars_);
@@ -135,8 +134,7 @@ int DiscreteGradient::setCriticalPoints(
     float incenter[3];
     triangulation.getCellIncenter(cell.id_, cell.dim_, incenter);
 
-    const auto scalar
-      = scalars[getCellGreaterVertex(cell, offsets, triangulation)];
+    const auto scalar = scalars[getCellGreaterVertex(cell, triangulation)];
     const char isOnBoundary = isBoundary(cell, triangulation);
 
     outputCriticalPoints_points_[3 * i] = incenter[0];
@@ -149,7 +147,7 @@ int DiscreteGradient::setCriticalPoints(
       (*outputCriticalPoints_points_cellScalars)[i] = scalar;
     }
     outputCriticalPoints_points_isOnBoundary_[i] = isOnBoundary;
-    auto vertId = getCellGreaterVertex(cell, offsets, triangulation);
+    auto vertId = getCellGreaterVertex(cell, triangulation);
     outputCriticalPoints_points_PLVertexIdentifiers_[i] = vertId;
   }
 
@@ -1658,7 +1656,6 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
                                       bool detectCriticalPoints) {
 
   std::vector<std::pair<SimplexId, char>> criticalPoints{};
-  const auto *const offsets = inputOffsets_;
 
   if(detectCriticalPoints) {
 
@@ -1672,7 +1669,7 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
     for(size_t i = 0; i < criticalCells.size(); ++i) {
       const auto &c = criticalCells[i];
       criticalPoints[i]
-        = {getCellGreaterVertex(c, offsets, triangulation),
+        = {getCellGreaterVertex(c, triangulation),
            static_cast<char>(criticalTypeFromCellDimension(c.dim_))};
     }
 
@@ -3049,9 +3046,9 @@ int DiscreteGradient::reverseDescendingPathOnWall(
 
 template <typename triangulationType>
 ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
-  const Cell c,
-  const SimplexId *const offsets,
-  const triangulationType &triangulation) const {
+  const Cell c, const triangulationType &triangulation) const {
+
+  const auto offsets = this->inputOffsets_;
 
   auto cellDim = c.dim_;
   auto cellId = c.id_;
@@ -3112,9 +3109,9 @@ ttk::SimplexId DiscreteGradient::getCellGreaterVertex(
 
 template <typename triangulationType>
 ttk::SimplexId DiscreteGradient::getCellLowerVertex(
-  const Cell c,
-  const SimplexId *const offsets,
-  const triangulationType &triangulation) const {
+  const Cell c, const triangulationType &triangulation) const {
+
+  const auto offsets = this->inputOffsets_;
 
   auto cellDim = c.dim_;
   auto cellId = c.id_;

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -247,18 +247,18 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
     const dcg::Cell &src = sep.source_; // saddle1
 
     // compute separatrix function diff
-    const dataType sepFuncMin = scalars[discreteGradient_.getCellLowerVertex(
-      src, offsets, triangulation)];
+    const dataType sepFuncMin
+      = scalars[discreteGradient_.getCellLowerVertex(src, triangulation)];
     const auto maxId = *std::max_element(
       sepSaddles.begin(), sepSaddles.end(),
       [&triangulation, offsets, this](const SimplexId a, const SimplexId b) {
         return offsets[discreteGradient_.getCellGreaterVertex(
-                 Cell{2, a}, offsets, triangulation)]
+                 Cell{2, a}, triangulation)]
                < offsets[discreteGradient_.getCellGreaterVertex(
-                 Cell{2, b}, offsets, triangulation)];
+                 Cell{2, b}, triangulation)];
       });
     const dataType sepFuncMax = scalars[discreteGradient_.getCellGreaterVertex(
-      Cell{2, maxId}, offsets, triangulation)];
+      Cell{2, maxId}, triangulation)];
 
     // get boundary condition
     const char onBoundary
@@ -515,18 +515,18 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
     const char sepType = 2;
 
     // compute separatrix function diff
-    const dataType sepFuncMax = scalars[discreteGradient_.getCellGreaterVertex(
-      src, offsets, triangulation)];
+    const dataType sepFuncMax
+      = scalars[discreteGradient_.getCellGreaterVertex(src, triangulation)];
     const auto minId = *std::min_element(
       sepSaddles.begin(), sepSaddles.end(),
       [&triangulation, offsets, this](const SimplexId a, const SimplexId b) {
         return offsets[discreteGradient_.getCellLowerVertex(
-                 Cell{1, a}, offsets, triangulation)]
+                 Cell{1, a}, triangulation)]
                < offsets[discreteGradient_.getCellLowerVertex(
-                 Cell{1, b}, offsets, triangulation)];
+                 Cell{1, b}, triangulation)];
       });
     const dataType sepFuncMin = scalars[discreteGradient_.getCellLowerVertex(
-      Cell{1, minId}, offsets, triangulation)];
+      Cell{1, minId}, triangulation)];
     const dataType sepFuncDiff = sepFuncMax - sepFuncMin;
 
     // get boundary condition

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -36,16 +36,6 @@ namespace ttk {
     template <typename dataType, typename triangulationType>
     int execute(const triangulationType &triangulation);
 
-    /**
-     * Compute the (saddle1, saddle2) pairs not detected by the
-     * contour tree.
-     */
-    template <typename dataType, typename triangulationType>
-    int computePersistencePairs(
-      std::vector<std::tuple<SimplexId, SimplexId, dataType>>
-        &pl_saddleSaddlePairs,
-      const triangulationType &triangulation);
-
     template <typename dataType>
     int setAugmentedCriticalPoints(const std::vector<dcg::Cell> &criticalPoints,
                                    SimplexId *ascendingManifold,
@@ -806,47 +796,6 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
                    + " points) processed",
                  1.0, t.getElapsedTime(), this->threadNumber_);
 
-  return 0;
-}
-
-template <typename dataType, typename triangulationType>
-int ttk::MorseSmaleComplex3D::computePersistencePairs(
-  std::vector<std::tuple<SimplexId, SimplexId, dataType>> &pl_saddleSaddlePairs,
-  const triangulationType &triangulation) {
-
-  const dataType *scalars = static_cast<const dataType *>(inputScalarField_);
-  const auto offsets = inputOffsets_;
-
-  std::vector<std::array<dcg::Cell, 2>> dmt_pairs;
-  {
-    // simplify to be PL-conformant
-    discreteGradient_.setDebugLevel(debugLevel_);
-    discreteGradient_.setThreadNumber(threadNumber_);
-    discreteGradient_.setCollectPersistencePairs(false);
-    discreteGradient_.buildGradient<triangulationType>(triangulation);
-    discreteGradient_.reverseGradient<dataType>(triangulation);
-
-    // collect saddle-saddle connections
-    discreteGradient_.setCollectPersistencePairs(true);
-    discreteGradient_.setOutputPersistencePairs(&dmt_pairs);
-    discreteGradient_.reverseGradient<dataType>(triangulation, false);
-  }
-
-  // transform DMT pairs into PL pairs
-  for(const auto &pair : dmt_pairs) {
-    const SimplexId v0
-      = discreteGradient_.getCellGreaterVertex(pair[0], offsets, triangulation);
-    const SimplexId v1
-      = discreteGradient_.getCellGreaterVertex(pair[1], offsets, triangulation);
-    const dataType persistence = scalars[v1] - scalars[v0];
-
-    if(v0 != -1 and v1 != -1 and persistence >= 0) {
-      if(!triangulation.isVertexOnBoundary(v0)
-         or !triangulation.isVertexOnBoundary(v1)) {
-        pl_saddleSaddlePairs.emplace_back(v0, v1, persistence);
-      }
-    }
-  }
   return 0;
 }
 

--- a/core/base/persistenceCurve/CMakeLists.txt
+++ b/core/base/persistenceCurve/CMakeLists.txt
@@ -6,6 +6,5 @@ ttk_add_base_library(persistenceCurve
   DEPENDS
     discreteGradient
     triangulation
-    morseSmaleComplex3D
     ftmTreePP
     )

--- a/core/base/persistenceCurve/PersistenceCurve.cpp
+++ b/core/base/persistenceCurve/PersistenceCurve.cpp
@@ -1,11 +1,5 @@
 #include <PersistenceCurve.h>
 
-using namespace std;
-using namespace ttk;
-
-PersistenceCurve::PersistenceCurve() {
+ttk::PersistenceCurve::PersistenceCurve() {
   setDebugMsgPrefix("PersistenceCurve");
-}
-
-PersistenceCurve::~PersistenceCurve() {
 }

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -18,8 +18,8 @@
 #pragma once
 
 // base code includes
+#include <DiscreteGradient.h>
 #include <FTMTreePP.h>
-#include <MorseSmaleComplex3D.h>
 #include <Triangulation.h>
 
 namespace ttk {
@@ -32,7 +32,6 @@ namespace ttk {
 
   public:
     PersistenceCurve();
-    ~PersistenceCurve();
 
     inline void setComputeSaddleConnectors(bool state) {
       ComputeSaddleConnectors = state;
@@ -62,9 +61,11 @@ namespace ttk {
         triangulation->preconditionBoundaryVertices();
         contourTree_.setDebugLevel(debugLevel_);
         contourTree_.preconditionTriangulation(triangulation);
-        morseSmaleComplex_.setDebugLevel(debugLevel_);
-        morseSmaleComplex_.setThreadNumber(threadNumber_);
-        morseSmaleComplex_.preconditionTriangulation(triangulation);
+        if(this->ComputeSaddleConnectors) {
+          dcg_.setDebugLevel(debugLevel_);
+          dcg_.setThreadNumber(threadNumber_);
+          dcg_.preconditionTriangulation(triangulation);
+        }
       }
     }
 
@@ -88,7 +89,7 @@ namespace ttk {
     void *MSCPlot_{};
     bool ComputeSaddleConnectors{false};
     ftm::FTMTreePP contourTree_{};
-    MorseSmaleComplex3D morseSmaleComplex_{};
+    dcg::DiscreteGradient dcg_{};
   };
 } // namespace ttk
 
@@ -158,9 +159,9 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
   if(dimensionality == 3 and ComputeSaddleConnectors and MSCPlot_ != nullptr) {
     std::vector<std::tuple<SimplexId, SimplexId, scalarType>>
       pl_saddleSaddlePairs;
-    morseSmaleComplex_.setInputScalarField(inputScalars);
-    morseSmaleComplex_.setInputOffsets(inputOffsets);
-    morseSmaleComplex_.computePersistencePairs<scalarType>(
+    dcg_.setInputScalarField(inputScalars);
+    dcg_.setInputOffsets(inputOffsets);
+    dcg_.computeSaddleSaddlePersistencePairs<scalarType>(
       pl_saddleSaddlePairs, *triangulation);
 
     // sort the saddle-saddle pairs by persistence value and compute curve

--- a/core/base/persistenceDiagram/CMakeLists.txt
+++ b/core/base/persistenceDiagram/CMakeLists.txt
@@ -6,6 +6,5 @@ ttk_add_base_library(persistenceDiagram
   DEPENDS
     discreteGradient
     triangulation
-    morseSmaleComplex3D
     ftmTreePP
     )


### PR DESCRIPTION
This PR removes the PersistenceDiagram and PersistenceCurve dependency to the MorseSmaleComplex module for saddle-saddle pairs by moving the called MorseSmaleComplex method into the DiscreteGradient module.

Since the `MorseSmaleComplex3D::computePersistencePairs` method doesn't use anything specific to the MorseSmaleComplex and rather calls directly into the DiscreteGradient, moving it to the DiscreteGradient module is the logic action.

As a consequence, a modification of the MorseSmaleComplex headers should not trigger the recompilation of the PersistenceDiagram and other modules that depend on it (TrackingFromFields). However, no reduction of the build times of ttkPersistenceDiagram and ttkPersistenceCurve has been observed.

Also including a little bit of cleaning of the DiscreteGradient module.

No change has been observed on the ttk-data states.

Enjoy,
Pierre