### PR TITLE
MorseSmaleComplex: Don't copy base layer output into VTK arrays

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -282,14 +282,14 @@ namespace ttk {
       std::vector<char> *const separatrices1_points_cellDimensions,
       std::vector<SimplexId> *const separatrices1_points_cellIds,
       SimplexId *const separatrices1_numberOfCells,
-      std::vector<SimplexId> *const separatrices1_cells_connectivity,
+      std::vector<long long> *const separatrices1_cells_connectivity,
       std::vector<SimplexId> *const separatrices1_cells_sourceIds,
       std::vector<SimplexId> *const separatrices1_cells_destinationIds,
       std::vector<SimplexId> *const separatrices1_cells_separatrixIds,
       std::vector<char> *const separatrices1_cells_separatrixTypes,
-      void *const separatrices1_cells_separatrixFunctionMaxima,
-      void *const separatrices1_cells_separatrixFunctionMinima,
-      void *const separatrices1_cells_separatrixFunctionDiffs,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionMaxima,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionMinima,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionDiffs,
       std::vector<char> *const separatrices1_cells_isOnBoundary) {
       outputSeparatrices1_numberOfPoints_ = separatrices1_numberOfPoints;
       outputSeparatrices1_points_ = separatrices1_points;
@@ -457,14 +457,14 @@ namespace ttk {
     std::vector<char> *outputSeparatrices1_points_cellDimensions_{};
     std::vector<SimplexId> *outputSeparatrices1_points_cellIds_{};
     SimplexId *outputSeparatrices1_numberOfCells_{};
-    std::vector<SimplexId> *outputSeparatrices1_cells_connectivity_{};
+    std::vector<long long> *outputSeparatrices1_cells_connectivity_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_sourceIds_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_destinationIds_{};
     std::vector<SimplexId> *outputSeparatrices1_cells_separatrixIds_{};
     std::vector<char> *outputSeparatrices1_cells_separatrixTypes_{};
-    void *outputSeparatrices1_cells_separatrixFunctionMaxima_{};
-    void *outputSeparatrices1_cells_separatrixFunctionMinima_{};
-    void *outputSeparatrices1_cells_separatrixFunctionDiffs_{};
+    std::vector<double> *outputSeparatrices1_cells_separatrixFunctionMaxima_{};
+    std::vector<double> *outputSeparatrices1_cells_separatrixFunctionMinima_{};
+    std::vector<double> *outputSeparatrices1_cells_separatrixFunctionDiffs_{};
     std::vector<char> *outputSeparatrices1_cells_isOnBoundary_{};
 
     SimplexId *outputSeparatrices2_numberOfPoints_{};
@@ -578,12 +578,12 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 #endif
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
-  auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices1_cells_separatrixFunctionMaxima_);
-  auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices1_cells_separatrixFunctionMinima_);
-  auto separatrixFunctionDiffs = static_cast<std::vector<dataType> *>(
-    outputSeparatrices1_cells_separatrixFunctionDiffs_);
+  auto separatrixFunctionMaxima
+    = outputSeparatrices1_cells_separatrixFunctionMaxima_;
+  auto separatrixFunctionMinima
+    = outputSeparatrices1_cells_separatrixFunctionMinima_;
+  auto separatrixFunctionDiffs
+    = outputSeparatrices1_cells_separatrixFunctionDiffs_;
 
   // max existing separatrix id + 1 or 0
   const SimplexId separatrixId
@@ -673,12 +673,12 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
       = saddleConnector ? 1 : std::min(dst.dim_, dimensionality - 1);
 
     // compute separatrix function diff
-    const auto sepFuncMax = std::max(
+    const auto sepFuncMax = static_cast<double>(std::max(
       scalars[discreteGradient_.getCellGreaterVertex(src, triangulation)],
-      scalars[discreteGradient_.getCellGreaterVertex(dst, triangulation)]);
-    const auto sepFuncMin = std::min(
+      scalars[discreteGradient_.getCellGreaterVertex(dst, triangulation)]));
+    const auto sepFuncMin = static_cast<double>(std::min(
       scalars[discreteGradient_.getCellLowerVertex(src, triangulation)],
-      scalars[discreteGradient_.getCellLowerVertex(dst, triangulation)]);
+      scalars[discreteGradient_.getCellLowerVertex(dst, triangulation)]));
     const auto sepFuncDiff = sepFuncMax - sepFuncMin;
 
     // get boundary condition

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -326,14 +326,14 @@ namespace ttk {
       SimplexId *const separatrices2_numberOfPoints,
       std::vector<float> *const separatrices2_points,
       SimplexId *const separatrices2_numberOfCells,
-      std::vector<SimplexId> *const separatrices2_cells_offsets,
-      std::vector<SimplexId> *const separatrices2_cells_connectivity,
+      std::vector<long long> *const separatrices2_cells_offsets,
+      std::vector<long long> *const separatrices2_cells_connectivity,
       std::vector<SimplexId> *const separatrices2_cells_sourceIds,
       std::vector<SimplexId> *const separatrices2_cells_separatrixIds,
       std::vector<char> *const separatrices2_cells_separatrixTypes,
-      void *const separatrices2_cells_separatrixFunctionMaxima,
-      void *const separatrices2_cells_separatrixFunctionMinima,
-      void *const separatrices2_cells_separatrixFunctionDiffs,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionMaxima,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionMinima,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionDiffs,
       std::vector<char> *const separatrices2_cells_isOnBoundary) {
       outputSeparatrices2_numberOfPoints_ = separatrices2_numberOfPoints;
       outputSeparatrices2_points_ = separatrices2_points;
@@ -470,14 +470,14 @@ namespace ttk {
     SimplexId *outputSeparatrices2_numberOfPoints_{};
     std::vector<float> *outputSeparatrices2_points_{};
     SimplexId *outputSeparatrices2_numberOfCells_{};
-    std::vector<SimplexId> *outputSeparatrices2_cells_offsets_{};
-    std::vector<SimplexId> *outputSeparatrices2_cells_connectivity_{};
+    std::vector<long long> *outputSeparatrices2_cells_offsets_{};
+    std::vector<long long> *outputSeparatrices2_cells_connectivity_{};
     std::vector<SimplexId> *outputSeparatrices2_cells_sourceIds_{};
     std::vector<SimplexId> *outputSeparatrices2_cells_separatrixIds_{};
     std::vector<char> *outputSeparatrices2_cells_separatrixTypes_{};
-    void *outputSeparatrices2_cells_separatrixFunctionMaxima_{};
-    void *outputSeparatrices2_cells_separatrixFunctionMinima_{};
-    void *outputSeparatrices2_cells_separatrixFunctionDiffs_{};
+    std::vector<double> *outputSeparatrices2_cells_separatrixFunctionMaxima_{};
+    std::vector<double> *outputSeparatrices2_cells_separatrixFunctionMinima_{};
+    std::vector<double> *outputSeparatrices2_cells_separatrixFunctionDiffs_{};
     std::vector<char> *outputSeparatrices2_cells_isOnBoundary_{};
 
     void *outputAscendingManifold_{};

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -352,14 +352,14 @@ namespace ttk {
       std::vector<char> *const separatrices1_points_cellDimensions,
       std::vector<SimplexId> *const separatrices1_points_cellIds,
       SimplexId *const separatrices1_numberOfCells,
-      std::vector<SimplexId> *const separatrices1_cells,
+      std::vector<long long> *const separatrices1_cells_connectivity,
       std::vector<SimplexId> *const separatrices1_cells_sourceIds,
       std::vector<SimplexId> *const separatrices1_cells_destinationIds,
       std::vector<SimplexId> *const separatrices1_cells_separatrixIds,
       std::vector<char> *const separatrices1_cells_separatrixTypes,
-      void *const separatrices1_cells_separatrixFunctionMaxima,
-      void *const separatrices1_cells_separatrixFunctionMinima,
-      void *const separatrices1_cells_separatrixFunctionDiffs,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionMaxima,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionMinima,
+      std::vector<double> *const separatrices1_cells_separatrixFunctionDiffs,
       std::vector<char> *const separatrices1_cells_isOnBoundary) {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!abstractMorseSmaleComplex_) {
@@ -370,7 +370,7 @@ namespace ttk {
         separatrices1_numberOfPoints, separatrices1_points,
         separatrices1_points_smoothingMask, separatrices1_points_cellDimensions,
         separatrices1_points_cellIds, separatrices1_numberOfCells,
-        separatrices1_cells, separatrices1_cells_sourceIds,
+        separatrices1_cells_connectivity, separatrices1_cells_sourceIds,
         separatrices1_cells_destinationIds, separatrices1_cells_separatrixIds,
         separatrices1_cells_separatrixTypes,
         separatrices1_cells_separatrixFunctionMaxima,

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -385,14 +385,14 @@ namespace ttk {
       SimplexId *const separatrices2_numberOfPoints,
       std::vector<float> *const separatrices2_points,
       SimplexId *const separatrices2_numberOfCells,
-      std::vector<SimplexId> *const separatrices2_cells_offsets,
-      std::vector<SimplexId> *const separatrices2_cells_connectivity,
+      std::vector<long long> *const separatrices2_cells_offsets,
+      std::vector<long long> *const separatrices2_cells_connectivity,
       std::vector<SimplexId> *const separatrices2_cells_sourceIds,
       std::vector<SimplexId> *const separatrices2_cells_separatrixIds,
       std::vector<char> *const separatrices2_cells_separatrixTypes,
-      void *const separatrices2_cells_separatrixFunctionMaxima,
-      void *const separatrices2_cells_separatrixFunctionMinima,
-      void *const separatrices2_cells_separatrixFunctionDiffs,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionMaxima,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionMinima,
+      std::vector<double> *const separatrices2_cells_separatrixFunctionDiffs,
       std::vector<char> *const separatrices2_cells_isOnBoundary) {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!abstractMorseSmaleComplex_) {

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -180,12 +180,12 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
   const auto offsets = inputOffsets_;
-  auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionMaxima_);
-  auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionMinima_);
-  auto separatrixFunctionDiffs = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionDiffs_);
+  auto separatrixFunctionMaxima
+    = outputSeparatrices2_cells_separatrixFunctionMaxima_;
+  auto separatrixFunctionMinima
+    = outputSeparatrices2_cells_separatrixFunctionMinima_;
+  auto separatrixFunctionDiffs
+    = outputSeparatrices2_cells_separatrixFunctionDiffs_;
 
   // max existing separatrix id + 1 or 0 if no previous separatrices
   const SimplexId separatrixId
@@ -247,8 +247,8 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
     const dcg::Cell &src = sep.source_; // saddle1
 
     // compute separatrix function diff
-    const dataType sepFuncMin
-      = scalars[discreteGradient_.getCellLowerVertex(src, triangulation)];
+    const double sepFuncMin = static_cast<double>(
+      scalars[discreteGradient_.getCellLowerVertex(src, triangulation)]);
     const auto maxId = *std::max_element(
       sepSaddles.begin(), sepSaddles.end(),
       [&triangulation, offsets, this](const SimplexId a, const SimplexId b) {
@@ -257,8 +257,9 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
                < offsets[discreteGradient_.getCellGreaterVertex(
                  Cell{2, b}, triangulation)];
       });
-    const dataType sepFuncMax = scalars[discreteGradient_.getCellGreaterVertex(
-      Cell{2, maxId}, triangulation)];
+    const double sepFuncMax
+      = static_cast<double>(scalars[discreteGradient_.getCellGreaterVertex(
+        Cell{2, maxId}, triangulation)]);
 
     // get boundary condition
     const char onBoundary
@@ -432,12 +433,12 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
 
   const auto scalars = static_cast<const dataType *>(inputScalarField_);
   const auto offsets = inputOffsets_;
-  auto separatrixFunctionMaxima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionMaxima_);
-  auto separatrixFunctionMinima = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionMinima_);
-  auto separatrixFunctionDiffs = static_cast<std::vector<dataType> *>(
-    outputSeparatrices2_cells_separatrixFunctionDiffs_);
+  auto separatrixFunctionMaxima
+    = outputSeparatrices2_cells_separatrixFunctionMaxima_;
+  auto separatrixFunctionMinima
+    = outputSeparatrices2_cells_separatrixFunctionMinima_;
+  auto separatrixFunctionDiffs
+    = outputSeparatrices2_cells_separatrixFunctionDiffs_;
 
   // max existing separatrix id + 1 or 0 if no previous separatrices
   const SimplexId separatrixId
@@ -515,8 +516,8 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
     const char sepType = 2;
 
     // compute separatrix function diff
-    const dataType sepFuncMax
-      = scalars[discreteGradient_.getCellGreaterVertex(src, triangulation)];
+    const double sepFuncMax = static_cast<double>(
+      scalars[discreteGradient_.getCellGreaterVertex(src, triangulation)]);
     const auto minId = *std::min_element(
       sepSaddles.begin(), sepSaddles.end(),
       [&triangulation, offsets, this](const SimplexId a, const SimplexId b) {
@@ -525,9 +526,10 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
                < offsets[discreteGradient_.getCellLowerVertex(
                  Cell{1, b}, triangulation)];
       });
-    const dataType sepFuncMin = scalars[discreteGradient_.getCellLowerVertex(
-      Cell{1, minId}, triangulation)];
-    const dataType sepFuncDiff = sepFuncMax - sepFuncMin;
+    const double sepFuncMin
+      = static_cast<double>(scalars[discreteGradient_.getCellLowerVertex(
+        Cell{1, minId}, triangulation)]);
+    const auto sepFuncDiff = sepFuncMax - sepFuncMin;
 
     // get boundary condition
     const char onBoundary

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -64,14 +64,43 @@ int ttkMorseSmaleComplex::dispatch(
   // critical points
   SimplexId criticalPoints_numberOfPoints{};
   std::vector<scalarType> criticalPoints_points_cellScalars;
+  criticalPoints_points.clear();
+  criticalPoints_points_cellDimensions.clear();
+  criticalPoints_points_cellIds.clear();
+  criticalPoints_points_isOnBoundary.clear();
+  criticalPoints_points_PLVertexIdentifiers.clear();
+  criticalPoints_points_manifoldSize.clear();
 
   // 1-separatrices
   SimplexId separatrices1_numberOfPoints{};
   SimplexId separatrices1_numberOfCells{};
+  separatrices1_points.clear();
+  separatrices1_points_smoothingMask.clear();
+  separatrices1_points_cellDimensions.clear();
+  separatrices1_points_cellIds.clear();
+  separatrices1_cells_connectivity.clear();
+  separatrices1_cells_sourceIds.clear();
+  separatrices1_cells_destinationIds.clear();
+  separatrices1_cells_separatrixIds.clear();
+  separatrices1_cells_separatrixTypes.clear();
+  separatrices1_cells_isOnBoundary.clear();
+  separatrices1_cells_separatrixFunctionMaxima.clear();
+  separatrices1_cells_separatrixFunctionMinima.clear();
+  separatrices1_cells_separatrixFunctionDiffs.clear();
 
   // 2-separatrices
   SimplexId separatrices2_numberOfPoints{};
   SimplexId separatrices2_numberOfCells{};
+  separatrices2_points.clear();
+  separatrices2_cells_offsets.clear();
+  separatrices2_cells_connectivity.clear();
+  separatrices2_cells_sourceIds.clear();
+  separatrices2_cells_separatrixIds.clear();
+  separatrices2_cells_separatrixTypes.clear();
+  separatrices2_cells_isOnBoundary.clear();
+  separatrices2_cells_separatrixFunctionMaxima.clear();
+  separatrices2_cells_separatrixFunctionMinima.clear();
+  separatrices2_cells_separatrixFunctionDiffs.clear();
 
   if(ComputeCriticalPoints) {
     this->setOutputCriticalPoints(

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -44,6 +44,11 @@ int ttkMorseSmaleComplex::FillOutputPortInformation(int port,
   return 0;
 }
 
+template <typename vtkArrayType, typename vectorType>
+void setArray(vtkArrayType &vtkArray, vectorType &vector) {
+  ttkUtils::SetVoidArray(vtkArray, vector.data(), vector.size(), 1);
+}
+
 template <typename scalarType, typename triangulationType>
 int ttkMorseSmaleComplex::dispatch(
   vtkDataArray *const inputScalars,
@@ -243,78 +248,56 @@ int ttkMorseSmaleComplex::dispatch(
 
     smoothingMask->SetNumberOfComponents(1);
     smoothingMask->SetName(ttk::MaskScalarFieldName);
-    ttkUtils::SetVoidArray(smoothingMask,
-                           separatrices1_points_smoothingMask.data(),
-                           separatrices1_points_smoothingMask.size(), 1);
+    setArray(smoothingMask, separatrices1_points_smoothingMask);
 
     cellDimensions->SetNumberOfComponents(1);
     cellDimensions->SetName("CellDimension");
-    ttkUtils::SetVoidArray(cellDimensions,
-                           separatrices1_points_cellDimensions.data(),
-                           separatrices1_points_cellDimensions.size(), 1);
+    setArray(cellDimensions, separatrices1_points_cellDimensions);
 
     cellIds->SetNumberOfComponents(1);
     cellIds->SetName("CellId");
-    ttkUtils::SetVoidArray(cellIds, separatrices1_points_cellIds.data(),
-                           separatrices1_points_cellIds.size(), 1);
+    setArray(cellIds, separatrices1_points_cellIds);
 
     sourceIds->SetNumberOfComponents(1);
     sourceIds->SetName("SourceId");
-    ttkUtils::SetVoidArray(sourceIds, separatrices1_cells_sourceIds.data(),
-                           separatrices1_cells_sourceIds.size(), 1);
+    setArray(sourceIds, separatrices1_cells_sourceIds);
 
     destinationIds->SetNumberOfComponents(1);
     destinationIds->SetName("DestinationId");
-    ttkUtils::SetVoidArray(destinationIds,
-                           separatrices1_cells_destinationIds.data(),
-                           separatrices1_cells_destinationIds.size(), 1);
+    setArray(destinationIds, separatrices1_cells_destinationIds);
 
     separatrixIds->SetNumberOfComponents(1);
     separatrixIds->SetName("SeparatrixId");
-    ttkUtils::SetVoidArray(separatrixIds,
-                           separatrices1_cells_separatrixIds.data(),
-                           separatrices1_cells_separatrixIds.size(), 1);
+    setArray(separatrixIds, separatrices1_cells_separatrixIds);
 
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
-    ttkUtils::SetVoidArray(separatrixTypes,
-                           separatrices1_cells_separatrixTypes.data(),
-                           separatrices1_cells_separatrixTypes.size(), 1);
+    setArray(separatrixTypes, separatrices1_cells_separatrixTypes);
 
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-    ttkUtils::SetVoidArray(separatrixFunctionMaxima,
-                           separatrices1_cells_separatrixFunctionMaxima.data(),
-                           separatrices1_cells_separatrixFunctionMaxima.size(),
-                           1);
+    setArray(
+      separatrixFunctionMaxima, separatrices1_cells_separatrixFunctionMaxima);
 
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-    ttkUtils::SetVoidArray(separatrixFunctionMinima,
-                           separatrices1_cells_separatrixFunctionMinima.data(),
-                           separatrices1_cells_separatrixFunctionMinima.size(),
-                           1);
+    setArray(
+      separatrixFunctionMinima, separatrices1_cells_separatrixFunctionMinima);
 
     separatrixFunctionDiffs->SetNumberOfComponents(1);
     separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-    ttkUtils::SetVoidArray(separatrixFunctionDiffs,
-                           separatrices1_cells_separatrixFunctionDiffs.data(),
-                           separatrices1_cells_separatrixFunctionDiffs.size(),
-                           1);
+    setArray(
+      separatrixFunctionDiffs, separatrices1_cells_separatrixFunctionDiffs);
 
     isOnBoundary->SetNumberOfComponents(1);
     isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-    ttkUtils::SetVoidArray(isOnBoundary,
-                           separatrices1_cells_isOnBoundary.data(),
-                           separatrices1_cells_isOnBoundary.size(), 1);
+    setArray(isOnBoundary, separatrices1_cells_isOnBoundary);
 
     vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
     offsets->SetNumberOfComponents(1);
     offsets->SetNumberOfTuples(separatrices1_numberOfCells + 1);
     connectivity->SetNumberOfComponents(1);
-    ttkUtils::SetVoidArray(connectivity,
-                           separatrices1_cells_connectivity.data(),
-                           separatrices1_cells_connectivity.size(), 1);
+    setArray(connectivity, separatrices1_cells_connectivity);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
@@ -387,53 +370,41 @@ int ttkMorseSmaleComplex::dispatch(
 
     sourceIds->SetNumberOfComponents(1);
     sourceIds->SetName("SourceId");
-    ttkUtils::SetVoidArray(sourceIds, separatrices2_cells_sourceIds.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(sourceIds, separatrices2_cells_sourceIds);
 
     separatrixIds->SetNumberOfComponents(1);
     separatrixIds->SetName("SeparatrixId");
-    ttkUtils::SetVoidArray(separatrixIds,
-                           separatrices2_cells_separatrixIds.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(separatrixIds, separatrices2_cells_separatrixIds);
 
     separatrixTypes->SetNumberOfComponents(1);
     separatrixTypes->SetName("SeparatrixType");
-    ttkUtils::SetVoidArray(separatrixTypes,
-                           separatrices2_cells_separatrixTypes.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(separatrixTypes, separatrices2_cells_separatrixTypes);
 
     separatrixFunctionMaxima->SetNumberOfComponents(1);
     separatrixFunctionMaxima->SetName("SeparatrixFunctionMaximum");
-    ttkUtils::SetVoidArray(separatrixFunctionMaxima,
-                           separatrices2_cells_separatrixFunctionMaxima.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(
+      separatrixFunctionMaxima, separatrices2_cells_separatrixFunctionMaxima);
 
     separatrixFunctionMinima->SetNumberOfComponents(1);
     separatrixFunctionMinima->SetName("SeparatrixFunctionMinimum");
-    ttkUtils::SetVoidArray(separatrixFunctionMinima,
-                           separatrices2_cells_separatrixFunctionMinima.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(
+      separatrixFunctionMinima, separatrices2_cells_separatrixFunctionMinima);
 
     separatrixFunctionDiffs->SetNumberOfComponents(1);
     separatrixFunctionDiffs->SetName("SeparatrixFunctionDifference");
-    ttkUtils::SetVoidArray(separatrixFunctionDiffs,
-                           separatrices2_cells_separatrixFunctionDiffs.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(
+      separatrixFunctionDiffs, separatrices2_cells_separatrixFunctionDiffs);
 
     isOnBoundary->SetNumberOfComponents(1);
     isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
-    ttkUtils::SetVoidArray(isOnBoundary,
-                           separatrices2_cells_isOnBoundary.data(),
-                           separatrices2_numberOfCells, 1);
+    setArray(isOnBoundary, separatrices2_cells_isOnBoundary);
 
     vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
     offsets->SetNumberOfComponents(1);
-    ttkUtils::SetVoidArray(offsets, separatrices2_cells_offsets.data(),
-                           separatrices2_cells_offsets.size(), 1);
+    setArray(offsets, separatrices2_cells_offsets);
+
     connectivity->SetNumberOfComponents(1);
-    ttkUtils::SetVoidArray(connectivity,
-                           separatrices2_cells_connectivity.data(),
-                           separatrices2_cells_connectivity.size(), 1);
+    setArray(connectivity, separatrices2_cells_connectivity);
 
     vtkNew<vtkUnsignedCharArray> cellTypes{};
     cellTypes->SetNumberOfComponents(1);

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -85,15 +85,6 @@ int ttkMorseSmaleComplex::dispatch(
   SimplexId separatrices2_numberOfPoints{};
   std::vector<float> separatrices2_points;
   SimplexId separatrices2_numberOfCells{};
-  std::vector<SimplexId> separatrices2_cells_offsets;
-  std::vector<SimplexId> separatrices2_cells_connectivity;
-  std::vector<SimplexId> separatrices2_cells_sourceIds;
-  std::vector<SimplexId> separatrices2_cells_separatrixIds;
-  std::vector<char> separatrices2_cells_separatrixTypes;
-  std::vector<char> separatrices2_cells_isOnBoundary;
-  std::vector<scalarType> separatrices2_cells_separatrixFunctionMaxima;
-  std::vector<scalarType> separatrices2_cells_separatrixFunctionMinima;
-  std::vector<scalarType> separatrices2_cells_separatrixFunctionDiffs;
 
   if(ComputeCriticalPoints) {
     this->setOutputCriticalPoints(

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -142,7 +142,21 @@ private:
   int ReturnSaddleConnectors{false};
   double SaddleConnectorsPersistenceThreshold{0.0};
 
-  // 2-separatrices
+  // 1-separatrices data
+  std::vector<char> separatrices1_points_smoothingMask;
+  std::vector<char> separatrices1_points_cellDimensions;
+  std::vector<ttk::SimplexId> separatrices1_points_cellIds;
+  std::vector<vtkIdType> separatrices1_cells_connectivity;
+  std::vector<ttk::SimplexId> separatrices1_cells_sourceIds;
+  std::vector<ttk::SimplexId> separatrices1_cells_destinationIds;
+  std::vector<ttk::SimplexId> separatrices1_cells_separatrixIds;
+  std::vector<char> separatrices1_cells_separatrixTypes;
+  std::vector<char> separatrices1_cells_isOnBoundary;
+  std::vector<double> separatrices1_cells_separatrixFunctionMaxima;
+  std::vector<double> separatrices1_cells_separatrixFunctionMinima;
+  std::vector<double> separatrices1_cells_separatrixFunctionDiffs;
+
+  // 2-separatrices data
   std::vector<vtkIdType> separatrices2_cells_offsets;
   std::vector<vtkIdType> separatrices2_cells_connectivity;
   std::vector<ttk::SimplexId> separatrices2_cells_sourceIds;

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -142,6 +142,14 @@ private:
   int ReturnSaddleConnectors{false};
   double SaddleConnectorsPersistenceThreshold{0.0};
 
+  // critical points
+  std::vector<float> criticalPoints_points;
+  std::vector<char> criticalPoints_points_cellDimensions;
+  std::vector<ttk::SimplexId> criticalPoints_points_cellIds;
+  std::vector<char> criticalPoints_points_isOnBoundary;
+  std::vector<ttk::SimplexId> criticalPoints_points_PLVertexIdentifiers;
+  std::vector<ttk::SimplexId> criticalPoints_points_manifoldSize;
+
   // 1-separatrices data
   std::vector<float> separatrices1_points;
   std::vector<char> separatrices1_points_smoothingMask;

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -141,4 +141,15 @@ private:
   bool ComputeFinalSegmentation{true};
   int ReturnSaddleConnectors{false};
   double SaddleConnectorsPersistenceThreshold{0.0};
+
+  // 2-separatrices
+  std::vector<vtkIdType> separatrices2_cells_offsets;
+  std::vector<vtkIdType> separatrices2_cells_connectivity;
+  std::vector<ttk::SimplexId> separatrices2_cells_sourceIds;
+  std::vector<ttk::SimplexId> separatrices2_cells_separatrixIds;
+  std::vector<char> separatrices2_cells_separatrixTypes;
+  std::vector<char> separatrices2_cells_isOnBoundary;
+  std::vector<double> separatrices2_cells_separatrixFunctionMaxima;
+  std::vector<double> separatrices2_cells_separatrixFunctionMinima;
+  std::vector<double> separatrices2_cells_separatrixFunctionDiffs;
 };

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -143,37 +143,37 @@ private:
   double SaddleConnectorsPersistenceThreshold{0.0};
 
   // critical points
-  std::vector<float> criticalPoints_points;
-  std::vector<char> criticalPoints_points_cellDimensions;
-  std::vector<ttk::SimplexId> criticalPoints_points_cellIds;
-  std::vector<char> criticalPoints_points_isOnBoundary;
-  std::vector<ttk::SimplexId> criticalPoints_points_PLVertexIdentifiers;
-  std::vector<ttk::SimplexId> criticalPoints_points_manifoldSize;
+  std::vector<float> criticalPoints_points{};
+  std::vector<char> criticalPoints_points_cellDimensions{};
+  std::vector<ttk::SimplexId> criticalPoints_points_cellIds{};
+  std::vector<char> criticalPoints_points_isOnBoundary{};
+  std::vector<ttk::SimplexId> criticalPoints_points_PLVertexIdentifiers{};
+  std::vector<ttk::SimplexId> criticalPoints_points_manifoldSize{};
 
   // 1-separatrices data
-  std::vector<float> separatrices1_points;
-  std::vector<char> separatrices1_points_smoothingMask;
-  std::vector<char> separatrices1_points_cellDimensions;
-  std::vector<ttk::SimplexId> separatrices1_points_cellIds;
-  std::vector<vtkIdType> separatrices1_cells_connectivity;
-  std::vector<ttk::SimplexId> separatrices1_cells_sourceIds;
-  std::vector<ttk::SimplexId> separatrices1_cells_destinationIds;
-  std::vector<ttk::SimplexId> separatrices1_cells_separatrixIds;
-  std::vector<char> separatrices1_cells_separatrixTypes;
-  std::vector<char> separatrices1_cells_isOnBoundary;
-  std::vector<double> separatrices1_cells_separatrixFunctionMaxima;
-  std::vector<double> separatrices1_cells_separatrixFunctionMinima;
-  std::vector<double> separatrices1_cells_separatrixFunctionDiffs;
+  std::vector<float> separatrices1_points{};
+  std::vector<char> separatrices1_points_smoothingMask{};
+  std::vector<char> separatrices1_points_cellDimensions{};
+  std::vector<ttk::SimplexId> separatrices1_points_cellIds{};
+  std::vector<vtkIdType> separatrices1_cells_connectivity{};
+  std::vector<ttk::SimplexId> separatrices1_cells_sourceIds{};
+  std::vector<ttk::SimplexId> separatrices1_cells_destinationIds{};
+  std::vector<ttk::SimplexId> separatrices1_cells_separatrixIds{};
+  std::vector<char> separatrices1_cells_separatrixTypes{};
+  std::vector<char> separatrices1_cells_isOnBoundary{};
+  std::vector<double> separatrices1_cells_separatrixFunctionMaxima{};
+  std::vector<double> separatrices1_cells_separatrixFunctionMinima{};
+  std::vector<double> separatrices1_cells_separatrixFunctionDiffs{};
 
   // 2-separatrices data
-  std::vector<float> separatrices2_points;
-  std::vector<vtkIdType> separatrices2_cells_offsets;
-  std::vector<vtkIdType> separatrices2_cells_connectivity;
-  std::vector<ttk::SimplexId> separatrices2_cells_sourceIds;
-  std::vector<ttk::SimplexId> separatrices2_cells_separatrixIds;
-  std::vector<char> separatrices2_cells_separatrixTypes;
-  std::vector<char> separatrices2_cells_isOnBoundary;
-  std::vector<double> separatrices2_cells_separatrixFunctionMaxima;
-  std::vector<double> separatrices2_cells_separatrixFunctionMinima;
-  std::vector<double> separatrices2_cells_separatrixFunctionDiffs;
+  std::vector<float> separatrices2_points{};
+  std::vector<vtkIdType> separatrices2_cells_offsets{};
+  std::vector<vtkIdType> separatrices2_cells_connectivity{};
+  std::vector<ttk::SimplexId> separatrices2_cells_sourceIds{};
+  std::vector<ttk::SimplexId> separatrices2_cells_separatrixIds{};
+  std::vector<char> separatrices2_cells_separatrixTypes{};
+  std::vector<char> separatrices2_cells_isOnBoundary{};
+  std::vector<double> separatrices2_cells_separatrixFunctionMaxima{};
+  std::vector<double> separatrices2_cells_separatrixFunctionMinima{};
+  std::vector<double> separatrices2_cells_separatrixFunctionDiffs{};
 };

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -143,6 +143,7 @@ private:
   double SaddleConnectorsPersistenceThreshold{0.0};
 
   // 1-separatrices data
+  std::vector<float> separatrices1_points;
   std::vector<char> separatrices1_points_smoothingMask;
   std::vector<char> separatrices1_points_cellDimensions;
   std::vector<ttk::SimplexId> separatrices1_points_cellIds;
@@ -157,6 +158,7 @@ private:
   std::vector<double> separatrices1_cells_separatrixFunctionDiffs;
 
   // 2-separatrices data
+  std::vector<float> separatrices2_points;
   std::vector<vtkIdType> separatrices2_cells_offsets;
   std::vector<vtkIdType> separatrices2_cells_connectivity;
   std::vector<ttk::SimplexId> separatrices2_cells_sourceIds;

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -245,15 +245,15 @@ int main(int argc, char **argv) {
   std::vector<char> separatrices1_points_cellDimensions;
   std::vector<ttk::SimplexId> separatrices1_points_cellIds;
   ttk::SimplexId separatrices1_numberOfCells{};
-  std::vector<ttk::SimplexId> separatrices1_cells;
+  std::vector<long long> separatrices1_cells_connectivity;
   std::vector<ttk::SimplexId> separatrices1_cells_sourceIds;
   std::vector<ttk::SimplexId> separatrices1_cells_destinationIds;
   std::vector<ttk::SimplexId> separatrices1_cells_separatrixIds;
   std::vector<char> separatrices1_cells_separatrixTypes;
   std::vector<char> separatrices1_cells_isOnBoundary;
-  std::vector<float> separatrices1_cells_separatrixFunctionMaxima;
-  std::vector<float> separatrices1_cells_separatrixFunctionMinima;
-  std::vector<float> separatrices1_cells_separatrixFunctionDiffs;
+  std::vector<double> separatrices1_cells_separatrixFunctionMaxima;
+  std::vector<double> separatrices1_cells_separatrixFunctionMinima;
+  std::vector<double> separatrices1_cells_separatrixFunctionDiffs;
   // segmentation
   std::vector<ttk::SimplexId> ascendingSegmentation(
     triangulation.getNumberOfVertices(), -1),
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
     &separatrices1_numberOfPoints, &separatrices1_points,
     &separatrices1_points_smoothingMask, &separatrices1_points_cellDimensions,
     &separatrices1_points_cellIds, &separatrices1_numberOfCells,
-    &separatrices1_cells, &separatrices1_cells_sourceIds,
+    &separatrices1_cells_connectivity, &separatrices1_cells_sourceIds,
     &separatrices1_cells_destinationIds, &separatrices1_cells_separatrixIds,
     &separatrices1_cells_separatrixTypes,
     &separatrices1_cells_separatrixFunctionMaxima,


### PR DESCRIPTION
This PR aims at eliminate data copies in the VTK layer of the MorseSmaleComplex module. To do so, local vectors that held the output of the base layer have been promoted to class members. VTK arrays now point to these class members using the `ttkUtils::SetVoidArray` method.

Some templated vectors (separatrixFunctionMaxima, separatrixFunctionMinima, separatrixFunctionDiffs) have been converted to vectors of double to allow this transformation. However, the `criticalPoints_points_cellScalars` vector has been kept templatized (critical points arrays should be smaller than separatrices arrays).

To keep compatibility with the ExplicitTriangulation, offset and connectivity cell arrays use the `long long` type (c.f. #490) instead of the more generic (and less memory-consuming) `SimplexId`.

Execution times on the relevant part of code (the second half of the `dispatch` method in `ttkMorseSmaleComplex.cpp`) of a full MorseSmaleComplex on `ctBones.vti` have been reduced to 0.5s from 5s (was 60s before #504).

No changes in the relevant ttk-data have been observed.

Enjoy,
Pierre