### PR TITLE
MorseSmaleComplex: Reduce ascending 2-separatrices computation memory footprint

### DIFF
--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -234,10 +234,9 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
   };
 
   struct PolygonCell {
-    SimplexId edgeId_{};
     SimplexId nTetras_{};
+    SimplexId edgeId_{};
     SimplexId sepInfosId_{};
-    bool valid_{false};
   };
 
   // store the separatrices info (one per separatrix)
@@ -289,12 +288,11 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
       const auto k = geomCellsBegId[i] + j - noldcells;
       auto &polyCell = polygonTetras[k];
 
-      polyCell.edgeId_ = cell.id_;
       polyCell.nTetras_ = triangulation.getEdgeStarNumber(cell.id_);
 
       if(polyCell.nTetras_ > 2) {
+        polyCell.edgeId_ = cell.id_;
         polyCell.sepInfosId_ = i;
-        polyCell.valid_ = true;
       }
     }
   }
@@ -304,7 +302,7 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
   validTetraIds.reserve(polygonTetras.size());
 
   for(size_t i = 0; i < polygonTetras.size(); ++i) {
-    if(polygonTetras[i].valid_) {
+    if(polygonTetras[i].nTetras_ > 2) {
       validTetraIds.emplace_back(i);
     }
   }


### PR DESCRIPTION
This PR improves the work done in #387 on parallelizing the computation of the ascending 2-separatrices. After some memory profiling using [heaptrack](https://github.com/KDE/heaptrack), memory allocations have been reworked to reduce the memory footprint of the `MorseSmaleComplex3D::setAscendingSeparatrices2` method.

As a result, the peak memory consumption of this method on `ctBones.vti` has been reduced from 35GB to 24GB. As it turns out, execution times of this particular method on the same dataset have also dropped from 33s to 22s.

No changes observed in the relevant ttk-data states.

Enjoy,
Pierre

