### PR TITLE
Exit Gracefully

### DIFF
--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -45,6 +45,8 @@ int ttkGeometrySmoother::RequestData(vtkInformation *request,
   auto outputPointSet = vtkPointSet::GetData(outputVector);
 
   auto triangulation = ttkAlgorithm::GetTriangulation(inputPointSet);
+  if(!triangulation)
+    return 0;
   this->preconditionTriangulation(triangulation);
 
   vtkDataArray *inputMaskField = ttkAlgorithm::GetOptionalArray(


### PR DESCRIPTION
This PR consists of two lines that let the ttkGeometrySmoother exit gracefully if the filter can not fetch a triangulation. Note: the ttkScalarFieldSmoother does this already.

Best
Jonas