### PR TITLE
Enable shared base libraries to solve Windows log problem

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -145,6 +145,10 @@ function(ttk_set_compile_options library)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_DOUBLE_TEMPLATING)
   endif()
 
+  if (TTK_ENABLE_SHARED_BASE_LIBRARIES)
+    target_compile_definitions(${library} PUBLIC TTK_ENABLE_SHARED_BASE_LIBRARIES)
+  endif()
+
   if (TTK_ENABLE_KAMIKAZE)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_KAMIKAZE)
   endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -606,7 +606,7 @@ jobs:
     displayName: 'Build TTKVTK Example'
 
   - bash: |
-      ./ttkExample-c++ -i ../examples/data/inputData.off
+      cmd.exe /C 'set PATH=$(Build.ArtifactStagingDirectory)/ttk-install/bin/ttk;%PATH% & ttkExample-c++.exe -i ../examples/data/inputData.off'
       if [ ! -f output.off ]; then
         exit 1
       fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -513,13 +513,8 @@ jobs:
         VTKVPath: 9.0
 
   variables:
-    TTK_MODULE_DISABLE: '-DVTK_MODULE_ENABLE_ttkAddFieldData=NO
-                         -DVTK_MODULE_ENABLE_ttkWRLExporter=NO
-                         -DVTK_MODULE_ENABLE_ttkCinemaWriter=NO
-                         -DVTK_MODULE_ENABLE_ttkCinemaReader=NO
-                         -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO
-                         -DVTK_MODULE_ENABLE_ttkCinemaImaging=NO
-                         -DVTK_MODULE_ENABLE_ttkUserInterfaceBase=NO'
+    TTK_MODULE_DISABLE: '-DVTK_MODULE_ENABLE_ttkCinemaWriter=NO
+                         -DVTK_MODULE_ENABLE_ttkCinemaQuery=NO'
     # used for dev
     TTK_MODULE_TEST: ''
 

--- a/config.cmake
+++ b/config.cmake
@@ -75,7 +75,7 @@ mark_as_advanced(TTK_ENABLE_CPU_OPTIMIZATION)
 option(TTK_ENABLE_DOUBLE_TEMPLATING "Use double templating for bivariate data" OFF)
 mark_as_advanced(TTK_ENABLE_DOUBLE_TEMPLATING)
 
-option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" OFF)
+option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" ON)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/config.cmake
+++ b/config.cmake
@@ -77,6 +77,9 @@ mark_as_advanced(TTK_ENABLE_DOUBLE_TEMPLATING)
 
 option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" OFF)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
+if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 option(TTK_BUILD_DOCUMENTATION "Build doxygen developer documentation" OFF)
 if(TTK_BUILD_DOCUMENTATION)

--- a/core/base/common/BaseClass.cpp
+++ b/core/base/common/BaseClass.cpp
@@ -1,9 +1,9 @@
 #include <BaseClass.h>
 
 #ifdef TTK_ENABLE_OPENMP
-int ttk::globalThreadNumber_ = omp_get_num_procs();
+COMMON_EXPORTS int ttk::globalThreadNumber_ = omp_get_num_procs();
 #else
-int ttk::globalThreadNumber_ = 1;
+COMMON_EXPORTS int ttk::globalThreadNumber_ = 1;
 #endif
 
 using namespace ttk;

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -19,9 +19,17 @@
 
 #include <DataTypes.h>
 
+#if defined(_MSC_VER) && defined(common_EXPORTS)
+#define COMMON_EXPORTS __declspec(dllexport)
+#elif defined(_MSC_VER)
+#define COMMON_EXPORTS __declspec(dllimport)
+#else
+#define COMMON_EXPORTS
+#endif // _MSC_VER
+
 namespace ttk {
 
-  extern int globalThreadNumber_;
+  COMMON_EXPORTS extern int globalThreadNumber_;
 
   class Wrapper;
 

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -19,13 +19,17 @@
 
 #include <DataTypes.h>
 
-#if defined(_MSC_VER) && defined(common_EXPORTS)
+#if defined(_MSC_VER) && defined(TTK_ENABLE_SHARED_BASE_LIBRARIES)
+#if defined(common_EXPORTS)
+// building common.dll
 #define COMMON_EXPORTS __declspec(dllexport)
-#elif defined(_MSC_VER)
+// building every other .dll that include this header
+#else
 #define COMMON_EXPORTS __declspec(dllimport)
+#endif // common_EXPORTS
 #else
 #define COMMON_EXPORTS
-#endif // _MSC_VER
+#endif // _MSC_VER && TTK_ENABLE_SHARED_BASE_LIBRARIES
 
 namespace ttk {
 

--- a/core/base/common/Debug.cpp
+++ b/core/base/common/Debug.cpp
@@ -1,10 +1,11 @@
 #include <Debug.h>
 
-ttk::debug::LineMode ttk::Debug::lastLineMode = ttk::debug::LineMode::NEW;
+COMMON_EXPORTS ttk::debug::LineMode ttk::Debug::lastLineMode
+  = ttk::debug::LineMode::NEW;
 
-bool ttk::welcomeMsg_ = true;
-bool ttk::goodbyeMsg_ = true;
-int ttk::globalDebugLevel_ = 0;
+COMMON_EXPORTS bool ttk::welcomeMsg_ = true;
+COMMON_EXPORTS bool ttk::goodbyeMsg_ = true;
+COMMON_EXPORTS int ttk::globalDebugLevel_ = 0;
 
 using namespace std;
 using namespace ttk;

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -34,9 +34,9 @@
 
 namespace ttk {
 
-  extern bool welcomeMsg_;
-  extern bool goodbyeMsg_;
-  extern int globalDebugLevel_;
+  COMMON_EXPORTS extern bool welcomeMsg_;
+  COMMON_EXPORTS extern bool goodbyeMsg_;
+  COMMON_EXPORTS extern int globalDebugLevel_;
 
   namespace debug {
     enum class Priority : int {
@@ -401,7 +401,7 @@ namespace ttk {
   protected:
     mutable int debugLevel_;
 
-    static debug::LineMode lastLineMode;
+    COMMON_EXPORTS static debug::LineMode lastLineMode;
 
     std::string debugMsgPrefix_;
 

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -5,9 +5,6 @@ ttk::TopologicalCompression::TopologicalCompression() {
   this->setDebugMsgPrefix("TopologicalCompression");
 }
 
-const char *ttk::TopologicalCompression::magicBytes_{"TTKCompressedFileFormat"};
-const unsigned long ttk::TopologicalCompression::formatVersion_{1};
-
 // Dependencies.
 
 #ifdef TTK_ENABLE_ZFP

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -409,10 +409,10 @@ namespace ttk {
     char *fileName{};
 
     // Char array that identifies the file format.
-    static const char *magicBytes_;
+    const char *magicBytes_{"TTKCompressedFileFormat"};
     // Current version of the file format. To be incremented at every
     // breaking change to keep backward compatibility.
-    static const unsigned long formatVersion_;
+    const unsigned long formatVersion_{1};
   };
 
 } // namespace ttk

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -5,10 +5,10 @@
 ///
 /// \brief Interactions and rendering.
 
-#ifndef _TTK_USERINTERFACE_BASE_H
-#define _TTK_USERINTERFACE_BASE_H
+#pragma once
 
 #include <ttkProgramBase.h>
+#include <ttkUserInterfaceBaseModule.h>
 
 // VTK includes
 #include <ttkTextureMapFromField.h>
@@ -28,7 +28,8 @@
 class ttkUserInterfaceBase;
 
 // Custom interactors
-class ttkCustomInteractor : public vtkInteractorStyleTrackballCamera {
+class TTKUSERINTERFACEBASE_EXPORT ttkCustomInteractor
+  : public vtkInteractorStyleTrackballCamera {
 
 public:
   static ttkCustomInteractor *New();
@@ -47,7 +48,7 @@ protected:
   ttkUserInterfaceBase *userInterface_;
 };
 
-class ttkKeyHandler : public ttk::Debug {
+class TTKUSERINTERFACEBASE_EXPORT ttkKeyHandler : public ttk::Debug {
 
 public:
   virtual int OnKeyPress(vtkRenderWindowInteractor *interactor,
@@ -55,7 +56,7 @@ public:
     = 0;
 };
 
-class VTKFILTERSCORE_EXPORT ttkUserInterfaceBase : public ttkProgramBase {
+class TTKUSERINTERFACEBASE_EXPORT ttkUserInterfaceBase : public ttkProgramBase {
 
 public:
   ttkUserInterfaceBase();
@@ -136,5 +137,3 @@ public:
 
   vtkSmartPointer<ttkModule> ttkObject_;
 };
-
-#endif //_TTK_USERINTERFACE_BASE_H

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -28,7 +28,7 @@
 
 #include <ttkWRLExporter.h>
 
-vtkPolyData *ttkWRLExporterPolyData_ = nullptr;
+TTKWRLEXPORTER_EXPORT vtkPolyData *ttkWRLExporterPolyData_ = nullptr;
 
 // Over-ride the appropriate functions of the vtkVRMLExporter class.
 void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.h
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.h
@@ -8,5 +8,7 @@
 
 #pragma once
 
+#include <ttkWRLExporterModule.h>
+
 class vtkPolyData;
-extern vtkPolyData *wrlExporterPolyData_;
+TTKWRLEXPORTER_EXPORT vtkPolyData *wrlExporterPolyData_;

--- a/standalone/GeometrySmoother/cmd/CMakeLists.txt
+++ b/standalone/GeometrySmoother/cmd/CMakeLists.txt
@@ -7,7 +7,7 @@ if(TARGET ttkGeometrySmoother)
   target_link_libraries(${PROJECT_NAME}
     PRIVATE
       ttkGeometrySmoother
-      ttkProgramBase
+      VTK::IOXML
     )
   set_target_properties(${PROJECT_NAME}
     PROPERTIES


### PR DESCRIPTION
This PR aims at fixing the second #505 issue. As a reminder, the issue was that setting the `ttk::globalDebugLevel_` global variable inside the vtk-c++ example had not the expected effect. Due to our default build process, since the base layer is built as static libraries that are replicated inside the shared libraries in the VTK layer, every global variable is duplicated inside those VTK layer shared libraries. 

After some documentation, it appears that in a Windows process, shared libraries don't share the same memory space, thus making it impossible to modify the duplicated global variables. In Linux, the dynamic loader and the runtime loader seem to handle this situation quite fine (apart from some duplicated welcome messages).

The solution is to leverage work done in #493 to build base libraries as shared libraries instead of static. In this case, the `common.dll` containing the global variables is linked to all VTK layer shared libraries and the global variables have a unique memory address.

This lead to some interesting discoveries on Windows shared libraries: by default, their symbols are hidden, causing link errors. For functions and classes, this is easily fixed by using the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` option. For global (and static) variables, you have to annotate their declaration and their definition with `__declspec(dllexport)` in the compilation units of the current library, and their extern declarations in other compilation units with `__declspec(dllimport)`. Fortunately, the compilation process identifies every library its builds with a unique macro. I thus leveraged the `common_EXPORTS` macro to annotate the 4 global variables inside the `common` library: `globalDebugLevel_`, `welcomeMsg_`, `goodbyeMsg_` and `globalThreadNumber_` and the static variable `Debug::lastLineMode`. To avoid expanding too much this solution, I removed the also problematic static variables inside the `TopologicalCompression` class (😢). One consequence is that TTK devs should now avoid to use global or static variables in the base layer or else annotate them in a similar (and quite ugly) way.

In the VTK layer, the configuration process generates the `Module.h` headers that define  those `TTKMODULE_EXPORTS` macros automatically, as explained in https://github.com/topology-tool-kit/ttk/pull/502#issuecomment-702186739. Some VTK layer modules (`ttkUserInterfaceBase`, `ttkWRLExporter`) using the wrong annotations have been fixed in the process.

One maybe breaking change of this PR is that the `TTK_ENABLE_SHARED_BASE_LIBRARIES` has been switched to ON by default. This might force TTK devs to expand their `LD_LIBRARY_PATH` environment variable with the install path of the base libraries. This also might solve the same issue on MacOS.

Everything should still work with static libraries on Windows (except the log problem of course).

Enjoy,
Pierre