### PR TITLE
Fix HDF5 error in macOS ParaView build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -388,6 +388,7 @@ jobs:
                     -DPARAVIEW_BUILD_TESTING=OFF
                     -DPARAVIEW_ENABLE_PYTHON=ON
                     -DVTK_PYTHON_VERSION=3
+                    -DCMAKE_CXX_FLAGS="-Wno-error=implicit-function-declaration"
                     -DPARAVIEW_BUILD_QT_GUI=NO'
     condition: ne(variables.CACHE_RESTORED, 'true')
     displayName: 'Configure ParaView'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -378,6 +378,8 @@ jobs:
       xz -d ParaView-$(PV_VERSION).tar.xz
       tar xvf ParaView-$(PV_VERSION).tar
       mkdir -p ParaView-$(PV_VERSION)/build
+      # switch to Xcode 11 since Xcode 12 breaks the ParaView build
+      sudo xcode-select -s "/Applications/Xcode_11.7.app"
     displayName: 'Download and extract ParaView $(PV_VERSION)'
 
   - task: CMake@1
@@ -388,7 +390,6 @@ jobs:
                     -DPARAVIEW_BUILD_TESTING=OFF
                     -DPARAVIEW_ENABLE_PYTHON=ON
                     -DVTK_PYTHON_VERSION=3
-                    -DCMAKE_CXX_FLAGS="-Wno-error=implicit-function-declaration"
                     -DPARAVIEW_BUILD_QT_GUI=NO'
     condition: ne(variables.CACHE_RESTORED, 'true')
     displayName: 'Configure ParaView'


### PR DESCRIPTION
Today, an Xcode update in the macOS image in Azure changed the default compiler flags:

> Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (-Werror=implicit-function-declaration flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)

(from the [Xcode 12 Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes))

This broke the vtkhdf5 build in our CI pipelines.
This PR aims at solving this issue by removing the offended compiler flag.

Enjoy,
Pierre