### PR TITLE
Make ParaView plugin depend on VTK modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
   message(FATAL_ERROR "Build in sources is not supported by TTK, please use a separate build folder")
 endif()
 
+include(CMakeDependentOption)
+
 option(TTK_BUILD_VTK_WRAPPERS "Build the TTK VTK Wrappers" ON)
-option(TTK_BUILD_PARAVIEW_PLUGINS "Build the TTK ParaView Plugins" ON)
+cmake_dependent_option(TTK_BUILD_PARAVIEW_PLUGINS "Build the TTK ParaView Plugins" ON "TTK_BUILD_VTK_WRAPPERS" OFF)
 option(TTK_BUILD_STANDALONE_APPS "Build the TTK Standalone Applications" ON)
 option(TTK_WHITELIST_MODE "Explicitely enable each filter" OFF)
 mark_as_advanced(TTK_WHITELIST_MODE BUILD_SHARED_LIBS)
@@ -96,30 +98,6 @@ install(
 
 set(VTKWRAPPER_DIR "${CMAKE_CURRENT_LIST_DIR}/core/vtk/")
 
-if(TTK_BUILD_PARAVIEW_PLUGINS)
-  include(CMake/ParaViewFilter.cmake)
-  add_compile_definitions("TTK_BUILD_PARAVIEW_PLUGINS")
-
-  # Install location
-  if(NOT "$ENV{PV_PLUGIN_PATH}" STREQUAL "")
-    set(TTK_INSTALL_PLUGIN_DIR
-      $ENV{PV_PLUGIN_PATH}
-      CACHE
-      PATH
-        "Directory where the ParaView plugin will be installed"
-      )
-  else()
-    set(TTK_INSTALL_PLUGIN_DIR
-      ${ParaView_DIR}/../../../bin/plugins/
-      CACHE
-      PATH
-      "Directory where the ParaView plugin will be installed"
-      )
-  endif()
-
-  add_subdirectory(paraview)
-endif()
-
 # VTK Wrappers
 # ------------
 
@@ -161,6 +139,30 @@ if(TTK_BUILD_VTK_WRAPPERS)
     DESTINATION
       lib/cmake/ttk
     )
+endif()
+
+if(TTK_BUILD_PARAVIEW_PLUGINS)
+  include(CMake/ParaViewFilter.cmake)
+  add_compile_definitions("TTK_BUILD_PARAVIEW_PLUGINS")
+
+  # Install location
+  if(NOT "$ENV{PV_PLUGIN_PATH}" STREQUAL "")
+    set(TTK_INSTALL_PLUGIN_DIR
+        $ENV{PV_PLUGIN_PATH}
+        CACHE
+        PATH
+        "Directory where the ParaView plugin will be installed"
+        )
+  else()
+    set(TTK_INSTALL_PLUGIN_DIR
+        ${ParaView_DIR}/../../../bin/plugins/
+        CACHE
+        PATH
+        "Directory where the ParaView plugin will be installed"
+        )
+  endif()
+
+  add_subdirectory(paraview)
 endif()
 
 # Standalones

--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -22,15 +22,13 @@ foreach(TTK_MODULE ${TTK_PROVIDED_MODULES})
   endif()
 endforeach()
 
-if(NOT ${TTK_BUILD_PARAVIEW_PLUGINS})
-  # when build against ParaView,
-  # vtk_module_build is already called
-  # by the paraview_add_plugin
-  vtk_module_build(
-    MODULES
-      ${TTK_ENABLED_MODULES}
-    )
-endif()
+vtk_module_build(
+  MODULES
+    ${TTK_ENABLED_MODULES}
+  INSTALL_HEADERS
+    ON
+)
+
 
 if(VTK_WRAP_PYTHON)
   set(TTK_BUILD_VTK_PYTHON_MODULE

--- a/paraview/Compatibility/TTKFilter.cmake
+++ b/paraview/Compatibility/TTKFilter.cmake
@@ -1,1 +1,5 @@
-list(APPEND TTK_XMLS "${CMAKE_CURRENT_LIST_DIR}/Compatibility.xml")
+option(PARAVIEW_PLUGIN_ENABLE_Compatibility "Add filter definitions for backwards compatibility with v0.9.8.9 to the TopologyToolkit plugin." OFF)
+
+if(PARAVIEW_PLUGIN_ENABLE_Compatibility)
+  list(APPEND TTK_XMLS "${CMAKE_CURRENT_LIST_DIR}/Compatibility.xml")
+endif()

--- a/paraview/singlePlugin/CMakeLists.txt
+++ b/paraview/singlePlugin/CMakeLists.txt
@@ -8,10 +8,6 @@ paraview_add_plugin(TopologyToolKit
   REQUIRED_ON_SERVER
   MODULES
     ${TTK_MODULES}
-  MODULE_FILES
-    ${TTK_VTK_MODULE_FILES}
-  MODULE_ARGS # BUG: see above
-    INSTALL_HEADERS ON
   SERVER_MANAGER_XML
     ${TTK_XMLS}
   )


### PR DESCRIPTION
- VTK modules are now built first and the ParaView plugin only links against them
- CMake option `TTK_BUILD_PARAVIEW_PLUGINS` now depends on `TTK_BUILD_VTK_WRAPPERS`
- this fixes the issue that VTK modules are installed twice when installing the ParaView plugin