### PR TITLE
Add Windows & macOS packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build-linux:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
@@ -107,8 +107,8 @@ jobs:
         name: ttk-${{ matrix.os }}.deb
         path: build/ttk-${{ matrix.os }}.deb
 
-  test:
-    needs: build
+  test-linux:
+    needs: build-linux
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -157,9 +157,119 @@ jobs:
         cd $GITHUB_WORKSPACE
         ttkHelloWorldCmd -i examples/data/inputData.vtu
 
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install dependencies with conda
+      shell: bash
+      run: |
+        conda install -c anaconda qt boost
+        conda install -c conda-forge eigen spectralib zfp scikit-learn openmp
+
+    - name: Fetch ParaView installer
+      run: |
+        Invoke-WebRequest `
+        -OutFile ttk-paraview.exe `
+        -Uri https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.exe
+
+    - name: Install ParaView .exe
+      shell: cmd
+      run: |
+        ttk-paraview.exe /S
+
+    - name: Configure TTK
+      shell: cmd
+      run: |
+        set CONDA_ROOT="C:\Miniconda"
+        set CMAKE_PREFIX_PATH="%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake"
+        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        mkdir build
+        cd build
+        cmake ^
+          -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
+          -DBUILD_SHARED_LIBS:BOOL=TRUE ^
+          -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
+          -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
+          -DTTK_BUILD_STANDALONE_APPS=TRUE ^
+          -DTTK_ENABLE_KAMIKAZE=TRUE ^
+          -DTTK_ENABLE_DOUBLE_TEMPLATING=TRUE ^
+          -DTTK_ENABLE_OPENMP=TRUE ^
+          -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE ^
+          -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE ^
+          -G"Visual Studio 16 2019" ^
+          -Tclangcl ^
+          ..
+
+    - name: Build & Package TTK
+      shell: bash
+      run: |
+        cd build
+        # use the correct OpenMP flags
+        find . -name "*.vcxproj" -exec sed -i "s/-Xclang -fopenmp/-openmp/g" {} \;
+        cmake --build . --config Release --parallel
+        cpack -C Release -G NSIS64
+
+    - name: Upload TTK .exe package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk.exe
+        path: build/ttk.exe
+
+    - name: Install TTK
+      shell: cmd
+      run: |
+        cd build
+        ttk.exe /S
+
+    - name: Build & Test native TTK examples
+      shell: cmd
+      run: |
+        :: set environment variables
+        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        set PV_DIR=%ProgramFiles%\TTK-ParaView
+        set TTK_DIR=%ProgramFiles%\TTK
+        set CMAKE_PREFIX_PATH=%TTK_DIR%\lib\cmake;%PV_DIR%\lib\cmake
+        set PATH=%PATH%;%PV_DIR%\bin;%TTK_DIR%\bin;%TTK_DIR%\bin\ttk
+        :: base layer
+        cd %GITHUB_WORKSPACE%\examples\c++
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
+        ninja
+        ttkExample-c++.exe -i ..\..\data\inputData.off
+        :: VTK layer
+        cd %GITHUB_WORKSPACE%\examples\vtk-c++
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
+        ninja
+        ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
+        :: HelloWorld standalone
+        ttkHelloWorldCmd.exe -i %GITHUB_WORKSPACE%\examples\data\inputData.vtu
+
+    - name: Test Python examples
+      shell: bash
+      run: |
+        # set environment variables
+        export PV_BIN="/c/Program Files/TTK-ParaView/bin"
+        export TTK_BIN="/c/Program Files/TTK/bin"
+        export CONDA_ROOT="/c/Miniconda"
+        export PV_PLUGIN_PATH="$TTK_BIN/plugins"
+        export PATH="$PATH:$PV_PLUGIN_PATH:$PV_BIN:$TTK_BIN:$TTK_BIN/ttk"
+        export PYTHONPATH="$PV_BIN/Lib/site-packages:$TTK_BIN/Lib/site-packages:$CONDA_ROOT/Lib"
+        # pure python
+        cd $GITHUB_WORKSPACE/examples/python
+        python example.py ../data/inputData.vtu
+        # pvpython
+        cd $GITHUB_WORKSPACE/examples/pvpython
+        pvpython.exe example.py ../data/inputData.vtu
+
   create-release:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test-linux, build-windows]
     steps:
 
     - name: Create Release
@@ -195,3 +305,13 @@ jobs:
         asset_path: ttk-ubuntu-20.04.deb/ttk-ubuntu-20.04.deb
         asset_name: ttk-ubuntu-20.04.deb
         asset_content_type: application/vnd.debian.binary-package
+
+    - name: Upload Windows .exe as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk.exe/ttk.exe
+        asset_name: ttk.exe
+        asset_content_type: application/vnd.microsoft.portable-executable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,12 @@ jobs:
     - name: Build TTK
       run: |
         cd build
-        make -j$(nproc) package
+        make -j$(nproc)
 
-    - name: Update package informations
+    - name: Package TTK & update package informations
       run: |
         cd build
+        cpack -G DEB
         # unpack deb package to access control file
         mkdir tmp
         dpkg-deb --extract ttk.deb tmp
@@ -214,6 +215,10 @@ jobs:
       run: |
         cd build
         make -j$(nproc)
+
+    - name: Package TTK
+      run: |
+        cd build
         cpack -G productbuild
 
     - name: Upload .pgk package
@@ -326,13 +331,18 @@ jobs:
           -Tclangcl ^
           ..
 
-    - name: Build & Package TTK
+    - name: Build TTK
       shell: bash
       run: |
         cd build
         # use the correct OpenMP flags
         find . -name "*.vcxproj" -exec sed -i "s/-Xclang -fopenmp/-openmp/g" {} \;
         cmake --build . --config Release --parallel
+
+    - name: Package TTK
+      shell: bash
+      run: |
+        cd build
         cpack -C Release -G NSIS64
 
     - name: Upload TTK .exe package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -351,10 +351,34 @@ jobs:
         name: ttk.exe
         path: build/ttk.exe
 
-    - name: Install TTK
+  test-windows:
+    needs: build-windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install run-time dependencies with conda
+      shell: bash
+      run: |
+        conda install -c anaconda qt boost
+        conda install -c conda-forge zfp scikit-learn openmp
+
+    - name: Fetch ParaView installer
+      run: |
+        Invoke-WebRequest `
+        -OutFile ttk-paraview.exe `
+        -Uri https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.exe
+
+    - name: Fetch TTK .exe artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ttk.exe
+
+    - name: Install TTK-ParaView and TTK
       shell: cmd
       run: |
-        cd build
+        ttk-paraview.exe /S
         ttk.exe /S
 
     - name: Build & Test native TTK examples
@@ -400,9 +424,10 @@ jobs:
         cd $GITHUB_WORKSPACE/examples/pvpython
         pvpython.exe example.py ../data/inputData.vtu
 
+
   create-release:
     runs-on: ubuntu-latest
-    needs: [test-linux, test-macos, build-windows]
+    needs: [test-linux, test-macos, test-windows]
     steps:
 
     - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,7 @@ jobs:
           -DBUILD_SHARED_LIBS=OFF \
           -DBUILD_TESTING=OFF \
           ../zfp
-        sudo make -j$(nproc) install
+        sudo make -j$(sysctl -n hw.physicalcpu) install
 
     - name: Fetch & install ttk-paraview
       run: |
@@ -214,7 +214,7 @@ jobs:
     - name: Build TTK
       run: |
         cd build
-        make -j$(nproc)
+        make -j$(sysctl -n hw.physicalcpu)
 
     - name: Package TTK
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,6 +222,63 @@ jobs:
         name: ttk.pkg
         path: build/ttk.pkg
 
+  test-macos:
+    needs: build-macos
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install macOS run-time dependencies
+      run: |
+        # ParaView dependencies
+        brew cask install xquartz
+        brew install wget python libomp mesa glew qt
+        # TTK dependencies
+        brew install boost graphviz
+        python3 -m pip install scikit-learn
+
+    - name: Fetch ttk-paraview
+      run: |
+        wget https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.pkg
+
+    - name: Fetch TTK .pkg artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ttk.pkg
+
+    - name: Install .pkg packages
+      run: |
+        sudo installer -pkg ttk-paraview.pkg -target /
+        sudo installer -pkg ttk.pkg -target /
+
+    - name: Test TTK examples
+      run: |
+        # base layer
+        cd $GITHUB_WORKSPACE/examples/c++
+        mkdir build && cd build
+        cmake ..
+        make
+        ./ttkExample-c++ -i ../../data/inputData.off
+        # VTK layer
+        export CMAKE_PREFIX_PATH=$(brew --prefix qt)/lib/cmake:$CMAKE_PREFIX_PATH
+        cd $GITHUB_WORKSPACE/examples/vtk-c++
+        mkdir build &&  cd build
+        cmake ..
+        make
+        ./ttkExample-vtk-c++ -i ../../data/inputData.vtu
+        # pure Python
+        export PYTHONPATH=/Applications/lib/python3.8/site-packages
+        export DYLD_LIBRARY_PATH=/Applications/lib:$DYLD_LIBRARY_PATH
+        cd $GITHUB_WORKSPACE/examples/python
+        python3 example.py ../data/inputData.vtu
+        # pvpython
+        export PATH=/Applications/bin:$PATH
+        cd $GITHUB_WORKSPACE/examples/pvpython
+        pvpython example.py ../data/inputData.vtu
+        # standalones
+        cd $GITHUB_WORKSPACE
+        ttkHelloWorldCmd -i examples/data/inputData.vtu
+
   build-windows:
     runs-on: windows-latest
     steps:
@@ -334,7 +391,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [test-linux, build-windows]
+    needs: [test-linux, test-macos, build-windows]
     steps:
 
     - name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,6 +313,8 @@ jobs:
         cmake ^
           -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
           -DBUILD_SHARED_LIBS:BOOL=TRUE ^
+          -DPYTHON_LIBRARY="%CONDA_ROOT%\libs\python38.lib" ^
+          -DPYTHON_INCLUDE_DIR="%CONDA_ROOT%\include" ^
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
           -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
           -DTTK_BUILD_STANDALONE_APPS=TRUE ^

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,8 +313,7 @@ jobs:
         cmake ^
           -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
           -DBUILD_SHARED_LIBS:BOOL=TRUE ^
-          -DPYTHON_LIBRARY="%CONDA_ROOT%\libs\python38.lib" ^
-          -DPYTHON_INCLUDE_DIR="%CONDA_ROOT%\include" ^
+          -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
           -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
           -DTTK_BUILD_STANDALONE_APPS=TRUE ^

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -335,8 +335,6 @@ jobs:
       shell: bash
       run: |
         cd build
-        # use the correct OpenMP flags
-        find . -name "*.vcxproj" -exec sed -i "s/-Xclang -fopenmp/-openmp/g" {} \;
         cmake --build . --config Release --parallel
 
     - name: Package TTK
@@ -394,16 +392,16 @@ jobs:
         cd %GITHUB_WORKSPACE%\examples\c++
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
-        ninja
-        ttkExample-c++.exe -i ..\..\data\inputData.off
+        cmake -G"Visual Studio 16 2019" -Tclangcl ..
+        cmake --build . --config Release --parallel
+        Release\ttkExample-c++.exe -i ..\..\data\inputData.off
         :: VTK layer
         cd %GITHUB_WORKSPACE%\examples\vtk-c++
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
-        ninja
-        ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
+        cmake -G"Visual Studio 16 2019" -Tclangcl ..
+        cmake --build . --config Release --parallel
+        Release\ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
         :: HelloWorld standalone
         ttkHelloWorldCmd.exe -i %GITHUB_WORKSPACE%\examples\data\inputData.vtu
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,71 @@ jobs:
         cd $GITHUB_WORKSPACE
         ttkHelloWorldCmd -i examples/data/inputData.vtu
 
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install macOS dependencies
+      run: |
+        # ParaView dependencies
+        brew cask install xquartz
+        brew install wget python libomp mesa glew qt
+        # TTK dependencies
+        brew install boost eigen graphviz
+        python3 -m pip install scikit-learn
+
+    - name: Install Spectra dependency
+      run: |
+        git clone --depth 1 https://github.com/yixuan/spectra
+        mkdir build_spectra && cd build_spectra
+        cmake ../spectra
+        sudo make install
+
+    - name: Install ZFP dependency
+      run: |
+        git clone --depth 1 https://github.com/LLNL/zfp
+        mkdir build_zfp && cd build_zfp
+        cmake \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_TESTING=OFF \
+          ../zfp
+        sudo make -j$(nproc) install
+
+    - name: Fetch & install ttk-paraview
+      run: |
+        wget https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.pkg
+        sudo installer -pkg ttk-paraview.pkg -target /
+
+    - name: Create & configure TTK build directory
+      run: |
+        mkdir build
+        cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DQt5_DIR=$(brew --prefix qt)/lib/cmake/Qt5 \
+          -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
+          -DTTK_BUILD_VTK_WRAPPERS=TRUE \
+          -DTTK_BUILD_STANDALONE_APPS=TRUE \
+          -DTTK_ENABLE_KAMIKAZE=TRUE \
+          -DTTK_ENABLE_DOUBLE_TEMPLATING=TRUE \
+          -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
+          -DTTK_ENABLE_SCIKIT_LEARN=TRUE \
+          -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          $GITHUB_WORKSPACE
+
+    - name: Build TTK
+      run: |
+        cd build
+        make -j$(nproc)
+        cpack -G productbuild
+
+    - name: Upload .pgk package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk.pkg
+        path: build/ttk.pkg
+
   build-windows:
     runs-on: windows-latest
     steps:
@@ -305,6 +370,16 @@ jobs:
         asset_path: ttk-ubuntu-20.04.deb/ttk-ubuntu-20.04.deb
         asset_name: ttk-ubuntu-20.04.deb
         asset_content_type: application/vnd.debian.binary-package
+
+    - name: Upload macOS .pkg as Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ttk.pkg/ttk.pkg
+        asset_name: ttk.pkg
+        asset_content_type: application/x-newton-compatible-pkg
 
     - name: Upload Windows .exe as Release Asset
       uses: actions/upload-release-asset@v1

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -188,55 +188,23 @@ endfunction()
 # Used by basedCode requiring "Python.h"
 
 function(ttk_find_python)
-  find_package(PythonLibs QUIET)
+  find_package(Python3 COMPONENTS Development NumPy)
 
-  if(PYTHON_INCLUDE_DIRS)
-    include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
+  if(Python3_FOUND)
+    include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
 
-    string(REPLACE \".\" \" \"
-      PYTHON_VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
-
-    if(NOT PYTHON_VERSION_LIST)
-      string(REPLACE "." " "
-        PYTHON_VERSION_LIST ${PYTHONLIBS_VERSION_STRING})
-    endif()
-
-    separate_arguments(PYTHON_VERSION_LIST)
-    list(GET PYTHON_VERSION_LIST 0 PYTHON_MAJOR_VERSION)
-    list(GET PYTHON_VERSION_LIST 1 PYTHON_MINOR_VERSION)
-
-    set(TTK_PYTHON_MAJOR_VERSION "${PYTHON_MAJOR_VERSION}"
+    set(TTK_PYTHON_MAJOR_VERSION "${Python3_VERSION_MAJOR}"
       CACHE INTERNAL "TTK_PYTHON_MAJOR_VERSION")
-    set(TTK_PYTHON_MINOR_VERSION "${PYTHON_MINOR_VERSION}"
+    set(TTK_PYTHON_MINOR_VERSION "${Python3_VERSION_MINOR}"
       CACHE INTERNAL "TTK_PYTHON_MINOR_VERSION")
 
-    if(TTK_PYTHON_MAJOR_VERSION)
-      message(STATUS "Python version: ${TTK_PYTHON_MAJOR_VERSION}.${TTK_PYTHON_MINOR_VERSION}")
+    if(Python3_NumPy_FOUND)
+      option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" ON)
     else()
-      message(STATUS "Python version: NOT-FOUND")
+      option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
+      message(STATUS
+        "Improper Python/NumPy setup. Disabling scikit-learn support in TTK.")
     endif()
-
-    find_path(PYTHON_NUMPY_INCLUDE_DIR numpy/arrayobject.h PATHS
-      ${PYTHON_INCLUDE_DIRS}
-      /usr/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include/
-      /usr/local/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include
-      C:/ProgramData/Anaconda3/Lib/site-packages/numpy/core/include
-      C:/Miniconda/Lib/site-packages/numpy/core/include
-      )
-    if(PYTHON_NUMPY_INCLUDE_DIR)
-      message(STATUS "Numpy headers: ${PYTHON_NUMPY_INCLUDE_DIR}")
-      include_directories(SYSTEM ${PYTHON_NUMPY_INCLUDE_DIR})
-    else()
-      message(STATUS "Numpy headers: NOT-FOUND")
-    endif()
-  endif()
-
-  if(PYTHON_NUMPY_INCLUDE_DIR)
-    option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" ON)
-  else()
-    option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
-    message(STATUS
-      "Improper python/numpy setup. Disabling sckikit-learn support in TTK.")
   endif()
 
 endfunction()

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -219,7 +219,10 @@ function(ttk_find_python)
     find_path(PYTHON_NUMPY_INCLUDE_DIR numpy/arrayobject.h PATHS
       ${PYTHON_INCLUDE_DIRS}
       /usr/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include/
-      /usr/local/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include)
+      /usr/local/lib/python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}/site-packages/numpy/core/include
+      C:/ProgramData/Anaconda3/Lib/site-packages/numpy/core/include
+      C:/Miniconda/Lib/site-packages/numpy/core/include
+      )
     if(PYTHON_NUMPY_INCLUDE_DIR)
       message(STATUS "Numpy headers: ${PYTHON_NUMPY_INCLUDE_DIR}")
       include_directories(SYSTEM ${PYTHON_NUMPY_INCLUDE_DIR})
@@ -232,7 +235,7 @@ function(ttk_find_python)
     option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" ON)
   else()
     option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
-    message(STATUS 
+    message(STATUS
       "Improper python/numpy setup. Disabling sckikit-learn support in TTK.")
   endif()
 

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -90,7 +90,7 @@ function(ttk_add_base_template_library library)
 
   if(TTK_ENABLE_OPENMP)
     target_compile_definitions(${library} INTERFACE TTK_ENABLE_OPENMP)
-    target_compile_options(${library} INTERFACE ${OpenMP_CXX_FLAGS})
+    target_link_libraries(${library} INTERFACE OpenMP::OpenMP_CXX)
   endif()
 
   if(ARG_DEPENDS)
@@ -144,8 +144,7 @@ function(ttk_set_compile_options library)
 
   if (TTK_ENABLE_OPENMP)
     target_compile_definitions(${library} PUBLIC TTK_ENABLE_OPENMP)
-    target_compile_options(${library} PUBLIC ${OpenMP_CXX_FLAGS})
-    target_link_libraries(${library} PUBLIC ${OpenMP_CXX_LIBRARIES})
+    target_link_libraries(${library} PUBLIC OpenMP::OpenMP_CXX)
 
     if (TTK_ENABLE_OMP_PRIORITY)
       target_compile_definitions(${library} PUBLIC TTK_ENABLE_OMP_PRIORITY)

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -183,27 +183,3 @@ function(ttk_set_compile_options library)
   endif()
 
 endfunction()
-
-# Used by basedCode requiring "Python.h"
-
-function(ttk_find_python)
-  find_package(Python3 COMPONENTS Development NumPy)
-
-  if(Python3_FOUND)
-    include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
-
-    set(TTK_PYTHON_MAJOR_VERSION "${Python3_VERSION_MAJOR}"
-      CACHE INTERNAL "TTK_PYTHON_MAJOR_VERSION")
-    set(TTK_PYTHON_MINOR_VERSION "${Python3_VERSION_MINOR}"
-      CACHE INTERNAL "TTK_PYTHON_MINOR_VERSION")
-
-    if(Python3_NumPy_FOUND)
-      option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" ON)
-    else()
-      option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
-      message(STATUS
-        "Improper Python/NumPy setup. Disabling scikit-learn support in TTK.")
-    endif()
-  endif()
-
-endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS
   "ttk-paraview (= 5.8.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev")
 # autogenerate dependency information
 set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+# package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK")
 include(CPack)
 
 if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK")
 # let the installer uninstall previous installations on Windows
 set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+# generate components, fix productbuild packaging for macOS
+if(APPLE)
+  set(CPACK_COMPONENTS_ALL Unspecified python development)
+endif()
 include(CPack)
 
 if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS
 set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 # package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK")
+# let the installer uninstall previous installations on Windows
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 include(CPack)
 
 if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_CONTACT "Julien Tierny <julien.tierny@sorbonne-universite.fr>")
 set(CPACK_PACKAGE_VENDOR "LIP6 - Sorbonne Université")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://topology-tool-kit.github.io/")
-set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
-set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+if(NOT APPLE)
+  set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
+  set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+endif()
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
   "ttk-paraview (= 5.8.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev")
 # autogenerate dependency information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ set(CPACK_PACKAGE_HOMEPAGE_URL "https://topology-tool-kit.github.io/")
 if(NOT APPLE)
   set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
   set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+else()
+  # macOS needs license & readme files ending with .txt
+  configure_file(LICENSE License.txt COPYONLY)
+  configure_file(README.md Readme.txt COPYONLY)
+  set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_BINARY_DIR}/License.txt)
+  set(CPACK_RESOURCE_FILE_README ${PROJECT_BINARY_DIR}/Readme.txt)
 endif()
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
   "ttk-paraview (= 5.8.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev")

--- a/config.cmake
+++ b/config.cmake
@@ -260,18 +260,17 @@ if(APPLE)
   message(STATUS "Disabling scikit-learn support by default under MacOs.")
 endif()
 
-if(NOT APPLE)
-  if(MSVC)
-    option(TTK_ENABLE_OPENMP "Enable OpenMP support" FALSE)
-  else()
-    option(TTK_ENABLE_OPENMP "Enable OpenMP support" TRUE)
-  endif()
+if(MSVC)
+  option(TTK_ENABLE_OPENMP "Enable OpenMP support" FALSE)
+else()
+  option(TTK_ENABLE_OPENMP "Enable OpenMP support" TRUE)
 endif()
+
 option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 
 if(TTK_ENABLE_OPENMP)
   find_package(OpenMP REQUIRED)
-  if(OPENMP_FOUND)
+  if(OpenMP_CXX_FOUND)
     option(TTK_ENABLE_OMP_PRIORITY
       "Gives tasks priority, high perf improvement"
       OFF

--- a/config.cmake
+++ b/config.cmake
@@ -254,10 +254,27 @@ else()
   message(STATUS "Spectra not found, disabling Spectra support in TTK.")
 endif()
 
-# scikit-learn support is disabled by default for now under MacOs
-if(APPLE)
-  option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
-  message(STATUS "Disabling scikit-learn support by default under MacOs.")
+find_package(Python3 COMPONENTS Development NumPy)
+
+if(Python3_FOUND)
+  include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
+
+  set(TTK_PYTHON_MAJOR_VERSION "${Python3_VERSION_MAJOR}"
+    CACHE INTERNAL "TTK_PYTHON_MAJOR_VERSION")
+  set(TTK_PYTHON_MINOR_VERSION "${Python3_VERSION_MINOR}"
+    CACHE INTERNAL "TTK_PYTHON_MINOR_VERSION")
+
+  if(Python3_NumPy_FOUND AND NOT APPLE)
+    option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" ON)
+  elseif(APPLE)
+    # scikit-learn support is disabled by default for now under macOS
+    option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
+    message(STATUS "Disabling scikit-learn support by default under macOS.")
+  else()
+    option(TTK_ENABLE_SCIKIT_LEARN "Enable scikit-learn support" OFF)
+    message(STATUS
+      "Improper Python/NumPy setup. Disabling scikit-learn support in TTK.")
+  endif()
 endif()
 
 if(MSVC)

--- a/config.cmake
+++ b/config.cmake
@@ -101,13 +101,13 @@ if(TTK_BUILD_DOCUMENTATION)
       DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR}/doc/html
       DESTINATION
-        ${CMAKE_INSTALL_PREFIX}/share/doc/ttk
+        ${CMAKE_INSTALL_DATAROOTDIR}/doc/ttk
         )
     install(
       DIRECTORY
         ${CMAKE_SOURCE_DIR}/doc/img
       DESTINATION
-        ${CMAKE_INSTALL_PREFIX}/share/doc/ttk
+        ${CMAKE_INSTALL_DATAROOTDIR}/doc/ttk
         )
   endif()
 endif()

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -11,10 +11,10 @@ install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dimensionReduction.py
   DESTINATION
-    "${CMAKE_INSTALL_DATAROOTDIR}/ttk"
+    scripts/ttk
   )
 
-target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_FULL_DATAROOTDIR}/ttk)
+target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=scripts/ttk)
 
 if(TTK_ENABLE_SCIKIT_LEARN)
   target_link_libraries(dimensionReduction PRIVATE Python3::Python Python3::NumPy)

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -1,5 +1,3 @@
-ttk_find_python()
-
 ttk_add_base_library(dimensionReduction
   SOURCES
     DimensionReduction.cpp

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -17,4 +17,7 @@ install(
   )
 
 target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_FULL_DATAROOTDIR}/ttk)
-target_link_libraries(dimensionReduction PRIVATE ${PYTHON_LIBRARY})
+
+if(TTK_ENABLE_SCIKIT_LEARN)
+  target_link_libraries(dimensionReduction PRIVATE Python3::Python Python3::NumPy)
+endif()

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -13,8 +13,8 @@ install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dimensionReduction.py
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/scripts/ttk
+    "${CMAKE_INSTALL_DATAROOTDIR}/ttk"
   )
 
-target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_PREFIX}/scripts/ttk)
+target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_FULL_DATAROOTDIR}/ttk)
 target_link_libraries(dimensionReduction PRIVATE ${PYTHON_LIBRARY})

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -666,7 +666,7 @@ const vector<vector<SimplexId>> *
   return &vertexEdgeList_;
 }
 
-inline SimplexId ImplicitTriangulation::getVertexTriangleNumberInternal(
+SimplexId ImplicitTriangulation::getVertexTriangleNumberInternal(
   const SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -986,7 +986,7 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getVertexStarNumber)(const SimplexId &vertexId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -1337,7 +1337,7 @@ const vector<pair<SimplexId, SimplexId>> *
   return &edgeList_;
 }
 
-inline SimplexId ImplicitTriangulation::getEdgeTriangleNumberInternal(
+SimplexId ImplicitTriangulation::getEdgeTriangleNumberInternal(
   const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -1576,8 +1576,8 @@ const vector<vector<SimplexId>> *
   return &edgeTriangleList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
-  getEdgeLinkNumber)(const SimplexId &edgeId) const {
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
+  const SimplexId &edgeId) const {
   return getEdgeStarNumber(edgeId);
 }
 
@@ -1652,8 +1652,8 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
-  getEdgeStarNumber)(const SimplexId &edgeId) const {
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+  const SimplexId &edgeId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -2026,7 +2026,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
   return 0;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getTriangleLinkNumber)(const SimplexId &triangleId) const {
   return getTriangleStarNumber(triangleId);
 }
@@ -2049,7 +2049,7 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-inline SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getTriangleStarNumber)(const SimplexId &triangleId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2135,7 +2135,7 @@ const vector<vector<SimplexId>> *
   return &triangleStarList_;
 }
 
-inline SimplexId ImplicitTriangulation::getTriangleNeighborNumber(
+SimplexId ImplicitTriangulation::getTriangleNeighborNumber(
   const SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -450,7 +450,7 @@ bool PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return false;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getVertexNeighborNumber)(const SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -581,7 +581,7 @@ const vector<vector<SimplexId>> *
   return &vertexEdgeList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::getVertexTriangleNumberInternal(
+SimplexId PeriodicImplicitTriangulation::getVertexTriangleNumberInternal(
   const SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -677,7 +677,7 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getVertexStarNumber)(const SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -877,7 +877,7 @@ const vector<pair<SimplexId, SimplexId>> *
   return &edgeList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::getEdgeTriangleNumberInternal(
+SimplexId PeriodicImplicitTriangulation::getEdgeTriangleNumberInternal(
   const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -973,7 +973,7 @@ const vector<vector<SimplexId>> *
   return &edgeTriangleList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getEdgeLinkNumber)(const SimplexId &edgeId) const {
 
   return getEdgeStarNumber(edgeId);
@@ -1047,7 +1047,7 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getEdgeStarNumber)(const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -1356,7 +1356,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
   return 0;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getTriangleLinkNumber)(const SimplexId &triangleId) const {
 
   return getTriangleStarNumber(triangleId);
@@ -1382,7 +1382,7 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   getTriangleStarNumber)(const SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
@@ -1453,7 +1453,7 @@ const vector<vector<SimplexId>> *
   return &triangleStarList_;
 }
 
-inline SimplexId PeriodicImplicitTriangulation::getTriangleNeighborNumber(
+SimplexId PeriodicImplicitTriangulation::getTriangleNeighborNumber(
   const SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)

--- a/core/vtk/ttkDimensionReduction/CMakeLists.txt
+++ b/core/vtk/ttkDimensionReduction/CMakeLists.txt
@@ -1,6 +1,7 @@
 ttk_add_vtk_module()
 
 if(NOT TTK_ENABLE_SCIKIT_LEARN)
-  set(VTK_MODULE_ENABLE_ttkDimensionReduction "NO" CACHE STRING "Disable dimension reduction" FORCE)
-  message(STATUS "No python or scikit-learn found, disable ttk dimension reduction filter")
+  set(VTK_MODULE_ENABLE_ttkDimensionReduction "NO"
+    CACHE STRING "Enable the ttkDimensionReduction module." FORCE)
+  message(STATUS "No Python or scikit-learn found, ttkDimensionReduction filter disabled")
 endif()

--- a/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
+++ b/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
@@ -2,7 +2,7 @@ diff --git c/CMakeLists.txt w/CMakeLists.txt
 index 792bfff6..3870fbb5 100644
 --- c/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -803,3 +803,21 @@ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
+@@ -803,3 +803,23 @@ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
  install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example3.vti
    DESTINATION share/paraview-5.8/examples/
    COMPONENT development)
@@ -23,4 +23,6 @@ index 792bfff6..3870fbb5 100644
 +set(CPACK_PACKAGE_VERSION_PATCH ${PARAVIEW_VERSION_PATCH})
 +# autogenerate dependency information
 +set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
++# package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
++set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK-ParaView")
 +include(CPack)

--- a/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
+++ b/paraview/patch/paraview-5.8.0-CPack-CMakeLists.txt.patch
@@ -2,7 +2,7 @@ diff --git c/CMakeLists.txt w/CMakeLists.txt
 index 792bfff6..3870fbb5 100644
 --- c/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -803,3 +803,23 @@ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
+@@ -803,3 +803,25 @@ install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example2.vti
  install(FILES ${ParaView_SOURCE_DIR}/TTK/Data/Example3.vti
    DESTINATION share/paraview-5.8/examples/
    COMPONENT development)
@@ -25,4 +25,6 @@ index 792bfff6..3870fbb5 100644
 +set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 +# package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
 +set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK-ParaView")
++# let the installer uninstall previous installations on Windows
++set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 +include(CPack)

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -20,4 +20,4 @@ foreach(STANDALONE ${STANDALONE_DIRS})
   endif()
 endforeach()
 
-install(DIRECTORY textures DESTINATION share/ttk)
+install(DIRECTORY textures DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/ttk")


### PR DESCRIPTION
This PR adds Windows and macOS packaging jobs alongside Ubuntu 18.04 and 20.04 inside the GitHub Actions YAML workflow file. Similarly to Ubuntu, the jobs are divided in two: in a first job, TTK is build upon the ttk-paraview packages and packaged. In a second part, on a new virtual machine, the packages are installed and tested on the examples and the `ttkHelloWorldCmd` standalone.

As described in #308, the `clang-cl` driver was used as a front-end to the Visual C++ compiler to provide the support of (not so) recent OpenMP parallelism out-of-the-box.

To prevent CMake to find wrong OpenMP flags for the Windows and macOS targets, the OpenMP support in the CMake code has been improved following these [Modern CMake guidelines](https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html) (CMake >= 3.9).

A similar effort has been done for Python: I switched from [FindPythonLibs](https://cmake.org/cmake/help/latest/module/FindPythonLibs.html) to [FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html), available from CMake 3.12 and onwards, which is the current minimum version of CMake supported in TTK. This also helps a lot CMake finding the NumPy headers. This code has been moved into `config.cmake` alongside the other dependencies.

Some `inline` keywords prefixing methods definitions were removed from `ImplicitTriangulation` and `PeriodicImplicitTriangulation` since they caused link errors in macOS: since the inline methods were not used in the compilation unit, the compiler may have discarded them.

On Windows, the destination folder of ttk and ttk-paraview were hard-coded to `TTK` and `TTK-ParaView` (by default, they would have been `TTK 0.9.9` and `TTK-ParaView 5.8.1`). This should make it easier to set environment variables. The ttk-paraview Windows package should be rebuild with the corresponding patch for the examples not to fail though. To support the Windows packaging system, absolute paths in the CMake `install` calls were also replaced by prefix-relative ones.

Compared to the (current) Ubuntu packages, one drawback of the current approach is that we still need to set environment variables. On Windows, TTK and TTK-ParaView are installed in two different prefixes inside `C:\Program Files\`, thus hindering ParaView to find the TTK plugin. On macOS, both are installed under `/Applications/`, which does not seems to be covered by the standard environment variables (PATH, DYLD_LIBRARY_PATH, PYTHONPATH). See the code running the examples in the YAML file for more details about what variable to use.

A second drawback concerns the TTK  and ParaView run-time dependencies. Contrary to Ubuntu, Windows and macOS don't have a centralized packaging system managing the dependencies. On Windows, we rely on conda to provide us all TTK dependencies (except `graphviz`, its headers are missing). On macOS, I tried to use brew and pip (for scikit-learn). Refer to the workflow file to get a list of the dependencies I used.

Enjoy,
Pierre 