### PR TITLE
Make PersistenceDiagram stateless

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: VTK | $(Agent.OS) | "$(VTKVersion)"
+      key: VTK | $(Agent.OS) | "$(VTKVersion)" | "v-11-12-20"
       path: $(Build.ArtifactStagingDirectory)/vtk-install
       cacheHitVar: CACHE_RESTORED
     displayName: Cache VTK build
@@ -214,7 +214,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: ParaView | $(Agent.OS) | "$(PV_VERSION)"
+      key: ParaView | $(Agent.OS) | "$(PV_VERSION)" | "v-11-12-20"
       path: $(Build.ArtifactStagingDirectory)/pv-install
       cacheHitVar: CACHE_RESTORED
     displayName: Cache ParaView build
@@ -500,7 +500,7 @@ jobs:
   steps:
   - task: Cache@2
     inputs:
-      key: VTK | $(Agent.OS) | "$(VTKVersion)"
+      key: VTK | $(Agent.OS) | "$(VTKVersion)" | "v-11-12-20"
       path: $(Build.ArtifactStagingDirectory)/vtk-install
       cacheHitVar: CACHE_RESTORED
     displayName: Cache VTK build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -535,7 +535,7 @@ jobs:
     # need to disable filters linked to rendering
   - script: |
       $(compilerInitialization)
-      set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
+      set BOOST_ROOT=$(BOOST_ROOT_1_72_0)
       cmake -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_POLICY_DEFAULT_CMP0092=NEW -DCMAKE_C_COMPILER:FILEPATH="$(cCompiler)" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="$(cxxCompiler)" -DCMAKE_INSTALL_PREFIX="$(Build.ArtifactStagingDirectory)/ttk-install" -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-$(VTKVPath) -DCMAKE_BUILD_TYPE:STRING=Release -DTTK_BUILD_PARAVIEW_PLUGINS=OFF $(TTK_MODULE_DISABLE) $(CMAKE_TEST) -GNinja ..
     workingDirectory: build/
     displayName: 'Configure TTK'
@@ -553,7 +553,7 @@ jobs:
 
   - script: |
       $(compilerInitialization)
-      set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
+      set BOOST_ROOT=$(BOOST_ROOT_1_72_0)
       cmake ../examples/c++ -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$(Build.ArtifactStagingDirectory)/ttk-install/lib/cmake
     workingDirectory: 'build-example/'
     displayName: 'Configure C++ Example'
@@ -570,7 +570,7 @@ jobs:
 
   - script: |
       $(compilerInitialization)
-      set BOOST_ROOT=$(BOOST_ROOT_1_69_0)
+      set BOOST_ROOT=$(BOOST_ROOT_1_72_0)
       cmake ../examples/vtk-c++ -GNinja -DCMAKE_BUILD_TYPE=Release -DVTK_DIR=$(Build.ArtifactStagingDirectory)/vtk-install/lib/cmake/vtk-$(VTKVPath) -DCMAKE_PREFIX_PATH="$(Build.ArtifactStagingDirectory)/ttk-install/lib/cmake
     workingDirectory: 'build-example-vtk/'
     displayName: 'Configure TTKVTK Example'

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -6,7 +6,6 @@
 #include <vtkConnectivityFilter.h>
 #include <vtkDataObject.h>
 #include <vtkInformation.h>
-#include <vtkThreshold.h>
 
 using namespace ttk::ftr;
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -71,12 +71,8 @@ public:
   vtkSetMacro(ComputeSaddleConnectors, bool);
   vtkGetMacro(ComputeSaddleConnectors, bool);
 
-  void SetShowInsideDomain(int onOff) {
-    ShowInsideDomain = onOff;
-    Modified();
-    computeDiagram_ = false;
-  }
-  vtkGetMacro(ShowInsideDomain, int);
+  vtkSetMacro(ShowInsideDomain, bool);
+  vtkGetMacro(ShowInsideDomain, bool);
 
 protected:
   ttkPersistenceDiagram();
@@ -87,7 +83,6 @@ protected:
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
-  void Modified() override;
 
 private:
   template <typename scalarType, typename triangulationType>
@@ -105,8 +100,5 @@ private:
                             const triangulationType *triangulation) const;
 
   bool ForceInputOffsetScalarField{false};
-  int ShowInsideDomain{false};
-
-  bool computeDiagram_{true};
-  std::vector<ttk::PersistencePair> CTDiagram_{};
+  bool ShowInsideDomain{false};
 };

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.cpp
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.cpp
@@ -13,6 +13,8 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
+#include <array>
+
 vtkStandardNewMacro(ttkProjectionFromField);
 
 ttkProjectionFromField::ttkProjectionFromField() {
@@ -83,8 +85,10 @@ int ttkProjectionFromField::projectDiagramInsideDomain(
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(int i = 0; i < nPoints; ++i) {
-    births->SetTuple1(i, inputPoints->GetPoint(i)[0]);
-    deaths->SetTuple1(i, inputPoints->GetPoint(i)[1]);
+    std::array<double, 3> pt{};
+    inputPoints->GetPoint(i, pt.data());
+    births->SetTuple1(i, pt[0]);
+    deaths->SetTuple1(i, pt[1]);
   }
 
   diagonalLessData->AddArray(births);

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.cpp
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.cpp
@@ -1,9 +1,13 @@
 #include <ttkProjectionFromField.h>
 
+#include <vtkCellData.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
+#include <vtkUnstructuredGrid.h>
 
 #include <ttkMacros.h>
 #include <ttkUtils.h>
@@ -35,6 +39,119 @@ int ttkProjectionFromField::FillOutputPortInformation(int port,
   return 0;
 }
 
+int ttkProjectionFromField::projectPersistenceDiagram(
+  vtkUnstructuredGrid *const inputDiagram,
+  vtkUnstructuredGrid *const outputDiagram) {
+
+  ttk::Timer tm{};
+
+  auto pointData = inputDiagram->GetPointData();
+
+  const auto vertexIdentifierScalars = vtkIntArray::SafeDownCast(
+    pointData->GetAbstractArray(ttk::VertexScalarFieldName));
+  const auto nodeTypeScalars
+    = vtkIntArray::SafeDownCast(pointData->GetAbstractArray("CriticalType"));
+  const auto critCoordinates
+    = vtkFloatArray::SafeDownCast(pointData->GetAbstractArray("Coordinates"));
+
+  auto cellData = inputDiagram->GetCellData();
+
+  const auto pairIdentifierScalars
+    = vtkIntArray::SafeDownCast(cellData->GetAbstractArray("PairIdentifier"));
+  const auto extremumIndexScalars
+    = vtkIntArray::SafeDownCast(cellData->GetAbstractArray("PairType"));
+  const auto persistenceScalars
+    = vtkDoubleArray::SafeDownCast(cellData->GetAbstractArray("Persistence"));
+
+  // ensure we have a Coordinates array
+  if(critCoordinates == nullptr) {
+    this->printErr("Missing `Coordinates' vtkPointData array");
+    return 0;
+  }
+  if(critCoordinates->GetNumberOfComponents() != 3) {
+    this->printErr("`Coordinates' array should have 3 components");
+    return 0;
+  }
+  if(vertexIdentifierScalars == nullptr || nodeTypeScalars == nullptr
+     || critCoordinates == nullptr || pairIdentifierScalars == nullptr
+     || extremumIndexScalars == nullptr || persistenceScalars == nullptr) {
+    this->printErr("Missing at least one data array");
+    return 0;
+  }
+
+  // set new points from Coordinates array
+  vtkNew<vtkFloatArray> coords{};
+  coords->DeepCopy(critCoordinates);
+  coords->SetName("Points");
+  vtkNew<vtkPoints> points{};
+  points->SetData(coords);
+
+  const auto inputPoints = inputDiagram->GetPoints();
+
+  // generate a birth and death arrays from diagram points coordinates
+  vtkNew<vtkFloatArray> births{}, deaths{};
+  births->SetNumberOfComponents(1);
+  births->SetName("Birth");
+  births->SetNumberOfTuples(inputPoints->GetNumberOfPoints());
+  deaths->SetNumberOfComponents(1);
+  deaths->SetName("Death");
+  deaths->SetNumberOfTuples(inputPoints->GetNumberOfPoints());
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(int i = 0; i < inputPoints->GetNumberOfPoints(); ++i) {
+    births->SetTuple1(i, inputPoints->GetPoint(i)[0]);
+    deaths->SetTuple1(i, inputPoints->GetPoint(i)[1]);
+  }
+
+  // remove diagonal data from cell arrays
+  const auto inputCells = inputDiagram->GetCells();
+  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+  offsets->DeepCopy(inputCells->GetOffsetsArray());
+  connectivity->DeepCopy(inputCells->GetConnectivityArray());
+  // remove last entry (diagonal data)
+  offsets->SetNumberOfTuples(offsets->GetNumberOfTuples() - 1);
+  connectivity->SetNumberOfTuples(connectivity->GetNumberOfTuples() - 1);
+  vtkNew<vtkCellArray> cells{};
+  cells->SetData(offsets, connectivity);
+
+  // copy cell data arrays, removing diagonal data
+  vtkNew<vtkIntArray> pairIds{}, pairTypes{};
+  pairIds->DeepCopy(pairIdentifierScalars);
+  pairTypes->DeepCopy(extremumIndexScalars);
+  pairIds->SetNumberOfTuples(cells->GetNumberOfCells());
+  pairTypes->SetNumberOfTuples(cells->GetNumberOfCells());
+  vtkNew<vtkDoubleArray> persistence{};
+  persistence->DeepCopy(persistenceScalars);
+  persistence->SetNumberOfTuples(cells->GetNumberOfCells());
+
+  // create a new vtkUnstructuredGrid
+  vtkNew<vtkUnstructuredGrid> persistenceDiagram{};
+  persistenceDiagram->SetPoints(points);
+  persistenceDiagram->SetCells(VTK_LINE, cells);
+
+  // add  data arrays
+  persistenceDiagram->GetPointData()->AddArray(vertexIdentifierScalars);
+  persistenceDiagram->GetPointData()->AddArray(nodeTypeScalars);
+  persistenceDiagram->GetPointData()->AddArray(births);
+  persistenceDiagram->GetPointData()->AddArray(deaths);
+
+  persistenceDiagram->GetCellData()->AddArray(pairIds);
+  persistenceDiagram->GetCellData()->AddArray(pairTypes);
+  persistenceDiagram->GetCellData()->AddArray(persistence);
+
+  outputDiagram->ShallowCopy(persistenceDiagram);
+
+  // don't forget to forward the Field Data
+  outputDiagram->GetFieldData()->ShallowCopy(inputDiagram->GetFieldData());
+
+  this->printMsg("Projected Persistence Diagram inside domain", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_);
+
+  return 1;
+}
+
 int ttkProjectionFromField::RequestData(vtkInformation *request,
                                         vtkInformationVector **inputVector,
                                         vtkInformationVector *outputVector) {
@@ -43,6 +160,16 @@ int ttkProjectionFromField::RequestData(vtkInformation *request,
 
   vtkPointSet *input = vtkPointSet::GetData(inputVector[0]);
   vtkPointSet *output = vtkPointSet::GetData(outputVector, 0);
+
+  if(this->ProjectPersistenceDiagram) {
+    auto inputGrid = vtkUnstructuredGrid::SafeDownCast(input);
+    auto outputGrid = vtkUnstructuredGrid::SafeDownCast(output);
+    if(inputGrid != nullptr && outputGrid != nullptr) {
+      return projectPersistenceDiagram(inputGrid, outputGrid);
+    }
+    this->printErr("Input should be a vtkUnstructuredGrid");
+    return 0;
+  }
 
   output->ShallowCopy(input);
 

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -57,6 +57,9 @@ public:
   vtkSetMacro(UseTextureCoordinates, bool);
   vtkGetMacro(UseTextureCoordinates, bool);
 
+  vtkSetMacro(Use3DCoordinatesArray, bool);
+  vtkGetMacro(Use3DCoordinatesArray, bool);
+
   vtkSetMacro(ProjectPersistenceDiagram, bool);
   vtkGetMacro(ProjectPersistenceDiagram, bool);
 
@@ -93,4 +96,5 @@ protected:
 private:
   bool ProjectPersistenceDiagram{false};
   bool UseTextureCoordinates{false};
+  bool Use3DCoordinatesArray{false};
 };

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -68,10 +68,23 @@ protected:
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
   /**
-   * @brief Generate the spatial embedding of a given Persistence Diagram
+   * @brief Switch a given Persistence Diagram representation
    */
   int projectPersistenceDiagram(vtkUnstructuredGrid *const inputDiagram,
                                 vtkUnstructuredGrid *const outputDiagram);
+  /**
+   * @brief Generate the spatial embedding of a given Persistence Diagram
+   */
+  int projectDiagramInsideDomain(vtkUnstructuredGrid *const inputDiagram,
+                                 vtkUnstructuredGrid *const outputDiagram);
+  /**
+   * @brief Generate the 2D embedding of a given Persistence Diagram
+   */
+  template <typename VTK_TT>
+  int projectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
+                         vtkUnstructuredGrid *const outputDiagram,
+                         const VTK_TT *const births,
+                         const VTK_TT *const deaths);
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -38,9 +38,6 @@
 ///
 #pragma once
 
-// VTK includes
-#include <vtkSmartPointer.h>
-
 // VTK Module
 #include <ttkProjectionFromFieldModule.h>
 
@@ -61,8 +58,6 @@ public:
 protected:
   ttkProjectionFromField();
 
-  ~ttkProjectionFromField() override;
-
   int FillInputPortInformation(int port, vtkInformation *info) override;
 
   int FillOutputPortInformation(int port, vtkInformation *info) override;
@@ -73,5 +68,4 @@ protected:
 
 private:
   bool UseTextureCoordinates{false};
-  vtkSmartPointer<vtkPoints> pointSet_;
 };

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -44,6 +44,8 @@
 // ttk code includes
 #include <ttkAlgorithm.h>
 
+class vtkUnstructuredGrid;
+
 class TTKPROJECTIONFROMFIELD_EXPORT ttkProjectionFromField
   : public ttkAlgorithm {
 
@@ -55,6 +57,9 @@ public:
   vtkSetMacro(UseTextureCoordinates, bool);
   vtkGetMacro(UseTextureCoordinates, bool);
 
+  vtkSetMacro(ProjectPersistenceDiagram, bool);
+  vtkGetMacro(ProjectPersistenceDiagram, bool);
+
 protected:
   ttkProjectionFromField();
 
@@ -62,10 +67,17 @@ protected:
 
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
+  /**
+   * @brief Generate the spatial embedding of a given Persistence Diagram
+   */
+  int projectPersistenceDiagram(vtkUnstructuredGrid *const inputDiagram,
+                                vtkUnstructuredGrid *const outputDiagram);
+
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
 
 private:
+  bool ProjectPersistenceDiagram{false};
   bool UseTextureCoordinates{false};
 };

--- a/paraview/ProjectionFromField/ProjectionFromField.xml
+++ b/paraview/ProjectionFromField/ProjectionFromField.xml
@@ -35,17 +35,31 @@ point-data scalar fields to be used as 2D coordinates.
         </Documentation>
       </InputProperty>
 
+      <IntVectorProperty name="ProjectPersistenceDiagram"
+                     command="SetProjectPersistenceDiagram"
+                     label="Project Persistence Diagram"
+                     number_of_elements="1"
+                     default_values="0">
+        <BooleanDomain name="bool"/>
+      </IntVectorProperty>
+
       <IntVectorProperty name="UseTextureCoordinates"
                      command="SetUseTextureCoordinates"
                      label="Use Texture Coordinates"
                      number_of_elements="1"
                      default_values="0">
         <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ProjectPersistenceDiagram"
+                                   value="0" />
+        </Hints>
       </IntVectorProperty>
 
-      <StringVectorProperty name="UComponentNew" label="U Component" 
-                            command="SetInputArrayToProcess" 
-                            element_types="0 0 0 0 2" 
+      <StringVectorProperty name="UComponentNew" label="U Component"
+                            command="SetInputArrayToProcess"
+                            element_types="0 0 0 0 2"
                             number_of_elements="5" default_values="0">
         <ArrayListDomain
           name="array_list"
@@ -54,14 +68,20 @@ point-data scalar fields to be used as 2D coordinates.
             <Property name="Input" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ProjectPersistenceDiagram"
+                                   value="0" />
+        </Hints>
         <Documentation>
           Select the scalar field to use as the U component.
         </Documentation>
       </StringVectorProperty>
 
-      <StringVectorProperty name="VComponentNew" label="V Component" 
-                            command="SetInputArrayToProcess" 
-                            element_types="0 0 0 0 2" 
+      <StringVectorProperty name="VComponentNew" label="V Component"
+                            command="SetInputArrayToProcess"
+                            element_types="0 0 0 0 2"
                             number_of_elements="5" default_values="1">
         <ArrayListDomain
           name="array_list"
@@ -70,6 +90,12 @@ point-data scalar fields to be used as 2D coordinates.
             <Property name="Input" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ProjectPersistenceDiagram"
+                                   value="0" />
+        </Hints>
         <Documentation>
           Select the scalar field to use as the V component.
         </Documentation>
@@ -77,12 +103,13 @@ point-data scalar fields to be used as 2D coordinates.
 
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="UseTextureCoordinates" />
+        <Property name="ProjectPersistenceDiagram" />
         <Property name="UComponentNew" />
         <Property name="VComponentNew" />
       </PropertyGroup>
 
       ${DEBUG_WIDGETS}
-      
+
       <Hints>
         <ShowInMenu category="TTK - Misc" />
       </Hints>

--- a/paraview/ProjectionFromField/ProjectionFromField.xml
+++ b/paraview/ProjectionFromField/ProjectionFromField.xml
@@ -34,56 +34,6 @@ point-data scalar fields to be used as 2D coordinates.
         </Documentation>
       </InputProperty>
 
-      <IntVectorProperty name="ProjectPersistenceDiagram"
-                     command="SetProjectPersistenceDiagram"
-                     label="Project Persistence Diagram"
-                     number_of_elements="1"
-                     default_values="0">
-        <BooleanDomain name="bool"/>
-        <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-                                   mode="visibility"
-                                   property="Use3DCoordinatesArray"
-                                   value="0" />
-        </Hints>
-      </IntVectorProperty>
-
-      <IntVectorProperty name="Use3DCoordinatesArray"
-                     command="SetUse3DCoordinatesArray"
-                     label="Use 3D Coordinates Array"
-                     number_of_elements="1"
-                     default_values="0">
-        <BooleanDomain name="bool"/>
-        <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-                                   mode="visibility"
-                                   property="ProjectPersistenceDiagram"
-                                   value="0" />
-        </Hints>
-      </IntVectorProperty>
-
-      <IntVectorProperty name="UseTextureCoordinates"
-                     command="SetUseTextureCoordinates"
-                     label="Use Texture Coordinates"
-                     number_of_elements="1"
-                     default_values="0">
-        <BooleanDomain name="bool"/>
-        <Hints>
-          <PropertyWidgetDecorator type="CompositeDecorator">
-            <Expression type="and">
-              <PropertyWidgetDecorator type="GenericDecorator"
-                                       mode="visibility"
-                                       property="Use3DCoordinatesArray"
-                                       value="0" />
-              <PropertyWidgetDecorator type="GenericDecorator"
-                                       mode="visibility"
-                                       property="ProjectPersistenceDiagram"
-                                       value="0" />
-            </Expression>
-          </PropertyWidgetDecorator>
-        </Hints>
-      </IntVectorProperty>
-
       <StringVectorProperty name="UComponentNew" label="U Component"
                             command="SetInputArrayToProcess"
                             element_types="0 0 0 0 2"
@@ -146,6 +96,43 @@ point-data scalar fields to be used as 2D coordinates.
         </Documentation>
       </StringVectorProperty>
 
+
+      <IntVectorProperty name="Use3DCoordinatesArray"
+                     command="SetUse3DCoordinatesArray"
+                     label="Use 3D Coordinates Array"
+                     number_of_elements="1"
+                     default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ProjectPersistenceDiagram"
+                                   value="0" />
+        </Hints>
+      </IntVectorProperty>
+
+      <IntVectorProperty name="UseTextureCoordinates"
+                     command="SetUseTextureCoordinates"
+                     label="Use Texture Coordinates"
+                     number_of_elements="1"
+                     default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Use3DCoordinatesArray"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="ProjectPersistenceDiagram"
+                                       value="0" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+      </IntVectorProperty>
+
       <StringVectorProperty name="3DCoordinates" label="3D Coordinates"
                             command="SetInputArrayToProcess"
                             element_types="0 0 0 0 2"
@@ -168,14 +155,28 @@ point-data scalar fields to be used as 2D coordinates.
         </Documentation>
       </StringVectorProperty>
 
+      <IntVectorProperty name="ProjectPersistenceDiagram"
+                     command="SetProjectPersistenceDiagram"
+                     label="Project Persistence Diagram"
+                     number_of_elements="1"
+                     default_values="0"
+                     panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="Use3DCoordinatesArray"
+                                   value="0" />
+        </Hints>
+      </IntVectorProperty>
 
       <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="UseTextureCoordinates" />
-        <Property name="Use3DCoordinatesArray" />
-        <Property name="ProjectPersistenceDiagram" />
         <Property name="UComponentNew" />
         <Property name="VComponentNew" />
+        <Property name="UseTextureCoordinates" />
+        <Property name="Use3DCoordinatesArray" />
         <Property name="3DCoordinates" />
+        <Property name="ProjectPersistenceDiagram" />
       </PropertyGroup>
 
       ${DEBUG_WIDGETS}

--- a/paraview/ProjectionFromField/ProjectionFromField.xml
+++ b/paraview/ProjectionFromField/ProjectionFromField.xml
@@ -27,9 +27,8 @@ point-data scalar fields to be used as 2D coordinates.
         <DataTypeDomain name="input_type">
           <DataType value="vtkPointSet"/>
         </DataTypeDomain>
-<!--         <InputArrayDomain name="input_scalars" number_of_components="1"> -->
-<!--           <Property name="Input" function="FieldDataSelection" /> -->
-<!--         </InputArrayDomain> -->
+        <InputArrayDomain name="uv_comp" number_of_components="1" attribute_type="point" optional="1" />
+        <InputArrayDomain name="coords_array" number_of_components="3" attribute_type="point" optional="1" />
         <Documentation>
           Data-set to texture map.
         </Documentation>
@@ -41,11 +40,17 @@ point-data scalar fields to be used as 2D coordinates.
                      number_of_elements="1"
                      default_values="0">
         <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="Use3DCoordinatesArray"
+                                   value="0" />
+        </Hints>
       </IntVectorProperty>
 
-      <IntVectorProperty name="UseTextureCoordinates"
-                     command="SetUseTextureCoordinates"
-                     label="Use Texture Coordinates"
+      <IntVectorProperty name="Use3DCoordinatesArray"
+                     command="SetUse3DCoordinatesArray"
+                     label="Use 3D Coordinates Array"
                      number_of_elements="1"
                      default_values="0">
         <BooleanDomain name="bool"/>
@@ -57,22 +62,53 @@ point-data scalar fields to be used as 2D coordinates.
         </Hints>
       </IntVectorProperty>
 
+      <IntVectorProperty name="UseTextureCoordinates"
+                     command="SetUseTextureCoordinates"
+                     label="Use Texture Coordinates"
+                     number_of_elements="1"
+                     default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Use3DCoordinatesArray"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="ProjectPersistenceDiagram"
+                                       value="0" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+      </IntVectorProperty>
+
       <StringVectorProperty name="UComponentNew" label="U Component"
                             command="SetInputArrayToProcess"
                             element_types="0 0 0 0 2"
                             number_of_elements="5" default_values="0">
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+            name="array_list"
+            input_domain_name="uv_comp"
+            default_values="0">
           <RequiredProperties>
             <Property name="Input" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
         <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-                                   mode="visibility"
-                                   property="ProjectPersistenceDiagram"
-                                   value="0" />
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Use3DCoordinatesArray"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="ProjectPersistenceDiagram"
+                                       value="0" />
+            </Expression>
+          </PropertyWidgetDecorator>
         </Hints>
         <Documentation>
           Select the scalar field to use as the U component.
@@ -84,8 +120,39 @@ point-data scalar fields to be used as 2D coordinates.
                             element_types="0 0 0 0 2"
                             number_of_elements="5" default_values="1">
         <ArrayListDomain
-          name="array_list"
-          default_values="1">
+            name="array_list"
+            input_domain_name="uv_comp"
+            default_values="1">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Use3DCoordinatesArray"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="ProjectPersistenceDiagram"
+                                       value="0" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          Select the scalar field to use as the V component.
+        </Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty name="3DCoordinates" label="3D Coordinates"
+                            command="SetInputArrayToProcess"
+                            element_types="0 0 0 0 2"
+                            number_of_elements="5" default_values="2">
+        <ArrayListDomain
+            name="array_list"
+            input_domain_name="coords_array">
           <RequiredProperties>
             <Property name="Input" function="Input" />
           </RequiredProperties>
@@ -93,19 +160,22 @@ point-data scalar fields to be used as 2D coordinates.
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
                                    mode="visibility"
-                                   property="ProjectPersistenceDiagram"
-                                   value="0" />
+                                   property="Use3DCoordinatesArray"
+                                   value="1" />
         </Hints>
         <Documentation>
-          Select the scalar field to use as the V component.
+          Select the 3D coordinates array.
         </Documentation>
       </StringVectorProperty>
 
+
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="UseTextureCoordinates" />
+        <Property name="Use3DCoordinatesArray" />
         <Property name="ProjectPersistenceDiagram" />
         <Property name="UComponentNew" />
         <Property name="VComponentNew" />
+        <Property name="3DCoordinates" />
       </PropertyGroup>
 
       ${DEBUG_WIDGETS}


### PR DESCRIPTION
This PR fixes #515 by making the `PersistenceDiagram` VTK layer stateless. Switching to the "embedded in domain" representation now requires a full recomputation of the diagram.

To still allow users to quickly switch between diagram representations, I hijacked the `ProjectionFromField` module and put some conversion code there. The transformation is still a bit involving since, for the spatial embedding, the diagonal has to be removed and the point coordinates need to be transformed into the Birth and Death arrays. In a symmetrical manner, the back transformation has also been implemented, the state of input diagrams being automatically detected (presence or absence of the Coordinates, Birth and Death point data arrays). 

From the user's point of view, there is a new checkbox inside `ProjectionFromField` that needs to be checked to switch the diagram representation (unchecked by default).

As a bonus, an unused include was removed from `ftrGraph`.

Enjoy,
Pierre
