### PR TITLE
Fix handling of eigen dependency in HarmonicField and Laplacian base modules

### DIFF
--- a/core/base/harmonicField/CMakeLists.txt
+++ b/core/base/harmonicField/CMakeLists.txt
@@ -9,7 +9,7 @@ ttk_add_base_library(harmonicField
     triangulation
     )
 
-if (EIGEN3_FOUND)
+if(TTK_ENABLE_EIGEN)
   target_compile_definitions(harmonicField PRIVATE TTK_ENABLE_EIGEN)
   target_include_directories(harmonicField SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 endif()

--- a/core/base/laplacian/CMakeLists.txt
+++ b/core/base/laplacian/CMakeLists.txt
@@ -8,7 +8,7 @@ ttk_add_base_library(laplacian
     triangulation
     )
 
-if (EIGEN3_FOUND)
+if(TTK_ENABLE_EIGEN)
   target_compile_definitions(laplacian PRIVATE TTK_ENABLE_EIGEN)
   target_include_directories(laplacian SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
Following Christopher Kappe's email on the ttk-dev mailing list, here are the suggested changes. This should allow a user to prevent building the HarmonicField and Laplacian modules even though eigen is present on its system. The `TTK_ENABLE_EIGEN` CMake variable is set in the config.cmake file.

The EigenField module is not concerned by this, as it already depends on `TTK_ENABLE_SPECTRA`.

Enjoy,
Pierre

