### PR TITLE
Embed Visual C++ redistribuable in Windows installer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,6 +307,12 @@ jobs:
       run: |
         ttk-paraview.exe /S
 
+    - name: Fetch Visual C++ redistribuable run-time
+      run: |
+        Invoke-WebRequest `
+          -OutFile vc_redist.x64.exe `
+          -Uri https://aka.ms/vs/16/release/vc_redist.x64.exe
+
     - name: Configure TTK
       shell: cmd
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,13 @@ set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 if(APPLE)
   set(CPACK_COMPONENTS_ALL Unspecified python development)
 endif()
+# embed Visual C++ redistribuable for Windows
+if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe")
+  install(PROGRAMS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe" DESTINATION bin)
+  list(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+    " ExecWait '$INSTDIR\\\\bin\\\\vc_redist.x64.exe /passive /norestart'
+      Delete '$INSTDIR\\\\bin\\\\vc_redist.x64.exe' ")
+endif()
 include(CPack)
 
 if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)


### PR DESCRIPTION
This PR improves the Windows packaging by downloading the Visual C++ redistribuable (the Windows C++ standard library) and embeds it into the Windows package. The redistribuable installer is automatically and silently run during the TTK installation. The installer is removed afterwards.

Note that the redistribuable won't be uninstalled when TTK uninstaller is run.

Enjoy,
Pierre