### PR TITLE
Use Actions/Tasks to force Python 3.8 on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,10 +167,14 @@ jobs:
       run: |
         # ParaView dependencies
         brew cask install xquartz
-        brew install wget python@3.8 libomp mesa glew qt
+        brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost eigen graphviz
         python3 -m pip install scikit-learn
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
 
     - name: Install Spectra dependency
       run: |
@@ -237,10 +241,14 @@ jobs:
       run: |
         # ParaView dependencies
         brew cask install xquartz
-        brew install wget python@3.8 libomp mesa glew qt
+        brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost graphviz
         python3 -m pip install scikit-learn
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
 
     - name: Fetch ttk-paraview
       run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,8 +364,12 @@ jobs:
   steps:
   - script: |
       brew cask install xquartz
-      brew install wget python@3.8 libomp mesa glew boost ccache qt
+      brew install wget libomp mesa glew boost ccache qt
     displayName: 'Install dependencies'
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
 
   - script: |
       wget https://github.com/topology-tool-kit/ttk-paraview/releases/download/$(PV_VERSION)/ttk-paraview.pkg

--- a/paraview/patch/main.yml
+++ b/paraview/patch/main.yml
@@ -79,7 +79,11 @@ jobs:
     - name: Install macOS dependencies
       run: |
         brew cask install xquartz
-        brew install wget python@3.8 libomp mesa glew boost qt ninja
+        brew install wget libomp mesa glew boost qt ninja
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
 
     - name: Build patched ParaView & create package
       run: |


### PR DESCRIPTION
Following the brew upgrade of Python (3.8->3.9), this PR forces the Python version on macOS to 3.8, since there seems to be an incompatibility between Python 3.9 and CMake.

Following [the update notice](https://github.com/actions/virtual-environments/issues/1929), I used the `setup-python` action for GitHub Actions and the `UsePythonVersion` Task for Azure Pipelines.

Enjoy,
Pierre