### PR TITLE
Fix Python 3.8 dependencies for macOS packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
@@ -170,7 +174,7 @@ jobs:
         brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost eigen graphviz
-        python3 -m pip install scikit-learn
+        python -m pip install scikit-learn
 
     - uses: actions/setup-python@v2
       with:
@@ -205,6 +209,8 @@ jobs:
         cmake \
           -DCMAKE_BUILD_TYPE=Release \
           -DQt5_DIR=$(brew --prefix qt)/lib/cmake/Qt5 \
+          -DPython3_FIND_STRATEGY=LOCATION \
+          -DPython3_ROOT_DIR=$(python -c "import sys; print(sys.prefix)") \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
@@ -237,6 +243,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+
     - name: Install macOS run-time dependencies
       run: |
         # ParaView dependencies
@@ -244,7 +254,7 @@ jobs:
         brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost graphviz
-        python3 -m pip install scikit-learn
+        python -m pip install scikit-learn
 
     - uses: actions/setup-python@v2
       with:
@@ -283,7 +293,7 @@ jobs:
         export PYTHONPATH=/Applications/lib/python3.8/site-packages
         export DYLD_LIBRARY_PATH=/Applications/lib:$DYLD_LIBRARY_PATH
         cd $GITHUB_WORKSPACE/examples/python
-        python3 example.py ../data/inputData.vtu
+        python example.py ../data/inputData.vtu
         # pvpython
         export PATH=/Applications/bin:$PATH
         cd $GITHUB_WORKSPACE/examples/pvpython


### PR DESCRIPTION
This PR completes #535  by fixing the way CMake finds Python and NumPy in GitHub Actions.

Enjoy,
Pierre

