### PR TITLE
Packaging: Add tag name to release assets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,7 +411,7 @@ jobs:
         set PV_DIR=%ProgramFiles%\TTK-ParaView
         set TTK_DIR=%ProgramFiles%\TTK
         set CMAKE_PREFIX_PATH=%TTK_DIR%\lib\cmake;%PV_DIR%\lib\cmake
-        set PATH=%PATH%;%PV_DIR%\bin;%TTK_DIR%\bin;%TTK_DIR%\bin\ttk
+        set PATH=%PATH%;%PV_DIR%\bin;%TTK_DIR%\bin
         :: base layer
         cd %GITHUB_WORKSPACE%\examples\c++
         mkdir build
@@ -437,7 +437,7 @@ jobs:
         export TTK_BIN="/c/Program Files/TTK/bin"
         export CONDA_ROOT="/c/Miniconda"
         export PV_PLUGIN_PATH="$TTK_BIN/plugins"
-        export PATH="$PATH:$PV_PLUGIN_PATH:$PV_BIN:$TTK_BIN:$TTK_BIN/ttk"
+        export PATH="$PATH:$PV_BIN:$TTK_BIN"
         export PYTHONPATH="$PV_BIN/Lib/site-packages:$TTK_BIN/Lib/site-packages:$CONDA_ROOT/Lib"
         # pure python
         cd $GITHUB_WORKSPACE/examples/python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -467,41 +467,33 @@ jobs:
       uses: actions/download-artifact@v2
 
     - name: Upload Ubuntu Bionic .deb as Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ttk-ubuntu-18.04.deb/ttk-ubuntu-18.04.deb
-        asset_name: ttk-ubuntu-18.04.deb
-        asset_content_type: application/vnd.debian.binary-package
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ubuntu-18.04.deb/ttk-ubuntu-18.04.deb
+        asset_name: ttk-$tag-ubuntu-18.04.deb
 
     - name: Upload Ubuntu Focal .deb as Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ttk-ubuntu-20.04.deb/ttk-ubuntu-20.04.deb
-        asset_name: ttk-ubuntu-20.04.deb
-        asset_content_type: application/vnd.debian.binary-package
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ubuntu-20.04.deb/ttk-ubuntu-20.04.deb
+        asset_name: ttk-$tag-ubuntu-20.04.deb
 
     - name: Upload macOS .pkg as Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ttk.pkg/ttk.pkg
-        asset_name: ttk.pkg
-        asset_content_type: application/x-newton-compatible-pkg
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk.pkg/ttk.pkg
+        asset_name: ttk-$tag.pkg
 
     - name: Upload Windows .exe as Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ttk.exe/ttk.exe
-        asset_name: ttk.exe
-        asset_content_type: application/vnd.microsoft.portable-executable
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk.exe/ttk.exe
+        asset_name: ttk-$tag.exe

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Hidden files
 .*
 !.gitignore
+!.github
 
 # Temporary and backup files
 \#*\#


### PR DESCRIPTION
This PR modifies the GitHub Action uploading a release asset to include the tag name (without the `refs/tags/`) prefix in the package names. To do so, I switched from actions/upload-release-asset to  svenstaro/upload-release-action, which is more convenient.

Some seemingly useless environment variables for the Windows test job have been removed.

Enjoy,
Pierre