### PR TITLE
Support setting environment variables in Windows packages

### DIFF
--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -23,6 +23,13 @@ if (NOT MSVC) # GCC and Clang
       )
   endif()
 
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
+  # clang-cl on Windows
+  # c.f. https://stackoverflow.com/questions/50857779/cmake-detects-clang-cl-as-clang
+
+  # warning flags
+  list(APPEND TTK_COMPILER_FLAGS -Wno-unused-parameter)
+
 else() # MSVC
 
   # warning flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,17 @@ set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 if(APPLE)
   set(CPACK_COMPONENTS_ALL Unspecified python development)
 endif()
-# embed Visual C++ redistribuable for Windows
+# embed Visual C++ redistribuable for Windows + set environment variables
 if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe")
+  install(FILES "${CMAKE_SOURCE_DIR}/scripts/set_windows_env_vars.ps1" DESTINATION bin)
   install(PROGRAMS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe" DESTINATION bin)
+  set(CPACK_VERBATIM_VARIABLES TRUE)
   list(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-    " ExecWait '$INSTDIR\\\\bin\\\\vc_redist.x64.exe /passive /norestart'
-      Delete '$INSTDIR\\\\bin\\\\vc_redist.x64.exe' ")
+    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\" install'
+      ExecWait '$INSTDIR\\bin\\vc_redist.x64.exe /passive /norestart'
+      Delete '$INSTDIR\\bin\\vc_redist.x64.exe' ")
+  list(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\"' ")
 endif()
 include(CPack)
 

--- a/scripts/set_windows_env_vars.ps1
+++ b/scripts/set_windows_env_vars.ps1
@@ -1,0 +1,40 @@
+function append_to_env_var($var, $val) {
+    # target the current user environment variables registry
+    $dest = [EnvironmentVariableTarget]::User
+    # existing value of the current environment variable
+    $old_val = [Environment]::GetEnvironmentVariable($var, $dest)
+    If ($null -eq $old_val) {
+        # set environment variable to value
+        $new_val = $val
+    } else {
+        # append new value to existing ones
+        $new_val = $old_val + ";" + $val
+    }
+    [Environment]::SetEnvironmentVariable($var, $new_val, $dest)
+}
+
+function remove_from_env_var($var, $val) {
+    # target the current user environment variables registry
+    $dest = [EnvironmentVariableTarget]::User
+    # existing value of the current environment variable
+    $old_val = [Environment]::GetEnvironmentVariable($var, $dest)
+    # remove $val from $old_val
+    If ($null -ne $old_val) {
+        $new_val = $old_val -replace [Regex]::Escape($val), ""
+        # remove trailing semi-colon
+        $new_val = $new_val -replace ";$", ""
+        [Environment]::SetEnvironmentVariable($var, $new_val, $dest)
+    }
+}
+
+If ($args[0] -eq "install") {
+    $main = ${function:append_to_env_var}
+} else {
+    $main = ${function:remove_from_env_var}
+}
+
+& $main "PATH" "C:\Program Files\TTK\bin;C:\Program Files\TTK-ParaView\bin"
+& $main "PV_PLUGIN_PATH" "C:\Program Files\TTK\bin\plugins"
+& $main "QT_PLUGIN_PATH" "C:\ProgramData\Anaconda3\Library\plugins"
+& $main "PYTHONPATH ""C:\ProgramData\Anaconda3\Lib;C:\Program Files\TTK\bin\Lib\site-packages;C:\Program Files\TTK-ParaView\bin\Lib\site-packages"
+& $main "CMAKE_PREFIX_PATH" "C:\Program Files\TTK\lib\cmake;C:\Program Files\TTK-ParaView\lib\cmake"

--- a/scripts/set_windows_env_vars.ps1
+++ b/scripts/set_windows_env_vars.ps1
@@ -33,8 +33,30 @@ If ($args[0] -eq "install") {
     $main = ${function:remove_from_env_var}
 }
 
-& $main "PATH" "C:\Program Files\TTK\bin;C:\Program Files\TTK-ParaView\bin"
-& $main "PV_PLUGIN_PATH" "C:\Program Files\TTK\bin\plugins"
-& $main "QT_PLUGIN_PATH" "C:\ProgramData\Anaconda3\Library\plugins"
-& $main "PYTHONPATH ""C:\ProgramData\Anaconda3\Lib;C:\Program Files\TTK\bin\Lib\site-packages;C:\Program Files\TTK-ParaView\bin\Lib\site-packages"
-& $main "CMAKE_PREFIX_PATH" "C:\Program Files\TTK\lib\cmake;C:\Program Files\TTK-ParaView\lib\cmake"
+$ttk_dir = $MyInvocation.MyCommand.Definition | Split-Path | Split-Path
+$prefix = $ttk_dir | Split-Path
+# assumption: TTK and TTK-ParaView installed in the same prefix
+$pv_dir = "${prefix}\TTK-ParaView"
+
+function find_conda_dir() {
+    # assumption: Anaconda environment variables set
+    $python_exe = Get-Command python
+    If ($null -eq $python_exe) {
+        Write-Output "Error: Python executable not accessible in PATH"
+        exit
+    }
+    $conda_dir = $python_exe.Definition | Split-Path
+    If (-not ($conda_dir -Match "conda")) {
+        Write-Output "Error: Python not part of an Anaconda distribution"
+        exit
+    }
+    return $conda_dir
+}
+
+$conda_dir = find_conda_dir
+
+& $main "PATH" "${ttk_dir}\bin;${pv_dir}\bin"
+& $main "PV_PLUGIN_PATH" "${ttk_dir}\bin\plugins"
+& $main "QT_PLUGIN_PATH" "${conda_dir}\Library\plugins"
+& $main "PYTHONPATH" "${conda_dir}\Lib;${ttk_dir}\bin\Lib\site-packages;${pv_dir}\bin\Lib\site-packages"
+& $main "CMAKE_PREFIX_PATH" "${ttk_dir}\lib\cmake;${pv_dir}\lib\cmake"


### PR DESCRIPTION
This PR introduces a Powershell script used in the packaging step for setting environment variables when installing Windows packages. The script is also called at uninstall to remove those environment variables.

Additionally, a clang-cl warning about unused parameters cluttering the Windows packaging CI has been disabled.

Enjoy,
Pierre
