### PR TITLE
Removed fixed iteration limit from LTS procedure

### DIFF
--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -623,10 +623,8 @@ namespace ttk {
       while(containsResidualExtrema) {
         propagation->nIterations++;
 
-        if(propagation->nIterations > 20) {
-          this->printErr("Unable to converge within 20 iterations!");
-          return 0;
-        }
+        if(this->debugLevel_ > 3 && propagation->nIterations == 20)
+          this->printWrn("Unable to converge with less than 20 iterations!");
 
         // execute superlevel set propagation
         status = this->computeLocalOrderOfSegmentIteration<IT, TT>(


### PR DESCRIPTION
Hi Julien,
this is the oneliner fix for issue #541. I did not run all state files again, since I just removed the limit that is not reached for these states anyway.

Best
Jonas