### PR TITLE
Fix MSVC std::min overload error

### DIFF
--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -141,7 +141,7 @@ int OneSkeleton::buildEdgeList(
   printMsg("Building edges", 0, 0, 1, ttk::debug::LineMode::REPLACE);
 
   const SimplexId cellNumber = cellArray.getNbCells();
-  const int timeBuckets = std::min(10, cellNumber);
+  const int timeBuckets = std::min<ttk::SimplexId>(10, cellNumber);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -144,7 +144,7 @@ int ThreeSkeleton::buildCellNeighborsFromTriangles(
   if(threadNumber_ == 1) {
 
     const SimplexId nbTriStars = localTriangleStars->size();
-    const SimplexId timeBuckets = std::min(10, nbTriStars);
+    const SimplexId timeBuckets = std::min<ttk::SimplexId>(10, nbTriStars);
 
     for(SimplexId i = 0; i < nbTriStars; i++) {
 

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -309,7 +309,7 @@ int TwoSkeleton::buildTriangleList(
     vector<vector<pair<vector<SimplexId>, SimplexId>>> triangleTable(
       vertexNumber);
 
-    const SimplexId timeBuckets = std::min(10, cellNumber);
+    const SimplexId timeBuckets = std::min<ttk::SimplexId>(10, cellNumber);
 
     for(SimplexId i = 0; i < vertexNumber; i++)
       triangleTable[i].reserve(32);

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -545,7 +545,7 @@ int ZeroSkeleton::buildVertexStars(
   }
 
   const SimplexId cellNumber = cellArray.getNbCells();
-  const SimplexId timeBuckets = std::min(10, cellNumber);
+  const SimplexId timeBuckets = std::min<ttk::SimplexId>(10, cellNumber);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)


### PR DESCRIPTION
- Handle multiple template types for std::min
 without a static_cast.
- Call it with wider type ttk::SimplexId
- Contribution `std::min(int, ttk::SimplexId)` -> `std::min<ttk::SimplexId>(a, b)`

Resolves #546
