### PR TITLE
WhiteList mode changes to selectively enable filters

### DIFF
--- a/CMake/ParaViewFilter.cmake
+++ b/CMake/ParaViewFilter.cmake
@@ -23,7 +23,6 @@ macro(ttk_register_pv_filter vtkModuleDir xmlFile)
   ttk_get_target(${TTK_NAME} TTK_TARGET)
   if(NOT "${TTK_TARGET}" STREQUAL "")
     list(APPEND TTK_MODULES ${TTK_TARGET})
-    list(APPEND TTK_VTK_MODULE_FILES ${VTKWRAPPER_DIR}/${vtkModuleDir}/vtk.module)
     if(NOT "${xmlFile}" STREQUAL "")
 
       # replace variables of original XML file and store generated file in build dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,6 @@ option(TTK_BUILD_STANDALONE_APPS "Build the TTK Standalone Applications" ON)
 option(TTK_WHITELIST_MODE "Explicitely enable each filter" OFF)
 mark_as_advanced(TTK_WHITELIST_MODE BUILD_SHARED_LIBS)
 
-if(${TTK_WHITELIST_MODE})
-  set(TTK_ENABLE_FILTER_DEFAULT "DONT_WANT" CACHE INTERNAL "Default value for each filter build")
-else()
-  set(TTK_ENABLE_FILTER_DEFAULT "WANT" CACHE INTERNAL "Default value for each filter build")
-endif()
-
 # This option allows library to be built dynamic
 # like the TopologyToolKit.so file for paraview
 option(BUILD_SHARED_LIBS "Build TTK as shared lib" ON)

--- a/config.cmake
+++ b/config.cmake
@@ -1,11 +1,13 @@
 set(CMAKE_CXX_STANDARD 11)
 
-# Set a predefined build type
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+# Set a default build type if none was specified
+get_property(generator_is_multi_config GLOBAL
+  PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (NOT CMAKE_BUILD_TYPE AND NOT generator_is_multi_config)
   message(STATUS "Setting build type to 'Release'.")
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
-endif()
+endif ()
 
 # Options & dependencies
 

--- a/paraview/CMakeLists.txt
+++ b/paraview/CMakeLists.txt
@@ -3,7 +3,6 @@
 # The goal is to create a single plugin for parview
 set(TTK_XMLS             "" CACHE INTERNAL "")
 set(TTK_MODULES          "" CACHE INTERNAL "")
-set(TTK_VTK_MODULE_FILES "" CACHE INTERNAL "")
 file(GLOB PARAVIEW_PLUGIN_DIRS *)
 foreach(PARAVIEW_PLUGIN ${PARAVIEW_PLUGIN_DIRS})
   if(IS_DIRECTORY ${PARAVIEW_PLUGIN})

--- a/paraview/singlePlugin/CMakeLists.txt
+++ b/paraview/singlePlugin/CMakeLists.txt
@@ -2,6 +2,8 @@
 # https://discourse.paraview.org/t/install-headers-for-vtk-modules-build-by-paraview-5-7-0/2721
 set(_paraview_add_plugin_MODULES_FILES TRUE)
 
+list(REMOVE_DUPLICATES TTK_MODULES)
+
 paraview_add_plugin(TopologyToolKit
   VERSION "1.0"
   REQUIRED_ON_CLIENT


### PR DESCRIPTION
Dear Julien,

This PR bring some changes (and fixes) for the whitelist mode of TTK.
Now, when the Whitelist mode is switched to ON, all filters with `DEFAULT` status are switched to `DONT_WANT`. This makes the whitelist functional even when enabled on an already configured TTK.

I have also fixed the ninja generator (no more -w duplicate=err needed) and clean some unused stuff.
Fix #298 

Best !
Charles


