### PR TITLE
Add GetOutput, SetInputData, AddInputData convenience methods to ttkAlgorithm

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -8,6 +8,7 @@
 
 #include <vtkCellTypes.h>
 #include <vtkCommand.h>
+#include <vtkDataSet.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
 #include <vtkInformationIntegerKey.h>
@@ -219,6 +220,30 @@ int prepOutput(vtkInformation *info, std::string className) {
     info->Set(vtkDataObject::DATA_OBJECT(), newOutput);
   }
   return 1;
+}
+
+vtkDataSet *ttkAlgorithm::GetOutput() {
+  return this->GetOutput(0);
+}
+
+vtkDataSet *ttkAlgorithm::GetOutput(int port) {
+  return vtkDataSet::SafeDownCast(this->GetOutputDataObject(port));
+}
+
+void ttkAlgorithm::SetInputData(vtkDataSet *input) {
+  this->SetInputData(0, input);
+}
+
+void ttkAlgorithm::SetInputData(int index, vtkDataSet *input) {
+  this->SetInputDataInternal(index, input);
+}
+
+void ttkAlgorithm::AddInputData(vtkDataSet *input) {
+  this->AddInputData(0, input);
+}
+
+void ttkAlgorithm::AddInputData(int index, vtkDataSet *input) {
+  this->AddInputDataInternal(index, input);
 }
 
 int ttkAlgorithm::RequestDataObject(vtkInformation *request,

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -158,6 +158,28 @@ public:
                      vtkInformationVector **inputVectors,
                      vtkInformationVector *outputVector) override;
 
+  /**
+   * Get the output data object for a port on this algorithm.
+   */
+  vtkDataSet *GetOutput();
+  vtkDataSet *GetOutput(int);
+
+  /**
+   * Assign a data object as input. Note that this method does not
+   * establish a pipeline connection. Use SetInputConnection() to
+   * setup a pipeline connection.
+   */
+  void SetInputData(vtkDataSet *);
+  void SetInputData(int, vtkDataSet *);
+
+  /**
+   * Assign a data object as input. Note that this method does not
+   * establish a pipeline connection. Use AddInputConnection() to
+   * setup a pipeline connection.
+   */
+  void AddInputData(vtkDataSet *);
+  void AddInputData(int, vtkDataSet *);
+
 protected:
   ttkAlgorithm();
   virtual ~ttkAlgorithm();


### PR DESCRIPTION
This PR adds convenience methods for getting and setting input/output data to `ttkAlgorithm`.
These methods used to exist in TTK <= 0.9.8, as part of `vtkDataSetAlgorithm`.

See also #544 