### PR TITLE
Remove unused cmake variable.

### DIFF
--- a/core/vtk/CMakeLists.txt
+++ b/core/vtk/CMakeLists.txt
@@ -1,6 +1,6 @@
 vtk_module_find_modules(
   TTK_VTK_MODULE_FILE
-    "${CMAKE_CURRENT_SOURCE_DIR}/${VTKWRAPPER}"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
   )
 
 vtk_module_scan(


### PR DESCRIPTION
This concerns target `ttkAll`.
 
`${VTKWRAPPER}` is neither set nor used anywhere else in the build system. Perhaps it was leftover from previous commits :smile: 

