### PR TITLE
Enforce clang-format code formatting with GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,9 +23,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Use clang-format to detect formatting issues [NOT ENFORCED]
+    - name: Use clang-format to detect formatting issues
       run: |
-        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs clang-format -n
+        sudo apt update
+        sudo apt install -y clang-format-11
+        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs clang-format-11 -n -Werror
 
     - name: Check line endings (Unix rather than DOS) [NOT ENFORCED]
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,9 +76,7 @@ jobs:
           graphviz \
           python3-sklearn \
           zlib1g-dev \
-          dpkg-dev \
-          clang-tidy \
-          clang-tools
+          clang-tidy
 
     - uses: dsaltares/fetch-gh-release-asset@master
       with:
@@ -134,8 +132,6 @@ jobs:
           graphviz \
           python3-sklearn \
           zlib1g-dev \
-          dpkg-dev \
-          clang-tidy \
           clang-tools
 
     - uses: dsaltares/fetch-gh-release-asset@master

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,9 +29,9 @@ jobs:
         sudo apt install -y clang-format-11
         git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs clang-format-11 -n -Werror
 
-    - name: Check line endings (Unix rather than DOS) [NOT ENFORCED]
+    - name: Check line endings (Unix rather than DOS)
       run: |
-        git ls-files | xargs file "{}" ";" | grep CRLF || true
+        ! git ls-files | xargs file "{}" ";" | grep CRLF
 
     - name: Check files not ending with a newline [NOT ENFORCED]
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,6 +99,7 @@ jobs:
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
+          -DTTK_ENABLE_OPENMP=FALSE \
           $GITHUB_WORKSPACE
 
     - name: Use clang-tidy to lint code [NOT ENFORCED]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,25 @@ on:
 
 jobs:
 
+
+  # ----------------------- #
+  # Check source formatting #
+  # ----------------------- #
+  check-formatting:
+    runs-on: ubuntu-20.04
+    env:
+      CLANG_FORMAT: clang-format-11
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install latest clang-format
+      run: |
+        sudo apt update
+        sudo apt install -y $CLANG_FORMAT
+    - name: Use clang-format to detect formatting issues
+      run: |
+        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs $CLANG_FORMAT -n -Werror
+
+
   # ------------- #
   # Code lint job #
   # ------------- #
@@ -22,12 +41,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-
-    - name: Use clang-format to detect formatting issues
-      run: |
-        sudo apt update
-        sudo apt install -y clang-format-11
-        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs clang-format-11 -n -Werror
 
     - name: Check line endings (Unix rather than DOS)
       run: |


### PR DESCRIPTION
This PR uses the latest clang-format (v11), now available on Ubuntu 20.04 in a separate package, to check source code formatting.
This check has been moved in a specific job that fails if the source code in not properly formatted (using this particular version of clang-format).

In case this check proves to fail too often, it can be disabled by removing the `-Werror` argument in the command line.

Enjoy,
Pierre