### PR TITLE
Fix TTK compilation with ENABLE_64BIT_IDS=ON

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,6 +117,7 @@ jobs:
       matrix:
         kamikaze: [KAMIKAZE=TRUE, KAMIKAZE=FALSE]
         omp: [OPENMP=TRUE, OPENMP=FALSE]
+        simplexId: [64BIT_IDS=TRUE, 64BIT_IDS=FALSE]
     steps:
     - uses: actions/checkout@v2
 
@@ -155,6 +156,7 @@ jobs:
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
           -DTTK_ENABLE_${{ matrix.kamikaze }} \
           -DTTK_ENABLE_${{ matrix.omp }} \
+          -DTTK_ENABLE_${{ matrix.simplexId }} \
           $GITHUB_WORKSPACE
 
     - name: Use clang-check for compiler warnings

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -315,7 +315,7 @@ namespace ttk {
         std::tuple<std::vector<SimplexId>, std::vector<SimplexId>> overlaps
           = getOverlaps(i);
         const SimplexId &partitionSize
-          = abs(std::get<0>(rangeJT) - std::get<1>(rangeJT))
+          = std::abs(std::get<0>(rangeJT) - std::get<1>(rangeJT))
             + std::get<0>(overlaps).size() + std::get<1>(overlaps).size();
 
         // ---------------

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -875,12 +875,13 @@ namespace ttk {
           msg << "partition : " << static_cast<unsigned>(treeData_.partition);
           msg << ", isJT : " << isJT;
           msg << ",  size : ";
-          msg << "before  : " << abs(beforeEnd - beforeStart);
-          msg << ", main : " << abs(mainEnd - mainStart);
-          msg << ", after : " << abs(afterEnd - afterStart);
+          msg << "before  : " << std::abs(beforeEnd - beforeStart);
+          msg << ", main : " << std::abs(mainEnd - mainStart);
+          msg << ", after : " << std::abs(afterEnd - afterStart);
           msg << ", Total : ";
-          msg << abs(beforeEnd - beforeStart) + abs(mainEnd - mainStart)
-                   + abs(afterEnd - afterStart);
+          msg << std::abs(beforeEnd - beforeStart)
+                   + std::abs(mainEnd - mainStart)
+                   + std::abs(afterEnd - afterStart);
           this->printMsg(msg.str());
         }
       }

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -239,7 +239,7 @@ int ttk::TopologicalCompression::PerformSimplification(
   const triangulationType &triangulation) {
 
   std::vector<int> inputOffsets(vertexNumber);
-  std::vector<int> critConstraints(nbConstraints);
+  std::vector<SimplexId> critConstraints(nbConstraints);
   std::vector<double> inArray(vertexNumber);
   // std::vector<int> *oo = new std::vector<int>(vertexNumber);
   decompressedOffsets_.resize(vertexNumber); // oo->data();
@@ -449,7 +449,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
 
   const char *sq = SQMethod.c_str();
   int nbCrit = 0;
-  std::vector<int> simplifiedConstraints;
+  std::vector<SimplexId> simplifiedConstraints;
   if(strcmp(sq, "") == 0 && !ZFPOnly) {
     // No SQ: perform topological control
 

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -166,10 +166,10 @@ namespace ttk {
     inline std::vector<double> &getDecompressedData() {
       return decompressedData_;
     }
-    inline std::vector<int> &getDecompressedOffsets() {
+    inline std::vector<SimplexId> &getDecompressedOffsets() {
       return decompressedOffsets_;
     }
-    inline std::vector<int> &getCompressedOffsets() {
+    inline std::vector<SimplexId> &getCompressedOffsets() {
       return compressedOffsets_;
     }
 
@@ -403,8 +403,8 @@ namespace ttk {
     int NbSegments{0};
     int rawFileLength{0};
     std::vector<double> decompressedData_{};
-    std::vector<int> decompressedOffsets_{};
-    std::vector<int> compressedOffsets_{};
+    std::vector<SimplexId> decompressedOffsets_{};
+    std::vector<SimplexId> compressedOffsets_{};
     int vertexNumberRead_{};
     char *fileName{};
 

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vtkIntArray.h>
+#include <vtkLongLongArray.h>
 
 #define TTK_COMMA ,
 

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -123,7 +123,7 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   for(size_t i = 0; i < jacobiSet_.size(); i++) {
 
     int edgeId = jacobiSet_[i].first;
-    int vertexId0 = -1, vertexId1 = -1;
+    ttk::SimplexId vertexId0 = -1, vertexId1 = -1;
     triangulation->getEdgeVertex(edgeId, 0, vertexId0);
     triangulation->getEdgeVertex(edgeId, 1, vertexId1);
 
@@ -176,7 +176,7 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
 
       for(size_t j = 0; j < jacobiSet_.size(); j++) {
         int edgeId = jacobiSet_[j].first;
-        int vertexId0 = -1, vertexId1 = -1;
+        ttk::SimplexId vertexId0 = -1, vertexId1 = -1;
         triangulation->getEdgeVertex(edgeId, 0, vertexId0);
         triangulation->getEdgeVertex(edgeId, 1, vertexId1);
 

--- a/core/vtk/ttkReebSpace/ttkReebSpace.cpp
+++ b/core/vtk/ttkReebSpace/ttkReebSpace.cpp
@@ -312,7 +312,7 @@ int ttkReebSpace::RequestData(vtkInformation *request,
 
       if((sheet) && (!sheet->pruned_)) {
 
-        int vertexId0 = -1, vertexId1 = -1;
+        ttk::SimplexId vertexId0 = -1, vertexId1 = -1;
         triangulation->getEdgeVertex(i, 0, vertexId0);
         triangulation->getEdgeVertex(i, 1, vertexId1);
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -168,7 +168,7 @@ int ttkTopologicalSimplification::RequestData(
         ret = this->execute(
           static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
           static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
-          static_cast<int *>(ttkUtils::GetVoidPointer(identifiers)),
+          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(identifiers)),
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsets)),
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
           numberOfConstraints, *triangulation->getData()));


### PR DESCRIPTION
This PR fixes the TTK build with `TTK_ENABLE_64BIT_IDS=ON`. Mainly a matter of switching `std::vector<int>` to `std::vector<SimplexId>` and using `std::abs` instead of the non-templated `abs` alternative.

This should fix #554.

A new warning check configuration has been added to the GitHub Actions CI to make sure that TTK stays able to be built in this configuration without errors.

No change has been observed in ttk-data with the default `TTK_ENABLE_64BIT_IDS=OFF`. I have not tested the states with it enabled though (as I suspect this would cause some crashes).

Enjoy,
Pierre