### PR TITLE
Collection of fixes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,7 @@ on:
     tags:
       - 'v*'
       - 'dev*'
+      - 'ci*'
   pull_request:
     # also triggered by pull requests on the "dev" branch
     branches:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,9 +61,9 @@ jobs:
       run: |
         git ls-files | xargs file | grep Unicode || true
 
-    - name: Check for empty files [NOT ENFORCED]
+    - name: Check for empty files
       run: |
-        git ls-files | xargs file | grep empty || true
+        ! git ls-files | xargs file | grep empty
 
     - name: Install Ubuntu dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
-        brew cask install xquartz
+        brew install --cask xquartz
         brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost eigen graphviz embree
@@ -251,7 +251,7 @@ jobs:
     - name: Install macOS run-time dependencies
       run: |
         # ParaView dependencies
-        brew cask install xquartz
+        brew install --cask xquartz
         brew install wget libomp mesa glew qt
         # TTK dependencies
         brew install boost graphviz embree

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -346,7 +346,7 @@ jobs:
 
 - job:
   condition: true
-  displayName: MacOS-PV-Python3-OpenMP-Make (no install)
+  displayName: MacOS-PV-Python3-OpenMP-Ninja
   timeoutInMinutes: 180
 
   variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -363,7 +363,7 @@ jobs:
 
   steps:
   - script: |
-      brew cask install xquartz
+      brew install --cask xquartz
       brew install wget libomp mesa glew boost ccache qt ninja python
     displayName: 'Install dependencies'
 

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -60,16 +60,16 @@ namespace ttk {
     }
 
     explicit Separatrix(Separatrix &&separatrix)
-      : isValid_{separatrix.isValid_}, source_{std::move(separatrix.source_)},
-        destination_{std::move(separatrix.destination_)},
-        isReversed_{std::move(separatrix.isReversed_)},
+      : isValid_{separatrix.isValid_}, source_{separatrix.source_},
+        destination_{separatrix.destination_}, isReversed_{std::move(
+                                                 separatrix.isReversed_)},
         geometry_{std::move(separatrix.geometry_)} {
     }
 
     Separatrix &operator=(Separatrix &&separatrix) {
       isValid_ = separatrix.isValid_;
-      source_ = std::move(separatrix.source_);
-      destination_ = std::move(separatrix.destination_);
+      source_ = separatrix.source_;
+      destination_ = separatrix.destination_;
       isReversed_ = std::move(separatrix.isReversed_);
       geometry_ = std::move(separatrix.geometry_);
 

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -20,19 +20,7 @@
 
 #include <queue>
 
-#if defined(__GNUC__) && !defined(__clang__)
-#include <parallel/algorithm>
-#endif
-
 namespace ttk {
-
-#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
-#define PSORT                               \
-  omp_set_num_threads(this->threadNumber_); \
-  __gnu_parallel::sort
-#else
-#define PSORT std::sort
-#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
 
   /**
    * Utility class representing Ridge lines, Valley lines
@@ -942,7 +930,7 @@ int ttk::AbstractMorseSmaleComplex::setFinalSegmentation(
     morseSmaleManifold, morseSmaleManifold + nVerts);
 
   // get unique "sparse region ids"
-  PSORT(sparseRegionIds.begin(), sparseRegionIds.end());
+  PSORT(this->threadNumber_)(sparseRegionIds.begin(), sparseRegionIds.end());
   const auto last = std::unique(sparseRegionIds.begin(), sparseRegionIds.end());
   sparseRegionIds.erase(last, sparseRegionIds.end());
 

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -59,14 +59,14 @@ namespace ttk {
         isReversed_{separatrix.isReversed_}, geometry_{separatrix.geometry_} {
     }
 
-    explicit Separatrix(Separatrix &&separatrix)
+    explicit Separatrix(Separatrix &&separatrix) noexcept
       : isValid_{separatrix.isValid_}, source_{separatrix.source_},
         destination_{separatrix.destination_}, isReversed_{std::move(
                                                  separatrix.isReversed_)},
         geometry_{std::move(separatrix.geometry_)} {
     }
 
-    Separatrix &operator=(Separatrix &&separatrix) {
+    Separatrix &operator=(Separatrix &&separatrix) noexcept {
       isValid_ = separatrix.isValid_;
       source_ = separatrix.source_;
       destination_ = separatrix.destination_;

--- a/core/base/abstractTriangulation/AbstractTriangulation.cpp
+++ b/core/base/abstractTriangulation/AbstractTriangulation.cpp
@@ -66,7 +66,7 @@ int AbstractTriangulation::clear() {
 template <class itemType>
 size_t AbstractTriangulation::tableTableFootprint(
   const vector<vector<itemType>> &table,
-  const string tableName,
+  const string &tableName,
   ostream &stream) const {
 
   size_t localByteNumber = 0;

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3143,7 +3143,7 @@ namespace ttk {
 
     template <class itemType>
     size_t tableFootprint(const std::vector<itemType> &table,
-                          const std::string tableName = "",
+                          const std::string &tableName = "",
                           std::ostream &stream = std::cout) const {
 
       std::stringstream msg;
@@ -3158,7 +3158,7 @@ namespace ttk {
 
     template <class itemType>
     size_t tableTableFootprint(const std::vector<std::vector<itemType>> &table,
-                               const std::string tableName = "",
+                               const std::string &tableName = "",
                                std::ostream &stream = std::cout) const;
 
     int updateProgress(const float &progress) {

--- a/core/base/common/OrderDisambiguation.h
+++ b/core/base/common/OrderDisambiguation.h
@@ -39,28 +39,28 @@ namespace ttk {
     }
 
 #if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
-#define PSORT                    \
-  omp_set_num_threads(nThreads); \
+#define PSORT(NTHREADS)          \
+  omp_set_num_threads(NTHREADS); \
   __gnu_parallel::sort
 #else
-#define PSORT std::sort
+#define PSORT(NTHREADS) std::sort
 #endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
 
     if(offsets != nullptr) {
-      PSORT(sortedVertices.begin(), sortedVertices.end(),
-            [&](const SimplexId a, const SimplexId b) {
-              return (scalars[a] < scalars[b])
-                     || (scalars[a] == scalars[b] && offsets[a] < offsets[b]);
-            });
+      PSORT(nThreads)
+      (sortedVertices.begin(), sortedVertices.end(),
+       [&](const SimplexId a, const SimplexId b) {
+         return (scalars[a] < scalars[b])
+                || (scalars[a] == scalars[b] && offsets[a] < offsets[b]);
+       });
     } else {
-      PSORT(sortedVertices.begin(), sortedVertices.end(),
-            [&](const SimplexId a, const SimplexId b) {
-              return (scalars[a] < scalars[b])
-                     || (scalars[a] == scalars[b] && a < b);
-            });
+      PSORT(nThreads)
+      (sortedVertices.begin(), sortedVertices.end(),
+       [&](const SimplexId a, const SimplexId b) {
+         return (scalars[a] < scalars[b])
+                || (scalars[a] == scalars[b] && a < b);
+       });
     }
-
-#undef PSORT
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(nThreads)

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -305,7 +305,7 @@ int SubLevelSetTree::build() {
 
     if(!vertexSeeds[vertexId]) {
 
-      vertexSeeds[vertexId] = makeUnion(starSets);
+      vertexSeeds[vertexId] = UnionFind::makeUnion(starSets);
 
       int newNodeId = makeNode(vertexId);
 

--- a/core/base/depthImageBasedGeometryApproximation/CMakeLists.txt
+++ b/core/base/depthImageBasedGeometryApproximation/CMakeLists.txt
@@ -1,6 +1,4 @@
-ttk_add_base_library(depthImageBasedGeometryApproximation
-  SOURCES
-    DepthImageBasedGeometryApproximation.cpp
+ttk_add_base_template_library(depthImageBasedGeometryApproximation
   HEADERS
     DepthImageBasedGeometryApproximation.h
   DEPENDS

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -151,11 +151,10 @@ int DiscreteGradient::setCriticalPoints(
     outputCriticalPoints_points_PLVertexIdentifiers_[i] = vertId;
   }
 
-  std::vector<std::vector<std::string>> rows{};
+  std::vector<std::vector<std::string>> rows(numberOfDimensions);
   for(int i = 0; i < numberOfDimensions; ++i) {
-    rows.emplace_back(
-      std::vector<std::string>{"#" + std::to_string(i) + "-cell(s)",
-                               std::to_string(nCriticalPointsByDim[i])});
+    rows[i] = std::vector<std::string>{"#" + std::to_string(i) + "-cell(s)",
+                                       std::to_string(nCriticalPointsByDim[i])};
   }
   this->printMsg(rows);
 
@@ -1689,12 +1688,12 @@ int DiscreteGradient::reverseGradient(const triangulationType &triangulation,
         }
       }
 
-      std::vector<std::vector<std::string>> rows{};
+      std::vector<std::vector<std::string>> rows(numberOfDimensions);
       for(int i = 0; i < numberOfDimensions; ++i) {
-        rows.emplace_back(std::vector<std::string>{
+        rows[i] = std::vector<std::string>{
           "#" + std::to_string(i) + "-cell(s)",
           std::to_string(nDMTCriticalPoints[i]) + " (with "
-            + std::to_string(nPLInteriorCriticalPoints[i]) + " interior PL)"});
+            + std::to_string(nPLInteriorCriticalPoints[i]) + " interior PL)"};
       }
       this->printMsg(rows);
     }

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -52,7 +52,7 @@ namespace ttk {
 #endif
     }
 
-    FTMAtomicVector(FTMAtomicVector &&other) = default;
+    FTMAtomicVector(FTMAtomicVector &&other) noexcept = default;
 
     virtual ~FTMAtomicVector() = default;
 

--- a/core/base/ftmTree/FTMNode.h
+++ b/core/base/ftmTree/FTMNode.h
@@ -168,12 +168,12 @@ namespace ttk {
       }
 
       void sortUpArcs(
-        std::function<bool(const idSuperArc, const idSuperArc)> comp) {
+        const std::function<bool(const idSuperArc, const idSuperArc)> &comp) {
         sort(vect_upSuperArcList_.begin(), vect_upSuperArcList_.end(), comp);
       }
 
       void sortDownArcs(
-        std::function<bool(const idSuperArc, const idSuperArc)> comp) {
+        const std::function<bool(const idSuperArc, const idSuperArc)> &comp) {
         sort(
           vect_downSuperArcList_.begin(), vect_downSuperArcList_.end(), comp);
       }

--- a/core/base/ftmTree/FTMStructures.h
+++ b/core/base/ftmTree/FTMStructures.h
@@ -64,11 +64,11 @@ namespace ttk {
       boost::heap::fibonacci_heap<SimplexId, boost::heap::compare<VertCompFN>>
         propagation;
 
-      CurrentState(SimplexId startVert, VertCompFN vertComp)
+      CurrentState(SimplexId startVert, VertCompFN &vertComp)
         : vertex(startVert), propagation(vertComp) {
       }
 
-      CurrentState(VertCompFN vertComp)
+      CurrentState(VertCompFN &vertComp)
         : vertex(nullVertex), propagation(vertComp) {
         // will need to use setStartVert before use
       }

--- a/core/base/ftrGraph/FTRAtomicVector.h
+++ b/core/base/ftrGraph/FTRAtomicVector.h
@@ -52,7 +52,7 @@ namespace ttk {
     }
 
     // move constructor
-    FTRAtomicVector(FTRAtomicVector &&other) = default;
+    FTRAtomicVector(FTRAtomicVector &&other) noexcept = default;
 
     virtual ~FTRAtomicVector() = default;
 
@@ -154,7 +154,7 @@ namespace ttk {
       return *this;
     }
 
-    FTRAtomicVector<type> &operator=(FTRAtomicVector<type> &&other) {
+    FTRAtomicVector<type> &operator=(FTRAtomicVector<type> &&other) noexcept {
       std::vector<type>::operator=(std::move(other));
       nextId = std::move(other.nextId);
       return *this;

--- a/core/base/ftrGraph/Graph.h
+++ b/core/base/ftrGraph/Graph.h
@@ -55,11 +55,11 @@ namespace ttk {
       std::vector<valence> valDown_, valUp_;
 
       Graph();
-      Graph(Graph &&other) = default;
+      Graph(Graph &&other) noexcept = default;
       Graph(const Graph &other) = delete;
       virtual ~Graph();
 
-      Graph &operator=(Graph &&other) {
+      Graph &operator=(Graph &&other) noexcept {
         if(this != &other) {
           leaves_ = std::move(other.leaves_);
           nodes_ = std::move(other.nodes_);

--- a/core/base/helloWorld/HelloWorld.cpp
+++ b/core/base/helloWorld/HelloWorld.cpp
@@ -1,0 +1,6 @@
+#include <HelloWorld.h>
+
+ttk::HelloWorld::HelloWorld() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("HelloWorld");
+}

--- a/core/base/helloWorld/HelloWorld.h
+++ b/core/base/helloWorld/HelloWorld.h
@@ -30,12 +30,7 @@ namespace ttk {
   class HelloWorld : virtual public Debug {
 
   public:
-    HelloWorld() {
-      this->setDebugMsgPrefix(
-        "HelloWorld"); // inherited from Debug: prefix will be printed at the
-      // beginning of every msg
-    };
-    ~HelloWorld(){};
+    HelloWorld();
 
     /**
      * TODO 2: This method preconditions the triangulation for all operations

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -322,7 +322,7 @@ namespace ttk {
     bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
       const SimplexId &edgeId) const override;
 
-    bool isEmptyInternal() const {
+    inline bool isEmpty() const override {
       return !vertexNumber_;
     };
 

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -492,8 +492,8 @@ char ttk::JacobiSet::getCriticalType(const SimplexId &edgeId,
               }
 
               if((lowerId0 != -1) && (lowerId1 != -1)) {
-                (*seeds)[lowerId0]
-                  = makeUnion((*seeds)[lowerId0], (*seeds)[lowerId1]);
+                (*seeds)[lowerId0] = UnionFind::makeUnion(
+                  (*seeds)[lowerId0], (*seeds)[lowerId1]);
                 (*seeds)[lowerId1] = (*seeds)[lowerId0];
               }
             }

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.cpp
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.cpp
@@ -1,0 +1,7 @@
+#include <LocalizedTopologicalSimplification.h>
+
+std::string ttk::toFixed(const float &number, const int precision) {
+  std::stringstream vFraction;
+  vFraction << std::fixed << std::setprecision(precision) << number;
+  return vFraction.str();
+}

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -34,11 +34,7 @@
 
 namespace ttk {
 
-  std::string toFixed(const float &number, const int precision = 2) {
-    std::stringstream vFraction;
-    vFraction << std::fixed << std::setprecision(precision) << number;
-    return vFraction.str();
-  };
+  std::string toFixed(const float &number, const int precision = 2);
 
   template <typename IT>
   std::string

--- a/core/base/manifoldCheck/ManifoldCheck.h
+++ b/core/base/manifoldCheck/ManifoldCheck.h
@@ -75,7 +75,8 @@ namespace ttk {
     /// \param triangulation Pointer to a valid triangulation.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa ttk::Triangulation
-    inline int preconditionTriangulation(Triangulation *triangulation) {
+    inline int
+      preconditionTriangulation(AbstractTriangulation *const triangulation) {
 
       if(triangulation) {
 

--- a/core/base/manifoldCheck/ManifoldCheck.h
+++ b/core/base/manifoldCheck/ManifoldCheck.h
@@ -278,7 +278,7 @@ int ttk::ManifoldCheck::vertexManifoldCheck(
         }
       }
 
-      seedList[uf0] = makeUnion(seedList[uf0], seedList[uf1]);
+      seedList[uf0] = UnionFind::makeUnion(seedList[uf0], seedList[uf1]);
       seedList[uf1] = seedList[uf0];
     }
 
@@ -307,8 +307,8 @@ int ttk::ManifoldCheck::vertexManifoldCheck(
         }
       }
 
-      seedList[uf0] = makeUnion(seedList[uf0], seedList[uf1]);
-      seedList[uf0] = makeUnion(seedList[uf0], seedList[uf2]);
+      seedList[uf0] = UnionFind::makeUnion(seedList[uf0], seedList[uf1]);
+      seedList[uf0] = UnionFind::makeUnion(seedList[uf0], seedList[uf2]);
       seedList[uf1] = seedList[uf0];
       seedList[uf2] = seedList[uf0];
     }
@@ -402,7 +402,7 @@ int ttk::ManifoldCheck::edgeManifoldCheck(
       }
     }
 
-    seedList[uf0] = makeUnion(seedList[uf0], seedList[uf1]);
+    seedList[uf0] = UnionFind::makeUnion(seedList[uf0], seedList[uf1]);
     seedList[uf1] = seedList[uf0];
   }
 

--- a/core/base/meshGraph/CMakeLists.txt
+++ b/core/base/meshGraph/CMakeLists.txt
@@ -1,6 +1,4 @@
-ttk_add_base_library(meshGraph
-  SOURCES
-    MeshGraph.cpp
+ttk_add_base_template_library(meshGraph
   HEADERS
     MeshGraph.h
   DEPENDS

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -332,7 +332,7 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
     }
   }
 
-  PSORT(cellVertsIds.begin(), cellVertsIds.end());
+  PSORT(this->threadNumber_)(cellVertsIds.begin(), cellVertsIds.end());
   const auto last = std::unique(cellVertsIds.begin(), cellVertsIds.end());
   cellVertsIds.erase(last, cellVertsIds.end());
 
@@ -590,7 +590,7 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
 
   // reduce the cell vertices ids
   // (cells are triangles sharing two vertices)
-  PSORT(cellVertsIds.begin(), cellVertsIds.end());
+  PSORT(this->threadNumber_)(cellVertsIds.begin(), cellVertsIds.end());
   const auto last = std::unique(cellVertsIds.begin(), cellVertsIds.end());
   cellVertsIds.erase(last, cellVertsIds.end());
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -266,7 +266,7 @@ namespace ttk {
     bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
       const SimplexId &edgeId) const override;
 
-    bool isEmpty() const override {
+    inline bool isEmpty() const override {
       return !vertexNumber_;
     };
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -974,15 +974,7 @@ inline ttk::SimplexId
 inline ttk::SimplexId
   ttk::PeriodicImplicitTriangulation::getEdgeStar2dL(const SimplexId p[2],
                                                      const int id) const {
-  if(p[1] > 0 and p[1] < nbvoxels_[Dj_]) {
-    switch(id) {
-      case 0:
-        return p[0] * 2 + p[1] * tshift_[0];
-      case 1:
-        return p[0] * 2 + (p[1] - 1) * tshift_[0] + 1;
-    }
-    return -1;
-  } else if(p[1] == 0) {
+  if(p[1] == 0) {
     switch(id) {
       case 0:
         return p[0] * 2 + p[1] * tshift_[0];
@@ -1004,15 +996,7 @@ inline ttk::SimplexId
 inline ttk::SimplexId
   ttk::PeriodicImplicitTriangulation::getEdgeStar2dH(const SimplexId p[2],
                                                      const int id) const {
-  if(p[0] > 0 and p[0] < nbvoxels_[Di_]) {
-    switch(id) {
-      case 0:
-        return p[0] * 2 + p[1] * tshift_[0];
-      case 1:
-        return (p[0] - 1) * 2 + p[1] * tshift_[0] + 1;
-    }
-    return -1;
-  } else if(p[0] == 0) {
+  if(p[0] == 0) {
     switch(id) {
       case 0:
         return p[0] * 2 + p[1] * tshift_[0];

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -56,7 +56,8 @@ namespace ttk {
                 const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
 
-    inline void preconditionTriangulation(Triangulation *triangulation) {
+    inline void
+      preconditionTriangulation(AbstractTriangulation *const triangulation) {
       if(triangulation) {
         triangulation->preconditionBoundaryVertices();
         contourTree_.setDebugLevel(debugLevel_);

--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -480,15 +480,17 @@ std::vector<int> PDClustering<dataType>::execute(
       }
     }
     resetDosToOriginalValues();
-    {
-      std::stringstream msg;
-      if(matchings_only) {
-        msg << " Wasserstein distance: " << cost_min_ + cost_sad_ + cost_max_;
-      } else {
-        msg << " Final Cost: " << min_cost_min + min_cost_sad + min_cost_max;
-      }
-      this->printMsg(msg.str());
-    }
+
+    // display results
+    std::vector<std::vector<std::string>> rows{
+      {" Min-saddle cost", std::to_string(cost_min_)},
+      {" Saddle-saddle cost", std::to_string(cost_sad_)},
+      {" Saddle-max cost", std::to_string(cost_max_)},
+      {matchings_only ? "Wasserstein Distance" : "Final Cost",
+       std::to_string(cost_min_ + cost_sad_ + cost_max_)},
+    };
+    this->printMsg(rows);
+
     // cout<<"TOTAL ELAPSED "<<total_time<<endl;
     // dataType real_cost=0;
     // real_cost=computeRealCost();

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.cpp
@@ -114,8 +114,8 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
       std::map<SimplexId, SimplexId>::iterator n1It
         = global2LowerLink.find(neighborId1);
 
-      lowerList[n0It->second]
-        = makeUnion(lowerList[n0It->second], lowerList[n1It->second]);
+      lowerList[n0It->second] = UnionFind::makeUnion(
+        lowerList[n0It->second], lowerList[n1It->second]);
       lowerList[n1It->second] = lowerList[n0It->second];
     }
 
@@ -129,8 +129,8 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
       std::map<SimplexId, SimplexId>::iterator n1It
         = global2UpperLink.find(neighborId1);
 
-      upperList[n0It->second]
-        = makeUnion(upperList[n0It->second], upperList[n1It->second]);
+      upperList[n0It->second] = UnionFind::makeUnion(
+        upperList[n0It->second], upperList[n1It->second]);
       upperList[n1It->second] = upperList[n0It->second];
     }
   }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -344,8 +344,8 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
                 }
               }
               if((lowerId0 != -1) && (lowerId1 != -1)) {
-                (*seeds)[lowerId0]
-                  = makeUnion((*seeds)[lowerId0], (*seeds)[lowerId1]);
+                (*seeds)[lowerId0] = UnionFind::makeUnion(
+                  (*seeds)[lowerId0], (*seeds)[lowerId1]);
                 (*seeds)[lowerId1] = (*seeds)[lowerId0];
               }
             }

--- a/core/base/triangulation/Triangulation.cpp
+++ b/core/base/triangulation/Triangulation.cpp
@@ -28,7 +28,7 @@ Triangulation::Triangulation(const Triangulation &rhs)
   }
 }
 
-Triangulation::Triangulation(Triangulation &&rhs)
+Triangulation::Triangulation(Triangulation &&rhs) noexcept
   : AbstractTriangulation(std::move(rhs)), abstractTriangulation_{nullptr},
     explicitTriangulation_{std::move(rhs.explicitTriangulation_)},
     implicitTriangulation_{std::move(rhs.implicitTriangulation_)},
@@ -69,7 +69,7 @@ Triangulation &Triangulation::operator=(const Triangulation &rhs) {
   return *this;
 }
 
-Triangulation &Triangulation::operator=(Triangulation &&rhs) {
+Triangulation &Triangulation::operator=(Triangulation &&rhs) noexcept {
   if(this != &rhs) {
     AbstractTriangulation::operator=(std::move(rhs));
     gridDimensions_ = std::move(rhs.gridDimensions_);

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -50,9 +50,9 @@ namespace ttk {
   public:
     Triangulation();
     Triangulation(const Triangulation &);
-    Triangulation(Triangulation &&);
+    Triangulation(Triangulation &&) noexcept;
     Triangulation &operator=(const Triangulation &);
-    Triangulation &operator=(Triangulation &&);
+    Triangulation &operator=(Triangulation &&) noexcept;
     ~Triangulation();
 
     enum class Type { EXPLICIT, IMPLICIT, PERIODIC };

--- a/core/base/unionFind/UnionFind.h
+++ b/core/base/unionFind/UnionFind.h
@@ -5,8 +5,7 @@
 ///
 /// \brief Union Find implementation for connectivity tracking.
 
-#ifndef _UNION_FIND_H
-#define _UNION_FIND_H
+#pragma once
 
 #include <Debug.h>
 
@@ -38,9 +37,39 @@ namespace ttk {
       return rank_;
     };
 
-    static inline UnionFind *makeUnion(UnionFind *uf0, UnionFind *uf1);
+    static inline UnionFind *makeUnion(UnionFind *uf0, UnionFind *uf1) {
+      uf0 = uf0->find();
+      uf1 = uf1->find();
 
-    static inline UnionFind *makeUnion(std::vector<UnionFind *> &sets);
+      if(uf0 == uf1) {
+        return uf0;
+      } else if(uf0->getRank() > uf1->getRank()) {
+        uf1->setParent(uf0);
+        return uf0;
+      } else if(uf0->getRank() < uf1->getRank()) {
+        uf0->setParent(uf1);
+        return uf1;
+      } else {
+        uf1->setParent(uf0);
+        uf0->setRank(uf0->getRank() + 1);
+        return uf0;
+      }
+    }
+
+    static inline UnionFind *makeUnion(std::vector<UnionFind *> &sets) {
+      UnionFind *n = NULL;
+
+      if(!sets.size())
+        return NULL;
+
+      if(sets.size() == 1)
+        return sets[0];
+
+      for(int i = 0; i < (int)sets.size() - 1; i++)
+        n = makeUnion(sets[i], sets[i + 1]);
+
+      return n;
+    }
 
     inline void setParent(UnionFind *parent) {
       parent_ = parent;
@@ -51,8 +80,8 @@ namespace ttk {
     };
 
   protected:
-    int rank_;
-    UnionFind *parent_;
+    int rank_{};
+    UnionFind *parent_{this};
   };
 
   inline UnionFind::UnionFind() {
@@ -77,42 +106,4 @@ namespace ttk {
     }
   }
 
-  static inline UnionFind *makeUnion(UnionFind *uf0, UnionFind *uf1) {
-
-    uf0 = uf0->find();
-    uf1 = uf1->find();
-
-    if(uf0 == uf1) {
-      return uf0;
-    } else if(uf0->getRank() > uf1->getRank()) {
-      uf1->setParent(uf0);
-      return uf0;
-    } else if(uf0->getRank() < uf1->getRank()) {
-      uf0->setParent(uf1);
-      return uf1;
-    } else {
-      uf1->setParent(uf0);
-      uf0->setRank(uf0->getRank() + 1);
-      return uf0;
-    }
-  }
-
-  static inline UnionFind *makeUnion(std::vector<UnionFind *> &sets) {
-
-    UnionFind *n = NULL;
-
-    if(!sets.size())
-      return NULL;
-
-    if(sets.size() == 1)
-      return sets[0];
-
-    for(int i = 0; i < (int)sets.size() - 1; i++)
-      n = makeUnion(sets[i], sets[i + 1]);
-
-    return n;
-  }
-
 } // namespace ttk
-
-#endif

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
@@ -67,9 +67,8 @@ int ttk::ttkCinemaImagingVTK::addValuePass(
   int fieldType,
   vtkRenderPassCollection *valuePassCollection,
   std::vector<std::string> &valuePassNames) const {
-  auto fd = static_cast<vtkFieldData *>(
-    fieldType == 0 ? (vtkFieldData *)object->GetPointData()
-                   : (vtkFieldData *)object->GetCellData());
+  auto fd = fieldType == 0 ? static_cast<vtkFieldData *>(object->GetPointData())
+                           : static_cast<vtkFieldData *>(object->GetCellData());
 
   for(size_t i = 0, j = fd->GetNumberOfArrays(); i < j; i++) {
     auto array = fd->GetArray(i);

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -61,7 +61,9 @@ int ttkDimensionReduction::RequestData(vtkInformation *request,
 
 #ifndef TTK_ENABLE_KAMIKAZE
     if(numberOfRows <= 0 || numberOfColumns <= 0) {
-      this->printErr("input matrix has invalid dimensions");
+      this->printErr("input matrix has invalid dimensions (rows: "
+                     + std::to_string(numberOfRows)
+                     + ", columns: " + std::to_string(numberOfColumns) + ")");
       return -1;
     }
 #endif

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -49,16 +49,8 @@ int shuffleScalarFieldValues(const T *const inputField,
   // copy input field into vector
   std::vector<T> inputValues(inputField, inputField + nValues);
 
-#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
-#define PSORT                    \
-  omp_set_num_threads(nThreads); \
-  __gnu_parallel::sort
-#else
-#define PSORT std::sort
-#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
-
   // reduce the copy
-  PSORT(inputValues.begin(), inputValues.end());
+  PSORT(nThreads)(inputValues.begin(), inputValues.end());
   const auto last = std::unique(inputValues.begin(), inputValues.end());
   inputValues.erase(last, inputValues.end());
 

--- a/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
+++ b/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
@@ -102,9 +102,9 @@ int ttkMatrixToHeatMap::RequestData(vtkInformation * /*request*/,
       const auto curr{static_cast<vtkIdType>(i * nptline + j)};
       const auto o = i * nRows + j;
       connectivity->SetTuple1(4 * o + 0, curr);
-      connectivity->SetTuple1(4 * o + 1, curr + nptline);
-      connectivity->SetTuple1(4 * o + 2, curr + nptline + 1);
-      connectivity->SetTuple1(4 * o + 3, curr + 1);
+      connectivity->SetTuple1(4 * o + 1, curr + 1);
+      connectivity->SetTuple1(4 * o + 2, curr + nptline);
+      connectivity->SetTuple1(4 * o + 3, curr + nptline + 1);
       offsets->SetTuple1(o, 4 * o);
 
       // copy distance matrix to heat map cell data
@@ -121,7 +121,7 @@ int ttkMatrixToHeatMap::RequestData(vtkInformation * /*request*/,
   vtkNew<vtkCellArray> cells{};
   cells->SetData(offsets, connectivity);
   output->SetPoints(points);
-  output->SetCells(VTK_QUAD, cells);
+  output->SetCells(VTK_PIXEL, cells);
   output->GetCellData()->AddArray(dist);
   output->GetCellData()->AddArray(prox);
 

--- a/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
+++ b/core/vtk/ttkPointDataConverter/ttkPointDataConverter.cpp
@@ -95,6 +95,10 @@ int ttkPointDataConverter::RequestData(vtkInformation *request,
   output->ShallowCopy(input);
 
   const auto inputScalarField = this->GetInputArrayToProcess(0, input);
+  if(inputScalarField == nullptr) {
+    this->printErr("No such input scalar field");
+    return 0;
+  }
   auto InputType = inputScalarField->GetDataType();
 
   bool oldUseNormalization{UseNormalization};

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -83,6 +83,10 @@ int ttkScalarFieldNormalizer::RequestData(vtkInformation *request,
 
   // get input scalar field
   vtkDataArray *inputArray = this->GetInputArrayToProcess(0, inputVector);
+  if(inputArray == nullptr) {
+    this->printErr("No such input scalar field");
+    return 0;
+  }
 
   vtkSmartPointer<vtkDataArray> outputArray
     = vtkSmartPointer<vtkDataArray>::Take(inputArray->NewInstance());

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -141,16 +141,16 @@ int ttkTopologicalSimplification::RequestData(
 
   int ret{};
   if(this->UseLTS) {
-    auto lts = new ttk::LocalizedTopologicalSimplification();
-    lts->setDebugLevel(this->debugLevel_);
-    lts->setThreadNumber(this->threadNumber_);
+    ttk::LocalizedTopologicalSimplification lts{};
+    lts.setDebugLevel(this->debugLevel_);
+    lts.setThreadNumber(this->threadNumber_);
 
-    lts->preconditionTriangulation(triangulation);
+    lts.preconditionTriangulation(triangulation);
 
     //   switch(inputScalars->GetDataType()) {
     ttkVtkTemplateMacro(
       inputScalars->GetDataType(), triangulation->getType(),
-      (ret = lts->removeUnauthorizedExtrema<VTK_TT, ttk::SimplexId, TTK_TT>(
+      (ret = lts.removeUnauthorizedExtrema<VTK_TT, ttk::SimplexId, TTK_TT>(
          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
 

--- a/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
+++ b/core/vtk/ttkTrackingFromFields/ttkTrackingFromFields.cpp
@@ -232,12 +232,12 @@ int ttkTrackingFromFields::RequestData(vtkInformation *request,
   this->setInputScalars(inputFields);
 
   // 0'. get offsets
-  std::vector<SimplexId *> inputOrders(fieldNumber);
+  std::vector<ttk::SimplexId *> inputOrders(fieldNumber);
   for(int i = 0; i < fieldNumber; ++i) {
     this->SetInputArrayToProcess(0, 0, 0, 0, inputScalarFields[i]->GetName());
     auto orderArray = this->GetOrderArray(input, 0, 0, false);
     inputOrders[i]
-      = static_cast<SimplexId *>(ttkUtils::GetVoidPointer(orderArray));
+      = static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(orderArray));
   }
   this->setInputOffsets(inputOrders);
 

--- a/paraview/patch/main.yml
+++ b/paraview/patch/main.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Install macOS dependencies
       run: |
-        brew cask install xquartz
+        brew install --cask xquartz
         brew install wget libomp mesa glew boost qt ninja
 
     - uses: actions/setup-python@v2

--- a/standalone/FTRGraph/CMakeLists.txt
+++ b/standalone/FTRGraph/CMakeLists.txt
@@ -12,7 +12,7 @@ if(TARGET ttkFTRGraph)
   set_target_properties(${PROJECT_NAME}
     PROPERTIES
       INSTALL_RPATH
-        "${CMAKE_INSTALL_RPATH}/lib64/TopologyToolKit"
+        "${CMAKE_INSTALL_RPATH}"
     )
   install(
     TARGETS


### PR DESCRIPTION
This PR fixes a collection of bugs I have encountered in the last trimester. Among them:
* use the new `brew install --cask` syntax in the macOS CI pipelines
* refactor the `PSORT` macro in order to make it independent of `BaseClass` derivatives by making the number of required threads a parameter
* removing empty source code files, making the corresponding base modules `ttk_add_base_template_library`
* `makeUnion` is now a member of `UnionFind` instead of a free function
* more explicit log messages for `PersistenceDiagramClustering` (distance per pair type) and `DimensionReduction`
* merging two if statements with the same body in `PeriodicImplicitGrid`
* reducing the number of clang-tidy warnings in shared C++ headers for the GitHub Action lint-code job
  + removing superfluous `std::move`
  + declaring move constructors/assignment operators `noexcept`
  + passing objects owning heap-allocated resources by reference instead of by value (`std::string`, functors…)
  + all the above reduce the clang-tidy job from 5,7k lines to 2,2k lines of warnings
* other potential segfaults and memory leaks fixes.

No change has been observed when running the ttk-data states.

Enjoy,
Pierre
