### PR TITLE
Fix the VTK array type for 64bit SimplexIds

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <vtkIdTypeArray.h>
 #include <vtkIntArray.h>
-#include <vtkLongLongArray.h>
 
 #define TTK_COMMA ,
 
 #ifdef TTK_ENABLE_64BIT_IDS
-using ttkSimplexIdTypeArray = vtkLongLongArray;
+using ttkSimplexIdTypeArray = vtkIdTypeArray;
 #else
 using ttkSimplexIdTypeArray = vtkIntArray;
 #endif


### PR DESCRIPTION
This PR alters the type of the `ttkSimplexIdTypeArray` from `vtkLongLongArray` to `vtkIdTypeArray` in the 64bit Ids mode.

Some TTK filters compare the offset array type to either `VTK_INT` (when SimplexId == int) or `VTK_ID_TYPE` (when SimplexId == long long): c.f. `ttkPersistenceDiagram.cpp`, `ttkMorseSmaleComplex.cpp` or `ttkTopologicalSimplification.cpp`. If the comparison fails, the filter aborts.

Since `vtkLongLongArray` datatype does not match `VTK_ID_TYPE` but `VTK_LONG_LONG`, those filters always failed in the 64bit Ids mode. The current PR fixes this issue.

I found this issue when testing the TTK examples in the 64bit ids mode after #556. Now, all 4 examples (C++, VTK-C++, Python and pvpython) seems to work correctly and output the correct Morse-Smale segmentation & separatrices. As a consequence, I believe that #337 can now be closed safely.

Enjoy,
Pierre
