### PR TITLE
MeshGraph with new CellRepresentation

### DIFF
--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.h
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.h
@@ -32,17 +32,12 @@ class TTKMESHGRAPH_EXPORT ttkMeshGraph : public ttkAlgorithm,
                                          protected ttk::MeshGraph {
 
 private:
-  bool UseVariableSize{false};
   int SizeAxis{0};
   float SizeScale{1};
   bool UseQuadraticCells{true};
   int Subdivisions{0};
-  bool Tetrahedralize{false};
 
 public:
-  vtkSetMacro(UseVariableSize, bool);
-  vtkGetMacro(UseVariableSize, bool);
-
   vtkSetMacro(SizeAxis, int);
   vtkGetMacro(SizeAxis, int);
 
@@ -54,9 +49,6 @@ public:
 
   vtkSetMacro(Subdivisions, int);
   vtkGetMacro(Subdivisions, int);
-
-  vtkSetMacro(Tetrahedralize, bool);
-  vtkGetMacro(Tetrahedralize, bool);
 
   static ttkMeshGraph *New();
   vtkTypeMacro(ttkMeshGraph, ttkAlgorithm);

--- a/paraview/MeshGraph/MeshGraph.xml
+++ b/paraview/MeshGraph/MeshGraph.xml
@@ -16,20 +16,13 @@
                 <Documentation>Input Graph.</Documentation>
             </InputProperty>
 
-            <IntVectorProperty name="UseVariableSize" label="Use Variable Size" command="SetUseVariableSize" number_of_elements="1" default_values="0">
-                <BooleanDomain name="bool" />
-                <Documentation>Use variable edge sizes.</Documentation>
-            </IntVectorProperty>
             <StringVectorProperty name="SizeArray" label="Size Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5">
                 <ArrayListDomain attribute_type="Scalars" name="array_list">
                     <RequiredProperties>
                         <Property function="Input" name="Input" />
                     </RequiredProperties>
                 </ArrayListDomain>
-                <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseVariableSize" value="1" />
-                </Hints>
-                <Documentation>Scalar array that contains point sizes.</Documentation>
+                <Documentation>Scalar array that contains point sizes (If you want constant scaling create a point array with the calculator filter).</Documentation>
             </StringVectorProperty>
 
             <DoubleVectorProperty name="SizeScale" label="Size Scale" command="SetSizeScale" number_of_elements="1" default_values="1">
@@ -54,16 +47,8 @@
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseQuadraticCells" value="0" />
                 </Hints>
             </IntVectorProperty>
-            <IntVectorProperty name="UseTetrahedralize" label="Tetrahedralize Output" command="SetTetrahedralize" number_of_elements="1" default_values="1">
-                <BooleanDomain name="bool" />
-                <Documentation>Tetrahedralize meshed graph because VTK has problems with concave polygons.</Documentation>
-                <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseQuadraticCells" value="0" />
-                </Hints>
-            </IntVectorProperty>
 
             <PropertyGroup panel_widget="Line" label="Input Options">
-                <Property name="UseVariableSize" />
                 <Property name="SizeArray" />
             </PropertyGroup>
             <PropertyGroup panel_widget="Line" label="Output Options">
@@ -71,7 +56,6 @@
                 <Property name="SizeScale" />
                 <Property name="UseQuadraticCells" />
                 <Property name="Subdivisions" />
-                <Property name="UseTetrahedralize" />
             </PropertyGroup>
 
             ${DEBUG_WIDGETS}


### PR DESCRIPTION
Hi Julien,
this PR updates the MeshGraph module to work with the new connectivity/offset format of vtkCells.

It also uses some new Macros that are currently only defined in the MeshGraph.cpp file, but I think these macros have an advantage over the macros we currently use since they mitigate template code explosion. In short, they work as the old ones, but you can limit the supported types per template dimension. So for instance the ttkTypeMacroARI macro expects three template parameters, where the first can be (A)ny type, the second must be a (R)eal, and the third an (I)nteger. This makes sense since coordinates of vtkPoints can only be stored as doubles or floats, whereas connectivity arrays must be integers (actually only int or long). This reduces the number of instances from 14x14x14 to 14x2x2. Lets see what you and @pierre-guillou have to say about this, but I think these macros should make it to the ttkMacros.h file and we should refactor some modules to get rid of template explosions where possible. A build with debug symbols already uses 16GB ram, this getting out of hand...

I will also open a new ttk-data PR that replaces both files that use the MeshGraph module (they still produce the same result).

Best
Jonas
