### PR TITLE
header cleanup; icosphere 2.0

### DIFF
--- a/core/base/icosphere/Icosphere.h
+++ b/core/base/icosphere/Icosphere.h
@@ -44,69 +44,70 @@ namespace ttk {
       return 1;
     };
 
-    template <typename dataType, typename idType>
+    /**
+     * Translates an icosphere
+     */
+    template <typename DT, typename IT>
     int translateIcosphere(
       // Output
-      dataType *vertexCoords,
-      idType *connectivityList,
+      DT *vertexCoords,
+      IT *connectivityList,
 
       // Input
       const size_t &icosphereIndex,
       const size_t &nVerticesPerIcosphere,
       const size_t &nTrianglesPerIcosphere,
-      const dataType *centers) const;
+      const DT *centers) const;
 
     /**
-     * Computes an icosphere for a given subdivision level, radius, and center.
+     * Computes an icosphere for a given subdivision level.
      */
-    template <typename dataType, typename idType>
+    template <typename DT, typename IT>
     int computeIcosphere(
       // Output
-      dataType *vertexCoords,
-      idType *connectivityList,
+      DT *vertexCoords,
+      IT *connectivityList,
 
       // Input
-      const size_t &nSubdivisions,
-      const dataType &radius) const;
+      const size_t &nSubdivisions) const;
 
     /**
      * Computes an icosphere for a given subdivision level, radius, and center.
      */
-    template <typename dataType, typename idType>
+    template <typename DT, typename IT>
     int computeIcospheres(
       // Output
-      dataType *vertexCoords,
-      idType *connectivityList,
+      DT *vertexCoords,
+      IT *connectivityList,
 
       // Input
       const size_t &nSpheres,
       const size_t &nSubdivisions,
-      const dataType &radius,
-      const dataType *center,
+      const DT &radius,
+      const DT *center,
 
       // Optional Output
-      float *normals = nullptr) const;
+      DT *normals = nullptr) const;
 
   private:
     /**
      * Adds the coordinates of a vertex to the vertexCoords array at
      * vertexIndex*3, return the current vertexIndex, and increases the
-     * vertexIndex by one. Note, the original coordinates are first
-     * normalized and then multiplied by the radius.
+     * vertexIndex by one.
      */
-    template <typename dataType, typename idType>
-    idType addVertex(const dataType &x,
-                     const dataType &y,
-                     const dataType &z,
-                     const dataType &radius,
-                     dataType *vertexCoords,
-                     idType &vertexIndex) const {
-      idType cIndex = vertexIndex * 3;
+    template <typename DT, typename IT>
+    IT addVertex(const DT &x,
+                 const DT &y,
+                 const DT &z,
+                 DT *vertexCoords,
+                 IT &vertexIndex) const {
+      IT cIndex = vertexIndex * 3;
 
-      double length = sqrt(x * x + y * y + z * z) / radius;
+      DT length = sqrt(x * x + y * y + z * z);
       vertexCoords[cIndex] = x / length;
       vertexCoords[cIndex + 1] = y / length;
       vertexCoords[cIndex + 2] = z / length;
+
       return vertexIndex++;
     };
 
@@ -115,18 +116,16 @@ namespace ttk {
      * triangleIndex*3, returns the current triangleIndex, and increases
      * the triangleIndex by one.
      */
-    template <class idType>
-    idType addTriangle(const idType &i,
-                       const idType &j,
-                       const idType &k,
-                       idType *connectivityList,
-                       idType &triangleIndex) const {
-      idType cIndex = triangleIndex * 4;
-
-      connectivityList[cIndex] = 3;
-      connectivityList[cIndex + 1] = i;
-      connectivityList[cIndex + 2] = j;
-      connectivityList[cIndex + 3] = k;
+    template <class IT>
+    IT addTriangle(const IT &i,
+                   const IT &j,
+                   const IT &k,
+                   IT *connectivityList,
+                   IT &triangleIndex) const {
+      IT cIndex = triangleIndex * 3;
+      connectivityList[cIndex + 0] = i;
+      connectivityList[cIndex + 1] = j;
+      connectivityList[cIndex + 2] = k;
       return triangleIndex++;
     };
 
@@ -136,20 +135,17 @@ namespace ttk {
      * an edge of an already processed triangle), the function only
      * returns the index of the existing vertex.
      */
-    template <typename dataType, typename idType>
-    idType
-      addMidVertex(const idType &i,
-                   const idType &j,
-                   std::unordered_map<std::pair<idType, idType>,
-                                      idType,
-                                      boost::hash<std::pair<idType, idType>>>
-                     &processedEdges,
-                   const dataType &radius,
-                   dataType *vertexCoords,
-                   idType &vertexIndex) const {
+    template <typename DT, typename IT>
+    IT addMidVertex(
+      const IT &i,
+      const IT &j,
+      std::unordered_map<std::pair<IT, IT>, IT, boost::hash<std::pair<IT, IT>>>
+        &processedEdges,
+      DT *vertexCoords,
+      IT &vertexIndex) const {
       bool firstIsSmaller = i < j;
-      idType a = firstIsSmaller ? i : j;
-      idType b = firstIsSmaller ? j : i;
+      IT a = firstIsSmaller ? i : j;
+      IT b = firstIsSmaller ? j : i;
 
       // Check if edge was already processed
       {
@@ -160,16 +156,14 @@ namespace ttk {
 
       // Otherwise add mid vertex
       {
-        idType aOffset = a * 3;
-        idType bOffset = b * 3;
-        dataType mx = (vertexCoords[aOffset] + vertexCoords[bOffset]) / 2.0;
-        dataType my
-          = (vertexCoords[aOffset + 1] + vertexCoords[bOffset + 1]) / 2.0;
-        dataType mz
-          = (vertexCoords[aOffset + 2] + vertexCoords[bOffset + 2]) / 2.0;
+        IT aOffset = a * 3;
+        IT bOffset = b * 3;
+        DT mx = (vertexCoords[aOffset] + vertexCoords[bOffset]) / 2.0;
+        DT my = (vertexCoords[aOffset + 1] + vertexCoords[bOffset + 1]) / 2.0;
+        DT mz = (vertexCoords[aOffset + 2] + vertexCoords[bOffset + 2]) / 2.0;
 
-        idType mIndex = this->addVertex<dataType, idType>(
-          mx, my, mz, radius, vertexCoords, vertexIndex);
+        IT mIndex
+          = this->addVertex<DT, IT>(mx, my, mz, vertexCoords, vertexIndex);
         processedEdges.insert({{a, b}, mIndex});
         return mIndex;
       }
@@ -177,79 +171,66 @@ namespace ttk {
   };
 } // namespace ttk
 
-template <typename dataType, typename idType>
+template <typename DT, typename IT>
 int ttk::Icosphere::computeIcosphere(
   // Output
-  dataType *vertexCoords,
-  idType *connectivityList,
+  DT *vertexCoords,
+  IT *connectivityList,
 
   // Input
-  const size_t &nSubdivisions,
-  const dataType &radius) const {
+  const size_t &nSubdivisions) const {
 
   // initialize timer and memory
   Timer timer;
 
   // print status
-  this->printMsg("Computing Icosphere (r:" + std::to_string(radius)
-                   + ", s:" + std::to_string(nSubdivisions) + ")",
-                 0, 0, this->threadNumber_, ttk::debug::LineMode::REPLACE);
+  const std::string msg
+    = "Computing Icosphere (S: " + std::to_string(nSubdivisions) + ")";
+  this->printMsg(msg, 0, 0, this->threadNumber_, ttk::debug::LineMode::REPLACE);
 
-  idType vertexIndex = 0;
-  idType triangleIndex = 0;
+  IT vertexIndex = 0;
+  IT triangleIndex = 0;
 
   // build icosahedron
   {
     // create 12 vertices
-    dataType t = (1.0 + sqrt(5.0)) / 2.0;
-    this->addVertex<dataType, idType>(
-      -1, t, 0, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      1, t, 0, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      -1, -t, 0, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      1, -t, 0, radius, vertexCoords, vertexIndex);
+    DT t = (1.0 + sqrt(5.0)) / 2.0;
+    this->addVertex<DT, IT>(-1, t, 0, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(1, t, 0, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(-1, -t, 0, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(1, -t, 0, vertexCoords, vertexIndex);
 
-    this->addVertex<dataType, idType>(
-      0, -1, t, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      0, 1, t, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      0, -1, -t, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      0, 1, -t, radius, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(0, -1, t, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(0, 1, t, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(0, -1, -t, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(0, 1, -t, vertexCoords, vertexIndex);
 
-    this->addVertex<dataType, idType>(
-      t, 0, -1, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      t, 0, 1, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      -t, 0, -1, radius, vertexCoords, vertexIndex);
-    this->addVertex<dataType, idType>(
-      -t, 0, 1, radius, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(t, 0, -1, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(t, 0, 1, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(-t, 0, -1, vertexCoords, vertexIndex);
+    this->addVertex<DT, IT>(-t, 0, 1, vertexCoords, vertexIndex);
 
     // create 20 triangles
-    this->addTriangle<idType>(0, 11, 5, connectivityList, triangleIndex);
-    this->addTriangle<idType>(0, 5, 1, connectivityList, triangleIndex);
-    this->addTriangle<idType>(0, 1, 7, connectivityList, triangleIndex);
-    this->addTriangle<idType>(0, 7, 10, connectivityList, triangleIndex);
-    this->addTriangle<idType>(0, 10, 11, connectivityList, triangleIndex);
-    this->addTriangle<idType>(1, 5, 9, connectivityList, triangleIndex);
-    this->addTriangle<idType>(5, 11, 4, connectivityList, triangleIndex);
-    this->addTriangle<idType>(11, 10, 2, connectivityList, triangleIndex);
-    this->addTriangle<idType>(10, 7, 6, connectivityList, triangleIndex);
-    this->addTriangle<idType>(7, 1, 8, connectivityList, triangleIndex);
-    this->addTriangle<idType>(3, 9, 4, connectivityList, triangleIndex);
-    this->addTriangle<idType>(3, 4, 2, connectivityList, triangleIndex);
-    this->addTriangle<idType>(3, 2, 6, connectivityList, triangleIndex);
-    this->addTriangle<idType>(3, 6, 8, connectivityList, triangleIndex);
-    this->addTriangle<idType>(3, 8, 9, connectivityList, triangleIndex);
-    this->addTriangle<idType>(4, 9, 5, connectivityList, triangleIndex);
-    this->addTriangle<idType>(2, 4, 11, connectivityList, triangleIndex);
-    this->addTriangle<idType>(6, 2, 10, connectivityList, triangleIndex);
-    this->addTriangle<idType>(8, 6, 7, connectivityList, triangleIndex);
-    this->addTriangle<idType>(9, 8, 1, connectivityList, triangleIndex);
+    this->addTriangle<IT>(0, 11, 5, connectivityList, triangleIndex);
+    this->addTriangle<IT>(0, 5, 1, connectivityList, triangleIndex);
+    this->addTriangle<IT>(0, 1, 7, connectivityList, triangleIndex);
+    this->addTriangle<IT>(0, 7, 10, connectivityList, triangleIndex);
+    this->addTriangle<IT>(0, 10, 11, connectivityList, triangleIndex);
+    this->addTriangle<IT>(1, 5, 9, connectivityList, triangleIndex);
+    this->addTriangle<IT>(5, 11, 4, connectivityList, triangleIndex);
+    this->addTriangle<IT>(11, 10, 2, connectivityList, triangleIndex);
+    this->addTriangle<IT>(10, 7, 6, connectivityList, triangleIndex);
+    this->addTriangle<IT>(7, 1, 8, connectivityList, triangleIndex);
+    this->addTriangle<IT>(3, 9, 4, connectivityList, triangleIndex);
+    this->addTriangle<IT>(3, 4, 2, connectivityList, triangleIndex);
+    this->addTriangle<IT>(3, 2, 6, connectivityList, triangleIndex);
+    this->addTriangle<IT>(3, 6, 8, connectivityList, triangleIndex);
+    this->addTriangle<IT>(3, 8, 9, connectivityList, triangleIndex);
+    this->addTriangle<IT>(4, 9, 5, connectivityList, triangleIndex);
+    this->addTriangle<IT>(2, 4, 11, connectivityList, triangleIndex);
+    this->addTriangle<IT>(6, 2, 10, connectivityList, triangleIndex);
+    this->addTriangle<IT>(8, 6, 7, connectivityList, triangleIndex);
+    this->addTriangle<IT>(9, 8, 1, connectivityList, triangleIndex);
   }
 
   // refine icosahedron
@@ -259,82 +240,77 @@ int ttk::Icosphere::computeIcosphere(
     size_t nTriangles = 0;
     this->computeNumberOfVerticesAndTriangles(
       nVertices, nTriangles, nSubdivisions);
-    std::vector<idType> connectivityListTemp(nTriangles * 4, 0);
+
+    std::vector<IT> connectivityListTemp(nTriangles * 3, 0);
 
     // cache to store processed edges
-    std::unordered_map<std::pair<idType, idType>, idType,
-                       boost::hash<std::pair<idType, idType>>>
+    std::unordered_map<std::pair<IT, IT>, IT, boost::hash<std::pair<IT, IT>>>
       processedEdges;
 
     // iterate over nSubdivisions
     for(size_t s = 0; s < nSubdivisions; s++) {
       // swap lists
-      idType *oldList
+      const IT *oldList
         = s % 2 == 0 ? connectivityList : connectivityListTemp.data();
-      idType *newList
-        = s % 2 != 0 ? connectivityList : connectivityListTemp.data();
+      IT *newList = s % 2 != 0 ? connectivityList : connectivityListTemp.data();
 
       // reset indicies
-      size_t nOldTriangles = triangleIndex;
+      const size_t nOldTriangles = triangleIndex;
       triangleIndex = 0;
 
       for(size_t i = 0; i < nOldTriangles; i++) {
-        idType offset = i * 4;
+        const IT offset = i * 3;
 
         // compute mid points
-        idType a = this->addMidVertex(oldList[offset + 1], oldList[offset + 2],
-                                      processedEdges, radius, vertexCoords,
-                                      vertexIndex);
-        idType b = this->addMidVertex(oldList[offset + 2], oldList[offset + 3],
-                                      processedEdges, radius, vertexCoords,
-                                      vertexIndex);
-        idType c = this->addMidVertex(oldList[offset + 3], oldList[offset + 1],
-                                      processedEdges, radius, vertexCoords,
-                                      vertexIndex);
+        const IT a
+          = this->addMidVertex(oldList[offset + 0], oldList[offset + 1],
+                               processedEdges, vertexCoords, vertexIndex);
+        const IT b
+          = this->addMidVertex(oldList[offset + 1], oldList[offset + 2],
+                               processedEdges, vertexCoords, vertexIndex);
+        const IT c
+          = this->addMidVertex(oldList[offset + 2], oldList[offset + 0],
+                               processedEdges, vertexCoords, vertexIndex);
 
         // replace triangle by 4 triangles
-        this->addTriangle(oldList[offset + 1], a, c, newList, triangleIndex);
-        this->addTriangle(oldList[offset + 2], b, a, newList, triangleIndex);
-        this->addTriangle(oldList[offset + 3], c, b, newList, triangleIndex);
+        this->addTriangle(oldList[offset + 0], a, c, newList, triangleIndex);
+        this->addTriangle(oldList[offset + 1], b, a, newList, triangleIndex);
+        this->addTriangle(oldList[offset + 2], c, b, newList, triangleIndex);
         this->addTriangle(a, b, c, newList, triangleIndex);
       }
 
       // print progress
-      this->printMsg("Computing Icosphere (r:" + std::to_string(radius)
-                       + ", s:" + std::to_string(nSubdivisions) + ")",
-                     ((dataType)s) / nSubdivisions,
-                     ttk::debug::LineMode::REPLACE);
+      this->printMsg(
+        msg, ((DT)s) / nSubdivisions, ttk::debug::LineMode::REPLACE);
     }
 
     // if uneven number of nSubdivisions then copy temp buffer to output buffer
     if(nSubdivisions > 0 && nSubdivisions % 2 != 0) {
-      size_t n = nTriangles * 4;
+      size_t n = nTriangles * 3;
       for(size_t i = 0; i < n; i++)
         connectivityList[i] = connectivityListTemp[i];
     }
   }
 
   // print progress
-  this->printMsg("Computing Icosphere (r:" + std::to_string(radius)
-                   + ", s:" + std::to_string(nSubdivisions) + ")",
-                 1, timer.getElapsedTime(), this->threadNumber_);
+  this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
 
   return 1;
 };
 
-template <typename dataType, typename idType>
-int ttk::Icosphere::translateIcosphere(dataType *vertexCoords,
-                                       idType *connectivityList,
+template <typename DT, typename IT>
+int ttk::Icosphere::translateIcosphere(DT *vertexCoords,
+                                       IT *connectivityList,
                                        const size_t &icosphereIndex,
                                        const size_t &nVerticesPerIcosphere,
                                        const size_t &nTrianglesPerIcosphere,
-                                       const dataType *centers) const {
+                                       const DT *centers) const {
   size_t vertexCoordOffset = icosphereIndex * nVerticesPerIcosphere * 3;
-  size_t connectivityListOffset = icosphereIndex * nTrianglesPerIcosphere * 4;
+  size_t connectivityListOffset = icosphereIndex * nTrianglesPerIcosphere * 3;
   size_t temp = icosphereIndex * 3;
-  const dataType &centerX = centers[temp++];
-  const dataType &centerY = centers[temp++];
-  const dataType &centerZ = centers[temp];
+  const DT &centerX = centers[temp++];
+  const DT &centerY = centers[temp++];
+  const DT &centerZ = centers[temp];
 
   // vertex coords
   for(size_t i = 0, limit = nVerticesPerIcosphere * 3; i < limit;) {
@@ -345,8 +321,7 @@ int ttk::Icosphere::translateIcosphere(dataType *vertexCoords,
 
   // connectivity list
   size_t vertexIdOffset = icosphereIndex * nVerticesPerIcosphere;
-  for(size_t i = 0, limit = nTrianglesPerIcosphere * 4; i < limit;) {
-    connectivityList[connectivityListOffset++] = connectivityList[i++];
+  for(size_t i = 0, limit = nTrianglesPerIcosphere * 3; i < limit;) {
     connectivityList[connectivityListOffset++]
       = connectivityList[i++] + vertexIdOffset;
     connectivityList[connectivityListOffset++]
@@ -358,20 +333,20 @@ int ttk::Icosphere::translateIcosphere(dataType *vertexCoords,
   return 1;
 }
 
-template <typename dataType, typename idType>
+template <typename DT, typename IT>
 int ttk::Icosphere::computeIcospheres(
   // Output
-  dataType *vertexCoords,
-  idType *connectivityList,
+  DT *vertexCoords,
+  IT *connectivityList,
 
   // Input
   const size_t &nSpheres,
   const size_t &nSubdivisions,
-  const dataType &radius,
-  const dataType *centers,
+  const DT &radius,
+  const DT *centers,
 
   // Optional Output
-  float *normals) const {
+  DT *normals) const {
 
   if(nSpheres < 1) {
     this->printWrn("Number of input points smaller than 1.");
@@ -385,8 +360,7 @@ int ttk::Icosphere::computeIcospheres(
     return 0;
 
   // compute ico sphere around origin
-  if(!this->computeIcosphere(
-       vertexCoords, connectivityList, nSubdivisions, radius))
+  if(!this->computeIcosphere(vertexCoords, connectivityList, nSubdivisions))
     return 0;
 
   // store normals if requested
@@ -399,8 +373,8 @@ int ttk::Icosphere::computeIcospheres(
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
     for(size_t i = 0; i < nSpheres; i++) {
-      size_t offset = i * nVerticesPerIcosphere * 3;
       size_t n = nVerticesPerIcosphere * 3;
+      size_t offset = i * n;
       for(size_t j = 0; j < n; j++)
         normals[offset++] = vertexCoords[j];
     }
@@ -408,10 +382,19 @@ int ttk::Icosphere::computeIcospheres(
       "Computing Normals", 1, t.getElapsedTime(), this->threadNumber_);
   }
 
-  // translate remaining spheres
+  // Translating Icospheres
   ttk::Timer timer;
-  this->printMsg("Translating " + std::to_string(nSpheres) + " Icosphere(s)", 0,
-                 0, this->threadNumber_, ttk::debug::LineMode::REPLACE);
+  const std::string transMsg = "Transforming " + std::to_string(nSpheres)
+                               + " Icospheres (R: " + std::to_string(radius)
+                               + ")";
+  this->printMsg(
+    transMsg, 0, 0, this->threadNumber_, ttk::debug::LineMode::REPLACE);
+
+  // apply radius
+  if(radius != 1.0)
+    for(size_t i = 0, j = nVerticesPerIcosphere * 3; i < j; i++) {
+      vertexCoords[i] *= radius;
+    }
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
@@ -422,13 +405,12 @@ int ttk::Icosphere::computeIcospheres(
                              centers);
   }
 
-  // translate first ico sphere
+  // translate first icosphere
   this->translateIcosphere(vertexCoords, connectivityList, 0,
                            nVerticesPerIcosphere, nTrianglesPerIcosphere,
                            centers);
   // print status
-  this->printMsg("Translating " + std::to_string(nSpheres) + " Icosphere(s)", 1,
-                 timer.getElapsedTime(), this->threadNumber_);
+  this->printMsg(transMsg, 1, timer.getElapsedTime(), this->threadNumber_);
 
   return 1;
 }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -16,15 +16,9 @@
 
 // VTK Includes
 #include <vtkAlgorithm.h>
-class vtkCellArray;
-class vtkCommand;
 class vtkDataSet;
 class vtkInformation;
 class vtkInformationIntegerKey;
-class vtkPoints;
-
-template <class T>
-class vtkSmartPointer;
 
 // Base Includes
 #include <Debug.h>
@@ -32,7 +26,6 @@ class vtkSmartPointer;
 namespace ttk {
   class Triangulation;
 }
-// #include <Triangulation.h>
 
 class TTKALGORITHM_EXPORT ttkAlgorithm : public vtkAlgorithm,
                                          virtual public ttk::Debug {

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -53,6 +53,10 @@ public:
   // Emultate old VTK functions
   static void *GetVoidPointer(vtkDataArray *array, vtkIdType start = 0);
   static void *GetVoidPointer(vtkPoints *points, vtkIdType start = 0);
+  template <typename DT>
+  static DT *GetPointer(vtkDataArray *array, vtkIdType start = 0) {
+    return static_cast<DT *>(ttkUtils::GetVoidPointer(array, start));
+  };
 
   static void *
     WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.h
@@ -29,6 +29,9 @@
 
 class vtkUnstructuredGrid;
 
+template <typename T>
+class vtkSmartPointer;
+
 class TTKBARYCENTRICSUBDIVISION_EXPORT ttkBarycentricSubdivision
   : public ttkAlgorithm,
     protected ttk::BarycentricSubdivision {

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
@@ -29,12 +29,12 @@
 namespace ttk {
   class CinemaImaging;
 }
-class vtkPolyData;
 class vtkMultiBlockDataSet;
 class vtkPointSet;
 class vtkFieldData;
 class vtkImageData;
 class vtkPointData;
+class vtkCellArray;
 
 class TTKCINEMAIMAGING_EXPORT ttkCinemaImaging : public ttkAlgorithm {
 

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
@@ -83,7 +83,6 @@ int ttk::ttkCinemaImagingVTK::addValuePass(
     size_t nComponents = array->GetNumberOfComponents();
     for(size_t c = 0; c < nComponents; c++) {
       auto valuePass = vtkSmartPointer<vtkValuePass>::New();
-      valuePass->SetRenderingMode(vtkValuePass::FLOATING_POINT);
       valuePass->SetInputArrayToProcess(fieldType == 0
                                           ? VTK_SCALAR_MODE_USE_POINT_FIELD_DATA
                                           : VTK_SCALAR_MODE_USE_CELL_FIELD_DATA,

--- a/core/vtk/ttkIcosphere/ttkIcosphere.cpp
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.cpp
@@ -3,6 +3,7 @@
 #include <ttkUtils.h>
 
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 
 #include <vtkCellArray.h>
 #include <vtkDoubleArray.h>

--- a/core/vtk/ttkIcosphere/ttkIcosphere.cpp
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.cpp
@@ -5,10 +5,11 @@
 #include <vtkInformation.h>
 
 #include <vtkCellArray.h>
+#include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
 #include <vtkPointData.h>
+#include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
-#include <vtkUnstructuredGrid.h>
 
 vtkStandardNewMacro(ttkIcosphere);
 
@@ -25,7 +26,7 @@ int ttkIcosphere::FillInputPortInformation(int port, vtkInformation *info) {
 
 int ttkIcosphere::FillOutputPortInformation(int port, vtkInformation *info) {
   if(port == 0)
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
   else
     return 0;
   return 1;
@@ -35,8 +36,8 @@ int ttkIcosphere::RequestData(vtkInformation *request,
                               vtkInformationVector **inputVector,
                               vtkInformationVector *outputVector) {
   // get parameter
-  int nSpheres = this->Centers ? this->Centers->GetNumberOfPoints() : 1;
-  int nSubdivisions = this->GetNumberOfSubdivisions();
+  size_t nSpheres = this->Centers ? this->Centers->GetNumberOfTuples() : 1;
+  size_t nSubdivisions = this->GetNumberOfSubdivisions();
   double radius = this->GetRadius();
 
   bool useDoublePrecision
@@ -48,84 +49,70 @@ int ttkIcosphere::RequestData(vtkInformation *request,
   this->computeNumberOfVerticesAndTriangles(
     nVertices, nTriangles, nSubdivisions);
 
+  const size_t nTotalVertices = nSpheres * nVertices;
+  const size_t nTotalTriangles = nSpheres * nTriangles;
+
   auto points = vtkSmartPointer<vtkPoints>::New();
   points->SetDataType(useDoublePrecision ? VTK_DOUBLE : VTK_FLOAT);
-  points->SetNumberOfPoints(nSpheres * nVertices);
+  points->SetNumberOfPoints(nTotalVertices);
 
-  auto normals = vtkSmartPointer<vtkFloatArray>::New();
+  vtkSmartPointer<vtkDataArray> normals;
   if(this->ComputeNormals) {
+    if(useDoublePrecision)
+      normals = vtkSmartPointer<vtkDoubleArray>::New();
+    else
+      normals = vtkSmartPointer<vtkFloatArray>::New();
+
     normals->SetName("Normals");
     normals->SetNumberOfComponents(3);
-    normals->SetNumberOfTuples(nVertices * nSpheres);
+    normals->SetNumberOfTuples(nTotalVertices);
   }
 
-  auto cells = vtkSmartPointer<vtkCellArray>::New();
+  auto offsets = vtkSmartPointer<vtkIdTypeArray>::New();
+  offsets->SetNumberOfTuples(nTotalTriangles + 1);
+  auto offsetsData
+    = static_cast<vtkIdType *>(ttkUtils::GetVoidPointer(offsets));
+  for(size_t i = 0; i <= nTotalTriangles; i++)
+    offsetsData[i] = i * 3;
 
-  // execute base code
-  // TODO: Improve here
-#ifdef TTK_CELL_ARRAY_NEW
-  std::vector<vtkIdType> cellArray;
-  cellArray.resize(nSpheres * nTriangles * 4);
+  auto connectivity = vtkSmartPointer<vtkIdTypeArray>::New();
+  connectivity->SetNumberOfTuples(nTotalTriangles * 3);
+
+  int status = 0;
   if(useDoublePrecision) {
-    if(!this->computeIcospheres<double, vtkIdType>(
-         (double *)ttkUtils::GetVoidPointer(points), cellArray.data(),
+    typedef double DT;
+    status = this->computeIcospheres<DT, vtkIdType>(
+      ttkUtils::GetPointer<DT>(points->GetData()),
+      ttkUtils::GetPointer<vtkIdType>(connectivity),
 
-         nSpheres, nSubdivisions, radius,
-         this->Centers ? (double *)ttkUtils::GetVoidPointer(this->Centers)
-                       : this->Center,
-         this->ComputeNormals ? (float *)ttkUtils::GetVoidPointer(normals)
-                              : nullptr)) {
-      return 0;
-    }
+      nSpheres, nSubdivisions, radius,
+      this->Centers ? ttkUtils::GetPointer<DT>(this->Centers) : this->Center,
+      this->ComputeNormals ? ttkUtils::GetPointer<DT>(normals) : nullptr);
   } else {
-    float centerFloat[3]{
-      (float)this->Center[0], (float)this->Center[1], (float)this->Center[2]};
-    if(!this->computeIcospheres<float, vtkIdType>(
-         (float *)ttkUtils::GetVoidPointer(points), cellArray.data(),
+    typedef float DT;
+    DT centerFloat[3]{
+      (DT)this->Center[0], (DT)this->Center[1], (DT)this->Center[2]};
+    status = this->computeIcospheres<DT, vtkIdType>(
+      ttkUtils::GetPointer<DT>(points->GetData()),
+      ttkUtils::GetPointer<vtkIdType>(connectivity),
 
-         nSpheres, nSubdivisions, radius,
-         this->Centers ? (float *)ttkUtils::GetVoidPointer(this->Centers)
-                       : centerFloat,
-         this->ComputeNormals ? (float *)ttkUtils::GetVoidPointer(normals)
-                              : nullptr))
-      return 0;
+      nSpheres, nSubdivisions, radius,
+      this->Centers ? ttkUtils::GetPointer<DT>(this->Centers) : centerFloat,
+      this->ComputeNormals ? ttkUtils::GetPointer<DT>(normals) : nullptr);
   }
-  ttkUtils::FillCellArrayFromSingle(
-    cellArray.data(), nSpheres * nTriangles, cells);
-#else
-  if(useDoublePrecision) {
-    if(!this->computeIcospheres<double, vtkIdType>(
-         (double *)ttkUtils::GetVoidPointer(points),
-         cells->WritePointer(nSpheres * nTriangles, nSpheres * nTriangles * 4),
 
-         nSpheres, nSubdivisions, radius,
-         this->Centers ? (double *)ttkUtils::GetVoidPointer(this->Centers)
-                       : this->Center,
-         this->ComputeNormals ? (float *)ttkUtils::GetVoidPointer(normals)
-                              : nullptr))
-      return 0;
-  } else {
-    float centerFloat[3]{
-      (float)this->Center[0], (float)this->Center[1], (float)this->Center[2]};
-    if(!this->computeIcospheres<float, vtkIdType>(
-         (float *)ttkUtils::GetVoidPointer(points),
-         cells->WritePointer(nSpheres * nTriangles, nSpheres * nTriangles * 4),
+  if(!status)
+    return 0;
 
-         nSpheres, nSubdivisions, radius,
-         this->Centers ? (float *)ttkUtils::GetVoidPointer(this->Centers)
-                       : centerFloat,
-         this->ComputeNormals ? (float *)ttkUtils::GetVoidPointer(normals)
-                              : nullptr))
-      return 0;
-  }
-#endif
-
-  // module easily finalize output
+  // finalize output
   {
-    auto output = vtkUnstructuredGrid::GetData(outputVector);
+    auto output = vtkPolyData::GetData(outputVector);
     output->SetPoints(points);
 
-    output->SetCells(VTK_TRIANGLE, cells);
+    auto cells = vtkSmartPointer<vtkCellArray>::New();
+    cells->SetData(offsets, connectivity);
+    output->SetPolys(cells);
+
     if(this->ComputeNormals)
       output->GetPointData()->SetNormals(normals);
   }

--- a/core/vtk/ttkIcosphere/ttkIcosphere.cpp
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.cpp
@@ -7,6 +7,7 @@
 #include <vtkCellArray.h>
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>

--- a/core/vtk/ttkIcosphere/ttkIcosphere.h
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.h
@@ -20,6 +20,8 @@
 // TTK Base Includes
 #include <Icosphere.h>
 
+class vtkDataArray;
+
 class TTKICOSPHERE_EXPORT ttkIcosphere : public ttkAlgorithm,
                                          protected ttk::Icosphere {
 private:
@@ -31,7 +33,7 @@ private:
   double Center[3]{0, 0, 0};
 
   // alternatvely create a sphere at each point
-  vtkPoints *Centers{nullptr};
+  vtkDataArray *Centers{nullptr};
 
 public:
   static ttkIcosphere *New();
@@ -49,8 +51,8 @@ public:
   vtkSetMacro(ComputeNormals, bool);
   vtkGetMacro(ComputeNormals, bool);
 
-  vtkSetMacro(Centers, vtkPoints *);
-  vtkGetMacro(Centers, vtkPoints *);
+  vtkSetMacro(Centers, vtkDataArray *);
+  vtkGetMacro(Centers, vtkDataArray *);
 
 protected:
   ttkIcosphere();

--- a/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.cpp
+++ b/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.cpp
@@ -2,7 +2,6 @@
 
 #include <vtkInformation.h>
 #include <vtkObjectFactory.h>
-// #include <vtkInformationVector.h>
 
 #include <vtkDataSet.h>
 #include <vtkMultiBlockDataSet.h>

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
@@ -4,7 +4,8 @@
 
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
-#include <vtkUnstructuredGrid.h>
+
+#include <ttkUtils.h>
 
 vtkStandardNewMacro(ttkIcospheresFromPoints);
 
@@ -30,8 +31,8 @@ int copyArrayData(vtkDataArray *oldArray,
                   const size_t &nSpheres,
                   const size_t &nVerticesPerSphere,
                   const size_t &nComponents) {
-  auto oldData = (VTK_TT *)oldArray->GetVoidPointer(0);
-  auto newData = (VTK_TT *)newArray->GetVoidPointer(0);
+  auto oldData = ttkUtils::GetPointer<VTK_TT>(oldArray);
+  auto newData = ttkUtils::GetPointer<VTK_TT>(newArray);
 
   for(size_t i = 0; i < nSpheres; i++) {
     size_t sphereIndex = i * nVerticesPerSphere * nComponents;
@@ -51,7 +52,7 @@ int ttkIcospheresFromPoints::RequestData(vtkInformation *request,
                                          vtkInformationVector **inputVector,
                                          vtkInformationVector *outputVector) {
   auto input = vtkPointSet::GetData(inputVector[0], 0);
-  this->SetCenters(input->GetPoints());
+  this->SetCenters(input->GetPoints()->GetData());
 
   // compute spheres
   int status
@@ -64,7 +65,7 @@ int ttkIcospheresFromPoints::RequestData(vtkInformation *request,
   this->computeNumberOfVerticesAndTriangles(
     nVertices, nTriangles, this->GetNumberOfSubdivisions());
 
-  auto output = vtkUnstructuredGrid::GetData(outputVector);
+  auto output = vtkDataSet::GetData(outputVector);
   auto outputPD = output->GetPointData();
 
   // copy point data

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
@@ -1,6 +1,7 @@
 #include <ttkIcospheresFromPoints.h>
 
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 
 #include <vtkPointData.h>
 #include <vtkPointSet.h>


### PR DESCRIPTION
Hi Julien, this PR:
* removes some unnecessary headers from the ttkAlgorithm which then had to be included in one or two submodules.
* overhauls the icosphere code to write directly into vtk9 cell arrays and now produces vtkPolyData output instead of vtkUnstructuredGrid (big memory/performance improvement)
* adds a new function to ttkUtils which can be used to access the pointer of an array directly for a given type. This is very convenient as I use this all over the place. The new call
`ttkUtils::GetPointer<float>(array)`
is equivalent to
`static_cast<float*>(ttkUtils::GetVoidPointer(array))`

Best
Jonas