### PR TITLE
CinemaQuery: Fix vtkCharArray/vtkSignedArray support

### DIFF
--- a/core/base/cinemaQuery/CinemaQuery.cpp
+++ b/core/base/cinemaQuery/CinemaQuery.cpp
@@ -56,7 +56,7 @@ int ttk::CinemaQuery::execute(
     for(auto &sqlTableDefinition : sqlTableDefinitions) {
       rc = sqlite3_exec(db, sqlTableDefinition.data(), nullptr, 0, &zErrMsg);
       if(rc != SQLITE_OK) {
-        this->printErr(zErrMsg);
+        this->printErr("Create table: " + std::string{zErrMsg});
 
         sqlite3_free(zErrMsg);
         sqlite3_close(db);
@@ -69,7 +69,7 @@ int ttk::CinemaQuery::execute(
     for(auto &sqlInsertStatement : sqlInsertStatements) {
       rc = sqlite3_exec(db, sqlInsertStatement.data(), nullptr, 0, &zErrMsg);
       if(rc != SQLITE_OK) {
-        this->printErr(zErrMsg);
+        this->printErr("Insert values: " + std::string{zErrMsg});
 
         sqlite3_free(zErrMsg);
         sqlite3_close(db);
@@ -89,7 +89,7 @@ int ttk::CinemaQuery::execute(
 
     if(sqlite3_prepare_v2(db, sqlQuery.data(), -1, &sqlStatement, NULL)
        != SQLITE_OK) {
-      this->printErr(sqlite3_errmsg(db));
+      this->printErr("Query: " + std::string{sqlite3_errmsg(db)});
 
       sqlite3_close(db);
       return 0;

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -123,11 +123,17 @@ int ttkCinemaQuery::RequestData(vtkInformation *request,
             if(firstCol) {
               firstCol = false;
             }
-            if(isNumeric[k])
-              sqlInsertStatement += inTable->GetValue(q, k).ToString();
-            else
+            if(isNumeric[k]) {
+              const auto var = inTable->GetValue(q, k);
+              if(var.IsChar() || var.IsSignedChar()) {
+                sqlInsertStatement += std::to_string(var.ToInt());
+              } else {
+                sqlInsertStatement += var.ToString();
+              }
+            } else {
               sqlInsertStatement
                 += "'" + inTable->GetValue(q, k).ToString() + "'";
+            }
           }
           sqlInsertStatement += ")";
           q++;


### PR DESCRIPTION
According to VTK, applying the `ToString()` method on a `vtkCharArray`/`vtkSignedCharArray` element returns its character representation. Since we use primarly those array types to store small integers irrelevant to their character representation, this leads to bugs when the `CinemaQuery` module converts arrays of those types to SQL. For instance, applying the `CinemaQuery` filter on a `vtkTable` conversion of a `ttkScalarFieldCriticalPoints` Point output returns a SQLite error caused by the CriticalType and the IsOnBoundary `vtkSignedCharArray`.

This PR makes sure that the corresponding array elements are kept into their integer representation when sending them to SQLite.
Also, to help debug, SQLite error messages are now more explicit about the corresponding step in which they fail.

No modifications observed on the relevant ttk-data states.

Enjoy,
Pierre