### PR TITLE
ttkExtract update

### DIFF
--- a/core/vtk/ttkExtract/ttkExtract.h
+++ b/core/vtk/ttkExtract/ttkExtract.h
@@ -29,7 +29,7 @@ private:
   int CellMode{0};
   int ArrayAttributeType{0};
   std::string OutputArrayName{"Data"};
-  double ImageBounds[6]{0, 0, 0, 0, 0, 0};
+  int ImageExtent[6]{0, 0, 0, 0, 0, 0};
 
 public:
   vtkSetMacro(ExtractionMode, int);
@@ -56,8 +56,8 @@ public:
   vtkSetMacro(OutputArrayName, std::string);
   vtkGetMacro(OutputArrayName, std::string);
 
-  vtkSetVector6Macro(ImageBounds, double);
-  vtkGetVector6Macro(ImageBounds, double);
+  vtkSetVector6Macro(ImageExtent, int);
+  vtkGetVector6Macro(ImageExtent, int);
 
   int GetVtkDataTypeName(std::string &dataTypeName, const int outputType) const;
 

--- a/paraview/Extract/Extract.xml
+++ b/paraview/Extract/Extract.xml
@@ -71,22 +71,18 @@ vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMulti
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="0" />
                 </Hints>
             </IntVectorProperty>
-            <DoubleVectorProperty command="SetImageBounds" default_values="0 1 0 1 0 1" name="ImageBounds" number_of_elements="6" panel_visibility="default">
-                <BoundsDomain name="bounds">
-                    <RequiredProperties>
-                        <Property function="Input" name="Input" />
-                    </RequiredProperties>
-                </BoundsDomain>
-                <Documentation>The image bounds of the extracted block of type 'vtkImageData'. It is necessary to explicitly specify the bounds as currently the VTK pipeline is unable to automatically derive the image extent and bounds during the 'RequestInformation' pass.</Documentation>
-                <Hints>
-                    <PropertyWidgetDecorator type="CompositeDecorator">
-                        <Expression type="and">
-                            <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="0"/>
-                            <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="OutputType" value="6"/>
-                        </Expression>
-                    </PropertyWidgetDecorator>
-                </Hints>
-            </DoubleVectorProperty>
+
+            <IntVectorProperty command="SetImageExtent" default_values="0 0 0 0 0 0" name="ImageExtent" number_of_elements="6">
+              <ExtentDomain name="extent">
+                <RequiredProperties>
+                  <Property function="Input" name="Input" />
+                </RequiredProperties>
+              </ExtentDomain>
+              <Hints>
+                <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="OutputType" value="6"/>
+              </Hints>
+              <Documentation>Controls the minimum and maximum extent index in each dimension for outputs of type vtkImageData.</Documentation>
+            </IntVectorProperty>
 
             <!-- Array Mode -->
             <IntVectorProperty name="ExtractUniqueValues" label="Extract unique values" number_of_elements="1" default_values="1" command="SetExtractUniqueValues" >
@@ -95,6 +91,20 @@ vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMulti
                 <Hints>
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="3" />
                 </Hints>
+            </IntVectorProperty>
+
+            <IntVectorProperty name="ValidationMode" command="SetValidationMode" number_of_elements="1" animateable="0" label="Validation Mode" default_values="2">
+                <EnumerationDomain name="enum">
+                    <Entry value="0" text="&lt;"/>
+                    <Entry value="1" text="&lt;="/>
+                    <Entry value="2" text="=="/>
+                    <Entry value="3" text="&gt;="/>
+                    <Entry value="4" text="&gt; "/>
+                </EnumerationDomain>
+                <Hints>
+                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="2" />
+                </Hints>
+                <Documentation>Determines how vertex values are compared agains each value of the expression.</Documentation>
             </IntVectorProperty>
 
             <!-- Geometry Mode -->
@@ -114,20 +124,6 @@ vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMulti
                 </Hints>
                 <Documentation>The array that will be used to determine which part of the geometry should be extracted.</Documentation>
             </StringVectorProperty>
-
-            <IntVectorProperty name="ValidationMode" command="SetValidationMode" number_of_elements="1" animateable="0" label="Validation Mode" default_values="2">
-                <EnumerationDomain name="enum">
-                    <Entry value="0" text="&lt;"/>
-                    <Entry value="1" text="&lt;="/>
-                    <Entry value="2" text="=="/>
-                    <Entry value="3" text="&gt;="/>
-                    <Entry value="4" text="&gt; "/>
-                </EnumerationDomain>
-                <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="2" />
-                </Hints>
-                <Documentation>Determines how vertex values are compared agains each value of the expression.</Documentation>
-            </IntVectorProperty>
 
             <IntVectorProperty name="CellMode" command="SetCellMode" number_of_elements="1" animateable="0" label="Cell Mode" default_values="0">
                 <EnumerationDomain name="enum">
@@ -162,15 +158,14 @@ vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMulti
                 <Documentation>.</Documentation>
             </StringVectorProperty>
 
-
             <PropertyGroup panel_widget="Line" label="Input Options">
                 <Property name="ExtractionMode" />
                 <Property name="ExpressionString" />
                 <Property name="OutputType" />
-                <Property name="ImageBounds" />
+                <Property name="ImageExtent" />
+                <Property name="ValidationMode" />
                 <Property name="InputArray" />
                 <Property name="ExtractUniqueValues" />
-                <Property name="ValidationMode" />
                 <Property name="CellMode" />
                 <Property name="ArrayAttributeType" />
             </PropertyGroup>

--- a/paraview/ForEach/ForEach.xml
+++ b/paraview/ForEach/ForEach.xml
@@ -60,7 +60,7 @@
                 <EnumerationDomain name="enum">
                     <Entry value="-1" text="Auto"/>
                     <Entry value="13" text="vtkMultiBlockDataSet"/>
-                    <!--<Entry value="6" text="vtkImageData"/>-->
+                    <Entry value="6" text="vtkImageData"/>
                     <Entry value="4" text="vtkUnstructuredGrid"/>
                     <Entry value="19" text="vtkTable"/>
                 </EnumerationDomain>
@@ -83,9 +83,25 @@ vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMulti
                 </Hints>
             </IntVectorProperty>
 
+            <IntVectorProperty command="SetImageExtent" default_values="0 0 0 0 0 0" name="ImageExtent" number_of_elements="6">
+              <ExtentDomain name="extent">
+                <RequiredProperties>
+                  <Property function="Input" name="Input" />
+                </RequiredProperties>
+              </ExtentDomain>
+              <Hints>
+                <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="OutputType" value="6"/>
+              </Hints>
+              <Documentation>
+                Controls the minimum and maximum extent index in each dimension for outputs of type vtkImageData.
+                Unfortunately, VTK requires that this information is explicitly defined during the RequestInformation pass, so it can not be deduced later during the RequestData pass.
+              </Documentation>
+            </IntVectorProperty>
+
             <PropertyGroup panel_widget="Line" label="Input Parameters">
                 <Property name="IterationMode" />
                 <Property name="OutputType" />
+                <Property name="ImageExtent" />
                 <Property name="InputArray" />
                 <Property name="ArrayAttributeType" />
             </PropertyGroup>


### PR DESCRIPTION
Hi Julien,
this PR contains an upgrade of the ttkExtract filter. In the past the filter was already able to extract a vtkImageData object from a vtkMultiBlockDataSet, but due to vtk's pipeline concept one has to specify the available image extent already during the RequestInformation pass. Unfortunately, deducing this during the RequestData pass is too late. To cope with this the filter guessed during the RequestInformation pass the extent based on the bounds of the input object. This works as long as the bounds are equal to the extent. With this PR we can actually specify the extent directly with some help of the PV UI instead of using the bounds to do some guessing. The filter will work as before but now it will also support extractions of grids that are deformed, e.g., lat-lng grids.

Note, the corresponding property `ImageBounds` is now renamed to `ImageExtent` which effects some state files in ttk-data. I will open a PR for those.

TLDR; The ttkExtract filter can now extract any vtkImageData object based on a specified extent (initially autocompleted by PV). This is very useful for any pipeline that utilizes the Cinema filters since they produce vtkMultiBlockDataSet outputs. For convenience, block iterations of the ttkForEach filter also supports this by explicitly setting its output type to vtkImageData.

Best
Jonas