### PR TITLE
DiscreteGradient: Move allocations outside main loop

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -425,6 +425,7 @@ according to them.
             // for filterSaddleConnectors
             contourTree_.preconditionTriangulation(data);
           }
+          this->initMemory(*data);
         }
       }
 
@@ -931,8 +932,10 @@ gradient, false otherwise.
       int reverseDescendingPathOnWall(const std::vector<Cell> &vpath,
                                       const triangulationType &triangulation);
 
-      template <typename triangulationType>
-      void initMemory(const triangulationType &triangulation);
+      /**
+       * @brief Initialize/Allocate discrete gradient memory
+       */
+      void initMemory(const AbstractTriangulation &triangulation);
 
     protected:
       ftm::FTMTree contourTree_{};

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -931,6 +931,9 @@ gradient, false otherwise.
       int reverseDescendingPathOnWall(const std::vector<Cell> &vpath,
                                       const triangulationType &triangulation);
 
+      template <typename triangulationType>
+      void initMemory(const triangulationType &triangulation);
+
     protected:
       ftm::FTMTree contourTree_{};
 

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -664,10 +664,10 @@ in the gradient.
        * 3-cells)
        */
       template <typename triangulationType>
-      inline lowerStarType
-        lowerStar(const SimplexId a,
-                  const SimplexId *const offsets,
-                  const triangulationType &triangulation) const;
+      inline void lowerStar(lowerStarType &ls,
+                            const SimplexId a,
+                            const SimplexId *const offsets,
+                            const triangulationType &triangulation) const;
 
       /**
        * @brief Return the number of unpaired faces of a given cell in

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -38,17 +38,15 @@ dataType DiscreteGradient::getPersistence(
 }
 
 template <typename triangulationType>
-int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
-  Timer t;
+void DiscreteGradient::initMemory(const triangulationType &triangulation) {
 
-  const auto *const offsets = inputOffsets_;
-
-  const int numberOfDimensions = getNumberOfDimensions();
+  Timer tm{};
+  const int numberOfDimensions = this->getNumberOfDimensions();
 
   // init number of cells by dimension
   std::vector<SimplexId> numberOfCells(numberOfDimensions);
   for(int i = 0; i < numberOfDimensions; ++i) {
-    numberOfCells[i] = getNumberOfCells(i, triangulation);
+    numberOfCells[i] = this->getNumberOfCells(i, triangulation);
   }
 
   dmtMax2PL_.clear();
@@ -56,15 +54,13 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   dmt2Saddle2PL_.clear();
   gradient_.clear();
   gradient_.resize(dimensionality_);
+
   for(int i = 0; i < dimensionality_; ++i) {
     // init gradient memory
     gradient_[i].resize(numberOfDimensions);
     gradient_[i][i].resize(numberOfCells[i], -1);
     gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
   }
-
-  // compute gradient pairs
-  processLowerStars(offsets, triangulation);
 
   std::vector<std::vector<std::string>> rows{
     {"#Vertices", std::to_string(numberOfCells[0])},
@@ -77,6 +73,22 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   }
 
   this->printMsg(rows);
+  this->printMsg("Initialized discrete gradient memory", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+template <typename triangulationType>
+int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
+  Timer t;
+
+  const auto *const offsets = inputOffsets_;
+
+  this->initMemory(triangulation);
+
+  // compute gradient pairs
+  processLowerStars(offsets, triangulation);
+
   this->printMsg(
     "Built discrete gradient", 1.0, t.getElapsedTime(), this->threadNumber_);
 

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -38,56 +38,11 @@ dataType DiscreteGradient::getPersistence(
 }
 
 template <typename triangulationType>
-void DiscreteGradient::initMemory(const triangulationType &triangulation) {
-
-  Timer tm{};
-  const int numberOfDimensions = this->getNumberOfDimensions();
-
-  // init number of cells by dimension
-  std::vector<SimplexId> numberOfCells(numberOfDimensions);
-  for(int i = 0; i < numberOfDimensions; ++i) {
-    numberOfCells[i] = this->getNumberOfCells(i, triangulation);
-  }
-
-  dmtMax2PL_.clear();
-  dmt1Saddle2PL_.clear();
-  dmt2Saddle2PL_.clear();
-  gradient_.clear();
-  gradient_.resize(dimensionality_);
-
-  for(int i = 0; i < dimensionality_; ++i) {
-    // init gradient memory
-    gradient_[i].resize(numberOfDimensions);
-    gradient_[i][i].resize(numberOfCells[i], -1);
-    gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
-  }
-
-  std::vector<std::vector<std::string>> rows{
-    {"#Vertices", std::to_string(numberOfCells[0])},
-    {"#Edges", std::to_string(numberOfCells[1])},
-    {"#Triangles", std::to_string(numberOfCells[2])}};
-
-  if(dimensionality_ == 3) {
-    rows.emplace_back(
-      std::vector<std::string>{"#Tetras", std::to_string(numberOfCells[3])});
-  }
-
-  this->printMsg(rows);
-  this->printMsg("Initialized discrete gradient memory", 1.0,
-                 tm.getElapsedTime(), this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 
-  const auto *const offsets = inputOffsets_;
-
-  this->initMemory(triangulation);
-
   // compute gradient pairs
-  processLowerStars(offsets, triangulation);
+  processLowerStars(this->inputOffsets_, triangulation);
 
   this->printMsg(
     "Built discrete gradient", 1.0, t.getElapsedTime(), this->threadNumber_);


### PR DESCRIPTION
This PR moves some memory allocations in the DiscreteGradient module:

- allocating the `gradient_` vector is now done during the preconditioning step (previously done in the `buildGradient` method).
- the `lowerStar` and the priority queue variables have been hoisted out of the parallel loop in order to reduce the dynamic allocations by cleaning & reusing their storage between iterations by a same thread (with the help of OpenMP's firstprivate clause).

Depending on the dataset size and the number of threads used, a small speedup is observed.

No modification observed in the ttk-data state files.

Enjoy,
Pierre 

