### PR TITLE
BlockTuple Extraction Mode; Auto ForEach Update

### DIFF
--- a/core/vtk/ttkEndFor/ttkEndFor.h
+++ b/core/vtk/ttkEndFor/ttkEndFor.h
@@ -21,6 +21,9 @@
 
 class TTKENDFOR_EXPORT ttkEndFor : public ttkAlgorithm {
 
+private:
+  int LastIterationIdx{-1};
+
 public:
   static ttkEndFor *New();
   vtkTypeMacro(ttkEndFor, ttkAlgorithm);

--- a/core/vtk/ttkExtract/ttkExtract.h
+++ b/core/vtk/ttkExtract/ttkExtract.h
@@ -59,11 +59,12 @@ public:
   vtkSetVector6Macro(ImageExtent, int);
   vtkGetVector6Macro(ImageExtent, int);
 
-  int GetVtkDataTypeName(std::string &dataTypeName, const int outputType) const;
+  std::string GetVtkDataTypeName(const int outputType) const;
 
   int ExtractBlocks(vtkDataObject *output,
                     vtkDataObject *input,
-                    const std::vector<double> &indices) const;
+                    const std::vector<double> &indices,
+                    const bool &extractTuples) const;
 
   int ExtractRows(vtkDataObject *output,
                   vtkDataObject *input,

--- a/paraview/Extract/Extract.xml
+++ b/paraview/Extract/Extract.xml
@@ -25,6 +25,7 @@ This filter uses a list of values to extract either blocks of a 'vtkMultiBlockDa
                     <Entry value="2" text="Geometry"/>
                     <Entry value="3" text="Array Values"/>
                     <Entry value="4" text="Arrays"/>
+                    <Entry value="5" text="Block Tuples"/>
                 </EnumerationDomain>
                 <Documentation>Extraction Mode.</Documentation>
             </IntVectorProperty>
@@ -37,6 +38,7 @@ This filter uses a list of values to extract either blocks of a 'vtkMultiBlockDa
                             <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="1"/>
                             <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="2"/>
                             <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="4"/>
+                            <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="5"/>
                             <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractUniqueValues" value="0"/>
                         </Expression>
                     </PropertyWidgetDecorator>
@@ -47,26 +49,18 @@ This filter uses a list of values to extract either blocks of a 'vtkMultiBlockDa
             <!-- Block Mode -->
             <IntVectorProperty name="OutputType" label="Output Type" command="SetOutputType" number_of_elements="1" default_values="-1">
                 <EnumerationDomain name="enum">
-                    <Entry value="-1" text="Auto"/>
-                    <Entry value="13" text="vtkMultiBlockDataSet"/>
-                    <Entry value="6" text="vtkImageData"/>
-                    <Entry value="4" text="vtkUnstructuredGrid"/>
-                    <Entry value="19" text="vtkTable"/>
+                  <Entry value="-1" text="Auto"/>
+                  <Entry value="13" text="vtkMultiBlockDataSet"/>
+                  <Entry value= "6" text="vtkImageData"/>
+                  <Entry value= "0" text="vtkPolyData"/>
+                  <Entry value= "4" text="vtkUnstructuredGrid"/>
+                  <Entry value="19" text="vtkTable"/>
                 </EnumerationDomain>
-                <Documentation>If mode is set to 'Block', then this parameter is used to set the output type of the filter at the 'RequestInformation' pass.
+                <Documentation>
+If mode is set to 'Block', then this parameter is used to set the output type of the filter at the 'RequestInformation' pass.
 
-Auto: Extracted blocks (of any type) are appended to a new 'vtkMultiBlockDataSet'.
-
-
-vtkImageData: If only one block is extracted and it is of type 'vtkImageData', then this block is returned as the output.
-
-
-vtkUnstructuredGrid: If only one block is extracted and it is of type 'vtkUnstructuredGrid', then this block is returned as the output.
-
-
-vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMultiBlockDataSet', then this block is returned as the output.
-
-</Documentation>
+Auto: Extracted blocks (of any type) are appended to a new 'vtkMultiBlockDataSet'. If the output type is specified, then only one object is returned which is of the specified type (Note: In this case the object is not contained in a 'vtkMultiBlockDataSet').
+                </Documentation>
                 <Hints>
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="0" />
                 </Hints>

--- a/paraview/ForEach/ForEach.xml
+++ b/paraview/ForEach/ForEach.xml
@@ -24,6 +24,7 @@
                     <Entry value="1" text="Rows"/>
                     <Entry value="3" text="Array Values"/>
                     <Entry value="4" text="Arrays"/>
+                    <Entry value="5" text="Block Tuples"/>
                 </EnumerationDomain>
                 <Documentation>
                     Iteration Mode.
@@ -58,25 +59,17 @@
 
             <IntVectorProperty name="OutputType" label="Output Type" command="SetOutputType" number_of_elements="1" default_values="-1">
                 <EnumerationDomain name="enum">
-                    <Entry value="-1" text="Auto"/>
-                    <Entry value="13" text="vtkMultiBlockDataSet"/>
-                    <Entry value="6" text="vtkImageData"/>
-                    <Entry value="4" text="vtkUnstructuredGrid"/>
-                    <Entry value="19" text="vtkTable"/>
+                  <Entry value="-1" text="Auto"/>
+                  <Entry value="13" text="vtkMultiBlockDataSet"/>
+                  <Entry value= "6" text="vtkImageData"/>
+                  <Entry value= "0" text="vtkPolyData"/>
+                  <Entry value= "4" text="vtkUnstructuredGrid"/>
+                  <Entry value="19" text="vtkTable"/>
                 </EnumerationDomain>
-                <Documentation>If mode is set to 'Block', then this parameter is used to set the output type of the filter at the 'RequestInformation' pass.
+                <Documentation>
+If mode is set to 'Block', then this parameter is used to set the output type of the filter at the 'RequestInformation' pass.
 
-Auto: Extracted blocks (of any type) are appended to a new 'vtkMultiBlockDataSet'.
-
-
-vtkImageData: If only one block is extracted and it is of type 'vtkImageData', then this block is returned as the output.
-
-
-vtkUnstructuredGrid: If only one block is extracted and it is of type 'vtkUnstructuredGrid', then this block is returned as the output.
-
-
-vtkMultiBlockDataSet: If only one block is extracted and it is of type 'vtkMultiBlockDataSet', then this block is returned as the output.
-
+Auto: Extracted blocks (of any type) are appended to a new 'vtkMultiBlockDataSet'. If the output type is specified, then only one object is returned which is of the specified type (Note: In this case the object is not contained in a 'vtkMultiBlockDataSet').
                 </Documentation>
                 <Hints>
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="0" />


### PR DESCRIPTION
Hi Julien,
this PR has two contributions:
1) The `ttkExtract` filter now makes it possible to extract so called block tuples. In many tracking use cases you encounter `vtkMultiBlockDataSets` of the following form:
  MB containing three lists:
  > List of Merge Trees over time
  > List of Merge Tree Domain Segmentations over time
  > List of Persistence Diagrams over time
Before it was not possible to simply extract the `MT+S+PD` tuple that corresponds to the i-th timestep. Now the `ttkExtract` filter understands this common data structure and makes it possible to extract tuples by index. The `ForEach` filter can not also be used to iterate over all tuples.

2) Right now if users change something inside a `ForEach` loop they need to manually restart the `ForEach` iterations. With this PR the `EndFor` filter detects if an iteration is executed twice (if a change inside the loop occurred), so for convenience it will automatically restart the iterations.

Best
Jonas
