### PR TITLE
(Explicit)Triangulation: Use vectors of arrays instead of vectors of vectors for additional performance

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.cpp
+++ b/core/base/abstractTriangulation/AbstractTriangulation.cpp
@@ -40,9 +40,9 @@ int AbstractTriangulation::clear() {
   boundaryTriangles_.clear();
   boundaryVertices_.clear();
 
-  cellEdgeList_.clear();
+  tetraEdgeList_.clear();
   cellNeighborList_.clear();
-  cellTriangleList_.clear();
+  tetraTriangleList_.clear();
 
   edgeLinkList_.clear();
   edgeList_.clear();
@@ -95,12 +95,12 @@ size_t AbstractTriangulation::footprint() const {
 
   size += tableFootprint<bool>(boundaryVertices_, "boundaryVertices_");
 
-  size += tableFootprint(cellEdgeList_, "cellEdgeList_");
+  size += tableFootprint(tetraEdgeList_, "tetraEdgeList_");
 
   size
     += tableTableFootprint<SimplexId>(cellNeighborList_, "cellNeighborList_");
 
-  size += tableFootprint(cellTriangleList_, "cellTriangleList_");
+  size += tableFootprint(tetraTriangleList_, "tetraTriangleList_");
 
   size += tableTableFootprint<SimplexId>(edgeLinkList_, "edgeLinkList_");
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.cpp
+++ b/core/base/abstractTriangulation/AbstractTriangulation.cpp
@@ -95,27 +95,25 @@ size_t AbstractTriangulation::footprint() const {
 
   size += tableFootprint<bool>(boundaryVertices_, "boundaryVertices_");
 
-  size += tableTableFootprint<SimplexId>(cellEdgeList_, "cellEdgeList_");
+  size += tableFootprint(cellEdgeList_, "cellEdgeList_");
 
   size
     += tableTableFootprint<SimplexId>(cellNeighborList_, "cellNeighborList_");
 
-  size
-    += tableTableFootprint<SimplexId>(cellTriangleList_, "cellTriangleList_");
+  size += tableFootprint(cellTriangleList_, "cellTriangleList_");
 
   size += tableTableFootprint<SimplexId>(edgeLinkList_, "edgeLinkList_");
 
-  size += tableFootprint<pair<SimplexId, SimplexId>>(edgeList_, "edgeList_");
+  size += tableFootprint(edgeList_, "edgeList_");
 
   size += tableTableFootprint<SimplexId>(edgeStarList_, "edgeStarList_");
 
   size
     += tableTableFootprint<SimplexId>(edgeTriangleList_, "edgeTriangleList_");
 
-  size += tableTableFootprint<SimplexId>(triangleList_, "triangleList_");
+  size += tableFootprint(triangleList_, "triangleList_");
 
-  size
-    += tableTableFootprint<SimplexId>(triangleEdgeList_, "triangleEdgeList_");
+  size += tableFootprint(triangleEdgeList_, "triangleEdgeList_");
 
   size
     += tableTableFootprint<SimplexId>(triangleLinkList_, "triangleLinkList_");
@@ -134,6 +132,10 @@ size_t AbstractTriangulation::footprint() const {
 
   size += tableTableFootprint<SimplexId>(
     vertexTriangleList_, "vertexTriangleList_");
+
+  size += tableTableFootprint(cellEdgeVector_, "cellEdgeVector_");
+  size += tableTableFootprint(cellTriangleVector_, "cellTriangleVector_");
+  size += tableTableFootprint(triangleEdgeVector_, "triangleEdgeVector_");
 
   msg << "Total footprint: " << (size / 1024) / 1024 << " MB.";
   printMsg(msg.str());

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -94,6 +94,9 @@ namespace ttk {
       if(getDimensionality() == 1)
         return getCellNeighbor(cellId, localEdgeId, edgeId);
 
+      else if(getDimensionality() == 2)
+        return getTriangleEdgeInternal(cellId, localEdgeId, edgeId);
+
       return getCellEdgeInternal(cellId, localEdgeId, edgeId);
     }
 
@@ -120,6 +123,9 @@ namespace ttk {
 #endif
       if(getDimensionality() == 1)
         return getCellNeighborNumber(cellId);
+
+      else if(getDimensionality() == 2)
+        return getTriangleEdgeNumber(cellId);
 
       return getCellEdgeNumberInternal(cellId);
     };
@@ -159,6 +165,9 @@ namespace ttk {
 #endif
       if(getDimensionality() == 1)
         return getCellNeighbors();
+
+      else if(getDimensionality() == 2)
+        return getTriangleEdgesInternal();
 
       return getCellEdgesInternal();
     };
@@ -937,8 +946,6 @@ namespace ttk {
       if(!hasPreconditionedTriangleEdges())
         return -2;
 #endif
-      if(getDimensionality() == 2)
-        return getCellEdge(triangleId, localEdgeId, edgeId);
 
       return getTriangleEdgeInternal(triangleId, localEdgeId, edgeId);
     };
@@ -966,8 +973,6 @@ namespace ttk {
       if(!hasPreconditionedTriangleEdges())
         return -2;
 #endif
-      if(getDimensionality() == 2)
-        return getCellEdgeNumber(triangleId);
 
       return getTriangleEdgeNumberInternal(triangleId);
     };
@@ -1006,8 +1011,6 @@ namespace ttk {
       if(!hasPreconditionedTriangleEdges())
         return NULL;
 #endif
-      if(getDimensionality() == 2)
-        return getCellEdges();
 
       return getTriangleEdgesInternal();
     };

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3181,9 +3181,9 @@ namespace ttk {
     std::array<int, 3> gridDimensions_;
 
     std::vector<bool> boundaryEdges_, boundaryTriangles_, boundaryVertices_;
-    std::vector<std::array<SimplexId, 6>> cellEdgeList_;
+    std::vector<std::array<SimplexId, 6>> tetraEdgeList_;
     std::vector<std::vector<SimplexId>> cellNeighborList_;
-    std::vector<std::array<SimplexId, 4>> cellTriangleList_;
+    std::vector<std::array<SimplexId, 4>> tetraTriangleList_;
     std::vector<std::vector<SimplexId>> edgeLinkList_;
     std::vector<std::array<SimplexId, 2>> edgeList_;
     std::vector<std::vector<SimplexId>> edgeStarList_;

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -433,8 +433,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge list.
-    virtual inline const std::vector<std::pair<SimplexId, SimplexId>> *
-      getEdges() {
+    virtual inline const std::vector<std::array<SimplexId, 2>> *getEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
         return NULL;
@@ -899,7 +898,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle list.
-    virtual inline const std::vector<std::vector<SimplexId>> *getTriangles() {
+    virtual inline const std::vector<std::array<SimplexId, 3>> *getTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedTriangles())
         return NULL;
@@ -2548,7 +2547,7 @@ namespace ttk {
       return 0;
     }
 
-    virtual inline const std::vector<std::pair<SimplexId, SimplexId>> *
+    virtual inline const std::vector<std::array<SimplexId, 2>> *
       getEdgesInternal() {
       return NULL;
     };
@@ -2623,7 +2622,7 @@ namespace ttk {
       return 0;
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    virtual inline const std::vector<std::array<SimplexId, 3>> *
       getTrianglesInternal() {
       return NULL;
     };
@@ -3179,15 +3178,15 @@ namespace ttk {
     std::array<int, 3> gridDimensions_;
 
     std::vector<bool> boundaryEdges_, boundaryTriangles_, boundaryVertices_;
-    std::vector<std::vector<SimplexId>> cellEdgeList_;
+    std::vector<std::array<SimplexId, 6>> cellEdgeList_;
     std::vector<std::vector<SimplexId>> cellNeighborList_;
-    std::vector<std::vector<SimplexId>> cellTriangleList_;
+    std::vector<std::array<SimplexId, 4>> cellTriangleList_;
     std::vector<std::vector<SimplexId>> edgeLinkList_;
-    std::vector<std::pair<SimplexId, SimplexId>> edgeList_;
+    std::vector<std::array<SimplexId, 2>> edgeList_;
     std::vector<std::vector<SimplexId>> edgeStarList_;
     std::vector<std::vector<SimplexId>> edgeTriangleList_;
-    std::vector<std::vector<SimplexId>> triangleList_;
-    std::vector<std::vector<SimplexId>> triangleEdgeList_;
+    std::vector<std::array<SimplexId, 3>> triangleList_;
+    std::vector<std::array<SimplexId, 3>> triangleEdgeList_;
     std::vector<std::vector<SimplexId>> triangleLinkList_;
     std::vector<std::vector<SimplexId>> triangleStarList_;
     std::vector<std::vector<SimplexId>> vertexEdgeList_;
@@ -3195,6 +3194,12 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> vertexNeighborList_;
     std::vector<std::vector<SimplexId>> vertexStarList_;
     std::vector<std::vector<SimplexId>> vertexTriangleList_;
+
+    // keep compatibility between getCellEdges(), getCellTriangles(),
+    // getCellNeighbors() and getTriangleEdges()
+    std::vector<std::vector<SimplexId>> cellEdgeVector_{};
+    std::vector<std::vector<SimplexId>> cellTriangleVector_{};
+    std::vector<std::vector<SimplexId>> triangleEdgeVector_{};
   };
 } // namespace ttk
 

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -8,6 +8,7 @@ ttk_add_base_library(common
         CommandLineParser.h
         Debug.h
         DataTypes.h
+        OpenMPLock.h
         OrderDisambiguation.h
         Os.h
         ProgramBase.h

--- a/core/base/common/OpenMPLock.h
+++ b/core/base/common/OpenMPLock.h
@@ -1,0 +1,39 @@
+#ifdef TTK_ENABLE_OPENMP
+#include <omp.h>
+#endif // TTK_ENABLE_OPENMP
+
+namespace ttk {
+  /**
+   * @brief RAII wrapper around OpenMP lock
+   */
+  class Lock {
+#ifdef TTK_ENABLE_OPENMP
+  public:
+    Lock() {
+      omp_init_lock(&this->lock_);
+    }
+    ~Lock() {
+      omp_destroy_lock(&this->lock_);
+    }
+    inline void lock() {
+      omp_set_lock(&this->lock_);
+    }
+    inline void unlock() {
+      omp_unset_lock(&this->lock_);
+    }
+    Lock(const Lock &) = delete;
+    Lock(Lock &&) = delete;
+    Lock &operator=(const Lock &) = delete;
+    Lock &operator=(Lock &&) = delete;
+
+  private:
+    omp_lock_t lock_{};
+#else
+  public:
+    inline void lock() {
+    }
+    inline void unlock() {
+    }
+#endif // TTK_ENABLE_OPENMP
+  };
+} // namespace ttk

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -14,16 +14,11 @@ ExplicitTriangulation::~ExplicitTriangulation() {
 }
 
 int ExplicitTriangulation::clear() {
-
-  AbstractTriangulation::clear();
-
   vertexNumber_ = 0;
   cellNumber_ = 0;
   doublePrecision_ = false;
 
-  printMsg(
-    "[ExplicitTriangulation] Triangulation cleared.", debug::Priority::DETAIL);
-  // clear twice ??
+  printMsg("Triangulation cleared.", debug::Priority::DETAIL);
 
   return AbstractTriangulation::clear();
 }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -35,23 +35,23 @@ namespace ttk {
                                    SimplexId &edgeId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
-      if((cellId < 0) || (cellId >= (SimplexId)cellEdgeList_.size()))
+      if((cellId < 0) || (cellId >= (SimplexId)tetraEdgeList_.size()))
         return -1;
       if((localEdgeId < 0)
-         || (localEdgeId >= (SimplexId)cellEdgeList_[cellId].size()))
+         || (localEdgeId >= (SimplexId)tetraEdgeList_[cellId].size()))
         return -2;
 #endif
-      edgeId = cellEdgeList_[cellId][localEdgeId];
+      edgeId = tetraEdgeList_[cellId][localEdgeId];
       return 0;
     }
 
     inline SimplexId
       getCellEdgeNumberInternal(const SimplexId &cellId) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
-      if((cellId < 0) || (cellId >= (SimplexId)cellEdgeList_.size()))
+      if((cellId < 0) || (cellId >= (SimplexId)tetraEdgeList_.size()))
         return -1;
 #endif
-      return cellEdgeList_[cellId].size();
+      return tetraEdgeList_[cellId].size();
     }
 
     template <std::size_t N>
@@ -66,7 +66,7 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *
       getCellEdgesInternal() override {
 
-      convertToVector(cellEdgeList_, cellEdgeVector_);
+      convertToVector(tetraEdgeList_, cellEdgeVector_);
       return &cellEdgeVector_;
     }
 
@@ -104,13 +104,13 @@ namespace ttk {
                                        SimplexId &triangleId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
-      if((cellId < 0) || (cellId >= (SimplexId)cellTriangleList_.size()))
+      if((cellId < 0) || (cellId >= (SimplexId)tetraTriangleList_.size()))
         return -1;
       if((localTriangleId < 0)
-         || (localTriangleId >= (SimplexId)cellTriangleList_[cellId].size()))
+         || (localTriangleId >= (SimplexId)tetraTriangleList_[cellId].size()))
         return -2;
 #endif
-      triangleId = cellTriangleList_[cellId][localTriangleId];
+      triangleId = tetraTriangleList_[cellId][localTriangleId];
 
       return 0;
     }
@@ -119,17 +119,17 @@ namespace ttk {
       getCellTriangleNumberInternal(const SimplexId &cellId) const override {
 
 #ifndef TTK_ENABLE_KAMIKAZE
-      if((cellId < 0) || (cellId >= (SimplexId)cellTriangleList_.size()))
+      if((cellId < 0) || (cellId >= (SimplexId)tetraTriangleList_.size()))
         return -1;
 #endif
 
-      return cellTriangleList_[cellId].size();
+      return tetraTriangleList_[cellId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() override {
 
-      convertToVector(cellTriangleList_, cellTriangleVector_);
+      convertToVector(tetraTriangleList_, cellTriangleVector_);
       return &cellTriangleVector_;
     }
 
@@ -728,8 +728,8 @@ namespace ttk {
       ThreeSkeleton threeSkeleton;
       threeSkeleton.setWrapper(this);
 
-      if(cellEdgeList_.empty() && getDimensionality() == 3) {
-        threeSkeleton.buildCellEdges(vertexNumber_, *cellArray_, cellEdgeList_,
+      if(tetraEdgeList_.empty() && getDimensionality() == 3) {
+        threeSkeleton.buildCellEdges(vertexNumber_, *cellArray_, tetraEdgeList_,
                                      &edgeList_, &vertexEdgeList_);
 
       } else if(triangleEdgeList_.empty() && getDimensionality() == 2) {
@@ -757,7 +757,7 @@ namespace ttk {
 
     inline int preconditionCellTrianglesInternal() override {
 
-      if(!cellTriangleList_.size()) {
+      if(!tetraTriangleList_.size()) {
 
         TwoSkeleton twoSkeleton;
         twoSkeleton.setWrapper(this);
@@ -765,27 +765,28 @@ namespace ttk {
         if(triangleList_.size()) {
           // we already computed this guy, let's just get the cell triangles
           if(triangleStarList_.size()) {
-            return twoSkeleton.buildTriangleList(
-              vertexNumber_, *cellArray_, nullptr, nullptr, &cellTriangleList_);
+            return twoSkeleton.buildTriangleList(vertexNumber_, *cellArray_,
+                                                 nullptr, nullptr,
+                                                 &tetraTriangleList_);
           } else {
             // let's compute the triangle star while we're at it...
             // it's just a tiny overhead.
             return twoSkeleton.buildTriangleList(vertexNumber_, *cellArray_,
                                                  nullptr, &triangleStarList_,
-                                                 &cellTriangleList_);
+                                                 &tetraTriangleList_);
           }
         } else {
           // we have not computed this guy, let's do it while we're at it
           if(triangleStarList_.size()) {
             return twoSkeleton.buildTriangleList(vertexNumber_, *cellArray_,
                                                  &triangleList_, nullptr,
-                                                 &cellTriangleList_);
+                                                 &tetraTriangleList_);
           } else {
             // let's compute the triangle star while we're at it...
             // it's just a tiny overhead.
             return twoSkeleton.buildTriangleList(
               vertexNumber_, *cellArray_, &triangleList_, &triangleStarList_,
-              &cellTriangleList_);
+              &tetraTriangleList_);
           }
         }
       }
@@ -824,7 +825,7 @@ namespace ttk {
           OneSkeleton oneSkeleton;
           oneSkeleton.setWrapper(this);
           return oneSkeleton.buildEdgeLinks(
-            edgeList_, edgeStarList_, cellEdgeList_, edgeLinkList_);
+            edgeList_, edgeStarList_, tetraEdgeList_, edgeLinkList_);
         } else {
           // unsupported dimension
           printErr("Unsupported dimension for edge link precondition");
@@ -861,7 +862,7 @@ namespace ttk {
         return twoSkeleton.buildEdgeTriangles(
           vertexNumber_, *cellArray_, edgeTriangleList_, &vertexStarList_,
           &edgeList_, &edgeStarList_, &triangleList_, &triangleStarList_,
-          &cellTriangleList_);
+          &tetraTriangleList_);
       }
 
       return 0;
@@ -876,7 +877,7 @@ namespace ttk {
 
         twoSkeleton.buildTriangleList(vertexNumber_, *cellArray_,
                                       &triangleList_, &triangleStarList_,
-                                      &cellTriangleList_);
+                                      &tetraTriangleList_);
       }
 
       return 0;
@@ -896,7 +897,7 @@ namespace ttk {
 
         return twoSkeleton.buildTriangleEdgeList(
           vertexNumber_, *cellArray_, triangleEdgeList_, &vertexEdgeList_,
-          &edgeList_, &triangleList_, &triangleStarList_, &cellTriangleList_);
+          &edgeList_, &triangleList_, &triangleStarList_, &tetraTriangleList_);
       }
 
       return 0;
@@ -966,8 +967,9 @@ namespace ttk {
 
           ZeroSkeleton zeroSkeleton;
           zeroSkeleton.setWrapper(this);
-          return zeroSkeleton.buildVertexLinks(
-            vertexStarList_, cellTriangleList_, triangleList_, vertexLinkList_);
+          return zeroSkeleton.buildVertexLinks(vertexStarList_,
+                                               tetraTriangleList_,
+                                               triangleList_, vertexLinkList_);
         } else {
           // unsupported dimension
           printErr("Unsupported dimension for vertex link precondition");

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -54,10 +54,20 @@ namespace ttk {
       return cellEdgeList_[cellId].size();
     }
 
+    template <std::size_t N>
+    inline void
+      convertToVector(const std::vector<std::array<SimplexId, N>> &table,
+                      std::vector<std::vector<SimplexId>> &vec) {
+      for(size_t i = 0; i < table.size(); ++i) {
+        vec[i] = {table[i].begin(), table[i].end()};
+      }
+    }
+
     inline const std::vector<std::vector<SimplexId>> *
       getCellEdgesInternal() override {
 
-      return &cellEdgeList_;
+      convertToVector(cellEdgeList_, cellEdgeVector_);
+      return &cellEdgeVector_;
     }
 
     inline int TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
@@ -119,7 +129,8 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() override {
 
-      return &cellTriangleList_;
+      convertToVector(cellTriangleList_, cellTriangleVector_);
+      return &cellTriangleVector_;
     }
 
     inline int TTK_TRIANGULATION_INTERNAL(getCellVertex)(
@@ -147,7 +158,7 @@ namespace ttk {
       return maxCellDim_;
     }
 
-    inline const std::vector<std::pair<SimplexId, SimplexId>> *
+    inline const std::vector<std::array<SimplexId, 2>> *
       TTK_TRIANGULATION_INTERNAL(getEdges)() override {
       return &edgeList_;
     }
@@ -254,9 +265,9 @@ namespace ttk {
         return -2;
 #endif
       if(!localVertexId)
-        vertexId = edgeList_[edgeId].first;
+        vertexId = edgeList_[edgeId][0];
       else
-        vertexId = edgeList_[edgeId].second;
+        vertexId = edgeList_[edgeId][1];
       return 0;
     }
 
@@ -278,7 +289,7 @@ namespace ttk {
       return vertexNumber_;
     }
 
-    inline const std::vector<std::vector<SimplexId>> *
+    inline const std::vector<std::array<SimplexId, 3>> *
       TTK_TRIANGULATION_INTERNAL(getTriangles)() override {
       return &triangleList_;
     }
@@ -315,7 +326,8 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *
       getTriangleEdgesInternal() override {
 
-      return &triangleEdgeList_;
+      convertToVector(triangleEdgeList_, triangleEdgeVector_);
+      return &triangleEdgeVector_;
     }
 
     inline int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
@@ -687,8 +699,8 @@ namespace ttk {
 
         for(SimplexId i = 0; i < (SimplexId)edgeStarList_.size(); i++) {
           if(edgeStarList_[i].size() == 1) {
-            boundaryVertices_[edgeList_[i].first] = true;
-            boundaryVertices_[edgeList_[i].second] = true;
+            boundaryVertices_[edgeList_[i][0]] = true;
+            boundaryVertices_[edgeList_[i][1]] = true;
           }
         }
       } else if(getDimensionality() == 3) {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -725,13 +725,17 @@ namespace ttk {
 
     inline int preconditionCellEdgesInternal() override {
 
-      if(!cellEdgeList_.size()) {
+      ThreeSkeleton threeSkeleton;
+      threeSkeleton.setWrapper(this);
 
-        ThreeSkeleton threeSkeleton;
-        threeSkeleton.setWrapper(this);
-
+      if(cellEdgeList_.empty() && getDimensionality() == 3) {
         threeSkeleton.buildCellEdges(vertexNumber_, *cellArray_, cellEdgeList_,
                                      &edgeList_, &vertexEdgeList_);
+
+      } else if(triangleEdgeList_.empty() && getDimensionality() == 2) {
+        threeSkeleton.buildCellEdges(vertexNumber_, *cellArray_,
+                                     triangleEdgeList_, &edgeList_,
+                                     &vertexEdgeList_);
       }
 
       return 0;
@@ -955,7 +959,7 @@ namespace ttk {
           ZeroSkeleton zeroSkeleton;
           zeroSkeleton.setWrapper(this);
           return zeroSkeleton.buildVertexLinks(
-            vertexStarList_, cellEdgeList_, edgeList_, vertexLinkList_);
+            vertexStarList_, triangleEdgeList_, edgeList_, vertexLinkList_);
         } else if(getDimensionality() == 3) {
           preconditionVertexStarsInternal();
           preconditionCellTrianglesInternal();

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1315,7 +1315,7 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
   return 0;
 }
 
-const vector<pair<SimplexId, SimplexId>> *
+const vector<std::array<SimplexId, 2>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
 
   if(!edgeList_.size()) {
@@ -1326,8 +1326,7 @@ const vector<pair<SimplexId, SimplexId>> *
       SimplexId id0, id1;
       getEdgeVertexInternal(i, 0, id0);
       getEdgeVertexInternal(i, 1, id1);
-      edgeList_[i].first = id0;
-      edgeList_[i].second = id1;
+      edgeList_[i] = {id0, id1};
     }
 
     printMsg(
@@ -1955,19 +1954,19 @@ int ImplicitTriangulation::getTriangleEdgesInternal(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::getTriangleEdgesInternal() {
-  if(!triangleEdgeList_.size()) {
+  if(triangleEdgeVector_.empty()) {
     Timer t;
 
-    getTriangleEdgesInternal(triangleEdgeList_);
+    getTriangleEdgesInternal(triangleEdgeVector_);
 
     printMsg("Built " + to_string(triangleNumber_) + " triangle edges.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &triangleEdgeList_;
+  return &triangleEdgeVector_;
 }
 
-const vector<vector<SimplexId>> *
+const vector<std::array<SimplexId, 3>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
 
   if(!triangleList_.size()) {
@@ -1975,7 +1974,6 @@ const vector<vector<SimplexId>> *
 
     triangleList_.resize(triangleNumber_);
     for(SimplexId i = 0; i < triangleNumber_; ++i) {
-      triangleList_[i].resize(3);
       for(int j = 0; j < 3; ++j)
         getTriangleVertexInternal(i, j, triangleList_[i][j]);
     }
@@ -2574,19 +2572,19 @@ int ImplicitTriangulation::getCellEdgeInternal(const SimplexId &cellId,
 }
 
 const vector<vector<SimplexId>> *ImplicitTriangulation::getCellEdgesInternal() {
-  if(!cellEdgeList_.size()) {
+  if(cellEdgeVector_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)
-      getTetrahedronEdges(cellEdgeList_);
+      getTetrahedronEdges(cellEdgeVector_);
     else if(dimensionality_ == 2)
-      getTriangleEdgesInternal(cellEdgeList_);
+      getTriangleEdgesInternal(cellEdgeVector_);
 
     printMsg("Built " + to_string(cellNumber_) + " cell edges.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &cellEdgeList_;
+  return &cellEdgeVector_;
 }
 
 int ImplicitTriangulation::getCellTriangleInternal(
@@ -2601,17 +2599,17 @@ int ImplicitTriangulation::getCellTriangleInternal(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::getCellTrianglesInternal() {
-  if(!cellTriangleList_.size()) {
+  if(cellTriangleVector_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)
-      getTetrahedronTriangles(cellTriangleList_);
+      getTetrahedronTriangles(cellTriangleVector_);
 
     printMsg("Built " + to_string(cellNumber_) + " cell triangles.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &cellTriangleList_;
+  return &cellTriangleVector_;
 }
 
 SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -104,7 +104,7 @@ namespace ttk {
                               const int &localVertexId,
                               SimplexId &vertexId) const override;
 
-    const std::vector<std::pair<SimplexId, SimplexId>> *
+    const std::vector<std::array<SimplexId, 2>> *
       TTK_TRIANGULATION_INTERNAL(getEdges)() override;
 
     SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfCells)() const override {
@@ -199,7 +199,7 @@ namespace ttk {
                                   const int &localVertexId,
                                   SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *
+    const std::vector<std::array<SimplexId, 3>> *
       TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
 
     int getVertexEdgeInternal(const SimplexId &vertexId,

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -855,7 +855,7 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
   return 0;
 }
 
-const vector<pair<SimplexId, SimplexId>> *
+const vector<std::array<SimplexId, 2>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
 
   if(!edgeList_.size()) {
@@ -866,8 +866,7 @@ const vector<pair<SimplexId, SimplexId>> *
       SimplexId id0, id1;
       getEdgeVertexInternal(i, 0, id0);
       getEdgeVertexInternal(i, 1, id1);
-      edgeList_[i].first = id0;
-      edgeList_[i].second = id1;
+      edgeList_[i] = {id0, id1};
     }
 
     printMsg(
@@ -1286,19 +1285,19 @@ int PeriodicImplicitTriangulation::getTriangleEdgesInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getTriangleEdgesInternal() {
-  if(!triangleEdgeList_.size()) {
+  if(triangleEdgeVector_.empty()) {
     Timer t;
 
-    getTriangleEdgesInternal(triangleEdgeList_);
+    getTriangleEdgesInternal(triangleEdgeVector_);
 
     printMsg("Built " + to_string(triangleNumber_) + " triangle edges.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &triangleEdgeList_;
+  return &triangleEdgeVector_;
 }
 
-const vector<vector<SimplexId>> *
+const vector<std::array<SimplexId, 3>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
 
   if(!triangleList_.size()) {
@@ -1306,7 +1305,6 @@ const vector<vector<SimplexId>> *
 
     triangleList_.resize(triangleNumber_);
     for(SimplexId i = 0; i < triangleNumber_; ++i) {
-      triangleList_[i].resize(3);
       for(int j = 0; j < 3; ++j)
         getTriangleVertexInternal(i, j, triangleList_[i][j]);
     }
@@ -1842,19 +1840,19 @@ int PeriodicImplicitTriangulation::getCellEdgeInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getCellEdgesInternal() {
-  if(!cellEdgeList_.size()) {
+  if(cellEdgeVector_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)
-      getTetrahedronEdges(cellEdgeList_);
+      getTetrahedronEdges(cellEdgeVector_);
     else if(dimensionality_ == 2)
-      getTriangleEdgesInternal(cellEdgeList_);
+      getTriangleEdgesInternal(cellEdgeVector_);
 
     printMsg("Built " + to_string(cellNumber_) + " cell edges.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &cellEdgeList_;
+  return &cellEdgeVector_;
 }
 
 int PeriodicImplicitTriangulation::getCellTriangleInternal(
@@ -1869,17 +1867,17 @@ int PeriodicImplicitTriangulation::getCellTriangleInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getCellTrianglesInternal() {
-  if(!cellTriangleList_.size()) {
+  if(cellTriangleVector_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)
-      getTetrahedronTriangles(cellTriangleList_);
+      getTetrahedronTriangles(cellTriangleVector_);
 
     printMsg("Built " + to_string(cellNumber_) + " cell triangles.", 1,
              t.getElapsedTime(), 1);
   }
 
-  return &cellTriangleList_;
+  return &cellTriangleVector_;
 }
 
 SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -107,7 +107,7 @@ namespace ttk {
                               const int &localVertexId,
                               SimplexId &vertexId) const override;
 
-    const std::vector<std::pair<SimplexId, SimplexId>> *
+    const std::vector<std::array<SimplexId, 2>> *
       TTK_TRIANGULATION_INTERNAL(getEdges)() override;
 
     SimplexId TTK_TRIANGULATION_INTERNAL(getNumberOfCells)() const override {
@@ -202,7 +202,7 @@ namespace ttk {
                                   const int &localVertexId,
                                   SimplexId &vertexId) const override;
 
-    const std::vector<std::vector<SimplexId>> *
+    const std::vector<std::array<SimplexId, 3>> *
       TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
 
     int getVertexEdgeInternal(const SimplexId &vertexId,

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -82,16 +82,15 @@ int OneSkeleton::buildEdgeLinks(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)edgeLinks.size(); i++) {
+  for(size_t i = 0; i < edgeLinks.size(); i++) {
 
     SimplexId otherEdgeId = -1;
 
-    for(SimplexId j = 0; j < (SimplexId)edgeStars[i].size(); j++) {
+    for(size_t j = 0; j < edgeStars[i].size(); j++) {
 
       SimplexId linkEdgeId = -1;
 
-      for(SimplexId k = 0; k < (SimplexId)cellEdges[edgeStars[i][j]].size();
-          k++) {
+      for(size_t k = 0; k < cellEdges[edgeStars[i][j]].size(); k++) {
         otherEdgeId = cellEdges[edgeStars[i][j]][k];
 
         if((edgeList[otherEdgeId][0] != edgeList[i][0])
@@ -240,7 +239,7 @@ int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
   }
 
   starList.resize(localEdgeList->size());
-  for(SimplexId i = 0; i < (SimplexId)starList.size(); i++)
+  for(size_t i = 0; i < starList.size(); i++)
     starList[i].reserve(16);
 
   auto localVertexStars = vertexStars;
@@ -263,18 +262,16 @@ int OneSkeleton::buildEdgeStars(const SimplexId &vertexNumber,
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)localEdgeList->size(); i++) {
+  for(size_t i = 0; i < localEdgeList->size(); i++) {
 
     SimplexId vertex0 = (*localEdgeList)[i][0];
     SimplexId vertex1 = (*localEdgeList)[i][1];
 
     // merge the two vertex stars
-    for(SimplexId j = 0; j < (SimplexId)(*localVertexStars)[vertex0].size();
-        j++) {
+    for(size_t j = 0; j < (*localVertexStars)[vertex0].size(); j++) {
 
       bool hasFound = false;
-      for(SimplexId k = 0; k < (SimplexId)(*localVertexStars)[vertex1].size();
-          k++) {
+      for(size_t k = 0; k < (*localVertexStars)[vertex1].size(); k++) {
         if((*localVertexStars)[vertex0][j] == (*localVertexStars)[vertex1][k]) {
           hasFound = true;
           break;

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -57,10 +57,11 @@ int OneSkeleton::buildEdgeLinks(
   return 0;
 }
 
+template <std::size_t n>
 int OneSkeleton::buildEdgeLinks(
   const vector<std::array<SimplexId, 2>> &edgeList,
   const vector<vector<SimplexId>> &edgeStars,
-  const vector<std::array<SimplexId, 6>> &cellEdges,
+  const vector<std::array<SimplexId, n>> &cellEdges,
   vector<vector<SimplexId>> &edgeLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -111,6 +112,20 @@ int OneSkeleton::buildEdgeLinks(
 
   return 0;
 }
+
+// explicit template instantiations for 3D cells (tetrahedrons)
+template int OneSkeleton::buildEdgeLinks<6>(
+  const vector<std::array<SimplexId, 2>> &edgeList,
+  const vector<vector<SimplexId>> &edgeStars,
+  const vector<std::array<SimplexId, 6>> &cellEdges,
+  vector<vector<SimplexId>> &edgeLinks) const;
+
+// explicit template instantiations for 2D cells (triangles)
+template int OneSkeleton::buildEdgeLinks<3>(
+  const vector<std::array<SimplexId, 2>> &edgeList,
+  const vector<vector<SimplexId>> &edgeStars,
+  const vector<std::array<SimplexId, 3>> &cellEdges,
+  vector<vector<SimplexId>> &edgeLinks) const;
 
 int OneSkeleton::buildEdgeList(
   const SimplexId &vertexNumber,

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -65,7 +65,7 @@ namespace ttk {
     /// entry will be a std::vector listing the vertices in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    template<std::size_t n>
+    template <std::size_t n>
     int buildEdgeLinks(const std::vector<std::array<SimplexId, 2>> &edgeList,
                        const std::vector<std::vector<SimplexId>> &edgeStars,
                        const std::vector<std::array<SimplexId, n>> &cellEdges,

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -13,6 +13,7 @@
 #ifndef _ONESKELETON_H
 #define _ONESKELETON_H
 
+#include <array>
 #include <map>
 
 // base code includes

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -44,11 +44,10 @@ namespace ttk {
     /// std::vector listing the vertices in the link of the corresponding
     /// vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildEdgeLinks(
-      const std::vector<std::pair<SimplexId, SimplexId>> &edgeList,
-      const std::vector<std::vector<SimplexId>> &edgeStars,
-      const CellArray &cellArray,
-      std::vector<std::vector<SimplexId>> &edgeLinks) const;
+    int buildEdgeLinks(const std::vector<std::array<SimplexId, 2>> &edgeList,
+                       const std::vector<std::vector<SimplexId>> &edgeStars,
+                       const CellArray &cellArray,
+                       std::vector<std::vector<SimplexId>> &edgeLinks) const;
 
     /// Compute the link of each edge of a 3D triangulation (unspecified
     /// behavior if the input mesh is not a valid triangulation).
@@ -66,11 +65,10 @@ namespace ttk {
     /// entry will be a std::vector listing the vertices in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildEdgeLinks(
-      const std::vector<std::pair<SimplexId, SimplexId>> &edgeList,
-      const std::vector<std::vector<SimplexId>> &edgeStars,
-      const std::vector<std::vector<SimplexId>> &cellEdges,
-      std::vector<std::vector<SimplexId>> &edgeLinks) const;
+    int buildEdgeLinks(const std::vector<std::array<SimplexId, 2>> &edgeList,
+                       const std::vector<std::vector<SimplexId>> &edgeStars,
+                       const std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       std::vector<std::vector<SimplexId>> &edgeLinks) const;
 
     /// Compute the list of edges of a valid triangulation.
     /// \param vertexNumber Number of vertices in the triangulation.
@@ -80,10 +78,9 @@ namespace ttk {
     /// of
     /// vertex identifiers).
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildEdgeList(
-      const SimplexId &vertexNumber,
-      const CellArray &cellArray,
-      std::vector<std::pair<SimplexId, SimplexId>> &edgeList) const;
+    int buildEdgeList(const SimplexId &vertexNumber,
+                      const CellArray &cellArray,
+                      std::vector<std::array<SimplexId, 2>> &edgeList) const;
 
     /// Compute the list of edges of multiple triangulations.
     /// \param cellArrays Vector of cells. For each triangulation, each entry
@@ -130,7 +127,7 @@ namespace ttk {
     int buildEdgeStars(const SimplexId &vertexNumber,
                        const CellArray &cellArray,
                        std::vector<std::vector<SimplexId>> &starList,
-                       std::vector<std::pair<SimplexId, SimplexId>> *edgeList
+                       std::vector<std::array<SimplexId, 2>> *edgeList
                        = nullptr,
                        std::vector<std::vector<SimplexId>> *vertexStars
                        = nullptr) const;
@@ -141,9 +138,8 @@ namespace ttk {
     /// \param edgeList Output edge list (each entry is an ordered std::pair
     /// of vertex identifiers).
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildEdgeSubList(
-      const CellArray &cellArray,
-      std::vector<std::pair<SimplexId, SimplexId>> &edgeList) const;
+    int buildEdgeSubList(const CellArray &cellArray,
+                         std::vector<std::array<SimplexId, 2>> &edgeList) const;
   };
 } // namespace ttk
 

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -65,9 +65,10 @@ namespace ttk {
     /// entry will be a std::vector listing the vertices in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
+    template<std::size_t n>
     int buildEdgeLinks(const std::vector<std::array<SimplexId, 2>> &edgeList,
                        const std::vector<std::vector<SimplexId>> &edgeStars,
-                       const std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       const std::vector<std::array<SimplexId, n>> &cellEdges,
                        std::vector<std::vector<SimplexId>> &edgeLinks) const;
 
     /// Compute the list of edges of a valid triangulation.

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -11,10 +11,11 @@ ThreeSkeleton::ThreeSkeleton() {
 ThreeSkeleton::~ThreeSkeleton() {
 }
 
+template <std::size_t n>
 int ThreeSkeleton::buildCellEdges(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<std::array<SimplexId, 6>> &cellEdges,
+  vector<std::array<SimplexId, n>> &cellEdges,
   vector<std::array<SimplexId, 2>> *edgeList,
   vector<vector<SimplexId>> *vertexEdges) const {
 
@@ -101,6 +102,22 @@ int ThreeSkeleton::buildCellEdges(
 
   return 0;
 }
+
+// explicit template instantiations for 3D cells (tetrahedrons)
+template int ThreeSkeleton::buildCellEdges<6>(
+  const SimplexId &vertexNumber,
+  const CellArray &cellArray,
+  std::vector<std::array<SimplexId, 6>> &cellEdges,
+  std::vector<std::array<SimplexId, 2>> *edgeList,
+  std::vector<std::vector<SimplexId>> *vertexEdges) const;
+
+// explicit template instantiations for 2D cells (triangles)
+template int ThreeSkeleton::buildCellEdges<3>(
+  const SimplexId &vertexNumber,
+  const CellArray &cellArray,
+  std::vector<std::array<SimplexId, 3>> &cellEdges,
+  std::vector<std::array<SimplexId, 2>> *edgeList,
+  std::vector<std::vector<SimplexId>> *vertexEdges) const;
 
 int ThreeSkeleton::buildCellNeighborsFromTriangles(
   const SimplexId &vertexNumber,

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -172,14 +172,14 @@ int ThreeSkeleton::buildCellNeighborsFromTriangles(
 
     for(ThreadId i = 0; i < threadNumber_; i++) {
       threadedCellNeighbors[i].resize(cellNumber);
-      for(SimplexId j = 0; j < (SimplexId)threadedCellNeighbors[i].size(); j++)
+      for(size_t j = 0; j < threadedCellNeighbors[i].size(); j++)
         threadedCellNeighbors[i][j].reserve(4);
     }
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId)(*localTriangleStars).size(); i++) {
+    for(size_t i = 0; i < (*localTriangleStars).size(); i++) {
 
       ThreadId threadId = 0;
 #ifdef TTK_ENABLE_OPENMP
@@ -200,11 +200,9 @@ int ThreeSkeleton::buildCellNeighborsFromTriangles(
 
     // now merge things
     for(ThreadId i = 0; i < threadNumber_; i++) {
-      for(SimplexId j = 0; j < (SimplexId)threadedCellNeighbors[i].size();
-          j++) {
+      for(size_t j = 0; j < threadedCellNeighbors[i].size(); j++) {
 
-        for(SimplexId k = 0; k < (SimplexId)threadedCellNeighbors[i][j].size();
-            k++) {
+        for(size_t k = 0; k < threadedCellNeighbors[i][j].size(); k++) {
           cellNeighbors[j].push_back(threadedCellNeighbors[i][j][k]);
         }
       }
@@ -279,7 +277,7 @@ int ThreeSkeleton::buildCellNeighborsFromVertices(
 
   const SimplexId cellNumber = cellArray.getNbCells();
   cellNeighbors.resize(cellNumber);
-  for(SimplexId i = 0; i < (SimplexId)cellNeighbors.size(); i++) {
+  for(size_t i = 0; i < cellNeighbors.size(); i++) {
     const SimplexId nbVertCell = cellArray.getCellVertexNumber(i);
     cellNeighbors[i].reserve(nbVertCell);
   }
@@ -305,12 +303,12 @@ int ThreeSkeleton::buildCellNeighborsFromVertices(
       SimplexId v2 = cellArray.getCellVertex(cid, (j + 2) % nbVertCell);
 
       // perform an intersection of the 3 (sorted) star lists
-      SimplexId pos0 = 0, pos1 = 0, pos2 = 0;
+      size_t pos0 = 0, pos1 = 0, pos2 = 0;
       SimplexId intersection = -1;
 
-      while((pos0 < (SimplexId)(*localVertexStars)[v0].size())
-            && (pos1 < (SimplexId)(*localVertexStars)[v1].size())
-            && (pos2 < (SimplexId)(*localVertexStars)[v2].size())) {
+      while((pos0 < (*localVertexStars)[v0].size())
+            && (pos1 < (*localVertexStars)[v1].size())
+            && (pos2 < (*localVertexStars)[v2].size())) {
 
         SimplexId biggest = (*localVertexStars)[v0][pos0];
         if((*localVertexStars)[v1][pos1] > biggest) {
@@ -320,24 +318,21 @@ int ThreeSkeleton::buildCellNeighborsFromVertices(
           biggest = (*localVertexStars)[v2][pos2];
         }
 
-        for(SimplexId l = pos0; l < (SimplexId)(*localVertexStars)[v0].size();
-            l++) {
+        for(size_t l = pos0; l < (*localVertexStars)[v0].size(); l++) {
           if((*localVertexStars)[v0][l] < biggest) {
             pos0++;
           } else {
             break;
           }
         }
-        for(SimplexId l = pos1; l < (SimplexId)(*localVertexStars)[v1].size();
-            l++) {
+        for(size_t l = pos1; l < (*localVertexStars)[v1].size(); l++) {
           if((*localVertexStars)[v1][l] < biggest) {
             pos1++;
           } else {
             break;
           }
         }
-        for(SimplexId l = pos2; l < (SimplexId)(*localVertexStars)[v2].size();
-            l++) {
+        for(size_t l = pos2; l < (*localVertexStars)[v2].size(); l++) {
           if((*localVertexStars)[v2][l] < biggest) {
             pos2++;
           } else {
@@ -345,9 +340,9 @@ int ThreeSkeleton::buildCellNeighborsFromVertices(
           }
         }
 
-        if((pos0 < (SimplexId)(*localVertexStars)[v0].size())
-           && (pos1 < (SimplexId)(*localVertexStars)[v1].size())
-           && (pos2 < (SimplexId)(*localVertexStars)[v2].size())) {
+        if((pos0 < (*localVertexStars)[v0].size())
+           && (pos1 < (*localVertexStars)[v1].size())
+           && (pos2 < (*localVertexStars)[v2].size())) {
 
           if(((*localVertexStars)[v0][pos0] == (*localVertexStars)[v1][pos1])
              && ((*localVertexStars)[v0][pos0]

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -14,8 +14,8 @@ ThreeSkeleton::~ThreeSkeleton() {
 int ThreeSkeleton::buildCellEdges(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<vector<SimplexId>> &cellEdges,
-  vector<pair<SimplexId, SimplexId>> *edgeList,
+  vector<std::array<SimplexId, 6>> &cellEdges,
+  vector<std::array<SimplexId, 2>> *edgeList,
   vector<vector<SimplexId>> *vertexEdges) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -25,7 +25,7 @@ int ThreeSkeleton::buildCellEdges(
 
   auto localEdgeList = edgeList;
   auto localVertexEdges = vertexEdges;
-  vector<pair<SimplexId, SimplexId>> defaultEdgeList{};
+  vector<std::array<SimplexId, 2>> defaultEdgeList{};
   vector<vector<SimplexId>> defaultVertexEdges{};
 
   if(!localEdgeList) {
@@ -60,10 +60,6 @@ int ThreeSkeleton::buildCellEdges(
 
   const SimplexId cellNumber = cellArray.getNbCells();
   cellEdges.resize(cellNumber);
-  for(SimplexId i = 0; i < cellNumber; i++) {
-    // optimized for tet meshes
-    cellEdges[i].reserve(6);
-  }
 
   // for each cell, for each pair of vertices, find the edge
   // TODO: check for parallel efficiency here
@@ -72,6 +68,7 @@ int ThreeSkeleton::buildCellEdges(
 #endif
   for(SimplexId cid = 0; cid < cellNumber; cid++) {
     const SimplexId nbVertCell = cellArray.getCellVertexNumber(cid);
+    SimplexId nEdges{};
 
     for(SimplexId j = 0; j < nbVertCell; j++) {
 
@@ -86,14 +83,15 @@ int ThreeSkeleton::buildCellEdges(
         for(SimplexId l = 0; l < nbEdges0; l++) {
 
           SimplexId localEdgeId = (*localVertexEdges)[vertexId0][l];
-          if(((*localEdgeList)[localEdgeId].first == vertexId1)
-             || ((*localEdgeList)[localEdgeId].second == vertexId1)) {
+          if(((*localEdgeList)[localEdgeId][0] == vertexId1)
+             || ((*localEdgeList)[localEdgeId][1] == vertexId1)) {
             edgeId = localEdgeId;
             break;
           }
         }
 
-        cellEdges[cid].push_back(edgeId);
+        cellEdges[cid][nEdges] = edgeId;
+        nEdges++;
       }
     }
   }

--- a/core/base/skeleton/ThreeSkeleton.h
+++ b/core/base/skeleton/ThreeSkeleton.h
@@ -55,7 +55,7 @@ namespace ttk {
     /// this std::vector as internal vertex edge list. If this std::vector is
     /// not empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
-    template<std::size_t n>
+    template <std::size_t n>
     int buildCellEdges(const SimplexId &vertexNumber,
                        const CellArray &cellArray,
                        std::vector<std::array<SimplexId, n>> &cellEdges,

--- a/core/base/skeleton/ThreeSkeleton.h
+++ b/core/base/skeleton/ThreeSkeleton.h
@@ -55,9 +55,10 @@ namespace ttk {
     /// this std::vector as internal vertex edge list. If this std::vector is
     /// not empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
+    template<std::size_t n>
     int buildCellEdges(const SimplexId &vertexNumber,
                        const CellArray &cellArray,
-                       std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       std::vector<std::array<SimplexId, n>> &cellEdges,
                        std::vector<std::array<SimplexId, 2>> *edgeList
                        = nullptr,
                        std::vector<std::vector<SimplexId>> *vertexEdges

--- a/core/base/skeleton/ThreeSkeleton.h
+++ b/core/base/skeleton/ThreeSkeleton.h
@@ -20,6 +20,7 @@
 #include <ZeroSkeleton.h>
 
 #include <algorithm>
+#include <array>
 
 namespace ttk {
 

--- a/core/base/skeleton/ThreeSkeleton.h
+++ b/core/base/skeleton/ThreeSkeleton.h
@@ -57,8 +57,8 @@ namespace ttk {
     /// \return Returns 0 upon success, negative values otherwise.
     int buildCellEdges(const SimplexId &vertexNumber,
                        const CellArray &cellArray,
-                       std::vector<std::vector<SimplexId>> &cellEdges,
-                       std::vector<std::pair<SimplexId, SimplexId>> *edgeList
+                       std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       std::vector<std::array<SimplexId, 2>> *edgeList
                        = nullptr,
                        std::vector<std::vector<SimplexId>> *vertexEdges
                        = nullptr) const;

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -63,27 +63,25 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
       SimplexId v1 = cellArray.getCellVertex(cid, (j + 1) % nbVertCell);
 
       // perform an intersection of the 2 sorted star lists
-      SimplexId pos0 = 0, pos1 = 0;
+      size_t pos0 = 0, pos1 = 0;
       SimplexId intersection = -1;
 
-      while((pos0 < (SimplexId)(*localVertexStars)[v0].size())
-            && (pos1 < (SimplexId)(*localVertexStars)[v1].size())) {
+      while(pos0 < (*localVertexStars)[v0].size()
+            && pos1 < (*localVertexStars)[v1].size()) {
 
         SimplexId biggest = (*localVertexStars)[v0][pos0];
         if((*localVertexStars)[v1][pos1] > biggest) {
           biggest = (*localVertexStars)[v1][pos1];
         }
 
-        for(SimplexId l = pos0; l < (SimplexId)(*localVertexStars)[v0].size();
-            l++) {
+        for(size_t l = pos0; l < (*localVertexStars)[v0].size(); l++) {
           if((*localVertexStars)[v0][l] < biggest) {
             pos0++;
           } else {
             break;
           }
         }
-        for(SimplexId l = pos1; l < (SimplexId)(*localVertexStars)[v1].size();
-            l++) {
+        for(size_t l = pos1; l < (*localVertexStars)[v1].size(); l++) {
           if((*localVertexStars)[v1][l] < biggest) {
             pos1++;
           } else {
@@ -194,14 +192,13 @@ int TwoSkeleton::buildEdgeTriangles(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)localEdgeList->size(); i++) {
+  for(size_t i = 0; i < localEdgeList->size(); i++) {
     SimplexId vertexId0, vertexId1, vertexId2;
 
-    for(SimplexId j = 0; j < (SimplexId)(*localEdgeStarList)[i].size(); j++) {
+    for(size_t j = 0; j < (*localEdgeStarList)[i].size(); j++) {
       SimplexId tetId = (*localEdgeStarList)[i][j];
 
-      for(SimplexId k = 0;
-          k < (SimplexId)(*localCellTriangleList)[tetId].size(); k++) {
+      for(size_t k = 0; k < (*localCellTriangleList)[tetId].size(); k++) {
         SimplexId triangleId = (*localCellTriangleList)[tetId][k];
 
         bool isAttached = false;
@@ -234,7 +231,7 @@ int TwoSkeleton::buildEdgeTriangles(
         if(isAttached) {
 
           bool isIn = false;
-          for(SimplexId l = 0; l < (SimplexId)edgeTriangleList[i].size(); l++) {
+          for(size_t l = 0; l < edgeTriangleList[i].size(); l++) {
             if(edgeTriangleList[i][l] == triangleId) {
               isIn = true;
               break;
@@ -470,14 +467,13 @@ int TwoSkeleton::buildTriangleEdgeList(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)localTriangleList->size(); i++) {
+  for(size_t i = 0; i < localTriangleList->size(); i++) {
     SimplexId nEdge{};
     SimplexId vertexId = -1;
-    for(SimplexId j = 0; j < (SimplexId)(*localTriangleList)[i].size(); j++) {
+    for(size_t j = 0; j < (*localTriangleList)[i].size(); j++) {
       vertexId = (*localTriangleList)[i][j];
 
-      for(SimplexId k = 0;
-          k < (SimplexId)(*localVertexEdgeList)[vertexId].size(); k++) {
+      for(size_t k = 0; k < (*localVertexEdgeList)[vertexId].size(); k++) {
         SimplexId edgeId = (*localVertexEdgeList)[vertexId][k];
 
         SimplexId otherVertexId = (*localEdgeList)[edgeId][0];
@@ -487,8 +483,7 @@ int TwoSkeleton::buildTriangleEdgeList(
         }
 
         bool isInTriangle = false;
-        for(SimplexId l = 0; l < (SimplexId)(*localTriangleList)[i].size();
-            l++) {
+        for(size_t l = 0; l < (*localTriangleList)[i].size(); l++) {
           if((*localTriangleList)[i][l] == otherVertexId) {
             isInTriangle = true;
             break;
@@ -497,7 +492,7 @@ int TwoSkeleton::buildTriangleEdgeList(
 
         if(isInTriangle) {
           bool isIn = false;
-          for(SimplexId l = 0; l < (SimplexId)triangleEdgeList[i].size(); l++) {
+          for(size_t l = 0; l < triangleEdgeList[i].size(); l++) {
             if(triangleEdgeList[i][l] == edgeId) {
               isIn = true;
               break;
@@ -543,11 +538,11 @@ int TwoSkeleton::buildTriangleLinks(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)triangleList.size(); i++) {
+  for(size_t i = 0; i < triangleList.size(); i++) {
 
-    for(SimplexId j = 0; j < (SimplexId)triangleStars[i].size(); j++) {
+    for(size_t j = 0; j < triangleStars[i].size(); j++) {
 
-      for(int k = 0; k < 4; k++) {
+      for(size_t k = 0; k < 4; k++) {
         SimplexId vertexId = cellArray.getCellVertex(triangleStars[i][j], k);
 
         if((vertexId != triangleList[i][0]) && (vertexId != triangleList[i][1])

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -119,11 +119,11 @@ int TwoSkeleton::buildEdgeTriangles(
   const CellArray &cellArray,
   vector<vector<SimplexId>> &edgeTriangleList,
   vector<vector<SimplexId>> *vertexStarList,
-  vector<pair<SimplexId, SimplexId>> *edgeList,
+  vector<std::array<SimplexId, 2>> *edgeList,
   vector<vector<SimplexId>> *edgeStarList,
-  vector<vector<SimplexId>> *triangleList,
+  vector<std::array<SimplexId, 3>> *triangleList,
   vector<vector<SimplexId>> *triangleStarList,
-  vector<vector<SimplexId>> *cellTriangleList) const {
+  vector<std::array<SimplexId, 4>> *cellTriangleList) const {
 
   // check the consistency of the variables -- to adapt
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -136,7 +136,7 @@ int TwoSkeleton::buildEdgeTriangles(
   // need it.
 
   auto localEdgeList = edgeList;
-  vector<pair<SimplexId, SimplexId>> defaultEdgeList{};
+  vector<std::array<SimplexId, 2>> defaultEdgeList{};
   if(!localEdgeList) {
     localEdgeList = &defaultEdgeList;
   }
@@ -148,7 +148,7 @@ int TwoSkeleton::buildEdgeTriangles(
   }
 
   auto localTriangleList = triangleList;
-  vector<vector<SimplexId>> defaultTriangleList{};
+  vector<std::array<SimplexId, 3>> defaultTriangleList{};
   if(!localTriangleList) {
     localTriangleList = &defaultTriangleList;
   }
@@ -158,7 +158,7 @@ int TwoSkeleton::buildEdgeTriangles(
   // need it.
 
   auto localCellTriangleList = cellTriangleList;
-  vector<vector<SimplexId>> defaultCellTriangleList{};
+  vector<std::array<SimplexId, 4>> defaultCellTriangleList{};
   if(!localCellTriangleList) {
     localCellTriangleList = &defaultCellTriangleList;
   }
@@ -209,23 +209,23 @@ int TwoSkeleton::buildEdgeTriangles(
         vertexId1 = (*localTriangleList)[triangleId][1];
         vertexId2 = (*localTriangleList)[triangleId][2];
 
-        if((*localEdgeList)[i].first == vertexId0) {
-          if(((*localEdgeList)[i].second == vertexId1)
-             || ((*localEdgeList)[i].second == vertexId2)) {
+        if((*localEdgeList)[i][0] == vertexId0) {
+          if(((*localEdgeList)[i][1] == vertexId1)
+             || ((*localEdgeList)[i][1] == vertexId2)) {
             isAttached = true;
           }
         }
 
-        if((*localEdgeList)[i].first == vertexId1) {
-          if(((*localEdgeList)[i].second == vertexId0)
-             || ((*localEdgeList)[i].second == vertexId2)) {
+        if((*localEdgeList)[i][0] == vertexId1) {
+          if(((*localEdgeList)[i][1] == vertexId0)
+             || ((*localEdgeList)[i][1] == vertexId2)) {
             isAttached = true;
           }
         }
 
-        if((*localEdgeList)[i].first == vertexId2) {
-          if(((*localEdgeList)[i].second == vertexId1)
-             || ((*localEdgeList)[i].second == vertexId0)) {
+        if((*localEdgeList)[i][0] == vertexId2) {
+          if(((*localEdgeList)[i][1] == vertexId1)
+             || ((*localEdgeList)[i][1] == vertexId0)) {
             isAttached = true;
           }
         }
@@ -258,9 +258,9 @@ int TwoSkeleton::buildEdgeTriangles(
 int TwoSkeleton::buildTriangleList(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<vector<SimplexId>> *triangleList,
+  vector<std::array<SimplexId, 3>> *triangleList,
   vector<vector<SimplexId>> *triangleStars,
-  vector<vector<SimplexId>> *cellTriangleList) const {
+  vector<std::array<SimplexId, 4>> *cellTriangleList) const {
 
   Timer t;
 
@@ -292,10 +292,7 @@ int TwoSkeleton::buildTriangleList(
     triangleStars->reserve(10 * vertexNumber);
   }
   if(cellTriangleList) {
-    cellTriangleList->resize(cellNumber);
-    for(SimplexId i = 0; i < cellNumber; i++)
-      // assuming tet-mesh here
-      (*cellTriangleList)[i].resize(4, -1);
+    cellTriangleList->resize(cellNumber, {-1, -1, -1, -1});
   }
 
   printMsg(
@@ -346,8 +343,7 @@ int TwoSkeleton::buildTriangleList(
           triangleNumber++;
 
           if(triangleList) {
-            triangleList->emplace_back(
-              std::vector<SimplexId>{triangle.begin(), triangle.end()});
+            triangleList->emplace_back(triangle);
           }
           if(triangleStars) {
             // store the tet i in the triangleStars list
@@ -397,15 +393,15 @@ int TwoSkeleton::buildTriangleList(
 int TwoSkeleton::buildTriangleEdgeList(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<vector<SimplexId>> &triangleEdgeList,
+  vector<std::array<SimplexId, 3>> &triangleEdgeList,
   vector<vector<SimplexId>> *vertexEdgeList,
-  vector<pair<SimplexId, SimplexId>> *edgeList,
-  vector<vector<SimplexId>> *triangleList,
+  vector<std::array<SimplexId, 2>> *edgeList,
+  vector<std::array<SimplexId, 3>> *triangleList,
   vector<vector<SimplexId>> *triangleStarList,
-  vector<vector<SimplexId>> *cellTriangleList) const {
+  vector<std::array<SimplexId, 4>> *cellTriangleList) const {
 
   auto localEdgeList = edgeList;
-  vector<pair<SimplexId, SimplexId>> defaultEdgeList{};
+  vector<std::array<SimplexId, 2>> defaultEdgeList{};
   if(!localEdgeList) {
     localEdgeList = &defaultEdgeList;
   }
@@ -439,7 +435,7 @@ int TwoSkeleton::buildTriangleEdgeList(
   // can compute them for free optionally.
 
   auto localTriangleList = triangleList;
-  vector<vector<SimplexId>> defaultTriangleList{};
+  vector<std::array<SimplexId, 3>> defaultTriangleList{};
   if(!localTriangleList) {
     localTriangleList = &defaultTriangleList;
   }
@@ -463,6 +459,7 @@ int TwoSkeleton::buildTriangleEdgeList(
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
   for(SimplexId i = 0; i < (SimplexId)localTriangleList->size(); i++) {
+    SimplexId nEdge{};
     SimplexId vertexId = -1;
     for(SimplexId j = 0; j < (SimplexId)(*localTriangleList)[i].size(); j++) {
       vertexId = (*localTriangleList)[i][j];
@@ -471,10 +468,10 @@ int TwoSkeleton::buildTriangleEdgeList(
           k < (SimplexId)(*localVertexEdgeList)[vertexId].size(); k++) {
         SimplexId edgeId = (*localVertexEdgeList)[vertexId][k];
 
-        SimplexId otherVertexId = (*localEdgeList)[edgeId].first;
+        SimplexId otherVertexId = (*localEdgeList)[edgeId][0];
 
         if(otherVertexId == vertexId) {
-          otherVertexId = (*localEdgeList)[edgeId].second;
+          otherVertexId = (*localEdgeList)[edgeId][1];
         }
 
         bool isInTriangle = false;
@@ -495,7 +492,8 @@ int TwoSkeleton::buildTriangleEdgeList(
             }
           }
           if(!isIn) {
-            triangleEdgeList[i].push_back(edgeId);
+            triangleEdgeList[i][nEdge] = edgeId;
+            nEdge++;
           }
         }
       }
@@ -511,7 +509,7 @@ int TwoSkeleton::buildTriangleEdgeList(
 }
 
 int TwoSkeleton::buildTriangleLinks(
-  const vector<vector<SimplexId>> &triangleList,
+  const vector<std::array<SimplexId, 3>> &triangleList,
   const vector<vector<SimplexId>> &triangleStars,
   const CellArray &cellArray,
   vector<vector<SimplexId>> &triangleLinks) const {
@@ -557,7 +555,7 @@ int TwoSkeleton::buildTriangleLinks(
 
 int TwoSkeleton::buildVertexTriangles(
   const SimplexId &vertexNumber,
-  const vector<vector<SimplexId>> &triangleList,
+  const vector<std::array<SimplexId, 3>> &triangleList,
   vector<vector<SimplexId>> &vertexTriangleList) const {
 
   Timer t;

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -565,6 +565,16 @@ int TwoSkeleton::buildVertexTriangles(
     }
   }
 
+  if(this->threadNumber_ > 1) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+    for(size_t i = 0; i < vertexTriangleList.size(); i++) {
+      auto &vec = vertexTriangleList[i];
+      std::sort(vec.begin(), vec.end());
+    }
+  }
+
   printMsg("Built " + std::to_string(vertexNumber) + " vertex triangles", 1,
            t.getElapsedTime(), threadNumber_);
 

--- a/core/base/skeleton/TwoSkeleton.h
+++ b/core/base/skeleton/TwoSkeleton.h
@@ -122,11 +122,11 @@ namespace ttk {
       const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &edgeTriangleList,
       std::vector<std::vector<SimplexId>> *vertexStarList = nullptr,
-      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = nullptr,
+      std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,
       std::vector<std::vector<SimplexId>> *edgeStarList = nullptr,
-      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::array<SimplexId, 3>> *triangleList = nullptr,
       std::vector<std::vector<SimplexId>> *triangleStarList = nullptr,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
+      std::vector<std::array<SimplexId, 4>> *cellTriangleList = nullptr) const;
 
     /// Compute the list of triangles of a triangulation represented by a
     /// vtkUnstructuredGrid object. Unspecified behavior if the input mesh is
@@ -142,9 +142,9 @@ namespace ttk {
     int buildTriangleList(
       const SimplexId &vertexNumber,
       const CellArray &cellArray,
-      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::array<SimplexId, 3>> *triangleList = nullptr,
       std::vector<std::vector<SimplexId>> *triangleStars = nullptr,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
+      std::vector<std::array<SimplexId, 4>> *cellTriangleList = nullptr) const;
 
     /// Compute the list of edges connected to each triangle for 3D
     /// triangulations (unspecified behavior if the input mesh is not a
@@ -204,12 +204,12 @@ namespace ttk {
     int buildTriangleEdgeList(
       const SimplexId &vertexNumber,
       const CellArray &cellArray,
-      std::vector<std::vector<SimplexId>> &triangleEdgeList,
+      std::vector<std::array<SimplexId, 3>> &triangleEdgeList,
       std::vector<std::vector<SimplexId>> *vertexEdgeList = nullptr,
-      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = nullptr,
-      std::vector<std::vector<SimplexId>> *triangleList = nullptr,
+      std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,
+      std::vector<std::array<SimplexId, 3>> *triangleList = nullptr,
       std::vector<std::vector<SimplexId>> *triangleStarList = nullptr,
-      std::vector<std::vector<SimplexId>> *cellTriangleList = nullptr) const;
+      std::vector<std::array<SimplexId, 4>> *cellTriangleList = nullptr) const;
 
     /// Compute the links of triangles in a 3D triangulation.
     /// \param triangleList Input triangle list. The number of entries of this
@@ -227,7 +227,7 @@ namespace ttk {
     /// corresponding triangle.
     /// \return Returns 0 upon success, negative values otherwise.
     int buildTriangleLinks(
-      const std::vector<std::vector<SimplexId>> &triangeList,
+      const std::vector<std::array<SimplexId, 3>> &triangeList,
       const std::vector<std::vector<SimplexId>> &triangleStars,
       const CellArray &cellArray,
       std::vector<std::vector<SimplexId>> &triangleLinks) const;
@@ -242,7 +242,7 @@ namespace ttk {
     /// std::vectors of triangle identifiers).
     int buildVertexTriangles(
       const SimplexId &vertexNumber,
-      const std::vector<std::vector<SimplexId>> &triangleList,
+      const std::vector<std::array<SimplexId, 3>> &triangleList,
       std::vector<std::vector<SimplexId>> &vertexTriangleList) const;
   };
 } // namespace ttk

--- a/core/base/skeleton/TwoSkeleton.h
+++ b/core/base/skeleton/TwoSkeleton.h
@@ -19,6 +19,7 @@
 #include <ZeroSkeleton.h>
 
 #include <algorithm>
+#include <array>
 
 namespace ttk {
 

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -367,9 +367,10 @@ int ZeroSkeleton::buildVertexLinks(
   return 0;
 }
 
+template <std::size_t n>
 int ZeroSkeleton::buildVertexLinks(
   const vector<vector<SimplexId>> &vertexStars,
-  const vector<std::array<SimplexId, 6>> &cellEdges,
+  const vector<std::array<SimplexId, n>> &cellEdges,
   const vector<std::array<SimplexId, 2>> &edgeList,
   vector<vector<SimplexId>> &vertexLinks) const {
 
@@ -414,6 +415,20 @@ int ZeroSkeleton::buildVertexLinks(
 
   return 0;
 }
+
+// explicit template instantiations for 3D cells (tetrahedrons)
+template int ZeroSkeleton::buildVertexLinks<6>(
+  const vector<vector<SimplexId>> &vertexStars,
+  const vector<std::array<SimplexId, 6>> &cellEdges,
+  const vector<std::array<SimplexId, 2>> &edgeList,
+  vector<vector<SimplexId>> &vertexLinks) const;
+
+// explicit template instantiations for 2D cells (triangles)
+template int ZeroSkeleton::buildVertexLinks<3>(
+  const vector<vector<SimplexId>> &vertexStars,
+  const vector<std::array<SimplexId, 3>> &cellEdges,
+  const vector<std::array<SimplexId, 2>> &edgeList,
+  vector<vector<SimplexId>> &vertexLinks) const;
 
 int ZeroSkeleton::buildVertexLinks(
   const vector<vector<SimplexId>> &vertexStars,

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -13,7 +13,7 @@ ZeroSkeleton::~ZeroSkeleton() {
 
 int ZeroSkeleton::buildVertexEdges(
   const SimplexId &vertexNumber,
-  const vector<pair<SimplexId, SimplexId>> &edgeList,
+  const vector<std::array<SimplexId, 2>> &edgeList,
   vector<vector<SimplexId>> &vertexEdges) const {
 
   Timer t;
@@ -39,8 +39,8 @@ int ZeroSkeleton::buildVertexEdges(
              ttk::debug::LineMode::REPLACE);
 
     for(SimplexId i = 0; i < (SimplexId)edgeList.size(); i++) {
-      vertexEdges[edgeList[i].first].push_back(i);
-      vertexEdges[edgeList[i].second].push_back(i);
+      vertexEdges[edgeList[i][0]].push_back(i);
+      vertexEdges[edgeList[i][1]].push_back(i);
 
       if(debugLevel_ >= (int)(debug::Priority::INFO)) {
         if(!(i % ((edgeList.size()) / timeBuckets))) {
@@ -66,8 +66,8 @@ int ZeroSkeleton::buildVertexEdges(
       threadId = omp_get_thread_num();
 #endif
 
-      threadedVertexEdges[threadId][edgeList[i].first].push_back(i);
-      threadedVertexEdges[threadId][edgeList[i].second].push_back(i);
+      threadedVertexEdges[threadId][edgeList[i][0]].push_back(i);
+      threadedVertexEdges[threadId][edgeList[i][1]].push_back(i);
     }
 
     // now merge the thing
@@ -370,8 +370,8 @@ int ZeroSkeleton::buildVertexLinks(
 
 int ZeroSkeleton::buildVertexLinks(
   const vector<vector<SimplexId>> &vertexStars,
-  const vector<vector<SimplexId>> &cellEdges,
-  const vector<pair<SimplexId, SimplexId>> &edgeList,
+  const vector<std::array<SimplexId, 6>> &cellEdges,
+  const vector<std::array<SimplexId, 2>> &edgeList,
   vector<vector<SimplexId>> &vertexLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -400,8 +400,8 @@ int ZeroSkeleton::buildVertexLinks(
           k++) {
         SimplexId edgeId = cellEdges[vertexStars[i][j]][k];
 
-        SimplexId vertexId0 = edgeList[edgeId].first;
-        SimplexId vertexId1 = edgeList[edgeId].second;
+        SimplexId vertexId0 = edgeList[edgeId][0];
+        SimplexId vertexId1 = edgeList[edgeId][1];
 
         if((vertexId0 != i) && (vertexId1 != i)) {
           vertexLinks[i].push_back(edgeId);
@@ -418,8 +418,8 @@ int ZeroSkeleton::buildVertexLinks(
 
 int ZeroSkeleton::buildVertexLinks(
   const vector<vector<SimplexId>> &vertexStars,
-  const vector<vector<SimplexId>> &cellTriangles,
-  const vector<vector<SimplexId>> &triangleList,
+  const vector<std::array<SimplexId, 4>> &cellTriangles,
+  const vector<std::array<SimplexId, 3>> &triangleList,
   vector<vector<SimplexId>> &vertexLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -473,12 +473,12 @@ int ZeroSkeleton::buildVertexNeighbors(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
   vector<vector<SimplexId>> &oneSkeleton,
-  vector<pair<SimplexId, SimplexId>> *edgeList) const {
+  vector<std::array<SimplexId, 2>> *edgeList) const {
 
   oneSkeleton.resize(vertexNumber);
 
   auto localEdgeList = edgeList;
-  vector<pair<SimplexId, SimplexId>> defaultEdgeList{};
+  vector<std::array<SimplexId, 2>> defaultEdgeList{};
   if(!localEdgeList) {
     localEdgeList = &defaultEdgeList;
   }
@@ -497,10 +497,8 @@ int ZeroSkeleton::buildVertexNeighbors(
 
   const SimplexId nbEdge = localEdgeList->size();
   for(SimplexId i = 0; i < nbEdge; i++) {
-    oneSkeleton[(*localEdgeList)[i].first].emplace_back(
-      (*localEdgeList)[i].second);
-    oneSkeleton[(*localEdgeList)[i].second].emplace_back(
-      (*localEdgeList)[i].first);
+    oneSkeleton[(*localEdgeList)[i][0]].emplace_back((*localEdgeList)[i][1]);
+    oneSkeleton[(*localEdgeList)[i][1]].emplace_back((*localEdgeList)[i][0]);
   }
 
   printMsg("Built " + std::to_string(vertexNumber) + " vertex neighbors", 1,

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -24,7 +24,7 @@ int ZeroSkeleton::buildVertexEdges(
   threadNumber_ = 1;
 
   vertexEdges.resize(vertexNumber);
-  for(SimplexId i = 0; i < (SimplexId)vertexEdges.size(); i++) {
+  for(size_t i = 0; i < vertexEdges.size(); i++) {
     vertexEdges[i].clear();
   }
 
@@ -38,7 +38,7 @@ int ZeroSkeleton::buildVertexEdges(
     printMsg("Building vertex edges", 0, 0, threadNumber_,
              ttk::debug::LineMode::REPLACE);
 
-    for(SimplexId i = 0; i < (SimplexId)edgeList.size(); i++) {
+    for(size_t i = 0; i < edgeList.size(); i++) {
       vertexEdges[edgeList[i][0]].push_back(i);
       vertexEdges[edgeList[i][1]].push_back(i);
 
@@ -58,7 +58,7 @@ int ZeroSkeleton::buildVertexEdges(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-    for(SimplexId i = 0; i < (SimplexId)edgeList.size(); i++) {
+    for(size_t i = 0; i < edgeList.size(); i++) {
 
       ThreadId threadId = 0;
 
@@ -72,12 +72,11 @@ int ZeroSkeleton::buildVertexEdges(
 
     // now merge the thing
     for(ThreadId i = 0; i < threadNumber_; i++) {
-      for(SimplexId j = 0; j < (SimplexId)threadedVertexEdges[i].size(); j++) {
-        for(SimplexId k = 0; k < (SimplexId)threadedVertexEdges[i][j].size();
-            k++) {
+      for(size_t j = 0; j < threadedVertexEdges[i].size(); j++) {
+        for(size_t k = 0; k < threadedVertexEdges[i][j].size(); k++) {
 
           bool hasFound = false;
-          for(SimplexId l = 0; l < (SimplexId)vertexEdges[j].size(); l++) {
+          for(size_t l = 0; l < vertexEdges[j].size(); l++) {
             if(vertexEdges[j][l] == threadedVertexEdges[i][j][k]) {
               hasFound = true;
               break;
@@ -155,7 +154,7 @@ int ZeroSkeleton::buildVertexLink(const SimplexId &vertexId,
 
                     // all the vertices of the face are different from our
                     // vertex. let's add that face to the link
-                    for(SimplexId n = 0; n < (SimplexId)faceIds.size(); n++) {
+                    for(size_t n = 0; n < faceIds.size(); n++) {
                       vertexLink[i * (nbVertCell) + n] = faceIds[n];
                     }
                     hasPivotVertex = true;
@@ -165,7 +164,7 @@ int ZeroSkeleton::buildVertexLink(const SimplexId &vertexId,
               } else if(nbVertCell == 3) {
                 // triangle case
                 // we're holding to an edge that does not contain our vertex
-                for(SimplexId n = 0; n < (SimplexId)faceIds.size(); n++) {
+                for(size_t n = 0; n < faceIds.size(); n++) {
                   vertexLink[i * (nbVertCell) + n] = faceIds[n];
                 }
                 hasPivotVertex = true;
@@ -178,7 +177,7 @@ int ZeroSkeleton::buildVertexLink(const SimplexId &vertexId,
         } else if(nbVertCell == 2) {
           // edge-mesh case
           // we're holding a neighbor different from our vertex
-          for(SimplexId n = 0; n < (SimplexId)faceIds.size(); n++) {
+          for(size_t n = 0; n < faceIds.size(); n++) {
             vertexLink[i * (nbVertCell) + n] = faceIds[n];
           }
           break;
@@ -337,15 +336,15 @@ int ZeroSkeleton::buildVertexLinks(
   }
 
   if(debugLevel_ >= (int)(debug::Priority::DETAIL)) {
-    for(SimplexId i = 0; i < (SimplexId)vertexLinks.size(); i++) {
+    for(size_t i = 0; i < vertexLinks.size(); i++) {
       stringstream msg;
       // TODO: ASSUME Regular Mesh Here!
       msg << "Vertex #" << i << " ("
           << vertexLinks[i].size() / (vertexLinks[i][0] + 1)
           << " items, length: " << vertexLinks[i].size() << "): ";
       printMsg(msg.str(), debug::Priority::DETAIL);
-      for(SimplexId j = 0;
-          j < (SimplexId)vertexLinks[i].size() / (vertexLinks[i][0] + 1); j++) {
+      for(size_t j = 0; j < vertexLinks[i].size() / (vertexLinks[i][0] + 1);
+          j++) {
         stringstream msgLine;
         msgLine << "  - " << j << ":";
         const SimplexId nbVertCell = cellArray.getCellVertexNumber(j);
@@ -393,17 +392,17 @@ int ZeroSkeleton::buildVertexLinks(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)vertexLinks.size(); i++) {
+  for(size_t i = 0; i < vertexLinks.size(); i++) {
 
-    for(SimplexId j = 0; j < (SimplexId)vertexStars[i].size(); j++) {
-      for(SimplexId k = 0; k < (SimplexId)cellEdges[vertexStars[i][j]].size();
-          k++) {
+    for(size_t j = 0; j < vertexStars[i].size(); j++) {
+      for(size_t k = 0; k < cellEdges[vertexStars[i][j]].size(); k++) {
         SimplexId edgeId = cellEdges[vertexStars[i][j]][k];
 
         SimplexId vertexId0 = edgeList[edgeId][0];
         SimplexId vertexId1 = edgeList[edgeId][1];
 
-        if((vertexId0 != i) && (vertexId1 != i)) {
+        if((vertexId0 != static_cast<SimplexId>(i))
+           && (vertexId1 != static_cast<SimplexId>(i))) {
           vertexLinks[i].push_back(edgeId);
         }
       }
@@ -441,16 +440,15 @@ int ZeroSkeleton::buildVertexLinks(
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif
-  for(SimplexId i = 0; i < (SimplexId)vertexLinks.size(); i++) {
+  for(size_t i = 0; i < vertexLinks.size(); i++) {
 
-    for(SimplexId j = 0; j < (SimplexId)vertexStars[i].size(); j++) {
-      for(SimplexId k = 0;
-          k < (SimplexId)cellTriangles[vertexStars[i][j]].size(); k++) {
+    for(size_t j = 0; j < vertexStars[i].size(); j++) {
+      for(size_t k = 0; k < cellTriangles[vertexStars[i][j]].size(); k++) {
         SimplexId triangleId = cellTriangles[vertexStars[i][j]][k];
 
         bool hasVertex = false;
         for(int l = 0; l < 3; l++) {
-          if(i == triangleList[triangleId][l]) {
+          if(static_cast<SimplexId>(i) == triangleList[triangleId][l]) {
             hasVertex = true;
             break;
           }
@@ -594,10 +592,10 @@ int ZeroSkeleton::buildVertexStars(
            t.getElapsedTime(), threadNumber_);
 
   if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
-    for(SimplexId i = 0; i < (SimplexId)vertexStars.size(); i++) {
+    for(size_t i = 0; i < vertexStars.size(); i++) {
       stringstream msg;
       msg << "Vertex #" << i << " (" << vertexStars[i].size() << " cell(s)): ";
-      for(SimplexId j = 0; j < (SimplexId)vertexStars[i].size(); j++) {
+      for(size_t j = 0; j < vertexStars[i].size(); j++) {
         msg << " " << vertexStars[i][j];
       }
       printMsg(msg.str(), debug::Priority::VERBOSE);

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -493,10 +493,9 @@ int ZeroSkeleton::buildVertexNeighbors(
   printMsg("Building vertex neighbors", 0, 0, threadNumber_,
            ttk::debug::LineMode::REPLACE);
 
-  const SimplexId nbEdge = localEdgeList->size();
-  for(SimplexId i = 0; i < nbEdge; i++) {
-    oneSkeleton[(*localEdgeList)[i][0]].emplace_back((*localEdgeList)[i][1]);
-    oneSkeleton[(*localEdgeList)[i][1]].emplace_back((*localEdgeList)[i][0]);
+  for(const auto &e : *localEdgeList) {
+    oneSkeleton[e[0]].emplace_back(e[1]);
+    oneSkeleton[e[1]].emplace_back(e[0]);
   }
 
   printMsg("Built " + std::to_string(vertexNumber) + " vertex neighbors", 1,

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -505,8 +505,7 @@ int ZeroSkeleton::buildVertexNeighbors(
 
   Timer t;
 
-  printMsg("Building vertex neighbors", 0, 0, threadNumber_,
-           ttk::debug::LineMode::REPLACE);
+  printMsg("Building vertex neighbors", 0, 0, 1, ttk::debug::LineMode::REPLACE);
 
   for(const auto &e : *localEdgeList) {
     oneSkeleton[e[0]].emplace_back(e[1]);
@@ -514,7 +513,7 @@ int ZeroSkeleton::buildVertexNeighbors(
   }
 
   printMsg("Built " + std::to_string(vertexNumber) + " vertex neighbors", 1,
-           t.getElapsedTime(), threadNumber_);
+           t.getElapsedTime(), 1);
 
   // ethaneDiolMedium.vtu, 70Mtets, hal9000 (12coresHT)
   // (only merging step, after edge list creation)

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -595,14 +595,14 @@ int ZeroSkeleton::buildVertexStars(
   printMsg("Built " + std::to_string(vertexNumber) + " vertex stars", 1,
            t.getElapsedTime(), threadNumber_);
 
-  if(debugLevel_ >= static_cast<int>(debug::Priority::DETAIL)) {
+  if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
     for(SimplexId i = 0; i < (SimplexId)vertexStars.size(); i++) {
       stringstream msg;
       msg << "Vertex #" << i << " (" << vertexStars[i].size() << " cell(s)): ";
       for(SimplexId j = 0; j < (SimplexId)vertexStars[i].size(); j++) {
         msg << " " << vertexStars[i][j];
       }
-      printMsg(msg.str(), debug::Priority::INFO);
+      printMsg(msg.str(), debug::Priority::VERBOSE);
     }
   }
 

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -37,10 +37,10 @@ namespace ttk {
     /// be a std::vector listing the identifiers of the edges connected to the
     /// entry's vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildVertexEdges(
-      const SimplexId &vertexNumber,
-      const std::vector<std::pair<SimplexId, SimplexId>> &edgeList,
-      std::vector<std::vector<SimplexId>> &vertexEdges) const;
+    int
+      buildVertexEdges(const SimplexId &vertexNumber,
+                       const std::vector<std::array<SimplexId, 2>> &edgeList,
+                       std::vector<std::vector<SimplexId>> &vertexEdges) const;
 
     /// Compute the link of a single vertex of a triangulation (unspecified
     /// behavior if the input mesh is not a valid triangulation).
@@ -96,11 +96,11 @@ namespace ttk {
     /// entry will be a std::vector listing the edges in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildVertexLinks(
-      const std::vector<std::vector<SimplexId>> &vertexStars,
-      const std::vector<std::vector<SimplexId>> &cellEdges,
-      const std::vector<std::pair<SimplexId, SimplexId>> &edgeList,
-      std::vector<std::vector<SimplexId>> &vertexLinks) const;
+    int
+      buildVertexLinks(const std::vector<std::vector<SimplexId>> &vertexStars,
+                       const std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       const std::vector<std::array<SimplexId, 2>> &edgeList,
+                       std::vector<std::vector<SimplexId>> &vertexLinks) const;
 
     /// Compute the link of each vertex of a 3D triangulation (unspecified
     /// behavior if the input mesh is not a valid triangulation).
@@ -117,11 +117,11 @@ namespace ttk {
     /// entry will be a std::vector listing the triangles in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
-    int
-      buildVertexLinks(const std::vector<std::vector<SimplexId>> &vertexStars,
-                       const std::vector<std::vector<SimplexId>> &cellTriangles,
-                       const std::vector<std::vector<SimplexId>> &triangleList,
-                       std::vector<std::vector<SimplexId>> &vertexLinks) const;
+    int buildVertexLinks(
+      const std::vector<std::vector<SimplexId>> &vertexStars,
+      const std::vector<std::array<SimplexId, 4>> &cellTriangles,
+      const std::vector<std::array<SimplexId, 3>> &triangleList,
+      std::vector<std::vector<SimplexId>> &vertexLinks) const;
 
     /// Compute the list of neighbors of each vertex of a triangulation.
     /// Unspecified behavior if the input mesh is not a valid triangulation).
@@ -140,11 +140,12 @@ namespace ttk {
     /// this function will use this std::vector as internal edge list. If this
     /// std::vector is not empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildVertexNeighbors(
-      const SimplexId &vertexNumber,
-      const CellArray &cellArray,
-      std::vector<std::vector<SimplexId>> &vertexNeighbors,
-      std::vector<std::pair<SimplexId, SimplexId>> *edgeList = NULL) const;
+    int
+      buildVertexNeighbors(const SimplexId &vertexNumber,
+                           const CellArray &cellArray,
+                           std::vector<std::vector<SimplexId>> &vertexNeighbors,
+                           std::vector<std::array<SimplexId, 2>> *edgeList
+                           = NULL) const;
 
     /// Compute the star of each vertex of a triangulation. Unspecified
     /// behavior if the input mesh is not a valid triangulation.

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -13,6 +13,7 @@
 #ifndef _ZEROSKELETON_H
 #define _ZEROSKELETON_H
 
+#include <array>
 #include <map>
 
 // base code includes

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -96,9 +96,10 @@ namespace ttk {
     /// entry will be a std::vector listing the edges in the link of the
     /// corresponding vertex.
     /// \return Returns 0 upon success, negative values otherwise.
+    template <std::size_t n>
     int
       buildVertexLinks(const std::vector<std::vector<SimplexId>> &vertexStars,
-                       const std::vector<std::array<SimplexId, 6>> &cellEdges,
+                       const std::vector<std::array<SimplexId, n>> &cellEdges,
                        const std::vector<std::array<SimplexId, 2>> &edgeList,
                        std::vector<std::vector<SimplexId>> &vertexLinks) const;
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -451,7 +451,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the edge list.
-    inline const std::vector<std::pair<SimplexId, SimplexId>> *getEdges() {
+    inline const std::vector<std::array<SimplexId, 2>> *getEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;
@@ -912,7 +912,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a pre-processing step
     /// from any time performance measurement.
     /// \return Returns a pointer to the triangle list.
-    inline const std::vector<std::vector<SimplexId>> *getTriangles() {
+    inline const std::vector<std::array<SimplexId, 3>> *getTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return NULL;


### PR DESCRIPTION
The explicit triangulation data are stored inside `std::vector<std::vector<SimplexId>>` which causes unnecessary pointer indirections when accessing data.

This PR replaces several of those vectors of vectors with vectors of `std::arrays` when their size is known at compile-time. This concerns:

* triangle vertices (3)
* tetrahedron vertices (4)
* triangle edges (3)
* tetrahedron edges (6)
* tetrahedron triangles (4)
* edge vertices (`std::pair<SimplexId, SimplexId>` has been replaced with `std::array<SimplexId, 2>` to keep a unified style)

The Triangulation API has been, for the most part, left untouched, apart from the `getEdges` and the `getTriangles` methods whose return type has been modified accordingly.

Since the `cells` can represent either triangles or tetrahedrons, 3 new vectors of vectors members have been introduced. They are to be filled by the triangulation implementations at each `getCells`, `getCellEdges` and `getCellTriangles` calls from the relevant vectors of arrays. This can cause memory duplication for explicit grids but since using those methods is not advised, this should be fine.

A conceptual change also occurred in the AbstractTriangulation between cells and triangles in 2D. Before this PR, triangle methods were redirected to cell methods whereas now cell methods redirect to triangle ones in 2D. Confer `getCellEdge`, `getCellEdgeNumber`, `getCellEdges` and triangle equivalents. Without this change, the explicit triangulation would request the wrong vector of arrays in 2D: `geTriangleEdge`  would call `getCellEdge` which would access the `cellEdgeList_`/`tetraEdgeList_` member, empty in 2D.

A little cleanup has also been done in the `skeleton` module to accelerate the preconditioning methods. In particular, the `buildTriangles` method gained an 3x speedup while staying (for the most part) sequential.
A C++ RAII wrapper around OpenMP locks has also been introduced in the `common` module. It is currently used in `buildVertexTriangles` and enables another 3x speedup with 16 threads.
Some unused because inefficient parallel implementations were removed (e.g. `OneSkeleton::buildEdgeList`).

To keep up with the cell being tetras in 3D and triangles in 2D, three skeleton methods were templated:
* `OneSkeleton::buildEdgeLinks`
* `ThreeSkeleton::buildCellEdges`
* `ZeroSkeleton::buildVertexLinks`

Explicit template instantiations were used to keep the method definitions in the .cpp files.

Performance improvements for the discrete gradient computation range from +30% to +90% on explicit triangulations. The discrete gradient triangulation preconditioning also gained a x2 speedup.

In addition, the log verbosity of `ZeroSkeleton::buildVertexStars` was reduced from DETAIL to VERBOSE.

In fine, this PR reworks the memory usage of the explicit triangulation by removing a lot of pointer indirections and reducing memory fragmentation, leading to better performances overall.

No change has been observed in the ttk-data states files.

Enjoy,
Pierre