### PR TITLE
PersistenceDiagramClustering: Fix segfault with non-default parameters

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -121,7 +121,10 @@ public:
     Spacing = spacing;
     oldSpacing = spacing;
     Modified();
-    needUpdate_ = false;
+    if(!intermediateDiagrams_.empty()) {
+      // skip clustering computation only if done at least once before
+      needUpdate_ = false;
+    }
   }
   vtkGetMacro(Spacing, double);
 
@@ -133,7 +136,10 @@ public:
       Spacing = oldSpacing;
     }
     Modified();
-    needUpdate_ = false;
+    if(!intermediateDiagrams_.empty()) {
+      // skip clustering computation only if done at least once before
+      needUpdate_ = false;
+    }
   }
 
   vtkGetMacro(DisplayMethod, bool);


### PR DESCRIPTION
When modifying the DisplayMethod prior to applying the PersistenceDiagramClustering filter in ParaView, the `needUpdate` member was always set to false, thus skipping the application of the base layer routines on the input diagrams and leading in fine to segfaults further down in the pipeline.

This PR adds check around the modification of the `needUpdate` member to allow a first pass on the input data while still skipping later computations. This should fix #564.

Enjoy,
Pierre