### PR TITLE
Add missing vtkCellArrays to vtkUnstructuredGrid outputs

### DIFF
--- a/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
+++ b/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
@@ -42,5 +42,21 @@ int ttkGaussianPointCloud::RequestData(vtkInformation *request,
 
   domain->SetPoints(points);
 
+  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+  offsets->SetNumberOfComponents(1);
+  offsets->SetNumberOfTuples(NumberOfSamples + 1);
+  connectivity->SetNumberOfComponents(1);
+  connectivity->SetNumberOfTuples(NumberOfSamples);
+
+  for(int i = 0; i < NumberOfSamples; i++) {
+    offsets->SetTuple1(i, i);
+    connectivity->SetTuple1(i, i);
+  }
+  offsets->SetTuple1(NumberOfSamples, NumberOfSamples);
+
+  vtkNew<vtkCellArray> cells{};
+  cells->SetData(offsets, connectivity);
+  domain->SetCells(VTK_VERTEX, cells);
+
   return 1;
 }

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -205,6 +205,24 @@ int ttkMorseSmaleComplex::dispatch(
     points->SetData(pointsCoords);
     outputCriticalPoints->SetPoints(points);
 
+    vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+    offsets->SetNumberOfComponents(1);
+    offsets->SetNumberOfTuples(criticalPoints_numberOfPoints + 1);
+    connectivity->SetNumberOfComponents(1);
+    connectivity->SetNumberOfTuples(criticalPoints_numberOfPoints);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < criticalPoints_numberOfPoints; ++i) {
+      offsets->SetTuple1(i, i);
+      connectivity->SetTuple1(i, i);
+    }
+    offsets->SetTuple1(
+      criticalPoints_numberOfPoints, criticalPoints_numberOfPoints);
+    vtkNew<vtkCellArray> cells{};
+    cells->SetData(offsets, connectivity);
+    outputCriticalPoints->SetCells(VTK_VERTEX, cells);
+
     auto pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE
     if(!pointData) {

--- a/standalone/MorseSmaleComplex/main.cpp
+++ b/standalone/MorseSmaleComplex/main.cpp
@@ -124,6 +124,12 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < msc->GetNumberOfOutputPorts(); i++) {
       auto output = msc->GetOutputDataObject(i);
+      if(output->GetNumberOfElements(vtkDataObject::AttributeTypes::POINT) == 0
+         || output->GetNumberOfElements(vtkDataObject::AttributeTypes::CELL)
+              == 0) {
+        continue;
+      }
+
       auto writer
         = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
 


### PR DESCRIPTION
Several TTK filters generate a point cloud output: `DiscreteGradient`, `MorseSmaleComplex`, `ScalarFieldCriticalPoints`, `GaussianPointCloud`. To do so, these filters fill their `vtkUnstructuredGrid` output with `vtkPoints` only. While this seems to be fine inside ParaView, this is causing segfaults in the corresponding standalones, because the writer expects cells inside the `vtkUnstructuredGrid`.

This PR adds a `vtkCellArray` to the output of the four filters previously cited. Among other things, this fixes the segfaults in the standalones and allow to Threshold directly the output without applying a `SphereFromPoints`.

In addition, VTK structure are now filled in parallel in DiscreteGradient and ScalarFieldCriticalPoints. Furthermore, the MorseSmaleComplex standalone has been modified to skip writing empty outputs.

No modification has been observed in the ttk-data state files.

Enjoy,
Pierre 

