### PR TITLE
ContourTreeAlignment - New metric and input structure

### DIFF
--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -20,8 +20,8 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
   // find path to global max
   std::shared_ptr<AlignmentNode> nextNode
-    = minNode->edgeList[0]->node1 == minNode ? minNode->edgeList[0]->node2
-                                             : minNode->edgeList[0]->node1;
+    = minNode->edgeList[0]->node1.lock() == minNode ? minNode->edgeList[0]->node2.lock()
+                                             : minNode->edgeList[0]->node1.lock();
   std::vector<std::shared_ptr<AlignmentNode>> maxPath_
     = pathToMax(nextNode, minNode).second;
   std::vector<std::shared_ptr<AlignmentNode>> maxPath;
@@ -45,7 +45,7 @@ void ttk::ContourTreeAlignment::computeBranches() {
       for(std::shared_ptr<AlignmentEdge> cE : currNode->edgeList) {
 
         std::shared_ptr<AlignmentNode> cN
-          = cE->node1 == currNode ? cE->node2 : cE->node1;
+          = (cE->node1.lock()) == currNode ? cE->node2.lock() : cE->node1.lock();
         if(cN == path[i - 1])
           continue;
         if(cN == path[i + 1])
@@ -74,7 +74,7 @@ void ttk::ContourTreeAlignment::computeBranches() {
     for(std::shared_ptr<AlignmentEdge> cE : path.back()->edgeList) {
 
       std::shared_ptr<AlignmentNode> cN
-        = cE->node1 == path.back() ? cE->node2 : cE->node1;
+        = cE->node1.lock() == path.back() ? cE->node2.lock() : cE->node1.lock();
       if(cN == path[path.size() - 2])
         continue;
 
@@ -117,7 +117,7 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   for(std::shared_ptr<AlignmentEdge> cE : root->edgeList) {
 
     std::shared_ptr<AlignmentNode> nextNode
-      = cE->node1 == root ? cE->node2 : cE->node1;
+      = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
     if(parent == nextNode)
       continue;
     if(nextNode->scalarValue < root->scalarValue)
@@ -152,7 +152,7 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   for(std::shared_ptr<AlignmentEdge> cE : root->edgeList) {
 
     std::shared_ptr<AlignmentNode> nextNode
-      = cE->node1 == root ? cE->node2 : cE->node1;
+      = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
     if(parent == nextNode)
       continue;
     if(nextNode->scalarValue > root->scalarValue)
@@ -1722,7 +1722,7 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
     if(edge != parent) {
 
       std::shared_ptr<BinaryTree> child = computeRootedTree(
-        edge->node1 == node ? edge->node2 : edge->node1, edge, id);
+        edge->node1.lock() == node ? edge->node2.lock() : edge->node1.lock(), edge, id);
       children.push_back(child);
       t->size += child->size;
       if(t->height < child->height + 1)
@@ -1747,8 +1747,8 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
   t->area = arc->area;
   t->volume = t->area * t->scalardistanceParent;
   t->freq = arc->freq;
-  t->type = arc->node1->type == maxNode || arc->node2->type == maxNode ? maxNode
-            : arc->node1->type == minNode || arc->node2->type == minNode
+  t->type = arc->node1.lock()->type == maxNode || arc->node2.lock()->type == maxNode ? maxNode
+            : arc->node1.lock()->type == minNode || arc->node2.lock()->type == minNode
               ? minNode
               : saddleNode;
   t->child1 = nullptr;
@@ -1763,14 +1763,14 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
 
   std::vector<std::shared_ptr<BinaryTree>> children;
 
-  std::shared_ptr<AlignmentNode> node = parent1 ? arc->node2 : arc->node1;
+  std::shared_ptr<AlignmentNode> node = parent1 ? arc->node2.lock() : arc->node1.lock();
 
   for(std::shared_ptr<AlignmentEdge> edge : node->edgeList) {
 
     if(edge != arc) {
 
       std::shared_ptr<BinaryTree> child
-        = computeRootedDualTree(edge, edge->node1 == node ? true : false, id);
+        = computeRootedDualTree(edge, edge->node1.lock() == node ? true : false, id);
       children.push_back(child);
       t->size += child->size;
       if(t->height < child->height + 1)

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -544,13 +544,12 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
   } else if(alignmenttreeType == averageValues) {
 
-    currNode->scalarValue = res->node1 == nullptr
-                              ? res->node2->scalarValue
-                              : res->node2 == nullptr
-                                  ? res->node1->scalarValue
-                                  : (res->node1->scalarValue * res->node1->freq
-                                     + res->node2->scalarValue)
-                                      / currNode->freq;
+    currNode->scalarValue = res->node1 == nullptr ? res->node2->scalarValue
+                            : res->node2 == nullptr
+                              ? res->node1->scalarValue
+                              : (res->node1->scalarValue * res->node1->freq
+                                 + res->node2->scalarValue)
+                                  / currNode->freq;
 
   } else {
 
@@ -622,15 +621,14 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childNode->scalarValue
-          = currTree->child1->node1 == nullptr
-              ? currTree->child1->node2->scalarValue
-              : currTree->child1->node2 == nullptr
-                  ? currTree->child1->node1->scalarValue
-                  : (currTree->child1->node1->scalarValue
-                       * currTree->child1->node1->freq
-                     + currTree->child1->node2->scalarValue)
-                      / childNode->freq;
+        childNode->scalarValue = currTree->child1->node1 == nullptr
+                                   ? currTree->child1->node2->scalarValue
+                                 : currTree->child1->node2 == nullptr
+                                   ? currTree->child1->node1->scalarValue
+                                   : (currTree->child1->node1->scalarValue
+                                        * currTree->child1->node1->freq
+                                      + currTree->child1->node2->scalarValue)
+                                       / childNode->freq;
 
       } else {
 
@@ -676,24 +674,23 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childEdge->area = currTree->child1->node1 == nullptr
-                            ? currTree->child1->node2->area
-                            : currTree->child1->node2 == nullptr
-                                ? currTree->child1->node1->area
-                                : (currTree->child1->node1->area
-                                     * currTree->child1->node1->freq
-                                   + currTree->child1->node2->area)
-                                    / childNode->freq;
+        childEdge->area
+          = currTree->child1->node1 == nullptr ? currTree->child1->node2->area
+            : currTree->child1->node2 == nullptr
+              ? currTree->child1->node1->area
+              : (currTree->child1->node1->area * currTree->child1->node1->freq
+                 + currTree->child1->node2->area)
+                  / childNode->freq;
 
         childEdge->scalardistance
           = currTree->child1->node1 == nullptr
               ? currTree->child1->node2->scalardistanceParent
-              : currTree->child1->node2 == nullptr
-                  ? currTree->child1->node1->scalardistanceParent
-                  : (currTree->child1->node1->scalardistanceParent
-                       * currTree->child1->node1->freq
-                     + currTree->child1->node2->scalardistanceParent)
-                      / childNode->freq;
+            : currTree->child1->node2 == nullptr
+              ? currTree->child1->node1->scalardistanceParent
+              : (currTree->child1->node1->scalardistanceParent
+                   * currTree->child1->node1->freq
+                 + currTree->child1->node2->scalardistanceParent)
+                  / childNode->freq;
 
       } else {
 
@@ -798,15 +795,14 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childNode->scalarValue
-          = currTree->child2->node1 == nullptr
-              ? currTree->child2->node2->scalarValue
-              : currTree->child2->node2 == nullptr
-                  ? currTree->child2->node1->scalarValue
-                  : (currTree->child2->node1->scalarValue
-                       * currTree->child2->node1->freq
-                     + currTree->child2->node2->scalarValue)
-                      / childNode->freq;
+        childNode->scalarValue = currTree->child2->node1 == nullptr
+                                   ? currTree->child2->node2->scalarValue
+                                 : currTree->child2->node2 == nullptr
+                                   ? currTree->child2->node1->scalarValue
+                                   : (currTree->child2->node1->scalarValue
+                                        * currTree->child2->node1->freq
+                                      + currTree->child2->node2->scalarValue)
+                                       / childNode->freq;
 
       } else {
 
@@ -852,24 +848,23 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childEdge->area = currTree->child2->node1 == nullptr
-                            ? currTree->child2->node2->area
-                            : currTree->child2->node2 == nullptr
-                                ? currTree->child2->node1->area
-                                : (currTree->child2->node1->area
-                                     * currTree->child2->node1->freq
-                                   + currTree->child2->node2->area)
-                                    / childNode->freq;
+        childEdge->area
+          = currTree->child2->node1 == nullptr ? currTree->child2->node2->area
+            : currTree->child2->node2 == nullptr
+              ? currTree->child2->node1->area
+              : (currTree->child2->node1->area * currTree->child2->node1->freq
+                 + currTree->child2->node2->area)
+                  / childNode->freq;
 
         childEdge->scalardistance
           = currTree->child2->node1 == nullptr
               ? currTree->child2->node2->scalardistanceParent
-              : currTree->child2->node2 == nullptr
-                  ? currTree->child2->node1->scalardistanceParent
-                  : (currTree->child2->node1->scalardistanceParent
-                       * currTree->child2->node1->freq
-                     + currTree->child2->node2->scalardistanceParent)
-                      / childNode->freq;
+            : currTree->child2->node2 == nullptr
+              ? currTree->child2->node1->scalardistanceParent
+              : (currTree->child2->node1->scalardistanceParent
+                   * currTree->child2->node1->freq
+                 + currTree->child2->node2->scalardistanceParent)
+                  / childNode->freq;
 
       } else {
 
@@ -1193,13 +1188,13 @@ float ttk::ContourTreeAlignment::editCost(std::shared_ptr<BinaryTree> t1,
 
   float v1 = 0, v2 = 0;
   if(t1 != nullptr)
-    v1 = arcMatchMode == persistence
-           ? t1->scalardistanceParent
-           : arcMatchMode == area ? t1->area : t1->volume;
+    v1 = arcMatchMode == persistence ? t1->scalardistanceParent
+         : arcMatchMode == area      ? t1->area
+                                     : t1->volume;
   if(t2 != nullptr)
-    v2 = arcMatchMode == persistence
-           ? t2->scalardistanceParent
-           : arcMatchMode == area ? t2->area : t2->volume;
+    v2 = arcMatchMode == persistence ? t2->scalardistanceParent
+         : arcMatchMode == area      ? t2->area
+                                     : t2->volume;
 
   if(arcMatchMode == overlap) {
     // this->printMsg("overlap");
@@ -1763,10 +1758,9 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
   t->type
     = arc->node1.lock()->type == maxNode || arc->node2.lock()->type == maxNode
         ? maxNode
-        : arc->node1.lock()->type == minNode
-              || arc->node2.lock()->type == minNode
-            ? minNode
-            : saddleNode;
+      : arc->node1.lock()->type == minNode || arc->node2.lock()->type == minNode
+        ? minNode
+        : saddleNode;
   t->child1 = nullptr;
   t->child2 = nullptr;
   t->id = id;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -20,8 +20,9 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
   // find path to global max
   std::shared_ptr<AlignmentNode> nextNode
-    = minNode->edgeList[0]->node1.lock() == minNode ? minNode->edgeList[0]->node2.lock()
-                                             : minNode->edgeList[0]->node1.lock();
+    = minNode->edgeList[0]->node1.lock() == minNode
+        ? minNode->edgeList[0]->node2.lock()
+        : minNode->edgeList[0]->node1.lock();
   std::vector<std::shared_ptr<AlignmentNode>> maxPath_
     = pathToMax(nextNode, minNode).second;
   std::vector<std::shared_ptr<AlignmentNode>> maxPath;
@@ -44,8 +45,9 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
       for(std::shared_ptr<AlignmentEdge> cE : currNode->edgeList) {
 
-        std::shared_ptr<AlignmentNode> cN
-          = (cE->node1.lock()) == currNode ? cE->node2.lock() : cE->node1.lock();
+        std::shared_ptr<AlignmentNode> cN = (cE->node1.lock()) == currNode
+                                              ? cE->node2.lock()
+                                              : cE->node1.lock();
         if(cN == path[i - 1])
           continue;
         if(cN == path[i + 1])
@@ -542,12 +544,13 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
   } else if(alignmenttreeType == averageValues) {
 
-    currNode->scalarValue = res->node1 == nullptr ? res->node2->scalarValue
-                            : res->node2 == nullptr
-                              ? res->node1->scalarValue
-                              : (res->node1->scalarValue * res->node1->freq
-                                 + res->node2->scalarValue)
-                                  / currNode->freq;
+    currNode->scalarValue = res->node1 == nullptr
+                              ? res->node2->scalarValue
+                              : res->node2 == nullptr
+                                  ? res->node1->scalarValue
+                                  : (res->node1->scalarValue * res->node1->freq
+                                     + res->node2->scalarValue)
+                                      / currNode->freq;
 
   } else {
 
@@ -619,14 +622,15 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childNode->scalarValue = currTree->child1->node1 == nullptr
-                                   ? currTree->child1->node2->scalarValue
-                                 : currTree->child1->node2 == nullptr
-                                   ? currTree->child1->node1->scalarValue
-                                   : (currTree->child1->node1->scalarValue
-                                        * currTree->child1->node1->freq
-                                      + currTree->child1->node2->scalarValue)
-                                       / childNode->freq;
+        childNode->scalarValue
+          = currTree->child1->node1 == nullptr
+              ? currTree->child1->node2->scalarValue
+              : currTree->child1->node2 == nullptr
+                  ? currTree->child1->node1->scalarValue
+                  : (currTree->child1->node1->scalarValue
+                       * currTree->child1->node1->freq
+                     + currTree->child1->node2->scalarValue)
+                      / childNode->freq;
 
       } else {
 
@@ -672,23 +676,24 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childEdge->area
-          = currTree->child1->node1 == nullptr ? currTree->child1->node2->area
-            : currTree->child1->node2 == nullptr
-              ? currTree->child1->node1->area
-              : (currTree->child1->node1->area * currTree->child1->node1->freq
-                 + currTree->child1->node2->area)
-                  / childNode->freq;
+        childEdge->area = currTree->child1->node1 == nullptr
+                            ? currTree->child1->node2->area
+                            : currTree->child1->node2 == nullptr
+                                ? currTree->child1->node1->area
+                                : (currTree->child1->node1->area
+                                     * currTree->child1->node1->freq
+                                   + currTree->child1->node2->area)
+                                    / childNode->freq;
 
         childEdge->scalardistance
           = currTree->child1->node1 == nullptr
               ? currTree->child1->node2->scalardistanceParent
-            : currTree->child1->node2 == nullptr
-              ? currTree->child1->node1->scalardistanceParent
-              : (currTree->child1->node1->scalardistanceParent
-                   * currTree->child1->node1->freq
-                 + currTree->child1->node2->scalardistanceParent)
-                  / childNode->freq;
+              : currTree->child1->node2 == nullptr
+                  ? currTree->child1->node1->scalardistanceParent
+                  : (currTree->child1->node1->scalardistanceParent
+                       * currTree->child1->node1->freq
+                     + currTree->child1->node2->scalardistanceParent)
+                      / childNode->freq;
 
       } else {
 
@@ -725,8 +730,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
       }
 
       childEdge->region = currTree->child1->node2 == nullptr
-                          ? currTree->child1->node1->region
-                          : currTree->child1->node2->region;
+                            ? currTree->child1->node1->region
+                            : currTree->child1->node2->region;
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
       if(currTree->child1->node1 != nullptr) {
@@ -793,14 +798,15 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childNode->scalarValue = currTree->child2->node1 == nullptr
-                                   ? currTree->child2->node2->scalarValue
-                                 : currTree->child2->node2 == nullptr
-                                   ? currTree->child2->node1->scalarValue
-                                   : (currTree->child2->node1->scalarValue
-                                        * currTree->child2->node1->freq
-                                      + currTree->child2->node2->scalarValue)
-                                       / childNode->freq;
+        childNode->scalarValue
+          = currTree->child2->node1 == nullptr
+              ? currTree->child2->node2->scalarValue
+              : currTree->child2->node2 == nullptr
+                  ? currTree->child2->node1->scalarValue
+                  : (currTree->child2->node1->scalarValue
+                       * currTree->child2->node1->freq
+                     + currTree->child2->node2->scalarValue)
+                      / childNode->freq;
 
       } else {
 
@@ -846,23 +852,24 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       } else if(alignmenttreeType == averageValues) {
 
-        childEdge->area
-          = currTree->child2->node1 == nullptr ? currTree->child2->node2->area
-            : currTree->child2->node2 == nullptr
-              ? currTree->child2->node1->area
-              : (currTree->child2->node1->area * currTree->child2->node1->freq
-                 + currTree->child2->node2->area)
-                  / childNode->freq;
+        childEdge->area = currTree->child2->node1 == nullptr
+                            ? currTree->child2->node2->area
+                            : currTree->child2->node2 == nullptr
+                                ? currTree->child2->node1->area
+                                : (currTree->child2->node1->area
+                                     * currTree->child2->node1->freq
+                                   + currTree->child2->node2->area)
+                                    / childNode->freq;
 
         childEdge->scalardistance
           = currTree->child2->node1 == nullptr
               ? currTree->child2->node2->scalardistanceParent
-            : currTree->child2->node2 == nullptr
-              ? currTree->child2->node1->scalardistanceParent
-              : (currTree->child2->node1->scalardistanceParent
-                   * currTree->child2->node1->freq
-                 + currTree->child2->node2->scalardistanceParent)
-                  / childNode->freq;
+              : currTree->child2->node2 == nullptr
+                  ? currTree->child2->node1->scalardistanceParent
+                  : (currTree->child2->node1->scalardistanceParent
+                       * currTree->child2->node1->freq
+                     + currTree->child2->node2->scalardistanceParent)
+                      / childNode->freq;
 
       } else {
 
@@ -899,8 +906,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
       }
 
       childEdge->region = currTree->child2->node2 == nullptr
-                          ? currTree->child2->node1->region
-                          : currTree->child2->node2->region;
+                            ? currTree->child2->node1->region
+                            : currTree->child2->node2->region;
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
       if(currTree->child2->node1 != nullptr) {
@@ -1186,42 +1193,47 @@ float ttk::ContourTreeAlignment::editCost(std::shared_ptr<BinaryTree> t1,
 
   float v1 = 0, v2 = 0;
   if(t1 != nullptr)
-    v1 = arcMatchMode == persistence ? t1->scalardistanceParent
-         : arcMatchMode == area      ? t1->area
-                                     : t1->volume;
+    v1 = arcMatchMode == persistence
+           ? t1->scalardistanceParent
+           : arcMatchMode == area ? t1->area : t1->volume;
   if(t2 != nullptr)
-    v2 = arcMatchMode == persistence ? t2->scalardistanceParent
-         : arcMatchMode == area      ? t2->area
-                                     : t2->volume;
+    v2 = arcMatchMode == persistence
+           ? t2->scalardistanceParent
+           : arcMatchMode == area ? t2->area : t2->volume;
 
-  if(arcMatchMode == overlap){
-    //this->printMsg("overlap");
+  if(arcMatchMode == overlap) {
+    // this->printMsg("overlap");
     int unionsize = 0;
     int intersectionsize = 0;
     size_t i = 0;
     size_t j = 0;
-    if(t1 && t2){
-      while(i<t1->region.size() && j<t2->region.size()){
+    if(t1 && t2) {
+      while(i < t1->region.size() && j < t2->region.size()) {
         int vi = t1->region[i];
         int vj = t2->region[j];
-        if(vi==vj){
+        if(vi == vj) {
           intersectionsize++;
           i++;
           j++;
-        }
-        else if(vi<vj) i++;
-        else j++;
+        } else if(vi < vj)
+          i++;
+        else
+          j++;
         unionsize++;
       }
-      unionsize += i==(t1->region.size()) ? t2->region.size() - j : t1->region.size() - i;
-      if(false){
+      unionsize += i == (t1->region.size()) ? t2->region.size() - j
+                                            : t1->region.size() - i;
+      if(false) {
         std::cout << "========================\nRegion 1: ";
-        for(size_t k=0; k<t1->region.size(); k++) std::cout << t1->region[k] << " ";
+        for(size_t k = 0; k < t1->region.size(); k++)
+          std::cout << t1->region[k] << " ";
         std::cout << std::endl;
         std::cout << "Region 2: ";
-        for(size_t k=0; k<t2->region.size(); k++) std::cout << t2->region[k] << " ";
+        for(size_t k = 0; k < t2->region.size(); k++)
+          std::cout << t2->region[k] << " ";
         std::cout << std::endl;
-        std::cout << "Intersection size: " << intersectionsize << "\nUnion size: " << unionsize << std::endl;
+        std::cout << "Intersection size: " << intersectionsize
+                  << "\nUnion size: " << unionsize << std::endl;
       }
     }
 
@@ -1230,16 +1242,16 @@ float ttk::ContourTreeAlignment::editCost(std::shared_ptr<BinaryTree> t1,
 
     else if(t1 == nullptr)
       return weightCombinatorialMatch + weightArcMatch * 1
-            + weightScalarValueMatch;
+             + weightScalarValueMatch;
 
     else if(t2 == nullptr)
       return weightCombinatorialMatch + weightArcMatch * 1
-            + weightScalarValueMatch;
+             + weightScalarValueMatch;
 
     else if(t1->type == t2->type)
-      return weightArcMatch * (1-((float)intersectionsize/(float)unionsize))
-            + weightScalarValueMatch
-                * std::abs(t1->scalarValue - t2->scalarValue);
+      return weightArcMatch * (1 - ((float)intersectionsize / (float)unionsize))
+             + weightScalarValueMatch
+                 * std::abs(t1->scalarValue - t2->scalarValue);
 
     else
       return FLT_MAX;
@@ -1692,7 +1704,7 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
     t->scalardistanceParent = 10000;
     t->area = 10000;
     t->volume = 10000;
-    t->region = std::vector<int>(1,-1);
+    t->region = std::vector<int>(1, -1);
   } else {
     t->scalardistanceParent = parent->scalardistance;
     t->area = parent->area;
@@ -1722,7 +1734,8 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
     if(edge != parent) {
 
       std::shared_ptr<BinaryTree> child = computeRootedTree(
-        edge->node1.lock() == node ? edge->node2.lock() : edge->node1.lock(), edge, id);
+        edge->node1.lock() == node ? edge->node2.lock() : edge->node1.lock(),
+        edge, id);
       children.push_back(child);
       t->size += child->size;
       if(t->height < child->height + 1)
@@ -1747,10 +1760,13 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
   t->area = arc->area;
   t->volume = t->area * t->scalardistanceParent;
   t->freq = arc->freq;
-  t->type = arc->node1.lock()->type == maxNode || arc->node2.lock()->type == maxNode ? maxNode
-            : arc->node1.lock()->type == minNode || arc->node2.lock()->type == minNode
-              ? minNode
-              : saddleNode;
+  t->type
+    = arc->node1.lock()->type == maxNode || arc->node2.lock()->type == maxNode
+        ? maxNode
+        : arc->node1.lock()->type == minNode
+              || arc->node2.lock()->type == minNode
+            ? minNode
+            : saddleNode;
   t->child1 = nullptr;
   t->child2 = nullptr;
   t->id = id;
@@ -1763,14 +1779,15 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
 
   std::vector<std::shared_ptr<BinaryTree>> children;
 
-  std::shared_ptr<AlignmentNode> node = parent1 ? arc->node2.lock() : arc->node1.lock();
+  std::shared_ptr<AlignmentNode> node
+    = parent1 ? arc->node2.lock() : arc->node1.lock();
 
   for(std::shared_ptr<AlignmentEdge> edge : node->edgeList) {
 
     if(edge != arc) {
 
-      std::shared_ptr<BinaryTree> child
-        = computeRootedDualTree(edge, edge->node1.lock() == node ? true : false, id);
+      std::shared_ptr<BinaryTree> child = computeRootedDualTree(
+        edge, edge->node1.lock() == node ? true : false, id);
       children.push_back(child);
       t->size += child->size;
       if(t->height < child->height + 1)

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -291,7 +291,6 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     for(size_t i=0; i<nTrees; i++){
       int maxSegId = -1;
       std::vector<int> seg(segsizes[i]);
-      int* seg_arr = segmentations[i];
       for(size_t j=0; j<segsizes[i]; j++){
         maxSegId = std::max(maxSegId,segmentations[i][j]);
         seg[j] = segmentations[i][j];

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -60,8 +60,8 @@ struct AlignmentNode {
 
 struct AlignmentEdge {
 
-  std::shared_ptr<AlignmentNode> node1;
-  std::shared_ptr<AlignmentNode> node2;
+  std::weak_ptr<AlignmentNode> node1;
+  std::weak_ptr<AlignmentNode> node2;
   float scalardistance;
   float area;
   float volume;
@@ -488,11 +488,11 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     int i = 0;
     for(std::shared_ptr<AlignmentNode> node : nodes) {
 
-      if(node == edge->node1) {
+      if(node == edge->node1.lock()) {
         outputEdges.push_back(i);
       }
 
-      if(node == edge->node2) {
+      if(node == edge->node2.lock()) {
         outputEdges.push_back(i);
       }
 

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -287,32 +287,34 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
   }
 
   std::vector<std::vector<std::vector<int>>> segRegions;
-  if(!segsizes.empty()){
-    for(size_t i=0; i<nTrees; i++){
+  if(!segsizes.empty()) {
+    for(size_t i = 0; i < nTrees; i++) {
       int maxSegId = -1;
       std::vector<int> seg(segsizes[i]);
-      int* seg_arr = segmentations[i];
-      for(size_t j=0; j<segsizes[i]; j++){
-        maxSegId = std::max(maxSegId,segmentations[i][j]);
+      int *seg_arr = segmentations[i];
+      for(size_t j = 0; j < segsizes[i]; j++) {
+        maxSegId = std::max(maxSegId, segmentations[i][j]);
         seg[j] = segmentations[i][j];
       }
-      std::vector<std::vector<int>> reg(maxSegId+1);
-      for(size_t j=0; j<segsizes[i]; j++){
+      std::vector<std::vector<int>> reg(maxSegId + 1);
+      for(size_t j = 0; j < segsizes[i]; j++) {
         reg[segmentations[i][j]].push_back(j);
       }
       segRegions.push_back(reg);
     }
-    for(size_t i=0; i<nTrees; i++){
-      int sum=0;
-      for(auto seg : segRegions[i]){
-        sum+=seg.size();
+    for(size_t i = 0; i < nTrees; i++) {
+      int sum = 0;
+      for(auto seg : segRegions[i]) {
+        sum += seg.size();
       }
-      this->printMsg("Tree "+std::to_string(i)+", sum of segment sizes: "+std::to_string(sum));
-      sum=0;
-      for(size_t j = 0; j<nEdges[i]; j++){
-        sum+=regionSizes[i][j];
+      this->printMsg("Tree " + std::to_string(i)
+                     + ", sum of segment sizes: " + std::to_string(sum));
+      sum = 0;
+      for(size_t j = 0; j < nEdges[i]; j++) {
+        sum += regionSizes[i][j];
       }
-      this->printMsg("Tree "+std::to_string(i)+", sum of region sizes: "+std::to_string(sum));
+      this->printMsg("Tree " + std::to_string(i)
+                     + ", sum of region sizes: " + std::to_string(sum));
     }
   }
 
@@ -365,7 +367,8 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     std::shared_ptr<ContourTree> ct(new ContourTree(
       scalars[permutation[i]], regionSizes[permutation[i]],
       segmentationIds[permutation[i]], topologies[permutation[i]],
-      nVertices[permutation[i]], nEdges[permutation[i]], segRegions.empty()?std::vector<std::vector<int>>():segRegions[i]));
+      nVertices[permutation[i]], nEdges[permutation[i]],
+      segRegions.empty() ? std::vector<std::vector<int>>() : segRegions[i]));
     if(ct->isBinary()) {
       contourtreesToAlign.push_back(ct);
     } else {

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -32,7 +32,7 @@
 
 enum Type_Alignmenttree { averageValues, medianValues, lastMatchedValue };
 // enum Type_Match { matchNodes, matchArcs };
-enum Mode_ArcMatch { persistence, area, volume };
+enum Mode_ArcMatch { persistence, area, volume, overlap };
 
 struct AlignmentTree {
   std::shared_ptr<AlignmentTree> child1;
@@ -65,6 +65,7 @@ struct AlignmentEdge {
   float scalardistance;
   float area;
   float volume;
+  std::vector<int> region;
   int freq;
 
   std::vector<std::pair<int, int>> arcRefs;
@@ -112,6 +113,8 @@ namespace ttk {
                 const vector<long long *> &topologies,
                 const vector<size_t> &nVertices,
                 const vector<size_t> &nEdges,
+                const vector<int *> &segmentations,
+                const vector<size_t> &segsizes,
 
                 vector<float> &outputVertices,
                 vector<long long> &outputFrequencies,
@@ -225,6 +228,8 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
                                        const vector<long long *> &topologies,
                                        const vector<size_t> &nVertices,
                                        const vector<size_t> &nEdges,
+                                       const vector<int *> &segmentations,
+                                       const vector<size_t> &segsizes,
                                        vector<float> &outputVertices,
                                        vector<long long> &outputFrequencies,
                                        vector<long long> &outputVertexIds,
@@ -281,6 +286,36 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     this->printMsg(tableLines, debug::Priority::VERBOSE);
   }
 
+  std::vector<std::vector<std::vector<int>>> segRegions;
+  if(!segsizes.empty()){
+    for(size_t i=0; i<nTrees; i++){
+      int maxSegId = -1;
+      std::vector<int> seg(segsizes[i]);
+      int* seg_arr = segmentations[i];
+      for(size_t j=0; j<segsizes[i]; j++){
+        maxSegId = std::max(maxSegId,segmentations[i][j]);
+        seg[j] = segmentations[i][j];
+      }
+      std::vector<std::vector<int>> reg(maxSegId+1);
+      for(size_t j=0; j<segsizes[i]; j++){
+        reg[segmentations[i][j]].push_back(j);
+      }
+      segRegions.push_back(reg);
+    }
+    for(size_t i=0; i<nTrees; i++){
+      int sum=0;
+      for(auto seg : segRegions[i]){
+        sum+=seg.size();
+      }
+      this->printMsg("Tree "+std::to_string(i)+", sum of segment sizes: "+std::to_string(sum));
+      sum=0;
+      for(size_t j = 0; j<nEdges[i]; j++){
+        sum+=regionSizes[i][j];
+      }
+      this->printMsg("Tree "+std::to_string(i)+", sum of region sizes: "+std::to_string(sum));
+    }
+  }
+
   // prepare data structures
   contourtrees = std::vector<std::shared_ptr<ContourTree>>();
   nodes = std::vector<std::shared_ptr<AlignmentNode>>();
@@ -330,7 +365,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     std::shared_ptr<ContourTree> ct(new ContourTree(
       scalars[permutation[i]], regionSizes[permutation[i]],
       segmentationIds[permutation[i]], topologies[permutation[i]],
-      nVertices[permutation[i]], nEdges[permutation[i]]));
+      nVertices[permutation[i]], nEdges[permutation[i]], segRegions.empty()?std::vector<std::vector<int>>():segRegions[i]));
     if(ct->isBinary()) {
       contourtreesToAlign.push_back(ct);
     } else {

--- a/core/base/contourTreeAlignment/contourtree.cpp
+++ b/core/base/contourTreeAlignment/contourtree.cpp
@@ -158,10 +158,9 @@ std::shared_ptr<BinaryTree> ContourTree::computeRootedTree_binary(
   // if(parent != nullptr)
   // t->arcRefs.push_back(std::make_pair(-1,parent->segId));
   if(parent != nullptr) {
-    int arcRef = arcs[node->edgeList[0]] == parent
-                   ? node->edgeList[0]
-                   : arcs[node->edgeList[1]] == parent ? node->edgeList[1]
-                                                       : node->edgeList[2];
+    int arcRef = arcs[node->edgeList[0]] == parent   ? node->edgeList[0]
+                 : arcs[node->edgeList[1]] == parent ? node->edgeList[1]
+                                                     : node->edgeList[2];
     t->arcRefs.push_back(std::make_pair(-1, arcRef));
   }
 

--- a/core/base/contourTreeAlignment/contourtree.cpp
+++ b/core/base/contourTreeAlignment/contourtree.cpp
@@ -1,13 +1,15 @@
 #include "contourtree.h"
 #include <cmath>
 #include <float.h>
+#include <algorithm>
 
 ContourTree::ContourTree(float *scalars,
                          int *regionSizes,
                          int *segmentationIds,
                          long long *topology,
                          size_t nVertices,
-                         size_t nEdges) {
+                         size_t nEdges,
+                         std::vector<std::vector<int>> regions) {
 
   nodes = std::vector<std::shared_ptr<CTNode>>();
   arcs = std::vector<std::shared_ptr<CTEdge>>();
@@ -31,6 +33,9 @@ ContourTree::ContourTree(float *scalars,
     std::shared_ptr<CTEdge> edge(new CTEdge);
     edge->area = regionSizes[i];
     edge->segId = segmentationIds[i];
+    if(!regions.empty()) edge->region = regions[segmentationIds[i]];
+    std::sort(edge->region.begin(),edge->region.end());
+    //if(!regions.empty()) std::cout << regionSizes[i] << " " << regions[segmentationIds[i]].size() << std::endl;
     edge->node1Idx = topology[j + 0];
     nodes[topology[j + 0]]->edgeList.push_back(i);
     edge->node2Idx = topology[j + 1];
@@ -201,10 +206,12 @@ std::shared_ptr<BinaryTree> ContourTree::computeRootedTree_binary(
     t->scalardistanceParent = 10000;
     t->area = 10000;
     t->volume = 10000;
+    t->region = std::vector<int>(1,-1);
   } else {
     t->scalardistanceParent = parent->scalardistance;
     t->area = parent->area;
     t->volume = t->scalardistanceParent * parent->area;
+    t->region = parent->region;
   }
 
   return t;

--- a/core/base/contourTreeAlignment/contourtree.cpp
+++ b/core/base/contourTreeAlignment/contourtree.cpp
@@ -1,7 +1,7 @@
 #include "contourtree.h"
+#include <algorithm>
 #include <cmath>
 #include <float.h>
-#include <algorithm>
 
 ContourTree::ContourTree(float *scalars,
                          int *regionSizes,
@@ -33,9 +33,11 @@ ContourTree::ContourTree(float *scalars,
     std::shared_ptr<CTEdge> edge(new CTEdge);
     edge->area = regionSizes[i];
     edge->segId = segmentationIds[i];
-    if(!regions.empty()) edge->region = regions[segmentationIds[i]];
-    std::sort(edge->region.begin(),edge->region.end());
-    //if(!regions.empty()) std::cout << regionSizes[i] << " " << regions[segmentationIds[i]].size() << std::endl;
+    if(!regions.empty())
+      edge->region = regions[segmentationIds[i]];
+    std::sort(edge->region.begin(), edge->region.end());
+    // if(!regions.empty()) std::cout << regionSizes[i] << " " <<
+    // regions[segmentationIds[i]].size() << std::endl;
     edge->node1Idx = topology[j + 0];
     nodes[topology[j + 0]]->edgeList.push_back(i);
     edge->node2Idx = topology[j + 1];
@@ -156,9 +158,10 @@ std::shared_ptr<BinaryTree> ContourTree::computeRootedTree_binary(
   // if(parent != nullptr)
   // t->arcRefs.push_back(std::make_pair(-1,parent->segId));
   if(parent != nullptr) {
-    int arcRef = arcs[node->edgeList[0]] == parent   ? node->edgeList[0]
-                 : arcs[node->edgeList[1]] == parent ? node->edgeList[1]
-                                                     : node->edgeList[2];
+    int arcRef = arcs[node->edgeList[0]] == parent
+                   ? node->edgeList[0]
+                   : arcs[node->edgeList[1]] == parent ? node->edgeList[1]
+                                                       : node->edgeList[2];
     t->arcRefs.push_back(std::make_pair(-1, arcRef));
   }
 
@@ -206,7 +209,7 @@ std::shared_ptr<BinaryTree> ContourTree::computeRootedTree_binary(
     t->scalardistanceParent = 10000;
     t->area = 10000;
     t->volume = 10000;
-    t->region = std::vector<int>(1,-1);
+    t->region = std::vector<int>(1, -1);
   } else {
     t->scalardistanceParent = parent->scalardistance;
     t->area = parent->area;

--- a/core/base/contourTreeAlignment/contourtree.h
+++ b/core/base/contourTreeAlignment/contourtree.h
@@ -92,7 +92,8 @@ public:
               long long *topology,
               size_t nVertices,
               size_t nEdges,
-              std::vector<std::vector<int>> regions=std::vector<std::vector<int>>());
+              std::vector<std::vector<int>> regions
+              = std::vector<std::vector<int>>());
   ~ContourTree();
 
   std::shared_ptr<BinaryTree> rootAtMax();

--- a/core/base/contourTreeAlignment/contourtree.h
+++ b/core/base/contourTreeAlignment/contourtree.h
@@ -43,6 +43,7 @@ struct BinaryTree {
   float area;
   float volume;
   float scalarValue;
+  std::vector<int> region;
 
   // for fuzzy trees
   int freq;
@@ -73,6 +74,7 @@ struct CTEdge {
   int node2Idx;
   float scalardistance;
   float area;
+  std::vector<int> region;
   float volume;
   int segId;
 };
@@ -89,7 +91,8 @@ public:
               int *segmentationIds,
               long long *topology,
               size_t nVertices,
-              size_t nEdges);
+              size_t nEdges,
+              std::vector<std::vector<int>> regions=std::vector<std::vector<int>>());
   ~ContourTree();
 
   std::shared_ptr<BinaryTree> rootAtMax();

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
@@ -79,17 +79,33 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
   vector<void *> scalars(n); // scalar type will be determined dynamically
   vector<int *> regionSizes(n);
   vector<int *> segmentationIds(n);
+  vector<int *> segmentations;
+  vector<size_t> segSizes;
   vector<long long *> topologies(n);
   vector<size_t> nVertices(n);
   vector<size_t> nEdges(n);
 
   for(size_t i = 0; i < n; i++) {
     auto contourTree = vtkUnstructuredGrid::SafeDownCast(inputMB->GetBlock(i));
+    vtkDataSet* segmentation = nullptr;
 
     if(!contourTree) {
-      this->printErr("block " + std::to_string(i)
-                     + " is not an unstructured grid.");
-      return 0;
+      auto pair = vtkMultiBlockDataSet::SafeDownCast(inputMB->GetBlock(i));
+      
+      if(!pair || pair->GetNumberOfBlocks()!=2){
+        this->printErr("block " + std::to_string(i)
+                      + " is not an unstructured grid or a pair of unstructured grid and segmentation.");
+        return 0;
+      }
+
+      contourTree = vtkUnstructuredGrid::SafeDownCast(pair->GetBlock(0));
+      segmentation = vtkDataSet::SafeDownCast(pair->GetBlock(1));
+
+      if(!contourTree){
+        this->printErr("block " + std::to_string(i)
+                      + " is not an unstructured grid or a pair of unstructured grid and segmentation.");
+        return 0;
+      }
     }
 
     this->printMsg("Block " + std::to_string(i) + " read from multiblock.",
@@ -113,7 +129,7 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
     }
     auto scalarArray = this->GetInputArrayToProcess(0, contourTree);
     if(!scalarArray) {
-      printErr("No Point Array \"Scalar\" found.");
+      printErr("No Point Array \"Scalar\" found in contour tree.");
       return 0;
     }
     scalars[i] = ttkUtils::GetVoidPointer(scalarArray);
@@ -131,7 +147,7 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
     }
     auto regionArray = this->GetInputArrayToProcess(1, contourTree);
     if(!regionArray) {
-      printErr("No Cell Array \"RegionSize\" found.");
+      printErr("No Cell Array \"RegionSize\" found in contour tree.");
       return 0;
     }
     regionSizes[i] = (int *)ttkUtils::GetVoidPointer(regionArray);
@@ -145,12 +161,25 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
     }
     auto segArray = this->GetInputArrayToProcess(2, contourTree);
     if(!segArray) {
-      printErr("No Cell Array \"SegmentationId\" found.");
+      printErr("No Cell Array \"SegmentationId\" found in contour tree.");
       return 0;
     }
     segmentationIds[i] = (int *)ttkUtils::GetVoidPointer(segArray);
     this->printMsg(
       "SegmentationId Array read from cell data.", debug::Priority::VERBOSE);
+
+    if(segmentation){
+      //auto segArray_segmentation = this->GetInputArrayToProcess(2, segmentation);
+      auto segArray_segmentation = segmentation->GetPointData()->GetArray("SegmentationId");
+      if(!segArray_segmentation) {
+        printErr("No Cell Array \"SegmentationId\" found in segmentation.");
+        return 0;
+      }
+      segmentations.push_back( (int *)ttkUtils::GetVoidPointer(segArray_segmentation) );
+      this->printMsg(
+        "Segmentation read.", debug::Priority::VERBOSE);
+      segSizes.push_back(segArray_segmentation->GetNumberOfValues());
+    }
 
     auto cells = contourTree->GetCells();
     auto cellSizes
@@ -180,6 +209,10 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
       "Extracting topologies for " + std::to_string(n) + " trees", 1);
   }
 
+  for(auto s : segSizes){
+    this->printMsg(std::to_string(s));
+  }
+
   this->printMsg("Starting alignment computation.");
 
   //==================================================================================================================
@@ -207,7 +240,7 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
   switch(scalarType) {
     vtkTemplateMacro({
       success = this->execute<VTK_TT>(
-        scalars, regionSizes, segmentationIds, topologies, nVertices, nEdges,
+        scalars, regionSizes, segmentationIds, topologies, nVertices, nEdges, segmentations, segSizes,
 
         outputVertices, outputFrequencies, outputVertexIds, outputBranchIds,
         outputSegmentationIds, outputArcIds, outputEdges,

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
@@ -87,23 +87,25 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
 
   for(size_t i = 0; i < n; i++) {
     auto contourTree = vtkUnstructuredGrid::SafeDownCast(inputMB->GetBlock(i));
-    vtkDataSet* segmentation = nullptr;
+    vtkDataSet *segmentation = nullptr;
 
     if(!contourTree) {
       auto pair = vtkMultiBlockDataSet::SafeDownCast(inputMB->GetBlock(i));
-      
-      if(!pair || pair->GetNumberOfBlocks()!=2){
+
+      if(!pair || pair->GetNumberOfBlocks() != 2) {
         this->printErr("block " + std::to_string(i)
-                      + " is not an unstructured grid or a pair of unstructured grid and segmentation.");
+                       + " is not an unstructured grid or a pair of "
+                         "unstructured grid and segmentation.");
         return 0;
       }
 
       contourTree = vtkUnstructuredGrid::SafeDownCast(pair->GetBlock(0));
       segmentation = vtkDataSet::SafeDownCast(pair->GetBlock(1));
 
-      if(!contourTree){
+      if(!contourTree) {
         this->printErr("block " + std::to_string(i)
-                      + " is not an unstructured grid or a pair of unstructured grid and segmentation.");
+                       + " is not an unstructured grid or a pair of "
+                         "unstructured grid and segmentation.");
         return 0;
       }
     }
@@ -168,16 +170,18 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
     this->printMsg(
       "SegmentationId Array read from cell data.", debug::Priority::VERBOSE);
 
-    if(segmentation){
-      auto segArray_segmentation = this->GetInputArrayToProcess(3, segmentation);
-      //auto segArray_segmentation = segmentation->GetPointData()->GetArray("SegmentationId");
+    if(segmentation) {
+      auto segArray_segmentation
+        = this->GetInputArrayToProcess(3, segmentation);
+      // auto segArray_segmentation =
+      // segmentation->GetPointData()->GetArray("SegmentationId");
       if(!segArray_segmentation) {
         printErr("No Cell Array \"SegmentationId\" found in segmentation.");
         return 0;
       }
-      segmentations.push_back( (int *)ttkUtils::GetVoidPointer(segArray_segmentation) );
-      this->printMsg(
-        "Segmentation read.", debug::Priority::VERBOSE);
+      segmentations.push_back(
+        (int *)ttkUtils::GetVoidPointer(segArray_segmentation));
+      this->printMsg("Segmentation read.", debug::Priority::VERBOSE);
       segSizes.push_back(segArray_segmentation->GetNumberOfValues());
     }
 
@@ -209,7 +213,7 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
       "Extracting topologies for " + std::to_string(n) + " trees", 1);
   }
 
-  for(auto s : segSizes){
+  for(auto s : segSizes) {
     this->printMsg(std::to_string(s));
   }
 
@@ -240,7 +244,8 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
   switch(scalarType) {
     vtkTemplateMacro({
       success = this->execute<VTK_TT>(
-        scalars, regionSizes, segmentationIds, topologies, nVertices, nEdges, segmentations, segSizes,
+        scalars, regionSizes, segmentationIds, topologies, nVertices, nEdges,
+        segmentations, segSizes,
 
         outputVertices, outputFrequencies, outputVertexIds, outputBranchIds,
         outputSegmentationIds, outputArcIds, outputEdges,

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
@@ -169,8 +169,8 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *request,
       "SegmentationId Array read from cell data.", debug::Priority::VERBOSE);
 
     if(segmentation){
-      //auto segArray_segmentation = this->GetInputArrayToProcess(2, segmentation);
-      auto segArray_segmentation = segmentation->GetPointData()->GetArray("SegmentationId");
+      auto segArray_segmentation = this->GetInputArrayToProcess(3, segmentation);
+      //auto segArray_segmentation = segmentation->GetPointData()->GetArray("SegmentationId");
       if(!segArray_segmentation) {
         printErr("No Cell Array \"SegmentationId\" found in segmentation.");
         return 0;

--- a/paraview/ContourTreeAlignment/ContourTreeAlignment.xml
+++ b/paraview/ContourTreeAlignment/ContourTreeAlignment.xml
@@ -85,7 +85,7 @@
                 number_of_elements="5"
                 default_values="2 0 0 1 SegmentationId"
                 animateable="0"
-                label="Segmentation ID array"
+                label="Segmentation ID array for CT"
                 >
                 <ArrayListDomain
                     name="seg_list"
@@ -98,6 +98,28 @@
                 </ArrayListDomain>
                 <Documentation>
                     The cell array for the segmentation ids of arcs.
+                </Documentation>
+            </StringVectorProperty>
+
+            <StringVectorProperty
+                name="SegmentationArray"
+                command="SetInputArrayToProcess"
+                element_types="0 0 0 0 2"
+                number_of_elements="5"
+                default_values="3 0 0 0 SegmentationId"
+                animateable="0"
+                label="Segment ID array for segmentation"
+                >
+                <ArrayListDomain
+                    name="segseg_list"
+                    attribute_type="Scalars"
+                    input_domain_name="input_array">
+                    <RequiredProperties>
+                        <Property name="Input" function="Input" />
+                    </RequiredProperties>
+                </ArrayListDomain>
+                <Documentation>
+                    The point array for the segment ids of points in segmentation.
                 </Documentation>
             </StringVectorProperty>
 

--- a/paraview/ContourTreeAlignment/ContourTreeAlignment.xml
+++ b/paraview/ContourTreeAlignment/ContourTreeAlignment.xml
@@ -146,6 +146,7 @@
           		    <Entry value="0" text="persistence"/>
           		    <Entry value="1" text="area"/>
           		    <Entry value="2" text="volume"/>
+          		    <Entry value="3" text="overlap"/>
         	    </EnumerationDomain>
         	    <Documentation>
           		    This property indicates which arc property will be used for matching.


### PR DESCRIPTION
Added overlap metric for matching on time dependent data sets to the ContourTreeAlignment module. The overlap metric for contour tree arcs needs the corresponding segmentations. Therefore the filter now has to input options:
- A multiblock of contour trees (old mode, does not work with overlap metric, but is kept to still have the lightweight option without segmentation)
- A multiblock of multiblocks, where the inner multiblocks contain a contour tree and its segmentation

Also fixed some memory leaks from the conversion of raw pointers to smart pointers in the base layer.