### PR TITLE
Switch some filters output to PolyData, rework memory in Quadrangulation, DiscreteGradient filters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -315,7 +315,7 @@ jobs:
 
   - script: |
       ./ttkExample-vtk-c++ -i ../examples/data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'build-example-vtk/'
@@ -324,7 +324,7 @@ jobs:
   - script: |
       export PYTHONPATH=$(Build.ArtifactStagingDirectory)/ttk-install/lib/python3.6/site-packages
       $(Build.ArtifactStagingDirectory)/pv-install/bin/pvpython ./example.py ../data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'examples/python/'
@@ -333,7 +333,7 @@ jobs:
   - script: |
       export PV_PLUGIN_PATH=$(Build.ArtifactStagingDirectory)/ttk-install/bin/plugins
       $(Build.ArtifactStagingDirectory)/pv-install/bin/pvpython ./example.py ../data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'examples/pvpython/'
@@ -460,7 +460,7 @@ jobs:
 
   - script: |
       ./ttkExample-vtk-c++ -i ../examples/data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'build-example-vtk/'
@@ -470,7 +470,7 @@ jobs:
       export PYTHONPATH=$(Build.ArtifactStagingDirectory)/ttk-install/lib/python3.9/site-packages:$(Build.ArtifactStagingDirectory)/pv-install/lib/python3.9/site-packages
       export DYLD_LIBRARY_PATH=$(Build.ArtifactStagingDirectory)/pv-install/lib:$(Build.ArtifactStagingDirectory)/ttk-install/lib
       $(Build.ArtifactStagingDirectory)/pv-install/bin/pvpython ./example.py ../data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'examples/python/'
@@ -480,7 +480,7 @@ jobs:
       export PV_PLUGIN_PATH=$(Build.ArtifactStagingDirectory)/ttk-install/bin/plugins
       export DYLD_LIBRARY_PATH=$(Build.ArtifactStagingDirectory)/pv-install/lib:$(Build.ArtifactStagingDirectory)/ttk-install/lib
       $(Build.ArtifactStagingDirectory)/pv-install/bin/pvpython ./example.py ../data/inputData.vtu
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'examples/pvpython/'
@@ -618,7 +618,7 @@ jobs:
 
   - bash: |
       cmd.exe /C 'set PATH=$(Build.ArtifactStagingDirectory)/vtk-install/bin;$(Build.ArtifactStagingDirectory)/ttk-install/bin;%PATH% & ttkExample-vtk-c++.exe -i ../examples/data/inputData.vtu'
-      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtu ] || [ ! -f segmentation.vtu ] ; then
+      if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then
         exit 1
       fi
     workingDirectory: 'build-example-vtk/'

--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -233,30 +233,22 @@ namespace ttk {
      * Set the output critical points data pointers.
      */
     inline int setOutputCriticalPoints(
-      SimplexId *const criticalPoints_numberOfPoints,
-      std::vector<float> *const criticalPoints_points,
+      std::vector<std::array<float, 3>> *const criticalPoints_points,
       std::vector<char> *const criticalPoints_points_cellDimensons,
       std::vector<SimplexId> *const criticalPoints_points_cellIds,
-      void *const criticalPoints_points_cellScalars,
       std::vector<char> *const criticalPoints_points_isOnBoundary,
       std::vector<SimplexId> *const criticalPoints_points_PLVertexIdentifiers,
       std::vector<SimplexId> *criticalPoints_points_manifoldSize) {
-      outputCriticalPoints_numberOfPoints_ = criticalPoints_numberOfPoints;
       outputCriticalPoints_points_ = criticalPoints_points;
       outputCriticalPoints_points_cellDimensions_
         = criticalPoints_points_cellDimensons;
       outputCriticalPoints_points_cellIds_ = criticalPoints_points_cellIds;
-      outputCriticalPoints_points_cellScalars_
-        = criticalPoints_points_cellScalars;
       outputCriticalPoints_points_isOnBoundary_
         = criticalPoints_points_isOnBoundary;
       outputCriticalPoints_points_PLVertexIdentifiers_
         = criticalPoints_points_PLVertexIdentifiers;
       outputCriticalPoints_points_manifoldSize_
         = criticalPoints_points_manifoldSize;
-
-      discreteGradient_.setOutputCriticalPoints(
-        criticalPoints_points_cellScalars);
       return 0;
     }
 
@@ -430,11 +422,9 @@ namespace ttk {
     const void *inputScalarField_{};
     const SimplexId *inputOffsets_{};
 
-    SimplexId *outputCriticalPoints_numberOfPoints_{};
-    std::vector<float> *outputCriticalPoints_points_{};
+    std::vector<std::array<float, 3>> *outputCriticalPoints_points_{};
     std::vector<char> *outputCriticalPoints_points_cellDimensions_{};
     std::vector<SimplexId> *outputCriticalPoints_points_cellIds_{};
-    void *outputCriticalPoints_points_cellScalars_{};
     std::vector<char> *outputCriticalPoints_points_isOnBoundary_{};
     std::vector<SimplexId> *outputCriticalPoints_points_PLVertexIdentifiers_{};
     std::vector<SimplexId> *outputCriticalPoints_points_manifoldSize_{};

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -27,9 +27,19 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
   dmt1Saddle2PL_.clear();
   dmt2Saddle2PL_.clear();
 
+  outputCriticalPoints_numberOfPoints_ = 0;
+  outputCriticalPoints_points_.clear();
+  outputCriticalPoints_points_cellDimensions_.clear();
+  outputCriticalPoints_points_cellIds_.clear();
+  outputCriticalPoints_points_isOnBoundary_.clear();
+  outputCriticalPoints_points_PLVertexIdentifiers_.clear();
+  outputCriticalPoints_points_manifoldSize_.clear();
+
+  // clear & init gradient memory
   for(int i = 0; i < dimensionality_; ++i) {
-    // init gradient memory
+    gradient_[2 * i].clear();
     gradient_[2 * i].resize(numberOfCells[i], -1);
+    gradient_[2 * i + 1].clear();
     gradient_[2 * i + 1].resize(numberOfCells[i + 1], -1);
   }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -27,14 +27,6 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
   dmt1Saddle2PL_.clear();
   dmt2Saddle2PL_.clear();
 
-  outputCriticalPoints_numberOfPoints_ = 0;
-  outputCriticalPoints_points_.clear();
-  outputCriticalPoints_points_cellDimensions_.clear();
-  outputCriticalPoints_points_cellIds_.clear();
-  outputCriticalPoints_points_isOnBoundary_.clear();
-  outputCriticalPoints_points_PLVertexIdentifiers_.clear();
-  outputCriticalPoints_points_manifoldSize_.clear();
-
   // clear & init gradient memory
   for(int i = 0; i < dimensionality_; ++i) {
     gradient_[2 * i].clear();
@@ -218,12 +210,13 @@ int DiscreteGradient::setManifoldSize(
   const std::vector<size_t> &nCriticalPointsByDim,
   const std::vector<SimplexId> &maxSeeds,
   const SimplexId *const ascendingManifold,
-  const SimplexId *const descendingManifold) {
+  const SimplexId *const descendingManifold,
+  std::vector<SimplexId> &manifoldSize) const {
 
   const auto nCritPoints = criticalPoints.size();
   const auto nDimensions = getNumberOfDimensions();
 
-  outputCriticalPoints_points_manifoldSize_.resize(nCritPoints, 0);
+  manifoldSize.resize(nCritPoints, 0);
 
   // pre-compute size of descending manifold cells
   std::map<SimplexId, size_t> descendingCellsSize{};
@@ -238,8 +231,7 @@ int DiscreteGradient::setManifoldSize(
   for(size_t i = 0; i < nCriticalPointsByDim[0]; ++i) {
     const Cell &cell = criticalPoints[i];
     const SimplexId seedId = descendingManifold[cell.id_];
-    const SimplexId manifoldSize = descendingCellsSize[seedId];
-    outputCriticalPoints_points_manifoldSize_[i] = manifoldSize;
+    manifoldSize[i] = descendingCellsSize[seedId];
   }
 
   // index of first maximum in critical points array
@@ -268,8 +260,7 @@ int DiscreteGradient::setManifoldSize(
     const Cell &cell = criticalPoints[i];
     if(seedsPos.find(cell.id_) != seedsPos.end()) {
       const auto seedId = seedsPos[cell.id_];
-      const SimplexId manifoldSize = ascendingCellsSize[seedId];
-      outputCriticalPoints_points_manifoldSize_[i] = manifoldSize;
+      manifoldSize[i] = ascendingCellsSize[seedId];
     }
   }
 

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -29,8 +29,8 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
 
   for(int i = 0; i < dimensionality_; ++i) {
     // init gradient memory
-    gradient_[i][i].resize(numberOfCells[i], -1);
-    gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
+    gradient_[2 * i].resize(numberOfCells[i], -1);
+    gradient_[2 * i + 1].resize(numberOfCells[i + 1], -1);
   }
 
   std::vector<std::vector<std::string>> rows{
@@ -113,7 +113,7 @@ CriticalType
 
 bool DiscreteGradient::isMinimum(const Cell &cell) const {
   if(cell.dim_ == 0) {
-    return (gradient_[0][0][cell.id_] == -1);
+    return (gradient_[0][cell.id_] == -1);
   }
 
   return false;
@@ -121,8 +121,7 @@ bool DiscreteGradient::isMinimum(const Cell &cell) const {
 
 bool DiscreteGradient::isSaddle1(const Cell &cell) const {
   if(cell.dim_ == 1) {
-    return (gradient_[0][1][cell.id_] == -1
-            and gradient_[1][1][cell.id_] == -1);
+    return (gradient_[1][cell.id_] == -1 and gradient_[2][cell.id_] == -1);
   }
 
   return false;
@@ -130,8 +129,7 @@ bool DiscreteGradient::isSaddle1(const Cell &cell) const {
 
 bool DiscreteGradient::isSaddle2(const Cell &cell) const {
   if(dimensionality_ == 3 and cell.dim_ == 2) {
-    return (gradient_[1][2][cell.id_] == -1
-            and gradient_[2][2][cell.id_] == -1);
+    return (gradient_[3][cell.id_] == -1 and gradient_[4][cell.id_] == -1);
   }
 
   return false;
@@ -139,11 +137,11 @@ bool DiscreteGradient::isSaddle2(const Cell &cell) const {
 
 bool DiscreteGradient::isMaximum(const Cell &cell) const {
   if(dimensionality_ == 2 and cell.dim_ == 2) {
-    return (gradient_[1][2][cell.id_] == -1);
+    return (gradient_[3][cell.id_] == -1);
   }
 
   if(dimensionality_ == 3 and cell.dim_ == 3) {
-    return (gradient_[2][3][cell.id_] == -1);
+    return (gradient_[5][cell.id_] == -1);
   }
 
   return false;
@@ -154,36 +152,33 @@ bool DiscreteGradient::isCellCritical(const int cellDim,
   if(dimensionality_ == 2) {
     switch(cellDim) {
       case 0:
-        return (gradient_[0][0][cellId] == -1);
+        return (gradient_[0][cellId] == -1);
         break;
 
       case 1:
-        return (gradient_[0][1][cellId] == -1
-                and gradient_[1][1][cellId] == -1);
+        return (gradient_[1][cellId] == -1 and gradient_[2][cellId] == -1);
         break;
 
       case 2:
-        return (gradient_[1][2][cellId] == -1);
+        return (gradient_[3][cellId] == -1);
         break;
     }
   } else if(dimensionality_ == 3) {
     switch(cellDim) {
       case 0:
-        return (gradient_[0][0][cellId] == -1);
+        return (gradient_[0][cellId] == -1);
         break;
 
       case 1:
-        return (gradient_[0][1][cellId] == -1
-                and gradient_[1][1][cellId] == -1);
+        return (gradient_[1][cellId] == -1 and gradient_[2][cellId] == -1);
         break;
 
       case 2:
-        return (gradient_[1][2][cellId] == -1
-                and gradient_[2][2][cellId] == -1);
+        return (gradient_[3][cellId] == -1 and gradient_[4][cellId] == -1);
         break;
 
       case 3:
-        return (gradient_[2][3][cellId] == -1);
+        return (gradient_[5][cellId] == -1);
         break;
     }
   }

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -26,12 +26,9 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
   dmtMax2PL_.clear();
   dmt1Saddle2PL_.clear();
   dmt2Saddle2PL_.clear();
-  gradient_.clear();
-  gradient_.resize(dimensionality_);
 
   for(int i = 0; i < dimensionality_; ++i) {
     // init gradient memory
-    gradient_[i].resize(numberOfDimensions);
     gradient_[i][i].resize(numberOfCells[i], -1);
     gradient_[i][i + 1].resize(numberOfCells[i + 1], -1);
   }

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -457,39 +457,6 @@ according to them.
       }
 
       /**
-       * Set the output data pointer to the critical points.
-       */
-      inline void setOutputCriticalPoints(void *const cellScalars) {
-        outputCriticalPoints_points_cellScalars_ = cellScalars;
-      }
-
-      /**
-       * Get back output critical points arrays from class members
-       */
-      inline void fetchOutputCriticalPoints(
-        SimplexId *const cp_numberOfPoints,
-        std::vector<float> *const cp_points,
-        std::vector<char> *const cp_points_cellDimensions,
-        std::vector<SimplexId> *const cp_points_cellIds,
-        std::vector<char> *const cp_points_isOnBoundary,
-        std::vector<SimplexId> *const cp_points_PLVertexIdentifiers) {
-
-        *cp_numberOfPoints = outputCriticalPoints_numberOfPoints_;
-        *cp_points = std::move(outputCriticalPoints_points_);
-        *cp_points_cellDimensions
-          = std::move(outputCriticalPoints_points_cellDimensions_);
-        *cp_points_cellIds = std::move(outputCriticalPoints_points_cellIds_);
-        *cp_points_isOnBoundary
-          = std::move(outputCriticalPoints_points_isOnBoundary_);
-        *cp_points_PLVertexIdentifiers
-          = std::move(outputCriticalPoints_points_PLVertexIdentifiers_);
-      }
-      inline void
-        fetchOutputManifoldSize(std::vector<SimplexId> *const manifoldSize) {
-        *manifoldSize = std::move(outputCriticalPoints_points_manifoldSize_);
-      }
-
-      /**
        * Get the dimensionality of the triangulation.
        */
       int getDimensionality() const;
@@ -615,23 +582,33 @@ in the gradient.
 
       /**
        * Build the geometric embedding of the given STL vector of cells.
-       * The output data pointers are modified accordingly. This
+       * The output vectors are modified accordingly. This
        * function needs the following internal pointers to be set:
        * outputCriticalPoints_numberOfPoints_
        * outputCriticalPoints_points_
        * inputScalarField_
        */
-      template <typename dataType, typename triangulationType>
+      template <typename triangulationType>
       int setCriticalPoints(const std::vector<Cell> &criticalPoints,
                             std::vector<size_t> &nCriticalPointsByDim,
-                            const triangulationType &triangulation);
+                            std::vector<std::array<float, 3>> &points,
+                            std::vector<char> &cellDimensions,
+                            std::vector<SimplexId> &cellIds,
+                            std::vector<char> &isOnBoundary,
+                            std::vector<SimplexId> &PLVertexIdentifiers,
+                            const triangulationType &triangulation) const;
 
       /**
        * Detect the critical points and build their geometric embedding.
-       * The output data pointers are modified accordingly.
+       * The output vectors are modified accordingly.
        */
-      template <typename dataType, typename triangulationType>
-      int setCriticalPoints(const triangulationType &triangulation);
+      template <typename triangulationType>
+      int setCriticalPoints(std::vector<std::array<float, 3>> &points,
+                            std::vector<char> &cellDimensions,
+                            std::vector<SimplexId> &cellIds,
+                            std::vector<char> &isOnBoundary,
+                            std::vector<SimplexId> &PLVertexIdentifiers,
+                            const triangulationType &triangulation) const;
 
       /**
        * Get the output critical points as a STL vector of cells.
@@ -647,7 +624,8 @@ in the gradient.
                           const std::vector<size_t> &nCriticalPointsByDim,
                           const std::vector<SimplexId> &maxSeeds,
                           const SimplexId *const ascendingManifold,
-                          const SimplexId *const descendingManifold);
+                          const SimplexId *const descendingManifold,
+                          std::vector<SimplexId> &manifoldSize) const;
 
       /**
        * Build the glyphs representing the discrete gradient vector field.
@@ -968,20 +946,10 @@ gradient, false otherwise.
       std::vector<SimplexId> dmtMax2PL_{};
       std::vector<SimplexId> dmt1Saddle2PL_{};
       std::vector<SimplexId> dmt2Saddle2PL_{};
+      std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
 
       const void *inputScalarField_{};
       const SimplexId *inputOffsets_{};
-
-      SimplexId outputCriticalPoints_numberOfPoints_{};
-      std::vector<float> outputCriticalPoints_points_{};
-      std::vector<char> outputCriticalPoints_points_cellDimensions_{};
-      std::vector<SimplexId> outputCriticalPoints_points_cellIds_{};
-      void *outputCriticalPoints_points_cellScalars_{};
-      std::vector<char> outputCriticalPoints_points_isOnBoundary_{};
-      std::vector<SimplexId> outputCriticalPoints_points_PLVertexIdentifiers_{};
-      std::vector<SimplexId> outputCriticalPoints_points_manifoldSize_{};
-
-      std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
     };
 
   } // namespace dcg

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -293,17 +293,24 @@ namespace ttk {
       }
     };
 
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
+    using gradIdType = char;
+#else
+    using gradIdType = SimplexId;
+#endif
+
     /**
      * @brief Discrete gradient struct
      *
-     * Per dimension (from 0 to 2), 4 vector: 2 for dim <-> dim+1
-     * pairs and 2 for reverse pairs
+     * 0: paired edge id per vertex
+     * 1: paired vertex id per edge
+     * 2: paired triangle id per edge
+     * 3: paired edge id per triangle
+     * 4: paired tetra id per triangle
+     * 5: paired triangle id per tetra
+     * -1 if critical or paired to a cell of another dimension
      */
-#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-    using gradientType = std::array<std::array<std::vector<char>, 4>, 3>;
-#else
-    using gradientType = std::array<std::array<std::vector<SimplexId>, 4>, 3>;
-#endif
+    using gradientType = std::array<std::vector<gradIdType>, 6>;
 
     /**
      * Compute and manage a discrete gradient of a function on a triangulation.

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -293,10 +293,16 @@ namespace ttk {
       }
     };
 
+    /**
+     * @brief Discrete gradient struct
+     *
+     * Per dimension (from 0 to 2), 4 vector: 2 for dim <-> dim+1
+     * pairs and 2 for reverse pairs
+     */
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-    using gradientType = std::vector<std::vector<std::vector<char>>>;
+    using gradientType = std::array<std::array<std::vector<char>, 4>, 3>;
 #else
-    using gradientType = std::vector<std::vector<std::vector<SimplexId>>>;
+    using gradientType = std::array<std::array<std::vector<SimplexId>, 4>, 3>;
 #endif
 
     /**

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -653,11 +653,8 @@ in the gradient.
        * Build the glyphs representing the discrete gradient vector field.
        */
       template <typename triangulationType>
-      int setGradientGlyphs(SimplexId &numberOfPoints,
-                            std::vector<float> &points,
+      int setGradientGlyphs(std::vector<std::array<float, 3>> &points,
                             std::vector<char> &points_pairOrigins,
-                            SimplexId &numberOfCells,
-                            std::vector<SimplexId> &cells,
                             std::vector<char> &cells_pairTypes,
                             const triangulationType &triangulation) const;
 

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -919,6 +919,13 @@ gradient, false otherwise.
                                const triangulationType &triangulation);
 
       /**
+       * Reverse the given descending VPath.
+       */
+      template <typename triangulationType>
+      int reverseDescendingPath(const std::vector<Cell> &vpath,
+                                const triangulationType &triangulation);
+
+      /**
        * Reverse the given ascending VPath restricted on a 2-separatrice.
        */
       template <typename triangulationType>

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -2956,6 +2956,43 @@ int DiscreteGradient::reverseAscendingPath(
 }
 
 template <typename triangulationType>
+int DiscreteGradient::reverseDescendingPath(
+  const std::vector<Cell> &vpath, const triangulationType &triangulation) {
+
+  // assume that the first cell is an edge
+  for(size_t i = 0; i < vpath.size(); i += 2) {
+    const SimplexId edgeId = vpath[i].id_;
+    const SimplexId vertId = vpath[i + 1].id_;
+
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
+    const auto nneighs = triangulation.getVertexEdgeNumber();
+    for(int k = 0; k < nneighs; ++k) {
+      SimplexId tmp;
+      triangulation.getVertexEdge(vertId, k, tmp);
+      if(tmp == edgeId) {
+        gradient_[0][0][vertId] = k;
+        break;
+      }
+    }
+    const auto nverts = triangulation.getEdgeStarNumber(edgeId);
+    for(int k = 0; k < nverts; ++k) {
+      SimplexId tmp;
+      triangulation.getEdgeVertex(edgeId, k, tmp);
+      if(tmp == vertId) {
+        gradient_[0][1][edgeId] = k;
+        break;
+      }
+    }
+#else
+    gradient_[0][0][vertId] = edgeId;
+    gradient_[0][1][edgeId] = vertId;
+#endif
+  }
+
+  return 0;
+}
+
+template <typename triangulationType>
 int DiscreteGradient::reverseAscendingPathOnWall(
   const std::vector<Cell> &vpath, const triangulationType &triangulation) {
 

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1978,11 +1978,11 @@ inline void DiscreteGradient::pairCells(
       }
     }
   }
-  gradient_[alpha.dim_][alpha.dim_][alpha.id_] = localBId;
-  gradient_[alpha.dim_][alpha.dim_ + 1][beta.id_] = localAId;
+  gradient_[2 * alpha.dim_][alpha.id_] = localBId;
+  gradient_[2 * alpha.dim_ + 1][beta.id_] = localAId;
 #else
-  gradient_[alpha.dim_][alpha.dim_][alpha.id_] = beta.id_;
-  gradient_[alpha.dim_][alpha.dim_ + 1][beta.id_] = alpha.id_;
+  gradient_[2 * alpha.dim_][alpha.id_] = beta.id_;
+  gradient_[2 * alpha.dim_ + 1][beta.id_] = alpha.id_;
 #endif // TTK_ENABLE_DCG_OPTIMIZE_MEMORY
   alpha.paired_ = true;
   beta.paired_ = true;
@@ -2259,36 +2259,36 @@ SimplexId
     switch(cell.dim_) {
       case 0:
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-        triangulation.getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
+        triangulation.getVertexEdge(cell.id_, gradient_[0][cell.id_], id);
 #else
-        return gradient_[0][0][cell.id_];
+        return gradient_[0][cell.id_];
 #endif
         break;
 
       case 1:
         if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-          triangulation.getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
+          triangulation.getEdgeVertex(cell.id_, gradient_[1][cell.id_], id);
           return id;
 #else
-          return gradient_[0][1][cell.id_];
+          return gradient_[1][cell.id_];
 #endif
         }
 
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-        triangulation.getEdgeStar(cell.id_, gradient_[1][1][cell.id_], id);
+        triangulation.getEdgeStar(cell.id_, gradient_[2][cell.id_], id);
 #else
-        return gradient_[1][1][cell.id_];
+        return gradient_[2][cell.id_];
 #endif
         break;
 
       case 2:
         if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-          triangulation.getCellEdge(cell.id_, gradient_[1][2][cell.id_], id);
+          triangulation.getCellEdge(cell.id_, gradient_[3][cell.id_], id);
           return id;
 #else
-          return gradient_[1][2][cell.id_];
+          return gradient_[3][cell.id_];
 #endif
         }
         break;
@@ -2297,55 +2297,53 @@ SimplexId
     switch(cell.dim_) {
       case 0:
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-        triangulation.getVertexEdge(cell.id_, gradient_[0][0][cell.id_], id);
+        triangulation.getVertexEdge(cell.id_, gradient_[0][cell.id_], id);
 #else
-        return gradient_[0][0][cell.id_];
+        return gradient_[0][cell.id_];
 #endif
         break;
 
       case 1:
         if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-          triangulation.getEdgeVertex(cell.id_, gradient_[0][1][cell.id_], id);
+          triangulation.getEdgeVertex(cell.id_, gradient_[1][cell.id_], id);
           return id;
 #else
-          return gradient_[0][1][cell.id_];
+          return gradient_[1][cell.id_];
 #endif
         }
 
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-        triangulation.getEdgeTriangle(cell.id_, gradient_[1][1][cell.id_], id);
+        triangulation.getEdgeTriangle(cell.id_, gradient_[2][cell.id_], id);
 #else
-        return gradient_[1][1][cell.id_];
+        return gradient_[2][cell.id_];
 #endif
         break;
 
       case 2:
         if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-          triangulation.getTriangleEdge(
-            cell.id_, gradient_[1][2][cell.id_], id);
+          triangulation.getTriangleEdge(cell.id_, gradient_[3][cell.id_], id);
           return id;
 #else
-          return gradient_[1][2][cell.id_];
+          return gradient_[3][cell.id_];
 #endif
         }
 
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-        triangulation.getTriangleStar(cell.id_, gradient_[2][2][cell.id_], id);
+        triangulation.getTriangleStar(cell.id_, gradient_[4][cell.id_], id);
 #else
-        return gradient_[2][2][cell.id_];
+        return gradient_[4][cell.id_];
 #endif
         break;
 
       case 3:
         if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-          triangulation.getCellTriangle(
-            cell.id_, gradient_[2][3][cell.id_], id);
+          triangulation.getCellTriangle(cell.id_, gradient_[5][cell.id_], id);
           return id;
 #else
-          return gradient_[2][3][cell.id_];
+          return gradient_[5][cell.id_];
 #endif
         }
         break;
@@ -2904,7 +2902,7 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getCellEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[1][2][triangleId] = k;
+          gradient_[3][triangleId] = k;
           break;
         }
       }
@@ -2912,13 +2910,13 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getEdgeStar(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[1][1][edgeId] = k;
+          gradient_[2][edgeId] = k;
           break;
         }
       }
 #else
-      gradient_[1][2][triangleId] = edgeId;
-      gradient_[1][1][edgeId] = triangleId;
+      gradient_[3][triangleId] = edgeId;
+      gradient_[2][edgeId] = triangleId;
 #endif
     }
   } else if(dimensionality_ == 3) {
@@ -2933,7 +2931,7 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getCellTriangle(tetraId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[2][3][tetraId] = k;
+          gradient_[5][tetraId] = k;
           break;
         }
       }
@@ -2941,13 +2939,13 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getTriangleStar(triangleId, k, tmp);
         if(tmp == tetraId) {
-          gradient_[2][2][triangleId] = k;
+          gradient_[4][triangleId] = k;
           break;
         }
       }
 #else
-      gradient_[2][3][tetraId] = triangleId;
-      gradient_[2][2][triangleId] = tetraId;
+      gradient_[5][tetraId] = triangleId;
+      gradient_[4][triangleId] = tetraId;
 #endif
     }
   }
@@ -2970,7 +2968,7 @@ int DiscreteGradient::reverseDescendingPath(
       SimplexId tmp;
       triangulation.getVertexEdge(vertId, k, tmp);
       if(tmp == edgeId) {
-        gradient_[0][0][vertId] = k;
+        gradient_[0][vertId] = k;
         break;
       }
     }
@@ -2979,13 +2977,13 @@ int DiscreteGradient::reverseDescendingPath(
       SimplexId tmp;
       triangulation.getEdgeVertex(edgeId, k, tmp);
       if(tmp == vertId) {
-        gradient_[0][1][edgeId] = k;
+        gradient_[1][edgeId] = k;
         break;
       }
     }
 #else
-    gradient_[0][0][vertId] = edgeId;
-    gradient_[0][1][edgeId] = vertId;
+    gradient_[0][vertId] = edgeId;
+    gradient_[1][edgeId] = vertId;
 #endif
   }
 
@@ -3008,7 +3006,7 @@ int DiscreteGradient::reverseAscendingPathOnWall(
         SimplexId tmp;
         triangulation.getTriangleEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[1][2][triangleId] = k;
+          gradient_[3][triangleId] = k;
           break;
         }
       }
@@ -3016,13 +3014,13 @@ int DiscreteGradient::reverseAscendingPathOnWall(
         SimplexId tmp;
         triangulation.getEdgeTriangle(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[1][1][edgeId] = k;
+          gradient_[2][edgeId] = k;
           break;
         }
       }
 #else
-      gradient_[1][2][triangleId] = edgeId;
-      gradient_[1][1][edgeId] = triangleId;
+      gradient_[3][triangleId] = edgeId;
+      gradient_[2][edgeId] = triangleId;
 #endif
     }
   }
@@ -3046,7 +3044,7 @@ int DiscreteGradient::reverseDescendingPathOnWall(
         SimplexId tmp;
         triangulation.getTriangleEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[1][2][triangleId] = k;
+          gradient_[3][triangleId] = k;
           break;
         }
       }
@@ -3054,13 +3052,13 @@ int DiscreteGradient::reverseDescendingPathOnWall(
         SimplexId tmp;
         triangulation.getEdgeTriangle(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[1][1][edgeId] = k;
+          gradient_[2][edgeId] = k;
           break;
         }
       }
 #else
-      gradient_[1][1][edgeId] = triangleId;
-      gradient_[1][2][triangleId] = edgeId;
+      gradient_[2][edgeId] = triangleId;
+      gradient_[3][triangleId] = edgeId;
 #endif
     }
   }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -322,11 +322,9 @@ namespace ttk {
     }
 
     inline int setOutputCriticalPoints(
-      SimplexId *const criticalPoints_numberOfPoints,
-      std::vector<float> *const criticalPoints_points,
+      std::vector<std::array<float, 3>> *const criticalPoints_points,
       std::vector<char> *const criticalPoints_points_cellDimensons,
       std::vector<SimplexId> *const criticalPoints_points_cellIds,
-      void *const criticalPoints_points_cellScalars,
       std::vector<char> *const criticalPoints_points_isOnBoundary,
       std::vector<SimplexId> *const criticalPoints_points_PLVertexIdentifiers,
       std::vector<SimplexId> *const criticalPoints_points_manifoldSize) {
@@ -336,9 +334,8 @@ namespace ttk {
       }
 #endif
       abstractMorseSmaleComplex_->setOutputCriticalPoints(
-        criticalPoints_numberOfPoints, criticalPoints_points,
-        criticalPoints_points_cellDimensons, criticalPoints_points_cellIds,
-        criticalPoints_points_cellScalars, criticalPoints_points_isOnBoundary,
+        criticalPoints_points, criticalPoints_points_cellDimensons,
+        criticalPoints_points_cellIds, criticalPoints_points_isOnBoundary,
         criticalPoints_points_PLVertexIdentifiers,
         criticalPoints_points_manifoldSize);
 

--- a/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
+++ b/core/base/morseSmaleComplex2D/MorseSmaleComplex2D.h
@@ -137,24 +137,19 @@ int ttk::MorseSmaleComplex2D::execute(const triangulationType &triangulation) {
     }
   }
 
-  if(outputCriticalPoints_numberOfPoints_ and outputCriticalPoints_points_) {
+  if(outputCriticalPoints_points_ != nullptr) {
     std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType>(
-      criticalPoints, nCriticalPointsByDim, triangulation);
-
-    discreteGradient_.fetchOutputCriticalPoints(
-      outputCriticalPoints_numberOfPoints_, outputCriticalPoints_points_,
-      outputCriticalPoints_points_cellDimensions_,
-      outputCriticalPoints_points_cellIds_,
-      outputCriticalPoints_points_isOnBoundary_,
-      outputCriticalPoints_points_PLVertexIdentifiers_);
+    discreteGradient_.setCriticalPoints(
+      criticalPoints, nCriticalPointsByDim, *outputCriticalPoints_points_,
+      *outputCriticalPoints_points_cellDimensions_,
+      *outputCriticalPoints_points_cellIds_,
+      *outputCriticalPoints_points_isOnBoundary_,
+      *outputCriticalPoints_points_PLVertexIdentifiers_, triangulation);
 
     if(ascendingManifold and descendingManifold) {
-      discreteGradient_.setManifoldSize(criticalPoints, nCriticalPointsByDim,
-                                        maxSeeds, ascendingManifold,
-                                        descendingManifold);
-      discreteGradient_.fetchOutputManifoldSize(
-        outputCriticalPoints_points_manifoldSize_);
+      discreteGradient_.setManifoldSize(
+        criticalPoints, nCriticalPointsByDim, maxSeeds, ascendingManifold,
+        descendingManifold, *outputCriticalPoints_points_manifoldSize_);
     }
   }
 

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -784,24 +784,19 @@ int ttk::MorseSmaleComplex3D::execute(const triangulationType &triangulation) {
     }
   }
 
-  if(outputCriticalPoints_numberOfPoints_ and outputSeparatrices1_points_) {
-    std::vector<size_t> nCriticalPointsByDim{};
-    discreteGradient_.setCriticalPoints<dataType>(
-      criticalPoints, nCriticalPointsByDim, triangulation);
-
-    discreteGradient_.fetchOutputCriticalPoints(
-      outputCriticalPoints_numberOfPoints_, outputCriticalPoints_points_,
-      outputCriticalPoints_points_cellDimensions_,
-      outputCriticalPoints_points_cellIds_,
-      outputCriticalPoints_points_isOnBoundary_,
-      outputCriticalPoints_points_PLVertexIdentifiers_);
+  if(outputCriticalPoints_points_ != nullptr) {
+    std::vector<size_t> nCriticalPointsByDim;
+    discreteGradient_.setCriticalPoints(
+      criticalPoints, nCriticalPointsByDim, *outputCriticalPoints_points_,
+      *outputCriticalPoints_points_cellDimensions_,
+      *outputCriticalPoints_points_cellIds_,
+      *outputCriticalPoints_points_isOnBoundary_,
+      *outputCriticalPoints_points_PLVertexIdentifiers_, triangulation);
 
     if(ascendingManifold and descendingManifold) {
-      discreteGradient_.setManifoldSize(criticalPoints, nCriticalPointsByDim,
-                                        maxSeeds, ascendingManifold,
-                                        descendingManifold);
-      discreteGradient_.fetchOutputManifoldSize(
-        outputCriticalPoints_points_manifoldSize_);
+      discreteGradient_.setManifoldSize(
+        criticalPoints, nCriticalPointsByDim, maxSeeds, ascendingManifold,
+        descendingManifold, *outputCriticalPoints_points_manifoldSize_);
     }
   }
 

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.cpp
@@ -33,20 +33,18 @@ int ttk::MorseSmaleQuadrangulation::dualQuadrangulate() {
   // iterate over separatrices middles to build quadrangles around
   // them: the separatrix vertices and two barycenters
 
-  auto quads = reinterpret_cast<std::vector<Quad> *>(&outputCells_);
-  std::vector<LongSimplexId> dualQuads{};
-  auto dquads = reinterpret_cast<std::vector<Quad> *>(&dualQuads);
+  std::vector<Quad> dualQuads{};
 
   auto quadNeighbors = [&](const LongSimplexId a) {
     std::set<LongSimplexId> neighs{};
-    for(const auto &q : *quads) {
-      if(a == q.i || a == q.k) {
-        neighs.emplace(q.j);
-        neighs.emplace(q.l);
+    for(const auto &q : outputCells_) {
+      if(a == q[0] || a == q[2]) {
+        neighs.emplace(q[1]);
+        neighs.emplace(q[3]);
       }
-      if(a == q.j || a == q.l) {
-        neighs.emplace(q.i);
-        neighs.emplace(q.k);
+      if(a == q[1] || a == q[3]) {
+        neighs.emplace(q[0]);
+        neighs.emplace(q[2]);
       }
     }
     return neighs;
@@ -79,7 +77,7 @@ int ttk::MorseSmaleQuadrangulation::dualQuadrangulate() {
       }
     }
 
-    dquads->emplace_back(Quad{4, crit[0], gen[0], crit[1], gen[1]});
+    dualQuads.emplace_back(Quad{crit[0], gen[0], crit[1], gen[1]});
   }
 
   // for degenerate quadrangles, iterate over the single extremum, and
@@ -124,7 +122,7 @@ int ttk::MorseSmaleQuadrangulation::dualQuadrangulate() {
       }
     }
 
-    dquads->emplace_back(Quad{4, crit[0], gen[0], crit[1], gen[1]});
+    dualQuads.emplace_back(Quad{crit[0], gen[0], crit[1], gen[1]});
   }
 
   outputCells_ = std::move(dualQuads);

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
@@ -246,6 +246,9 @@ int ttk::MorseSmaleQuadrangulation::detectCellSeps(
   ExplicitTriangulation newT{};
   bs.execute(triangulation, newT);
 
+  newT.setDebugLevel(this->debugLevel_);
+  newT.setThreadNumber(this->threadNumber_);
+  newT.preconditionEdges();
   newT.preconditionVertexNeighbors();
   newT.preconditionVertexEdges();
   newT.preconditionVertexTriangles();

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
@@ -347,7 +347,7 @@ int ttk::MorseSmaleQuadrangulation::detectCellSeps(
       sepId.emplace(edgeOnSep[e0]);
       sepId.emplace(edgeOnSep[e1]);
     } else if(edgeOnSep[e1] != -1 && edgeOnSep[e2] != -1) {
-      sepId.emplace(edgeOnSep[e0]);
+      sepId.emplace(edgeOnSep[e1]);
       sepId.emplace(edgeOnSep[e2]);
     } else if(edgeOnSep[e0] != -1 && edgeOnSep[e2] != -1) {
       sepId.emplace(edgeOnSep[e0]);

--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
@@ -164,6 +164,11 @@ namespace ttk {
     void clearData();
 
     /**
+     * @brief Ad-hoc quad data structure
+     */
+    using Quad = std::array<LongSimplexId, 4>;
+
+    /**
      * @brief Subdivise degenerate quads in the quadrangulation
      *
      * @param[out] outputSubd Quad subdivision to be completed
@@ -171,17 +176,8 @@ namespace ttk {
      * @return 0
      */
     template <typename triangulationType>
-    int subdiviseDegenerateQuads(std::vector<LongSimplexId> &outputSubd,
+    int subdiviseDegenerateQuads(std::vector<Quad> &outputSubd,
                                  const triangulationType &triangulation);
-
-    // ad-hoc quad data structure (see QuadrangulationSubdivision.h)
-    struct Quad {
-      LongSimplexId n;
-      LongSimplexId i;
-      LongSimplexId j;
-      LongSimplexId k;
-      LongSimplexId l;
-    };
 
     // number of vertices in triangulation
     SimplexId verticesNumber_{};
@@ -222,8 +218,8 @@ namespace ttk {
     std::vector<std::vector<size_t>> quadSeps_{};
 
   protected:
-    // array of output polygons
-    std::vector<LongSimplexId> outputCells_{};
+    // array of output quads
+    std::vector<Quad> outputCells_{};
     // array of output vertices (generated middles of duplicated separatrices)
     std::vector<float> outputPoints_{};
     // array of output vertices identifiers
@@ -542,8 +538,7 @@ int ttk::MorseSmaleQuadrangulation::quadrangulate(
 
   detectCellSeps(triangulation);
 
-  outputCells_.reserve(5 * quadSeps_.size());
-  auto quads = reinterpret_cast<std::vector<Quad> *>(&outputCells_);
+  outputCells_.reserve(quadSeps_.size());
 
   for(const auto &qs : quadSeps_) {
 
@@ -568,9 +563,9 @@ int ttk::MorseSmaleQuadrangulation::quadrangulate(
     }
 
     if(srcs.size() == 2) {
-      quads->emplace_back(Quad{4, dsts[0], srcs[0], dsts[1], srcs[1]});
+      outputCells_.emplace_back(Quad{dsts[0], srcs[0], dsts[1], srcs[1]});
     } else if(srcs.size() == 1) {
-      quads->emplace_back(Quad{4, dsts[0], srcs[0], dsts[1], srcs[0]});
+      outputCells_.emplace_back(Quad{dsts[0], srcs[0], dsts[1], srcs[0]});
       ndegen++;
     } else {
       found = false;
@@ -655,18 +650,14 @@ size_t ttk::MorseSmaleQuadrangulation::findSeparatrixMiddle(
 
 template <typename triangulationType>
 int ttk::MorseSmaleQuadrangulation::subdiviseDegenerateQuads(
-  std::vector<LongSimplexId> &outputSubd,
-  const triangulationType &triangulation) {
+  std::vector<Quad> &outputSubd, const triangulationType &triangulation) {
 
-  auto quads = reinterpret_cast<std::vector<Quad> *>(&outputCells_);
-  auto qsubd = reinterpret_cast<std::vector<Quad> *>(&outputSubd);
-
-  for(size_t i = 0; i < quads->size(); ++i) {
-    auto q = quads->at(i);
+  for(size_t i = 0; i < outputCells_.size(); ++i) {
+    auto q = outputCells_[i];
     auto seps = quadSeps_[i];
 
     // don't deal with normal quadrangles
-    if(q.j != q.l) {
+    if(q[1] != q[3]) {
       continue;
     }
 
@@ -678,20 +669,20 @@ int ttk::MorseSmaleQuadrangulation::subdiviseDegenerateQuads(
     // identify the extremum that is twice dest
     int count_vi = 0, count_vk = 0;
     for(const auto &s : dsts) {
-      if(s == q.i) {
+      if(s == q[0]) {
         count_vi++;
       }
-      if(s == q.k) {
+      if(s == q[2]) {
         count_vk++;
       }
     }
     // extremum index
-    LongSimplexId vert2Seps = count_vi > count_vk ? q.i : q.k;
-    LongSimplexId vert1Sep = count_vi > count_vk ? q.k : q.i;
+    LongSimplexId vert2Seps = count_vi > count_vk ? q[0] : q[2];
+    LongSimplexId vert1Sep = count_vi > count_vk ? q[2] : q[0];
     // the two seps from j to vert2Seps
     std::vector<size_t> borderseps{};
     for(size_t j = 0; j < seps.size(); ++j) {
-      if(dsts[j] == vert2Seps && srcs[j] == q.j) {
+      if(dsts[j] == vert2Seps && srcs[j] == q[1]) {
         borderseps.emplace_back(seps[j]);
       }
     }
@@ -702,14 +693,14 @@ int ttk::MorseSmaleQuadrangulation::subdiviseDegenerateQuads(
 
     // find a midpoint between the two extrema on the triangulation
 
-    std::vector<SimplexId> boundi{criticalPointsIdentifier_[q.i]};
-    std::vector<SimplexId> boundk{criticalPointsIdentifier_[q.k]};
+    std::vector<SimplexId> boundi{criticalPointsIdentifier_[q[0]]};
+    std::vector<SimplexId> boundk{criticalPointsIdentifier_[q[2]]};
     std::array<std::vector<float>, 6> outputDists{};
 
     Dijkstra::shortestPath(
-      criticalPointsIdentifier_[q.i], triangulation, outputDists[0], boundk);
+      criticalPointsIdentifier_[q[0]], triangulation, outputDists[0], boundk);
     Dijkstra::shortestPath(
-      criticalPointsIdentifier_[q.k], triangulation, outputDists[1], boundi);
+      criticalPointsIdentifier_[q[2]], triangulation, outputDists[1], boundi);
 
     auto inf = std::numeric_limits<float>::infinity();
     std::vector<float> sum(outputDists[0].size(), inf);
@@ -742,9 +733,9 @@ int ttk::MorseSmaleQuadrangulation::subdiviseDegenerateQuads(
 
     // find two other points
 
-    std::vector<SimplexId> bounds{criticalPointsIdentifier_[q.i],
-                                  criticalPointsIdentifier_[q.j],
-                                  criticalPointsIdentifier_[q.k]};
+    std::vector<SimplexId> bounds{criticalPointsIdentifier_[q[0]],
+                                  criticalPointsIdentifier_[q[1]],
+                                  criticalPointsIdentifier_[q[2]]};
 
     auto m0Pos = sepMids_[borderseps[0]];
     auto m1Pos = sepMids_[borderseps[1]];
@@ -788,11 +779,11 @@ int ttk::MorseSmaleQuadrangulation::subdiviseDegenerateQuads(
     auto v2 = std::min_element(sum.begin(), sum.end()) - sum.begin();
     auto v2Pos = static_cast<LongSimplexId>(insertNewPoint(v2, i, 4));
 
-    qsubd->emplace_back(Quad{4, vert2Seps, m0Pos, v1Pos, v0Pos});
-    qsubd->emplace_back(Quad{4, vert2Seps, m1Pos, v2Pos, v0Pos});
-    qsubd->emplace_back(Quad{4, q.j, m0Pos, v1Pos, vert1Sep});
-    qsubd->emplace_back(Quad{4, q.j, m1Pos, v2Pos, vert1Sep});
-    qsubd->emplace_back(Quad{4, vert1Sep, v1Pos, v0Pos, v2Pos});
+    outputSubd.emplace_back(Quad{vert2Seps, m0Pos, v1Pos, v0Pos});
+    outputSubd.emplace_back(Quad{vert2Seps, m1Pos, v2Pos, v0Pos});
+    outputSubd.emplace_back(Quad{q[1], m0Pos, v1Pos, vert1Sep});
+    outputSubd.emplace_back(Quad{q[1], m1Pos, v2Pos, vert1Sep});
+    outputSubd.emplace_back(Quad{vert1Sep, v1Pos, v0Pos, v2Pos});
   }
   return 0;
 }
@@ -819,15 +810,13 @@ int ttk::MorseSmaleQuadrangulation::subdivise(
   // hold quad subdivision
   decltype(outputCells_) outputSubd{};
   outputSubd.reserve(4 * outputCells_.size());
-  auto quads = reinterpret_cast<std::vector<Quad> *>(&outputCells_);
-  auto qsubd = reinterpret_cast<std::vector<Quad> *>(&outputSubd);
 
-  for(size_t i = 0; i < quads->size(); ++i) {
-    auto q = quads->at(i);
+  for(size_t i = 0; i < outputCells_.size(); ++i) {
+    auto q = outputCells_[i];
     auto seps = quadSeps_[i];
 
     // skip degenerate case here
-    if(q.j == q.l) {
+    if(q[1] == q[3]) {
       continue;
     }
 
@@ -842,8 +831,8 @@ int ttk::MorseSmaleQuadrangulation::subdivise(
 
     // bound Dijkstra by parent quad vertices
     std::vector<SimplexId> bounds{
-      criticalPointsIdentifier_[q.i], criticalPointsIdentifier_[q.j],
-      criticalPointsIdentifier_[q.k], criticalPointsIdentifier_[q.l]};
+      criticalPointsIdentifier_[q[0]], criticalPointsIdentifier_[q[1]],
+      criticalPointsIdentifier_[q[2]], criticalPointsIdentifier_[q[3]]};
 
     // Dijkstra propagation mask
     std::vector<bool> mask(morseSeg_.size(), false);
@@ -935,10 +924,10 @@ int ttk::MorseSmaleQuadrangulation::subdivise(
 
     auto sepsQuadVertex = [&](const size_t a, const size_t b) {
       if(srcs[a] == srcs[b]) {
-        qsubd->emplace_back(Quad{4, srcs[a], sepMids[a], baryPos, sepMids[b]});
+        outputSubd.emplace_back(Quad{srcs[a], sepMids[a], baryPos, sepMids[b]});
       }
       if(dsts[a] == dsts[b]) {
-        qsubd->emplace_back(Quad{4, dsts[a], sepMids[a], baryPos, sepMids[b]});
+        outputSubd.emplace_back(Quad{dsts[a], sepMids[a], baryPos, sepMids[b]});
       }
     };
 
@@ -977,29 +966,28 @@ bool ttk::MorseSmaleQuadrangulation::checkSurfaceCloseness(
     quadEdges{};
 
   // sweep over quadrangulation edges
-  auto quads = reinterpret_cast<const std::vector<Quad> *>(&outputCells_);
-  for(size_t i = 0; i < quads->size(); ++i) {
-    auto q = quads->at(i);
+  for(size_t i = 0; i < outputCells_.size(); ++i) {
+    auto q = outputCells_[i];
     // store edges in order
-    if(q.i < q.j) {
-      quadEdges[std::make_pair(q.i, q.j)].emplace(i);
+    if(q[0] < q[1]) {
+      quadEdges[std::make_pair(q[0], q[1])].emplace(i);
     } else {
-      quadEdges[std::make_pair(q.j, q.i)].emplace(i);
+      quadEdges[std::make_pair(q[1], q[0])].emplace(i);
     }
-    if(q.j < q.k) {
-      quadEdges[std::make_pair(q.j, q.k)].emplace(i);
+    if(q[1] < q[2]) {
+      quadEdges[std::make_pair(q[1], q[2])].emplace(i);
     } else {
-      quadEdges[std::make_pair(q.k, q.j)].emplace(i);
+      quadEdges[std::make_pair(q[2], q[1])].emplace(i);
     }
-    if(q.k < q.l) {
-      quadEdges[std::make_pair(q.k, q.l)].emplace(i);
+    if(q[2] < q[3]) {
+      quadEdges[std::make_pair(q[2], q[3])].emplace(i);
     } else {
-      quadEdges[std::make_pair(q.l, q.k)].emplace(i);
+      quadEdges[std::make_pair(q[3], q[2])].emplace(i);
     }
-    if(q.l < q.i) {
-      quadEdges[std::make_pair(q.l, q.i)].emplace(i);
+    if(q[3] < q[0]) {
+      quadEdges[std::make_pair(q[3], q[0])].emplace(i);
     } else {
-      quadEdges[std::make_pair(q.i, q.l)].emplace(i);
+      quadEdges[std::make_pair(q[0], q[3])].emplace(i);
     }
   }
 
@@ -1074,10 +1062,7 @@ int ttk::MorseSmaleQuadrangulation::execute(
     }
   }
 
-  // number of produced quads
-  size_t quadNumber = outputCells_.size() / 5;
-
-  this->printMsg("Produced " + std::to_string(quadNumber) + " ("
+  this->printMsg("Produced " + std::to_string(outputCells_.size()) + " ("
                    + std::to_string(ndegen) + " degenerated)",
                  1.0, tm.getElapsedTime(), this->threadNumber_);
 

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.cpp
@@ -52,7 +52,7 @@ ttk::QuadrangulationSubdivision::Point
   std::vector<Quad> quads{};
   for(auto &q : outputQuads_) {
     auto _a = static_cast<LongSimplexId>(a);
-    if(q.i == _a || q.j == _a || q.k == _a || q.l == _a) {
+    if(q[0] == _a || q[1] == _a || q[2] == _a || q[3] == _a) {
       quads.emplace_back(q);
     }
   }
@@ -64,18 +64,18 @@ ttk::QuadrangulationSubdivision::Point
   for(auto &q : quads) {
     auto _a = static_cast<LongSimplexId>(a);
     std::array<size_t, 2> tmp{};
-    if(q.i == _a) {
-      tmp[0] = static_cast<size_t>(q.l);
-      tmp[1] = static_cast<size_t>(q.j);
-    } else if(q.j == _a) {
-      tmp[0] = static_cast<size_t>(q.i);
-      tmp[1] = static_cast<size_t>(q.k);
-    } else if(q.k == _a) {
-      tmp[0] = static_cast<size_t>(q.j);
-      tmp[1] = static_cast<size_t>(q.l);
-    } else if(q.l == _a) {
-      tmp[0] = static_cast<size_t>(q.k);
-      tmp[1] = static_cast<size_t>(q.i);
+    if(q[0] == _a) {
+      tmp[0] = static_cast<size_t>(q[3]);
+      tmp[1] = static_cast<size_t>(q[1]);
+    } else if(q[1] == _a) {
+      tmp[0] = static_cast<size_t>(q[0]);
+      tmp[1] = static_cast<size_t>(q[2]);
+    } else if(q[2] == _a) {
+      tmp[0] = static_cast<size_t>(q[1]);
+      tmp[1] = static_cast<size_t>(q[3]);
+    } else if(q[3] == _a) {
+      tmp[0] = static_cast<size_t>(q[2]);
+      tmp[1] = static_cast<size_t>(q[0]);
     }
     couples.insert(tmp);
   }
@@ -131,10 +131,10 @@ int ttk::QuadrangulationSubdivision::getQuadNeighbors(
   Timer tm;
 
   for(auto &q : quads) {
-    auto i = static_cast<size_t>(q.i);
-    auto j = static_cast<size_t>(q.j);
-    auto k = static_cast<size_t>(q.k);
-    auto l = static_cast<size_t>(q.l);
+    auto i = static_cast<size_t>(q[0]);
+    auto j = static_cast<size_t>(q[1]);
+    auto k = static_cast<size_t>(q[2]);
+    auto l = static_cast<size_t>(q[3]);
     if(secondNeighbors) {
       neighbors[i].insert(j);
       neighbors[i].insert(k);

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
@@ -84,12 +84,6 @@ namespace ttk {
     template <typename triangulationType = AbstractTriangulation>
     int execute(const triangulationType &triangulation);
 
-    inline LongSimplexId *getQuadBuf() {
-      return reinterpret_cast<LongSimplexId *>(outputQuads_.data());
-    }
-    inline size_t getQuadNumber() const {
-      return outputQuads_.size();
-    }
     inline float *getPointsBuf() {
       return reinterpret_cast<float *>(outputPoints_.data());
     }
@@ -128,14 +122,11 @@ namespace ttk {
         return stream;
       }
     };
-    // VTK_QUAD representation with vtkIdType
-    struct Quad {
-      LongSimplexId n; // number of vertices, 4
-      LongSimplexId i; // index of first vertex
-      LongSimplexId j; // second vertex
-      LongSimplexId k; // third vertex
-      LongSimplexId l; // fourth vertex
-    };
+
+    /**
+     * @brief Ad-hoc quad data structure (4 vertex ids)
+     */
+    using Quad = std::array<LongSimplexId, 4>;
 
     /**
      * @brief Subdivise a quadrangular mesh
@@ -733,10 +724,10 @@ int ttk::QuadrangulationSubdivision::subdivise(
   for(auto &q : outputQuads_) {
     assert(q.n == 4); // magic number...
 
-    auto i = static_cast<size_t>(q.i);
-    auto j = static_cast<size_t>(q.j);
-    auto k = static_cast<size_t>(q.k);
-    auto l = static_cast<size_t>(q.l);
+    auto i = static_cast<size_t>(q[0]);
+    auto j = static_cast<size_t>(q[1]);
+    auto k = static_cast<size_t>(q[2]);
+    auto l = static_cast<size_t>(q[3]);
 
     // middles of edges
     auto ijid = findEdgeMiddle(i, j, triangulation);
@@ -761,10 +752,10 @@ int ttk::QuadrangulationSubdivision::subdivise(
     triangulation.getVertexPoint(baryid, bary.x, bary.y, bary.z);
 
     // order edges to avoid duplicates (ij vs. ji)
-    auto ij = std::make_pair(std::min(q.i, q.j), std::max(q.i, q.j));
-    auto jk = std::make_pair(std::min(q.j, q.k), std::max(q.j, q.k));
-    auto kl = std::make_pair(std::min(q.k, q.l), std::max(q.k, q.l));
-    auto li = std::make_pair(std::min(q.l, q.i), std::max(q.l, q.i));
+    auto ij = std::make_pair(std::min(q[0], q[1]), std::max(q[0], q[1]));
+    auto jk = std::make_pair(std::min(q[1], q[2]), std::max(q[1], q[2]));
+    auto kl = std::make_pair(std::min(q[2], q[3]), std::max(q[2], q[3]));
+    auto li = std::make_pair(std::min(q[3], q[0]), std::max(q[3], q[0]));
 
     auto process_edge_middle
       = [&](const std::pair<LongSimplexId, LongSimplexId> &pair,
@@ -793,14 +784,14 @@ int ttk::QuadrangulationSubdivision::subdivise(
     nearestVertexIdentifier_.emplace_back(baryid);
 
     // add the four new quads
-    tmp.emplace_back(Quad{
-      4, q.i, processedEdges[ij].first, baryIdx, processedEdges[li].first});
-    tmp.emplace_back(Quad{
-      4, q.j, processedEdges[jk].first, baryIdx, processedEdges[ij].first});
-    tmp.emplace_back(Quad{
-      4, q.k, processedEdges[kl].first, baryIdx, processedEdges[jk].first});
-    tmp.emplace_back(Quad{
-      4, q.l, processedEdges[li].first, baryIdx, processedEdges[kl].first});
+    tmp.emplace_back(
+      Quad{q[0], processedEdges[ij].first, baryIdx, processedEdges[li].first});
+    tmp.emplace_back(
+      Quad{q[1], processedEdges[jk].first, baryIdx, processedEdges[ij].first});
+    tmp.emplace_back(
+      Quad{q[2], processedEdges[kl].first, baryIdx, processedEdges[jk].first});
+    tmp.emplace_back(
+      Quad{q[3], processedEdges[li].first, baryIdx, processedEdges[kl].first});
   }
 
   // output subdivision level
@@ -842,10 +833,10 @@ void ttk::QuadrangulationSubdivision::quadStatistics(
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < outputQuads_.size(); ++i) {
     const auto &q = outputQuads_[i];
-    Point pi = outputPoints_[q.i];
-    Point pj = outputPoints_[q.j];
-    Point pk = outputPoints_[q.k];
-    Point pl = outputPoints_[q.l];
+    Point pi = outputPoints_[q[0]];
+    Point pj = outputPoints_[q[1]];
+    Point pk = outputPoints_[q[2]];
+    Point pl = outputPoints_[q[3]];
 
     // quadrangle area
     float area0{}, area1{};

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -40,6 +40,8 @@ int ttkDiscreteGradient::fillCriticalPoints(
   vtkDataArray *const inputScalars,
   const triangulationType &triangulation) {
 
+  ttk::Timer tm{};
+
   // critical points
   std::vector<scalarType> criticalPoints_points_cellScalars;
   this->setOutputCriticalPoints(&criticalPoints_points_cellScalars);
@@ -123,6 +125,9 @@ int ttkDiscreteGradient::fillCriticalPoints(
   pointData->AddArray(isOnBoundary);
   pointData->AddArray(PLVertexIdentifiers);
 
+  this->printMsg(
+    "Extracted critical points", 1.0, tm.getElapsedTime(), this->threadNumber_);
+
   return 0;
 }
 
@@ -130,8 +135,8 @@ template <typename triangulationType>
 int ttkDiscreteGradient::fillGradientGlyphs(
   vtkPolyData *const outputGradientGlyphs,
   const triangulationType &triangulation) {
-  ttk::Timer tm{};
 
+  ttk::Timer tm{};
   SimplexId gradientGlyphs_numberOfPoints{};
   std::vector<float> gradientGlyphs_points;
   std::vector<char> gradientGlyphs_points_pairOrigins;
@@ -199,7 +204,10 @@ int ttkDiscreteGradient::fillGradientGlyphs(
   pointData->AddArray(pairOrigins);
   cellData->AddArray(pairTypes);
 
-  this->printMsg("Computed gradient glyphs", 1.0, tm.getElapsedTime(), 1);
+  this->printMsg(
+    "Computed gradient glyphs", 1.0, tm.getElapsedTime(), this->threadNumber_);
+
+  return 0;
 }
 
 int ttkDiscreteGradient::RequestData(vtkInformation *request,

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -45,7 +45,7 @@
 #include <DiscreteGradient.h>
 #include <ttkAlgorithm.h>
 
-class vtkUnstructuredGrid;
+class vtkPolyData;
 
 class TTKDISCRETEGRADIENT_EXPORT ttkDiscreteGradient
   : public ttkAlgorithm,
@@ -75,7 +75,7 @@ protected:
 
 private:
   template <typename scalarType, typename triangulationType>
-  int dispatch(vtkUnstructuredGrid *outputCriticalPoints,
+  int dispatch(vtkPolyData *outputCriticalPoints,
                vtkDataArray *const inputScalars,
                vtkDataArray *const inputOffsets,
                const triangulationType &triangulation);

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -75,10 +75,9 @@ protected:
 
 private:
   template <typename scalarType, typename triangulationType>
-  int dispatch(vtkPolyData *outputCriticalPoints,
-               vtkDataArray *const inputScalars,
-               vtkDataArray *const inputOffsets,
-               const triangulationType &triangulation);
+  int fillCriticalPoints(vtkPolyData *output,
+                         vtkDataArray *const inputScalars,
+                         const triangulationType &triangulation);
 
   bool ForceInputOffsetScalarField{false};
   bool ComputeGradientGlyphs{true};

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -61,9 +61,6 @@ public:
   vtkSetMacro(ComputeGradientGlyphs, bool);
   vtkGetMacro(ComputeGradientGlyphs, bool);
 
-  vtkSetMacro(IterationThreshold, int);
-  vtkGetMacro(IterationThreshold, int);
-
 protected:
   ttkDiscreteGradient();
 

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.h
@@ -79,6 +79,10 @@ private:
                          vtkDataArray *const inputScalars,
                          const triangulationType &triangulation);
 
+  template <typename triangulationType>
+  int fillGradientGlyphs(vtkPolyData *const outputGradientGlyphs,
+                         const triangulationType &triangulation);
+
   bool ForceInputOffsetScalarField{false};
   bool ComputeGradientGlyphs{true};
 };

--- a/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
+++ b/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
@@ -1,6 +1,7 @@
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
-#include <vtkUnstructuredGrid.h>
+#include <vtkPolyData.h>
 
 #include <ttkGaussianPointCloud.h>
 #include <ttkUtils.h>
@@ -15,7 +16,7 @@ ttkGaussianPointCloud::ttkGaussianPointCloud() {
 int ttkGaussianPointCloud::FillOutputPortInformation(int port,
                                                      vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
     return 1;
   }
   return 0;
@@ -25,7 +26,7 @@ int ttkGaussianPointCloud::RequestData(vtkInformation *request,
                                        vtkInformationVector **inputVector,
                                        vtkInformationVector *outputVector) {
 
-  auto domain = vtkUnstructuredGrid::GetData(outputVector);
+  auto domain = vtkPolyData::GetData(outputVector);
 
   vtkNew<vtkPoints> points{};
   points->SetNumberOfPoints(NumberOfSamples);
@@ -56,7 +57,7 @@ int ttkGaussianPointCloud::RequestData(vtkInformation *request,
 
   vtkNew<vtkCellArray> cells{};
   cells->SetData(offsets, connectivity);
-  domain->SetCells(VTK_VERTEX, cells);
+  domain->SetVerts(cells);
 
   return 1;
 }

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -12,9 +12,9 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
+#include <vtkPolyData.h>
 #include <vtkSignedCharArray.h>
 #include <vtkUnsignedCharArray.h>
-#include <vtkUnstructuredGrid.h>
 
 vtkStandardNewMacro(ttkMorseSmaleComplex);
 
@@ -36,7 +36,7 @@ int ttkMorseSmaleComplex::FillInputPortInformation(int port,
 int ttkMorseSmaleComplex::FillOutputPortInformation(int port,
                                                     vtkInformation *info) {
   if(port == 0 || port == 1 || port == 2) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
     return 1;
   } else if(port == 3) {
     info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
@@ -54,9 +54,9 @@ template <typename scalarType, typename triangulationType>
 int ttkMorseSmaleComplex::dispatch(
   vtkDataArray *const inputScalars,
   vtkDataArray *const inputOffsets,
-  vtkUnstructuredGrid *const outputCriticalPoints,
-  vtkUnstructuredGrid *const outputSeparatrices1,
-  vtkUnstructuredGrid *const outputSeparatrices2,
+  vtkPolyData *const outputCriticalPoints,
+  vtkPolyData *const outputSeparatrices1,
+  vtkPolyData *const outputSeparatrices2,
   const triangulationType &triangulation) {
 
   const int dimensionality = triangulation.getCellVertexNumber(0) - 1;
@@ -221,7 +221,7 @@ int ttkMorseSmaleComplex::dispatch(
       criticalPoints_numberOfPoints, criticalPoints_numberOfPoints);
     vtkNew<vtkCellArray> cells{};
     cells->SetData(offsets, connectivity);
-    outputCriticalPoints->SetCells(VTK_VERTEX, cells);
+    outputCriticalPoints->SetVerts(cells);
 
     auto pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -334,7 +334,7 @@ int ttkMorseSmaleComplex::dispatch(
     outputSeparatrices1->SetPoints(points);
     vtkNew<vtkCellArray> cells{};
     cells->SetData(offsets, connectivity);
-    outputSeparatrices1->SetCells(VTK_LINE, cells);
+    outputSeparatrices1->SetLines(cells);
 
     auto pointData = outputSeparatrices1->GetPointData();
     auto cellData = outputSeparatrices1->GetCellData();
@@ -416,21 +416,6 @@ int ttkMorseSmaleComplex::dispatch(
     isOnBoundary->SetName("NumberOfCriticalPointsOnBoundary");
     setArray(isOnBoundary, separatrices2_cells_isOnBoundary);
 
-    vtkNew<vtkUnsignedCharArray> cellTypes{};
-    cellTypes->SetNumberOfComponents(1);
-    cellTypes->SetNumberOfTuples(separatrices2_numberOfCells);
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-    for(SimplexId i = 0; i < separatrices2_numberOfCells; ++i) {
-      if(separatrices2_cells_separatrixTypes[i] == 2) {
-        cellTypes->SetTuple1(i, VTK_TRIANGLE);
-      } else if(separatrices2_cells_separatrixTypes[i] == 1) {
-        cellTypes->SetTuple1(i, VTK_POLYGON);
-      }
-    }
-
     vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
     offsets->SetNumberOfComponents(1);
     setArray(offsets, separatrices2_cells_offsets);
@@ -442,7 +427,7 @@ int ttkMorseSmaleComplex::dispatch(
     outputSeparatrices2->SetPoints(points);
     vtkNew<vtkCellArray> cells{};
     cells->SetData(offsets, connectivity);
-    outputSeparatrices2->SetCells(cellTypes, cells);
+    outputSeparatrices2->SetPolys(cells);
 
     auto cellData = outputSeparatrices2->GetCellData();
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -469,9 +454,9 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *request,
                                       vtkInformationVector *outputVector) {
 
   const auto input = vtkDataSet::GetData(inputVector[0]);
-  auto outputCriticalPoints = vtkUnstructuredGrid::GetData(outputVector, 0);
-  auto outputSeparatrices1 = vtkUnstructuredGrid::GetData(outputVector, 1);
-  auto outputSeparatrices2 = vtkUnstructuredGrid::GetData(outputVector, 2);
+  auto outputCriticalPoints = vtkPolyData::GetData(outputVector, 0);
+  auto outputSeparatrices1 = vtkPolyData::GetData(outputVector, 1);
+  auto outputSeparatrices2 = vtkPolyData::GetData(outputVector, 2);
   auto outputMorseComplexes = vtkDataSet::GetData(outputVector, 3);
 
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -19,9 +19,9 @@
 /// \param Input Input scalar field, defined as a point data scalar field
 /// attached to a geometry, either 2D or 3D, either regular grid or
 /// triangulation (vtkDataSet)
-/// \param Output0 Output critical points (vtkUnstructuredGrid)
-/// \param Output1 Output 1-separatrices (vtkUnstructuredGrid)
-/// \param Output2 Output 2-separatrices (vtkUnstructuredGrid)
+/// \param Output0 Output critical points (vtkPolyData)
+/// \param Output1 Output 1-separatrices (vtkPolyData)
+/// \param Output2 Output 2-separatrices (vtkPolyData)
 /// \param Output3 Output data segmentation (vtkDataSet)
 ///
 /// The input data array needs to be specified via the standard VTK call
@@ -60,7 +60,7 @@
 #include <MorseSmaleComplex.h>
 #include <ttkAlgorithm.h>
 
-class vtkUnstructuredGrid;
+class vtkPolyData;
 
 class TTKMORSESMALECOMPLEX_EXPORT ttkMorseSmaleComplex
   : public ttkAlgorithm,
@@ -114,9 +114,9 @@ protected:
   template <typename scalarType, typename triangulationType>
   int dispatch(vtkDataArray *const inputScalars,
                vtkDataArray *const inputOffsets,
-               vtkUnstructuredGrid *const outputCriticalPoints,
-               vtkUnstructuredGrid *const outputSeparatrices1,
-               vtkUnstructuredGrid *const outputSeparatrices2,
+               vtkPolyData *const outputCriticalPoints,
+               vtkPolyData *const outputSeparatrices1,
+               vtkPolyData *const outputSeparatrices2,
                const triangulationType &triangulation);
 
   ttkMorseSmaleComplex();

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -143,7 +143,7 @@ private:
   double SaddleConnectorsPersistenceThreshold{0.0};
 
   // critical points
-  std::vector<float> criticalPoints_points{};
+  std::vector<std::array<float, 3>> criticalPoints_points{};
   std::vector<char> criticalPoints_points_cellDimensions{};
   std::vector<ttk::SimplexId> criticalPoints_points_cellIds{};
   std::vector<char> criticalPoints_points_isOnBoundary{};

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
@@ -133,8 +133,8 @@ int ttkMorseSmaleQuadrangulation::RequestData(
 
   // vtkCellArray of quadrangle values containing outArray
   vtkNew<vtkCellArray> cells{};
-  for(size_t i = 0; i < outputCells_.size() / 5; i++) {
-    cells->InsertNextCell(4, &outputCells_[5 * i + 1]);
+  for(size_t i = 0; i < outputCells_.size(); i++) {
+    cells->InsertNextCell(4, outputCells_[i].data());
   }
 
   // update output: get quadrangle values

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
@@ -5,7 +5,7 @@
 #include <vtkInformation.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
-#include <vtkUnstructuredGrid.h>
+#include <vtkPolyData.h>
 
 vtkStandardNewMacro(ttkMorseSmaleQuadrangulation);
 
@@ -22,7 +22,7 @@ int ttkMorseSmaleQuadrangulation::FillInputPortInformation(
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
     return 1;
   } else if(port == 1) { // MSC separatrices
-    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkUnstructuredGrid");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
     return 1;
   } else if(port == 2) { // triangulated domain
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
@@ -34,7 +34,7 @@ int ttkMorseSmaleQuadrangulation::FillInputPortInformation(
 int ttkMorseSmaleQuadrangulation::FillOutputPortInformation(
   int port, vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
     return 1;
   }
   return 0;
@@ -46,9 +46,9 @@ int ttkMorseSmaleQuadrangulation::RequestData(
   vtkInformationVector *outputVector) {
 
   auto critpoints = vtkPointSet::GetData(inputVector[0]);
-  auto seprs = vtkUnstructuredGrid::GetData(inputVector[1]);
+  auto seprs = vtkPolyData::GetData(inputVector[1]);
   auto domain = vtkDataSet::GetData(inputVector[2]);
-  auto output = vtkUnstructuredGrid::GetData(outputVector);
+  auto output = vtkPolyData::GetData(outputVector);
 
   auto triangulation = ttkAlgorithm::GetTriangulation(domain);
   if(triangulation == nullptr) {
@@ -90,24 +90,10 @@ int ttkMorseSmaleQuadrangulation::RequestData(
     ttkUtils::GetVoidPointer(sepdim), ttkUtils::GetVoidPointer(sepmask),
     ttkUtils::GetVoidPointer(seprsPoints));
 
-#define MSQUAD_EXPLICIT_CALLS(TRIANGL_CASE, TRIANGL_TYPE)                   \
-  case TRIANGL_CASE: {                                                      \
-    const auto tri = static_cast<TRIANGL_TYPE *>(triangulation->getData()); \
-    if(tri != nullptr) {                                                    \
-      res = this->execute<TRIANGL_TYPE>(*tri);                              \
-    }                                                                       \
-    break;                                                                  \
-  }
-
   int res{-1};
-  switch(triangulation->getType()) {
-    MSQUAD_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::EXPLICIT, ttk::ExplicitTriangulation);
-    MSQUAD_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::IMPLICIT, ttk::ImplicitTriangulation);
-    MSQUAD_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::PERIODIC, ttk::PeriodicImplicitTriangulation);
-  }
+  ttkTemplateMacro(
+    triangulation->getType(),
+    res = this->execute(*static_cast<TTK_TT *>(triangulation->getData())););
 
   if(res != 0) {
     this->printWrn("Consider another (eigen) function, persistence threshold "
@@ -118,41 +104,41 @@ int ttkMorseSmaleQuadrangulation::RequestData(
   }
 
   // output points: critical points + generated separatrices middles
-  auto outQuadPoints = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> outQuadPoints{};
   for(size_t i = 0; i < outputPoints_.size() / 3; i++) {
     outQuadPoints->InsertNextPoint(&outputPoints_[3 * i]);
   }
   output->SetPoints(outQuadPoints);
 
   // quad vertices identifiers
-  auto identifiers = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> identifiers{};
   identifiers->SetName(ttk::VertexScalarFieldName);
   ttkUtils::SetVoidArray(
     identifiers, outputPointsIds_.data(), outputPointsIds_.size(), 1);
   output->GetPointData()->AddArray(identifiers);
 
   // quad vertices type
-  auto type = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> type{};
   type->SetName("QuadVertType");
   ttkUtils::SetVoidArray(
     type, outputPointsTypes_.data(), outputPointsTypes_.size(), 1);
   output->GetPointData()->AddArray(type);
 
   // quad vertices cells
-  auto cellid = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> cellid{};
   cellid->SetName("QuadCellId");
   ttkUtils::SetVoidArray(
     cellid, outputPointsCells_.data(), outputPointsCells_.size(), 1);
   output->GetPointData()->AddArray(cellid);
 
   // vtkCellArray of quadrangle values containing outArray
-  auto cells = vtkSmartPointer<vtkCellArray>::New();
+  vtkNew<vtkCellArray> cells{};
   for(size_t i = 0; i < outputCells_.size() / 5; i++) {
     cells->InsertNextCell(4, &outputCells_[5 * i + 1]);
   }
 
   // update output: get quadrangle values
-  output->SetCells(VTK_QUAD, cells);
+  output->SetPolys(cells);
 
   // shallow copy input field data
   output->GetFieldData()->ShallowCopy(domain->GetFieldData());

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -75,8 +75,10 @@ int ttkQuadrangulationSubdivision::RequestData(
                    + std::string(ttk::VertexScalarFieldName));
   }
 
-  this->setInputQuads(ttkUtils::GetVoidPointer(inputCells->GetData()),
-                      inputCells->GetNumberOfCells());
+  this->setInputQuads(
+    // get quads from PolyData's connectivity array
+    ttkUtils::GetVoidPointer(inputCells->GetConnectivityArray()),
+    inputCells->GetNumberOfCells());
   this->setInputVertices(ttkUtils::GetVoidPointer(inputPoints->GetData()),
                          inputPoints->GetNumberOfPoints());
   this->setInputVertexIdentifiers(
@@ -98,16 +100,16 @@ int ttkQuadrangulationSubdivision::RequestData(
 
   vtkNew<vtkCellArray> cells{};
 
-  for(size_t i = 0; i < getQuadNumber(); i++) {
-    cells->InsertNextCell(4, &this->getQuadBuf()[5 * i + 1]);
+  for(size_t i = 0; i < outputQuads_.size(); i++) {
+    cells->InsertNextCell(4, this->outputQuads_[i].data());
   }
 
   // update output: get quadrangle values
   output->SetPolys(cells);
 
   vtkNew<vtkPoints> points{};
-  for(size_t i = 0; i < getPointsNumber(); ++i) {
-    points->InsertNextPoint(&this->getPointsBuf()[3 * i]);
+  for(size_t i = 0; i < outputPoints_.size(); ++i) {
+    points->InsertNextPoint(&outputPoints_[i].x);
   }
 
   // update output: get quadrangle vertices

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -73,6 +73,7 @@ int ttkQuadrangulationSubdivision::RequestData(
   if(identifiers == nullptr) {
     this->printErr("Missing point data array named "
                    + std::string(ttk::VertexScalarFieldName));
+    return 0;
   }
 
   this->setInputQuads(

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -7,7 +7,7 @@
 #include <vtkInformation.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
-#include <vtkUnstructuredGrid.h>
+#include <vtkPolyData.h>
 
 vtkStandardNewMacro(ttkQuadrangulationSubdivision);
 
@@ -21,7 +21,7 @@ ttkQuadrangulationSubdivision::ttkQuadrangulationSubdivision() {
 int ttkQuadrangulationSubdivision::FillInputPortInformation(
   int port, vtkInformation *info) {
   if(port == 0) { // input quadrangulation
-    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkUnstructuredGrid");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
     return 1;
   } else if(port == 1) { // triangulated domain
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
@@ -33,7 +33,7 @@ int ttkQuadrangulationSubdivision::FillInputPortInformation(
 int ttkQuadrangulationSubdivision::FillOutputPortInformation(
   int port, vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
     return 1;
   }
   return 0;
@@ -44,9 +44,9 @@ int ttkQuadrangulationSubdivision::RequestData(
   vtkInformationVector **inputVector,
   vtkInformationVector *outputVector) {
 
-  auto quads = vtkUnstructuredGrid::GetData(inputVector[0]);
+  auto quads = vtkPolyData::GetData(inputVector[0]);
   auto mesh = vtkDataSet::GetData(inputVector[1]);
-  auto output = vtkUnstructuredGrid::GetData(outputVector);
+  auto output = vtkPolyData::GetData(outputVector);
 
   auto triangulation = ttkAlgorithm::GetTriangulation(mesh);
   if(triangulation == nullptr) {
@@ -54,7 +54,7 @@ int ttkQuadrangulationSubdivision::RequestData(
   }
   this->preconditionTriangulation(triangulation);
 
-  auto inputCells = quads->GetCells();
+  auto inputCells = quads->GetPolys();
   if(inputCells == nullptr || inputCells->GetData() == nullptr) {
     this->printErr("Invalid input quadrangle cells");
     return 0;
@@ -82,24 +82,10 @@ int ttkQuadrangulationSubdivision::RequestData(
   this->setInputVertexIdentifiers(
     ttkUtils::GetVoidPointer(identifiers), identifiers->GetNumberOfTuples());
 
-#define QUADSUB_EXPLICIT_CALLS(TRIANGL_CASE, TRIANGL_TYPE)                  \
-  case TRIANGL_CASE: {                                                      \
-    const auto tri = static_cast<TRIANGL_TYPE *>(triangulation->getData()); \
-    if(tri != nullptr) {                                                    \
-      res = this->execute<TRIANGL_TYPE>(*tri);                              \
-    }                                                                       \
-    break;                                                                  \
-  }
-
   int res{-1};
-  switch(triangulation->getType()) {
-    QUADSUB_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::EXPLICIT, ttk::ExplicitTriangulation);
-    QUADSUB_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::IMPLICIT, ttk::ImplicitTriangulation);
-    QUADSUB_EXPLICIT_CALLS(
-      ttk::Triangulation::Type::PERIODIC, ttk::PeriodicImplicitTriangulation);
-  }
+  ttkTemplateMacro(
+    triangulation->getType(),
+    res = this->execute(*static_cast<TTK_TT *>(triangulation->getData())));
 
   if(res != 0) {
     this->printWrn("Please increase the number of relaxation iterations, of "
@@ -110,16 +96,16 @@ int ttkQuadrangulationSubdivision::RequestData(
     }
   }
 
-  auto cells = vtkSmartPointer<vtkCellArray>::New();
+  vtkNew<vtkCellArray> cells{};
 
   for(size_t i = 0; i < getQuadNumber(); i++) {
     cells->InsertNextCell(4, &this->getQuadBuf()[5 * i + 1]);
   }
 
   // update output: get quadrangle values
-  output->SetCells(VTK_QUAD, cells);
+  output->SetPolys(cells);
 
-  auto points = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> points{};
   for(size_t i = 0; i < getPointsNumber(); ++i) {
     points->InsertNextPoint(&this->getPointsBuf()[3 * i]);
   }
@@ -128,20 +114,20 @@ int ttkQuadrangulationSubdivision::RequestData(
   output->SetPoints(points);
 
   // add data array of points valences
-  auto valences = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> valences{};
   valences->SetName("Valence");
   ttkUtils::SetVoidArray(
     valences, outputValences_.data(), outputValences_.size(), 1);
   output->GetPointData()->AddArray(valences);
 
   // add data array of points infos
-  auto infos = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> infos{};
   infos->SetName("Type");
   ttkUtils::SetVoidArray(
     infos, outputVertType_.data(), outputVertType_.size(), 1);
   output->GetPointData()->AddArray(infos);
 
-  auto subd = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+  vtkNew<ttkSimplexIdTypeArray> subd{};
   subd->SetName("Subdivision");
   ttkUtils::SetVoidArray(
     subd, outputSubdivision_.data(), outputSubdivision_.size(), 1);
@@ -150,14 +136,14 @@ int ttkQuadrangulationSubdivision::RequestData(
   if(RelaxationIterations > 0) {
 
     // add data array of number of triangles checked
-    auto trChecked = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+    vtkNew<ttkSimplexIdTypeArray> trChecked{};
     trChecked->SetName("Triangles checked");
     ttkUtils::SetVoidArray(
       trChecked, trianglesChecked_.data(), trianglesChecked_.size(), 1);
     output->GetPointData()->AddArray(trChecked);
 
     // add data array of projection success
-    auto projSucc = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
+    vtkNew<ttkSimplexIdTypeArray> projSucc{};
     projSucc->SetName("Projection");
     ttkUtils::SetVoidArray(
       projSucc, projSucceeded_.data(), projSucceeded_.size(), 1);
@@ -165,30 +151,30 @@ int ttkQuadrangulationSubdivision::RequestData(
   }
 
   if(QuadStatistics) {
-    auto quadArea = vtkSmartPointer<vtkFloatArray>::New();
+    vtkNew<vtkFloatArray> quadArea{};
     quadArea->SetName("Quad Area");
     ttkUtils::SetVoidArray(quadArea, quadArea_.data(), quadArea_.size(), 1);
     output->GetCellData()->AddArray(quadArea);
 
-    auto diagsRatio = vtkSmartPointer<vtkFloatArray>::New();
+    vtkNew<vtkFloatArray> diagsRatio{};
     diagsRatio->SetName("Diagonals Ratio");
     ttkUtils::SetVoidArray(
       diagsRatio, quadDiagsRatio_.data(), quadDiagsRatio_.size(), 1);
     output->GetCellData()->AddArray(diagsRatio);
 
-    auto edgesRatio = vtkSmartPointer<vtkFloatArray>::New();
+    vtkNew<vtkFloatArray> edgesRatio{};
     edgesRatio->SetName("Edges Ratio");
     ttkUtils::SetVoidArray(
       edgesRatio, quadEdgesRatio_.data(), quadEdgesRatio_.size(), 1);
     output->GetCellData()->AddArray(edgesRatio);
 
-    auto anglesRatio = vtkSmartPointer<vtkFloatArray>::New();
+    vtkNew<vtkFloatArray> anglesRatio{};
     anglesRatio->SetName("Angles Ratio");
     ttkUtils::SetVoidArray(
       anglesRatio, quadAnglesRatio_.data(), quadAnglesRatio_.size(), 1);
     output->GetCellData()->AddArray(anglesRatio);
 
-    auto hausDist = vtkSmartPointer<vtkFloatArray>::New();
+    vtkNew<vtkFloatArray> hausDist{};
     hausDist->SetName("Hausdorff");
     ttkUtils::SetVoidArray(hausDist, hausdorff_.data(), hausdorff_.size(), 1);
     output->GetPointData()->AddArray(hausDist);

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -7,8 +7,8 @@
 #include <vtkIntArray.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
+#include <vtkPolyData.h>
 #include <vtkSignedCharArray.h>
-#include <vtkUnstructuredGrid.h>
 
 #include <ttkMacros.h>
 #include <ttkUtils.h>
@@ -40,7 +40,7 @@ int ttkScalarFieldCriticalPoints::FillInputPortInformation(
 int ttkScalarFieldCriticalPoints::FillOutputPortInformation(
   int port, vtkInformation *info) {
   if(port == 0)
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
   else
     return 0;
 
@@ -53,7 +53,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
   vtkInformationVector *outputVector) {
 
   vtkDataSet *input = vtkDataSet::GetData(inputVector[0]);
-  vtkUnstructuredGrid *output = vtkUnstructuredGrid::GetData(outputVector, 0);
+  vtkPolyData *output = vtkPolyData::GetData(outputVector, 0);
 
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
   if(!triangulation)
@@ -121,7 +121,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
 
   vtkNew<vtkCellArray> cells{};
   cells->SetData(offsets, connectivity);
-  output->SetCells(VTK_VERTEX, cells);
+  output->SetVerts(cells);
   output->SetPoints(pointSet);
   output->GetPointData()->AddArray(vertexTypes);
 

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -25,14 +25,6 @@
 #include <Triangulation.h>
 #include <ttkAlgorithm.h>
 
-// VTK includes
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkInformation.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
-#include <vtkUnstructuredGrid.h>
-
 // VTK Module
 #include <ttkTriangulationRequestModule.h>
 

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -230,12 +230,10 @@ int main(int argc, char **argv) {
   // 7. computing the Morse-Smale complex
   ttk::MorseSmaleComplex morseSmaleComplex;
   // critical points
-  ttk::SimplexId criticalPoints_numberOfPoints{};
-  std::vector<float> criticalPoints_points;
+  std::vector<std::array<float, 3>> criticalPoints_points;
   std::vector<char> criticalPoints_points_cellDimensions;
   std::vector<ttk::SimplexId> criticalPoints_points_cellIds;
   std::vector<char> criticalPoints_points_isOnBoundary;
-  std::vector<float> criticalPoints_points_cellScalars;
   std::vector<ttk::SimplexId> criticalPoints_points_PLVertexIdentifiers;
   std::vector<ttk::SimplexId> criticalPoints_points_manifoldSize;
   // 1-separatrices
@@ -266,9 +264,8 @@ int main(int argc, char **argv) {
                                             descendingSegmentation.data(),
                                             mscSegmentation.data());
   morseSmaleComplex.setOutputCriticalPoints(
-    &criticalPoints_numberOfPoints, &criticalPoints_points,
-    &criticalPoints_points_cellDimensions, &criticalPoints_points_cellIds,
-    &criticalPoints_points_cellScalars, &criticalPoints_points_isOnBoundary,
+    &criticalPoints_points, &criticalPoints_points_cellDimensions,
+    &criticalPoints_points_cellIds, &criticalPoints_points_isOnBoundary,
     &criticalPoints_points_PLVertexIdentifiers,
     &criticalPoints_points_manifoldSize);
   morseSmaleComplex.setOutputSeparatrices1(

--- a/examples/pvpython/example.py
+++ b/examples/pvpython/example.py
@@ -60,5 +60,5 @@ morseSmaleComplex.ScalarField = ['POINTS', 'data']
 
 # 8. saving the output data
 SaveData('curve.vtk', OutputPort(persistenceCurve, 3))
-SaveData('separatrices.vtu', OutputPort(morseSmaleComplex, 1))
+SaveData('separatrices.vtp', OutputPort(morseSmaleComplex, 1))
 SaveData('segmentation.vtu', OutputPort(morseSmaleComplex, 3))

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -23,6 +23,7 @@ from vtk import (
     vtkDataObject,
     vtkTableWriter,
     vtkThreshold,
+    vtkXMLPolyDataWriter,
     vtkXMLUnstructuredGridReader,
     vtkXMLUnstructuredGridWriter,
 )
@@ -89,9 +90,9 @@ curveWriter.SetInputConnection(curve.GetOutputPort())
 curveWriter.SetFileName("curve.vtk")
 curveWriter.Write()
 
-sepWriter = vtkXMLUnstructuredGridWriter()
+sepWriter = vtkXMLPolyDataWriter()
 sepWriter.SetInputConnection(morseSmaleComplex.GetOutputPort(1))
-sepWriter.SetFileName("separatrices.vtu")
+sepWriter.SetFileName("separatrices.vtp")
 sepWriter.Write()
 
 segWriter = vtkXMLUnstructuredGridWriter()

--- a/examples/vtk-c++/main.cpp
+++ b/examples/vtk-c++/main.cpp
@@ -27,6 +27,7 @@
 #include <vtkNew.h>
 #include <vtkTableWriter.h>
 #include <vtkThreshold.h>
+#include <vtkXMLPolyDataWriter.h>
 #include <vtkXMLUnstructuredGridReader.h>
 #include <vtkXMLUnstructuredGridWriter.h>
 
@@ -91,9 +92,9 @@ int main(int argc, char **argv) {
   curveWriter->SetFileName("curve.vtk");
   curveWriter->Write();
 
-  vtkNew<vtkXMLUnstructuredGridWriter> sepWriter{};
+  vtkNew<vtkXMLPolyDataWriter> sepWriter{};
   sepWriter->SetInputConnection(morseSmaleComplex->GetOutputPort(1));
-  sepWriter->SetFileName("separatrices.vtu");
+  sepWriter->SetFileName("separatrices.vtp");
   sepWriter->Write();
 
   vtkNew<vtkXMLUnstructuredGridWriter> segWriter{};

--- a/paraview/DiscreteGradient/DiscreteGradient.xml
+++ b/paraview/DiscreteGradient/DiscreteGradient.xml
@@ -108,18 +108,6 @@
         </Documentation>
       </IntVectorProperty>
 
-      <IntVectorProperty name="IterationThreshold"
-        label="Iteration Threshold"
-        command="SetIterationThreshold"
-        number_of_elements="1"
-        default_values="-1"
-        panel_visibility="advanced">
-        <IntRangeDomain name="range" min="0" max="100" />
-        <Documentation>
-          Iteration threshold.
-        </Documentation>
-      </IntVectorProperty>
-
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
@@ -127,10 +115,6 @@
         <Property name="ForceInputOffsetScalarField"/>
         <Property name="Offset Field"/>
         <Property name="ComputeGradientGlyphs"/>
-      </PropertyGroup>
-
-      <PropertyGroup panel_widget="Line" label="Testing">
-        <Property name="IterationThreshold"/>
       </PropertyGroup>
 
       <OutputPort name="Critical Points" index="0" id="port0"/>

--- a/paraview/MorseSmaleQuadrangulation/MorseSmaleQuadrangulation.xml
+++ b/paraview/MorseSmaleQuadrangulation/MorseSmaleQuadrangulation.xml
@@ -21,7 +21,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkDataSet"/>
         </DataTypeDomain>
         <Documentation>
           Input triangulated surface.
@@ -38,7 +38,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkPointSet"/>
         </DataTypeDomain>
         <InputArrayDomain name="input_scalars" number_of_components="1">
           <Property name="CriticalPoints" function="FieldDataSelection" />
@@ -58,7 +58,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkPolyData"/>
         </DataTypeDomain>
         <InputArrayDomain name="input_scalars" number_of_components="1">
           <Property name="Separatrices" function="FieldDataSelection" />

--- a/paraview/QuadrangulationSubdivision/QuadrangulationSubdivision.xml
+++ b/paraview/QuadrangulationSubdivision/QuadrangulationSubdivision.xml
@@ -21,7 +21,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkDataSet"/>
         </DataTypeDomain>
         <Documentation>
           Input triangulated surface.
@@ -38,7 +38,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkPolyData"/>
         </DataTypeDomain>
         <Documentation>
           Input coarse quadrangulation.


### PR DESCRIPTION
As a follow-up to #588 and per Jonas' suggestion, this PR changes the output of point cloud generating filters from `vtkUnstructuredGrid` to `vtkPolyData`. The concerned filters are:

* the two outputs (critical points, glyphs) of the DiscreteGradient,
* the critical points and separatrices outputs of the MorseSmaleComplex,
* the quadrangulations generated by MorseSmaleQuadrangulation and QuadrangulationSubdivision,
* the MatrixToHeatMap output,
* the point clouds outputs of ScalarFieldCriticalPoints and GaussianPointCloud.

TriangulationRequest, forgotten in #588, now also outputs cells for vertex requests. Since `vtkPolyData` only works with 2D cells and can't represent tetrahedrons, the `vtkUnstructuredGrid` output has been kept.

In addition to this work on filters output, I also did a bit of cleaning in the DiscreteGradient and the Quadrangulation filters:

* the critical points and glyphs outputs of the DiscreteGradient have been refactored in specific methods,
* the glyphs are now computed in parallel,
* the gradient structure has been changed from `std::vector<std::vector<std::vector<SimplexId>>>` to `std::array<std::vector<SimplexId>, 6>` to reduce indirections. The documentation of this type has been modified accordingly.
* the `setCriticalPoints` and `setManifoldSize` methods have been refactored to use references, thus enabling to remove some state in the DiscreteGradient class,
* the critical points `cellScalars` point data array is now filled directly in the DiscreteGradient and the MorseSmaleComplex VTK layer, which avoids passing void pointers and templating some base methods according to the scalar field type,
* the quadrangulation data structures have also been slightly modified: instead of a struct, I now use `std::array` for quadrangles. The "interleaved" cell structure has also been dropped: the quadrangles now don't embed their number of points,
* some leftovers of the Great Migration have been fixed in the Quadrangulation filters (using the correct macro calls, replacing `vtkSmartPointers` with `vtkNew`…)

No modification observed in the ttk-data state files.

Enjoy,
Pierre