### PR TITLE
Fix ttkIdentifiers/GenerateIds compatibility

### DIFF
--- a/core/base/distanceField/DistanceField.h
+++ b/core/base/distanceField/DistanceField.h
@@ -52,7 +52,7 @@ namespace ttk {
       return triangulation->preconditionVertexNeighbors();
     }
 
-    inline void setVertexIdentifierScalarFieldPointer(void *data) {
+    inline void setVertexIdentifierScalarFieldPointer(SimplexId *const data) {
       vertexIdentifierScalarFieldPointer_ = data;
     }
 
@@ -71,7 +71,7 @@ namespace ttk {
   protected:
     SimplexId vertexNumber_{};
     SimplexId sourceNumber_{};
-    void *vertexIdentifierScalarFieldPointer_{};
+    SimplexId *vertexIdentifierScalarFieldPointer_{};
     void *outputScalarFieldPointer_{};
     void *outputIdentifiers_{};
     void *outputSegmentation_{};
@@ -84,8 +84,7 @@ int ttk::DistanceField::execute(const triangulationType *triangulation_) const {
   // start global timer
   ttk::Timer globalTimer;
 
-  SimplexId *identifiers
-    = static_cast<SimplexId *>(vertexIdentifierScalarFieldPointer_);
+  const SimplexId *identifiers = vertexIdentifierScalarFieldPointer_;
   dataType *dist = static_cast<dataType *>(outputScalarFieldPointer_);
   SimplexId *origin = static_cast<SimplexId *>(outputIdentifiers_);
   SimplexId *seg = static_cast<SimplexId *>(outputSegmentation_);

--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -36,13 +36,13 @@ int ttk::HarmonicField::solve(SparseMatrixType const &lap,
 // main routine
 template <class T, class TriangulationType>
 int ttk::HarmonicField::execute(const TriangulationType &triangulation,
-                                SimplexId constraintNumber,
-                                SimplexId *sources,
-                                T *constraints,
-                                T *outputScalarField,
-                                bool useCotanWeights,
-                                SolvingMethodUserType solvingMethod,
-                                double logAlpha) const {
+                                const SimplexId constraintNumber,
+                                const SimplexId *const sources,
+                                const T *const constraints,
+                                T *const outputScalarField,
+                                const bool useCotanWeights,
+                                const SolvingMethodUserType solvingMethod,
+                                const double logAlpha) const {
 
 #ifdef TTK_ENABLE_EIGEN
 
@@ -196,10 +196,11 @@ int ttk::HarmonicField::execute(const TriangulationType &triangulation,
 }
 
 // explicit template specializations for double and float types
-#define HARMONICFIELD_SPECIALIZE(TYPE)                                   \
-  template int ttk::HarmonicField::execute<TYPE>(                        \
-    const Triangulation &, SimplexId, SimplexId *, TYPE *, TYPE *, bool, \
-    SolvingMethodUserType, double) const
+#define HARMONICFIELD_SPECIALIZE(TYPE)                                       \
+  template int ttk::HarmonicField::execute<TYPE>(                            \
+    const Triangulation &, const SimplexId, const SimplexId *const,          \
+    const TYPE *const, TYPE *const, const bool, const SolvingMethodUserType, \
+    const double) const
 
 HARMONICFIELD_SPECIALIZE(float);
 HARMONICFIELD_SPECIALIZE(double);

--- a/core/base/harmonicField/HarmonicField.h
+++ b/core/base/harmonicField/HarmonicField.h
@@ -40,14 +40,14 @@ namespace ttk {
 
     template <class T, class TriangulationType = AbstractTriangulation>
     int execute(const TriangulationType &triangulation,
-                SimplexId constraintNumber,
-                SimplexId *sources,
-                T *constraints,
-                T *outputScalarField,
-                bool useCotanWeights = true,
-                SolvingMethodUserType solvingMethod
+                const SimplexId constraintNumber,
+                const SimplexId *const sources,
+                const T *const constraints,
+                T *const outputScalarField,
+                const bool useCotanWeights = true,
+                const SolvingMethodUserType solvingMethod
                 = SolvingMethodUserType::AUTO,
-                double logAlpha = 5.0) const;
+                const double logAlpha = 5.0) const;
 
   private:
     SolvingMethodType findBestSolver(const SimplexId vertexNumber,

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -92,7 +92,7 @@ namespace ttk {
       inputOffsets_ = data;
     }
 
-    inline void setVertexIdentifierScalarField(void *data) {
+    inline void setVertexIdentifierScalarField(SimplexId *const data) {
       vertexIdentifierScalarField_ = data;
     }
 
@@ -107,7 +107,7 @@ namespace ttk {
     int direction_;
     void *inputScalarField_;
     const SimplexId *inputOffsets_;
-    void *vertexIdentifierScalarField_;
+    SimplexId *vertexIdentifierScalarField_;
     std::vector<std::vector<SimplexId>> *outputTrajectories_;
   };
 } // namespace ttk
@@ -115,8 +115,7 @@ namespace ttk {
 template <typename dataType, class triangulationType>
 int ttk::IntegralLines::execute(const triangulationType *triangulation) const {
   const auto offsets = inputOffsets_;
-  SimplexId *identifiers
-    = static_cast<SimplexId *>(vertexIdentifierScalarField_);
+  SimplexId *identifiers = vertexIdentifierScalarField_;
   dataType *scalars = static_cast<dataType *>(inputScalarField_);
   std::vector<std::vector<SimplexId>> *trajectories = outputTrajectories_;
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -110,6 +110,25 @@ public:
                               const bool enforceOrderArrayIdx = false);
 
   /**
+   * Retrieve an identifier field and provides a ttk::SimplexId
+   * pointer to the underlaying buffer.
+   *
+   * Use the same parameters as GetOptionalArray to fetch the VTK data
+   * array.
+   *
+   * Fills the vector \p spareStorage if the VTK data array is not a
+   * ttkSimplexIdTypeArray. This vector should have a lifetime of a
+   * least the filter's RequestData method.
+   */
+  ttk::SimplexId *
+    GetIdentifierArrayPtr(const bool &enforceArrayIndex,
+                          const int &arrayIndex,
+                          const std::string &arrayName,
+                          vtkDataSet *const inputData,
+                          std::vector<ttk::SimplexId> &spareStorage,
+                          const int inputPort = 0);
+
+  /**
    * This method retrieves the ttk::Triangulation of a vtkDataSet.
    *
    * Note, this method initializes a triangulation if one does not exist

--- a/core/vtk/ttkDistanceField/ttkDistanceField.cpp
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.cpp
@@ -56,8 +56,10 @@ int ttkDistanceField::RequestData(vtkInformation *request,
   }
 #endif
 
-  vtkDataArray *identifiers = this->GetOptionalArray(
-    ForceInputVertexScalarField, 0, ttk::VertexScalarFieldName, sources);
+  std::vector<ttk::SimplexId> idSpareStorage{};
+  auto *identifiers = this->GetIdentifierArrayPtr(ForceInputVertexScalarField,
+                                                  0, ttk::VertexScalarFieldName,
+                                                  sources, idSpareStorage);
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!identifiers) {
     printErr("wrong identifiers.");
@@ -110,8 +112,7 @@ int ttkDistanceField::RequestData(vtkInformation *request,
 
   this->setVertexNumber(numberOfPointsInDomain);
   this->setSourceNumber(numberOfPointsInSources);
-  this->setVertexIdentifierScalarFieldPointer(
-    ttkUtils::GetVoidPointer(identifiers));
+  this->setVertexIdentifierScalarFieldPointer(identifiers);
   this->setOutputIdentifiers(ttkUtils::GetVoidPointer(origin));
   this->setOutputSegmentation(ttkUtils::GetVoidPointer(seg));
 

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -53,8 +53,10 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
   this->preconditionTriangulation(*triangulation, UseCotanWeights);
 
   vtkDataArray *inputField = this->GetInputArrayToProcess(0, identifiers);
-  vtkDataArray *vertsid = this->GetOptionalArray(
-    ForceConstraintIdentifiers, 1, ttk::VertexScalarFieldName, identifiers);
+  std::vector<ttk::SimplexId> idSpareStorage{};
+  const auto *vertsid = this->GetIdentifierArrayPtr(
+    ForceConstraintIdentifiers, 1, ttk::VertexScalarFieldName, identifiers,
+    idSpareStorage);
 
   if(vertsid == nullptr || inputField == nullptr) {
     this->printErr("Input fields are NULL");
@@ -104,16 +106,14 @@ int ttkHarmonicField::RequestData(vtkInformation *request,
   switch(OutputScalarFieldType) {
     case FieldType::FLOAT:
       res = this->execute<float>(
-        *triangulation, nSources,
-        static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(vertsid)),
+        *triangulation, nSources, vertsid,
         static_cast<float *>(ttkUtils::GetVoidPointer(inputField)),
         static_cast<float *>(ttkUtils::GetVoidPointer(outputField)),
         UseCotanWeights, SolvingMethod, LogAlpha);
       break;
     case FieldType::DOUBLE:
       res = this->execute<double>(
-        *triangulation, nSources,
-        static_cast<ttk::SimplexId *>(ttkUtils::GetVoidPointer(vertsid)),
+        *triangulation, nSources, vertsid,
         static_cast<double *>(ttkUtils::GetVoidPointer(inputField)),
         static_cast<double *>(ttkUtils::GetVoidPointer(outputField)),
         UseCotanWeights, SolvingMethod, LogAlpha);

--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -130,8 +130,10 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   vtkDataArray *inputOffsets
     = this->GetOrderArray(domain, 0, 1, ForceInputOffsetScalarField);
 
-  vtkDataArray *inputIdentifiers = this->GetOptionalArray(
-    ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, seeds);
+  std::vector<SimplexId> idSpareStorage{};
+  auto *inputIdentifiers = this->GetIdentifierArrayPtr(
+    ForceInputVertexScalarField, 2, ttk::VertexScalarFieldName, seeds,
+    idSpareStorage);
 
   const SimplexId numberOfPointsInDomain = domain->GetNumberOfPoints();
   const SimplexId numberOfPointsInSeeds = seeds->GetNumberOfPoints();
@@ -179,7 +181,7 @@ int ttkIntegralLines::RequestData(vtkInformation *request,
   this->setInputOffsets(
     static_cast<SimplexId *>(inputOffsets->GetVoidPointer(0)));
 
-  this->setVertexIdentifierScalarField(inputIdentifiers->GetVoidPointer(0));
+  this->setVertexIdentifierScalarField(inputIdentifiers);
   this->setOutputTrajectories(&trajectories);
 
   this->preconditionTriangulation(triangulation);

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -87,8 +87,10 @@ int ttkTopologicalSimplification::RequestData(
   }
 
   // constraint identifier field
-  const auto identifiers = this->GetOptionalArray(
-    ForceInputVertexScalarField, 1, ttk::VertexScalarFieldName, constraints);
+  std::vector<SimplexId> idSpareStorage{};
+  const auto identifiers = this->GetIdentifierArrayPtr(
+    ForceInputVertexScalarField, 1, ttk::VertexScalarFieldName, constraints,
+    idSpareStorage);
 
   if(!identifiers) {
     this->printErr("Wrong vertex identifier scalar field.");
@@ -134,11 +136,6 @@ int ttkTopologicalSimplification::RequestData(
     return -10;
   }
 
-  if(identifiers->GetDataType() != offsets->GetDataType()) {
-    this->printErr("Type of identifiers and offsets are different.");
-    return -11;
-  }
-
   int ret{};
   if(this->UseLTS) {
     ttk::LocalizedTopologicalSimplification lts{};
@@ -157,8 +154,7 @@ int ttkTopologicalSimplification::RequestData(
          static_cast<TTK_TT *>(triangulation->getData()),
          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsets)),
-         static_cast<SimplexId *>(ttkUtils::GetVoidPointer(identifiers)),
-         numberOfConstraints, this->AddPerturbation)));
+         identifiers, numberOfConstraints, this->AddPerturbation)));
 
     // TODO: fix convention in original ttk module
     ret = !ret;
@@ -168,7 +164,7 @@ int ttkTopologicalSimplification::RequestData(
         ret = this->execute(
           static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
           static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
-          static_cast<SimplexId *>(ttkUtils::GetVoidPointer(identifiers)),
+          identifiers,
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsets)),
           static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
           numberOfConstraints, *triangulation->getData()));


### PR DESCRIPTION
The `ttkIdentifiers` filter is soon to be deprecated in favor of `GenerateIds`/`GenerateGlobalIds`. However, the latter generate `vtkIdTypeArrays` while `ttkIdentifiers` only generates a `ttkSimplexIdTypeArray` (an 32-bit `int` by default, instead of a 64-bit `long long`). Since the client filters (`HarmonicField`, `DistanceField`, `IntegralLines` and `TopologicalSimplification`) expect a SimplexId buffer, we can't replace `ttkIdentifiers` directly.

This PR introduces a new mechanism to ensure compatibility between the Identifiers array type. A new method, `ttkAlgorithm::GetIdentifierArrayPtr`, returns a `SimplexId` pointer to either the Identifier array or to a spare storage if the Identifier array is not a `ttkSimplexIdTypeArray`. This new method replicates the signature of `ttkAlgorithm::GetOptionalArray` plus the spare storage (a vector of SimplexIds).

The aforementioned client filters have been modified to use this new method instead of `GetOptionalArray`. Other filters that extract an identifier field from a Persistence Diagram or a Morse-Smale Complex have been left untouched.

No modification observed when running the ttk-data states.

Enjoy,
Pierre

