### PR TITLE
Remove assert using q.n

### DIFF
--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
@@ -723,7 +723,6 @@ int ttk::QuadrangulationSubdivision::subdivise(
   }
 
   for(auto &q : outputQuads_) {
-    assert(q.n == 4); // magic number...
 
     auto i = static_cast<size_t>(q[0]);
     auto j = static_cast<size_t>(q[1]);


### PR DESCRIPTION
Quad was reimplemented as `std::array` container in #592. It does not have a member named 'n'. 

