### PR TITLE
Fix #585

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vtkIdTypeArray.h>
-#include <vtkIntArray.h>
+class vtkIdTypeArray;
+class vtkIntArray;
 
 #define TTK_COMMA ,
 

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -1,15 +1,15 @@
 #include <OrderDisambiguation.h>
 #include <ttkArrayPreconditioning.h>
-
-#include <vtkInformation.h>
+#include <ttkMacros.h>
+#include <ttkUtils.h>
 
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
+#include <vtkIdTypeArray.h>
+#include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkPointData.h>
-
-#include <ttkMacros.h>
-#include <ttkUtils.h>
 
 #include <regex>
 

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -3,7 +3,9 @@
 #include <ttkUtils.h>
 
 #include <vtkCellData.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkLine.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>

--- a/core/vtk/ttkDistanceField/ttkDistanceField.cpp
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.cpp
@@ -1,6 +1,8 @@
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkPointSet.h>

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
@@ -4,6 +4,7 @@
 
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>
 

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -1,8 +1,10 @@
 #include <ttkIdentifierRandomizer.h>
 
 #include <vtkCellData.h>
+#include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 
 #include <ttkMacros.h>

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
@@ -1,12 +1,13 @@
 #include <ttkIdentifiers.h>
+#include <ttkMacros.h>
+#include <ttkUtils.h>
 
 #include <vtkCellData.h>
 #include <vtkDataSet.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkPointData.h>
-
-#include <ttkMacros.h>
-#include <ttkUtils.h>
 
 using namespace std;
 using namespace ttk;

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.cpp
@@ -1,19 +1,22 @@
 #include <numeric>
+
 #include <ttkIdentifyByScalarField.h>
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
 #include <vtkCellData.h>
 #include <vtkDataSet.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkPointData.h>
 
 using namespace std;
 using namespace ttk;
 
-vtkStandardNewMacro(ttkIdentifyByScalarField)
+vtkStandardNewMacro(ttkIdentifyByScalarField);
 
-  ttkIdentifyByScalarField::ttkIdentifyByScalarField() {
+ttkIdentifyByScalarField::ttkIdentifyByScalarField() {
   this->setDebugMsgPrefix("IdentifyByScalarField");
   SetNumberOfInputPorts(1);
   SetNumberOfOutputPorts(1);

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
@@ -6,6 +6,7 @@
 #include <ttkUtils.h>
 
 // VTK includes
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
 #include <vtkPointSet.h>
 #include <vtkTable.h>

--- a/core/vtk/ttkManifoldCheck/ttkManifoldCheck.cpp
+++ b/core/vtk/ttkManifoldCheck/ttkManifoldCheck.cpp
@@ -3,7 +3,9 @@
 #include <vtkCellData.h>
 #include <vtkDataSet.h>
 #include <vtkGenericCell.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkPointData.h>
 
 #include <ttkMacros.h>

--- a/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.cpp
+++ b/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.cpp
@@ -3,6 +3,7 @@
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -8,9 +8,9 @@
 #include <vtkDataSet.h>
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
-#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkSignedCharArray.h>

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.cpp
@@ -2,8 +2,8 @@
 #include <ttkMorseSmaleQuadrangulation.h>
 #include <ttkUtils.h>
 
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
-#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -2,14 +2,17 @@
 #include <ttkPersistenceCurve.h>
 #include <ttkUtils.h>
 
+#include <vtkIdTypeArray.h>
+#include <vtkIntArray.h>
+
 using namespace std;
 using namespace ttk;
 
 using namespace ftm;
 
-vtkStandardNewMacro(ttkPersistenceCurve)
+vtkStandardNewMacro(ttkPersistenceCurve);
 
-  ttkPersistenceCurve::ttkPersistenceCurve() {
+ttkPersistenceCurve::ttkPersistenceCurve() {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(4);
 }

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.cpp
@@ -4,8 +4,8 @@
 
 #include <vtkCellData.h>
 #include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
-#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -4,6 +4,7 @@
 
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkIntArray.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -2,8 +2,10 @@
 
 #include <Geometry.h>
 
+#include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 
 #include <ttkMacros.h>

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -3,8 +3,10 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
+#include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkInformation.h>
+#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 
 using namespace std;

--- a/core/vtk/ttkTableDataSelector/ttkTableDataSelector.cpp
+++ b/core/vtk/ttkTableDataSelector/ttkTableDataSelector.cpp
@@ -2,15 +2,17 @@
 #include <ttkTableDataSelector.h>
 #include <ttkUtils.h>
 
+#include <vtkObjectFactory.h>
+
 #include <regex>
 
 using namespace std;
 using namespace ttk;
 
-vtkStandardNewMacro(ttkTableDataSelector)
+vtkStandardNewMacro(ttkTableDataSelector);
 
-  int ttkTableDataSelector::FillInputPortInformation(int port,
-                                                     vtkInformation *info) {
+int ttkTableDataSelector::FillInputPortInformation(int port,
+                                                   vtkInformation *info) {
   if(port == 0) {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
     return 1;

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.cpp
@@ -5,9 +5,11 @@
 #include <vtkDataObject.h>
 #include <vtkDataSet.h>
 #include <vtkDoubleArray.h>
+#include <vtkIdTypeArray.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
+#include <vtkIntArray.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
 #include <vtkStreamingDemandDrivenPipeline.h>

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -8,6 +8,7 @@
 #include <vtkIdTypeArray.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkPointData.h>
 #include <vtkSignedCharArray.h>
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -1,8 +1,9 @@
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
+#include <vtkIdTypeArray.h>
 #include <vtkInformation.h>
+#include <vtkIntArray.h>
 #include <vtkNew.h>
-#include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
 #include <vtkSmartPointer.h>


### PR DESCRIPTION
This PR replaces the includes in `ttkMacros.h` with forward declarations. The includes were put back in the `.cpp` files when needed. It fixes #585.

No modification observed in the ttk-data states.

Enjoy,
Pierre