### PR TITLE
Do not modify input with FTM Tree

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -76,10 +76,12 @@ int ttkFTMTree::RequestData(vtkInformation *request,
     // This data set may have several connected components,
     // we need to apply the FTM Tree for each one of these components
     // We then reconstruct the global tree using an offest mecanism
-    identify(input);
+    auto inputWithId = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    inputWithId->ShallowCopy(input);
+    identify(inputWithId);
 
     vtkNew<vtkConnectivityFilter> connectivity{};
-    connectivity->SetInputData(input);
+    connectivity->SetInputData(inputWithId);
     connectivity->SetExtractionModeToAllRegions();
     connectivity->ColorRegionsOn();
     connectivity->Update();
@@ -106,8 +108,7 @@ int ttkFTMTree::RequestData(vtkInformation *request,
         connected_components_[cc]->ShallowCopy(threshold->GetOutput());
       }
     } else {
-      connected_components_[0] = vtkSmartPointer<vtkUnstructuredGrid>::New();
-      connected_components_[0]->ShallowCopy(input);
+      connected_components_[0] = inputWithId;
     }
   } else if(input->IsA("vtkPolyData")) {
     // NOTE: CC check should not be implemented on a per vtk module layer.


### PR DESCRIPTION
Dear Julien,

The way the FTM wrapper is done requires to add an identifier array on the data to process.
As noted in #570, the way it was done lead to a violation to the pipeline mechanism where FTM added a new array on the input (for unstructured meshes). This MR solve the issue.

Best,
Charles

fix #570


