### PR TITLE
GitHub Actions: Rollback to a tagged version of dsaltares/fetch-gh-release-asset

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,7 +79,7 @@ jobs:
           zlib1g-dev \
           clang-tidy
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: "topology-tool-kit/ttk-paraview"
         version: "tags/v5.8.1"
@@ -137,7 +137,7 @@ jobs:
           zlib1g-dev \
           clang-tools
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: "topology-tool-kit/ttk-paraview"
         version: "tags/v5.8.1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           ../zfp
         sudo make -j$(nproc) install
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: "topology-tool-kit/ttk-paraview"
         version: "tags/v5.8.1"
@@ -119,7 +119,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: "topology-tool-kit/ttk-paraview"
         version: "tags/v5.8.1"


### PR DESCRIPTION
A recent commit in the `dsaltares/fetch-gh-release-asset` repository broke the Action. This PR switch from tracking the `master` branch to an older tagged version to get the working code back.

Enjoy,
Pierre