### PR TITLE
Remove GCC 11 from the GitHub Actions CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,6 +78,8 @@ jobs:
     - name: Install Ubuntu dependencies
       run: |
         sudo apt update
+        # workaround: remove GCC 11
+        sudo apt purge gcc-11 libgcc-11-dev libgfortran-11-dev libstdc++-11-dev
         # TTK dependencies
         sudo apt install -y \
           libboost-system-dev \
@@ -145,6 +147,8 @@ jobs:
     - name: Install Ubuntu dependencies
       run: |
         sudo apt update
+        # workaround: remove GCC 11
+        sudo apt purge gcc-11 libgcc-11-dev libgfortran-11-dev libstdc++-11-dev
         # TTK dependencies
         sudo apt install -y \
           libboost-system-dev \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,8 @@ jobs:
   # ------------- #
   lint-code:
     runs-on: ubuntu-20.04
+    env:
+      CLANG_TIDY: clang-tidy-11
     strategy:
       matrix:
         config:
@@ -83,7 +85,7 @@ jobs:
           graphviz \
           python3-sklearn \
           zlib1g-dev \
-          clang-tidy
+          $CLANG_TIDY
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
@@ -113,7 +115,7 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 clang-tidy -p build 2> /dev/null
+        | xargs -n1 $CLANG_TIDY -p build 2> /dev/null
 
     - name: Use Clang static analyzer [NOT ENFORCED]
       if: matrix.config.sa
@@ -121,7 +123,7 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 clang-tidy -p build --checks="-*,clang-analyzer-*" 2> /dev/null
+        | xargs -n1 $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" 2> /dev/null
 
 
   # ----------------------- #
@@ -150,7 +152,7 @@ jobs:
           graphviz \
           python3-sklearn \
           zlib1g-dev \
-          clang-tools
+          clang-tools-11
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
@@ -182,4 +184,4 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs clang-check -p build --extra-arg=-Werror
+        | xargs clang-check-11 -p build --extra-arg=-Werror

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -127,7 +127,7 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" 2> /dev/null
+        | xargs -n1 -P2 $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" 2> /dev/null
 
 
   # ----------------------- #

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,12 @@ jobs:
   # ------------- #
   lint-code:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        config:
+          - {tidy: true, sa: false}
+          - {tidy: false, sa: true}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -102,11 +108,20 @@ jobs:
           $GITHUB_WORKSPACE
 
     - name: Use clang-tidy to lint code [NOT ENFORCED]
+      if: matrix.config.tidy
       run: |
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
         | xargs -n1 clang-tidy -p build 2> /dev/null
+
+    - name: Use Clang static analyzer [NOT ENFORCED]
+      if: matrix.config.sa
+      run: |
+        git ls-files \
+        | grep core \
+        | grep -E "\.cpp$|\.cxx$" \
+        | xargs -n1 clang-tidy -p build --checks="-*,clang-analyzer-*" 2> /dev/null
 
 
   # ----------------------- #

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,30 +26,15 @@ jobs:
       CLANG_FORMAT: clang-format-11
     steps:
     - uses: actions/checkout@v2
+
     - name: Install latest clang-format
       run: |
         sudo apt update
         sudo apt install -y $CLANG_FORMAT
+
     - name: Use clang-format to detect formatting issues
       run: |
         git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs $CLANG_FORMAT -n -Werror
-
-
-  # ------------- #
-  # Code lint job #
-  # ------------- #
-  lint-code:
-    runs-on: ubuntu-20.04
-    env:
-      CLANG_TIDY: clang-tidy-11
-    strategy:
-      matrix:
-        config:
-          - {tidy: true, sa: false}
-          - {tidy: false, sa: true}
-
-    steps:
-    - uses: actions/checkout@v2
 
     - name: Check line endings (Unix rather than DOS)
       run: |
@@ -72,6 +57,23 @@ jobs:
     - name: Check for empty files
       run: |
         ! git ls-files | xargs file | grep empty
+
+
+  # ------------- #
+  # Code lint job #
+  # ------------- #
+  lint-code:
+    runs-on: ubuntu-20.04
+    env:
+      CLANG_TIDY: clang-tidy-11
+    strategy:
+      matrix:
+        config:
+          - {tidy: true, sa: false}
+          - {tidy: false, sa: true}
+
+    steps:
+    - uses: actions/checkout@v2
 
     - name: Install Ubuntu dependencies
       run: |


### PR DESCRIPTION
GCC 11 just arrived in the GitHub Actions `ubuntu-latest` virtual environment and it broke everything…

An include has been removed in a `libstdc++` header, I think, causing domino effect build errors: a VTK header is missing the `limits` include and, as a consequence, TTK fails to build (see #611 CI jobs).

To alleviate this issue, this PR removes GCC 11 (compiler, headers + libraries) from these CI jobs. This should work for the time being (but does not fix the underlying compatibility issue with GCC 11).

As a bonus, this PR sets a fixed version of `clang-check` and `clang-tidy`. And also introduces a new job for performing static analysis, also via `clang-tidy` (informational only).

Enjoy,
Pierre
