### PR TITLE
Fix GCC 11 missing includes

### DIFF
--- a/core/base/continuousScatterPlot/ContinuousScatterPlot.h
+++ b/core/base/continuousScatterPlot/ContinuousScatterPlot.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <limits>
+
 // base code includes
 #include <Geometry.h>
 #include <Triangulation.h>

--- a/core/base/dijkstra/Dijkstra.h
+++ b/core/base/dijkstra/Dijkstra.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <functional>
+#include <limits>
 #include <queue>
 
 namespace ttk {

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -18,6 +18,7 @@
 #include <Triangulation.h>
 
 // std includes
+#include <limits>
 #include <unordered_set>
 
 namespace ttk {


### PR DESCRIPTION
As a follow-up to #612, this PR adds missing `<limits>` header includes that cause build errors with the brand new GCC 11.

Still, this is not enough to build the VTK layer: this include is still missing in the `vtkGenericDataArrayLookupHelper.h` header in the ParaView installation prefix. The other source files listed in https://gitlab.kitware.com/vtk/vtk/-/issues/18194 may also have to be modified to allow ParaView to build without errors.

For now, I am waiting to see how this will be handled in the ParaView side (v5.9.1, released two days ago, still seems to be affected) to avoid providing ParaView patches ourselves.

Enjoy,
Pierre

