### PR TITLE
MorseSmaleComplex: Fix boundary critical points numbering on separatrices

### DIFF
--- a/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
+++ b/core/base/abstractMorseSmaleComplex/AbstractMorseSmaleComplex.h
@@ -656,13 +656,8 @@ int ttk::AbstractMorseSmaleComplex::setSeparatrices1(
 
     // get boundary condition
     const auto onBoundary
-      = saddleConnector
-          ? static_cast<char>(
-            discreteGradient_.isBoundary(src, triangulation)
-            && discreteGradient_.isBoundary(dst, triangulation))
-          : static_cast<char>(discreteGradient_.isBoundary(src, triangulation))
-              + static_cast<char>(
-                discreteGradient_.isBoundary(dst, triangulation));
+      = static_cast<char>(discreteGradient_.isBoundary(src, triangulation))
+        + static_cast<char>(discreteGradient_.isBoundary(dst, triangulation));
 
     for(size_t j = 0; j < sepGeom.size(); ++j) {
       const auto &cell = sepGeom[j];

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -258,8 +258,9 @@ int ttk::MorseSmaleComplex3D::setAscendingSeparatrices2(
     const char onBoundary
       = std::count_if(sepSaddles.begin(), sepSaddles.end(),
                       [&triangulation](const SimplexId a) {
-                        return triangulation.isEdgeOnBoundary(a);
-                      });
+                        return triangulation.isTriangleOnBoundary(a);
+                      })
+        + triangulation.isEdgeOnBoundary(src.id_);
 
     sepIds[i] = sepId;
     sepSourceIds[i] = src.id_;
@@ -524,7 +525,8 @@ int ttk::MorseSmaleComplex3D::setDescendingSeparatrices2(
       = std::count_if(sepSaddles.begin(), sepSaddles.end(),
                       [&triangulation](const SimplexId a) {
                         return triangulation.isEdgeOnBoundary(a);
-                      });
+                      })
+        + triangulation.isTriangleOnBoundary(src.id_);
 
     for(size_t j = 0; j < sepGeom.size(); ++j) {
       const auto &cell = sepGeom[j];


### PR DESCRIPTION
This PR fixes the numbering of boundary critical points on 1- and 2-separatrices.
Previously, saddle connectors were treated separately from ascending and descending 1-separatrices. 
For 2-separatrices, the source was not counted.

The ttk-data morseMolecule is affected by this change. A PR is coming soon.

Enjoy,
Pierre