### PR TITLE
ContourTreeAlignment: Use shared_ptr references to boost performance

### DIFF
--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -1,10 +1,5 @@
 #include "ContourTreeAlignment.h"
 
-#include "float.h"
-#include <algorithm>
-#include <limits.h>
-#include <list>
-
 ///=====================================================================================================================
 /// branch decomposition
 ///=====================================================================================================================
@@ -527,6 +522,10 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
   currNode = std::shared_ptr<AlignmentNode>(new AlignmentNode());
 
+  if(res->node1 == nullptr && res->node2 == nullptr) {
+    return;
+  }
+
   currNode->freq = (res->node1 == nullptr ? 0 : res->node1->freq)
                    + (res->node2 == nullptr ? 0 : res->node2->freq);
   currNode->type = res->node1 == nullptr ? res->node2->type : res->node1->type;
@@ -602,6 +601,11 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
     // type 'rootNode' not possible, otherwise has to be catched
 
     if(currTree->child1 != nullptr) {
+
+      if(currTree->child1->node1 == nullptr
+         && currTree->child1->node2 == nullptr) {
+        continue;
+      }
 
       std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
 
@@ -776,6 +780,11 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
     }
 
     if(currTree->child2 != nullptr) {
+
+      if(currTree->child2->node1 == nullptr
+         && currTree->child2->node2 == nullptr) {
+        continue;
+      }
 
       std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
 
@@ -1193,11 +1202,11 @@ float ttk::ContourTreeAlignment::editCost(
   const std::shared_ptr<BinaryTree> &t2) {
 
   float v1 = 0, v2 = 0;
-  if(t1 != nullptr)
+  if(t1.get() != nullptr)
     v1 = arcMatchMode == persistence ? t1->scalardistanceParent
          : arcMatchMode == area      ? t1->area
                                      : t1->volume;
-  if(t2 != nullptr)
+  if(t2.get() != nullptr)
     v2 = arcMatchMode == persistence ? t2->scalardistanceParent
          : arcMatchMode == area      ? t2->area
                                      : t2->volume;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -43,7 +43,7 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
       std::shared_ptr<AlignmentNode> currNode = path[i];
 
-      for(std::shared_ptr<AlignmentEdge> cE : currNode->edgeList) {
+      for(const auto &cE : currNode->edgeList) {
 
         std::shared_ptr<AlignmentNode> cN = (cE->node1.lock()) == currNode
                                               ? cE->node2.lock()
@@ -73,7 +73,7 @@ void ttk::ContourTreeAlignment::computeBranches() {
       currNode->branchID = currID;
     }
 
-    for(std::shared_ptr<AlignmentEdge> cE : path.back()->edgeList) {
+    for(const auto &cE : path.back()->edgeList) {
 
       std::shared_ptr<AlignmentNode> cN
         = cE->node1.lock() == path.back() ? cE->node2.lock() : cE->node1.lock();
@@ -103,8 +103,9 @@ void ttk::ContourTreeAlignment::computeBranches() {
 }
 
 std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-  ttk::ContourTreeAlignment::pathToMax(std::shared_ptr<AlignmentNode> root,
-                                       std::shared_ptr<AlignmentNode> parent) {
+  ttk::ContourTreeAlignment::pathToMax(
+    const std::shared_ptr<AlignmentNode> &root,
+    const std::shared_ptr<AlignmentNode> &parent) {
 
   std::vector<std::shared_ptr<AlignmentNode>> path;
   path.push_back(root);
@@ -116,7 +117,7 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   std::vector<std::shared_ptr<AlignmentNode>> bestPath;
   float bestVal = -FLT_MAX;
 
-  for(std::shared_ptr<AlignmentEdge> cE : root->edgeList) {
+  for(const auto &cE : root->edgeList) {
 
     std::shared_ptr<AlignmentNode> nextNode
       = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
@@ -138,8 +139,9 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
 }
 
 std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-  ttk::ContourTreeAlignment::pathToMin(std::shared_ptr<AlignmentNode> root,
-                                       std::shared_ptr<AlignmentNode> parent) {
+  ttk::ContourTreeAlignment::pathToMin(
+    const std::shared_ptr<AlignmentNode> &root,
+    const std::shared_ptr<AlignmentNode> &parent) {
 
   std::vector<std::shared_ptr<AlignmentNode>> path;
   path.push_back(root);
@@ -151,7 +153,7 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   std::vector<std::shared_ptr<AlignmentNode>> bestPath;
   float bestVal = FLT_MAX;
 
-  for(std::shared_ptr<AlignmentEdge> cE : root->edgeList) {
+  for(const auto &cE : root->edgeList) {
 
     std::shared_ptr<AlignmentNode> nextNode
       = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
@@ -176,7 +178,8 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
 /// iterated aligning
 ///=====================================================================================================================
 
-bool ttk::ContourTreeAlignment::initialize(std::shared_ptr<ContourTree> ct) {
+bool ttk::ContourTreeAlignment::initialize(
+  const std::shared_ptr<ContourTree> &ct) {
 
   contourtrees.push_back(ct);
 
@@ -274,7 +277,7 @@ bool ttk::ContourTreeAlignment::initialize(std::shared_ptr<ContourTree> ct) {
 }
 
 bool ttk::ContourTreeAlignment::initialize_consistentRoot(
-  std::shared_ptr<ContourTree> ct, int rootIdx) {
+  const std::shared_ptr<ContourTree> &ct, int rootIdx) {
 
   // cancel computation if tree is not binary
   if(!ct->isBinary())
@@ -388,7 +391,8 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
   return true;
 }
 
-bool ttk::ContourTreeAlignment::alignTree(std::shared_ptr<ContourTree> ct) {
+bool ttk::ContourTreeAlignment::alignTree(
+  const std::shared_ptr<ContourTree> &ct) {
 
   contourtrees.push_back(ct);
 
@@ -409,13 +413,13 @@ bool ttk::ContourTreeAlignment::alignTree(std::shared_ptr<ContourTree> ct) {
   int i = 0;
   int j = 0;
 
-  for(std::shared_ptr<AlignmentNode> node1 : nodes1) {
+  for(const auto &node1 : nodes1) {
 
     t1 = this->rootAtNode(node1);
 
     j = 0;
 
-    for(std::shared_ptr<CTNode> node2 : nodes2) {
+    for(const auto &node2 : nodes2) {
 
       t2 = ct->rootAtNode(node2);
 
@@ -450,7 +454,7 @@ bool ttk::ContourTreeAlignment::alignTree(std::shared_ptr<ContourTree> ct) {
 }
 
 bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
-  std::shared_ptr<ContourTree> ct) {
+  const std::shared_ptr<ContourTree> &ct) {
 
   // cancel computation if tree not binary
   if(!ct->isBinary())
@@ -471,7 +475,7 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 
   t1 = this->rootAtNode(alignmentRoot);
 
-  for(std::shared_ptr<CTNode> node2 : nodes2) {
+  for(const auto &node2 : nodes2) {
 
     // compute matching
 
@@ -507,7 +511,7 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 }
 
 void ttk::ContourTreeAlignment::computeNewAlignmenttree(
-  std::shared_ptr<AlignmentTree> res) {
+  const std::shared_ptr<AlignmentTree> &res) {
 
   nodes.clear();
   arcs.clear();
@@ -732,7 +736,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
       if(currTree->child1->node1 != nullptr) {
-        for(std::shared_ptr<AlignmentEdge> e : openEdgesOld1) {
+        for(const auto &e : openEdgesOld1) {
           e->arcRefs.insert(e->arcRefs.end(),
                             currTree->child1->node1->arcRefs.begin(),
                             currTree->child1->node1->arcRefs.end());
@@ -744,7 +748,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
       } else
         openEdgesOld1.push_back(childEdge);
       if(currTree->child1->node2 != nullptr) {
-        for(std::shared_ptr<AlignmentEdge> e : openEdgesNew1) {
+        for(const auto &e : openEdgesNew1) {
           e->arcRefs.push_back(
             std::make_pair((int)contourtrees.size() - 1,
                            currTree->child1->node2->arcRefs[0].second));
@@ -906,7 +910,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
       if(currTree->child2->node1 != nullptr) {
-        for(std::shared_ptr<AlignmentEdge> e : openEdgesOld2) {
+        for(const auto &e : openEdgesOld2) {
           e->arcRefs.insert(e->arcRefs.end(),
                             currTree->child2->node1->arcRefs.begin(),
                             currTree->child2->node1->arcRefs.end());
@@ -918,7 +922,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
       } else
         openEdgesOld2.push_back(childEdge);
       if(currTree->child2->node2 != nullptr) {
-        for(std::shared_ptr<AlignmentEdge> e : openEdgesNew1) {
+        for(const auto &e : openEdgesNew1) {
           e->arcRefs.push_back(
             std::make_pair((int)contourtrees.size() - 1,
                            currTree->child2->node2->arcRefs[0].second));
@@ -954,7 +958,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
 int ttk::ContourTreeAlignment::getAlignmentRootIdx() {
   int idx = 0;
-  for(auto node : nodes) {
+  for(const auto &node : nodes) {
     if(node == alignmentRoot)
       break;
     idx++;
@@ -976,7 +980,7 @@ std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
                         std::vector<std::shared_ptr<CTEdge>>>>
     trees_simplified;
 
-  for(std::shared_ptr<ContourTree> ct : contourtrees) {
+  for(const auto &ct : contourtrees) {
     trees_simplified.push_back(ct->getGraph());
   }
 
@@ -995,7 +999,7 @@ std::shared_ptr<BinaryTree>
 
   std::shared_ptr<AlignmentNode> root = nodes[0];
   float maxScalar = FLT_MIN;
-  for(std::shared_ptr<AlignmentNode> node : nodes) {
+  for(const auto &node : nodes) {
 
     // if(node->type==maxNode && node->edgeList[0]->scalardistance > maxRange){
     if(node->scalarValue > maxScalar) {
@@ -1013,7 +1017,8 @@ std::shared_ptr<BinaryTree>
 
 std::pair<float, std::shared_ptr<AlignmentTree>>
   ttk::ContourTreeAlignment::getAlignmentBinary(
-    std::shared_ptr<BinaryTree> t1, std::shared_ptr<BinaryTree> t2) {
+    const std::shared_ptr<BinaryTree> &t1,
+    const std::shared_ptr<BinaryTree> &t2) {
 
   // initialize memoization tables
   std::vector<std::vector<float>> memT(
@@ -1031,8 +1036,8 @@ std::pair<float, std::shared_ptr<AlignmentTree>>
 }
 
 float ttk::ContourTreeAlignment::alignTreeBinary(
-  std::shared_ptr<BinaryTree> t1,
-  std::shared_ptr<BinaryTree> t2,
+  const std::shared_ptr<BinaryTree> &t1,
+  const std::shared_ptr<BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1105,8 +1110,8 @@ float ttk::ContourTreeAlignment::alignTreeBinary(
 }
 
 float ttk::ContourTreeAlignment::alignForestBinary(
-  std::shared_ptr<BinaryTree> t1,
-  std::shared_ptr<BinaryTree> t2,
+  const std::shared_ptr<BinaryTree> &t1,
+  const std::shared_ptr<BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1183,8 +1188,9 @@ float ttk::ContourTreeAlignment::alignForestBinary(
   }
 }
 
-float ttk::ContourTreeAlignment::editCost(std::shared_ptr<BinaryTree> t1,
-                                          std::shared_ptr<BinaryTree> t2) {
+float ttk::ContourTreeAlignment::editCost(
+  const std::shared_ptr<BinaryTree> &t1,
+  const std::shared_ptr<BinaryTree> &t2) {
 
   float v1 = 0, v2 = 0;
   if(t1 != nullptr)
@@ -1273,8 +1279,8 @@ float ttk::ContourTreeAlignment::editCost(std::shared_ptr<BinaryTree> t1,
 }
 
 std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
-  std::shared_ptr<BinaryTree> t1,
-  std::shared_ptr<BinaryTree> t2,
+  const std::shared_ptr<BinaryTree> &t1,
+  const std::shared_ptr<BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1284,7 +1290,7 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
     return traceNullAlignment(t1, true);
 
   auto id
-    = [](std::shared_ptr<BinaryTree> t) { return t == nullptr ? 0 : t->id; };
+    = [](std::shared_ptr<BinaryTree> &t) { return t == nullptr ? 0 : t->id; };
 
   if(memT[t1->id][t2->id] == editCost(t1, t2) + memF[t1->id][t2->id]) {
 
@@ -1305,7 +1311,7 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
     if(resChildren.size() > 1)
       resNode->child2 = resChildren[1];
 
-    for(std::shared_ptr<AlignmentTree> child : resChildren) {
+    for(const auto &child : resChildren) {
 
       if(child != nullptr) {
         resNode->height = std::max(resNode->height, child->height + 1);
@@ -1423,8 +1429,8 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
 
 std::vector<std::shared_ptr<AlignmentTree>>
   ttk::ContourTreeAlignment::traceAlignmentForest(
-    std::shared_ptr<BinaryTree> t1,
-    std::shared_ptr<BinaryTree> t2,
+    const std::shared_ptr<BinaryTree> &t1,
+    const std::shared_ptr<BinaryTree> &t2,
     std::vector<std::vector<float>> &memT,
     std::vector<std::vector<float>> &memF) {
 
@@ -1445,8 +1451,9 @@ std::vector<std::shared_ptr<AlignmentTree>>
       res.push_back(traceNullAlignment(t1->child2, true));
   }
 
-  auto id
-    = [](std::shared_ptr<BinaryTree> t) { return t == nullptr ? 0 : t->id; };
+  auto id = [](const std::shared_ptr<BinaryTree> &t) {
+    return t == nullptr ? 0 : t->id;
+  };
 
   if(memF[t1->id][t2->id]
      == memT[id(t1->child1)][id(t2->child1)]
@@ -1507,7 +1514,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       if(resChildren.size() > 1)
         t->child2 = resChildren[1];
 
-      for(std::shared_ptr<AlignmentTree> c : resChildren) {
+      for(const auto &c : resChildren) {
         if(c != nullptr) {
           t->height = std::max(t->height, c->height + 1);
           t->size += c->size;
@@ -1547,7 +1554,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       if(resChildren.size() > 1)
         t->child2 = resChildren[1];
 
-      for(std::shared_ptr<AlignmentTree> c : resChildren) {
+      for(const auto &c : resChildren) {
         if(c != nullptr) {
           t->height = std::max(t->height, c->height + 1);
           t->size += c->size;
@@ -1587,7 +1594,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       if(resChildren.size() > 1)
         t->child2 = resChildren[1];
 
-      for(std::shared_ptr<AlignmentTree> c : resChildren) {
+      for(const auto &c : resChildren) {
         if(c != nullptr) {
           t->height = std::max(t->height, c->height + 1);
           t->size += c->size;
@@ -1627,7 +1634,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       if(resChildren.size() > 1)
         t->child2 = resChildren[1];
 
-      for(std::shared_ptr<AlignmentTree> c : resChildren) {
+      for(const auto &c : resChildren) {
         if(c != nullptr) {
           t->height = std::max(t->height, c->height + 1);
           t->size += c->size;
@@ -1647,9 +1654,8 @@ std::vector<std::shared_ptr<AlignmentTree>>
   return std::vector<std::shared_ptr<AlignmentTree>>();
 }
 
-std::shared_ptr<AlignmentTree>
-  ttk::ContourTreeAlignment::traceNullAlignment(std::shared_ptr<BinaryTree> t,
-                                                bool first) {
+std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceNullAlignment(
+  const std::shared_ptr<BinaryTree> &t, bool first) {
 
   if(t == nullptr)
     return nullptr;
@@ -1667,21 +1673,21 @@ std::shared_ptr<AlignmentTree>
 /// helper functions
 ///=====================================================================================================================
 
-bool ttk::ContourTreeAlignment::isBinary(std::shared_ptr<Tree> t) {
+bool ttk::ContourTreeAlignment::isBinary(const std::shared_ptr<Tree> &t) {
 
   if(t->children.size() > 2)
     return false;
   else {
     bool res = true;
-    for(std::shared_ptr<Tree> c : t->children) {
+    for(const auto &c : t->children) {
       res = res & isBinary(c);
     }
     return res;
   }
 }
 
-std::shared_ptr<BinaryTree>
-  ttk::ContourTreeAlignment::rootAtNode(std::shared_ptr<AlignmentNode> root) {
+std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::rootAtNode(
+  const std::shared_ptr<AlignmentNode> &root) {
 
   int id = 1;
   std::shared_ptr<BinaryTree> t = computeRootedTree(root, nullptr, id);
@@ -1689,8 +1695,8 @@ std::shared_ptr<BinaryTree>
 }
 
 std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
-  std::shared_ptr<AlignmentNode> node,
-  std::shared_ptr<AlignmentEdge> parent,
+  const std::shared_ptr<AlignmentNode> &node,
+  const std::shared_ptr<AlignmentEdge> &parent,
   int &id) {
 
   std::shared_ptr<BinaryTree> t(new BinaryTree);
@@ -1724,7 +1730,7 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
 
   std::vector<std::shared_ptr<BinaryTree>> children;
 
-  for(std::shared_ptr<AlignmentEdge> edge : node->edgeList) {
+  for(const auto &edge : node->edgeList) {
 
     if(edge != parent) {
 
@@ -1747,7 +1753,7 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
 }
 
 std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
-  std::shared_ptr<AlignmentEdge> arc, bool parent1, int &id) {
+  const std::shared_ptr<AlignmentEdge> &arc, bool parent1, int &id) {
 
   std::shared_ptr<BinaryTree> t(new BinaryTree);
 
@@ -1776,7 +1782,7 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
   std::shared_ptr<AlignmentNode> node
     = parent1 ? arc->node2.lock() : arc->node1.lock();
 
-  for(std::shared_ptr<AlignmentEdge> edge : node->edgeList) {
+  for(const auto &edge : node->edgeList) {
 
     if(edge != arc) {
 

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -126,10 +126,11 @@ namespace ttk {
                 int seed);
 
     /// functions for aligning single trees in iteration
-    bool alignTree(std::shared_ptr<ContourTree> t);
-    bool initialize(std::shared_ptr<ContourTree> t);
-    bool alignTree_consistentRoot(std::shared_ptr<ContourTree> t);
-    bool initialize_consistentRoot(std::shared_ptr<ContourTree> t, int rootIdx);
+    bool alignTree(const std::shared_ptr<ContourTree> &t);
+    bool initialize(const std::shared_ptr<ContourTree> &t);
+    bool alignTree_consistentRoot(const std::shared_ptr<ContourTree> &t);
+    bool initialize_consistentRoot(const std::shared_ptr<ContourTree> &t,
+                                   int rootIdx);
 
     /// getters for graph data structures
     std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
@@ -145,8 +146,8 @@ namespace ttk {
 
     /// function for aligning two sarbitrary binary trees
     std::pair<float, std::shared_ptr<AlignmentTree>>
-      getAlignmentBinary(std::shared_ptr<BinaryTree> t1,
-                         std::shared_ptr<BinaryTree> t2);
+      getAlignmentBinary(const std::shared_ptr<BinaryTree> &t1,
+                         const std::shared_ptr<BinaryTree> &t2);
 
     /// function that adds branch decomposition information
     void computeBranches();
@@ -172,52 +173,53 @@ namespace ttk {
 
     /// functions for aligning two trees (computing the alignment value and
     /// memoization matrix)
-    float alignTreeBinary(std::shared_ptr<BinaryTree> t1,
-                          std::shared_ptr<BinaryTree> t2,
+    float alignTreeBinary(const std::shared_ptr<BinaryTree> &t1,
+                          const std::shared_ptr<BinaryTree> &t2,
                           std::vector<std::vector<float>> &memT,
                           std::vector<std::vector<float>> &memF);
-    float alignForestBinary(std::shared_ptr<BinaryTree> t1,
-                            std::shared_ptr<BinaryTree> t2,
+    float alignForestBinary(const std::shared_ptr<BinaryTree> &t1,
+                            const std::shared_ptr<BinaryTree> &t2,
                             std::vector<std::vector<float>> &memT,
                             std::vector<std::vector<float>> &memF);
 
     /// functions for the traceback of the alignment computation (computing the
     /// actual alignment tree)
     std::shared_ptr<AlignmentTree>
-      traceAlignmentTree(std::shared_ptr<BinaryTree> t1,
-                         std::shared_ptr<BinaryTree> t2,
+      traceAlignmentTree(const std::shared_ptr<BinaryTree> &t1,
+                         const std::shared_ptr<BinaryTree> &t2,
                          std::vector<std::vector<float>> &memT,
                          std::vector<std::vector<float>> &memF);
     std::vector<std::shared_ptr<AlignmentTree>>
-      traceAlignmentForest(std::shared_ptr<BinaryTree> t1,
-                           std::shared_ptr<BinaryTree> t2,
+      traceAlignmentForest(const std::shared_ptr<BinaryTree> &t1,
+                           const std::shared_ptr<BinaryTree> &t2,
                            std::vector<std::vector<float>> &memT,
                            std::vector<std::vector<float>> &memF);
     std::shared_ptr<AlignmentTree>
-      traceNullAlignment(std::shared_ptr<BinaryTree> t, bool first);
+      traceNullAlignment(const std::shared_ptr<BinaryTree> &t, bool first);
 
     /// function that defines the local editing costs of two nodes
-    float editCost(std::shared_ptr<BinaryTree> t1,
-                   std::shared_ptr<BinaryTree> t2);
+    float editCost(const std::shared_ptr<BinaryTree> &t1,
+                   const std::shared_ptr<BinaryTree> &t2);
 
     /// helper functions for tree data structures
-    bool isBinary(std::shared_ptr<Tree> t);
-    std::shared_ptr<BinaryTree> rootAtNode(std::shared_ptr<AlignmentNode> root);
+    bool isBinary(const std::shared_ptr<Tree> &t);
     std::shared_ptr<BinaryTree>
-      computeRootedTree(std::shared_ptr<AlignmentNode> node,
-                        std::shared_ptr<AlignmentEdge> parent,
+      rootAtNode(const std::shared_ptr<AlignmentNode> &root);
+    std::shared_ptr<BinaryTree>
+      computeRootedTree(const std::shared_ptr<AlignmentNode> &node,
+                        const std::shared_ptr<AlignmentEdge> &parent,
                         int &id);
     std::shared_ptr<BinaryTree> computeRootedDualTree(
-      std::shared_ptr<AlignmentEdge> arc, bool parent1, int &id);
-    void computeNewAlignmenttree(std::shared_ptr<AlignmentTree> res);
+      const std::shared_ptr<AlignmentEdge> &arc, bool parent1, int &id);
+    void computeNewAlignmenttree(const std::shared_ptr<AlignmentTree> &res);
 
     /// helper functions for branch decomposition
     std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-      pathToMax(std::shared_ptr<AlignmentNode> root,
-                std::shared_ptr<AlignmentNode> parent);
+      pathToMax(const std::shared_ptr<AlignmentNode> &root,
+                const std::shared_ptr<AlignmentNode> &parent);
     std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-      pathToMin(std::shared_ptr<AlignmentNode> root,
-                std::shared_ptr<AlignmentNode> parent);
+      pathToMin(const std::shared_ptr<AlignmentNode> &root,
+                const std::shared_ptr<AlignmentNode> &parent);
   };
 } // namespace ttk
 
@@ -303,7 +305,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     }
     for(size_t i = 0; i < nTrees; i++) {
       int sum = 0;
-      for(auto seg : segRegions[i]) {
+      for(const auto &seg : segRegions[i]) {
         sum += seg.size();
       }
       this->printMsg("Tree " + std::to_string(i)
@@ -463,7 +465,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
   this->printMsg("Writing output pointers", 0, timer.getElapsedTime(),
                  debug::LineMode::REPLACE);
 
-  for(std::shared_ptr<AlignmentNode> node : nodes) {
+  for(const auto &node : nodes) {
 
     outputVertices.push_back(node->scalarValue);
     outputFrequencies.push_back(node->freq);
@@ -485,10 +487,10 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     }
   }
 
-  for(std::shared_ptr<AlignmentEdge> edge : arcs) {
+  for(const auto &edge : arcs) {
 
     int i = 0;
-    for(std::shared_ptr<AlignmentNode> node : nodes) {
+    for(const auto &node : nodes) {
 
       if(node == edge->node1.lock()) {
         outputEdges.push_back(i);

--- a/core/base/contourTreeAlignment/contourtree.cpp
+++ b/core/base/contourTreeAlignment/contourtree.cpp
@@ -49,7 +49,7 @@ ContourTree::ContourTree(float *scalars,
     j += 2;
   }
 
-  for(std::shared_ptr<CTNode> node : nodes) {
+  for(const std::shared_ptr<CTNode> &node : nodes) {
     if(node->edgeList.size() == 0)
       std::cout << "wtf?\n" << std::flush;
     if(node->edgeList.size() > 1)
@@ -67,7 +67,7 @@ ContourTree::ContourTree(float *scalars,
   }
 
   binary = true;
-  for(std::shared_ptr<CTNode> node : nodes) {
+  for(const std::shared_ptr<CTNode> &node : nodes) {
     if(node->edgeList.size() > 3)
       binary = false;
   }
@@ -76,8 +76,10 @@ ContourTree::ContourTree(float *scalars,
 ContourTree::~ContourTree() {
 }
 
-std::shared_ptr<Tree> ContourTree::computeRootedTree(
-  std::shared_ptr<CTNode> node, std::shared_ptr<CTEdge> parent, int &id) {
+std::shared_ptr<Tree>
+  ContourTree::computeRootedTree(const std::shared_ptr<CTNode> &node,
+                                 const std::shared_ptr<CTEdge> &parent,
+                                 int &id) {
 
   // initialize tree
   std::shared_ptr<Tree> t(new Tree);
@@ -138,8 +140,10 @@ std::shared_ptr<Tree> ContourTree::computeRootedTree(
   return t;
 }
 
-std::shared_ptr<BinaryTree> ContourTree::computeRootedTree_binary(
-  std::shared_ptr<CTNode> node, std::shared_ptr<CTEdge> parent, int &id) {
+std::shared_ptr<BinaryTree>
+  ContourTree::computeRootedTree_binary(const std::shared_ptr<CTNode> &node,
+                                        const std::shared_ptr<CTEdge> &parent,
+                                        int &id) {
 
   // initialize tree
   std::shared_ptr<BinaryTree> t(new BinaryTree);
@@ -225,7 +229,7 @@ std::shared_ptr<BinaryTree> ContourTree::rootAtMax() {
   float maxVal = -FLT_MAX;
   std::shared_ptr<CTNode> globalMax = nullptr;
 
-  for(std::shared_ptr<CTNode> node : nodes) {
+  for(const std::shared_ptr<CTNode> &node : nodes) {
     if(node->scalarValue > maxVal) {
       globalMax = node;
       maxVal = node->scalarValue;
@@ -238,7 +242,7 @@ std::shared_ptr<BinaryTree> ContourTree::rootAtMax() {
 }
 
 std::shared_ptr<BinaryTree>
-  ContourTree::rootAtNode(std::shared_ptr<CTNode> root) {
+  ContourTree::rootAtNode(const std::shared_ptr<CTNode> &root) {
 
   int id = 1;
 

--- a/core/base/contourTreeAlignment/contourtree.h
+++ b/core/base/contourTreeAlignment/contourtree.h
@@ -97,7 +97,7 @@ public:
   ~ContourTree();
 
   std::shared_ptr<BinaryTree> rootAtMax();
-  std::shared_ptr<BinaryTree> rootAtNode(std::shared_ptr<CTNode> root);
+  std::shared_ptr<BinaryTree> rootAtNode(const std::shared_ptr<CTNode> &root);
   bool isBinary();
   void computeBranches();
   std::pair<std::vector<std::shared_ptr<CTNode>>,
@@ -110,11 +110,13 @@ private:
 
   bool binary;
 
-  std::shared_ptr<Tree> computeRootedTree(std::shared_ptr<CTNode> node,
-                                          std::shared_ptr<CTEdge> parent,
+  std::shared_ptr<Tree> computeRootedTree(const std::shared_ptr<CTNode> &node,
+                                          const std::shared_ptr<CTEdge> &parent,
                                           int &id);
-  std::shared_ptr<BinaryTree> computeRootedTree_binary(
-    std::shared_ptr<CTNode> node, std::shared_ptr<CTEdge> parent, int &id);
+  std::shared_ptr<BinaryTree>
+    computeRootedTree_binary(const std::shared_ptr<CTNode> &node,
+                             const std::shared_ptr<CTEdge> &parent,
+                             int &id);
   std::pair<float, std::vector<int>> pathToMax(int root, int parent);
   std::pair<float, std::vector<int>> pathToMin(int root, int parent);
 };


### PR DESCRIPTION
The ContourTreeAligment module uses `std::shared_ptr` (a reference-counted smart pointer) extensively.
Passing them by copy incur a performance penalty in the form of an atomic increment (at the beginning of the function call) and a decrement (at the end of the function scope).

This PR replaces all the `std::shared_ptr` copies in this module by constant references, as suggested by the clang-tidy lints [performance-for-range-copy](https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html) and [performance-unnecessary-value-param](https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html).

The output of the ttk-data `contourTreeAligment.pvsm` state file is the same, while the time spent in the TTKContourTreeAlignment filter decreases from 120ms to 45ms.

Also, some run-time checks have been added to please the clang static analyzer.

@floWetzels Are you ok with these modifications? Is there a use-case of this module that requires the `std::shared_ptr` copies?

Enjoy,
Pierre