### PR TITLE
ProgressiveTopology: Improve integration

### DIFF
--- a/core/base/multiresTriangulation/MultiresTriangulation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation.cpp
@@ -35,7 +35,7 @@ int ttk::MultiresTriangulation::preconditionVerticesInternal() {
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
       std::array<SimplexId, 3> p{};
-      vertexToPosition2d(i, p.data());
+      vertexToPosition2d(i, p);
 
       if(0 < p[0] and p[0] < nbvoxels_[Di_]) {
         if(0 < p[1] and p[1] < nbvoxels_[Dj_])
@@ -68,7 +68,7 @@ int ttk::MultiresTriangulation::preconditionVerticesInternal() {
 #endif // TTK_ENABLE_OPENMP
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
       std::array<SimplexId, 3> p{};
-      vertexToPosition(i, p.data());
+      vertexToPosition(i, p);
 
       if(0 < p[0] and p[0] < nbvoxels_[0]) {
         if(0 < p[1] and p[1] < nbvoxels_[1]) {
@@ -3187,8 +3187,8 @@ void MultiresTriangulation::getInvertedLocalNeighborH(
   }
 }
 
-void MultiresTriangulation::vertexToPosition2d(const SimplexId vertex,
-                                               SimplexId p[2]) const {
+void MultiresTriangulation::vertexToPosition2d(
+  const SimplexId vertex, std::array<SimplexId, 3> &p) const {
   // if(isAccelerated_) {
   //   p[0] = vertex & mod_[0];
   //   p[1] = vertex >> div_[0];
@@ -3198,8 +3198,8 @@ void MultiresTriangulation::vertexToPosition2d(const SimplexId vertex,
   // }
 }
 
-void MultiresTriangulation::vertexToPosition(const SimplexId vertex,
-                                             SimplexId p[3]) const {
+void MultiresTriangulation::vertexToPosition(
+  const SimplexId vertex, std::array<SimplexId, 3> &p) const {
   // if(isAccelerated_) {
   //   p[0] = vertex & mod_[0];
   //   p[1] = (vertex & mod_[1]) >> div_[0];
@@ -3216,12 +3216,12 @@ bool MultiresTriangulation::isInTriangulation(const SimplexId vertexId) const {
   if(dimensionality_ == 1) {
     is_in_triangulation = ((vertexId % decimation_) == 0);
   } else if(dimensionality_ == 2) {
-    SimplexId p[2];
+    std::array<SimplexId, 3> p{};
     vertexToPosition2d(vertexId, p);
     is_in_triangulation
       = ((p[0] % decimation_) == 0) and ((p[1] % decimation_) == 0);
   } else if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
     is_in_triangulation = ((p[0] % decimation_) == 0)
                           and ((p[1] % decimation_) == 0)
@@ -3281,7 +3281,7 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
 
   SimplexId localNeighborId0 = -1, localNeighborId1 = -1;
   if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
 
     if(0 < p[0] and p[0] < nbvoxels_[0]) {
@@ -3358,7 +3358,7 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
     }
 
   } else if(dimensionality_ == 2) {
-    SimplexId p[2];
+    std::array<SimplexId, 3> p{};
     vertexToPosition2d(vertexId, p);
 
     if(0 < p[0] and p[0] < nbvoxels_[Di_]) {
@@ -3556,7 +3556,7 @@ int MultiresTriangulation::getInteriorInvertedVertexNeighbor(
   SimplexId &invertedLocalNeighborId) const {
 
   if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
     SimplexId shiftX = decimation_;
     SimplexId shiftY = decimation_;
@@ -3675,7 +3675,7 @@ int MultiresTriangulation::getInteriorInvertedVertexNeighbor(
     return -1;
 
   } else if(dimensionality_ == 2) {
-    SimplexId p[2];
+    std::array<SimplexId, 3> p{};
     vertexToPosition2d(vertexId, p);
     SimplexId shiftX = decimation_;
     SimplexId shiftY = decimation_;
@@ -3914,7 +3914,7 @@ SimplexId MultiresTriangulation::getInvertedLocalNeighbor2dCD(
 }
 
 void MultiresTriangulation::getImpactedVerticesABCDEFGH(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
 
@@ -3957,7 +3957,7 @@ void MultiresTriangulation::getImpactedVerticesABCDEFGH(
 }
 
 void MultiresTriangulation::getImpactedVerticesABDC(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in ABDC"<<endl;
@@ -3984,7 +3984,7 @@ void MultiresTriangulation::getImpactedVerticesABDC(
   }
 }
 void MultiresTriangulation::getImpactedVerticesEFHG(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in EFHG"<<endl;
@@ -4011,7 +4011,7 @@ void MultiresTriangulation::getImpactedVerticesEFHG(
   }
 }
 void MultiresTriangulation::getImpactedVerticesAEGC(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in AEGC"<<endl;
@@ -4037,7 +4037,7 @@ void MultiresTriangulation::getImpactedVerticesAEGC(
   }
 }
 void MultiresTriangulation::getImpactedVerticesBFHD(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in BFHD"<<endl;
@@ -4063,7 +4063,7 @@ void MultiresTriangulation::getImpactedVerticesBFHD(
   }
 }
 void MultiresTriangulation::getImpactedVerticesAEFB(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in AEFB"<<endl;
@@ -4089,7 +4089,7 @@ void MultiresTriangulation::getImpactedVerticesAEFB(
   }
 }
 void MultiresTriangulation::getImpactedVerticesGHDC(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in GHDC"<<endl;
@@ -4115,7 +4115,7 @@ void MultiresTriangulation::getImpactedVerticesGHDC(
   }
 }
 void MultiresTriangulation::getImpactedVerticesAB(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in AB"<<endl;
@@ -4133,7 +4133,7 @@ void MultiresTriangulation::getImpactedVerticesAB(
   }
 }
 void MultiresTriangulation::getImpactedVerticesCD(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in CD"<<endl;
@@ -4151,7 +4151,7 @@ void MultiresTriangulation::getImpactedVerticesCD(
   }
 }
 void MultiresTriangulation::getImpactedVerticesEF(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in EF"<<endl;
@@ -4169,7 +4169,7 @@ void MultiresTriangulation::getImpactedVerticesEF(
   }
 }
 void MultiresTriangulation::getImpactedVerticesGH(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in GH"<<endl;
@@ -4187,7 +4187,7 @@ void MultiresTriangulation::getImpactedVerticesGH(
   }
 }
 void MultiresTriangulation::getImpactedVerticesAC(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in AC"<<endl;
@@ -4205,7 +4205,7 @@ void MultiresTriangulation::getImpactedVerticesAC(
   }
 }
 void MultiresTriangulation::getImpactedVerticesBD(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in BD"<<endl;
@@ -4223,7 +4223,7 @@ void MultiresTriangulation::getImpactedVerticesBD(
   }
 }
 void MultiresTriangulation::getImpactedVerticesEG(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in EG"<<endl;
@@ -4241,7 +4241,7 @@ void MultiresTriangulation::getImpactedVerticesEG(
   }
 }
 void MultiresTriangulation::getImpactedVerticesFH(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in FH"<<endl;
@@ -4259,7 +4259,7 @@ void MultiresTriangulation::getImpactedVerticesFH(
   }
 }
 void MultiresTriangulation::getImpactedVerticesAE(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in AE"<<endl;
@@ -4278,7 +4278,7 @@ void MultiresTriangulation::getImpactedVerticesAE(
 }
 
 void MultiresTriangulation::getImpactedVerticesBF(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in BF"<<endl;
@@ -4297,7 +4297,7 @@ void MultiresTriangulation::getImpactedVerticesBF(
 }
 
 void MultiresTriangulation::getImpactedVerticesCG(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in CG"<<endl;
@@ -4316,7 +4316,7 @@ void MultiresTriangulation::getImpactedVerticesCG(
 }
 
 void MultiresTriangulation::getImpactedVerticesDH(
-  SimplexId p[3],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in DH"<<endl;
@@ -4335,7 +4335,7 @@ void MultiresTriangulation::getImpactedVerticesDH(
 }
 
 void MultiresTriangulation::getImpactedVertices2dABCD(
-  SimplexId p[2],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in 2dABCD"<<endl;
@@ -4362,7 +4362,7 @@ void MultiresTriangulation::getImpactedVertices2dABCD(
 }
 
 void MultiresTriangulation::getImpactedVertices2dAB(
-  SimplexId p[2],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in 2dAB"<<endl;
@@ -4381,7 +4381,7 @@ void MultiresTriangulation::getImpactedVertices2dAB(
 }
 
 void MultiresTriangulation::getImpactedVertices2dCD(
-  SimplexId p[2],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in 2dCD"<<endl;
@@ -4400,7 +4400,7 @@ void MultiresTriangulation::getImpactedVertices2dCD(
 }
 
 void MultiresTriangulation::getImpactedVertices2dAC(
-  SimplexId p[2],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in 2dAC"<<endl;
@@ -4418,7 +4418,7 @@ void MultiresTriangulation::getImpactedVertices2dAC(
   }
 }
 void MultiresTriangulation::getImpactedVertices2dBD(
-  SimplexId p[2],
+  std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
   // cout<<"getting impacted vertices in 2dBD"<<endl;
@@ -4441,7 +4441,7 @@ vector<SimplexId>
 
   vector<SimplexId> result;
   if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
     SimplexId shiftX = decimation_;
     SimplexId shiftY = decimation_;
@@ -4495,7 +4495,7 @@ vector<SimplexId>
     }
 
   } else if(dimensionality_ == 2) {
-    SimplexId p[2];
+    std::array<SimplexId, 3> p{};
     vertexToPosition2d(vertexId, p);
     SimplexId shiftX = decimation_;
     SimplexId shiftY = decimation_;
@@ -4545,7 +4545,7 @@ int MultiresTriangulation::getVertexBoundaryIndex(
   const SimplexId vertexId) const {
 
   if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
 
     if(0 < p[0] and p[0] < nbvoxels_[0]) {
@@ -4620,7 +4620,7 @@ int MultiresTriangulation::getVertexBoundaryIndex(
     }
 
   } else if(dimensionality_ == 2) {
-    SimplexId p[2];
+    std::array<SimplexId, 3> p{};
     vertexToPosition2d(vertexId, p);
 
     if(0 < p[0] and p[0] < nbvoxels_[Di_]) {
@@ -4757,7 +4757,7 @@ void MultiresTriangulation::findBoundaryRepresentatives(
 bool ttk::MultiresTriangulation::isBoundaryImpacted(SimplexId v) const {
   bool ret = false;
   if(dimensionality_ == 3) {
-    SimplexId p[3];
+    std::array<SimplexId, 3> p{};
     vertexToPosition(v, p);
     if((nbvoxels_[0] % decimation_) and (p[0] + decimation_ > nbvoxels_[0])) {
       ret = true;

--- a/core/base/multiresTriangulation/MultiresTriangulation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation.cpp
@@ -1,7 +1,7 @@
 #include <MultiresTriangulation.h>
 
-using namespace std;
-using namespace ttk;
+using ttk::MultiresTriangulation;
+using ttk::SimplexId;
 
 MultiresTriangulation::MultiresTriangulation() {
   decimation_ = 1;
@@ -947,7 +947,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborA(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(a)={b,c,e,g}
-  // cout << "A"<<endl;
   if(neighborId == v + shiftX)
     return 0; // b
   else if(neighborId == v + vshift_[0] * shiftY)
@@ -966,7 +965,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(a)={b,c,e,g}
-  // cout << "A"<<endl;
   switch(id) {
     case 0:
       return v + shiftX; // b
@@ -987,7 +985,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborB(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(b)={a,c,d,e,f,g,h}
-  // cout << "B"<<endl;
   if(neighborId == v - shiftX)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - shiftX))
@@ -1013,7 +1010,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(b)={a,c,d,e,f,g,h}
-  // cout << "B"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -1040,7 +1036,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborC(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(c)={a,b,d,g}
-  // cout << "C"<<endl;
   if(neighborId == v - vshift_[0] * shiftY)
     return 0; // a
   else if(neighborId == v + (shiftX - vshift_[0] * shiftY))
@@ -1059,7 +1054,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(c)={a,b,d,g}
-  // cout << "C"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // a
@@ -1080,7 +1074,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborD(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(d)={b,c,g,h}
-  // cout << "D"<<endl;
   if(neighborId == v - vshift_[0] * shiftY)
     return 0; // b
   else if(neighborId == v - shiftX)
@@ -1099,7 +1092,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(d)={b,c,g,h}
-  // cout << "D"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -1120,7 +1112,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborE(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(e)={a,b,f,g}
-  // cout << "E"<<endl;
   if(neighborId == v - vshift_[1] * shiftZ)
     return 0; // a
   else if(neighborId == v + (shiftX - vshift_[1] * shiftZ))
@@ -1139,7 +1130,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(e)={a,b,f,g}
-  // cout << "E"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // a
@@ -1160,7 +1150,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborF(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(f)={b,e,g,h}
-  // cout << "F"<<endl;
   if(neighborId == v - vshift_[1] * shiftZ)
     return 0; // b
   else if(neighborId == v - shiftX)
@@ -1179,7 +1168,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(f)={b,e,g,h}
-  // cout << "F"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -1200,7 +1188,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborG(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(g)={a,b,c,d,e,f,h}
-  // cout << "G"<<endl;
   if(neighborId == v - (vshift_[0] * shiftY + vshift_[1] * shiftZ))
     return 0; // a
   else if(neighborId
@@ -1226,7 +1213,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(g)={a,b,c,d,e,f,h}
-  // cout << "G"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * shiftZ); // a
@@ -1253,7 +1239,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(h)={b,d,f,g}
-  // cout << "invert H "<<"global "<<v<<" neighbor"<<neighborId<<endl;
   if(neighborId == v - (vshift_[0] * shiftY + vshift_[1] * shiftZ))
     return 0; // b
   else if(neighborId == v - vshift_[1] * shiftZ)
@@ -1272,7 +1257,6 @@ inline ttk::SimplexId
                                             const SimplexId shiftY,
                                             const SimplexId shiftZ) const {
   // V(h)={b,d,f,g}
-  // cout << "H"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * shiftZ); // b
@@ -1293,7 +1277,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborAB(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(ab)=V(b)+V(a)::{b}
-  // cout << "AB"<<endl;
   if(neighborId == v - decimation_)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - decimation_))
@@ -1321,7 +1304,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(ab)=V(b)+V(a)::{b}
-  // cout << "AB"<<endl;
   switch(id) {
     case 0:
       return v - decimation_; // a
@@ -1350,7 +1332,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborCD(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(cd)=V(d)+V(c)::{b,d}
-  // cout << "CD"<<endl;
   if(neighborId == v - vshift_[0] * shiftY)
     return 0; // b
   else if(neighborId == v - decimation_)
@@ -1372,7 +1353,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(cd)=V(d)+V(c)::{b,d}
-  // cout << "CD"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -1397,7 +1377,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborEF(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(ef)=V(f)+V(e)::{b,f}
-  // cout << "EF"<<endl;
   if(neighborId == v - vshift_[1] * shiftZ)
     return 0; // b
   else if(neighborId == v - decimation_)
@@ -1419,7 +1398,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(ef)=V(f)+V(e)::{b,f}
-  // cout << "EF"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -1444,7 +1422,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborGH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(gh)=V(g)+V(h)::{g}
-  // cout << "GH"<<endl;
   if(neighborId == v - (vshift_[0] * shiftY + vshift_[1] * shiftZ))
     return 0; // a
   else if(neighborId
@@ -1501,7 +1478,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborAC(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(ac)=V(c)+V(a)::{c,g}
-  // cout << "AC"<<endl;
   if(neighborId == v - vshift_[0] * decimation_)
     return 0; // a
   else if(neighborId == v + (shiftX - vshift_[0] * decimation_))
@@ -1523,7 +1499,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(ac)=V(c)+V(a)::{c,g}
-  // cout << "AC"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * decimation_; // a
@@ -1548,7 +1523,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborBD(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(bd)=V(b)+V(d)::{b}
-  // cout << "BD"<<endl;
   if(neighborId == v - shiftX)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - shiftX))
@@ -1575,7 +1549,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(bd)=V(b)+V(d)::{b}
-  // cout << "BD"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -1604,7 +1577,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborEG(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(eg)=V(g)+V(e)::{g}
-  // cout << "EG"<<endl;
   if(neighborId == v - (vshift_[0] * decimation_ + vshift_[1] * shiftZ))
     return 0; // a
   else if(neighborId
@@ -1631,7 +1603,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(eg)=V(g)+V(e)::{g}
-  // cout << "EG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation_ + vshift_[1] * shiftZ); // a
@@ -1660,7 +1631,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborFH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(fh)=V(f)+V(h)::{b,f}
-  // cout << "FH"<<endl;
   if(neighborId == v - vshift_[1] * shiftZ)
     return 0; // b
   else if(neighborId == v - shiftX)
@@ -1682,7 +1652,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(fh)=V(f)+V(h)::{b,f}
-  // cout << "FH"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -1707,7 +1676,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborAE(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(ae)=V(a)+V(e)::{a,b}
-  // cout << "AE"<<endl;
   if(neighborId == v + shiftX)
     return 0; // b
   else if(neighborId == v + vshift_[0] * shiftY)
@@ -1729,7 +1697,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(ae)=V(a)+V(e)::{a,b}
-  // cout << "AE"<<endl;
   switch(id) {
     case 0:
       return v + shiftX; // b
@@ -1754,7 +1721,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborBF(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(bf)=V(b)+V(f)::{b}
-  // cout << "BF"<<endl;
   if(neighborId == v - shiftX)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - shiftX))
@@ -1782,7 +1748,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(bf)=V(b)+V(f)::{b}
-  // cout << "BF"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -1811,7 +1776,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborCG(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(cg)=V(g)+V(c)::{g}
-  // cout << "CG"<<endl;
   if(neighborId == v - (vshift_[0] * shiftY + vshift_[1] * decimation_))
     return 0; // a
   else if(neighborId
@@ -1838,7 +1802,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(cg)=V(g)+V(c)::{g}
-  // cout << "CG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * decimation_); // a
@@ -1867,7 +1830,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborDH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(dh)=V(d)+V(h)::{b,d}
-  // cout << "DH"<<endl;
   if(neighborId == v - vshift_[0] * shiftY)
     return 0; // b
   else if(neighborId == v - shiftX)
@@ -1889,7 +1851,6 @@ inline ttk::SimplexId
                                              const SimplexId shiftY,
                                              const SimplexId shiftZ) const {
   // V(dh)=V(d)+V(h)::{b,d}
-  // cout << "DH"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -1914,7 +1875,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborABDC(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(abdc)=V(b)+V(d)::{b}+V(c)::{b}+V(a)::{b}
-  // cout << "ABDC"<<endl;
   if(neighborId == v - decimation_)
     return 0;
   else if(neighborId == v + (vshift_[0] * shiftY - decimation_)) // c
@@ -1946,7 +1906,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(abdc)=V(b)+V(d)::{b}+V(c)::{b}+V(a)::{b}
-  // cout << "ABDC"<<endl;
   switch(id) {
     case 0:
       return v - decimation_; // a
@@ -1979,7 +1938,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborEFHG(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(efhg)=V(g)+V(h)::{g}+V(f)::{g,h}
-  // cout << "EFHG"<<endl;
   if(neighborId == v - (vshift_[0] * decimation_ + vshift_[1] * shiftZ))
     return 0; // a
   else if(neighborId
@@ -2010,7 +1968,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(efhg)=V(g)+V(h)::{g}+V(f)::{g,h}
-  // cout << "EFHG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation_ + vshift_[1] * shiftZ); // a
@@ -2043,7 +2000,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborAEGC(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(aegc)=V(g)+V(a)::{c,g}+V(c)::{g}
-  // cout << "AEGC"<<endl;
   if(neighborId == v - (vshift_[0] * decimation_ + vshift_[1] * decimation_))
     return 0; // a
   else if(neighborId
@@ -2074,7 +2030,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(aegc)=V(g)+V(a)::{c,g}+V(c)::{g}
-  // cout << "AEGC"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation_ + vshift_[1] * decimation_); // a
@@ -2109,7 +2064,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborBFHD(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(bfhd)=V(b)+V(f)::{b}+V(h)::{b}+V(d)::{b}
-  // cout << "BFHD"<<endl;
   if(neighborId == v - shiftX)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - shiftX))
@@ -2141,7 +2095,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(bfhd)=V(b)+V(f)::{b}+V(h)::{b}+V(d)::{b}
-  // cout << "BFHD"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -2176,7 +2129,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborAEFB(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(aefb)=V(b)+V(a)::{b}+V(e)::{b}+V(f)::{b}
-  // cout << "AEFB"<<endl;
   if(neighborId == v - decimation_)
     return 0; // a
   else if(neighborId == v + (vshift_[0] * shiftY - decimation_))
@@ -2207,7 +2159,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(aefb)=V(b)+V(a)::{b}+V(e)::{b}+V(f)::{b}
-  // cout << "AEFB"<<endl;
   switch(id) {
     case 0:
       return v - decimation_; // a
@@ -2240,7 +2191,6 @@ inline ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborGHDC(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(ghdc)=V(g)+V(h)::{g}+V(d)::{g,h}
-  // cout << "GHDC"<<endl;
   if(neighborId == v - (vshift_[0] * shiftY + vshift_[1] * decimation_))
     return 0; // a
   else if(neighborId
@@ -2271,7 +2221,6 @@ inline ttk::SimplexId
                                                const SimplexId shiftY,
                                                const SimplexId shiftZ) const {
   // V(ghdc)=V(g)+V(h)::{g}+V(d)::{g,h}
-  // cout << "GHDC"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * decimation_); // a
@@ -2304,7 +2253,6 @@ ttk::SimplexId MultiresTriangulation::getInvertVertexNeighborABCDEFGH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(abcdefgh)=V(g)+V(d)::{g,h}+V(h)::{g}+V(b)::{c,d,g,h}
-  // cout << "ABCDEFGH"<<endl;
   if(neighborId == v - (vshift_[0] * decimation_ + vshift_[1] * decimation_))
     return 0; // a
   else if(neighborId
@@ -2344,7 +2292,6 @@ ttk::SimplexId MultiresTriangulation::getVertexNeighborABCDEFGH(
   const SimplexId shiftY,
   const SimplexId shiftZ) const {
   // V(abcdefgh)=V(g)+V(d)::{g,h}+V(h)::{g}+V(b)::{c,d,g,h}
-  // cout << "ABCDEFGH"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation_ + vshift_[1] * decimation_); // a
@@ -2389,7 +2336,6 @@ ttk::SimplexId MultiresTriangulation::getInvertedVertexNeighborABCDEFGH(
   const SimplexId shiftZ,
   SimplexId &invertedLocalNeighbor) const {
   // V(abcdefgh)=V(g)+V(d)::{g,h}+V(h)::{g}+V(b)::{c,d,g,h}
-  // cout << "ABCDEFGH"<<endl;
   SimplexId invertedVertexId = -1;
   switch(id) {
     case 0:
@@ -2459,8 +2405,6 @@ ttk::SimplexId MultiresTriangulation::getInvertedVertexNeighborABCDEFGH(
 }
 void MultiresTriangulation::getInvertedLocalNeighborABDC(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"ABDC"<<endl;
-  // } else if(boundary == 0) { // ABDC
   switch(id) {
     case 0:
       invertedLocalNeighbor = 6;
@@ -2497,8 +2441,6 @@ void MultiresTriangulation::getInvertedLocalNeighborABDC(
 
 void MultiresTriangulation::getInvertedLocalNeighborEFHG(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"EFHG"<<endl;
-  // } else if(boundary == 1) { // EFHG
   switch(id) {
     case 13:
       invertedLocalNeighbor = 0;
@@ -2535,9 +2477,7 @@ void MultiresTriangulation::getInvertedLocalNeighborEFHG(
 
 void MultiresTriangulation::getInvertedLocalNeighborAEFB(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"AEFB"<<endl;
   switch(id) {
-      // } else if(boundary == 2) { // AEFB
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -2572,9 +2512,7 @@ void MultiresTriangulation::getInvertedLocalNeighborAEFB(
 }
 void MultiresTriangulation::getInvertedLocalNeighborGHDC(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"GHDC"<<endl;
   switch(id) {
-      // } else if(boundary == 3) { // GHDC
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -2609,9 +2547,7 @@ void MultiresTriangulation::getInvertedLocalNeighborGHDC(
 }
 void MultiresTriangulation::getInvertedLocalNeighborAEGC(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"AEGC"<<endl;
   switch(id) {
-      // } else if(boundary == 4) { // AEGC
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -2646,9 +2582,7 @@ void MultiresTriangulation::getInvertedLocalNeighborAEGC(
 }
 void MultiresTriangulation::getInvertedLocalNeighborBFHD(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"BFHD"<<endl;
   switch(id) {
-    // } else if(boundary == 5) { // BFHD
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -2683,9 +2617,7 @@ void MultiresTriangulation::getInvertedLocalNeighborBFHD(
 }
 void MultiresTriangulation::getInvertedLocalNeighborAB(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"AB"<<endl;
   switch(id) {
-    // } else if(boundary == 6) { // AB
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -2714,9 +2646,7 @@ void MultiresTriangulation::getInvertedLocalNeighborAB(
 }
 void MultiresTriangulation::getInvertedLocalNeighborEF(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"EF"<<endl;
   switch(id) {
-    // } else if(boundary == 7) { // EF
     case 8:
       invertedLocalNeighbor = 0;
       break;
@@ -2739,9 +2669,7 @@ void MultiresTriangulation::getInvertedLocalNeighborEF(
 }
 void MultiresTriangulation::getInvertedLocalNeighborCD(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"CD"<<endl;
   switch(id) {
-      // } else if(boundary == 8) { // CD
     case 11:
       invertedLocalNeighbor = 0;
       break;
@@ -2764,9 +2692,7 @@ void MultiresTriangulation::getInvertedLocalNeighborCD(
 }
 void MultiresTriangulation::getInvertedLocalNeighborGH(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"GH"<<endl;
   switch(id) {
-    // } else if(boundary == 9) { // GH
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -2795,9 +2721,7 @@ void MultiresTriangulation::getInvertedLocalNeighborGH(
 }
 void MultiresTriangulation::getInvertedLocalNeighborAC(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"AC"<<endl;
   switch(id) {
-    // } else if(boundary == 10) { // AC
     case 11:
       invertedLocalNeighbor = 0;
       break;
@@ -2820,9 +2744,7 @@ void MultiresTriangulation::getInvertedLocalNeighborAC(
 }
 void MultiresTriangulation::getInvertedLocalNeighborEG(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"EG"<<endl;
   switch(id) {
-    // } else if(boundary == 11) { // EG
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -2851,8 +2773,6 @@ void MultiresTriangulation::getInvertedLocalNeighborEG(
 }
 void MultiresTriangulation::getInvertedLocalNeighborAE(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"AE"<<endl;
-  // }else if(boundary == 12) { // AE
   switch(id) {
     case 9:
       invertedLocalNeighbor = 0;
@@ -2876,9 +2796,7 @@ void MultiresTriangulation::getInvertedLocalNeighborAE(
 }
 void MultiresTriangulation::getInvertedLocalNeighborCG(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"CG"<<endl;
   switch(id) {
-      // } else if(boundary == 13) { // CG
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -2907,9 +2825,7 @@ void MultiresTriangulation::getInvertedLocalNeighborCG(
 }
 void MultiresTriangulation::getInvertedLocalNeighborBD(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"BD"<<endl;
   switch(id) {
-    // } else if(boundary == 14) { // BD
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -2938,9 +2854,7 @@ void MultiresTriangulation::getInvertedLocalNeighborBD(
 }
 void MultiresTriangulation::getInvertedLocalNeighborFH(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"FH"<<endl;
   switch(id) {
-      // } else if(boundary == 15) { // FH
     case 8:
       invertedLocalNeighbor = 0;
       break;
@@ -2963,9 +2877,7 @@ void MultiresTriangulation::getInvertedLocalNeighborFH(
 }
 void MultiresTriangulation::getInvertedLocalNeighborBF(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"BF"<<endl;
   switch(id) {
-      // } else if(boundary == 16) { // BF
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -2994,9 +2906,7 @@ void MultiresTriangulation::getInvertedLocalNeighborBF(
 }
 void MultiresTriangulation::getInvertedLocalNeighborDH(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"DH"<<endl;
   switch(id) {
-      // } else if(boundary == 17) { // DH
     case 11:
       invertedLocalNeighbor = 0;
       break;
@@ -3019,9 +2929,7 @@ void MultiresTriangulation::getInvertedLocalNeighborDH(
 }
 void MultiresTriangulation::getInvertedLocalNeighborA(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"A"<<endl;
   switch(id) {
-      // } else if(boundary == 18) { // A
     case 9:
       invertedLocalNeighbor = 0;
       break;
@@ -3039,7 +2947,6 @@ void MultiresTriangulation::getInvertedLocalNeighborA(
 void MultiresTriangulation::getInvertedLocalNeighborE(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
   switch(id) {
-      // } else if(boundary == 19) { // E
     case 8:
       invertedLocalNeighbor = 0;
       break;
@@ -3056,9 +2963,7 @@ void MultiresTriangulation::getInvertedLocalNeighborE(
 }
 void MultiresTriangulation::getInvertedLocalNeighborC(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"C"<<endl;
   switch(id) {
-      // } else if(boundary == 20) { // C
     case 11:
       invertedLocalNeighbor = 0;
       break;
@@ -3075,9 +2980,7 @@ void MultiresTriangulation::getInvertedLocalNeighborC(
 }
 void MultiresTriangulation::getInvertedLocalNeighborG(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"G"<<endl;
   switch(id) {
-      // } else if(boundary == 21) { // G
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -3103,9 +3006,7 @@ void MultiresTriangulation::getInvertedLocalNeighborG(
 }
 void MultiresTriangulation::getInvertedLocalNeighborB(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"B"<<endl;
   switch(id) {
-      // } else if(boundary == 22) { // B
     case 6:
       invertedLocalNeighbor = 0;
       break;
@@ -3131,9 +3032,7 @@ void MultiresTriangulation::getInvertedLocalNeighborB(
 }
 void MultiresTriangulation::getInvertedLocalNeighborF(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"F"<<endl;
   switch(id) {
-      // } else if(boundary == 23) { // F
     case 8:
       invertedLocalNeighbor = 0;
       break;
@@ -3150,9 +3049,7 @@ void MultiresTriangulation::getInvertedLocalNeighborF(
 }
 void MultiresTriangulation::getInvertedLocalNeighborD(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"D"<<endl;
   switch(id) {
-      // } else if(boundary == 24) { // D
     case 11:
       invertedLocalNeighbor = 0;
       break;
@@ -3169,9 +3066,7 @@ void MultiresTriangulation::getInvertedLocalNeighborD(
 }
 void MultiresTriangulation::getInvertedLocalNeighborH(
   SimplexId id, SimplexId &invertedLocalNeighbor) const {
-  // cout<<"H"<<endl;
   switch(id) {
-      // } else if(boundary == 25) { // H
     case 13:
       invertedLocalNeighbor = 0;
       break;
@@ -3189,26 +3084,15 @@ void MultiresTriangulation::getInvertedLocalNeighborH(
 
 void MultiresTriangulation::vertexToPosition2d(
   const SimplexId vertex, std::array<SimplexId, 3> &p) const {
-  // if(isAccelerated_) {
-  //   p[0] = vertex & mod_[0];
-  //   p[1] = vertex >> div_[0];
-  // } else {
   p[0] = vertex % vshift_[0];
   p[1] = vertex / vshift_[0];
-  // }
 }
 
 void MultiresTriangulation::vertexToPosition(
   const SimplexId vertex, std::array<SimplexId, 3> &p) const {
-  // if(isAccelerated_) {
-  //   p[0] = vertex & mod_[0];
-  //   p[1] = (vertex & mod_[1]) >> div_[0];
-  //   p[2] = vertex >> div_[1];
-  // } else {
   p[0] = vertex % vshift_[0];
   p[1] = (vertex % vshift_[1]) / vshift_[0];
   p[2] = vertex / vshift_[1];
-  // }
 }
 
 bool MultiresTriangulation::isInTriangulation(const SimplexId vertexId) const {
@@ -3227,9 +3111,7 @@ bool MultiresTriangulation::isInTriangulation(const SimplexId vertexId) const {
                           and ((p[1] % decimation_) == 0)
                           and ((p[2] % decimation_) == 0);
   } else {
-    stringstream msg;
-    msg << "[MultiresTriangulation] Dimension unknown : " << dimensionality_;
-    printErr(msg.str());
+    this->printErr("Unknown dimension " + std::to_string(dimensionality_));
   }
   return is_in_triangulation;
 }
@@ -3322,14 +3204,10 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
         if(0 < p[2] and p[2] < nbvoxels_[2])
           getImpactedVerticesAE(p, localNeighborId0,
                                 localNeighborId1); //
-        else
-          cout << "getImpactedVertices ; shouln't happen" << endl;
       } else {
         if(0 < p[2] and p[2] < nbvoxels_[2])
           getImpactedVerticesCG(p, localNeighborId0,
                                 localNeighborId1); //
-        else
-          cout << "getImpactedVertices ; shouln't happen" << endl;
       }
     } else {
       if(0 < p[1] and p[1] < nbvoxels_[1]) {
@@ -3346,14 +3224,10 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
         if(0 < p[2] and p[2] < nbvoxels_[2])
           getImpactedVerticesBF(p, localNeighborId0,
                                 localNeighborId1); //
-        else
-          cout << "getImpactedVertices ; shouln't happen" << endl;
       } else {
         if(0 < p[2] and p[2] < nbvoxels_[2])
           getImpactedVerticesDH(p, localNeighborId0,
                                 localNeighborId1); //
-        else
-          cout << "getImpactedVertices ; shouln't happen" << endl;
       }
     }
 
@@ -3365,15 +3239,12 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
       if(0 < p[1] and p[1] < nbvoxels_[Dj_]) {
         getImpactedVertices2dABCD(p, localNeighborId0,
                                   localNeighborId1); // abcd
-        // cout << "abcd" << endl;
       } else if(p[1] == 0) {
         getImpactedVertices2dAB(p, localNeighborId0,
                                 localNeighborId1); // ab
-        // cout << "ab" << endl;
       } else {
         getImpactedVertices2dCD(p, localNeighborId0,
                                 localNeighborId1); // cd
-        // cout << "cd" << endl;
       }
     } else if(p[0] == 0) {
       if(0 < p[1] and p[1] < nbvoxels_[Dj_]) {
@@ -3387,35 +3258,19 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
       }
     }
   } else {
-    cout << "function getImpactedVertices : not implemented for 1D yet" << endl;
-    // cout << " " << p[0] << " " << p[1] << " "<<p[2]<<endl;
+    this->printWrn("getImpactedVertices not implemented for 1D yet");
   }
   v0[0] = localNeighborId0;
   v1[0] = localNeighborId1;
-  // cout << "calling getVertexNeighbor " << v0[0] << " " << v1[0] << endl;
   getVertexNeighbor(vertexId, v0[0], v0[1]);
   getVertexNeighbor(vertexId, v1[0], v1[1]);
-  // cout << "got global neighbors " << v0[1] << " " << v1[1]
-  //      << "\n now calling getinvert" << endl;
   getInvertVertexNeighbor(v0[1], vertexId, v0[2]);
   getInvertVertexNeighbor(v1[1], vertexId, v1[2]);
-  // cout << "got invert local neighbors " << v0[2] << " " << v1[2] << endl;
-
-  // cout << "calld getinteriorinvertedneighbor, all good" << endl;
 }
-
-// SimplexId mappingProgressiveToGlobalIndex(Simplex vertexId, int
-// decimationLevel){
-//   SimplexId size = getSize(decimationLevel + 1);
-//   if(vertexId >= size) {
-//     return mappingProgressiveToGlobalIndex(vertexId, decimationLevel + 1);
-//   } else{
-//   }
-// }
 
 char MultiresTriangulation::localNeighborId(SimplexId neighborId,
                                             SimplexId vertexId) {
-  cout << "\nBOUNDARY CASES TO TAKE CARE OF\n" << endl;
+  this->printMsg("BOUNDARY CASES TO TAKE CARE OF");
 
   SimplexId pLocalNeighbor[3];
   pLocalNeighbor[0] = neighborId % gridDecimatedDimensions_[Di_];
@@ -3442,9 +3297,7 @@ char MultiresTriangulation::localNeighborId(SimplexId neighborId,
   if(dimensionality_ == 2) {
     if(pLocalNeighbor[0] == pLocalVertex[0]) {
       if(pLocalNeighbor[1] == pLocalVertex[1]) {
-        cout << "MultiresTriangulation::localNeighbor : not a neighbor ! "
-                "same point actually "
-             << endl;
+        this->printErr("localNeighbor: not a neighbor!");
       } else if(pLocalNeighbor[1] == pLocalVertex[1] + 1) {
         localNeighbor = 4;
       } else if(pLocalNeighbor[1] == pLocalVertex[1] - 1) {
@@ -3456,8 +3309,7 @@ char MultiresTriangulation::localNeighborId(SimplexId neighborId,
       } else if(pLocalNeighbor[1] == pLocalVertex[1] - 1) {
         localNeighbor = 2;
       } else {
-        cout << "MultiresTriangulation::localNeighbor : not a neighbor ! "
-             << endl;
+        this->printErr("localNeighbor: not a neighbor!");
       }
     } else if(pLocalNeighbor[0] == pLocalVertex[0] - 1) {
       if(pLocalNeighbor[1] == pLocalVertex[1]) {
@@ -3465,90 +3317,18 @@ char MultiresTriangulation::localNeighborId(SimplexId neighborId,
       } else if(pLocalNeighbor[1] == pLocalVertex[1] + 1) {
         localNeighbor = 5;
       } else {
-        cout << "MultiresTriangulation::localNeighbor : not a neighbor ! "
-             << endl;
+        this->printErr("localNeighbor: not a neighbor!");
       }
     } else {
-      cout << "MultiresTriangulation::localNeighbor : not a neighbor ! "
-           << endl;
+      this->printErr("localNeighbor: not a neighbor!");
     }
   } else if(dimensionality_ == 3) {
-    cout << " LOCAL NEIGHBORS IDs NOT IMPLEMENTED YET FOR 3D" << endl;
+    this->printWrn("Local neighbors ids not implemented yet for 3D");
   }
-
-  // int boundaryIndex = isBoundary(vertexId, pLocalVertex[0], pLocalVertex[1],
-  // pLocalVertex[2]); localNeighbor = localNeighborForBoundary(localNeighbor,
-  // boundaryIndex);
 
   return localNeighbor;
 }
 
-// int MultiresTriangulation::isBoundary(SimplexId vertexId, SimplexId p0=-1,
-// SimplexId p1=-1, SimplexId p2=-1){
-//   if(p0 == -1 or p1 == -1 or p2 == -1){
-//     p0 = vertexId % gridDecimatedDimensions_[Di_];
-//     p1 = (vertexId
-//           % (gridDecimatedDimensions_[Di_] * gridDecimatedDimensions_[Dj_]))
-//          / gridDecimatedDimensions_[Di_];
-//     p2 = vertexId
-//          / (gridDecimatedDimensions_[Di_] * gridDecimatedDimensions_[Dj_]);
-//   }
-//   int boundaryIndex = -1;
-//   /* boundary indexation
-//      7 ______2______ 6
-//       |             |
-//       |             |
-//      3|             |1
-//       |             |
-//       |_____________|
-//      4       0       5
-//   */
-//   if(p0 == 0) {
-//     if(p1 == 0) {
-//       boundaryIndex = 4;
-//     } else if(p1 == gridDecimatedDimensions_[Dj_] - 1) {
-//       boundaryIndex = 7;
-//     } else {
-//       boundaryIndex = 3;
-//     }
-//   } else if(p0 == gridDecimatedDimensions_[Di_] - 1) {
-//     if(p1 == 0) {
-//       boundaryIndex = 5;
-//     } else if(p1 == gridDecimatedDimensions_[Dj_] - 1) {
-//       boundaryIndex = 6;
-//     } else {
-//       boundaryIndex = 1;
-//     }
-//   } else {
-//     if(p1 == 0) {
-//       boundaryIndex = 0;
-//     } else if(p1 == gridDecimatedDimensions_[Dj_] - 1) {
-//       boundaryIndex = 2;
-//     }
-//   }
-//   if(dimensionality_==3){
-//     cout<<" BOUNDARIES LOCAL VERTICES NOT IMPLEMENTED IN 3D"<<endl;
-//   }
-//   return boundaryIndex;
-// }
-
-// inline int MultiresTriangulation::localNeighborForBoundary2d(int
-// localNeighborId, int boundaryIndex){
-//   switch(boundaryIndex) {
-//     case 0:
-//       return localNeighborId + 3+;
-//       break;
-//     case 1:
-//       return localNeighborId + 3;
-//       break;
-//     case 4:
-//       return localNeighborId + 3;
-//       break;
-//     case 5:
-//       return localNeighborId + 3;
-//       break;
-//   }
-// }
 int MultiresTriangulation::getInteriorInvertedVertexNeighbor(
   SimplexId vertexId,
   SimplexId localNeighborId,
@@ -3695,41 +3475,32 @@ int MultiresTriangulation::getInteriorInvertedVertexNeighbor(
 
     if(0 < p[0] and p[0] < nbvoxels_[Di_] - shiftX) {
       if(decimation_ < p[1] and p[1] < nbvoxels_[Dj_]) {
-        // cout << "abcd" << endl;
         // nothing to do here
       } else if(p[1] == decimation_) {
         getInvertedLocalNeighbor2dAB(vertexId, invertedLocalNeighborId);
-        // cout << "ab" << endl;
       } else {
         getInvertedLocalNeighbor2dCD(vertexId, invertedLocalNeighborId); // cd
-        // cout << "cd" << endl;
       }
     } else if(p[0] == decimation_) {
       if(decimation_ < p[1] and p[1] < nbvoxels_[Dj_] - shiftY) {
         getInvertedLocalNeighbor2dAC(vertexId, invertedLocalNeighborId); // ac
-        // cout << "ac" << endl;
       } else if(p[1] == decimation_) {
         getInvertedLocalNeighbor2dA(vertexId, invertedLocalNeighborId); // a
-        // cout << "a" << endl;
       } else {
         getInvertedLocalNeighbor2dC(vertexId, invertedLocalNeighborId); // c
-        // cout << "c" << endl;
       }
     } else {
       if(decimation_ < p[1] and p[1] < nbvoxels_[Dj_] - shiftY) {
         getInvertedLocalNeighbor2dBD(vertexId, invertedLocalNeighborId); // bd
-        // cout << "bd" << endl;
       } else if(p[1] == decimation_) {
         getInvertedLocalNeighbor2dB(vertexId, invertedLocalNeighborId); // b
-        // cout << "b" << endl;
       } else {
         getInvertedLocalNeighbor2dD(vertexId, invertedLocalNeighborId); // d
-        // cout << "d" << endl;
       }
     }
   } else if(dimensionality_ == 1) {
     // ab
-    cout << "NOT TESTED IN DIM 1" << endl;
+    this->printWrn("NOT TESTED IN 1D");
     if(vertexId > decimation_ and vertexId < nbvoxels_[Di_]) {
       if(localNeighborId == decimation_)
         invertedVertexId = vertexId + decimation_;
@@ -3913,12 +3684,22 @@ SimplexId MultiresTriangulation::getInvertedLocalNeighbor2dCD(
   return 0;
 }
 
+void MultiresTriangulation::getImpactedVerticesError(
+  const int prev_decim, const std::array<SimplexId, 3> &p) const {
+  this->printErr("THIS SHOULDNT HAPPEN");
+  this->printErr("previous decimation: " + std::to_string(prev_decim));
+  this->printErr("position: " + std::to_string(p[0]) + " "
+                 + std::to_string(p[1]) + " " + std::to_string(p[2]));
+  this->printErr("grid size: " + std::to_string(gridDimensions_[0]) + " "
+                 + std::to_string(gridDimensions_[1]) + " "
+                 + std::to_string(gridDimensions_[2]));
+}
+
 void MultiresTriangulation::getImpactedVerticesABCDEFGH(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
 
-  // cout<<"getting impacted vertices in ABCDEFGH"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
   if((p[0] % previous_decimation) and (p[1] % previous_decimation)
      and (p[2] % previous_decimation)) {
@@ -3948,11 +3729,7 @@ void MultiresTriangulation::getImpactedVerticesABCDEFGH(
     localNeighborId0 = 2;
     localNeighborId1 = 8;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -3960,7 +3737,6 @@ void MultiresTriangulation::getImpactedVerticesABDC(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in ABDC"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[0] % previous_decimation) and (p[1] % previous_decimation)) {
@@ -3976,18 +3752,13 @@ void MultiresTriangulation::getImpactedVerticesABDC(
     localNeighborId1 = 7;
 
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesEFHG(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in EFHG"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[0] % previous_decimation) and (p[1] % previous_decimation)) {
@@ -4003,18 +3774,13 @@ void MultiresTriangulation::getImpactedVerticesEFHG(
     localNeighborId1 = 9;
 
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesAEGC(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in AEGC"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[1] % previous_decimation) and (p[2] % previous_decimation)) {
@@ -4029,18 +3795,13 @@ void MultiresTriangulation::getImpactedVerticesAEGC(
     localNeighborId0 = 2;
     localNeighborId1 = 9;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesBFHD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in BFHD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[1] % previous_decimation) and (p[2] % previous_decimation)) {
@@ -4055,18 +3816,13 @@ void MultiresTriangulation::getImpactedVerticesBFHD(
     localNeighborId0 = 7;
     localNeighborId1 = 4;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesAEFB(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in AEFB"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[0] % previous_decimation) and (p[2] % previous_decimation)) {
@@ -4081,18 +3837,13 @@ void MultiresTriangulation::getImpactedVerticesAEFB(
     localNeighborId0 = 9;
     localNeighborId1 = 4;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesGHDC(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in GHDC"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[0] % previous_decimation) and (p[2] % previous_decimation)) {
@@ -4107,173 +3858,124 @@ void MultiresTriangulation::getImpactedVerticesGHDC(
     localNeighborId0 = 2;
     localNeighborId1 = 9;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesAB(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in AB"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 0;
     localNeighborId1 = 7;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesCD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in CD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 1;
     localNeighborId1 = 5;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesEF(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in EF"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 1;
     localNeighborId1 = 5;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesGH(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in GH"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 7;
     localNeighborId1 = 6;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesAC(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in AC"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 0;
     localNeighborId1 = 4;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesBD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in BD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 2;
     localNeighborId1 = 7;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesEG(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in EG"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 4;
     localNeighborId1 = 7;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesFH(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in FH"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 5;
     localNeighborId1 = 3;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVerticesAE(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in AE"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[2] % previous_decimation) {
     localNeighborId0 = 4;
     localNeighborId1 = 2;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4281,18 +3983,13 @@ void MultiresTriangulation::getImpactedVerticesBF(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in BF"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[2] % previous_decimation) {
     localNeighborId0 = 7;
     localNeighborId1 = 4;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4300,18 +3997,13 @@ void MultiresTriangulation::getImpactedVerticesCG(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in CG"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[2] % previous_decimation) {
     localNeighborId0 = 2;
     localNeighborId1 = 7;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4319,18 +4011,13 @@ void MultiresTriangulation::getImpactedVerticesDH(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in DH"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[2] % previous_decimation) {
     localNeighborId0 = 5;
     localNeighborId1 = 3;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4338,7 +4025,6 @@ void MultiresTriangulation::getImpactedVertices2dABCD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in 2dABCD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if((p[0] % previous_decimation) and (p[1] % previous_decimation)) {
@@ -4353,11 +4039,7 @@ void MultiresTriangulation::getImpactedVertices2dABCD(
     localNeighborId0 = 1;
     localNeighborId1 = 4;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4365,18 +4047,13 @@ void MultiresTriangulation::getImpactedVertices2dAB(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in 2dAB"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 0;
     localNeighborId1 = 3;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4384,18 +4061,13 @@ void MultiresTriangulation::getImpactedVertices2dCD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in 2dCD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[0] % previous_decimation) {
     localNeighborId0 = 0;
     localNeighborId1 = 3;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
@@ -4403,43 +4075,33 @@ void MultiresTriangulation::getImpactedVertices2dAC(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in 2dAC"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 0;
     localNeighborId1 = 3;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 void MultiresTriangulation::getImpactedVertices2dBD(
   std::array<SimplexId, 3> &p,
   SimplexId &localNeighborId0,
   SimplexId &localNeighborId1) const {
-  // cout<<"getting impacted vertices in 2dBD"<<endl;
   int previous_decimation = pow(2, (decimationLevel_ + 1));
 
   if(p[1] % previous_decimation) {
     localNeighborId0 = 2;
     localNeighborId1 = 1;
   } else {
-    cout << "THIS SHOULDNT HAPPEN" << endl;
-    cout << "previous decimation " << previous_decimation << endl;
-    cout << "position " << p[0] << " " << p[1] << " " << p[2] << endl;
-    cout << "gridsize " << gridDimensions_[0] << " " << gridDimensions_[1]
-         << " " << gridDimensions_[2] << endl;
+    this->getImpactedVerticesError(previous_decimation, p);
   }
 }
 
-vector<SimplexId>
+std::vector<SimplexId>
   MultiresTriangulation::getExtendedStar(const SimplexId &vertexId) const {
 
-  vector<SimplexId> result;
+  std::vector<SimplexId> result;
   if(dimensionality_ == 3) {
     std::array<SimplexId, 3> p{};
     vertexToPosition(vertexId, p);
@@ -4457,17 +4119,17 @@ vector<SimplexId>
       shiftZ = nbvoxels_[2] % decimation_;
     }
 
-    vector<SimplexId> vi;
+    std::vector<SimplexId> vi;
     vi.push_back(-decimation_);
     vi.push_back(0);
     vi.push_back(shiftX);
 
-    vector<SimplexId> vj;
+    std::vector<SimplexId> vj;
     vj.push_back(-decimation_);
     vj.push_back(0);
     vj.push_back(shiftY);
 
-    vector<SimplexId> vk;
+    std::vector<SimplexId> vk;
     vk.push_back(-decimation_);
     vk.push_back(0);
     vk.push_back(shiftZ);
@@ -4509,12 +4171,12 @@ vector<SimplexId>
       shiftY = nbvoxels_[1] % decimation_;
     }
 
-    vector<SimplexId> vi;
+    std::vector<SimplexId> vi;
     vi.push_back(-decimation_);
     vi.push_back(0);
     vi.push_back(shiftX);
 
-    vector<SimplexId> vj;
+    std::vector<SimplexId> vj;
     vj.push_back(-decimation_);
     vj.push_back(0);
     vj.push_back(shiftY);
@@ -4531,8 +4193,6 @@ vector<SimplexId>
     for(SimplexId i : vi) {
       for(SimplexId j : vj) {
         if(i != 0 or j != 0) {
-          cout << " lil test for " << vertexId << " " << i << " " << j << " "
-               << nbvoxels_[0] << " " << nbvoxels_[1] << endl;
           result.push_back(vertexId + i + j * vshift_[Di_]);
         }
       }
@@ -4653,7 +4313,7 @@ int MultiresTriangulation::getVertexBoundaryIndex(
 }
 
 void MultiresTriangulation::findBoundaryRepresentatives(
-  vector<SimplexId> &boundaryRepresentatives) {
+  std::vector<SimplexId> &boundaryRepresentatives) {
   int currentDecimationLevel = decimationLevel_;
   setDecimationLevel(0);
   if(dimensionality_ == 3) { // here gridDimension[i] > 1 for all i =0,1,2
@@ -4746,13 +4406,6 @@ void MultiresTriangulation::findBoundaryRepresentatives(
   }
   setDecimationLevel(currentDecimationLevel);
 }
-// void MultiresTriangulation::getImpactedVerticesSecondVersion(
-//   SimplexId vertexId,
-//   vector<SimplexId> &localIndices,
-//   vector<SimplexId> &globalIndices,
-//   vector<SimplexId> &invertedLocalIndices) {
-//   SimplexId neighborNumber = getVertexNeighborNumber(vertexId);
-// }
 
 bool ttk::MultiresTriangulation::isBoundaryImpacted(SimplexId v) const {
   bool ret = false;

--- a/core/base/multiresTriangulation/MultiresTriangulation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation.cpp
@@ -59,7 +59,7 @@ int ttk::MultiresTriangulation::preconditionVerticesInternal() {
         else
           vertexPositions_[i] = VertexPosition::BOTTOM_RIGHT_CORNER_2D; // d
       }
-      vertexCoords_[i] = std::move(p);
+      vertexCoords_[i] = p;
     }
 
   } else if(dimensionality_ == 3) {
@@ -145,7 +145,7 @@ int ttk::MultiresTriangulation::preconditionVerticesInternal() {
               = VertexPosition::BOTTOM_RIGHT_BACK_CORNER_3D; // h
         }
       }
-      vertexCoords_[i] = std::move(p);
+      vertexCoords_[i] = p;
     }
   }
   return 0;
@@ -3379,21 +3379,11 @@ void MultiresTriangulation::getImpactedVertices(SimplexId vertexId,
       if(0 < p[1] and p[1] < nbvoxels_[Dj_]) {
         getImpactedVertices2dAC(p, localNeighborId0,
                                 localNeighborId1); // ac
-        // cout << "ac" << endl;
-      } else if(p[1] == 0) {
-        // cout << "a" << endl;
-      } else {
-        // cout << "c" << endl;
       }
     } else {
       if(0 < p[1] and p[1] < nbvoxels_[Dj_]) {
         getImpactedVertices2dBD(p, localNeighborId0,
                                 localNeighborId1); // bd
-        // cout << "bd" << endl;
-      } else if(p[1] == 0) {
-        // cout << "b" << endl;
-      } else {
-        // cout << "d" << endl;
       }
     }
   } else {

--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -29,11 +29,6 @@ namespace ttk {
     MultiresTriangulation();
     ~MultiresTriangulation();
 
-    // void findEnclosingVoxel(const SimplexId &vertexId,
-    //                         int decimation,
-    //                         std::vector<SimplexId> &vertexList,
-    //                         std::vector<float> &baryCentrics) const;
-
     SimplexId getVertexNeighborAtDecimation(const SimplexId &vertexId,
                                             const int &localNeighborId,
                                             SimplexId &neighborId,
@@ -694,6 +689,8 @@ namespace ttk {
     void getImpactedVertices2dAC(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
+    void getImpactedVerticesError(const int prev_decim,
+                                  const std::array<SimplexId, 3> &p) const;
 
     void getInvertedLocalNeighborA(SimplexId id,
                                    SimplexId &invertedLocalNeighbor) const;
@@ -858,10 +855,6 @@ namespace ttk {
       } else {
         printErr("Empty input triangulation !");
       }
-      // cout << "DIM " << dimensionality_ << " - gridDims " <<
-      // gridDimensions_[0]
-      //      << " " << gridDimensions_[1] << " " << gridDimensions_[2]
-      //      << "  -  vertexNb " << vertexNumber_ << endl;
     }
 
     /**
@@ -898,15 +891,6 @@ namespace ttk {
     void
       getImpactedVertices(SimplexId vertexId, SimplexId v0[3], SimplexId v1[3]);
 
-    inline void printInfos() const {
-      std::cout << "[MultiresTriangulation] INFOS\n\t decimationLvl : "
-                << decimationLevel_ << " , decimation : " << decimation_
-                << "\n dimensions : " << gridDimensions_[0] << ", "
-                << gridDimensions_[1] << ", " << gridDimensions_[2]
-                << "\n dimensionality : " << dimensionality_ << ", "
-                << "vshifts " << vshift_[0] << " " << vshift_[1] << std::endl;
-    }
-
     void computeDecimatedDimensions() {
       int xDim = gridDimensions_[0];
       int yDim = gridDimensions_[1];
@@ -925,11 +909,6 @@ namespace ttk {
       gridDecimatedDimensions_[1] = yDim;
       gridDecimatedDimensions_[2] = zDim;
       decimatedVertexNumber_ = xDim * yDim * zDim;
-      if(debugLevel_ > 5) {
-        std::cout << "[MultiresTriangulation] computing dimensions decimated "
-                  << decimationLevel_ << " times : " << xDim << " " << yDim
-                  << " " << zDim << std::endl;
-      }
     }
 
     void computeCoarsestDecimationLevel();

--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -13,14 +13,9 @@
 /// \sa ProgressiveTopology
 /// \sa Triangulation
 
-#ifndef _MULTIRESTRIANGULATION_H
-#define _MULTIRESTRIANGULATION_H
+#pragma once
 
 // base code includes
-
-#ifdef _WIN32
-#include <ciso646>
-#endif
 #include <Geometry.h>
 #include <ImplicitTriangulation.h>
 
@@ -1071,5 +1066,3 @@ inline bool ttk::MultiresTriangulation::areVerticesNeighbors(
   }
   return false;
 }
-
-#endif

--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -597,101 +597,101 @@ namespace ttk {
                                         const SimplexId shiftY,
                                         const SimplexId shiftZ,
                                         SimplexId &invertedLocalNeighbor) const;
-    void getImpactedVerticesA(SimplexId p[3],
+    void getImpactedVerticesA(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesB(SimplexId p[3],
+    void getImpactedVerticesB(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesC(SimplexId p[3],
+    void getImpactedVerticesC(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesD(SimplexId p[3],
+    void getImpactedVerticesD(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesE(SimplexId p[3],
+    void getImpactedVerticesE(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesF(SimplexId p[3],
+    void getImpactedVerticesF(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesG(SimplexId p[3],
+    void getImpactedVerticesG(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesH(SimplexId p[3],
+    void getImpactedVerticesH(std::array<SimplexId, 3> &p,
                               SimplexId &localNeighborId0,
                               SimplexId &localNeighborId1) const;
-    void getImpactedVerticesAB(SimplexId p[3],
+    void getImpactedVerticesAB(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesEF(SimplexId p[3],
+    void getImpactedVerticesEF(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesCD(SimplexId p[3],
+    void getImpactedVerticesCD(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesGH(SimplexId p[3],
+    void getImpactedVerticesGH(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesAC(SimplexId p[3],
+    void getImpactedVerticesAC(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesEG(SimplexId p[3],
+    void getImpactedVerticesEG(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesAE(SimplexId p[3],
+    void getImpactedVerticesAE(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesCG(SimplexId p[3],
+    void getImpactedVerticesCG(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesBD(SimplexId p[3],
+    void getImpactedVerticesBD(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesFH(SimplexId p[3],
+    void getImpactedVerticesFH(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesBF(SimplexId p[3],
+    void getImpactedVerticesBF(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesDH(SimplexId p[3],
+    void getImpactedVerticesDH(std::array<SimplexId, 3> &p,
                                SimplexId &localNeighborId0,
                                SimplexId &localNeighborId1) const;
-    void getImpactedVerticesABDC(SimplexId p[3],
+    void getImpactedVerticesABDC(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesEFHG(SimplexId p[3],
+    void getImpactedVerticesEFHG(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesAEFB(SimplexId p[3],
+    void getImpactedVerticesAEFB(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesGHDC(SimplexId p[3],
+    void getImpactedVerticesGHDC(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesAEGC(SimplexId p[3],
+    void getImpactedVerticesAEGC(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesBFHD(SimplexId p[3],
+    void getImpactedVerticesBFHD(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVerticesABCDEFGH(SimplexId p[3],
+    void getImpactedVerticesABCDEFGH(std::array<SimplexId, 3> &p,
                                      SimplexId &localNeighborId0,
                                      SimplexId &localNeighborId1) const;
 
-    void getImpactedVertices2dABCD(SimplexId p[2],
+    void getImpactedVertices2dABCD(std::array<SimplexId, 3> &p,
                                    SimplexId &localNeighborId0,
                                    SimplexId &localNeighborId1) const;
-    void getImpactedVertices2dAB(SimplexId p[2],
+    void getImpactedVertices2dAB(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVertices2dCD(SimplexId p[2],
+    void getImpactedVertices2dCD(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVertices2dBD(SimplexId p[2],
+    void getImpactedVertices2dBD(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
-    void getImpactedVertices2dAC(SimplexId p[2],
+    void getImpactedVertices2dAC(std::array<SimplexId, 3> &p,
                                  SimplexId &localNeighborId0,
                                  SimplexId &localNeighborId1) const;
 
@@ -799,8 +799,10 @@ namespace ttk {
     bool areVerticesNeighbors(const SimplexId, const SimplexId) const;
     bool isBoundaryImpacted(SimplexId) const;
     SimplexId getVertexNeighborNumber(const SimplexId &vertexId) const;
-    void vertexToPosition2d(const SimplexId vertex, SimplexId p[2]) const;
-    void vertexToPosition(const SimplexId vertex, SimplexId p[3]) const;
+    void vertexToPosition2d(const SimplexId vertex,
+                            std::array<SimplexId, 3> &p) const;
+    void vertexToPosition(const SimplexId vertex,
+                          std::array<SimplexId, 3> &p) const;
     SimplexId localToGlobalVertexId(const SimplexId localId) const;
     int getVertexBoundaryIndex(const SimplexId) const;
 

--- a/core/base/multiresTriangulation/MultiresTriangulation_CustomDecimation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation_CustomDecimation.cpp
@@ -1,22 +1,13 @@
 #include <MultiresTriangulation.h>
 
-using namespace std;
-using namespace ttk;
+using ttk::MultiresTriangulation;
+using ttk::SimplexId;
 
 SimplexId MultiresTriangulation::getVertexNeighborAtDecimation(
   const SimplexId &vertexId,
   const int &localNeighborId,
   SimplexId &neighborId,
   int decimation) const {
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  // if(triangulation_->isEmptyCheck()) {
-  //   return -1;
-  // }
-  // if(localNeighborId < 0
-  //    or localNeighborId >= getVertexNeighborNumber(vertexId))
-  //   return -1;
-#endif
 
   const auto &p = this->vertexCoords_[vertexId];
 
@@ -380,7 +371,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationA(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(a)={b,c,e,g}
-  // cout << "A"<<endl;
   switch(id) {
     case 0:
       return v + shiftX; // b
@@ -402,7 +392,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationB(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(b)={a,c,d,e,f,g,h}
-  // cout << "B"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -429,7 +418,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationC(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(c)={a,b,d,g}
-  // cout << "C"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // a
@@ -451,7 +439,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationD(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(d)={b,c,g,h}
-  // cout << "D"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -473,7 +460,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationE(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(e)={a,b,f,g}
-  // cout << "E"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // a
@@ -495,7 +481,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationF(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(f)={b,e,g,h}
-  // cout << "F"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -517,7 +502,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationG(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(g)={a,b,c,d,e,f,h}
-  // cout << "G"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * shiftZ); // a
@@ -545,7 +529,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationH(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(h)={b,d,f,g}
-  // cout << "H"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * shiftZ); // b
@@ -567,7 +550,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationAB(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(ab)=V(b)+V(a)::{b}
-  // cout << "AB"<<endl;
   switch(id) {
     case 0:
       return v - decimation; // a
@@ -597,7 +579,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationCD(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(cd)=V(d)+V(c)::{b,d}
-  // cout << "CD"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -623,7 +604,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationEF(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(ef)=V(f)+V(e)::{b,f}
-  // cout << "EF"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -679,7 +659,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationAC(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(ac)=V(c)+V(a)::{c,g}
-  // cout << "AC"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * decimation; // a
@@ -705,7 +684,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationBD(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(bd)=V(b)+V(d)::{b}
-  // cout << "BD"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -735,7 +713,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationEG(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(eg)=V(g)+V(e)::{g}
-  // cout << "EG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation + vshift_[1] * shiftZ); // a
@@ -765,7 +742,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationFH(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(fh)=V(f)+V(h)::{b,f}
-  // cout << "FH"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[1] * shiftZ; // b
@@ -791,7 +767,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationAE(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(ae)=V(a)+V(e)::{a,b}
-  // cout << "AE"<<endl;
   switch(id) {
     case 0:
       return v + shiftX; // b
@@ -817,7 +792,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationBF(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(bf)=V(b)+V(f)::{b}
-  // cout << "BF"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -847,7 +821,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationCG(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(cg)=V(g)+V(c)::{g}
-  // cout << "CG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * decimation); // a
@@ -877,7 +850,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationDH(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(dh)=V(d)+V(h)::{b,d}
-  // cout << "DH"<<endl;
   switch(id) {
     case 0:
       return v - vshift_[0] * shiftY; // b
@@ -903,7 +875,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationABDC(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(abdc)=V(b)+V(d)::{b}+V(c)::{b}+V(a)::{b}
-  // cout << "ABDC"<<endl;
   switch(id) {
     case 0:
       return v - decimation; // a
@@ -937,7 +908,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationEFHG(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(efhg)=V(g)+V(h)::{g}+V(f)::{g,h}
-  // cout << "EFHG"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation + vshift_[1] * shiftZ); // a
@@ -971,7 +941,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationAEGC(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(aegc)=V(g)+V(a)::{c,g}+V(c)::{g}
-  // cout << "AEGC"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation + vshift_[1] * decimation); // a
@@ -1007,7 +976,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationBFHD(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(bfhd)=V(b)+V(f)::{b}+V(h)::{b}+V(d)::{b}
-  // cout << "BFHD"<<endl;
   switch(id) {
     case 0:
       return v - shiftX; // a
@@ -1042,7 +1010,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationAEFB(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(aefb)=V(b)+V(a)::{b}+V(e)::{b}+V(f)::{b}
-  // cout << "AEFB"<<endl;
   switch(id) {
     case 0:
       return v - decimation; // a
@@ -1076,7 +1043,6 @@ inline ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationGHDC(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(ghdc)=V(g)+V(h)::{g}+V(d)::{g,h}
-  // cout << "GHDC"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * shiftY + vshift_[1] * decimation); // a
@@ -1110,7 +1076,6 @@ ttk::SimplexId MultiresTriangulation::getVertexNeighborAtDecimationABCDEFGH(
   const SimplexId shiftZ,
   const int decimation) const {
   // V(abcdefgh)=V(g)+V(d)::{g,h}+V(h)::{g}+V(b)::{c,d,g,h}
-  // cout << "ABCDEFGH"<<endl;
   switch(id) {
     case 0:
       return v - (vshift_[0] * decimation + vshift_[1] * decimation); // a

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -254,15 +254,13 @@ int ttk::PersistenceDiagram::executeProgressiveTopology(
   progT_.setupTriangulation((ttk::ImplicitTriangulation *)triangulation);
   progT_.setStartingResolutionLevel(StartingResolutionLevel);
   progT_.setStoppingResolutionLevel(StoppingResolutionLevel);
-  // progT_.setStoppingDecimationLevel(StoppingDecimationLevel);
-  // progT_.setStartingDecimationLevel(StartingDecimationLevel);
   progT_.setTimeLimit(TimeLimit);
   progT_.setIsResumable(IsResumable);
   progT_.setPreallocateMemory(true);
 
   std::vector<ProgressiveTopology::PersistencePair> resultDiagram{};
 
-  progT_.computeProgressivePD(resultDiagram, inputScalars, inputOffsets);
+  progT_.computeProgressivePD(resultDiagram, inputOffsets);
 
   // create the final diagram
   for(const auto &p : resultDiagram) {

--- a/core/base/progressiveTopology/ProgressiveTopology.cpp
+++ b/core/base/progressiveTopology/ProgressiveTopology.cpp
@@ -1,5 +1,975 @@
 #include <ProgressiveTopology.h>
 
+int ttk::ProgressiveTopology::computeProgressivePD(
+  std::vector<PersistencePair> &CTDiagram, const SimplexId *offsets) {
+  int ret = -1;
+  printMsg("Progressive Persistence Diagram computation");
+  ret = executeCPProgressive(1, offsets);
+  CTDiagram = std::move(CTDiagram_);
+  CTDiagram_.clear();
+
+  return ret;
+}
+
+int ttk::ProgressiveTopology::executeCPProgressive(
+  int computePersistenceDiagram, const SimplexId *offsets) {
+
+  printMsg(ttk::debug::Separator::L1);
+
+  if(resumeProgressive_) {
+    resumeProgressive(computePersistenceDiagram, offsets);
+    return 0;
+  }
+
+  Timer timer;
+
+  decimationLevel_ = startingDecimationLevel_;
+  multiresTriangulation_.setDecimationLevel(0);
+  const SimplexId vertexNumber = multiresTriangulation_.getVertexNumber();
+
+#ifdef TTK_ENABLE_KAMIKAZE
+  if(vertexNumber == 0) {
+    this->printErr("No points in triangulation");
+    return 1;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
+
+  double tm_allocation = timer.getElapsedTime();
+
+  // clean state (in case previous operation was a resume)
+  clearResumableState();
+
+  const auto dim = multiresTriangulation_.getDimensionality();
+  const size_t maxNeigh = dim == 3 ? 14 : (dim == 2 ? 6 : 0);
+
+  std::vector<std::vector<SimplexId>> saddleCCMin{}, saddleCCMax{};
+  std::vector<std::vector<SimplexId>> vertexRepresentativesMin{},
+    vertexRepresentativesMax{};
+  std::vector<polarity> toPropageMin{}, toPropageMax{};
+  std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
+  std::vector<char> vertexTypes{};
+
+  if(computePersistenceDiagram) {
+    saddleCCMin.resize(vertexNumber);
+    saddleCCMax.resize(vertexNumber);
+    vertexRepresentativesMin.resize(vertexNumber);
+    vertexRepresentativesMax.resize(vertexNumber);
+    toPropageMin.resize(vertexNumber, 0);
+    toPropageMax.resize(vertexNumber, 0);
+    isUpToDateMin.resize(vertexNumber, 0);
+    isUpToDateMax.resize(vertexNumber, 0);
+  } else {
+    vertexTypes.resize(vertexNumber, static_cast<char>(CriticalType::Regular));
+  }
+
+  // index in vertexLinkByBoundaryType
+  std::vector<uint8_t> vertexLink(vertexNumber);
+  VLBoundaryType vertexLinkByBoundaryType{};
+  std::vector<DynamicTree> link(vertexNumber);
+  std::vector<polarity> isNew(vertexNumber, 255);
+  std::vector<std::vector<std::pair<polarity, polarity>>> vertexLinkPolarity(
+    vertexNumber);
+  std::vector<polarity> toProcess(vertexNumber, 0), toReprocess{};
+
+  if(this->startingDecimationLevel_ > this->stoppingDecimationLevel_
+     || this->isResumable_) {
+    // only needed for progressive computation
+    toReprocess.resize(vertexNumber, 0);
+  }
+
+  // lock vertex thread access for firstPropage
+  std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
+
+  // pre-allocate memory
+  if(preallocateMemory_) {
+    double tm_prealloc = timer.getElapsedTime();
+    printMsg("Pre-allocating data structures", 0, 0, threadNumber_,
+             ttk::debug::LineMode::REPLACE);
+    for(SimplexId i = 0; i < vertexNumber; ++i) {
+      vertexLinkPolarity[i].reserve(maxNeigh);
+      link[i].alloc(maxNeigh);
+    }
+    printMsg("Pre-allocating data structures", 1,
+             timer.getElapsedTime() - tm_prealloc, threadNumber_);
+  }
+
+  tm_allocation = timer.getElapsedTime() - tm_allocation;
+  printMsg("Total memory allocation", 1, tm_allocation, threadNumber_);
+
+  // computation of implicit link
+  std::vector<SimplexId> boundReps{};
+  multiresTriangulation_.findBoundaryRepresentatives(boundReps);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(size_t i = 0; i < boundReps.size(); i++) {
+    if(boundReps[i] != -1) {
+      buildVertexLinkByBoundary(boundReps[i], vertexLinkByBoundaryType);
+    }
+  }
+
+  printMsg(this->resolutionInfoString(), 0,
+           timer.getElapsedTime() - tm_allocation, this->threadNumber_,
+           ttk::debug::LineMode::REPLACE);
+  multiresTriangulation_.setDecimationLevel(decimationLevel_);
+
+  if(computePersistenceDiagram) {
+    initSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
+                    toProcess, link, vertexLink, vertexLinkByBoundaryType,
+                    saddleCCMin, saddleCCMax, offsets);
+    initPropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
+                    vertexRepresentativesMax, saddleCCMin, saddleCCMax,
+                    vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
+                    offsets);
+
+    // compute pairs in non-progressive mode
+    computePersistencePairsFromSaddles(
+      CTDiagram_, offsets, vertexRepresentativesMin, vertexRepresentativesMax,
+      toPropageMin, toPropageMax);
+  } else {
+    initCriticalPoints(isNew, vertexLinkPolarity, toProcess, link, vertexLink,
+                       vertexLinkByBoundaryType, vertexTypes, offsets);
+  }
+
+  printMsg(this->resolutionInfoString(), 1,
+           timer.getElapsedTime() - tm_allocation, this->threadNumber_);
+
+  // skip subsequent propagations if time limit is exceeded
+  stopComputationIf(timer.getElapsedTime() - tm_allocation
+                    > 0.9 * this->timeLimit_);
+
+  while(decimationLevel_ > stoppingDecimationLevel_) {
+    Timer tmIter{};
+    decimationLevel_--;
+    multiresTriangulation_.setDecimationLevel(decimationLevel_);
+
+    printMsg(this->resolutionInfoString(), 0,
+             timer.getElapsedTime() - tm_allocation, this->threadNumber_,
+             ttk::debug::LineMode::REPLACE);
+
+    if(computePersistenceDiagram) {
+      updateSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
+                        toProcess, toReprocess, link, vertexLink,
+                        vertexLinkByBoundaryType, saddleCCMin, saddleCCMax,
+                        isUpToDateMin, isUpToDateMax, offsets);
+      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
+                        vertexRepresentativesMax, saddleCCMin, saddleCCMax,
+                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
+                        offsets);
+      computePersistencePairsFromSaddles(
+        CTDiagram_, offsets, vertexRepresentativesMin, vertexRepresentativesMax,
+        toPropageMin, toPropageMax);
+    } else {
+      updateCriticalPoints(isNew, vertexLinkPolarity, toProcess, toReprocess,
+                           link, vertexLink, vertexLinkByBoundaryType,
+                           vertexTypes, offsets);
+    }
+
+    const auto itDuration = tmIter.getElapsedTime();
+    const auto nextItDuration
+      = predictNextIterationDuration(itDuration, CTDiagram_.size() + 1);
+
+    printMsg(this->resolutionInfoString(), 1,
+             timer.getElapsedTime() - tm_allocation, this->threadNumber_);
+
+    // skip subsequent propagations if time limit is exceeded
+    stopComputationIf(timer.getElapsedTime() + nextItDuration - tm_allocation
+                      > this->timeLimit_);
+
+    this->printMsg("current iteration", 1.0, itDuration, 1,
+                   debug::LineMode::NEW, debug::Priority::DETAIL);
+    this->printMsg("next iteration duration prediction", 1.0, nextItDuration, 1,
+                   debug::LineMode::NEW, debug::Priority::DETAIL);
+  }
+
+  // ADD GLOBAL MIN-MAX PAIR
+  if(computePersistenceDiagram) {
+    CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
+  }
+
+  // store state for resuming computation
+  if(this->isResumable_ and decimationLevel_ > 0) {
+    if(computePersistenceDiagram) {
+      this->vertexRepresentativesMax_ = std::move(vertexRepresentativesMax);
+      this->vertexRepresentativesMin_ = std::move(vertexRepresentativesMin);
+      this->saddleCCMin_ = std::move(saddleCCMin);
+      this->saddleCCMax_ = std::move(saddleCCMax);
+    }
+    this->isNew_ = std::move(isNew);
+    this->toProcess_ = std::move(toProcess);
+    this->toReprocess_ = std::move(toReprocess);
+    this->vertexLinkPolarity_ = std::move(vertexLinkPolarity);
+    this->link_ = std::move(link);
+    this->vertexLink_ = std::move(vertexLink);
+    this->vertexLinkByBoundaryType_ = std::move(vertexLinkByBoundaryType);
+    this->resumeProgressive_ = true;
+  }
+
+  // prepare outputs
+  vertexTypes_ = std::move(vertexTypes);
+
+  // finally sort the diagram
+  sortPersistenceDiagram2(CTDiagram_, offsets);
+  // sortPersistenceDiagram(CTDiagram,  offsets);
+  this->printMsg(
+    "Total", 1.0, timer.getElapsedTime() - tm_allocation, this->threadNumber_);
+  return 0;
+}
+
+int ttk::ProgressiveTopology::resumeProgressive(int computePersistenceDiagram,
+                                                const SimplexId *offsets) {
+
+  const auto vertexNumber = multiresTriangulation_.getVertexNumber();
+
+  this->printMsg(
+    "Resuming computation from resolution level "
+    + std::to_string(multiresTriangulation_.DL_to_RL(decimationLevel_))
+    + " to level "
+    + std::to_string(
+      multiresTriangulation_.DL_to_RL(stoppingDecimationLevel_)));
+
+  // lock vertex thread access for firstPropage
+  std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
+  // propagation markers
+  std::vector<polarity> toPropageMin{}, toPropageMax{};
+  std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
+
+  if(computePersistenceDiagram) {
+    toPropageMin.resize(vertexNumber, 0);
+    toPropageMax.resize(vertexNumber, 0);
+    isUpToDateMin.resize(vertexNumber, 0);
+    isUpToDateMax.resize(vertexNumber, 0);
+  }
+
+  Timer timer;
+
+  while(this->decimationLevel_ > this->stoppingDecimationLevel_) {
+    Timer tmIter{};
+    this->decimationLevel_--;
+    multiresTriangulation_.setDecimationLevel(this->decimationLevel_);
+    printMsg(this->resolutionInfoString(), 0, timer.getElapsedTime(),
+             this->threadNumber_, ttk::debug::LineMode::REPLACE);
+    if(computePersistenceDiagram) {
+      updateSaddleSeeds(isNew_, vertexLinkPolarity_, toPropageMin, toPropageMax,
+                        toProcess_, toReprocess_, link_, vertexLink_,
+                        vertexLinkByBoundaryType_, saddleCCMin_, saddleCCMax_,
+                        isUpToDateMin, isUpToDateMax, offsets);
+      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin_,
+                        vertexRepresentativesMax_, saddleCCMin_, saddleCCMax_,
+                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
+                        offsets);
+      computePersistencePairsFromSaddles(
+        CTDiagram_, offsets, vertexRepresentativesMin_,
+        vertexRepresentativesMax_, toPropageMin, toPropageMax);
+    } else {
+      updateCriticalPoints(isNew_, vertexLinkPolarity_, toProcess_,
+                           toReprocess_, link_, vertexLink_,
+                           vertexLinkByBoundaryType_, vertexTypes_, offsets);
+    }
+
+    const auto itDuration = tmIter.getElapsedTime();
+    const auto nextItDuration
+      = predictNextIterationDuration(itDuration, CTDiagram_.size() + 1);
+
+    printMsg(this->resolutionInfoString(), 1, timer.getElapsedTime(),
+             this->threadNumber_);
+
+    // skip subsequent propagations if time limit is exceeded
+    stopComputationIf(timer.getElapsedTime() + nextItDuration
+                      > this->timeLimit_);
+  }
+
+  // ADD GLOBAL MIN-MAX PAIR
+  if(computePersistenceDiagram) {
+    CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
+  }
+  // finally sort the diagram
+  sortPersistenceDiagram2(CTDiagram_, offsets);
+  // sortPersistenceDiagram(CTDiagram,  offsets);
+  this->printMsg("Total", 1.0, timer.getElapsedTime(), this->threadNumber_);
+
+  // clean state (we don't need it anymore)
+  if(this->decimationLevel_ == 0) {
+    clearResumableState();
+  }
+
+  return 0;
+}
+
+void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
+  std::vector<PersistencePair> &CTDiagram,
+  const SimplexId *const offsets,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+  const std::vector<polarity> &toPropageMin,
+  const std::vector<polarity> &toPropageMax) const {
+
+  Timer timer{};
+  std::vector<triplet> tripletsMax{}, tripletsMin{};
+  const SimplexId nbDecVert = multiresTriangulation_.getDecimatedVertexNumber();
+
+  for(SimplexId localId = 0; localId < nbDecVert; localId++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
+    if(toPropageMin[globalId]) {
+      getTripletsFromSaddles(globalId, tripletsMin, vertexRepresentativesMin);
+    }
+    if(toPropageMax[globalId]) {
+      getTripletsFromSaddles(globalId, tripletsMax, vertexRepresentativesMax);
+    }
+  }
+
+  this->printMsg("TRIPLETS", 1.0, timer.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
+  double tm_pairs = timer.getElapsedTime();
+
+  sortTriplets(tripletsMax, offsets, true);
+  sortTriplets(tripletsMin, offsets, false);
+
+  const auto tm_sort = timer.getElapsedTime();
+  this->printMsg("TRIPLETS SORT", 1.0, tm_sort - tm_pairs, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
+  typename std::remove_reference<decltype(CTDiagram)>::type CTDiagramMin{},
+    CTDiagramMax{};
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel sections num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp section
+#endif // TTK_ENABLE_OPENMP
+    tripletsToPersistencePairs(
+      CTDiagramMin, vertexRepresentativesMax, tripletsMax, offsets, true);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp section
+#endif // TTK_ENABLE_OPENMP
+    tripletsToPersistencePairs(
+      CTDiagramMax, vertexRepresentativesMin, tripletsMin, offsets, false);
+  }
+  CTDiagram = std::move(CTDiagramMin);
+  CTDiagram.insert(CTDiagram.end(), CTDiagramMax.begin(), CTDiagramMax.end());
+
+  this->printMsg("PAIRS", 1.0, timer.getElapsedTime() - tm_sort,
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::sortTriplets(std::vector<triplet> &triplets,
+                                            const SimplexId *const offsets,
+                                            const bool splitTree) const {
+  if(triplets.empty())
+    return;
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return offsets[a] < offsets[b];
+  };
+
+  // Sorting step
+  const auto cmp = [=](const triplet &t1, const triplet &t2) {
+    const SimplexId s1 = std::get<0>(t1);
+    const SimplexId s2 = std::get<0>(t2);
+    const SimplexId m1 = std::get<2>(t1);
+    const SimplexId m2 = std::get<2>(t2);
+    if(s1 != s2)
+      return lt(s1, s2) != splitTree;
+    else // s1 == s2
+      return lt(m1, m2) == splitTree;
+  };
+
+  PSORT(this->threadNumber_)(triplets.begin(), triplets.end(), cmp);
+}
+
+void ttk::ProgressiveTopology::tripletsToPersistencePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+  std::vector<triplet> &triplets,
+  const SimplexId *const offsets,
+  const bool splitTree) const {
+
+  Timer tm;
+  if(triplets.empty())
+    return;
+  size_t numberOfPairs = 0;
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return offsets[a] < offsets[b];
+  };
+
+  const auto getRep = [&](SimplexId v) -> SimplexId {
+    auto r = vertexRepresentatives[v][0];
+    while(r != v) {
+      v = r;
+      r = vertexRepresentatives[v][0];
+    }
+    return r;
+  };
+
+  for(const auto &t : triplets) {
+    SimplexId r1 = getRep(std::get<1>(t));
+    SimplexId r2 = getRep(std::get<2>(t));
+    if(r1 != r2) {
+      SimplexId s = std::get<0>(t);
+      numberOfPairs++;
+
+      // Add pair
+      if(splitTree) {
+        // r1 = min(r1, r2), r2 = max(r1, r2)
+        if(lt(r2, r1)) {
+          std::swap(r1, r2);
+        }
+        // pair saddle-max: s -> min(r1, r2);
+        pairs.emplace_back(s, r1, 2);
+
+      } else {
+        // r1 = max(r1, r2), r2 = min(r1, r2)
+        if(lt(r1, r2)) {
+          std::swap(r1, r2);
+        }
+        // pair min-saddle: max(r1, r2) -> s;
+        pairs.emplace_back(r1, s, 0);
+      }
+
+      vertexRepresentatives[std::get<1>(t)][0] = r2;
+      vertexRepresentatives[r1][0] = r2;
+    }
+  }
+
+  const std::string ptype = splitTree ? "sad-max" : "min-sad";
+  this->printMsg("found all " + ptype + " pairs", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::buildVertexLinkPolarity(
+  const SimplexId vertexId,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  const SimplexId *const offsets) const {
+
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  vlp.resize(neighborNumber);
+  for(SimplexId i = 0; i < neighborNumber; i++) {
+    SimplexId neighborId0 = -1;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId0);
+    const bool lower0 = offsets[neighborId0] < offsets[vertexId];
+    const polarity isUpper0 = static_cast<polarity>(!lower0) * 255;
+    vlp[i] = std::make_pair(isUpper0, 0);
+  }
+}
+
+void ttk::ProgressiveTopology::initDynamicLink(
+  const SimplexId &vertexId,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  uint8_t &vertexLink,
+  DynamicTree &link,
+  VLBoundaryType &vlbt,
+  const SimplexId *const offsets) const {
+
+  if(vlp.empty()) {
+    buildVertexLinkPolarity(vertexId, vlp, offsets);
+  }
+
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  link.alloc(neighborNumber);
+
+  // associate vertex link boundary
+  vertexLink = multiresTriangulation_.getVertexBoundaryIndex(vertexId);
+
+  // update the link polarity for old points that are processed for
+  // the first time
+  const auto &vl = vlbt[vertexLink];
+  for(size_t edgeId = 0; edgeId < vl.size(); edgeId++) {
+    const SimplexId n0 = vl[edgeId].first;
+    const SimplexId n1 = vl[edgeId].second;
+    if(vlp[n0].first == vlp[n1].first) {
+      // the smallest id (n0) becomes the parent of n1
+      link.insertEdge(n1, n0);
+    }
+  }
+}
+
+void ttk::ProgressiveTopology::updateCriticalPoints(
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toProcess,
+  std::vector<polarity> &toReprocess,
+  std::vector<DynamicTree> &link,
+  std::vector<uint8_t> &vertexLink,
+  VLBoundaryType &vertexLinkByBoundaryType,
+  std::vector<char> &vertexTypes,
+  const SimplexId *const offsets) const {
+
+  Timer tm;
+  const auto nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  // find breaking edges
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId localId = 0; localId < nDecVerts; localId++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
+    if(isNew[globalId]) {
+      if(decimationLevel_ > stoppingDecimationLevel_ || isResumable_) {
+        buildVertexLinkPolarity(
+          globalId, vertexLinkPolarity[globalId], offsets);
+      }
+    } else {
+      getMonotonyChangeByOldPointCP(globalId, isNew, toProcess, toReprocess,
+                                    vertexLinkPolarity[globalId], offsets);
+    }
+  }
+
+  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
+  double t_critical = tm.getElapsedTime();
+  // second Loop  process or reprocess
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(int i = 0; i < nDecVerts; i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+
+    if(isNew[globalId]) { // new point
+      if(toProcess[globalId]) {
+        initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                        vertexLink[globalId], link[globalId],
+                        vertexLinkByBoundaryType, offsets);
+        vertexTypes[globalId] = getCriticalTypeFromLink(
+          globalId, vertexLinkPolarity[globalId], link[globalId]);
+      }
+      isNew[globalId] = false;
+
+    } else { // old point
+      if(toReprocess[globalId]) {
+        if(toProcess[globalId]) { // was already processed : need to reprocess
+          updateDynamicLink(link[globalId], vertexLinkPolarity[globalId],
+                            vertexLinkByBoundaryType[vertexLink[globalId]]);
+        } else { // first processing
+          updateLinkPolarity(globalId, vertexLinkPolarity[globalId], offsets);
+          initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                          vertexLink[globalId], link[globalId],
+                          vertexLinkByBoundaryType, offsets);
+          toProcess[globalId] = 255; // mark as processed
+        }
+        vertexTypes[globalId] = getCriticalTypeFromLink(
+          globalId, vertexLinkPolarity[globalId], link[globalId]);
+        toReprocess[globalId] = 0;
+      }
+    }
+
+  } // end for openmp
+
+  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
+                 tm.getElapsedTime() - t_critical, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::updateSaddleSeeds(
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toProcess,
+  std::vector<polarity> &toReprocess,
+  std::vector<DynamicTree> &link,
+  std::vector<uint8_t> &vertexLink,
+  VLBoundaryType &vertexLinkByBoundaryType,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  std::vector<polarity> &isUpdatedMin,
+  std::vector<polarity> &isUpdatedMax,
+  const SimplexId *const offsets) const {
+
+  Timer tm;
+  const auto nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  // find breaking edges
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId localId = 0; localId < nDecVerts; localId++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
+    if(isNew[globalId]) {
+      if(decimationLevel_ > stoppingDecimationLevel_ || isResumable_) {
+        buildVertexLinkPolarity(
+          globalId, vertexLinkPolarity[globalId], offsets);
+      }
+    } else {
+      getMonotonyChangeByOldPointCP(globalId, isNew, toProcess, toReprocess,
+                                    vertexLinkPolarity[globalId], offsets);
+    }
+  }
+
+  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
+  double t_critical = tm.getElapsedTime();
+  // second Loop  process or reprocess
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(int i = 0; i < nDecVerts; i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+
+    if(isNew[globalId]) { // new point
+      if(toProcess[globalId]) {
+        initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                        vertexLink[globalId], link[globalId],
+                        vertexLinkByBoundaryType, offsets);
+        getValencesFromLink(globalId, vertexLinkPolarity[globalId],
+                            link[globalId], toPropageMin, toPropageMax,
+                            saddleCCMin, saddleCCMax);
+      }
+      isNew[globalId] = false;
+
+    } else { // old point
+      if(toReprocess[globalId]) {
+        if(toProcess[globalId]) { // was already processed : need to reprocess
+          updateDynamicLink(link[globalId], vertexLinkPolarity[globalId],
+                            vertexLinkByBoundaryType[vertexLink[globalId]]);
+        } else { // first processing
+          updateLinkPolarity(globalId, vertexLinkPolarity[globalId], offsets);
+          initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                          vertexLink[globalId], link[globalId],
+                          vertexLinkByBoundaryType, offsets);
+          toProcess[globalId] = 255; // mark as processed
+        }
+        getValencesFromLink(globalId, vertexLinkPolarity[globalId],
+                            link[globalId], toPropageMin, toPropageMax,
+                            saddleCCMin, saddleCCMax);
+        toReprocess[globalId] = 0;
+      }
+    }
+
+    // reset updated flag
+    isUpdatedMin[globalId] = 0;
+    isUpdatedMax[globalId] = 0;
+  } // end for openmp
+
+  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
+                 tm.getElapsedTime() - t_critical, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+}
+
+bool ttk::ProgressiveTopology::getMonotonyChangeByOldPointCP(
+  const SimplexId vertexId,
+  const std::vector<polarity> &isNew,
+  std::vector<polarity> &toProcess,
+  std::vector<polarity> &toReprocess,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  const SimplexId *const offsets) const {
+
+  bool hasMonotonyChanged = false;
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  for(SimplexId i = 0; i < neighborNumber; i++) {
+    SimplexId neighborId = -1;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
+
+    // check for monotony changes
+    const bool lower = offsets[neighborId] < offsets[vertexId];
+    const polarity isUpper = lower ? 0 : 255;
+    const polarity isUpperOld = vlp[i].first;
+
+    if(isUpper != isUpperOld) { // change of monotony
+      hasMonotonyChanged = true;
+
+      toReprocess[vertexId] = 255;
+      toProcess[neighborId] = 255;
+      const SimplexId neighborNumberNew
+        = multiresTriangulation_.getVertexNeighborNumber(neighborId);
+      for(SimplexId j = 0; j < neighborNumberNew; j++) {
+        SimplexId neighborIdNew = -1;
+        multiresTriangulation_.getVertexNeighbor(neighborId, j, neighborIdNew);
+        if(isNew[neighborIdNew])
+          toProcess[neighborIdNew] = 255;
+      }
+
+      vlp[i].second = 255;
+    }
+  }
+  return hasMonotonyChanged;
+}
+
+ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
+  const SimplexId vertexId,
+  std::vector<Lock> &vertLock,
+  std::vector<polarity> &toPropage,
+  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+  std::vector<std::vector<SimplexId>> &saddleCC,
+  std::vector<polarity> &isUpdated,
+  std::vector<SimplexId> &globalExtremum,
+  const SimplexId *const offsets,
+  const bool splitTree) const {
+
+  auto &toProp = toPropage[vertexId];
+  auto &reps = vertexRepresentatives[vertexId];
+  auto &updated = isUpdated[vertexId];
+
+  const auto gt = [=](const SimplexId a, const SimplexId b) {
+    return (offsets[a] > offsets[b]) == splitTree;
+  };
+
+  if(updated) {
+    return reps[0];
+  }
+
+  if(this->threadNumber_ > 1) {
+    vertLock[vertexId].lock();
+  }
+
+  if(toProp) { // SADDLE POINT
+    const auto &CC = saddleCC[vertexId];
+    reps.clear();
+    reps.reserve(CC.size());
+    for(size_t r = 0; r < CC.size(); r++) {
+      SimplexId neighborId = -1;
+      SimplexId localId = CC[r];
+      multiresTriangulation_.getVertexNeighbor(vertexId, localId, neighborId);
+      SimplexId ret = propageFromSaddles(
+        neighborId, vertLock, toPropage, vertexRepresentatives, saddleCC,
+        isUpdated, globalExtremum, offsets, splitTree);
+      reps.emplace_back(ret);
+    }
+
+    if(reps.size() > 1) {
+      // sort & remove duplicate elements
+      std::sort(reps.begin(), reps.end(), gt);
+      const auto last = std::unique(reps.begin(), reps.end());
+      reps.erase(last, reps.end());
+    }
+
+    updated = 255;
+    if(this->threadNumber_ > 1) {
+      vertLock[vertexId].unlock();
+    }
+
+    return reps[0];
+
+  } else {
+
+    SimplexId ret = vertexId;
+    SimplexId neighborNumber
+      = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+    SimplexId maxNeighbor = vertexId;
+    for(SimplexId i = 0; i < neighborNumber; i++) {
+      SimplexId neighborId = -1;
+      multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
+      if(gt(neighborId, maxNeighbor)) {
+        maxNeighbor = neighborId;
+      }
+    }
+    if(maxNeighbor != vertexId) { // not an extremum
+      ret = propageFromSaddles(maxNeighbor, vertLock, toPropage,
+                               vertexRepresentatives, saddleCC, isUpdated,
+                               globalExtremum, offsets, splitTree);
+    } else {
+#ifdef TTK_ENABLE_OPENMP
+      const auto tid = omp_get_thread_num();
+#else
+      const auto tid = 0;
+#endif // TTK_ENABLE_OPENMP
+      if(gt(vertexId, globalExtremum[tid])) {
+        globalExtremum[tid] = vertexId;
+      }
+    }
+    reps.resize(1);
+    reps[0] = ret;
+    updated = 255;
+    if(this->threadNumber_ > 1) {
+      vertLock[vertexId].unlock();
+    }
+    return ret;
+  }
+}
+
+void ttk::ProgressiveTopology::initCriticalPoints(
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toProcess,
+  std::vector<DynamicTree> &link,
+  std::vector<uint8_t> &vertexLink,
+  VLBoundaryType &vertexLinkByBoundaryType,
+  std::vector<char> &vertexTypes,
+  const SimplexId *const offsets) const {
+
+  Timer timer{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  // computes the critical types of all points
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+    buildVertexLinkPolarity(globalId, vertexLinkPolarity[globalId], offsets);
+    initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                    vertexLink[globalId], link[globalId],
+                    vertexLinkByBoundaryType, offsets);
+    vertexTypes[globalId] = getCriticalTypeFromLink(
+      globalId, vertexLinkPolarity[globalId], link[globalId]);
+    toProcess[globalId] = 255;
+    isNew[globalId] = 0;
+  }
+
+  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::initSaddleSeeds(
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toProcess,
+  std::vector<DynamicTree> &link,
+  std::vector<uint8_t> &vertexLink,
+  VLBoundaryType &vertexLinkByBoundaryType,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  const SimplexId *const offsets) const {
+
+  Timer timer{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  // computes the critical types of all points
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+    buildVertexLinkPolarity(globalId, vertexLinkPolarity[globalId], offsets);
+    initDynamicLink(globalId, vertexLinkPolarity[globalId],
+                    vertexLink[globalId], link[globalId],
+                    vertexLinkByBoundaryType, offsets);
+    getValencesFromLink(globalId, vertexLinkPolarity[globalId], link[globalId],
+                        toPropageMin, toPropageMax, saddleCCMin, saddleCCMax);
+    toProcess[globalId] = 255;
+    isNew[globalId] = 0;
+  }
+
+  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::initPropagation(
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  std::vector<Lock> &vertLockMin,
+  std::vector<Lock> &vertLockMax,
+  std::vector<polarity> &isUpdatedMin,
+  std::vector<polarity> &isUpdatedMax,
+  const SimplexId *const offsets) const {
+
+  Timer timer{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
+  std::vector<SimplexId> globalMinThr(threadNumber_, 0);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
+    if(toPropageMin[v]) {
+      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
+                         saddleCCMin, isUpdatedMin, globalMinThr, offsets,
+                         false);
+    }
+    if(toPropageMax[v]) {
+      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
+                         saddleCCMax, isUpdatedMax, globalMaxThr, offsets,
+                         true);
+    }
+  }
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return offsets[a] < offsets[b];
+  };
+
+  globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
+  globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
+
+  this->printMsg("FIRSTPROPAGATION", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::updatePropagation(
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  std::vector<Lock> &vertLockMin,
+  std::vector<Lock> &vertLockMax,
+  std::vector<polarity> &isUpdatedMin,
+  std::vector<polarity> &isUpdatedMax,
+  const SimplexId *const offsets) const {
+
+  Timer tm{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
+  std::vector<SimplexId> globalMinThr(threadNumber_, 0);
+
+  // propage along split tree
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
+    if(toPropageMin[v]) {
+      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
+                         saddleCCMin, isUpdatedMin, globalMinThr, offsets,
+                         false);
+    }
+    if(toPropageMax[v]) {
+      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
+                         saddleCCMax, isUpdatedMax, globalMaxThr, offsets,
+                         true);
+    }
+  }
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return offsets[a] < offsets[b];
+  };
+
+  globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
+  globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
+
+  this->printMsg("PROPAGATION UPDATE", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+void ttk::ProgressiveTopology::updateLinkPolarity(
+  const SimplexId vertexId,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  const SimplexId *const offsets) const {
+
+  for(size_t i = 0; i < vlp.size(); i++) {
+    SimplexId neighborId = -1;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
+    const bool lower = offsets[neighborId] < offsets[vertexId];
+    const polarity isUpper = lower ? 0 : 255;
+    vlp[i] = std::make_pair(isUpper, 0);
+  }
+}
+
 void ttk::ProgressiveTopology::getValencesFromLink(
   const SimplexId vertexId,
   const std::vector<std::pair<polarity, polarity>> &vlp,
@@ -286,8 +1256,7 @@ int ttk::ProgressiveTopology::computeProgressiveCP(
 
   printMsg("Progressive Critical Points computation");
   int ret = -1;
-  const double *dummyScalars{};
-  ret = executeCPProgressive<double>(0, dummyScalars, offsets);
+  ret = executeCPProgressive(0, offsets);
 
   SimplexId vertexNumber = multiresTriangulation_.getVertexNumber();
   criticalPoints->clear();

--- a/core/base/progressiveTopology/ProgressiveTopology.cpp
+++ b/core/base/progressiveTopology/ProgressiveTopology.cpp
@@ -152,7 +152,7 @@ void ttk::ProgressiveTopology::getTripletsFromSaddles(
 #ifndef TTK_ENABLE_KAMIKAZE
   const auto &repsm = vertexReps[m];
   if(m == -1 || repsm.empty() || repsm[0] != m) {
-    std::cout << "HERE PROBLEM" << std::endl;
+    this->printErr("HERE PROBLEM");
   }
 #endif // TTK_ENABLE_KAMIKAZE
   for(size_t i = 1; i < reps.size(); i++) {
@@ -160,7 +160,7 @@ void ttk::ProgressiveTopology::getTripletsFromSaddles(
 #ifndef TTK_ENABLE_KAMIKAZE
     const auto &repsn = vertexReps[n];
     if(n == -1 || repsn.empty() || repsn[0] != n) {
-      std::cout << "HERE2 PROBLEM" << std::endl;
+      this->printErr("HERE2 PROBLEM");
     }
 #endif // TTK_ENABLE_KAMIKAZE
     triplets.emplace_back(vertexId, m, n);

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -65,18 +65,9 @@ namespace ttk {
       this->setDebugMsgPrefix("ProgressiveTopology");
     }
 
-    inline int setupTriangulation(ImplicitTriangulation *data) {
+    inline void setupTriangulation(ImplicitTriangulation *const data) {
       triangulation_ = data;
       multiresTriangulation_.setTriangulation(triangulation_);
-      return 0;
-    }
-    inline int setInputScalars(void *data) {
-      inputScalars_ = data;
-      return 0;
-    }
-    inline int setInputOffsets(void *data) {
-      inputOffsets_ = data;
-      return 0;
     }
 
   protected:
@@ -85,14 +76,10 @@ namespace ttk {
 
     /* PROGRESSIVE MODE DECLARATIONS */
   public:
-    template <class scalarType>
     int executeCPProgressive(int computePersistenceDiagram,
-                             const scalarType *inputScalars,
                              const SimplexId *inputOffsets);
 
-    template <typename scalarType>
     int resumeProgressive(int computePersistenceDiagram,
-                          const scalarType *scalars,
                           const SimplexId *offsets);
 
     inline void setAlgorithm(int data) {
@@ -133,9 +120,7 @@ namespace ttk {
       return this->stoppingDecimationLevel_;
     }
 
-    template <typename scalarType>
     int computeProgressivePD(std::vector<PersistencePair> &CTDiagram,
-                             const scalarType *scalars,
                              const SimplexId *offsets);
 
     int computeProgressiveCP(
@@ -156,7 +141,6 @@ namespace ttk {
     using VLBoundaryType
       = std::array<std::vector<std::pair<SimplexId, SimplexId>>, nLink_>;
 
-    template <typename ScalarType, typename OffsetType>
     void
       initCriticalPoints(std::vector<polarity> &isNew,
                          std::vector<std::vector<std::pair<polarity, polarity>>>
@@ -166,10 +150,8 @@ namespace ttk {
                          std::vector<uint8_t> &vertexLink,
                          VLBoundaryType &vertexLinkByBoundaryType,
                          std::vector<char> &vertexTypes,
-                         const ScalarType *const scalars,
-                         const OffsetType *const offsets) const;
+                         const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void initSaddleSeeds(std::vector<polarity> &isNew,
                          std::vector<std::vector<std::pair<polarity, polarity>>>
                            &vertexLinkPolarity,
@@ -181,10 +163,8 @@ namespace ttk {
                          VLBoundaryType &vertexLinkByBoundaryType,
                          std::vector<std::vector<SimplexId>> &saddleCCMin,
                          std::vector<std::vector<SimplexId>> &saddleCCMax,
-                         const ScalarType *const scalars,
-                         const OffsetType *const offsets) const;
+                         const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void initPropagation(
       std::vector<polarity> &toPropageMin,
       std::vector<polarity> &toPropageMax,
@@ -196,10 +176,8 @@ namespace ttk {
       std::vector<Lock> &vertLockMax,
       std::vector<polarity> &isUpdatedMin,
       std::vector<polarity> &isUpdatedMax,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets) const;
+      const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void updatePropagation(
       std::vector<polarity> &toPropageMin,
       std::vector<polarity> &toPropageMax,
@@ -211,42 +189,33 @@ namespace ttk {
       std::vector<Lock> &vertLockMax,
       std::vector<polarity> &isUpdatedMin,
       std::vector<polarity> &isUpdatedMax,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets) const;
+      const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void
       buildVertexLinkPolarity(const SimplexId vertexId,
                               std::vector<std::pair<polarity, polarity>> &vlp,
-                              const ScalarType *const scalars,
-                              const OffsetType *const offsets) const;
+                              const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void sortTriplets(std::vector<triplet> &triplets,
-                      const ScalarType *const scalars,
-                      const OffsetType *const offsets,
+                      const SimplexId *const offsets,
                       const bool splitTree) const;
 
-    template <typename scalarType, typename offsetType>
     void tripletsToPersistencePairs(
       std::vector<PersistencePair> &pairs,
       std::vector<std::vector<SimplexId>> &vertexRepresentatives,
       std::vector<triplet> &triplets,
-      const scalarType *const scalars,
-      const offsetType *const offsets,
+      const SimplexId *const offsets,
       const bool splitTree) const;
 
     void buildVertexLinkByBoundary(const SimplexId vertexId,
                                    VLBoundaryType &vlbt) const;
 
-    template <typename ScalarType, typename OffsetType>
     void initDynamicLink(const SimplexId &vertexId,
                          std::vector<std::pair<polarity, polarity>> &vlp,
                          uint8_t &vertexLink,
                          DynamicTree &link,
                          VLBoundaryType &vlbt,
-                         const ScalarType *const scalars,
-                         const OffsetType *const offsets) const;
+                         const SimplexId *const offsets) const;
 
     char getCriticalTypeFromLink(
       const SimplexId vertexId,
@@ -267,7 +236,6 @@ namespace ttk {
                         std::vector<std::pair<polarity, polarity>> &vlp,
                         std::vector<std::pair<SimplexId, SimplexId>> &vl) const;
 
-    template <typename ScalarType, typename OffsetType>
     void updateCriticalPoints(
       std::vector<polarity> &isNew,
       std::vector<std::vector<std::pair<polarity, polarity>>>
@@ -278,10 +246,8 @@ namespace ttk {
       std::vector<uint8_t> &vertexLink,
       VLBoundaryType &vertexLinkByBoundaryType,
       std::vector<char> &vertexTypes,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets) const;
+      const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void
       updateSaddleSeeds(std::vector<polarity> &isNew,
                         std::vector<std::vector<std::pair<polarity, polarity>>>
@@ -297,26 +263,20 @@ namespace ttk {
                         std::vector<std::vector<SimplexId>> &saddleCCMax,
                         std::vector<polarity> &isUpdatedMin,
                         std::vector<polarity> &isUpdatedMax,
-                        const ScalarType *const scalars,
-                        const OffsetType *const offsets) const;
+                        const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     bool getMonotonyChangeByOldPointCP(
       const SimplexId vertexId,
       const std::vector<polarity> &isNew,
       std::vector<polarity> &toProcess,
       std::vector<polarity> &toReprocess,
       std::vector<std::pair<polarity, polarity>> &vlp,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets) const;
+      const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     void updateLinkPolarity(const SimplexId vertexId,
                             std::vector<std::pair<polarity, polarity>> &vlp,
-                            const ScalarType *const scalars,
-                            const OffsetType *const offsets) const;
+                            const SimplexId *const offsets) const;
 
-    template <typename ScalarType, typename OffsetType>
     ttk::SimplexId propageFromSaddles(
       const SimplexId vertexId,
       std::vector<Lock> &vertLock,
@@ -325,8 +285,7 @@ namespace ttk {
       std::vector<std::vector<SimplexId>> &saddleCC,
       std::vector<polarity> &isUpdated,
       std::vector<SimplexId> &globalExtremum,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets,
+      const SimplexId *const offsets,
       const bool splitTree) const;
 
     void getTripletsFromSaddles(
@@ -334,11 +293,9 @@ namespace ttk {
       std::vector<triplet> &triplets,
       const std::vector<std::vector<SimplexId>> &vertexReps) const;
 
-    template <typename ScalarType, typename OffsetType>
     void computePersistencePairsFromSaddles(
       std::vector<PersistencePair> &CTDiagram,
-      const ScalarType *const scalars,
-      const OffsetType *const offsets,
+      const SimplexId *const offsets,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
       const std::vector<polarity> &toPropageMin,
@@ -352,8 +309,6 @@ namespace ttk {
     std::string resolutionInfoString();
 
     ImplicitTriangulation *triangulation_{};
-    void *inputScalars_{};
-    void *inputOffsets_{};
 
     // new non-progressive approach
     MultiresTriangulation multiresTriangulation_{};
@@ -392,1015 +347,3 @@ namespace ttk {
     std::vector<PersistencePair> CTDiagram_;
   };
 } // namespace ttk
-
-template <typename scalarType>
-int ttk::ProgressiveTopology::computeProgressivePD(
-  std::vector<PersistencePair> &CTDiagram,
-  const scalarType *scalars,
-  const SimplexId *offsets) {
-  int ret = -1;
-  printMsg("Progressive Persistence Diagram computation");
-  ret = executeCPProgressive(1, scalars, offsets);
-  CTDiagram = std::move(CTDiagram_);
-  CTDiagram_.clear();
-
-  return ret;
-}
-
-template <typename scalarType>
-int ttk::ProgressiveTopology::executeCPProgressive(
-  int computePersistenceDiagram,
-  const scalarType *scalars,
-  const SimplexId *offsets) {
-
-  printMsg(ttk::debug::Separator::L1);
-
-  if(resumeProgressive_) {
-    resumeProgressive(computePersistenceDiagram, scalars, offsets);
-    return 0;
-  }
-
-  Timer timer;
-
-  decimationLevel_ = startingDecimationLevel_;
-  multiresTriangulation_.setDecimationLevel(0);
-  const SimplexId vertexNumber = multiresTriangulation_.getVertexNumber();
-
-#ifdef TTK_ENABLE_KAMIKAZE
-  if(vertexNumber == 0) {
-    this->printErr("No points in triangulation");
-    return 1;
-  }
-#endif // TTK_ENABLE_KAMIKAZE
-
-  double tm_allocation = timer.getElapsedTime();
-
-  // clean state (in case previous operation was a resume)
-  clearResumableState();
-
-  const auto dim = multiresTriangulation_.getDimensionality();
-  const size_t maxNeigh = dim == 3 ? 14 : (dim == 2 ? 6 : 0);
-
-  std::vector<std::vector<SimplexId>> saddleCCMin{}, saddleCCMax{};
-  std::vector<std::vector<SimplexId>> vertexRepresentativesMin{},
-    vertexRepresentativesMax{};
-  std::vector<polarity> toPropageMin{}, toPropageMax{};
-  std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
-  std::vector<char> vertexTypes{};
-
-  if(computePersistenceDiagram) {
-    saddleCCMin.resize(vertexNumber);
-    saddleCCMax.resize(vertexNumber);
-    vertexRepresentativesMin.resize(vertexNumber);
-    vertexRepresentativesMax.resize(vertexNumber);
-    toPropageMin.resize(vertexNumber, 0);
-    toPropageMax.resize(vertexNumber, 0);
-    isUpToDateMin.resize(vertexNumber, 0);
-    isUpToDateMax.resize(vertexNumber, 0);
-  } else {
-    vertexTypes.resize(vertexNumber, static_cast<char>(CriticalType::Regular));
-  }
-
-  // index in vertexLinkByBoundaryType
-  std::vector<uint8_t> vertexLink(vertexNumber);
-  VLBoundaryType vertexLinkByBoundaryType{};
-  std::vector<DynamicTree> link(vertexNumber);
-  std::vector<polarity> isNew(vertexNumber, 255);
-  std::vector<std::vector<std::pair<polarity, polarity>>> vertexLinkPolarity(
-    vertexNumber);
-  std::vector<polarity> toProcess(vertexNumber, 0), toReprocess{};
-
-  if(this->startingDecimationLevel_ > this->stoppingDecimationLevel_
-     || this->isResumable_) {
-    // only needed for progressive computation
-    toReprocess.resize(vertexNumber, 0);
-  }
-
-  // lock vertex thread access for firstPropage
-  std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
-
-  // pre-allocate memory
-  if(preallocateMemory_) {
-    double tm_prealloc = timer.getElapsedTime();
-    printMsg("Pre-allocating data structures", 0, 0, threadNumber_,
-             ttk::debug::LineMode::REPLACE);
-    for(SimplexId i = 0; i < vertexNumber; ++i) {
-      vertexLinkPolarity[i].reserve(maxNeigh);
-      link[i].alloc(maxNeigh);
-    }
-    printMsg("Pre-allocating data structures", 1,
-             timer.getElapsedTime() - tm_prealloc, threadNumber_);
-  }
-
-  tm_allocation = timer.getElapsedTime() - tm_allocation;
-  printMsg("Total memory allocation", 1, tm_allocation, threadNumber_);
-
-  // computation of implicit link
-  std::vector<SimplexId> boundReps{};
-  multiresTriangulation_.findBoundaryRepresentatives(boundReps);
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(size_t i = 0; i < boundReps.size(); i++) {
-    if(boundReps[i] != -1) {
-      buildVertexLinkByBoundary(boundReps[i], vertexLinkByBoundaryType);
-    }
-  }
-
-  printMsg(this->resolutionInfoString(), 0,
-           timer.getElapsedTime() - tm_allocation, this->threadNumber_,
-           ttk::debug::LineMode::REPLACE);
-  multiresTriangulation_.setDecimationLevel(decimationLevel_);
-
-  if(computePersistenceDiagram) {
-    initSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
-                    toProcess, link, vertexLink, vertexLinkByBoundaryType,
-                    saddleCCMin, saddleCCMax, scalars, offsets);
-    initPropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
-                    vertexRepresentativesMax, saddleCCMin, saddleCCMax,
-                    vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
-                    scalars, offsets);
-
-    // compute pairs in non-progressive mode
-    computePersistencePairsFromSaddles(
-      CTDiagram_, scalars, offsets, vertexRepresentativesMin,
-      vertexRepresentativesMax, toPropageMin, toPropageMax);
-  } else {
-    initCriticalPoints(isNew, vertexLinkPolarity, toProcess, link, vertexLink,
-                       vertexLinkByBoundaryType, vertexTypes, scalars, offsets);
-  }
-
-  printMsg(this->resolutionInfoString(), 1,
-           timer.getElapsedTime() - tm_allocation, this->threadNumber_);
-
-  // skip subsequent propagations if time limit is exceeded
-  stopComputationIf(timer.getElapsedTime() - tm_allocation
-                    > 0.9 * this->timeLimit_);
-
-  while(decimationLevel_ > stoppingDecimationLevel_) {
-    Timer tmIter{};
-    decimationLevel_--;
-    multiresTriangulation_.setDecimationLevel(decimationLevel_);
-
-    printMsg(this->resolutionInfoString(), 0,
-             timer.getElapsedTime() - tm_allocation, this->threadNumber_,
-             ttk::debug::LineMode::REPLACE);
-
-    if(computePersistenceDiagram) {
-      updateSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
-                        toProcess, toReprocess, link, vertexLink,
-                        vertexLinkByBoundaryType, saddleCCMin, saddleCCMax,
-                        isUpToDateMin, isUpToDateMax, scalars, offsets);
-      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
-                        vertexRepresentativesMax, saddleCCMin, saddleCCMax,
-                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
-                        scalars, offsets);
-      computePersistencePairsFromSaddles(
-        CTDiagram_, scalars, offsets, vertexRepresentativesMin,
-        vertexRepresentativesMax, toPropageMin, toPropageMax);
-    } else {
-      updateCriticalPoints(isNew, vertexLinkPolarity, toProcess, toReprocess,
-                           link, vertexLink, vertexLinkByBoundaryType,
-                           vertexTypes, scalars, offsets);
-    }
-
-    const auto itDuration = tmIter.getElapsedTime();
-    const auto nextItDuration
-      = predictNextIterationDuration(itDuration, CTDiagram_.size() + 1);
-
-    printMsg(this->resolutionInfoString(), 1,
-             timer.getElapsedTime() - tm_allocation, this->threadNumber_);
-
-    // skip subsequent propagations if time limit is exceeded
-    stopComputationIf(timer.getElapsedTime() + nextItDuration - tm_allocation
-                      > this->timeLimit_);
-
-    this->printMsg("current iteration", 1.0, itDuration, 1,
-                   debug::LineMode::NEW, debug::Priority::DETAIL);
-    this->printMsg("next iteration duration prediction", 1.0, nextItDuration, 1,
-                   debug::LineMode::NEW, debug::Priority::DETAIL);
-  }
-
-  // ADD GLOBAL MIN-MAX PAIR
-  if(computePersistenceDiagram) {
-    CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
-  }
-
-  // store state for resuming computation
-  if(this->isResumable_ and decimationLevel_ > 0) {
-    if(computePersistenceDiagram) {
-      this->vertexRepresentativesMax_ = std::move(vertexRepresentativesMax);
-      this->vertexRepresentativesMin_ = std::move(vertexRepresentativesMin);
-      this->saddleCCMin_ = std::move(saddleCCMin);
-      this->saddleCCMax_ = std::move(saddleCCMax);
-    }
-    this->isNew_ = std::move(isNew);
-    this->toProcess_ = std::move(toProcess);
-    this->toReprocess_ = std::move(toReprocess);
-    this->vertexLinkPolarity_ = std::move(vertexLinkPolarity);
-    this->link_ = std::move(link);
-    this->vertexLink_ = std::move(vertexLink);
-    this->vertexLinkByBoundaryType_ = std::move(vertexLinkByBoundaryType);
-    this->resumeProgressive_ = true;
-  }
-
-  // prepare outputs
-  vertexTypes_ = std::move(vertexTypes);
-
-  // finally sort the diagram
-  sortPersistenceDiagram2(CTDiagram_, offsets);
-  // sortPersistenceDiagram(CTDiagram, scalars, offsets);
-  this->printMsg(
-    "Total", 1.0, timer.getElapsedTime() - tm_allocation, this->threadNumber_);
-  return 0;
-}
-
-template <typename scalarType>
-int ttk::ProgressiveTopology::resumeProgressive(int computePersistenceDiagram,
-                                                const scalarType *scalars,
-                                                const SimplexId *offsets) {
-
-  const auto vertexNumber = multiresTriangulation_.getVertexNumber();
-
-  this->printMsg(
-    "Resuming computation from resolution level "
-    + std::to_string(multiresTriangulation_.DL_to_RL(decimationLevel_))
-    + " to level "
-    + std::to_string(
-      multiresTriangulation_.DL_to_RL(stoppingDecimationLevel_)));
-
-  // lock vertex thread access for firstPropage
-  std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
-  // propagation markers
-  std::vector<polarity> toPropageMin{}, toPropageMax{};
-  std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
-
-  if(computePersistenceDiagram) {
-    toPropageMin.resize(vertexNumber, 0);
-    toPropageMax.resize(vertexNumber, 0);
-    isUpToDateMin.resize(vertexNumber, 0);
-    isUpToDateMax.resize(vertexNumber, 0);
-  }
-
-  Timer timer;
-
-  while(this->decimationLevel_ > this->stoppingDecimationLevel_) {
-    Timer tmIter{};
-    this->decimationLevel_--;
-    multiresTriangulation_.setDecimationLevel(this->decimationLevel_);
-    printMsg(this->resolutionInfoString(), 0, timer.getElapsedTime(),
-             this->threadNumber_, ttk::debug::LineMode::REPLACE);
-    if(computePersistenceDiagram) {
-      updateSaddleSeeds(isNew_, vertexLinkPolarity_, toPropageMin, toPropageMax,
-                        toProcess_, toReprocess_, link_, vertexLink_,
-                        vertexLinkByBoundaryType_, saddleCCMin_, saddleCCMax_,
-                        isUpToDateMin, isUpToDateMax, scalars, offsets);
-      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin_,
-                        vertexRepresentativesMax_, saddleCCMin_, saddleCCMax_,
-                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
-                        scalars, offsets);
-      computePersistencePairsFromSaddles(
-        CTDiagram_, scalars, offsets, vertexRepresentativesMin_,
-        vertexRepresentativesMax_, toPropageMin, toPropageMax);
-    } else {
-      updateCriticalPoints(
-        isNew_, vertexLinkPolarity_, toProcess_, toReprocess_, link_,
-        vertexLink_, vertexLinkByBoundaryType_, vertexTypes_, scalars, offsets);
-    }
-
-    const auto itDuration = tmIter.getElapsedTime();
-    const auto nextItDuration
-      = predictNextIterationDuration(itDuration, CTDiagram_.size() + 1);
-
-    printMsg(this->resolutionInfoString(), 1, timer.getElapsedTime(),
-             this->threadNumber_);
-
-    // skip subsequent propagations if time limit is exceeded
-    stopComputationIf(timer.getElapsedTime() + nextItDuration
-                      > this->timeLimit_);
-  }
-
-  // ADD GLOBAL MIN-MAX PAIR
-  if(computePersistenceDiagram) {
-    CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
-  }
-  // finally sort the diagram
-  sortPersistenceDiagram2(CTDiagram_, offsets);
-  // sortPersistenceDiagram(CTDiagram, scalars, offsets);
-  this->printMsg("Total", 1.0, timer.getElapsedTime(), this->threadNumber_);
-
-  // clean state (we don't need it anymore)
-  if(this->decimationLevel_ == 0) {
-    clearResumableState();
-  }
-
-  return 0;
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
-  std::vector<PersistencePair> &CTDiagram,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-  const std::vector<polarity> &toPropageMin,
-  const std::vector<polarity> &toPropageMax) const {
-
-  Timer timer{};
-  std::vector<triplet> tripletsMax{}, tripletsMin{};
-  const SimplexId nbDecVert = multiresTriangulation_.getDecimatedVertexNumber();
-
-  for(SimplexId localId = 0; localId < nbDecVert; localId++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
-    if(toPropageMin[globalId]) {
-      getTripletsFromSaddles(globalId, tripletsMin, vertexRepresentativesMin);
-    }
-    if(toPropageMax[globalId]) {
-      getTripletsFromSaddles(globalId, tripletsMax, vertexRepresentativesMax);
-    }
-  }
-
-  this->printMsg("TRIPLETS", 1.0, timer.getElapsedTime(), this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-
-  double tm_pairs = timer.getElapsedTime();
-
-  sortTriplets(tripletsMax, scalars, offsets, true);
-  sortTriplets(tripletsMin, scalars, offsets, false);
-
-  const auto tm_sort = timer.getElapsedTime();
-  this->printMsg("TRIPLETS SORT", 1.0, tm_sort - tm_pairs, this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-
-  typename std::remove_reference<decltype(CTDiagram)>::type CTDiagramMin{},
-    CTDiagramMax{};
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel sections num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp section
-#endif // TTK_ENABLE_OPENMP
-    tripletsToPersistencePairs(CTDiagramMin, vertexRepresentativesMax,
-                               tripletsMax, scalars, offsets, true);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp section
-#endif // TTK_ENABLE_OPENMP
-    tripletsToPersistencePairs(CTDiagramMax, vertexRepresentativesMin,
-                               tripletsMin, scalars, offsets, false);
-  }
-  CTDiagram = std::move(CTDiagramMin);
-  CTDiagram.insert(CTDiagram.end(), CTDiagramMax.begin(), CTDiagramMax.end());
-
-  this->printMsg("PAIRS", 1.0, timer.getElapsedTime() - tm_sort,
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::sortTriplets(std::vector<triplet> &triplets,
-                                            const ScalarType *const scalars,
-                                            const OffsetType *const offsets,
-                                            const bool splitTree) const {
-  if(triplets.empty())
-    return;
-
-  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
-    return offsets[a] < offsets[b];
-  };
-
-  // Sorting step
-  const auto cmp = [=](const triplet &t1, const triplet &t2) {
-    const SimplexId s1 = std::get<0>(t1);
-    const SimplexId s2 = std::get<0>(t2);
-    const SimplexId m1 = std::get<2>(t1);
-    const SimplexId m2 = std::get<2>(t2);
-    if(s1 != s2)
-      return lt(s1, s2) != splitTree;
-    else // s1 == s2
-      return lt(m1, m2) == splitTree;
-  };
-
-  PSORT(this->threadNumber_)(triplets.begin(), triplets.end(), cmp);
-}
-
-template <typename scalarType, typename offsetType>
-void ttk::ProgressiveTopology::tripletsToPersistencePairs(
-  std::vector<PersistencePair> &pairs,
-  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
-  std::vector<triplet> &triplets,
-  const scalarType *const scalars,
-  const offsetType *const offsets,
-  const bool splitTree) const {
-
-  Timer tm;
-  if(triplets.empty())
-    return;
-  size_t numberOfPairs = 0;
-
-  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
-    return offsets[a] < offsets[b];
-  };
-
-  const auto getRep = [&](SimplexId v) -> SimplexId {
-    auto r = vertexRepresentatives[v][0];
-    while(r != v) {
-      v = r;
-      r = vertexRepresentatives[v][0];
-    }
-    return r;
-  };
-
-  for(const auto &t : triplets) {
-    SimplexId r1 = getRep(std::get<1>(t));
-    SimplexId r2 = getRep(std::get<2>(t));
-    if(r1 != r2) {
-      SimplexId s = std::get<0>(t);
-      numberOfPairs++;
-
-      // Add pair
-      if(splitTree) {
-        // r1 = min(r1, r2), r2 = max(r1, r2)
-        if(lt(r2, r1)) {
-          std::swap(r1, r2);
-        }
-        // pair saddle-max: s -> min(r1, r2);
-        pairs.emplace_back(s, r1, 2);
-
-      } else {
-        // r1 = max(r1, r2), r2 = min(r1, r2)
-        if(lt(r1, r2)) {
-          std::swap(r1, r2);
-        }
-        // pair min-saddle: max(r1, r2) -> s;
-        pairs.emplace_back(r1, s, 0);
-      }
-
-      vertexRepresentatives[std::get<1>(t)][0] = r2;
-      vertexRepresentatives[r1][0] = r2;
-    }
-  }
-
-  const std::string ptype = splitTree ? "sad-max" : "min-sad";
-  this->printMsg("found all " + ptype + " pairs", 1.0, tm.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::buildVertexLinkPolarity(
-  const SimplexId vertexId,
-  std::vector<std::pair<polarity, polarity>> &vlp,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  const SimplexId neighborNumber
-    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
-  vlp.resize(neighborNumber);
-  for(SimplexId i = 0; i < neighborNumber; i++) {
-    SimplexId neighborId0 = -1;
-    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId0);
-    const bool lower0 = offsets[neighborId0] < offsets[vertexId];
-    const polarity isUpper0 = static_cast<polarity>(!lower0) * 255;
-    vlp[i] = std::make_pair(isUpper0, 0);
-  }
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::initDynamicLink(
-  const SimplexId &vertexId,
-  std::vector<std::pair<polarity, polarity>> &vlp,
-  uint8_t &vertexLink,
-  DynamicTree &link,
-  VLBoundaryType &vlbt,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  if(vlp.empty()) {
-    buildVertexLinkPolarity(vertexId, vlp, scalars, offsets);
-  }
-
-  const SimplexId neighborNumber
-    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
-  link.alloc(neighborNumber);
-
-  // associate vertex link boundary
-  vertexLink = multiresTriangulation_.getVertexBoundaryIndex(vertexId);
-
-  // update the link polarity for old points that are processed for
-  // the first time
-  const auto &vl = vlbt[vertexLink];
-  for(size_t edgeId = 0; edgeId < vl.size(); edgeId++) {
-    const SimplexId n0 = vl[edgeId].first;
-    const SimplexId n1 = vl[edgeId].second;
-    if(vlp[n0].first == vlp[n1].first) {
-      // the smallest id (n0) becomes the parent of n1
-      link.insertEdge(n1, n0);
-    }
-  }
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::updateCriticalPoints(
-  std::vector<polarity> &isNew,
-  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toProcess,
-  std::vector<polarity> &toReprocess,
-  std::vector<DynamicTree> &link,
-  std::vector<uint8_t> &vertexLink,
-  VLBoundaryType &vertexLinkByBoundaryType,
-  std::vector<char> &vertexTypes,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer tm;
-  const auto nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  // find breaking edges
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(SimplexId localId = 0; localId < nDecVerts; localId++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
-    if(isNew[globalId]) {
-      if(decimationLevel_ > stoppingDecimationLevel_ || isResumable_) {
-        buildVertexLinkPolarity(
-          globalId, vertexLinkPolarity[globalId], scalars, offsets);
-      }
-    } else {
-      getMonotonyChangeByOldPointCP(globalId, isNew, toProcess, toReprocess,
-                                    vertexLinkPolarity[globalId], scalars,
-                                    offsets);
-    }
-  }
-
-  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-
-  double t_critical = tm.getElapsedTime();
-  // second Loop  process or reprocess
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(int i = 0; i < nDecVerts; i++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
-
-    if(isNew[globalId]) { // new point
-      if(toProcess[globalId]) {
-        initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                        vertexLink[globalId], link[globalId],
-                        vertexLinkByBoundaryType, scalars, offsets);
-        vertexTypes[globalId] = getCriticalTypeFromLink(
-          globalId, vertexLinkPolarity[globalId], link[globalId]);
-      }
-      isNew[globalId] = false;
-
-    } else { // old point
-      if(toReprocess[globalId]) {
-        if(toProcess[globalId]) { // was already processed : need to reprocess
-          updateDynamicLink(link[globalId], vertexLinkPolarity[globalId],
-                            vertexLinkByBoundaryType[vertexLink[globalId]]);
-        } else { // first processing
-          updateLinkPolarity(
-            globalId, vertexLinkPolarity[globalId], scalars, offsets);
-          initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                          vertexLink[globalId], link[globalId],
-                          vertexLinkByBoundaryType, scalars, offsets);
-          toProcess[globalId] = 255; // mark as processed
-        }
-        vertexTypes[globalId] = getCriticalTypeFromLink(
-          globalId, vertexLinkPolarity[globalId], link[globalId]);
-        toReprocess[globalId] = 0;
-      }
-    }
-
-  } // end for openmp
-
-  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
-                 tm.getElapsedTime() - t_critical, this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::updateSaddleSeeds(
-  std::vector<polarity> &isNew,
-  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
-  std::vector<polarity> &toProcess,
-  std::vector<polarity> &toReprocess,
-  std::vector<DynamicTree> &link,
-  std::vector<uint8_t> &vertexLink,
-  VLBoundaryType &vertexLinkByBoundaryType,
-  std::vector<std::vector<SimplexId>> &saddleCCMin,
-  std::vector<std::vector<SimplexId>> &saddleCCMax,
-  std::vector<polarity> &isUpdatedMin,
-  std::vector<polarity> &isUpdatedMax,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer tm;
-  const auto nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  // find breaking edges
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(SimplexId localId = 0; localId < nDecVerts; localId++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
-    if(isNew[globalId]) {
-      if(decimationLevel_ > stoppingDecimationLevel_ || isResumable_) {
-        buildVertexLinkPolarity(
-          globalId, vertexLinkPolarity[globalId], scalars, offsets);
-      }
-    } else {
-      getMonotonyChangeByOldPointCP(globalId, isNew, toProcess, toReprocess,
-                                    vertexLinkPolarity[globalId], scalars,
-                                    offsets);
-    }
-  }
-
-  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-
-  double t_critical = tm.getElapsedTime();
-  // second Loop  process or reprocess
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(int i = 0; i < nDecVerts; i++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
-
-    if(isNew[globalId]) { // new point
-      if(toProcess[globalId]) {
-        initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                        vertexLink[globalId], link[globalId],
-                        vertexLinkByBoundaryType, scalars, offsets);
-        getValencesFromLink(globalId, vertexLinkPolarity[globalId],
-                            link[globalId], toPropageMin, toPropageMax,
-                            saddleCCMin, saddleCCMax);
-      }
-      isNew[globalId] = false;
-
-    } else { // old point
-      if(toReprocess[globalId]) {
-        if(toProcess[globalId]) { // was already processed : need to reprocess
-          updateDynamicLink(link[globalId], vertexLinkPolarity[globalId],
-                            vertexLinkByBoundaryType[vertexLink[globalId]]);
-        } else { // first processing
-          updateLinkPolarity(
-            globalId, vertexLinkPolarity[globalId], scalars, offsets);
-          initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                          vertexLink[globalId], link[globalId],
-                          vertexLinkByBoundaryType, scalars, offsets);
-          toProcess[globalId] = 255; // mark as processed
-        }
-        getValencesFromLink(globalId, vertexLinkPolarity[globalId],
-                            link[globalId], toPropageMin, toPropageMax,
-                            saddleCCMin, saddleCCMax);
-        toReprocess[globalId] = 0;
-      }
-    }
-
-    // reset updated flag
-    isUpdatedMin[globalId] = 0;
-    isUpdatedMax[globalId] = 0;
-  } // end for openmp
-
-  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
-                 tm.getElapsedTime() - t_critical, this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-bool ttk::ProgressiveTopology::getMonotonyChangeByOldPointCP(
-  const SimplexId vertexId,
-  const std::vector<polarity> &isNew,
-  std::vector<polarity> &toProcess,
-  std::vector<polarity> &toReprocess,
-  std::vector<std::pair<polarity, polarity>> &vlp,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  bool hasMonotonyChanged = false;
-  const SimplexId neighborNumber
-    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
-  for(SimplexId i = 0; i < neighborNumber; i++) {
-    SimplexId neighborId = -1;
-    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
-
-    // check for monotony changes
-    const bool lower = offsets[neighborId] < offsets[vertexId];
-    const polarity isUpper = lower ? 0 : 255;
-    const polarity isUpperOld = vlp[i].first;
-
-    if(isUpper != isUpperOld) { // change of monotony
-      hasMonotonyChanged = true;
-
-      toReprocess[vertexId] = 255;
-      toProcess[neighborId] = 255;
-      const SimplexId neighborNumberNew
-        = multiresTriangulation_.getVertexNeighborNumber(neighborId);
-      for(SimplexId j = 0; j < neighborNumberNew; j++) {
-        SimplexId neighborIdNew = -1;
-        multiresTriangulation_.getVertexNeighbor(neighborId, j, neighborIdNew);
-        if(isNew[neighborIdNew])
-          toProcess[neighborIdNew] = 255;
-      }
-
-      vlp[i].second = 255;
-    }
-  }
-  return hasMonotonyChanged;
-}
-
-template <typename ScalarType, typename OffsetType>
-ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
-  const SimplexId vertexId,
-  std::vector<Lock> &vertLock,
-  std::vector<polarity> &toPropage,
-  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
-  std::vector<std::vector<SimplexId>> &saddleCC,
-  std::vector<polarity> &isUpdated,
-  std::vector<SimplexId> &globalExtremum,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets,
-  const bool splitTree) const {
-
-  auto &toProp = toPropage[vertexId];
-  auto &reps = vertexRepresentatives[vertexId];
-  auto &updated = isUpdated[vertexId];
-
-  const auto gt = [=](const SimplexId a, const SimplexId b) {
-    return (offsets[a] > offsets[b]) == splitTree;
-  };
-
-  if(updated) {
-    return reps[0];
-  }
-
-  if(this->threadNumber_ > 1) {
-    vertLock[vertexId].lock();
-  }
-
-  if(toProp) { // SADDLE POINT
-    const auto &CC = saddleCC[vertexId];
-    reps.clear();
-    reps.reserve(CC.size());
-    for(size_t r = 0; r < CC.size(); r++) {
-      SimplexId neighborId = -1;
-      SimplexId localId = CC[r];
-      multiresTriangulation_.getVertexNeighbor(vertexId, localId, neighborId);
-      SimplexId ret = propageFromSaddles(
-        neighborId, vertLock, toPropage, vertexRepresentatives, saddleCC,
-        isUpdated, globalExtremum, scalars, offsets, splitTree);
-      reps.emplace_back(ret);
-    }
-
-    if(reps.size() > 1) {
-      // sort & remove duplicate elements
-      std::sort(reps.begin(), reps.end(), gt);
-      const auto last = std::unique(reps.begin(), reps.end());
-      reps.erase(last, reps.end());
-    }
-
-    updated = 255;
-    if(this->threadNumber_ > 1) {
-      vertLock[vertexId].unlock();
-    }
-
-    return reps[0];
-
-  } else {
-
-    SimplexId ret = vertexId;
-    SimplexId neighborNumber
-      = multiresTriangulation_.getVertexNeighborNumber(vertexId);
-    SimplexId maxNeighbor = vertexId;
-    for(SimplexId i = 0; i < neighborNumber; i++) {
-      SimplexId neighborId = -1;
-      multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
-      if(gt(neighborId, maxNeighbor)) {
-        maxNeighbor = neighborId;
-      }
-    }
-    if(maxNeighbor != vertexId) { // not an extremum
-      ret = propageFromSaddles(maxNeighbor, vertLock, toPropage,
-                               vertexRepresentatives, saddleCC, isUpdated,
-                               globalExtremum, scalars, offsets, splitTree);
-    } else {
-#ifdef TTK_ENABLE_OPENMP
-      const auto tid = omp_get_thread_num();
-#else
-      const auto tid = 0;
-#endif // TTK_ENABLE_OPENMP
-      if(gt(vertexId, globalExtremum[tid])) {
-        globalExtremum[tid] = vertexId;
-      }
-    }
-    reps.resize(1);
-    reps[0] = ret;
-    updated = 255;
-    if(this->threadNumber_ > 1) {
-      vertLock[vertexId].unlock();
-    }
-    return ret;
-  }
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::initCriticalPoints(
-  std::vector<polarity> &isNew,
-  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toProcess,
-  std::vector<DynamicTree> &link,
-  std::vector<uint8_t> &vertexLink,
-  VLBoundaryType &vertexLinkByBoundaryType,
-  std::vector<char> &vertexTypes,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer timer{};
-  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  // computes the critical types of all points
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nDecVerts; i++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
-    buildVertexLinkPolarity(
-      globalId, vertexLinkPolarity[globalId], scalars, offsets);
-    initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                    vertexLink[globalId], link[globalId],
-                    vertexLinkByBoundaryType, scalars, offsets);
-    vertexTypes[globalId] = getCriticalTypeFromLink(
-      globalId, vertexLinkPolarity[globalId], link[globalId]);
-    toProcess[globalId] = 255;
-    isNew[globalId] = 0;
-  }
-
-  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::initSaddleSeeds(
-  std::vector<polarity> &isNew,
-  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
-  std::vector<polarity> &toProcess,
-  std::vector<DynamicTree> &link,
-  std::vector<uint8_t> &vertexLink,
-  VLBoundaryType &vertexLinkByBoundaryType,
-  std::vector<std::vector<SimplexId>> &saddleCCMin,
-  std::vector<std::vector<SimplexId>> &saddleCCMax,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer timer{};
-  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  // computes the critical types of all points
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nDecVerts; i++) {
-    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
-    buildVertexLinkPolarity(
-      globalId, vertexLinkPolarity[globalId], scalars, offsets);
-    initDynamicLink(globalId, vertexLinkPolarity[globalId],
-                    vertexLink[globalId], link[globalId],
-                    vertexLinkByBoundaryType, scalars, offsets);
-    getValencesFromLink(globalId, vertexLinkPolarity[globalId], link[globalId],
-                        toPropageMin, toPropageMax, saddleCCMin, saddleCCMax);
-    toProcess[globalId] = 255;
-    isNew[globalId] = 0;
-  }
-
-  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::initPropagation(
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-  std::vector<std::vector<SimplexId>> &saddleCCMin,
-  std::vector<std::vector<SimplexId>> &saddleCCMax,
-  std::vector<Lock> &vertLockMin,
-  std::vector<Lock> &vertLockMax,
-  std::vector<polarity> &isUpdatedMin,
-  std::vector<polarity> &isUpdatedMax,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer timer{};
-  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
-  std::vector<SimplexId> globalMinThr(threadNumber_, 0);
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nDecVerts; i++) {
-    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
-    if(toPropageMin[v]) {
-      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
-                         saddleCCMin, isUpdatedMin, globalMinThr, scalars,
-                         offsets, false);
-    }
-    if(toPropageMax[v]) {
-      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
-                         saddleCCMax, isUpdatedMax, globalMaxThr, scalars,
-                         offsets, true);
-    }
-  }
-
-  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
-    return offsets[a] < offsets[b];
-  };
-
-  globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
-  globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
-
-  this->printMsg("FIRSTPROPAGATION", 1.0, timer.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::updatePropagation(
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
-  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-  std::vector<std::vector<SimplexId>> &saddleCCMin,
-  std::vector<std::vector<SimplexId>> &saddleCCMax,
-  std::vector<Lock> &vertLockMin,
-  std::vector<Lock> &vertLockMax,
-  std::vector<polarity> &isUpdatedMin,
-  std::vector<polarity> &isUpdatedMax,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  Timer tm{};
-  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
-
-  std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
-  std::vector<SimplexId> globalMinThr(threadNumber_, 0);
-
-  // propage along split tree
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nDecVerts; i++) {
-    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
-    if(toPropageMin[v]) {
-      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
-                         saddleCCMin, isUpdatedMin, globalMinThr, scalars,
-                         offsets, false);
-    }
-    if(toPropageMax[v]) {
-      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
-                         saddleCCMax, isUpdatedMax, globalMaxThr, scalars,
-                         offsets, true);
-    }
-  }
-
-  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
-    return offsets[a] < offsets[b];
-  };
-
-  globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
-  globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
-
-  this->printMsg("PROPAGATION UPDATE", 1.0, tm.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-}
-
-template <typename ScalarType, typename OffsetType>
-void ttk::ProgressiveTopology::updateLinkPolarity(
-  const SimplexId vertexId,
-  std::vector<std::pair<polarity, polarity>> &vlp,
-  const ScalarType *const scalars,
-  const OffsetType *const offsets) const {
-
-  for(size_t i = 0; i < vlp.size(); i++) {
-    SimplexId neighborId = -1;
-    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
-    const bool lower = offsets[neighborId] < offsets[vertexId];
-    const polarity isUpper = lower ? 0 : 255;
-    vlp[i] = std::make_pair(isUpper, 0);
-  }
-}

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -23,10 +23,11 @@
 
 // base code includes
 #include <DynamicTree.h>
+#include <ImplicitTriangulation.h>
 #include <MultiresTriangulation.h>
 #include <OpenMPLock.h>
-#include <Triangulation.h>
 
+#include <limits>
 #include <tuple>
 
 namespace ttk {

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -673,12 +673,10 @@ int ttk::ProgressiveTopology::executeCPProgressive(
     stopComputationIf(timer.getElapsedTime() + nextItDuration - tm_allocation
                       > this->timeLimit_);
 
-    if(debugLevel_ > 3) {
-      std::cout << "current iteration lasted " << itDuration << "s"
-                << std::endl;
-      std::cout << "next iteration predicted to last at most " << nextItDuration
-                << "s" << std::endl;
-    }
+    this->printMsg("current iteration", 1.0, itDuration, 1,
+                   debug::LineMode::NEW, debug::Priority::DETAIL);
+    this->printMsg("next iteration duration prediction", 1.0, nextItDuration, 1,
+                   debug::LineMode::NEW, debug::Priority::DETAIL);
   }
 
   // ADD GLOBAL MIN-MAX PAIR
@@ -821,18 +819,17 @@ void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
     }
   }
 
-  if(debugLevel_ > 3) {
-    std::cout << "TRIPLETS " << timer.getElapsedTime() << std::endl;
-  }
+  this->printMsg("TRIPLETS", 1.0, timer.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
   double tm_pairs = timer.getElapsedTime();
 
   sortTriplets(tripletsMax, scalars, offsets, true);
   sortTriplets(tripletsMin, scalars, offsets, false);
 
   const auto tm_sort = timer.getElapsedTime();
-  if(debugLevel_ > 3) {
-    std::cout << "TRIPLETS SORT " << tm_sort - tm_pairs << std::endl;
-  }
+  this->printMsg("TRIPLETS SORT", 1.0, tm_sort - tm_pairs, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
 
   typename std::remove_reference<decltype(CTDiagram)>::type CTDiagramMin{},
     CTDiagramMax{};
@@ -855,9 +852,9 @@ void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
   CTDiagram = std::move(CTDiagramMin);
   CTDiagram.insert(CTDiagram.end(), CTDiagramMax.begin(), CTDiagramMax.end());
 
-  if(debugLevel_ > 3) {
-    std::cout << "PAIRS " << timer.getElapsedTime() - tm_sort << std::endl;
-  }
+  this->printMsg("PAIRS", 1.0, timer.getElapsedTime() - tm_sort,
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -948,11 +945,10 @@ void ttk::ProgressiveTopology::tripletsToPersistencePairs(
     }
   }
 
-  if(debugLevel_ > 3) {
-    std::string prefix = splitTree ? "[sad-max]" : "[min-sad]";
-    std::cout << prefix << "  found all pairs in " << tm.getElapsedTime()
-              << " s." << std::endl;
-  }
+  const std::string ptype = splitTree ? "sad-max" : "min-sad";
+  this->printMsg("found all " + ptype + " pairs", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -1045,9 +1041,8 @@ void ttk::ProgressiveTopology::updateCriticalPoints(
     }
   }
 
-  if(debugLevel_ > 3) {
-    std::cout << "MONOTONY " << tm.getElapsedTime() << " s." << std::endl;
-  }
+  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
 
   double t_critical = tm.getElapsedTime();
   // second Loop  process or reprocess
@@ -1088,10 +1083,9 @@ void ttk::ProgressiveTopology::updateCriticalPoints(
 
   } // end for openmp
 
-  if(debugLevel_ > 3) {
-    std::cout << "CRITICAL POINTS UPDATE " << tm.getElapsedTime() - t_critical
-              << std::endl;
-  }
+  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
+                 tm.getElapsedTime() - t_critical, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -1133,9 +1127,8 @@ void ttk::ProgressiveTopology::updateSaddleSeeds(
     }
   }
 
-  if(debugLevel_ > 3) {
-    std::cout << "MONOTONY " << tm.getElapsedTime() << " s." << std::endl;
-  }
+  this->printMsg("MONOTONY", 1.0, tm.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
 
   double t_critical = tm.getElapsedTime();
   // second Loop  process or reprocess
@@ -1181,13 +1174,12 @@ void ttk::ProgressiveTopology::updateSaddleSeeds(
     isUpdatedMax[globalId] = 0;
   } // end for openmp
 
-  if(debugLevel_ > 3) {
-    std::cout << "CRITICAL POINTS UPDATE " << tm.getElapsedTime() - t_critical
-              << std::endl;
-  }
+  this->printMsg("CRITICAL POINTS UPDATE", 1.0,
+                 tm.getElapsedTime() - t_critical, this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
 }
-template <typename ScalarType, typename OffsetType>
 
+template <typename ScalarType, typename OffsetType>
 bool ttk::ProgressiveTopology::getMonotonyChangeByOldPointCP(
   const SimplexId vertexId,
   const std::vector<polarity> &isNew,
@@ -1361,10 +1353,9 @@ void ttk::ProgressiveTopology::initCriticalPoints(
     isNew[globalId] = 0;
   }
 
-  if(debugLevel_ > 3) {
-    std::cout << "initial critical types in " << timer.getElapsedTime() << " s."
-              << std::endl;
-  }
+  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -1402,10 +1393,9 @@ void ttk::ProgressiveTopology::initSaddleSeeds(
     isNew[globalId] = 0;
   }
 
-  if(debugLevel_ > 3) {
-    std::cout << "initial critical types in " << timer.getElapsedTime() << " s."
-              << std::endl;
-  }
+  this->printMsg("initial critical types", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -1455,9 +1445,9 @@ void ttk::ProgressiveTopology::initPropagation(
   globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
   globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
 
-  if(debugLevel_ > 3) {
-    std::cout << "FIRSTPROPAGATION " << timer.getElapsedTime() << std::endl;
-  }
+  this->printMsg("FIRSTPROPAGATION", 1.0, timer.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>
@@ -1520,9 +1510,9 @@ void ttk::ProgressiveTopology::updatePropagation(
   globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
   globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
 
-  if(debugLevel_ > 3) {
-    std::cout << "PROPAGATION UPDATE " << tm.getElapsedTime() << std::endl;
-  }
+  this->printMsg("PROPAGATION UPDATE", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
 }
 
 template <typename ScalarType, typename OffsetType>

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -71,12 +71,7 @@ namespace ttk {
       multiresTriangulation_.setTriangulation(triangulation_);
     }
 
-  protected:
-    void sortPersistenceDiagram2(std::vector<PersistencePair> &diagram,
-                                 const SimplexId *const offsets) const;
-
     /* PROGRESSIVE MODE DECLARATIONS */
-  public:
     int executeCPProgressive(int computePersistenceDiagram,
                              const SimplexId *inputOffsets);
 
@@ -137,6 +132,9 @@ namespace ttk {
     }
 
   protected:
+    void sortPersistenceDiagram2(std::vector<PersistencePair> &diagram,
+                                 const SimplexId *const offsets) const;
+
     // maximum link size in 3D
     static const size_t nLink_ = 27;
     using VLBoundaryType

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -24,6 +24,7 @@
 // base code includes
 #include <DynamicTree.h>
 #include <MultiresTriangulation.h>
+#include <OpenMPLock.h>
 #include <Triangulation.h>
 
 #include <tuple>
@@ -36,40 +37,6 @@ namespace ttk {
 
   using triplet = std::tuple<ttk::SimplexId, ttk::SimplexId, ttk::SimplexId>;
   using polarity = unsigned char;
-
-  /**
-   * @brief RAII wrapper around OpenMP lock
-   */
-  class Lock {
-#ifdef TTK_ENABLE_OPENMP
-  public:
-    Lock() {
-      omp_init_lock(&this->lock_);
-    }
-    ~Lock() {
-      omp_destroy_lock(&this->lock_);
-    }
-    inline void lock() {
-      omp_set_lock(&this->lock_);
-    }
-    inline void unlock() {
-      omp_unset_lock(&this->lock_);
-    }
-    Lock(const Lock &) = delete;
-    Lock(Lock &&) = delete;
-    Lock &operator=(const Lock &) = delete;
-    Lock &operator=(Lock &&) = delete;
-
-  private:
-    omp_lock_t lock_{};
-#else
-  public:
-    inline void lock() {
-    }
-    inline void unlock() {
-    }
-#endif // TTK_ENABLE_OPENMP
-  };
 
   /**
    * Compute the persistence diagram of a function on a triangulation.

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -28,23 +28,11 @@
 
 #include <tuple>
 
-#if defined(__GNUC__) && !defined(__clang__)
-#include <parallel/algorithm>
-#endif
-
 namespace ttk {
 
   /**
    * @brief Persistence pair type (with persistence in double)
    */
-
-#if defined(_GLIBCXX_PARALLEL_FEATURES_H) && defined(TTK_ENABLE_OPENMP)
-#define PARALLEL_SORT                       \
-  omp_set_num_threads(this->threadNumber_); \
-  __gnu_parallel::sort
-#else
-#define PARALLEL_SORT std::sort
-#endif // _GLIBCXX_PARALLEL_FEATURES_H && TTK_ENABLE_OPENMP
 
   using triplet = std::tuple<ttk::SimplexId, ttk::SimplexId, ttk::SimplexId>;
   using polarity = unsigned char;
@@ -883,7 +871,7 @@ void ttk::ProgressiveTopology::sortTriplets(std::vector<triplet> &triplets,
       return lt(m1, m2) == splitTree;
   };
 
-  PARALLEL_SORT(triplets.begin(), triplets.end(), cmp);
+  PSORT(this->threadNumber_)(triplets.begin(), triplets.end(), cmp);
 }
 
 template <typename scalarType, typename offsetType>

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -1,4 +1,4 @@
-// \ingroup vtk
+/// \ingroup vtk
 /// \class ttkPersistenceDiagram
 /// \author Guillaume Favelier <guillaume.favelier@lip6.fr>
 /// \author Julien Tierny <julien.tierny@lip6.fr>


### PR DESCRIPTION
Following #614, this PR improves the integration of the ProgressiveToplogy module in TTK:
* dead code has been removed,
* `std::cout`, `std::cerr` were replaced with the Debug module log API,
* ProgressiveTopology now use the parallel sort and the OpenMP lock wrapper implementation from the Common module
* by using order fields of type `SimplexId` instead of templated scalar field and offset field, the majority of the ProgressiveTopology methods were detemplated, leading to build time improvements: a full rebuild of the `ttkPersistenceDiagram` target (base layer + VTK layer) decreased from 5min to 4min.
* clang-tidy warnings in MultiresTriangulation were fixed by using zero-initialized `std::array`s instead of C-arrays.

No change has been observed on the ttk-data states using the `ScalarFieldCriticalPoints` filter. Persistence diagrams still seems identical to FTM.

Enjoy,
Pierre