### PR TITLE
GitHub Actions: Add check for VTK includes in base layer

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,13 @@ jobs:
       run: |
         ! git ls-files | xargs file | grep empty
 
+    - name: Check for VTK includes in the base layer
+      run: |
+        ! git ls-files \
+          | grep "core/base" \
+          | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" \
+          | xargs grep -e "^#include.*vtk"
+
 
   # ------------- #
   # Code lint job #


### PR DESCRIPTION
This PR adds a simple, grep-based check to the GitHub Actions CI that fails if a VTK header (a header containing the "vtk" string) has been included in a C++ file in the base layer. This should be seen as a first line of defense only: it does not discriminate between external VTK headers and TTK base headers that may contain the "vtk" string in their name (that would be a weird name for a header in the base layer anyway).

Enjoy,
Pierre
