### PR TITLE
Extend Jacobi sets with Pareto flag

### DIFF
--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -40,7 +40,8 @@ namespace ttk {
     int execute(std::vector<std::pair<SimplexId, char>> &jacobiSet,
                 const dataTypeU *const uField,
                 const dataTypeV *const vField,
-                const triangulationType &triangulation);
+                const triangulationType &triangulation,
+                std::vector<char> *isPareto = NULL);
 
     template <class dataTypeU, class dataTypeV, typename triangulationType>
     char getCriticalType(const SimplexId &edgeId,

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -4,7 +4,8 @@ template <class dataTypeU, class dataTypeV, typename triangulationType>
 int ttk::JacobiSet::execute(std::vector<std::pair<SimplexId, char>> &jacobiSet,
                             const dataTypeU *const uField,
                             const dataTypeV *const vField,
-                            const triangulationType &triangulation) {
+                            const triangulationType &triangulation,
+                            std::vector<char> *isPareto) {
 
   Timer t;
 
@@ -71,6 +72,24 @@ int ttk::JacobiSet::execute(std::vector<std::pair<SimplexId, char>> &jacobiSet,
       case -1:
         monkeySaddleNumber++;
         break;
+    }
+  }
+
+  if(isPareto) {
+    isPareto->resize(jacobiSet.size(), 0);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+    for(int i = 0; i < (int)jacobiSet.size(); i++) {
+      int edgeId = jacobiSet[i].first;
+      int vertexId0 = -1, vertexId1 = -1;
+      triangulation.getEdgeVertex(edgeId, 0, vertexId0);
+      triangulation.getEdgeVertex(edgeId, 1, vertexId1);
+      double denominator = vField[vertexId1] - vField[vertexId0];
+      if(fabs(denominator) < Geometry::powIntTen(-DBL_DIG))
+        denominator = 1;
+      if((uField[vertexId1] - uField[vertexId0]) / denominator < 0)
+        (*isPareto)[i] = 1;
     }
   }
 

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -82,7 +82,7 @@ int ttk::JacobiSet::execute(std::vector<std::pair<SimplexId, char>> &jacobiSet,
 #endif
     for(int i = 0; i < (int)jacobiSet.size(); i++) {
       int edgeId = jacobiSet[i].first;
-      int vertexId0 = -1, vertexId1 = -1;
+      SimplexId vertexId0 = -1, vertexId1 = -1;
       triangulation.getEdgeVertex(edgeId, 0, vertexId0);
       triangulation.getEdgeVertex(edgeId, 1, vertexId1);
       double denominator = vField[vertexId1] - vField[vertexId0];

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.cpp
@@ -46,7 +46,8 @@ int ttkJacobiSet::dispatch(const dataTypeU *const uField,
   ttkTemplateMacro(
     triangulation->getType(),
     this->execute(jacobiSet_, uField, vField,
-                  *static_cast<TTK_TT *>(triangulation->getData())));
+                  *static_cast<TTK_TT *>(triangulation->getData()),
+                  &isPareto_));
   return 0;
 }
 
@@ -111,6 +112,11 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   edgeTypes->SetNumberOfTuples(2 * jacobiSet_.size());
   edgeTypes->SetName("Critical Type");
 
+  vtkNew<vtkSignedCharArray> isPareto{};
+  isPareto->SetNumberOfComponents(1);
+  isPareto->SetNumberOfTuples(2 * jacobiSet_.size());
+  isPareto->SetName("IsPareto");
+
   vtkNew<vtkPoints> pointSet{};
   pointSet->SetNumberOfPoints(2 * jacobiSet_.size());
 
@@ -130,12 +136,15 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
     input->GetPoint(vertexId0, p.data());
     pointSet->SetPoint(pointCount, p.data());
     edgeTypes->SetTuple1(pointCount, (float)jacobiSet_[i].second);
+    isPareto->SetTuple1(pointCount, (float)isPareto_[i]);
+
     idList->SetId(0, pointCount);
     pointCount++;
 
     input->GetPoint(vertexId1, p.data());
     pointSet->SetPoint(pointCount, p.data());
     edgeTypes->SetTuple1(pointCount, (float)jacobiSet_[i].second);
+    isPareto->SetTuple1(pointCount, (float)isPareto_[i]);
     idList->SetId(1, pointCount);
     pointCount++;
 
@@ -144,6 +153,7 @@ int ttkJacobiSet::RequestData(vtkInformation *request,
   output->SetPoints(pointSet);
   output->SetCells(VTK_LINE, cellArray);
   output->GetPointData()->AddArray(edgeTypes);
+  output->GetPointData()->AddArray(isPareto);
 
   if(EdgeIds) {
     vtkNew<ttkSimplexIdTypeArray> edgeIdArray{};

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.h
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.h
@@ -96,4 +96,5 @@ private:
   // for each edge, the one skeleton of its triangle fan
   std::vector<std::vector<ttk::SimplexId>> edgeFans_{};
   std::vector<std::pair<ttk::SimplexId, char>> jacobiSet_{};
+  std::vector<char> isPareto_{};
 };


### PR DESCRIPTION
With this PR, Jacobi sets can be filtered out if they do not belong to Pareto sets.

