### PR TITLE
PersistenceDiagramClustering: vtkMultiBlockDataSet ouputs, distances as FieldData

### DIFF
--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -60,6 +60,10 @@ namespace ttk {
       execute(std::vector<std::vector<diagramTuple>> &final_centroids,
               vector<vector<vector<vector<matchingTuple>>>> &all_matchings);
 
+    std::array<double, 3> getDistances() const {
+      return {this->cost_min_, this->cost_sad_, this->cost_max_};
+    }
+
     dataType getMostPersistent(int type = -1);
     vector<vector<int>> get_centroids_sizes();
     dataType getLessPersistent(int type = -1);

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -66,6 +66,10 @@ namespace ttk {
       std::vector<std::vector<diagramTuple>> &centroids,
       std::vector<std::vector<std::vector<matchingTuple>>> &all_matchings);
 
+    std::array<double, 3> getDistances() const {
+      return this->distances;
+    }
+
     template <class dataType>
     static dataType abs(const dataType var) {
       return (var >= 0) ? var : -var;
@@ -74,6 +78,9 @@ namespace ttk {
   protected:
     // Critical pairs used for clustering
     // 0:min-saddles ; 1:saddles-saddles ; 2:sad-max ; else : all
+
+    // distance results per pair type
+    std::array<double, 3> distances{};
 
     int DistanceWritingOptions{0};
     int PairTypeClustering{-1};
@@ -217,6 +224,8 @@ namespace ttk {
     inv_clustering
       = KMeans.execute(final_centroids, all_matchings_per_type_and_cluster);
     vector<vector<int>> centroids_sizes = KMeans.get_centroids_sizes();
+
+    this->distances = KMeans.getDistances();
 
     /// Reconstruct matchings
     //

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -1,9 +1,19 @@
 #include <ttkMacros.h>
 #include <ttkPersistenceDiagramClustering.h>
 #include <ttkUtils.h>
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDoubleArray.h>
 #include <vtkFieldData.h>
+#include <vtkFloatArray.h>
+#include <vtkInformation.h>
+#include <vtkIntArray.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
 #include <vtkTransform.h>
 #include <vtkTransformFilter.h>
+#include <vtkUnstructuredGrid.h>
 
 using namespace ttk;
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -51,6 +51,113 @@ void ttkPersistenceDiagramClustering::Modified() {
   ttkAlgorithm::Modified();
 }
 
+void ttkPersistenceDiagramClustering::diagramToVTU(
+  vtkUnstructuredGrid *output,
+  const diagramType &diagram,
+  const int cid,
+  const double max_persistence) const {
+
+  const auto nPoints = 2 * diagram.size();
+  if(nPoints == 0) {
+    this->printWrn("Diagram with no points");
+    return;
+  }
+
+  vtkNew<vtkPoints> points{};
+  points->SetNumberOfPoints(nPoints);
+  output->SetPoints(points);
+
+  // point data
+  vtkNew<vtkIntArray> critType{};
+  critType->SetName("CriticalType");
+  critType->SetNumberOfTuples(nPoints);
+  output->GetPointData()->AddArray(critType);
+
+  vtkNew<vtkIntArray> clusterId{};
+  clusterId->SetName("ClusterID");
+  clusterId->SetNumberOfComponents(1);
+  clusterId->SetNumberOfTuples(nPoints);
+  clusterId->Fill(cid);
+  output->GetPointData()->AddArray(clusterId);
+
+  vtkNew<vtkFloatArray> coords{};
+  coords->SetNumberOfComponents(3);
+  coords->SetName("Coordinates");
+  coords->SetNumberOfTuples(nPoints);
+  output->GetPointData()->AddArray(coords);
+
+  vtkNew<vtkDoubleArray> pointPers{};
+  pointPers->SetName("Persistence");
+  pointPers->SetNumberOfTuples(nPoints);
+  output->GetPointData()->AddArray(pointPers);
+
+  // cell data
+  vtkNew<vtkIntArray> pairId{};
+  pairId->SetName("PairID");
+  pairId->SetNumberOfTuples(diagram.size() + 1);
+  output->GetCellData()->AddArray(pairId);
+
+  vtkNew<vtkIntArray> pairType{};
+  pairType->SetName("PairType");
+  pairType->SetNumberOfTuples(diagram.size() + 1);
+  output->GetCellData()->AddArray(pairType);
+
+  vtkNew<vtkDoubleArray> pairPers{};
+  pairPers->SetName("Persistence");
+  pairPers->SetNumberOfTuples(diagram.size() + 1);
+  output->GetCellData()->AddArray(pairPers);
+
+  for(size_t j = 0; j < diagram.size(); ++j) {
+    const auto &pair{diagram[j]};
+    const auto birth{std::get<6>(pair)};
+    const auto death{std::get<10>(pair)};
+    const auto pType{std::get<5>(pair)};
+    const auto birthType{std::get<1>(pair)};
+    const auto deathType{std::get<3>(pair)};
+    std::array<float, 3> coordsBirth{
+      std::get<7>(pair), std::get<8>(pair), std::get<9>(pair)};
+    std::array<float, 3> coordsDeath{
+      std::get<11>(pair), std::get<12>(pair), std::get<13>(pair)};
+
+    // cell data
+    pairId->SetTuple1(j, j);
+    pairType->SetTuple1(j, pType);
+    pairPers->SetTuple1(j, death - birth);
+
+    // point data
+    coords->SetTuple(2 * j + 0, coordsBirth.data());
+    coords->SetTuple(2 * j + 1, coordsDeath.data());
+    pointPers->SetTuple1(2 * j + 0, death - birth);
+    pointPers->SetTuple1(2 * j + 1, death - birth);
+    critType->SetTuple1(2 * j + 0, static_cast<int>(birthType));
+    critType->SetTuple1(2 * j + 1, static_cast<int>(deathType));
+
+    points->SetPoint(2 * j + 0, birth, birth, 0);
+    points->SetPoint(2 * j + 1, birth, death, 0);
+
+    const std::array<vtkIdType, 2> ids{
+      2 * static_cast<vtkIdType>(j) + 0,
+      2 * static_cast<vtkIdType>(j) + 1,
+    };
+    output->InsertNextCell(VTK_LINE, 2, ids.data());
+  }
+
+  // add diagonal
+  const auto minmax_birth = std::minmax_element(
+    diagram.begin(), diagram.end(), [](const pairTuple &a, const pairTuple &b) {
+      return std::get<6>(a) < std::get<6>(b);
+    });
+  const std::array<vtkIdType, 2> ids{
+    2 * (minmax_birth.first - diagram.begin()),
+    2 * (minmax_birth.second - diagram.begin()),
+  };
+  output->InsertNextCell(VTK_LINE, 2, ids.data());
+  pairId->SetTuple1(diagram.size(), diagram.size());
+  pairType->SetTuple1(diagram.size(), -1);
+  // use the max persistence of all input diagrams...
+  pairPers->SetTuple1(diagram.size(), max_persistence);
+}
+
 void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
   vtkMultiBlockDataSet *output,
   const std::vector<diagramType> &diags,
@@ -79,110 +186,11 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
   }
 
   output->SetNumberOfBlocks(diags.size());
+
   for(size_t i = 0; i < diags.size(); ++i) {
-    const auto diag = diags[i];
-
-    const auto nPoints = 2 * diag.size();
-    if(nPoints == 0) {
-      this->printWrn("Diagram with no points");
-      continue;
-    }
-
-    vtkNew<vtkPoints> points{};
-    points->SetNumberOfPoints(nPoints);
-
     vtkNew<vtkUnstructuredGrid> vtu{};
-    vtu->SetPoints(points);
-
-    // point data
-    vtkNew<vtkIntArray> critType{};
-    critType->SetName("CriticalType");
-    critType->SetNumberOfTuples(nPoints);
-    vtu->GetPointData()->AddArray(critType);
-
-    vtkNew<vtkIntArray> clusterId{};
-    clusterId->SetName("ClusterID");
-    clusterId->SetNumberOfComponents(1);
-    clusterId->SetNumberOfTuples(nPoints);
-    clusterId->Fill(inv_clustering[i]);
-    vtu->GetPointData()->AddArray(clusterId);
-
-    vtkNew<vtkFloatArray> coords{};
-    coords->SetNumberOfComponents(3);
-    coords->SetName("Coordinates");
-    coords->SetNumberOfTuples(nPoints);
-    vtu->GetPointData()->AddArray(coords);
-
-    vtkNew<vtkDoubleArray> pointPers{};
-    pointPers->SetName("Persistence");
-    pointPers->SetNumberOfTuples(nPoints);
-    vtu->GetPointData()->AddArray(pointPers);
-
-    // cell data
-    vtkNew<vtkIntArray> pairId{};
-    pairId->SetName("PairID");
-    pairId->SetNumberOfTuples(diag.size() + 1);
-    vtu->GetCellData()->AddArray(pairId);
-
-    vtkNew<vtkIntArray> pairType{};
-    pairType->SetName("PairType");
-    pairType->SetNumberOfTuples(diag.size() + 1);
-    vtu->GetCellData()->AddArray(pairType);
-
-    vtkNew<vtkDoubleArray> pairPers{};
-    pairPers->SetName("Persistence");
-    pairPers->SetNumberOfTuples(diag.size() + 1);
-    vtu->GetCellData()->AddArray(pairPers);
-
-    for(size_t j = 0; j < diag.size(); ++j) {
-      const auto &pair{diag[j]};
-      const auto birth{std::get<6>(pair)};
-      const auto death{std::get<10>(pair)};
-      const auto pType{std::get<5>(pair)};
-      const auto birthType{std::get<1>(pair)};
-      const auto deathType{std::get<3>(pair)};
-      std::array<float, 3> coordsBirth{
-        std::get<7>(pair), std::get<8>(pair), std::get<9>(pair)};
-      std::array<float, 3> coordsDeath{
-        std::get<11>(pair), std::get<12>(pair), std::get<13>(pair)};
-
-      // cell data
-      pairId->SetTuple1(j, j);
-      pairType->SetTuple1(j, pType);
-      pairPers->SetTuple1(j, death - birth);
-
-      // point data
-      coords->SetTuple(2 * j + 0, coordsBirth.data());
-      coords->SetTuple(2 * j + 1, coordsDeath.data());
-      pointPers->SetTuple1(2 * j + 0, death - birth);
-      pointPers->SetTuple1(2 * j + 1, death - birth);
-      critType->SetTuple1(2 * j + 0, static_cast<int>(birthType));
-      critType->SetTuple1(2 * j + 1, static_cast<int>(deathType));
-
-      points->SetPoint(2 * j + 0, birth, birth, 0);
-      points->SetPoint(2 * j + 1, birth, death, 0);
-
-      const std::array<vtkIdType, 2> ids{
-        2 * static_cast<vtkIdType>(j) + 0,
-        2 * static_cast<vtkIdType>(j) + 1,
-      };
-      vtu->InsertNextCell(VTK_LINE, 2, ids.data());
-    }
-
-    // add diagonal
-    const auto minmax_birth = std::minmax_element(
-      diag.begin(), diag.end(), [](const pairTuple &a, const pairTuple &b) {
-        return std::get<6>(a) < std::get<6>(b);
-      });
-    const std::array<vtkIdType, 2> ids{
-      2 * (minmax_birth.first - diag.begin()),
-      2 * (minmax_birth.second - diag.begin()),
-    };
-    vtu->InsertNextCell(VTK_LINE, 2, ids.data());
-    pairId->SetTuple1(diag.size(), diag.size());
-    pairType->SetTuple1(diag.size(), -1);
-    // use the max persistence of all input diagrams...
-    pairPers->SetTuple1(diag.size(), max_persistence);
+    this->diagramToVTU(
+      vtu, diags[i], this->inv_clustering_[i], this->max_dimension_total_);
 
     if(dm == DISPLAY::MATCHINGS && spacing > 0) {
       // translate diagrams along the Z axis
@@ -223,111 +231,23 @@ void ttkPersistenceDiagramClustering::outputCentroids(
   const double max_persistence) const {
 
   for(size_t i = 0; i < final_centroids.size(); ++i) {
-    const auto &bary{final_centroids[i]};
+    vtkNew<vtkUnstructuredGrid> vtu{};
+    this->diagramToVTU(vtu, final_centroids[i], i, this->max_dimension_total_);
 
-    const auto nPoints = 2 * bary.size();
-    vtkNew<vtkPoints> points{};
-    points->SetNumberOfPoints(nPoints);
+    if(dm == DISPLAY::STARS && spacing > 0) {
+      // shift centroid along the X axis
+      vtkNew<vtkTransform> tr{};
+      tr->Translate(3.0 * (spacing + 0.2) * max_persistence * i, 0, 0);
+      vtkNew<vtkTransformFilter> trf{};
+      trf->SetTransform(tr);
+      trf->SetInputData(vtu);
+      trf->Update();
+      output->SetBlock(i, trf->GetOutputDataObject(0));
 
-    vtkNew<vtkUnstructuredGrid> diagram{};
-    diagram->SetPoints(points);
-
-    // point data
-    vtkNew<vtkIntArray> critType{};
-    critType->SetName("CriticalType");
-    critType->SetNumberOfTuples(nPoints);
-    diagram->GetPointData()->AddArray(critType);
-
-    vtkNew<vtkIntArray> clusterId{};
-    clusterId->SetName("ClusterID");
-    clusterId->SetNumberOfTuples(nPoints);
-    clusterId->Fill(i);
-    diagram->GetPointData()->AddArray(clusterId);
-
-    vtkNew<vtkFloatArray> coords{};
-    coords->SetNumberOfComponents(3);
-    coords->SetName("Coordinates");
-    coords->SetNumberOfTuples(nPoints);
-    diagram->GetPointData()->AddArray(coords);
-
-    vtkNew<vtkDoubleArray> pointPers{};
-    pointPers->SetName("Persistence");
-    pointPers->SetNumberOfTuples(nPoints);
-    diagram->GetPointData()->AddArray(pointPers);
-
-    // cell data
-    vtkNew<vtkIntArray> pairId{};
-    pairId->SetName("PairID");
-    pairId->SetNumberOfTuples(bary.size() + 1);
-    diagram->GetCellData()->AddArray(pairId);
-
-    vtkNew<vtkIntArray> pairType{};
-    pairType->SetName("PairType");
-    pairType->SetNumberOfTuples(bary.size() + 1);
-    diagram->GetCellData()->AddArray(pairType);
-
-    vtkNew<vtkDoubleArray> pairPers{};
-    pairPers->SetName("Persistence");
-    pairPers->SetNumberOfTuples(bary.size() + 1);
-    diagram->GetCellData()->AddArray(pairPers);
-
-    for(size_t j = 0; j < bary.size(); ++j) {
-      const auto &pair{bary[j]};
-      const auto birth{std::get<6>(pair)};
-      const auto death{std::get<10>(pair)};
-      const auto pType{std::get<5>(pair)};
-      const auto birthType{std::get<1>(pair)};
-      const auto deathType{std::get<3>(pair)};
-      std::array<float, 3> coordsBirth{
-        std::get<7>(pair), std::get<8>(pair), std::get<9>(pair)};
-      std::array<float, 3> coordsDeath{
-        std::get<11>(pair), std::get<12>(pair), std::get<13>(pair)};
-
-      // cell data
-      pairId->SetTuple1(j, j);
-      pairType->SetTuple1(j, pType);
-      pairPers->SetTuple1(j, death - birth);
-
-      // point data
-      coords->SetTuple(2 * j + 0, coordsBirth.data());
-      coords->SetTuple(2 * j + 1, coordsDeath.data());
-      pointPers->SetTuple1(2 * j + 0, death - birth);
-      pointPers->SetTuple1(2 * j + 1, death - birth);
-      critType->SetTuple1(2 * j + 0, static_cast<int>(birthType));
-      critType->SetTuple1(2 * j + 1, static_cast<int>(deathType));
-
-      auto birthShift{birth};
-      if(dm == DISPLAY::STARS && spacing > 0) {
-        // shift diagram along the X axis
-        birthShift += 3.0 * (spacing + 0.2) * max_persistence * i;
-      }
-      points->SetPoint(2 * j + 0, birthShift, birth, 0);
-      points->SetPoint(2 * j + 1, birthShift, death, 0);
-
-      const std::array<vtkIdType, 2> ids{
-        2 * static_cast<vtkIdType>(j) + 0,
-        2 * static_cast<vtkIdType>(j) + 1,
-      };
-      diagram->InsertNextCell(VTK_LINE, 2, ids.data());
+    } else {
+      // add centroid to output multi-block dataset
+      output->SetBlock(i, vtu);
     }
-
-    // add diagonal
-    const auto minmax_birth = std::minmax_element(
-      bary.begin(), bary.end(), [](const pairTuple &a, const pairTuple &b) {
-        return std::get<6>(a) < std::get<6>(b);
-      });
-    const std::array<vtkIdType, 2> ids{
-      2 * (minmax_birth.first - bary.begin()),
-      2 * (minmax_birth.second - bary.begin()),
-    };
-    diagram->InsertNextCell(VTK_LINE, 2, ids.data());
-    pairId->SetTuple1(bary.size(), bary.size());
-    pairType->SetTuple1(bary.size(), -1);
-    // use the max persistence of all input diagrams...
-    pairPers->SetTuple1(bary.size(), max_persistence);
-
-    // attach barycenter diagram to multi-block output
-    output->SetBlock(i, diagram);
   }
 }
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -164,6 +164,39 @@ int ttkPersistenceDiagramClustering::RequestData(
     }
   }
 
+  // add distance results to output_matchings FieldData
+  vtkNew<vtkDoubleArray> minSad{};
+  minSad->SetName("MinSaddleCost");
+  minSad->SetNumberOfTuples(1);
+  minSad->SetTuple1(0, this->distances[0]);
+
+  vtkNew<vtkDoubleArray> sadSad{};
+  sadSad->SetName("SaddleSaddleCost");
+  sadSad->SetNumberOfTuples(1);
+  sadSad->SetTuple1(0, this->distances[1]);
+
+  vtkNew<vtkDoubleArray> sadMax{};
+  sadMax->SetName("SaddleMaxCost");
+  sadMax->SetNumberOfTuples(1);
+  sadMax->SetTuple1(0, this->distances[2]);
+
+  vtkNew<vtkDoubleArray> wass{};
+  wass->SetName("WassersteinDistance");
+  wass->SetNumberOfTuples(1);
+  wass->SetTuple1(
+    0, std::accumulate(this->distances.begin(), this->distances.end(), 0.0));
+
+  for(size_t i = 0; i < output_matchings->GetNumberOfBlocks(); ++i) {
+    const auto block{
+      vtkUnstructuredGrid::SafeDownCast(output_matchings->GetBlock(i))};
+    if(block != nullptr && block->GetFieldData() != nullptr) {
+      block->GetFieldData()->AddArray(minSad);
+      block->GetFieldData()->AddArray(sadSad);
+      block->GetFieldData()->AddArray(sadMax);
+      block->GetFieldData()->AddArray(wass);
+    }
+  }
+
   return 1;
 }
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -162,7 +162,7 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
   vtkMultiBlockDataSet *output,
   const std::vector<diagramType> &diags,
   const std::vector<int> &inv_clustering,
-  const enum DISPLAY dm,
+  const DISPLAY dm,
   const double spacing,
   const double max_persistence) const {
 
@@ -225,7 +225,7 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
 
 void ttkPersistenceDiagramClustering::outputCentroids(
   vtkMultiBlockDataSet *output,
-  std::vector<diagramType> &final_centroids,
+  const std::vector<diagramType> &final_centroids,
   const DISPLAY dm,
   const double spacing,
   const double max_persistence) const {
@@ -413,11 +413,11 @@ void ttkPersistenceDiagramClustering::VTUToDiagram(
 
   int nPairs = pairId->GetNumberOfTuples();
 
-  // FIX : no more missed pairs
-  for(int pair_index = 0; pair_index < nPairs; pair_index++) {
-    const float index_of_pair = pair_index;
-    if(pairId->GetTuple1(pair_index) != -1)
-      pairId->SetTuple(pair_index, &index_of_pair);
+  // compact pairIds in [0, nPairs - 1] (diagonal excepted)
+  for(int i = 0; i < nPairs; i++) {
+    if(pairId->GetTuple1(i) != -1) {
+      pairId->SetTuple1(i, i);
+    }
   }
 
   // skip diagram diagonal if present (assuming it's the last pair in the

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -313,7 +313,7 @@ double ttkPersistenceDiagramClustering::getPersistenceDiagram(
   return max_dimension;
 }
 
-vtkSmartPointer<vtkUnstructuredGrid>
+vtkNew<vtkUnstructuredGrid>
   ttkPersistenceDiagramClustering::createOutputCentroids() {
   this->printMsg("Creating vtk diagrams", debug::Priority::VERBOSE);
   vtkNew<vtkPoints> points{};
@@ -466,7 +466,7 @@ vtkSmartPointer<vtkUnstructuredGrid>
   return persistenceDiagram;
 }
 
-vtkSmartPointer<vtkUnstructuredGrid>
+vtkNew<vtkUnstructuredGrid>
   ttkPersistenceDiagramClustering::createOutputClusteredDiagrams() {
   this->printMsg("Creating vtk outputs", debug::Priority::VERBOSE);
   vtkNew<vtkPoints> points{};
@@ -665,8 +665,7 @@ vtkSmartPointer<vtkUnstructuredGrid>
   return persistenceDiagram;
 }
 
-vtkSmartPointer<vtkUnstructuredGrid>
-  ttkPersistenceDiagramClustering::createMatchings() {
+vtkNew<vtkUnstructuredGrid> ttkPersistenceDiagramClustering::createMatchings() {
   this->printMsg("Creating vtk matchings", debug::Priority::VERBOSE);
   vtkNew<vtkPoints> matchingPoints{};
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -482,6 +482,12 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
     this->diagramToVTU(
       vtu, diags[i], this->inv_clustering_[i], this->max_dimension_total_);
 
+    vtkNew<vtkIntArray> diagId{};
+    diagId->SetName("DiagramID");
+    diagId->SetNumberOfTuples(vtu->GetNumberOfPoints());
+    diagId->Fill(i);
+    vtu->GetPointData()->AddArray(diagId);
+
     if(dm == DISPLAY::MATCHINGS && spacing > 0) {
       // translate diagrams along the Z axis
       vtkNew<vtkTransform> tr{};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -383,7 +383,7 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
 
   // cell data
   vtkNew<vtkIntArray> pairId{};
-  pairId->SetName("PairID");
+  pairId->SetName("PairIdentifier");
   pairId->SetNumberOfTuples(diagram.size() + 1);
   output->GetCellData()->AddArray(pairId);
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -43,12 +43,6 @@
 #include <PersistenceDiagramClustering.h>
 #include <ttkAlgorithm.h>
 
-enum class DisplayMethodType {
-  COMPACT = 0,
-  STARS = 1,
-  MATCHINGS = 2,
-};
-
 class TTKPERSISTENCEDIAGRAMCLUSTERING_EXPORT ttkPersistenceDiagramClustering
   : public ttkAlgorithm,
     protected ttk::PersistenceDiagramClustering {
@@ -57,6 +51,17 @@ public:
   static ttkPersistenceDiagramClustering *New();
 
   vtkTypeMacro(ttkPersistenceDiagramClustering, ttkAlgorithm);
+
+  enum class DISPLAY {
+    COMPACT = 0,
+    STARS = 1,
+    MATCHINGS = 2,
+  };
+
+  enum class METHOD {
+    PROGRESSIVE = 0,
+    AUCTION = 1,
+  };
 
   vtkSetMacro(WassersteinMetric, int);
   vtkGetMacro(WassersteinMetric, int);
@@ -109,30 +114,30 @@ public:
   vtkGetMacro(PairTypeClustering, int);
 
   void SetSpacing(double spacing) {
-    Spacing = spacing;
-    oldSpacing = spacing;
+    this->Spacing = spacing;
+    this->oldSpacing = spacing;
     Modified();
     if(!intermediateDiagrams_.empty()) {
       // skip clustering computation only if done at least once before
-      needUpdate_ = false;
+      this->needUpdate_ = false;
     }
   }
   vtkGetMacro(Spacing, double);
 
   void SetDisplayMethod(int displayMethod) {
-    DisplayMethod = displayMethod;
-    if(displayMethod == 0) { // compact display
-      Spacing = 0;
+    this->DisplayMethod = static_cast<DISPLAY>(displayMethod);
+    if(this->DisplayMethod == DISPLAY::COMPACT) {
+      this->Spacing = 0;
     } else {
-      Spacing = oldSpacing;
+      this->Spacing = this->oldSpacing;
     }
     Modified();
     if(!intermediateDiagrams_.empty()) {
       // skip clustering computation only if done at least once before
-      needUpdate_ = false;
+      this->needUpdate_ = false;
     }
   }
-  vtkGetMacro(DisplayMethod, bool);
+  vtkGetEnumMacro(DisplayMethod, DISPLAY);
 
   vtkSetMacro(UseAdditionalPrecision, bool);
   vtkGetMacro(UseAdditionalPrecision, bool);
@@ -143,8 +148,8 @@ public:
   vtkSetMacro(UseInterruptible, bool);
   vtkGetMacro(UseInterruptible, bool);
 
-  vtkSetMacro(Method, double);
-  vtkGetMacro(Method, double);
+  ttkSetEnumMacro(Method, METHOD);
+  vtkGetEnumMacro(Method, METHOD);
 
   // TODO: CONVERT TO A STRUCT!
   using pairTuple = std::tuple<ttk::SimplexId, // birth vertex id
@@ -178,12 +183,12 @@ protected:
   void outputClusteredDiagrams(vtkMultiBlockDataSet *output,
                                const std::vector<diagramType> &diags,
                                const std::vector<int> &inv_clustering,
-                               const DisplayMethodType dm,
+                               const DISPLAY dm,
                                const double spacing,
                                const double max_persistence) const;
   void outputCentroids(vtkMultiBlockDataSet *output,
                        std::vector<diagramType> &final_centroids,
-                       const DisplayMethodType dm,
+                       const DISPLAY dm,
                        const double spacing,
                        const double max_persistence) const;
 
@@ -200,10 +205,10 @@ private:
   std::vector<int> inv_clustering_{};
 
   double Spacing{1.0};
-  int DisplayMethod{0};
   double oldSpacing{1.0};
-
   double max_dimension_total_{};
-  int Method{0}; // 0 = progressive approach, 1 = Auction approach
+
+  DISPLAY DisplayMethod{DISPLAY::COMPACT};
+  METHOD Method{METHOD::PROGRESSIVE};
   bool needUpdate_{true};
 };

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -175,6 +175,11 @@ protected:
                        const double spacing,
                        const double max_persistence) const;
 
+  void diagramToVTU(vtkUnstructuredGrid *output,
+                    const diagramType &diagram,
+                    const int cid,
+                    const double max_persistence) const;
+
   vtkNew<vtkUnstructuredGrid> createMatchings();
 
   int RequestData(vtkInformation *request,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -43,6 +43,12 @@
 #include <PersistenceDiagramClustering.h>
 #include <ttkAlgorithm.h>
 
+enum class DisplayMethod {
+  COMPACT = 0,
+  STARS = 1,
+  MATCHINGS = 2,
+};
+
 class TTKPERSISTENCEDIAGRAMCLUSTERING_EXPORT ttkPersistenceDiagramClustering
   : public ttkAlgorithm,
     protected ttk::PersistenceDiagramClustering {
@@ -168,7 +174,6 @@ protected:
   void Modified() override;
 
   vtkNew<vtkUnstructuredGrid> createMatchings();
-  vtkNew<vtkUnstructuredGrid> createOutputClusteredDiagrams();
   vtkNew<vtkUnstructuredGrid> createOutputCentroids();
 
   int RequestData(vtkInformation *request,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -175,6 +175,18 @@ protected:
   int FillOutputPortInformation(int port, vtkInformation *info) override;
   void Modified() override;
 
+  void outputClusteredDiagrams(vtkMultiBlockDataSet *output,
+                               const std::vector<diagramType> &diags,
+                               const std::vector<int> &inv_clustering,
+                               const DisplayMethodType dm,
+                               const double spacing,
+                               const double max_persistence) const;
+  void outputCentroids(vtkMultiBlockDataSet *output,
+                       std::vector<diagramType> &final_centroids,
+                       const DisplayMethodType dm,
+                       const double spacing,
+                       const double max_persistence) const;
+
   vtkNew<vtkUnstructuredGrid> createMatchings();
 
   int RequestData(vtkInformation *request,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -163,14 +163,22 @@ protected:
                        const DISPLAY dm,
                        const double spacing,
                        const double max_persistence) const;
+  void outputMatchings(vtkMultiBlockDataSet *output,
+                       const size_t nClusters,
+                       const std::vector<diagramType> &diags,
+                       const std::vector<std::vector<std::vector<matchingType>>>
+                         &matchingsPerCluster,
+                       const std::vector<diagramType> &centroids,
+                       const std::vector<int> &inv_clustering,
+                       const ttkPersistenceDiagramClustering::DISPLAY dm,
+                       const double spacing,
+                       const double max_persistence) const;
 
   void VTUToDiagram(diagramType &diagram, vtkUnstructuredGrid *vtu) const;
   void diagramToVTU(vtkUnstructuredGrid *output,
                     const diagramType &diagram,
                     const int cid,
                     const double max_persistence) const;
-
-  vtkNew<vtkUnstructuredGrid> createMatchings();
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -18,22 +18,8 @@
 #pragma once
 
 // VTK includes
-#include <vtkCellData.h>
-#include <vtkCharArray.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDoubleArray.h>
-#include <vtkFiltersCoreModule.h>
-#include <vtkFloatArray.h>
-#include <vtkInformation.h>
-#include <vtkInformationVector.h>
-#include <vtkIntArray.h>
-#include <vtkMultiBlockDataSet.h>
 #include <vtkMultiBlockDataSetAlgorithm.h>
 #include <vtkNew.h>
-#include <vtkObjectFactory.h>
-#include <vtkPointData.h>
-#include <vtkUnstructuredGrid.h>
 
 // VTK Module
 #include <ttkPersistenceDiagramClusteringModule.h>
@@ -42,6 +28,9 @@
 #include <PersistenceDiagramBarycenter.h>
 #include <PersistenceDiagramClustering.h>
 #include <ttkAlgorithm.h>
+#include <ttkMacros.h>
+
+class vtkUnstructuredGrid;
 
 class TTKPERSISTENCEDIAGRAMCLUSTERING_EXPORT ttkPersistenceDiagramClustering
   : public ttkAlgorithm,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -45,7 +45,6 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
 
 // VTK Module
@@ -183,9 +182,9 @@ protected:
   int FillOutputPortInformation(int port, vtkInformation *info) override;
   void Modified() override;
 
-  vtkSmartPointer<vtkUnstructuredGrid> createMatchings();
-  vtkSmartPointer<vtkUnstructuredGrid> createOutputClusteredDiagrams();
-  vtkSmartPointer<vtkUnstructuredGrid> createOutputCentroids();
+  vtkNew<vtkUnstructuredGrid> createMatchings();
+  vtkNew<vtkUnstructuredGrid> createOutputClusteredDiagrams();
+  vtkNew<vtkUnstructuredGrid> createOutputCentroids();
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -156,9 +156,6 @@ public:
 protected:
   ttkPersistenceDiagramClustering();
 
-  double getPersistenceDiagram(diagramType &diagram,
-                               vtkUnstructuredGrid *CTPersistenceDiagram_);
-
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
   void Modified() override;
@@ -175,6 +172,7 @@ protected:
                        const double spacing,
                        const double max_persistence) const;
 
+  void VTUToDiagram(diagramType &diagram, vtkUnstructuredGrid *vtu) const;
   void diagramToVTU(vtkUnstructuredGrid *output,
                     const diagramType &diagram,
                     const int cid,

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -61,22 +61,14 @@ public:
   vtkSetMacro(TimeLimit, double);
   vtkGetMacro(TimeLimit, double);
 
-  void SetAlpha(double data) {
-    if(data > 0 && data <= 1) {
-      Alpha = data;
-    } else if(data > 1) {
-      Alpha = 1;
-    } else {
-      Alpha = 0.001;
-    }
+  void SetAlpha(const double alpha) {
+    this->Alpha = std::min(std::abs(alpha), 1.0);
     Modified();
   }
-  vtkGetMacro(Alpha, double);
-
-  void SetAntiAlpha(double data) {
-    double alpha = 1 - data;
-    SetAlpha(alpha);
+  void SetAntiAlpha(const double antiAlpha) {
+    SetAlpha(1.0 - antiAlpha);
   }
+  vtkGetMacro(Alpha, double);
 
   vtkSetMacro(DeltaLim, double);
   vtkGetMacro(DeltaLim, double);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -43,7 +43,7 @@
 #include <PersistenceDiagramClustering.h>
 #include <ttkAlgorithm.h>
 
-enum class DisplayMethod {
+enum class DisplayMethodType {
   COMPACT = 0,
   STARS = 1,
   MATCHINGS = 2,
@@ -146,27 +146,29 @@ public:
   vtkSetMacro(Method, double);
   vtkGetMacro(Method, double);
 
-  using diagramType = std::tuple<ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 ttk::SimplexId,
-                                 ttk::CriticalType,
-                                 double,
-                                 ttk::SimplexId,
-                                 double,
-                                 float,
-                                 float,
-                                 float,
-                                 double,
-                                 float,
-                                 float,
-                                 float>;
-
+  // TODO: CONVERT TO A STRUCT!
+  using pairTuple = std::tuple<ttk::SimplexId, // birth vertex id
+                               ttk::CriticalType, // birth critical type
+                               ttk::SimplexId, // death vertex id
+                               ttk::CriticalType, // death critical type
+                               double, // persistence
+                               ttk::SimplexId, // pair dimension
+                               double, // birth scalar field value
+                               float,
+                               float,
+                               float, // birth vertex 3D coordinates
+                               double, // death scalar field value
+                               float,
+                               float,
+                               float // death vertex 3D coordinates
+                               >;
+  using diagramType = std::vector<pairTuple>;
   using matchingType = std::tuple<ttk::SimplexId, ttk::SimplexId, double>;
 
 protected:
   ttkPersistenceDiagramClustering();
 
-  double getPersistenceDiagram(std::vector<diagramType> &diagram,
+  double getPersistenceDiagram(diagramType &diagram,
                                vtkUnstructuredGrid *CTPersistenceDiagram_);
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
@@ -180,9 +182,9 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  std::vector<std::vector<diagramType>> intermediateDiagrams_{};
+  std::vector<diagramType> intermediateDiagrams_{};
   std::vector<std::vector<std::vector<matchingType>>> all_matchings_{};
-  std::vector<std::vector<diagramType>> final_centroids_{};
+  std::vector<diagramType> final_centroids_{};
   std::vector<int> inv_clustering_{};
 
   double Spacing{1.0};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -104,7 +104,6 @@ public:
 
   void SetSpacing(double spacing) {
     this->Spacing = spacing;
-    this->oldSpacing = spacing;
     Modified();
     if(!intermediateDiagrams_.empty()) {
       // skip clustering computation only if done at least once before
@@ -115,11 +114,6 @@ public:
 
   void SetDisplayMethod(int displayMethod) {
     this->DisplayMethod = static_cast<DISPLAY>(displayMethod);
-    if(this->DisplayMethod == DISPLAY::COMPACT) {
-      this->Spacing = 0;
-    } else {
-      this->Spacing = this->oldSpacing;
-    }
     Modified();
     if(!intermediateDiagrams_.empty()) {
       // skip clustering computation only if done at least once before
@@ -194,7 +188,6 @@ private:
   std::vector<int> inv_clustering_{};
 
   double Spacing{1.0};
-  double oldSpacing{1.0};
   double max_dimension_total_{};
 
   DISPLAY DisplayMethod{DISPLAY::COMPACT};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -17,19 +17,7 @@
 
 #pragma once
 
-#ifndef diagramTuple
-#define diagramTuple                                                       \
-  std::tuple<ttk::SimplexId, ttk::CriticalType, ttk::SimplexId,            \
-             ttk::CriticalType, dataType, ttk::SimplexId, dataType, float, \
-             float, float, dataType, float, float, float>
-#endif
-
-#define BLocalMax ttk::CriticalType::Local_maximum
-#define BLocalMin ttk::CriticalType::Local_minimum
-#define BSaddle1 ttk::CriticalType::Saddle1
-#define BSaddle2 ttk::CriticalType::Saddle2
-
-// VTK includes -- to adapt
+// VTK includes
 #include <vtkCellData.h>
 #include <vtkCharArray.h>
 #include <vtkDataArray.h>
@@ -50,10 +38,9 @@
 // VTK Module
 #include <ttkPersistenceDiagramClusteringModule.h>
 
-// ttk code includes
+// TTK includes
 #include <PersistenceDiagramBarycenter.h>
 #include <PersistenceDiagramClustering.h>
-
 #include <ttkAlgorithm.h>
 
 class TTKPERSISTENCEDIAGRAMCLUSTERING_EXPORT ttkPersistenceDiagramClustering
@@ -76,7 +63,6 @@ public:
 
   void SetAlpha(double data) {
     if(data > 0 && data <= 1) {
-
       Alpha = data;
     } else if(data > 1) {
       Alpha = 1;
@@ -140,7 +126,6 @@ public:
       needUpdate_ = false;
     }
   }
-
   vtkGetMacro(DisplayMethod, bool);
 
   vtkSetMacro(UseAdditionalPrecision, bool);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -159,7 +159,7 @@ protected:
                                const double spacing,
                                const double max_persistence) const;
   void outputCentroids(vtkMultiBlockDataSet *output,
-                       std::vector<diagramType> &final_centroids,
+                       const std::vector<diagramType> &final_centroids,
                        const DISPLAY dm,
                        const double spacing,
                        const double max_persistence) const;

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -146,9 +146,6 @@ public:
   vtkSetMacro(Method, double);
   vtkGetMacro(Method, double);
 
-protected:
-  ttkPersistenceDiagramClustering();
-
   using diagramType = std::tuple<ttk::SimplexId,
                                  ttk::CriticalType,
                                  ttk::SimplexId,
@@ -166,6 +163,9 @@ protected:
 
   using matchingType = std::tuple<ttk::SimplexId, ttk::SimplexId, double>;
 
+protected:
+  ttkPersistenceDiagramClustering();
+
   double getPersistenceDiagram(std::vector<diagramType> &diagram,
                                vtkUnstructuredGrid *CTPersistenceDiagram_);
 
@@ -174,7 +174,6 @@ protected:
   void Modified() override;
 
   vtkNew<vtkUnstructuredGrid> createMatchings();
-  vtkNew<vtkUnstructuredGrid> createOutputCentroids();
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkPersistenceDiagramClustering/vtk.module
+++ b/core/vtk/ttkPersistenceDiagramClustering/vtk.module
@@ -2,3 +2,5 @@ NAME
  ttkPersistenceDiagramClustering
 DEPENDS
   ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersGeneral

--- a/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
+++ b/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
@@ -2,7 +2,6 @@
 
 #include <vtkPointData.h>
 #include <vtkPointSet.h>
-#include <vtkStringArray.h>
 #include <vtkUnstructuredGrid.h>
 
 #include <vtkInformation.h>


### PR DESCRIPTION
This PR reworks the VTK layer of the PersistenceDiagramClustering module to put every diagram in the "Clustered Diagrams" and every centroid of the "Clustered Centroids" outputs into their own `vtkMultiBlockDataSet` block. The matchings have also been put into blocks, one per input diagram.

To do so, a common method converting a diagram or a centroid in its intermediate form of a vector of tuples to a VTU ensures that diagrams and centroids share the same PointData and CellData arrays. Those VTU are later translated for the "Inspect Matchings" and the "Clusters as Stars" display options using `vtkTransformFilter`. The diagonal has been added to each diagram/centroid.

Additionally, the distance results are now accessible in the VTK layer and have been put as FieldData of the Matchings output (duplicated per block since multi-block FieldData are not visible in ParaView).

Since the diagonal has been added in the diagrams, there will be some small graphical modifications in the two ttk-data states using this filter. 

As a bonus, a unused include has been removed from PointSetToCurve.

Enjoy,
Pierre