### PR TITLE
ftmTree: Put back loose comparisons

### DIFF
--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -234,8 +234,8 @@ SimplexId ArcRegion::findBelow(SimplexId v,
   const bool chkOther = vert2treeOther.size() > 0;
 
   for(const auto &reg : segmentsIn_) {
-    if(s->isLower(*reg.segmentBegin, v)
-       && s->isHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isEqLower(*reg.segmentBegin, v)
+       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldBeg = reg.segmentBegin;
@@ -312,8 +312,8 @@ tuple<SimplexId, ArcRegion> ArcRegion::splitBack(SimplexId v,
   for(decltype(segmentsIn_)::iterator it = segmentsIn_.begin();
       it != segmentsIn_.end(); ++it) {
     auto &reg = *it;
-    if(s->isLower(*reg.segmentBegin, v)
-       && s->isHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isEqLower(*reg.segmentBegin, v)
+       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldBeg = reg.segmentBegin;
@@ -367,8 +367,8 @@ tuple<SimplexId, ArcRegion> ArcRegion::splitFront(SimplexId v,
   for(decltype(segmentsIn_)::iterator it = segmentsIn_.begin();
       it != segmentsIn_.end(); ++it) {
     auto &reg = *it;
-    if(s->isLower(*reg.segmentBegin, v)
-       && s->isHigher(*(reg.segmentEnd - 1), v)) {
+    if(s->isEqLower(*reg.segmentBegin, v)
+       && s->isEqHigher(*(reg.segmentEnd - 1), v)) {
       // is v is between beg/end
       // append once
       const auto &oldEnd = reg.segmentEnd;

--- a/core/base/ftmTree/FTMStructures.h
+++ b/core/base/ftmTree/FTMStructures.h
@@ -51,11 +51,17 @@ namespace ttk {
       // [size-1] -> vertex id of the global maximum
       std::vector<SimplexId> sortedVertices{};
 
-      bool isLower(SimplexId a, SimplexId b) const {
-        return offsets[a] < offsets[b];
+      inline bool isLower(const SimplexId a, const SimplexId b) const {
+        return this->offsets[a] < this->offsets[b];
       }
-      bool isHigher(SimplexId a, SimplexId b) const {
-        return offsets[a] > offsets[b];
+      inline bool isEqLower(const SimplexId a, const SimplexId b) const {
+        return this->offsets[a] <= this->offsets[b];
+      }
+      inline bool isHigher(const SimplexId a, const SimplexId b) const {
+        return this->offsets[a] > this->offsets[b];
+      }
+      inline bool isEqHigher(const SimplexId a, const SimplexId b) const {
+        return this->offsets[a] >= this->offsets[b];
       }
     };
 


### PR DESCRIPTION
Following @CharlesGueunet's comment in https://github.com/topology-tool-kit/ttk/commit/f6f21b0206cdbac6ba802d5afc5da31debae43ca#r53373160, the strict order comparisons where reverted back to loose comparisons.

@CharlesGueunet is this OK for you?

No change observed in the ttk-data states.

Enjoy,
Pierre 