### PR TITLE
ftmTree: Fix Archer2 HPC cluster GCC6 build error

### DIFF
--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -382,12 +382,13 @@ namespace ttk {
 
       // is last
       valence oldVal;
+      valence &tmp = (*mt_data_.valences)[currentState.vertex];
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic capture
 #endif
       {
-        oldVal = (*mt_data_.valences)[currentState.vertex];
-        (*mt_data_.valences)[currentState.vertex] -= decr;
+        oldVal = tmp;
+        tmp -= decr;
       }
       if(oldVal == decr) {
         isLast = true;


### PR DESCRIPTION
@julesvidal has been trying to build TTK on [Archer2](https://docs.archer2.ac.uk/index.html) an HPC cluster at Edinburgh. Sadly, the default compiler (GCC6) returns a build error on an OpenMP atomic section of the ftmTree module. 

This simple fix has been proposed by people at University of Edinburgh. I tested it on ttk-data and could not observe any difference.

@CharlesGueunet While we're at it, do you think this change can have unforeseen consequences with relation to the semantics of the atomic section?

Pierre