### PR TITLE
PersistenceDiagramClustering: Fix compatibility with PersistenceDiagramDistanceMatrix

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -496,6 +496,13 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
     diagId->Fill(i);
     vtu->GetPointData()->AddArray(diagId);
 
+    vtkNew<vtkIntArray> clusterId{};
+    clusterId->SetName("ClusterID");
+    clusterId->SetNumberOfComponents(1);
+    clusterId->SetNumberOfTuples(vtu->GetNumberOfPoints());
+    clusterId->Fill(inv_clustering[i]);
+    vtu->GetPointData()->AddArray(clusterId);
+
     // add Persistence data array on vertices
     vtkNew<vtkDoubleArray> pointPers{};
     pointPers->SetName("Persistence");

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -451,10 +451,10 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
     2 * (minmax_birth.second - diagram.begin()),
   };
   output->InsertNextCell(VTK_LINE, 2, ids.data());
-  pairId->SetTuple1(diagram.size(), diagram.size());
+  pairId->SetTuple1(diagram.size(), -1);
   pairType->SetTuple1(diagram.size(), -1);
-  // use the max persistence of all input diagrams...
-  pairPers->SetTuple1(diagram.size(), max_persistence);
+  // use twice the max persistence of all input diagrams...
+  pairPers->SetTuple1(diagram.size(), 2.0 * max_persistence);
 }
 
 void ttkPersistenceDiagramClustering::outputClusteredDiagrams(

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -137,9 +137,9 @@ int ttkPersistenceDiagramClustering::RequestData(
     }
   }
 
-  outputClusteredDiagrams(output_clusters, this->intermediateDiagrams_,
-                          this->inv_clustering_, this->DisplayMethod,
-                          this->Spacing, this->max_dimension_total_);
+  outputClusteredDiagrams(output_clusters, input, this->inv_clustering_,
+                          this->DisplayMethod, this->Spacing,
+                          this->max_dimension_total_);
   outputCentroids(output_centroids, this->final_centroids_, this->DisplayMethod,
                   this->Spacing, this->max_dimension_total_);
   outputMatchings(
@@ -459,7 +459,7 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
 
 void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
   vtkMultiBlockDataSet *output,
-  const std::vector<diagramType> &diags,
+  const std::vector<vtkUnstructuredGrid *> &diags,
   const std::vector<int> &inv_clustering,
   const DISPLAY dm,
   const double spacing,
@@ -488,8 +488,7 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
 
   for(size_t i = 0; i < diags.size(); ++i) {
     vtkNew<vtkUnstructuredGrid> vtu{};
-    this->diagramToVTU(
-      vtu, diags[i], this->inv_clustering_[i], this->max_dimension_total_);
+    vtu->ShallowCopy(diags[i]);
 
     vtkNew<vtkIntArray> diagId{};
     diagId->SetName("DiagramID");

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -381,6 +381,11 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
   pointPers->SetNumberOfTuples(nPoints);
   output->GetPointData()->AddArray(pointPers);
 
+  vtkNew<ttkSimplexIdTypeArray> vsf{};
+  vsf->SetName(ttk::VertexScalarFieldName);
+  vsf->SetNumberOfTuples(nPoints);
+  output->GetPointData()->AddArray(vsf);
+
   // cell data
   vtkNew<vtkIntArray> pairId{};
   pairId->SetName("PairIdentifier");
@@ -401,6 +406,8 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
     const auto &pair{diagram[j]};
     const auto birth{std::get<6>(pair)};
     const auto death{std::get<10>(pair)};
+    const auto birtVertId{std::get<0>(pair)};
+    const auto deathVertId{std::get<2>(pair)};
     const auto pType{std::get<5>(pair)};
     const auto birthType{std::get<1>(pair)};
     const auto deathType{std::get<3>(pair)};
@@ -421,6 +428,8 @@ void ttkPersistenceDiagramClustering::diagramToVTU(
     pointPers->SetTuple1(2 * j + 1, death - birth);
     critType->SetTuple1(2 * j + 0, static_cast<int>(birthType));
     critType->SetTuple1(2 * j + 1, static_cast<int>(deathType));
+    vsf->SetTuple1(2 * j + 0, birtVertId);
+    vsf->SetTuple1(2 * j + 1, deathVertId);
 
     points->SetPoint(2 * j + 0, birth, birth, 0);
     points->SetPoint(2 * j + 1, birth, death, 0);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -496,6 +496,20 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
     diagId->Fill(i);
     vtu->GetPointData()->AddArray(diagId);
 
+    // add Persistence data array on vertices
+    vtkNew<vtkDoubleArray> pointPers{};
+    pointPers->SetName("Persistence");
+    pointPers->SetNumberOfTuples(vtu->GetNumberOfPoints());
+    vtu->GetPointData()->AddArray(pointPers);
+
+    // diagonal uses two existing points
+    for(int j = 0; j < vtu->GetNumberOfCells() - 1; ++j) {
+      const auto persArray = vtu->GetCellData()->GetArray("Persistence");
+      const auto pers = persArray->GetTuple1(j);
+      pointPers->SetTuple1(2 * j + 0, pers);
+      pointPers->SetTuple1(2 * j + 1, pers);
+    }
+
     if(dm == DISPLAY::MATCHINGS && spacing > 0) {
       // translate diagrams along the Z axis
       vtkNew<vtkTransform> tr{};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -153,7 +153,7 @@ protected:
   void Modified() override;
 
   void outputClusteredDiagrams(vtkMultiBlockDataSet *output,
-                               const std::vector<diagramType> &diags,
+                               const std::vector<vtkUnstructuredGrid *> &diags,
                                const std::vector<int> &inv_clustering,
                                const DISPLAY dm,
                                const double spacing,

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -92,6 +92,10 @@ int ttkPersistenceDiagramDistanceMatrix::RequestData(
   for(int i = 0; i < nDiags; i++) {
     double max_dimension
       = getPersistenceDiagram(intermediateDiagrams[i], inputDiagrams[i]);
+    if(max_dimension < 0.0) {
+      this->printErr("Could not read Persistence Diagram");
+      return 0;
+    }
     if(max_dimension_total < max_dimension) {
       max_dimension_total = max_dimension;
     }
@@ -147,11 +151,10 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
   const auto cd = CTPersistenceDiagram_->GetCellData();
   const auto points = CTPersistenceDiagram_->GetPoints();
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(pd == nullptr || points == nullptr) {
-    return -2;
+  if(pd == nullptr || cd == nullptr || points == nullptr) {
+    this->printErr("Missing Diagram PointData, CellData or Points");
+    return -1.0;
   }
-#endif // TTK_ENABLE_KAMIKAZE
 
   const auto vertexIdentifierScalars
     = vtkIntArray::SafeDownCast(pd->GetArray(ttk::VertexScalarFieldName));
@@ -170,12 +173,10 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
 
   const bool embed = birthScalars != nullptr && deathScalars != nullptr;
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(!embed && critCoordinates == nullptr) {
-    // missing data
-    return -2;
+    this->printErr("Malformed Persistence Diagram");
+    return -2.0;
   }
-#endif // TTK_ENABLE_KAMIKAZE
 
   int pairingsSize = (int)pairIdentifierScalars->GetNumberOfTuples();
   // FIX : no more missed pairs
@@ -189,13 +190,12 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
   if(*pairIdentifierScalars->GetTuple(pairingsSize - 1) == -1)
     pairingsSize -= 1;
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(pairingsSize < 1 || !vertexIdentifierScalars || !pairIdentifierScalars
      || !nodeTypeScalars || !persistenceScalars || !extremumIndexScalars
      || !points) {
-    return -2;
+    this->printErr("Missing Persistence Diagram data array");
+    return -3.0;
   }
-#endif // TTK_ENABLE_KAMIKAZE
 
   diagram.resize(pairingsSize + 1);
   int nbNonCompact = 0;


### PR DESCRIPTION
This PR fixes the compatibility between the "Clustered Diagrams" output of the `PersistenceDiagramClustering` filter and the `PersistenceDiagramDistanceMatrix` filter after #632.

First, error handling in `PersistenceDiagramDistanceMatrix` has been overhauled to avoid segfaults when the input diagrams are malformed. Instead, error messages are printed.

To ensure that the correct distances are computed, the original diagrams that are fed to `PersistenceDiagramClustering`, are shallow copied to the "Clustered Diagrams" output. Reconstructing the diagrams from the intermediate representation (vector of tuples) is too error prone (especially around the global min-max pair).

No additional changes observed on the two concerned ttk-data states.

Enjoy and sorry for the trouble,
Pierre