### PR TITLE
Merge tree distance matrix

### DIFF
--- a/core/base/ftmTree/FTMTreeUtils.cpp
+++ b/core/base/ftmTree/FTMTreeUtils.cpp
@@ -491,5 +491,74 @@ namespace ttk {
       return ss;
     }
 
+    // --------------------
+    // Make tree utils
+    // --------------------
+    void manageInconsistentArcsMultiParent(FTMTree_MT *tree) {
+      ftm::idNode treeRoot = 0;
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
+        if(tree->getNode(i)->getNumberOfDownSuperArcs() != 0
+           and tree->getNode(i)->getNumberOfUpSuperArcs() == 0)
+          treeRoot = i;
+      }
+
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(tree->getNode(i)->getNumberOfUpSuperArcs() > 1) {
+          ftm::idNode lowestParent = std::numeric_limits<ftm::idNode>::max();
+          for(long unsigned int j = 0;
+              j < tree->getNode(i)->getNumberOfUpSuperArcs(); ++j) {
+            auto tParent
+              = tree->getSuperArc(tree->getNode(i)->getUpSuperArcId(j))
+                  ->getUpNodeId();
+            lowestParent = (lowestParent > tParent) ? tParent : lowestParent;
+          }
+
+          for(long unsigned int j = 0;
+              j < tree->getNode(i)->getNumberOfUpSuperArcs(); ++j) {
+            ftm::idSuperArc nodeArcId = tree->getNode(i)->getUpSuperArcId(j);
+            auto tParent = tree->getSuperArc(nodeArcId)->getUpNodeId();
+            if(tParent != lowestParent) {
+
+              if(tParent == treeRoot) {
+                for(long unsigned int k = 0;
+                    k < tree->getNode(i)->getNumberOfDownSuperArcs(); ++k) {
+                  ftm::idSuperArc nodeArcId2
+                    = tree->getNode(i)->getDownSuperArcId(k);
+                  auto tChildren
+                    = tree->getSuperArc(nodeArcId2)->getDownNodeId();
+                  if(tChildren > i) {
+                    tree->getNode(i)->removeDownSuperArc(nodeArcId2);
+                    tree->getNode(tChildren)->removeUpSuperArc(nodeArcId2);
+                    tree->makeSuperArc(tChildren, treeRoot);
+                    break;
+                  }
+                }
+              }
+
+              // Delete down arc from old parent
+              tree->getNode(tParent)->removeDownSuperArc(nodeArcId);
+              // Delete up arc from node
+              tree->getNode(i)->removeUpSuperArc(nodeArcId);
+            }
+          }
+        }
+    }
+
+    void removeSelfLink(FTMTree_MT *tree) {
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
+        for(unsigned int j = 0; j < tree->getNode(i)->getNumberOfUpSuperArcs();
+            ++j) {
+          ftm::idSuperArc nodeArcId = tree->getNode(i)->getUpSuperArcId(j);
+          auto tParent = tree->getSuperArc(nodeArcId)->getUpNodeId();
+          if(tParent == i) {
+            // Delete down arc
+            tree->getNode(i)->removeDownSuperArc(nodeArcId);
+            // Delete up arc
+            tree->getNode(i)->removeUpSuperArc(nodeArcId);
+          }
+        }
+      }
+    }
+
   } // namespace ftm
 } // namespace ttk

--- a/core/base/ftmTree/FTMTreeUtils.h
+++ b/core/base/ftmTree/FTMTreeUtils.h
@@ -90,71 +90,9 @@ namespace ttk {
     // --------------------
     // Make tree utils
     // --------------------
-    void manageInconsistentArcsMultiParent(FTMTree_MT *tree) {
-      ftm::idNode treeRoot = 0;
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
-        if(tree->getNode(i)->getNumberOfDownSuperArcs() != 0
-           and tree->getNode(i)->getNumberOfUpSuperArcs() == 0)
-          treeRoot = i;
-      }
+    void manageInconsistentArcsMultiParent(FTMTree_MT *tree);
 
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-        if(tree->getNode(i)->getNumberOfUpSuperArcs() > 1) {
-          ftm::idNode lowestParent = std::numeric_limits<ftm::idNode>::max();
-          for(long unsigned int j = 0;
-              j < tree->getNode(i)->getNumberOfUpSuperArcs(); ++j) {
-            auto tParent
-              = tree->getSuperArc(tree->getNode(i)->getUpSuperArcId(j))
-                  ->getUpNodeId();
-            lowestParent = (lowestParent > tParent) ? tParent : lowestParent;
-          }
-
-          for(long unsigned int j = 0;
-              j < tree->getNode(i)->getNumberOfUpSuperArcs(); ++j) {
-            ftm::idSuperArc nodeArcId = tree->getNode(i)->getUpSuperArcId(j);
-            auto tParent = tree->getSuperArc(nodeArcId)->getUpNodeId();
-            if(tParent != lowestParent) {
-
-              if(tParent == treeRoot) {
-                for(long unsigned int k = 0;
-                    k < tree->getNode(i)->getNumberOfDownSuperArcs(); ++k) {
-                  ftm::idSuperArc nodeArcId2
-                    = tree->getNode(i)->getDownSuperArcId(k);
-                  auto tChildren
-                    = tree->getSuperArc(nodeArcId2)->getDownNodeId();
-                  if(tChildren > i) {
-                    tree->getNode(i)->removeDownSuperArc(nodeArcId2);
-                    tree->getNode(tChildren)->removeUpSuperArc(nodeArcId2);
-                    tree->makeSuperArc(tChildren, treeRoot);
-                    break;
-                  }
-                }
-              }
-
-              // Delete down arc from old parent
-              tree->getNode(tParent)->removeDownSuperArc(nodeArcId);
-              // Delete up arc from node
-              tree->getNode(i)->removeUpSuperArc(nodeArcId);
-            }
-          }
-        }
-    }
-
-    void removeSelfLink(FTMTree_MT *tree) {
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
-        for(unsigned int j = 0; j < tree->getNode(i)->getNumberOfUpSuperArcs();
-            ++j) {
-          ftm::idSuperArc nodeArcId = tree->getNode(i)->getUpSuperArcId(j);
-          auto tParent = tree->getSuperArc(nodeArcId)->getUpNodeId();
-          if(tParent == i) {
-            // Delete down arc
-            tree->getNode(i)->removeDownSuperArc(nodeArcId);
-            // Delete up arc
-            tree->getNode(i)->removeUpSuperArc(nodeArcId);
-          }
-        }
-      }
-    }
+    void removeSelfLink(FTMTree_MT *tree);
 
     // --------------------
     // MergeTree

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -710,13 +710,11 @@ namespace ttk {
       // --------------------
       // Set
       // --------------------
-
       void setParent(idNode nodeId, idNode newParentNodeId);
 
       // --------------------
       // Delete
       // --------------------
-
       // Delete node by keeping subtree
       void deleteNode(idNode nodeId);
 
@@ -731,13 +729,11 @@ namespace ttk {
       // --------------------
       // Create/Delete/Modify Tree
       // --------------------
-
       void copyMergeTreeStructure(FTMTree_MT *tree);
 
       // --------------------
       // Utils
       // --------------------
-
       void printNodeSS(idNode node, std::stringstream &ss);
 
       template <class dataType>

--- a/core/base/mergeTreeDistanceMatrix/CMakeLists.txt
+++ b/core/base/mergeTreeDistanceMatrix/CMakeLists.txt
@@ -4,7 +4,6 @@ ttk_add_base_library(mergeTreeDistanceMatrix
   HEADERS
     MergeTreeDistanceMatrix.h
   DEPENDS
-    triangulation
     mergeTreeClustering
     ftmTree
     )

--- a/core/base/mergeTreeDistanceMatrix/CMakeLists.txt
+++ b/core/base/mergeTreeDistanceMatrix/CMakeLists.txt
@@ -1,0 +1,10 @@
+ttk_add_base_library(mergeTreeDistanceMatrix
+  SOURCES
+    MergeTreeDistanceMatrix.cpp
+  HEADERS
+    MergeTreeDistanceMatrix.h
+  DEPENDS
+    triangulation
+    mergeTreeClustering
+    ftmTree
+    )

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.cpp
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.cpp
@@ -1,0 +1,1 @@
+#include "MergeTreeDistanceMatrix.h"

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -1,12 +1,10 @@
-/// Provide your information
-///
 /// \ingroup base
 /// \class ttk::MergeTreeDistanceMatrix
-/// \author Mathieu Pont <mathieu.pont@outlook.com>
-/// \date 2020
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2021.
 ///
 /// This VTK filter uses the ttk::MergeTreeDistanceMatrix module to compute the
-/// edit distance matrix of a group of merge trees.
+/// distance matrix of a group of merge trees.
 ///
 
 #ifndef _MERGETREEDISTANCEMATRIX_H

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -66,8 +66,7 @@ namespace ttk {
                          std::vector<std::vector<double>> &distanceMatrix) {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(i) \
-  untied shared(distanceMatrix)
+#pragma omp task firstprivate(i) untied shared(distanceMatrix)
         {
 #endif
           std::stringstream stream;

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -1,0 +1,139 @@
+/// Provide your information
+///
+/// \ingroup base
+/// \class ttk::MergeTreeDistanceMatrix
+/// \author Mathieu Pont <mathieu.pont@outlook.com>
+/// \date 2020
+///
+/// This VTK filter uses the ttk::MergeTreeDistanceMatrix module to compute the
+/// edit distance matrix of a group of merge trees.
+///
+
+#ifndef _MERGETREEDISTANCEMATRIX_H
+#define _MERGETREEDISTANCEMATRIX_H
+
+#pragma once
+
+// ttk common includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+#include <FTMTree.h>
+#include <FTMTreeUtils.h>
+#include <MergeTreeBase.h>
+#include <MergeTreeDistance.h>
+
+namespace ttk {
+
+  /**
+   * The MergeTreeDistanceMatrix class provides methods to compute the edit
+   * distance between multiple merge trees and output a distance matrix.
+   */
+  class MergeTreeDistanceMatrix : virtual public Debug,
+                                  virtual public MergeTreeBase {
+
+  private:
+    bool parallelizeMatrix_ = true;
+
+  public:
+    MergeTreeDistanceMatrix() {
+      this->setDebugMsgPrefix(
+        "MergeTreeDistanceMatrix"); // inherited from Debug: prefix will be
+                                    // printed at the
+      // beginning of every msg
+    };
+    ~MergeTreeDistanceMatrix(){};
+
+    void setParallelizeMatrix(bool para) {
+      parallelizeMatrix_ = para;
+    }
+
+    /**
+     * Implementation of the algorithm.
+     */
+    template <class dataType>
+    void execute(std::vector<MergeTree<dataType>> trees,
+                 std::vector<std::vector<double>> &distanceMatrix) {
+      if(parallelizeMatrix_)
+        executePara<dataType>(trees, distanceMatrix);
+      else
+        executeParaImpl<dataType>(trees, distanceMatrix);
+    }
+
+    template <class dataType>
+    void executePara(std::vector<MergeTree<dataType>> trees,
+                     std::vector<std::vector<double>> &distanceMatrix) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel num_threads(this->threadNumber_)
+      {
+#pragma omp single nowait
+#endif
+        executeParaImpl<dataType>(trees, distanceMatrix);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp taskwait
+      } // pragma omp parallel
+#endif
+    }
+
+    template <class dataType>
+    void executeParaImpl(std::vector<MergeTree<dataType>> trees,
+                         std::vector<std::vector<double>> &distanceMatrix) {
+      for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task firstprivate(i) \
+  untied shared(distanceMatrix) if(parallelizeMatrix_)
+        {
+#endif
+          std::stringstream stream;
+          stream << i << " / " << distanceMatrix.size();
+          printMsg(stream.str());
+          // trees[i]->printTree2();
+
+          distanceMatrix[i][i] = 0.0;
+          for(unsigned int j = i + 1; j < distanceMatrix[0].size(); ++j) {
+            // std::cout << " ___ " << j << " / " << distanceMatrix[0].size() <<
+            // std::endl;
+            // Execute
+            MergeTreeDistance mergeTreeDistance;
+            mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
+            mergeTreeDistance.setEpsilonTree1(epsilonTree1_);
+            mergeTreeDistance.setEpsilonTree2(epsilonTree2_);
+            mergeTreeDistance.setEpsilon2Tree1(epsilon2Tree1_);
+            mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
+            mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
+            mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
+            mergeTreeDistance.setProgressiveComputation(
+              progressiveComputation_);
+            mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
+            mergeTreeDistance.setParallelize(parallelize_);
+            mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
+            mergeTreeDistance.setDebugLevel(2);
+            mergeTreeDistance.setThreadNumber(this->threadNumber_);
+            mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
+            mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
+            mergeTreeDistance.setNormalizedWassersteinReg(
+              normalizedWassersteinReg_);
+            mergeTreeDistance.setKeepSubtree(keepSubtree_);
+            mergeTreeDistance.setDistanceSquared(distanceSquared_);
+            mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
+            mergeTreeDistance.setSaveTree(true);
+            mergeTreeDistance.setCleanTree(true);
+            if(parallelizeMatrix_)
+              mergeTreeDistance.setIsCalled(true);
+            std::vector<std::tuple<ftm::idNode, ftm::idNode>> outputMatching;
+            distanceMatrix[i][j] = mergeTreeDistance.execute<dataType>(
+              trees[i], trees[j], outputMatching);
+            // distance matrix is symmetric
+            distanceMatrix[j][i] = distanceMatrix[i][j];
+          } // end for j
+#ifdef TTK_ENABLE_OPENMP
+        } // end task
+#endif
+      } // end for i
+    }
+
+  }; // MergeTreeDistanceMatrix class
+
+} // namespace ttk
+
+#endif

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -14,7 +14,6 @@
 
 // ttk common includes
 #include <Debug.h>
-#include <Triangulation.h>
 
 #include <FTMTree.h>
 #include <FTMTreeUtils.h>
@@ -24,15 +23,11 @@
 namespace ttk {
 
   /**
-   * The MergeTreeDistanceMatrix class provides methods to compute the edit
+   * The MergeTreeDistanceMatrix class provides methods to compute the
    * distance between multiple merge trees and output a distance matrix.
    */
   class MergeTreeDistanceMatrix : virtual public Debug,
                                   virtual public MergeTreeBase {
-
-  private:
-    bool parallelizeMatrix_ = true;
-
   public:
     MergeTreeDistanceMatrix() {
       this->setDebugMsgPrefix(
@@ -42,20 +37,13 @@ namespace ttk {
     };
     ~MergeTreeDistanceMatrix(){};
 
-    void setParallelizeMatrix(bool para) {
-      parallelizeMatrix_ = para;
-    }
-
     /**
      * Implementation of the algorithm.
      */
     template <class dataType>
     void execute(std::vector<MergeTree<dataType>> trees,
                  std::vector<std::vector<double>> &distanceMatrix) {
-      if(parallelizeMatrix_)
-        executePara<dataType>(trees, distanceMatrix);
-      else
-        executeParaImpl<dataType>(trees, distanceMatrix);
+      executePara<dataType>(trees, distanceMatrix);
     }
 
     template <class dataType>
@@ -79,7 +67,7 @@ namespace ttk {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(i) \
-  untied shared(distanceMatrix) if(parallelizeMatrix_)
+  untied shared(distanceMatrix)
         {
 #endif
           std::stringstream stream;
@@ -113,8 +101,7 @@ namespace ttk {
             mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
             mergeTreeDistance.setSaveTree(true);
             mergeTreeDistance.setCleanTree(true);
-            if(parallelizeMatrix_)
-              mergeTreeDistance.setIsCalled(true);
+            mergeTreeDistance.setIsCalled(true);
             std::vector<std::tuple<ftm::idNode, ftm::idNode>> outputMatching;
             distanceMatrix[i][j] = mergeTreeDistance.execute<dataType>(
               trees[i], trees[j], outputMatching);

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -85,12 +85,9 @@ namespace ttk {
           std::stringstream stream;
           stream << i << " / " << distanceMatrix.size();
           printMsg(stream.str());
-          // trees[i]->printTree2();
 
           distanceMatrix[i][i] = 0.0;
           for(unsigned int j = i + 1; j < distanceMatrix[0].size(); ++j) {
-            // std::cout << " ___ " << j << " / " << distanceMatrix[0].size() <<
-            // std::endl;
             // Execute
             MergeTreeDistance mergeTreeDistance;
             mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);

--- a/core/vtk/ttkMergeTreeDistanceMatrix/CMakeLists.txt
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttk.module
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttk.module
@@ -1,0 +1,12 @@
+NAME
+  ttkMergeTreeDistanceMatrix
+SOURCES
+  ttkMergeTreeDistanceMatrix.cpp
+HEADERS
+  ttkMergeTreeDistanceMatrix.h
+DEPENDS
+  mergeTreeDistanceMatrix
+  ftmTree
+  ttkFTMTree
+  ttkMergeTreeClustering
+  ttkAlgorithm

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttk.module
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttk.module
@@ -6,7 +6,5 @@ HEADERS
   ttkMergeTreeDistanceMatrix.h
 DEPENDS
   mergeTreeDistanceMatrix
-  ftmTree
   ttkFTMTree
-  ttkMergeTreeClustering
   ttkAlgorithm

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -3,7 +3,6 @@
 #include <FTMTreeUtils.h>
 #include <ttkFTMTreeUtils.h>
 #include <ttkMergeTreeDistanceMatrix.h>
-#include <ttkMergeTreeUtils.h>
 #include <ttkUtils.h>
 
 #include <vtkDataObject.h> // For port information

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -1,6 +1,3 @@
-#include <FTMStructures.h>
-#include <FTMTree.h>
-#include <FTMTreeUtils.h>
 #include <ttkFTMTreeUtils.h>
 #include <ttkMergeTreeDistanceMatrix.h>
 #include <ttkUtils.h>
@@ -8,15 +5,8 @@
 #include <vtkDataObject.h> // For port information
 #include <vtkObjectFactory.h> // for new macro
 
-#include <vtkCellData.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
 #include <vtkDoubleArray.h>
 #include <vtkInformation.h>
-#include <vtkInformationVector.h>
-#include <vtkMultiBlockDataSet.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 using namespace ttk;

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -1,0 +1,209 @@
+#include <FTMStructures.h>
+#include <FTMTree.h>
+#include <FTMTreeUtils.h>
+#include <ttkFTMTreeUtils.h>
+#include <ttkMergeTreeDistanceMatrix.h>
+#include <ttkMergeTreeUtils.h>
+#include <ttkUtils.h>
+
+#include <vtkDataObject.h> // For port information
+#include <vtkObjectFactory.h> // for new macro
+
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+
+using namespace ttk;
+using namespace ftm;
+
+// A VTK macro that enables the instantiation of this class via ::New()
+// You do not have to modify this
+vtkStandardNewMacro(ttkMergeTreeDistanceMatrix);
+
+/**
+ * Implement the filter constructor and destructor in the cpp file.
+ *
+ * The constructor has to specify the number of input and output ports
+ * with the functions SetNumberOfInputPorts and SetNumberOfOutputPorts,
+ * respectively. It should also set default values for all filter
+ * parameters.
+ *
+ * The destructor is usually empty unless you want to manage memory
+ * explicitly, by for example allocating memory on the heap that needs
+ * to be freed when the filter is destroyed.
+ */
+ttkMergeTreeDistanceMatrix::ttkMergeTreeDistanceMatrix() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+ttkMergeTreeDistanceMatrix::~ttkMergeTreeDistanceMatrix() {
+}
+
+/**
+ * Specify the required input data type of each input port
+ *
+ * This method specifies the required input object data types of the
+ * filter by adding the vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE() key to
+ * the port information.
+ */
+int ttkMergeTreeDistanceMatrix::FillInputPortInformation(int port,
+                                                         vtkInformation *info) {
+  if(port == 0)
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+  else
+    return 0;
+
+  return 1;
+}
+
+/**
+ * Specify the data object type of each output port
+ *
+ * This method specifies in the port information object the data type of the
+ * corresponding output objects. It is possible to either explicitly
+ * specify a type by adding a vtkDataObject::DATA_TYPE_NAME() key:
+ *
+ *      info->Set( ttkAlgorithm::DATA_TYPE_NAME(), "vtkUnstructuredGrid" );
+ *
+ * or to pass a type of an input port to an output port by adding the
+ * ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT() key (see below).
+ *
+ * Note: prior to the execution of the RequestData method the pipeline will
+ * initialize empty output data objects based on this information.
+ */
+int ttkMergeTreeDistanceMatrix::FillOutputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0)
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
+  else
+    return 0;
+
+  return 1;
+}
+
+/**
+ * Pass VTK data to the base code and convert base code output to VTK
+ *
+ * This method is called during the pipeline execution to update the
+ * already initialized output data objects based on the given input
+ * data objects and filter parameters.
+ *
+ * Note:
+ *     1) The passed input data objects are validated based on the information
+ *        provided by the FillInputPortInformation method.
+ *     2) The output objects are already initialized based on the information
+ *        provided by the FillOutputPortInformation method.
+ */
+template <class dataType>
+int ttkMergeTreeDistanceMatrix::run(
+  vtkInformationVector *outputVector,
+  std::vector<vtkMultiBlockDataSet *> inputTrees) {
+  const int numInputs = inputTrees.size();
+  std::vector<MergeTree<dataType>> intermediateTrees(numInputs);
+  constructTrees(inputTrees, intermediateTrees);
+
+  // Verify parameters
+  if(Backend == 0) {
+    branchDecomposition_ = true;
+    normalizedWasserstein_ = true;
+    keepSubtree_ = false;
+  } else if(Backend == 1) {
+    branchDecomposition_ = false;
+    normalizedWasserstein_ = false;
+    keepSubtree_ = true;
+  }
+  if(not branchDecomposition_) {
+    if(normalizedWasserstein_)
+      printMsg("NormalizedWasserstein is set to false since branch "
+               "decomposition is not asked.");
+    normalizedWasserstein_ = false;
+  }
+  epsilonTree2_ = epsilonTree1_;
+  epsilon2Tree2_ = epsilon2Tree1_;
+  epsilon3Tree2_ = epsilon3Tree1_;
+
+  // --- Call base
+  std::vector<std::vector<double>> treesDistMat(
+    numInputs, std::vector<double>(numInputs));
+  execute<dataType>(intermediateTrees, treesDistMat);
+
+  // --- Create output
+  auto treesDistTable = vtkTable::GetData(outputVector);
+
+  // zero-padd column name to keep Row Data columns ordered
+  const auto zeroPad
+    = [](std::string &colName, const size_t numberCols, const size_t colIdx) {
+        std::string max{std::to_string(numberCols - 1)};
+        std::string cur{std::to_string(colIdx)};
+        std::string zer(max.size() - cur.size(), '0');
+        colName.append(zer).append(cur);
+      };
+
+  // copy trees distance matrix to output
+  vtkNew<vtkIntArray> treeIds{};
+  treeIds->SetName("treeID");
+  treeIds->SetNumberOfTuples(numInputs);
+  for(size_t i = 0; i < treesDistMat.size(); ++i) {
+    treeIds->SetTuple1(i, i);
+
+    std::string name{"Tree"};
+    zeroPad(name, treesDistMat.size(), i);
+    vtkNew<vtkDoubleArray> col{};
+    col->SetNumberOfTuples(numInputs);
+    col->SetName(name.c_str());
+    for(size_t j = 0; j < treesDistMat[i].size(); ++j) {
+      col->SetTuple1(j, treesDistMat[i][j]);
+    }
+    treesDistTable->AddColumn(col);
+  }
+
+  treesDistTable->AddColumn(treeIds);
+
+  // aggregate input field data
+  vtkNew<vtkFieldData> fd{};
+  fd->CopyStructure(inputTrees[0]->GetFieldData());
+  fd->SetNumberOfTuples(inputTrees.size());
+  for(size_t i = 0; i < inputTrees.size(); ++i) {
+    fd->SetTuple(i, 0, inputTrees[i]->GetFieldData());
+  }
+
+  // copy input field data to output row data
+  for(int i = 0; i < fd->GetNumberOfArrays(); ++i) {
+    treesDistTable->AddColumn(fd->GetAbstractArray(i));
+  }
+
+  return 1;
+}
+
+int ttkMergeTreeDistanceMatrix::RequestData(
+  vtkInformation *request,
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector) {
+
+  // --- Get input object from input vector
+  auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+
+  // --- Construct trees
+  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  loadBlocks(inputTrees, blocks);
+
+  int dataType = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
+                   ->GetPointData()
+                   ->GetArray("Scalar")
+                   ->GetDataType();
+
+  int res = 0;
+  switch(dataType) {
+    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees));
+  }
+
+  return res;
+}

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -1,17 +1,15 @@
-/// Provide your information
-///
 /// \ingroup vtk
 /// \class ttkMergeTreeDistanceMatrix
-/// \author Mathieu Pont <mathieu.pont@outlook.com>
-/// \date 2020
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2021.
 ///
 /// \brief TTK VTK-filter that wraps the ttk::MergeTreeDistanceMatrix module.
 ///
 /// This VTK filter uses the ttk::MergeTreeDistanceMatrix module to compute the
 /// distance matrix of a group of merge trees.
 ///
-/// \param Input
-/// \param Output
+/// \param Input vtkMultiBlockDataset
+/// \param Output vtkTable
 ///
 /// This filter can be used as any other VTK filter (for instance, by using the
 /// sequence of calls SetInputData(), Update(), GetOutputDataObject()).

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -1,0 +1,199 @@
+/// Provide your information
+///
+/// \ingroup vtk
+/// \class ttkMergeTreeDistanceMatrix
+/// \author Mathieu Pont <mathieu.pont@outlook.com>
+/// \date 2020
+///
+/// \brief TTK VTK-filter that wraps the ttk::MergeTreeDistanceMatrix module.
+///
+/// This VTK filter uses the ttk::MergeTreeDistanceMatrix module to compute the
+/// distance matrix of a group of merge trees.
+///
+/// \param Input
+/// \param Output
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::MergeTreeDistanceMatrix
+/// \sa ttkAlgorithm
+
+#ifndef _TTKMERGETREEDISTANCEMATRIX_
+#define _TTKMERGETREEDISTANCEMATRIX_
+
+#pragma once
+
+// VTK Module
+#include <ttkMergeTreeDistanceMatrixModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+#include <vtkMultiBlockDataSet.h>
+
+// TTK Base Includes
+#include <MergeTreeDistanceMatrix.h>
+
+class TTKMERGETREEDISTANCEMATRIX_EXPORT ttkMergeTreeDistanceMatrix
+  : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
+  ,
+    protected ttk::MergeTreeDistanceMatrix // and we inherit from the base class
+{
+private:
+  /**
+   * Add all filter parameters only as private member variables and
+   * initialize them here.
+   */
+  // Execution Options
+  int Backend = 0;
+
+public:
+  /**
+   * Automatically generate getters and setters of filter
+   * parameters via vtkMacros.
+   */
+  // Input Options
+  void SetEpsilon1UseFarthestSaddle(bool epsilon1UseFarthestSaddle) {
+    epsilon1UseFarthestSaddle_ = epsilon1UseFarthestSaddle;
+    Modified();
+  }
+  bool GetEpsilon1UseFarthestSaddle() {
+    return epsilon1UseFarthestSaddle_;
+  }
+
+  void SetEpsilonTree1(double epsilonTree1) {
+    epsilonTree1_ = epsilonTree1;
+    Modified();
+  }
+  double SetEpsilonTree1() {
+    return epsilonTree1_;
+  }
+
+  void SetEpsilon2Tree1(double epsilon2Tree1) {
+    epsilon2Tree1_ = epsilon2Tree1;
+    Modified();
+  }
+  double SetEpsilon2Tree1() {
+    return epsilon2Tree1_;
+  }
+
+  void SetEpsilon3Tree1(double epsilon3Tree1) {
+    epsilon3Tree1_ = epsilon3Tree1;
+    Modified();
+  }
+  double SetEpsilon3Tree1() {
+    return epsilon3Tree1_;
+  }
+
+  void SetPersistenceThreshold(double persistenceThreshold) {
+    persistenceThreshold_ = persistenceThreshold;
+    Modified();
+  }
+  double SetPersistenceThreshold() {
+    return persistenceThreshold_;
+  }
+
+  void SetUseMinMaxPair(bool useMinMaxPair) {
+    useMinMaxPair_ = useMinMaxPair;
+    Modified();
+  }
+  bool SetUseMinMaxPair() {
+    return useMinMaxPair_;
+  }
+
+  void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
+    deleteMultiPersPairs_ = deleteMultiPersPairs;
+    Modified();
+  }
+  bool SetDeleteMultiPersPairs() {
+    return deleteMultiPersPairs_;
+  }
+
+  // Execution Options
+  vtkSetMacro(Backend, int);
+  vtkGetMacro(Backend, int);
+
+  void SetAssignmentSolver(int assignmentSolver) {
+    assignmentSolverID_ = assignmentSolver;
+    Modified();
+  }
+  int GetAssignmentSolver() {
+    return assignmentSolverID_;
+  }
+
+  void SetBranchDecomposition(bool branchDecomposition) {
+    branchDecomposition_ = branchDecomposition;
+    Modified();
+  }
+  int GetBranchDecomposition() {
+    return branchDecomposition_;
+  }
+
+  void SetNormalizedWasserstein(bool normalizedWasserstein) {
+    normalizedWasserstein_ = normalizedWasserstein;
+    Modified();
+  }
+  int GetNormalizedWasserstein() {
+    return normalizedWasserstein_;
+  }
+
+  void SetKeepSubtree(bool keepSubtree) {
+    keepSubtree_ = keepSubtree;
+    Modified();
+  }
+  int GetKeepSubtree() {
+    return keepSubtree_;
+  }
+
+  void SetDistanceSquared(bool distanceSquared) {
+    distanceSquared_ = distanceSquared;
+    Modified();
+  }
+  int GetDistanceSquared() {
+    return distanceSquared_;
+  }
+
+  /**
+   * This static method and the macro below are VTK conventions on how to
+   * instantiate VTK objects. You don't have to modify this.
+   */
+  static ttkMergeTreeDistanceMatrix *New();
+  vtkTypeMacro(ttkMergeTreeDistanceMatrix, ttkAlgorithm);
+
+protected:
+  /**
+   * Implement the filter constructor and destructor
+   *         (see cpp file)
+   */
+  ttkMergeTreeDistanceMatrix();
+  ~ttkMergeTreeDistanceMatrix() override;
+
+  /**
+   * Specify the input data type of each input port
+   *         (see cpp file)
+   */
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Specify the data object type of each output port
+   *         (see cpp file)
+   */
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Pass VTK data to the base code and convert base code output to VTK
+   *          (see cpp file)
+   */
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+  template <class dataType>
+  int run(vtkInformationVector *outputVector,
+          std::vector<vtkMultiBlockDataSet *> inputTrees);
+};
+
+#endif

--- a/core/vtk/ttkMergeTreeDistanceMatrix/vtk.module
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkMergeTreeDistanceMatrix
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/MergeTreeDistanceMatrix.xml
+++ b/paraview/xmls/MergeTreeDistanceMatrix.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
+<!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
+<!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
+
+<ServerManagerConfiguration>
+    <ProxyGroup name="filters">
+        <SourceProxy name="MergeTreeDistanceMatrix" class="ttkMergeTreeDistanceMatrix" label="TTK MergeTreeDistanceMatrix">
+           <Documentation long_help="MergeTreeDistanceMatrix Long" short_help="MergeTreeDistanceMatrix Short">
+               
+           </Documentation>
+
+            <!-- INPUT -->
+                <InputProperty
+                    name="Input"
+                    command="SetInputConnection">
+                  <ProxyGroupDomain name="groups">
+                    <Group name="sources"/>
+                    <Group name="filters"/> 
+                  </ProxyGroupDomain>
+                  <DataTypeDomain name="input_type">
+                    <DataType value="vtkMultiBlockDataSet"/>
+                  </DataTypeDomain>
+                  <InputArrayDomain name="input_scalars" number_of_components="1">
+                    <Property name="Input" function="FieldDataSelection" />
+                  </InputArrayDomain>
+                  <Documentation>
+                    Data-set to process.
+                  </Documentation>
+                </InputProperty>
+
+            <!-- INPUT PARAMETER WIDGETS -->
+                <IntVectorProperty
+                name="Backend"
+                label="Backend"
+                command="SetBackend"
+                number_of_elements="1"
+                default_values="0">
+                <EnumerationDomain name="enum">
+                    <Entry value="0" text="Wasserstein Distance (IEEE TVCG 2021)"/>
+                    <Entry value="1" text="Edit Distance (IEEE TVCG 2019)"/>
+                    <Entry value="2" text="Custom"/>
+                </EnumerationDomain>
+                  <Documentation>
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="BranchDecomposition"
+                command="SetBranchDecomposition"
+                label="Use Branch Decomposition"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="Backend"
+                                           value="2" />
+                  </Hints>
+                  <Documentation>
+                    Use branch decomposition representation.
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="NormalizedWasserstein"
+                command="SetNormalizedWasserstein"
+                label="Normalized Wasserstein"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="CompositeDecorator">
+                    <Expression type="and">
+                      <PropertyWidgetDecorator type="GenericDecorator"
+                                              mode="visibility"
+                                              property="BranchDecomposition"
+                                              value="1" />
+                      <PropertyWidgetDecorator type="GenericDecorator"
+                                              mode="visibility"
+                                              property="Backend"
+                                              value="2" />
+                    </Expression>
+                  </PropertyWidgetDecorator>
+                  </Hints>
+                  <Documentation>
+                    Use normalized Wasserstein (set to true to have a consistent barycenter of merge trees).
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="KeepSubtree"
+                command="SetKeepSubtree"
+                label="Keep Subtree"
+                number_of_elements="1"
+                default_values="0">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="Backend"
+                                           value="2" />
+                  </Hints>
+                  <Documentation>
+                    Keep subtree when destroying/inserting a node (set to false to have a consistent barycenter of merge tree).
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>  
+                
+                <IntVectorProperty
+                name="AssignmentSolver"
+                label="Assignment Solver"
+                command="SetAssignmentSolver"
+                number_of_elements="1"
+                default_values="0">
+                <EnumerationDomain name="enum">
+                    <Entry value="0" text="Auction"/>
+                    <Entry value="1" text="Exhaustive Search"/>
+                    <Entry value="2" text="Munkres"/>
+                </EnumerationDomain>
+                  <Documentation>
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="DistanceSquared"
+                command="SetDistanceSquared"
+                label="Distance Square Root"
+                number_of_elements="1"
+                default_values="1"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <!-- Input options -->
+                 <IntVectorProperty
+                name="DeleteMultiPersPairs"
+                command="SetDeleteMultiPersPairs"
+                label="Delete Multi Pers. Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="Epsilon1UseFarthestSaddle"
+                command="SetEpsilon1UseFarthestSaddle"
+                label="Epsilon1 Use Farthest Saddle"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="EpsilonTree1"
+                command="SetEpsilonTree1"
+                label="Epsilon 1 (%)"
+                number_of_elements="1"
+                default_values="5">
+                  <Documentation>
+                    Merge saddle points (in a bottom-up manner) having their difference in function value below epsilon times the biggest difference in function value.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>   
+                
+                <DoubleVectorProperty
+                name="Epsilon2Tree1"
+                command="SetEpsilon2Tree1"
+                label="Epsilon 2 (%)"
+                number_of_elements="1"
+                default_values="95"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="CompositeDecorator">
+                    <Expression type="or">
+                      <Expression type="and">
+                        <PropertyWidgetDecorator type="GenericDecorator"
+                                                mode="visibility"
+                                                property="BranchDecomposition"
+                                                value="1" />
+                        <PropertyWidgetDecorator type="GenericDecorator"
+                                                mode="visibility"
+                                                property="Backend"
+                                                value="2" />
+                      </Expression>
+                      <PropertyWidgetDecorator type="GenericDecorator"
+                                              mode="visibility"
+                                              property="Backend"
+                                              value="0" />
+                    </Expression>
+                  </PropertyWidgetDecorator>
+                  </Hints>
+                  <Documentation>
+                    Given a branch decomposition, ascend a pair (by making it children of the parent of its parent) if the ratio between its persistence and the persistence of its parent is above epsilon2. A high value will ascend only pairs having a close persistence to their parent, more epsilon2 is low more the pairs having a distant persistence to their parent will also be ascended.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>   
+                
+                <DoubleVectorProperty
+                name="Epsilon3Tree1"
+                command="SetEpsilon3Tree1"
+                label="Epsilon 3 (%)"
+                number_of_elements="1"
+                default_values="90"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="CompositeDecorator">
+                    <Expression type="or">
+                      <Expression type="and">
+                        <PropertyWidgetDecorator type="GenericDecorator"
+                                                mode="visibility"
+                                                property="BranchDecomposition"
+                                                value="1" />
+                        <PropertyWidgetDecorator type="GenericDecorator"
+                                                mode="visibility"
+                                                property="Backend"
+                                                value="2" />
+                      </Expression>
+                      <PropertyWidgetDecorator type="GenericDecorator"
+                                              mode="visibility"
+                                              property="Backend"
+                                              value="0" />
+                    </Expression>
+                  </PropertyWidgetDecorator>
+                  </Hints>
+                  <Documentation>
+                    Will apply the processing of Epsilon2 only for the pairs having a ratio between their persistence and the maximum persistence inferior to epsilon3. A low value will apply the processing of Epsilon2 only to the small persistence pairs, more epsilon3 is high more the pairs having a high persistence will also be processed.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="PersistenceThreshold"
+                command="SetPersistenceThreshold"
+                label="Persistence Threshold (%)"
+                number_of_elements="1"
+                default_values="0">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>  
+                
+            <PropertyGroup panel_widget="Line" label="Execution options">
+              <Property name="Backend"/>
+              <Property name="BranchDecomposition"/>
+              <Property name="NormalizedWasserstein"/>
+              <Property name="KeepSubtree"/>
+              <Property name="AssignmentSolver"/>
+              <Property name="DistanceSquared"/>
+            </PropertyGroup>
+            
+            <PropertyGroup panel_widget="Line" label="Input options">
+              <!-- <Property name="UseMinMaxPair"/> -->
+              <Property name="DeleteMultiPersPairs"/>
+              <Property name="Epsilon1UseFarthestSaddle"/>
+              <Property name="EpsilonTree1"/>
+              <Property name="Epsilon2Tree1"/>
+              <Property name="Epsilon3Tree1"/>
+              <Property name="PersistenceThreshold"/>
+            </PropertyGroup>
+
+            <!-- OUTPUT PARAMETER WIDGETS -->
+                <OutputPort name="Distance Matrix" index="0" id="port0" />
+
+            <!-- DEBUG -->
+            ${DEBUG_WIDGETS}
+
+            <!-- MENU CATEGORY -->
+                <Hints>
+                    <ShowInMenu category="TTK - Ensemble Scalar Data" />
+                </Hints>
+        </SourceProxy>
+    </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
This PR adds the `mergeTreeDistanceMatrix` module to TTK.

It allows to compute a distance matrix like `persistenceDiagramDistanceMatrix` do but for merge trees (it uses `MergeTreeDistance.h` of the `mergeTreeClustering` module of TTK).