### PR TITLE
TopologicalCompression: Use a relative tolerance for ZFP

### DIFF
--- a/CMake/topological_compression.xml
+++ b/CMake/topological_compression.xml
@@ -72,14 +72,15 @@
 
 <DoubleVectorProperty
     name="ZFPTolerance"
-    label="ZFP Absolute Error Tolerance (extra)"
+    label="ZFP Relative Error Tolerance (extra)"
     command="SetZFPTolerance"
     number_of_elements="1"
     default_values="50">
   <Documentation>
     Additionally compress the data with ZFP for improved geometrical
-    quality (absolute error tolerance).
+    quality (relative error tolerance in % of scalar field range).
   </Documentation>
+  <DoubleRangeDomain name="range" min="1" max="100" />
 </DoubleVectorProperty>
 
 <IntVectorProperty

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -149,6 +149,14 @@ namespace ttk {
     inline double getZFPTolerance() const {
       return ZFPTolerance;
     }
+    /**
+     * @brief Switch from a relative (% of scalar field range) to an
+     * absolute ZFP tolerance
+     */
+    inline void relToAbsZFPTolerance(const double zfpRelTol,
+                                     const std::array<double, 2> &sfRange) {
+      this->ZFPTolerance = zfpRelTol * (sfRange[1] - sfRange[0]) / 100.0;
+    }
     inline bool getZFPOnly() const {
       return ZFPOnly;
     }

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.cpp
@@ -123,6 +123,11 @@ int ttkTopologicalCompression::RequestData(vtkInformation *request,
   outputOffsetField->SetNumberOfTuples(vertexNumber);
   outputOffsetField->SetName(this->GetOrderArrayName(inputScalarField).data());
 
+  // manage tolerance (relative % -> absolute)
+  std::array<double, 2> sfRange{};
+  inputScalarField->GetRange(sfRange.data());
+  this->relToAbsZFPTolerance(this->ZFPTolerance, sfRange);
+
   // Call TopologicalCompression
   ttkVtkTemplateMacro(
     inputScalarField->GetDataType(), triangulation->getType(),

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.cpp
@@ -83,6 +83,11 @@ int ttkTopologicalCompressionWriter::Write() {
   outputScalarField->SetName(inputScalarField->GetName());
   Modified();
 
+  // manage tolerance (relative % -> absolute)
+  std::array<double, 2> sfRange{};
+  inputScalarField->GetRange(sfRange.data());
+  this->relToAbsZFPTolerance(this->ZFPTolerance, sfRange);
+
   ttkVtkTemplateMacro(
     inputScalarField->GetDataType(), triangulation->getType(),
     this->execute(


### PR DESCRIPTION
This PR modifies the way the ZFP Tolerance parameter is used in the TopologicalCompression and TopologicalCompressionWriter filters.

Since #603, ZFP is used with an absolute tolerance rate, set by default to the value 50. While this is fine for images with scalar field ranging from 0 to 255, compressing datasets with smaller scalar field values need updated tolerance values.

With this PR, the default tolerance value is now relative to the range of the scalar field (in percent). This way, the default tolerance value of 50(%) is sufficient to get good compression results.

Since only the compressors have been modified and since the absolute tolerance value is stored in the headers of the compressed files, the ttk-data state `persistenceDrivenCompression` is not modified by this change (apart from the displayed tolerance value, which is now not 100% correct anymore).

Enjoy,
Pierre