### PR TITLE
DiscreteGradient: Fix vtkCells offset field for gradient glyphs

### DIFF
--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -193,7 +193,7 @@ int ttkDiscreteGradient::fillGradientGlyphs(
     connectivity->SetTuple1(2 * i + 1, 2 * i + 1);
     pairTypes->SetTuple1(i, gradientGlyphs_cells_pairTypes[i]);
   }
-  offsets->SetTuple1(nCells, nCells);
+  offsets->SetTuple1(nCells, connectivity->GetNumberOfTuples());
 
   vtkNew<vtkCellArray> cells{};
   cells->SetData(offsets, connectivity);


### PR DESCRIPTION
An error in the DiscreteGradient filter is causing segfaults when trying to threshold the GradientGlyphs output. This PR fixes this error by providing the correct value at the end of the offset array used to define the `vtkCells`.

No other misuse of the offset array for building `vtkCells` spotted so far.

Enjoy,
Pierre