### PR TITLE
Enable -Wextra compilation flag, fix warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >-
   -bugprone-too-small-loop-variable,
   -bugprone-macro-parentheses,
   -bugprone-reserved-identifier,
+  cert-oop54-cpp,
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@ Checks: >-
   -*,
   bugprone-*,
   -bugprone-narrowing-conversions,
-  -bugprone-too-small-loop-variable,
   -bugprone-macro-parentheses,
   -bugprone-reserved-identifier,
   cert-oop54-cpp,

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -3,7 +3,13 @@
 if (NOT MSVC) # GCC and Clang
 
   # warning flags
-  list(APPEND TTK_COMPILER_FLAGS -Wall -Wshadow)
+  list(APPEND TTK_COMPILER_FLAGS
+    -Wall
+    -Wextra
+    -Wno-unused-parameter  # TODO fix warnings & remove
+    -Wtype-limits
+    -Wshadow
+    )
 
   # performance and debug flags
   if(TTK_ENABLE_CPU_OPTIMIZATION AND CMAKE_BUILD_TYPE MATCHES Release)

--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -99,7 +99,12 @@ int DimensionReduction::execute() const {
   string modulePath;
 
   if(PyArray_API == NULL) {
+#ifndef __clang_analyzer__
     import_array1(-1);
+#endif // __clang_analyzer__
+  }
+  if(PyArray_API == nullptr) {
+    return -1;
   }
 
   // convert the input matrix into a NumPy array.

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -129,8 +129,10 @@ namespace ttk {
     // --------
 
     FTMAtomicVector<type> &operator=(const FTMAtomicVector<type> &other) {
-      std::vector<type>::operator=(other);
-      nextId = other.nextId;
+      if(&other != this) {
+        std::vector<type>::operator=(other);
+        nextId = other.nextId;
+      }
       return *this;
     }
 

--- a/core/base/ftmTree/FTMTreeUtils.cpp
+++ b/core/base/ftmTree/FTMTreeUtils.cpp
@@ -15,9 +15,7 @@ namespace ttk {
     // --------------------
     bool FTMTree_MT::isNodeOriginDefined(idNode nodeId) {
       unsigned int origin = (unsigned int)this->getNode(nodeId)->getOrigin();
-      return origin != nullNodes and origin < this->getNumberOfNodes()
-             and origin >= 0;
-      ;
+      return origin != nullNodes && origin < this->getNumberOfNodes();
     }
 
     bool FTMTree_MT::isRoot(idNode nodeId) {
@@ -51,7 +49,7 @@ namespace ttk {
     }
 
     bool FTMTree_MT::isNodeIdInconsistent(idNode nodeId) {
-      return nodeId >= this->getNumberOfNodes() or nodeId < 0;
+      return nodeId >= this->getNumberOfNodes();
     }
 
     bool FTMTree_MT::isThereOnlyOnePersistencePair() {

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -921,7 +921,9 @@ namespace ttk {
       }
 
       MergeTree<dataType> &operator=(const MergeTree<dataType> &mt) {
-        copy(mt);
+        if(&mt != this) {
+          copy(mt);
+        }
         return *this;
       }
     };

--- a/core/base/ftrGraph/FTRAtomicVector.h
+++ b/core/base/ftrGraph/FTRAtomicVector.h
@@ -149,8 +149,10 @@ namespace ttk {
     // --------
 
     FTRAtomicVector<type> &operator=(const FTRAtomicVector<type> &other) {
-      std::vector<type>::operator=(other);
-      nextId = other.nextId;
+      if(&other != this) {
+        std::vector<type>::operator=(other);
+        nextId = other.nextId;
+      }
       return *this;
     }
 

--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -142,7 +142,9 @@ int ttk::HarmonicField::execute(const TriangulationType &triangulation,
   for(const auto &pair : idValues) {
     triplets.emplace_back(TripletType(pair.first, pair.first, alpha));
   }
+#ifndef __clang_analyzer__
   penalty.setFromTriplets(triplets.begin(), triplets.end());
+#endif // __clang_analyzer__
 
   int res = 0;
   SpMat sol;

--- a/core/base/laplacian/Laplacian.cpp
+++ b/core/base/laplacian/Laplacian.cpp
@@ -60,7 +60,9 @@ int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
       = Triplet(edgeVertices[1], edgeVertices[0], T(-1.0));
   }
 
+#ifndef __clang_analyzer__
   output.setFromTriplets(triplets.begin(), triplets.end());
+#endif // __clang_analyzer__
 
   return 0;
 }
@@ -178,7 +180,9 @@ int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
     triplets[2 * edgeNumber + i] = Triplet(i, i, vertexWeightSum[i]);
   }
 
+#ifndef __clang_analyzer__
   output.setFromTriplets(triplets.begin(), triplets.end());
+#endif // __clang_analyzer__
 
   return 0;
 }

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -627,7 +627,7 @@ public:
   void reverseNodeCorr(ftm::FTMTree_MT *tree, std::vector<int> &nodeCorr) {
     std::vector<int> newNodeCorr(tree->getNumberOfNodes());
     for(unsigned int i = 0; i < nodeCorr.size(); ++i)
-      if(nodeCorr[i] >= (int)0 and nodeCorr[i] < (int)newNodeCorr.size())
+      if(nodeCorr[i] >= 0 && nodeCorr[i] < (int)newNodeCorr.size())
         newNodeCorr[nodeCorr[i]] = i;
     nodeCorr = newNodeCorr;
   }

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -945,10 +945,10 @@ namespace ttk {
           treeQueue.emplace(leaf);
 
 #ifdef TTK_ENABLE_OPENMP
-      unsigned int nthreads = std::thread::hardware_concurrency();
+      const int nthreads = std::thread::hardware_concurrency();
 #pragma omp parallel num_threads(                                        \
   this->threadNumber_) if((firstCall or nthreads == this->threadNumber_) \
-                          and not isCalled_)
+                          && !isCalled_)
       {
 #pragma omp single nowait
 #endif
@@ -964,7 +964,7 @@ namespace ttk {
             ss << &treeTable[0] << " _ " << tree1 << " _ " << tree2
                << std::endl;
             // std::cout << ss.str();
-            while(nodeT != -1) {
+            while(static_cast<int>(nodeT) != -1) {
               int t = nodeT + 1;
 
               if(isTree1) {
@@ -1057,7 +1057,7 @@ namespace ttk {
   untied // shared(treeTable, forestTable, treeBackTable, forestBackTable)
           {
 #endif
-            while(nodeT != -1) {
+            while(static_cast<int>(nodeT) != -1) {
               if(isTree1) {
                 int i = nodeT + 1;
                 // --- Equation 8

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
@@ -33,13 +33,11 @@
 namespace ttk {
   template <typename dataType>
   struct Compare {
-    // clang-format off
     constexpr bool
       operator()(std::pair<int, dataType> const &a,
                  std::pair<int, dataType> const &b) const noexcept {
       return a.second > b.second;
     }
-    // clang-format on
   };
 
   template <typename dataType>

--- a/core/base/webSocketIO/WebSocketIO.h
+++ b/core/base/webSocketIO/WebSocketIO.h
@@ -110,7 +110,6 @@ namespace ttk {
     int on_close(websocketpp::connection_hdl hdl);
     int on_message(websocketpp::connection_hdl hdl, server::message_ptr msg);
 
-    int packageIndex = 0;
     std::list<Message> messageQueue;
 #endif
   };

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -818,13 +818,10 @@ public:
               printMsg("// Push arc bary branch id", debug::Priority::VERBOSE);
               if(clusteringOutput and ShiftMode != 1) {
                 int tBranchID = -1;
-                if(treeMatching[node] >= 0
-                   and treeMatching[node] < allBaryBranchingID[c].size()) {
+                if(treeMatching[node] < allBaryBranchingID[c].size()) {
                   tBranchID = allBaryBranchingID[c][treeMatching[node]];
-                  if(not trees[i]->isLeaf(node)
-                     and treeMatching[nodeOrigin] >= 0
-                     and treeMatching[nodeOrigin]
-                           < allBaryBranchingID[c].size())
+                  if(!trees[i]->isLeaf(node)
+                     && treeMatching[nodeOrigin] < allBaryBranchingID[c].size())
                     tBranchID = allBaryBranchingID[c][treeMatching[nodeOrigin]];
                 }
                 branchBaryID->InsertNextTuple1(tBranchID);
@@ -852,8 +849,7 @@ public:
                 idNode nodeToGet = treeBranching[node];
                 if(PlanarLayout and branchDecompositionPlanarLayout_)
                   nodeToGet = node;
-                if(treeMatching[nodeToGet] >= 0
-                   and treeMatching[nodeToGet] < allBaryBranchingID[c].size())
+                if(treeMatching[nodeToGet] < allBaryBranchingID[c].size())
                   persistenceBaryArc->InsertTuple1(
                     cellCount, barycenters[c]->getNodePersistence<dataType>(
                                  treeMatching[nodeToGet]));
@@ -928,11 +924,10 @@ public:
             printMsg("// Add node bary branch id", debug::Priority::VERBOSE);
             if(clusteringOutput and ShiftMode != 1) {
               int tBranchID = -1;
-              if(treeMatching[node] >= 0
-                 and treeMatching[node] < allBaryBranchingID[c].size()) {
+              if(treeMatching[node] < allBaryBranchingID[c].size()) {
                 tBranchID = allBaryBranchingID[c][treeMatching[node]];
-                if(not trees[i]->isLeaf(node) and treeMatching[nodeOrigin] >= 0
-                   and treeMatching[nodeOrigin] < allBaryBranchingID[c].size())
+                if(!trees[i]->isLeaf(node)
+                   && treeMatching[nodeOrigin] < allBaryBranchingID[c].size())
                   tBranchID = allBaryBranchingID[c][treeMatching[nodeOrigin]];
               }
               branchBaryNodeID->InsertNextTuple1(tBranchID);
@@ -951,8 +946,7 @@ public:
 
             // Add node persistence barycenter
             if(clusteringOutput and ShiftMode != 1)
-              if(treeMatching[node] >= 0
-                 and treeMatching[node] < allBaryBranchingID[c].size())
+              if(treeMatching[node] < allBaryBranchingID[c].size())
                 persistenceBaryNode->InsertTuple1(
                   pointCount, barycenters[c]->getNodePersistence<dataType>(
                                 treeMatching[node]));

--- a/core/vtk/ttkStableManifoldPersistence/ttkStableManifoldPersistence.cpp
+++ b/core/vtk/ttkStableManifoldPersistence/ttkStableManifoldPersistence.cpp
@@ -130,8 +130,8 @@ int ttkStableManifoldPersistence::AttachPersistence(vtkDataSet *output) const {
         ascendingManifoldArray->GetTuple(i, &extremumId);
         cellId = max2simplex_[(int)extremumId];
       }
-      double persistence = simplex2persistence_[(int)cellId];
-      double pairType = simplex2pairType_[(int)cellId];
+      double persistence = simplex2persistence_[cellId];
+      double pairType = simplex2pairType_[cellId];
       persistenceArray->SetTuple(i, &persistence);
       pairTypeArray->SetTuple(i, &pairType);
     }


### PR DESCRIPTION
As suggested in #637, this PR enables the -Wextra flag in CMake for GCC and Clang. Since -Wtype-limits is included in GCC's -Wextra but not in Clang, this flag is also added.

Note that this PR does disable the -Wunused-parameter warning flag, included by -Wextra, which was causing the warning in #637. A second PR will focus on fixing and enabling -Wunused-parameter.

All warnings caused by -Wextra -Wno-unused-parameters (-Wtype-limits) have been fixed by this PR. Since most of them have been already fixed in previous PRs, warning fixes are mostly located in newest modules.

This PR also contains some very small fixes for clang-tidy (self-assignment warnings) and the clang static analyzer (silencing warnings on Eigen and CPython). A third PR will fix all remaining clang-tidy/clang static analyzer warnings.

No change so far in the validation states screenshots.

Enjoy,
Pierre