### PR TITLE
BarycentricSubdivision: Fix #644

### DIFF
--- a/core/base/barycentricSubdivision/BarycentricSubdivision.h
+++ b/core/base/barycentricSubdivision/BarycentricSubdivision.h
@@ -190,12 +190,6 @@ template <typename triangulationType>
 int ttk::BarycentricSubdivision::subdiviseTriangulation(
   const triangulationType &inputTriangl) {
 
-  // not implemented for dimension >= 3
-  if(inputTriangl.getDimensionality() >= 3) {
-    this->printErr("Not yet implemented for dimension 3 and above");
-    return 1;
-  }
-
   const SimplexId newPoints{nVertices_ + nEdges_ + nTriangles_};
   const size_t dataPerPoint{3};
   points_.clear();
@@ -318,6 +312,12 @@ template <typename triangulationType>
 int ttk::BarycentricSubdivision::execute(
   const triangulationType &inputTriangl,
   ttk::ExplicitTriangulation &outputTriangl) {
+
+  // not implemented for dimension >= 3
+  if(inputTriangl.getDimensionality() >= 3) {
+    this->printErr("Not yet implemented for dimension 3 and above");
+    return 1;
+  }
 
   Timer tm;
 

--- a/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
+++ b/core/vtk/ttkBarycentricSubdivision/ttkBarycentricSubdivision.cpp
@@ -173,10 +173,14 @@ int ttkBarycentricSubdivision::RequestData(vtkInformation *ttkNotUsed(request),
   this->preconditionTriangulation(triangulation);
 
   // first iteration: generate the new triangulation
-  this->execute(*triangulation, triangulationSubdivision);
+  int ret = this->execute(*triangulation, triangulationSubdivision);
+  if(ret != 0) {
+    this->printErr("Could not subdivide input mesh");
+    return 0;
+  }
 
   // first iteration: interpolate input scalar fields
-  int ret = InterpolateScalarFields(input, output, *triangulation);
+  ret = InterpolateScalarFields(input, output, *triangulation);
   if(ret != 0) {
     this->printErr("Error interpolating input data array(s)");
     return 0;


### PR DESCRIPTION
This PR reworks the BarycentricSubdivision filter to properly exit with an error message when applied on 3D datasets (instead of segfaulting).

Enjoy,
Pierre

