### PR TITLE
Timer: Replace platform-specific code with std::chrono

### DIFF
--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -13,5 +13,6 @@ ttk_add_base_library(common
         OrderDisambiguation.h
         Os.h
         ProgramBase.h
+        Timer.h
         Wrapper.h
         )

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -451,6 +451,7 @@ namespace ttk {
 } // namespace ttk
 
 #include <Os.h>
+#include <Timer.h>
 
 namespace ttk {
   /// \brief Legacy backward compatibility

--- a/core/base/common/OrderDisambiguation.h
+++ b/core/base/common/OrderDisambiguation.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <DataTypes.h>
-#include <Debug.h>
+#include <BaseClass.h>
 
 #include <algorithm>
 #include <vector>

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -15,13 +15,11 @@
 #include <cwchar>
 #include <direct.h>
 #include <stdint.h>
-#include <time.h>
 
 #elif defined(__unix__) || defined(__APPLE__)
 
 #include <dirent.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif
@@ -68,30 +66,6 @@ namespace ttk {
     return omp_get_num_procs();
 #endif
     return 1;
-  }
-
-  double OsCall::getTimeStamp() {
-#ifdef _WIN32
-    LARGE_INTEGER frequency;
-    QueryPerformanceFrequency(&frequency);
-
-    LARGE_INTEGER temp;
-    QueryPerformanceCounter(&temp);
-
-    return (double)temp.QuadPart / frequency.QuadPart;
-#endif
-
-#ifdef __APPLE__
-    struct timeval stamp;
-    gettimeofday(&stamp, NULL);
-    return (stamp.tv_sec * 1000000 + stamp.tv_usec) / 1000000.0;
-#endif
-
-#ifdef __unix__
-    struct timeval stamp;
-    gettimeofday(&stamp, NULL);
-    return (stamp.tv_sec * 1000000 + stamp.tv_usec) / 1000000.0;
-#endif
   }
 
   std::vector<std::string>

--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -70,8 +70,6 @@ namespace ttk {
 
     static int getNumberOfCores();
 
-    static double getTimeStamp();
-
     static std::vector<std::string>
       listFilesInDirectory(const std::string &directoryName,
                            const std::string &extension);
@@ -121,38 +119,6 @@ namespace ttk {
     float initialMemory_;
   };
 
-  class Timer {
-
-  public:
-    Timer() {
-      start_ = getTimeStamp();
-    }
-
-    Timer(const Timer &other) {
-      start_ = other.start_;
-    }
-
-    inline double getElapsedTime() {
-
-      double end = getTimeStamp();
-      return end - start_;
-    }
-
-    inline double getStartTime() {
-      return start_;
-    }
-
-    inline void reStart() {
-      start_ = getTimeStamp();
-    }
-
-  protected:
-    inline double getTimeStamp() {
-      return OsCall::getTimeStamp();
-    }
-
-    double start_;
-  };
 } // namespace ttk
 
 #endif

--- a/core/base/common/Timer.h
+++ b/core/base/common/Timer.h
@@ -1,0 +1,31 @@
+#include <chrono>
+
+namespace ttk {
+
+  class Timer {
+    using ClockType = std::chrono::steady_clock;
+    using TimeType = std::chrono::time_point<ClockType>;
+    using DiffType = std::chrono::duration<double>;
+
+  public:
+    Timer() = default;
+
+    inline double getElapsedTime() {
+      const auto end = this->getTimeStamp();
+      const DiffType diff = end - start_;
+      return diff.count();
+    }
+
+    inline void reStart() {
+      start_ = this->getTimeStamp();
+    }
+
+  protected:
+    inline TimeType getTimeStamp() {
+      return ClockType::now();
+    }
+
+    TimeType start_{this->getTimeStamp()};
+  };
+
+} // namespace ttk


### PR DESCRIPTION
This PR replaces the platform-specific code (POSIX `gettimeofday` for Linux and MacOS, `QueryPerformanceFrequency` and `QueryPerformanceCounter` for Windows) with the `std::chrono` standard library calls (introduced in C++11).

Alternative TDA libraries, such as Gudhi and Oineus, already use `std::chrono` functions for computing timings.

The only drawback that I see of this new implementation is that it exposes `std::chrono` in the Timer struct fields instead of hiding them. I think this is worth the removal of the platform-specific code.

Struct size is identical (8 bytes, size of double). No change observed in the timings so far.

The Timer code has been moved in a separate header in the `base/common` directory.

Enjoy,
Pierre

