### PR TITLE
New MergeBlockTables filter

### DIFF
--- a/core/vtk/ttkMergeBlockTables/CMakeLists.txt
+++ b/core/vtk/ttkMergeBlockTables/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkMergeBlockTables/ttk.module
+++ b/core/vtk/ttkMergeBlockTables/ttk.module
@@ -1,0 +1,8 @@
+NAME
+  ttkMergeBlockTables
+SOURCES
+  ttkMergeBlockTables.cpp
+HEADERS
+  ttkMergeBlockTables.h
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkMergeBlockTables/ttkMergeBlockTables.cpp
+++ b/core/vtk/ttkMergeBlockTables/ttkMergeBlockTables.cpp
@@ -1,0 +1,91 @@
+#include <ttkMergeBlockTables.h>
+
+#include <vtkFieldData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkTable.h>
+
+vtkStandardNewMacro(ttkMergeBlockTables);
+
+ttkMergeBlockTables::ttkMergeBlockTables() {
+  this->setDebugMsgPrefix("MergeBlockTables");
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkMergeBlockTables::FillInputPortInformation(int port,
+                                                  vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkMergeBlockTables::FillOutputPortInformation(int port,
+                                                   vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkMergeBlockTables::RequestData(vtkInformation *ttkNotUsed(request),
+                                     vtkInformationVector **inputVector,
+                                     vtkInformationVector *outputVector) {
+  // Get input data
+  std::vector<vtkTable *> inputTables;
+
+  auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+
+  // Number of input tables
+  size_t nInputs{};
+
+  if(blocks != nullptr) {
+    nInputs = blocks->GetNumberOfBlocks();
+    for(size_t i = 0; i < nInputs; ++i) {
+      inputTables.emplace_back(vtkTable::SafeDownCast(blocks->GetBlock(i)));
+    }
+  }
+
+  // Sanity check
+  for(const auto table : inputTables) {
+    if(table == nullptr) {
+      this->printErr("Input tables are not all vtkTables");
+      return 0;
+    }
+  }
+
+  // Sanity check
+  if(nInputs == 0) {
+    this->printErr("No input table");
+    return 0;
+  }
+
+  // Set output
+  auto outputTable = vtkTable::GetData(outputVector);
+
+  // Copy first table to output
+  // (deep copy leaves the input untouched)
+  outputTable->DeepCopy(inputTables[0]);
+
+  // Clear out the FieldData that may have been copied
+  const auto fd = outputTable->GetFieldData();
+  if(fd != nullptr) {
+    fd->Reset();
+  }
+
+  // Insert row of every other table into output
+  for(size_t i = 1; i < nInputs; ++i) {
+    const auto currTable{inputTables[i]};
+    for(vtkIdType j = 0; j < currTable->GetNumberOfRows(); ++j) {
+      outputTable->InsertNextRow(currTable->GetRow(j));
+    }
+  }
+
+  return 1;
+}

--- a/core/vtk/ttkMergeBlockTables/ttkMergeBlockTables.h
+++ b/core/vtk/ttkMergeBlockTables/ttkMergeBlockTables.h
@@ -1,0 +1,31 @@
+/// \ingroup vtk
+/// \class ttkMergeBlockTables
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date July 2021
+///
+/// \brief TTK processing package for merging vtkTables from a
+/// vtkMultiBlockDataSet.
+
+#pragma once
+
+#include <ttkMergeBlockTablesModule.h>
+
+#include <ttkAlgorithm.h>
+
+class TTKMERGEBLOCKTABLES_EXPORT ttkMergeBlockTables : public ttkAlgorithm {
+
+public:
+  static ttkMergeBlockTables *New();
+
+  vtkTypeMacro(ttkMergeBlockTables, ttkAlgorithm);
+
+protected:
+  ttkMergeBlockTables();
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+};

--- a/core/vtk/ttkMergeBlockTables/vtk.module
+++ b/core/vtk/ttkMergeBlockTables/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkMergeBlockTables
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/MergeBlockTables.xml
+++ b/paraview/xmls/MergeBlockTables.xml
@@ -33,7 +33,7 @@
       ${DEBUG_WIDGETS}
 
       <Hints>
-        <ShowInMenu category="TTK - Misc" />
+        <ShowInMenu category="TTK - Pipeline" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>

--- a/paraview/xmls/MergeBlockTables.xml
+++ b/paraview/xmls/MergeBlockTables.xml
@@ -1,0 +1,40 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkMergeBlockTables"
+        class="ttkMergeBlockTables"
+        label="TTK MergeBlockTables">
+      <Documentation
+          long_help="Merge vtkTables from a vtkMultiBlockDataSet."
+          shorthelp="Merge vtkTables inside blocks."
+          >
+        This filter merges vtkTables stored in a vtkMultiBlockDataSet
+        into one unique vtkTable.
+      </Documentation>
+
+      <InputProperty
+          name="Input"
+          command="AddInputConnection"
+          clean_command="RemoveAllInputs"
+          multiple_input="1">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkMultiBlockDataSet"/>
+        </DataTypeDomain>
+        <Documentation>
+          MultiBlockDataSet of vtkTables to process.
+        </Documentation>
+      </InputProperty>
+
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
In #632, PersistenceDiagramClustering output has been moved into `vtkMultiBlockDataSets`, one for every diagram. Clustering information on diagrams, passed as Field Data on the "Clustered Diagrams" output, has also been split into blocks. Now, applying DatasetToTable on these Field Data produces a vtkMultiBlockDataSet of vtkTables instead of one unique vtkTable. Filters that take a vtkTable (CinemaQuery...) are then unable to operate on this multi-block structure. 

ParaView provides a filter called "Merge Blocks" to merge datasets in blocks into one dataset but it only acts on Unstructured Grids or Polygonal Meshes.

Since we rely on this clustering information in the VESTEC project, this PR introduces a new filter, MergeBlockTables, that aims to bridge the gap between the new PersistenceDiagramClustering output format and vtkTables filters. This new filter takes a vtkMultiBlockDataSet of vtkTables as an input and merges then into one vtkTable, similarly to ParaView's "Merge Blocks".

Enjoy,
Pierre


