### PR TITLE
ExplicitTriangulation: Fix segfault calling buildEdgeList with wrong template argument

### DIFF
--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -289,11 +289,11 @@ int ExplicitTriangulation::preconditionEdgesInternal() {
     oneSkeleton.setWrapper(this);
     // also computes edgeStar and triangleEdge / tetraEdge lists for free...
     if(getDimensionality() == 2) {
-      return oneSkeleton.buildEdgeList(vertexNumber_, *cellArray_, &edgeList_,
-                                       &edgeStarData_, &triangleEdgeList_);
+      return oneSkeleton.buildEdgeList(vertexNumber_, *cellArray_, edgeList_,
+                                       edgeStarData_, triangleEdgeList_);
     } else if(getDimensionality() == 3) {
-      return oneSkeleton.buildEdgeList(vertexNumber_, *cellArray_, &edgeList_,
-                                       &edgeStarData_, &tetraEdgeList_);
+      return oneSkeleton.buildEdgeList(
+        vertexNumber_, *cellArray_, edgeList_, edgeStarData_, tetraEdgeList_);
     }
   }
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -351,8 +351,13 @@ int ExplicitTriangulation::preconditionEdgeStarsInternal() {
   if(edgeStarData_.empty()) {
     OneSkeleton oneSkeleton;
     oneSkeleton.setWrapper(this);
-    return oneSkeleton.buildEdgeList<3>(
-      vertexNumber_, *cellArray_, nullptr, &edgeStarData_, nullptr);
+    if(this->getDimensionality() == 3) {
+      return oneSkeleton.buildEdgeList<6>(
+        vertexNumber_, *cellArray_, nullptr, &edgeStarData_, nullptr);
+    } else { // 2D and 1D
+      return oneSkeleton.buildEdgeList<3>(
+        vertexNumber_, *cellArray_, nullptr, &edgeStarData_, nullptr);
+    }
   }
   return 0;
 }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -201,15 +201,9 @@ int ExplicitTriangulation::preconditionCellEdgesInternal() {
     return 1;
   }
 
-  OneSkeleton os;
-  os.setWrapper(this);
-
-  if(tetraEdgeList_.empty() && getDimensionality() == 3) {
-    os.buildEdgeList(
-      vertexNumber_, *cellArray_, nullptr, nullptr, &tetraEdgeList_);
-  } else if(triangleEdgeList_.empty() && getDimensionality() == 2) {
-    os.buildEdgeList(
-      vertexNumber_, *cellArray_, nullptr, nullptr, &triangleEdgeList_);
+  if((tetraEdgeList_.empty() && getDimensionality() == 3)
+     || (triangleEdgeList_.empty() && getDimensionality() == 2)) {
+    this->preconditionEdgesInternal();
   }
 
   return 0;
@@ -350,15 +344,7 @@ int ExplicitTriangulation::preconditionEdgeStarsInternal() {
   }
 
   if(edgeStarData_.empty()) {
-    OneSkeleton oneSkeleton;
-    oneSkeleton.setWrapper(this);
-    if(this->getDimensionality() == 3) {
-      return oneSkeleton.buildEdgeList<6>(
-        vertexNumber_, *cellArray_, nullptr, &edgeStarData_, nullptr);
-    } else { // 2D and 1D
-      return oneSkeleton.buildEdgeList<3>(
-        vertexNumber_, *cellArray_, nullptr, &edgeStarData_, nullptr);
-    }
+    this->preconditionEdgesInternal();
   }
   return 0;
 }
@@ -479,9 +465,7 @@ int ExplicitTriangulation::preconditionVertexEdgesInternal() {
     ZeroSkeleton zeroSkeleton;
 
     if(edgeList_.empty()) {
-      OneSkeleton oneSkeleton;
-      oneSkeleton.setWrapper(this);
-      oneSkeleton.buildEdgeList(vertexNumber_, *cellArray_, &edgeList_);
+      this->preconditionEdgesInternal();
     }
 
     zeroSkeleton.setWrapper(this);

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -89,7 +89,7 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     }
   } else {
     // unsupported dimension
-    printErr("Unsupported dimension for boundary precondition");
+    printErr("Unsupported dimension for edge boundary precondition");
     return -1;
   }
 
@@ -128,7 +128,7 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     }
   } else {
     // unsupported dimension
-    printErr("Unsupported dimension for boundary precondition");
+    printErr("Unsupported dimension for triangle boundary precondition");
     return -1;
   }
 
@@ -185,7 +185,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     }
   } else {
     // unsupported dimension
-    printErr("Unsupported dimension for boundary precondition");
+    printErr("Unsupported dimension for vertex boundary precondition");
     return -1;
   }
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -227,7 +227,7 @@ int ExplicitTriangulation::preconditionCellNeighborsInternal() {
       TwoSkeleton twoSkeleton;
       twoSkeleton.setWrapper(this);
       twoSkeleton.buildCellNeighborsFromEdges(
-        vertexNumber_, *cellArray_, cellNeighborData_, edgeStarData_);
+        *cellArray_, cellNeighborData_, edgeStarData_);
     }
   }
 
@@ -521,7 +521,7 @@ int ExplicitTriangulation::preconditionVertexNeighborsInternal() {
     ZeroSkeleton zeroSkeleton;
     zeroSkeleton.setWrapper(this);
     return zeroSkeleton.buildVertexNeighbors(
-      vertexNumber_, *cellArray_, vertexNeighborData_, edgeList_);
+      vertexNumber_, vertexNeighborData_, edgeList_);
   }
   return 0;
 }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -229,10 +229,11 @@ int ExplicitTriangulation::preconditionCellNeighborsInternal() {
       threeSkeleton.buildCellNeighborsFromTriangles(
         vertexNumber_, *cellArray_, cellNeighborData_, &triangleStarData_);
     } else if(getDimensionality() == 2) {
+      this->preconditionEdgeStarsInternal();
       TwoSkeleton twoSkeleton;
       twoSkeleton.setWrapper(this);
       twoSkeleton.buildCellNeighborsFromEdges(
-        vertexNumber_, *cellArray_, cellNeighborData_, &edgeStarData_);
+        vertexNumber_, *cellArray_, cellNeighborData_, edgeStarData_);
     }
   }
 
@@ -370,12 +371,13 @@ int ExplicitTriangulation::preconditionEdgeTrianglesInternal() {
   }
 
   if(edgeTriangleData_.empty()) {
-    preconditionTriangleEdgesInternal();
+    this->preconditionEdgesInternal();
+    this->preconditionTriangleEdgesInternal();
 
     TwoSkeleton twoSkeleton;
     twoSkeleton.setWrapper(this);
     return twoSkeleton.buildEdgeTriangles(vertexNumber_, *cellArray_,
-                                          edgeTriangleData_, &edgeList_,
+                                          edgeTriangleData_, edgeList_,
                                           &triangleEdgeList_);
   }
 
@@ -409,6 +411,7 @@ int ExplicitTriangulation::preconditionTriangleEdgesInternal() {
   }
 
   if(triangleEdgeList_.empty()) {
+    this->preconditionEdgesInternal();
 
     // WARNING
     // here triangleStarList and cellTriangleList will be computed (for
@@ -419,8 +422,9 @@ int ExplicitTriangulation::preconditionTriangleEdgesInternal() {
     twoSkeleton.setWrapper(this);
 
     return twoSkeleton.buildTriangleEdgeList(
-      vertexNumber_, *cellArray_, triangleEdgeList_, &vertexEdgeData_,
-      &edgeList_, &triangleList_, &triangleStarData_, &tetraTriangleList_);
+      vertexNumber_, *cellArray_, triangleEdgeList_, edgeList_,
+      &vertexEdgeData_, &triangleList_, &triangleStarData_,
+      &tetraTriangleList_);
   }
 
   return 0;
@@ -529,10 +533,11 @@ int ExplicitTriangulation::preconditionVertexNeighborsInternal() {
   }
 
   if((SimplexId)vertexNeighborData_.subvectorsNumber() != vertexNumber_) {
+    this->preconditionEdgesInternal();
     ZeroSkeleton zeroSkeleton;
     zeroSkeleton.setWrapper(this);
     return zeroSkeleton.buildVertexNeighbors(
-      vertexNumber_, *cellArray_, vertexNeighborData_, &edgeList_);
+      vertexNumber_, *cellArray_, vertexNeighborData_, edgeList_);
   }
   return 0;
 }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -288,7 +288,11 @@ int ExplicitTriangulation::preconditionEdgesInternal() {
     OneSkeleton oneSkeleton;
     oneSkeleton.setWrapper(this);
     // also computes edgeStar and triangleEdge / tetraEdge lists for free...
-    if(getDimensionality() == 2) {
+    if(getDimensionality() == 1) {
+      std::vector<std::array<SimplexId, 1>> tmp{};
+      return oneSkeleton.buildEdgeList<1>(
+        vertexNumber_, *cellArray_, edgeList_, edgeStarData_, tmp);
+    } else if(getDimensionality() == 2) {
       return oneSkeleton.buildEdgeList(vertexNumber_, *cellArray_, edgeList_,
                                        edgeStarData_, triangleEdgeList_);
     } else if(getDimensionality() == 3) {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -560,11 +560,7 @@ namespace ttk {
 
       // TODO: ASSUME Regular Mesh Here to compute dimension!
       if(cellNumber) {
-        if(cellArray_->getCellVertexNumber(0) == 3) {
-          maxCellDim_ = 2;
-        } else {
-          maxCellDim_ = 3;
-        }
+        maxCellDim_ = cellArray_->getCellVertexNumber(0) - 1;
       }
       return 0;
     }

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -1,7 +1,6 @@
 #include <OneSkeleton.h>
 #include <boost/container/small_vector.hpp>
 
-using namespace std;
 using namespace ttk;
 
 OneSkeleton::OneSkeleton() {
@@ -10,7 +9,7 @@ OneSkeleton::OneSkeleton() {
 
 // 2D cells (triangles)
 int OneSkeleton::buildEdgeLinks(
-  const vector<std::array<SimplexId, 2>> &edgeList,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   const FlatJaggedArray &edgeStars,
   const CellArray &cellArray,
   FlatJaggedArray &edgeLinks) const {
@@ -57,7 +56,7 @@ int OneSkeleton::buildEdgeLinks(
 
   edgeLinks.setData(std::move(links), std::move(offsets));
 
-  printMsg("Built " + to_string(edgeNumber) + " edge links", 1,
+  printMsg("Built " + std::to_string(edgeNumber) + " edge links", 1,
            t.getElapsedTime(), threadNumber_);
 
   return 0;
@@ -65,9 +64,9 @@ int OneSkeleton::buildEdgeLinks(
 
 // 3D cells (tetrahedron)
 int OneSkeleton::buildEdgeLinks(
-  const vector<std::array<SimplexId, 2>> &edgeList,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   const FlatJaggedArray &edgeStars,
-  const vector<std::array<SimplexId, 6>> &cellEdges,
+  const std::vector<std::array<SimplexId, 6>> &cellEdges,
   FlatJaggedArray &edgeLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -120,7 +119,7 @@ int OneSkeleton::buildEdgeLinks(
 
   edgeLinks.setData(std::move(links), std::move(offsets));
 
-  printMsg("Built " + to_string(edgeNumber) + " edge links", 1,
+  printMsg("Built " + std::to_string(edgeNumber) + " edge links", 1,
            t.getElapsedTime(), threadNumber_);
 
   return 0;
@@ -251,7 +250,7 @@ int OneSkeleton::buildEdgeList(
   edgeStars.setData(std::move(edgeSt), std::move(offsets));
 
   printMsg(
-    "Built " + to_string(edgeCount) + " edges", 1, t.getElapsedTime(), 1);
+    "Built " + std::to_string(edgeCount) + " edges", 1, t.getElapsedTime(), 1);
 
   // ethaneDiolMedium.vtu, 70Mtets, hal9000 (12coresHT)
   // 1 thread: 10.4979 s
@@ -264,7 +263,7 @@ int OneSkeleton::buildEdgeList(
 template int OneSkeleton::buildEdgeList<3>(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<std::array<SimplexId, 2>> &edgeList,
+  std::vector<std::array<SimplexId, 2>> &edgeList,
   FlatJaggedArray &edgeStars,
   std::vector<std::array<SimplexId, 3>> &cellEdgeList) const;
 
@@ -272,6 +271,6 @@ template int OneSkeleton::buildEdgeList<3>(
 template int OneSkeleton::buildEdgeList<6>(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<std::array<SimplexId, 2>> &edgeList,
+  std::vector<std::array<SimplexId, 2>> &edgeList,
   FlatJaggedArray &edgeStars,
   std::vector<std::array<SimplexId, 6>> &cellEdgeList) const;

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -259,6 +259,14 @@ int OneSkeleton::buildEdgeList(
   return 0;
 }
 
+// explicit template instantiation for 1D cells (edges)
+template int OneSkeleton::buildEdgeList<1>(
+  const SimplexId &vertexNumber,
+  const CellArray &cellArray,
+  std::vector<std::array<SimplexId, 2>> &edgeList,
+  FlatJaggedArray &edgeStars,
+  std::vector<std::array<SimplexId, 1>> &cellEdgeList) const;
+
 // explicit template instantiation for 2D cells (triangles)
 template int OneSkeleton::buildEdgeList<3>(
   const SimplexId &vertexNumber,

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -138,11 +138,11 @@ int OneSkeleton::buildEdgeList(
 
   // check parameters consistency (we need n to be consistent with the
   // dimensionality of the mesh)
-  const auto dim = cellArray.getCellVertexNumber(0) - 1;
-  if(n != dim * (dim + 1) / 2 && cellEdgeList != nullptr) {
+  const size_t dim = cellArray.getCellVertexNumber(0) - 1;
+  if(n != dim * (dim + 1) / 2) {
     this->printErr("Wrong template parameter (" + std::to_string(n)
-                   + "edges per cell in dim " + std::to_string(dim)
-                   + "), unable to compute cellEdgeList");
+                   + " edges per " + std::to_string(dim) + "D cell)");
+    this->printErr("Cannot build edge list");
     return -1;
   }
 

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -79,7 +79,7 @@ namespace ttk {
     /// \param cellEdgeList Optional output for cell edges: per cell,
     /// the list of its edges identifiers
     /// \return Returns 0 upon success, negative values otherwise.
-    template <std::size_t n = 3>
+    template <std::size_t n>
     int buildEdgeList(const SimplexId &vertexNumber,
                       const CellArray &cellArray,
                       std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,

--- a/core/base/skeleton/OneSkeleton.h
+++ b/core/base/skeleton/OneSkeleton.h
@@ -72,19 +72,19 @@ namespace ttk {
     /// \param vertexNumber Number of vertices in the triangulation.
     /// \param cellArray Cell container allowing to retrieve the vertices ids
     /// of each cell.
-    /// \param edgeList Optional output edge list (each entry is an
-    /// ordered std::array of vertex identifiers).
-    /// \param edgeStars Optional output for edge cell adjacency (for
-    /// each edge, a list of adjacent cells)
-    /// \param cellEdgeList Optional output for cell edges: per cell,
-    /// the list of its edges identifiers
+    /// \param edgeList Output edge list (each entry is an ordered
+    /// std::array of vertex identifiers).
+    /// \param edgeStars Output for edge cell adjacency (for each
+    /// edge, a list of adjacent cells)
+    /// \param cellEdgeList Output for cell edges: per cell, the list
+    /// of its edges identifiers
     /// \return Returns 0 upon success, negative values otherwise.
     template <std::size_t n>
-    int buildEdgeList(const SimplexId &vertexNumber,
-                      const CellArray &cellArray,
-                      std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,
-                      FlatJaggedArray *edgeStars = nullptr,
-                      std::vector<std::array<SimplexId, n>> *cellEdgeList
-                      = nullptr) const;
+    int
+      buildEdgeList(const SimplexId &vertexNumber,
+                    const CellArray &cellArray,
+                    std::vector<std::array<SimplexId, 2>> &edgeList,
+                    FlatJaggedArray &edgeStars,
+                    std::vector<std::array<SimplexId, n>> &cellEdgeList) const;
   };
 } // namespace ttk

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -1,7 +1,6 @@
 #include <ThreeSkeleton.h>
 #include <boost/container/small_vector.hpp>
 
-using namespace std;
 using namespace ttk;
 
 ThreeSkeleton::ThreeSkeleton() {
@@ -223,7 +222,7 @@ int ThreeSkeleton::buildCellNeighborsFromVertices(
   // convert to a FlatJaggedArray
   cellNeighbors.fillFrom(neighbors);
 
-  printMsg("Built " + to_string(cellNumber) + " cell neighbors", 1,
+  printMsg("Built " + std::to_string(cellNumber) + " cell neighbors", 1,
            t.getElapsedTime(), threadNumber_);
 
   // ethaneDiol.vtu, 8.7Mtets, richard (4coresHT)

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -8,7 +8,6 @@ TwoSkeleton::TwoSkeleton() {
 }
 
 int TwoSkeleton::buildCellNeighborsFromEdges(
-  const SimplexId &vertexNumber,
   const CellArray &cellArray,
   FlatJaggedArray &cellNeighbors,
   const FlatJaggedArray &edgeStars) const {

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -1,49 +1,33 @@
 #include <TwoSkeleton.h>
 #include <boost/container/small_vector.hpp>
 
-using namespace std;
 using namespace ttk;
 
 TwoSkeleton::TwoSkeleton() {
-
   setDebugMsgPrefix("TwoSkeleton");
 }
 
-int TwoSkeleton::buildCellNeighborsFromEdges(const SimplexId &vertexNumber,
-                                             const CellArray &cellArray,
-                                             FlatJaggedArray &cellNeighbors,
-                                             FlatJaggedArray *edgeStars) const {
-
-  auto localEdgeStars = edgeStars;
-  FlatJaggedArray defaultEdgeStars{};
-
-  if(!localEdgeStars) {
-    localEdgeStars = &defaultEdgeStars;
-  }
-
-  if(localEdgeStars->empty()) {
-    OneSkeleton os;
-    os.setThreadNumber(threadNumber_);
-    os.setDebugLevel(debugLevel_);
-    os.buildEdgeList<3>(
-      vertexNumber, cellArray, nullptr, localEdgeStars, nullptr);
-  }
+int TwoSkeleton::buildCellNeighborsFromEdges(
+  const SimplexId &vertexNumber,
+  const CellArray &cellArray,
+  FlatJaggedArray &cellNeighbors,
+  const FlatJaggedArray &edgeStars) const {
 
   Timer t;
 
   printMsg("Building cell neighbors", 0, 0, 1, debug::LineMode::REPLACE);
 
   const SimplexId cellNumber = cellArray.getNbCells();
-  const SimplexId edgeNumber = localEdgeStars->subvectorsNumber();
+  const SimplexId edgeNumber = edgeStars.subvectorsNumber();
   std::vector<SimplexId> offsets(cellNumber + 1);
   // number of neigbhors processed per cell
   std::vector<SimplexId> neighborsId(cellNumber);
 
   for(SimplexId i = 0; i < edgeNumber; i++) {
-    if(localEdgeStars->size(i) == 2) {
+    if(edgeStars.size(i) == 2) {
       // tetra cells in edge i's star
-      const auto cs0 = localEdgeStars->get(i, 0);
-      const auto cs1 = localEdgeStars->get(i, 1);
+      const auto cs0 = edgeStars.get(i, 0);
+      const auto cs1 = edgeStars.get(i, 1);
       offsets[cs0 + 1]++;
       offsets[cs1 + 1]++;
     }
@@ -59,10 +43,10 @@ int TwoSkeleton::buildCellNeighborsFromEdges(const SimplexId &vertexNumber,
 
   // fill flat neighbors vector using offsets and neighbors count vectors
   for(SimplexId i = 0; i < edgeNumber; i++) {
-    if(localEdgeStars->size(i) == 2) {
+    if(edgeStars.size(i) == 2) {
       // tetra cells in edge i's star
-      const auto cs0 = localEdgeStars->get(i, 0);
-      const auto cs1 = localEdgeStars->get(i, 1);
+      const auto cs0 = edgeStars.get(i, 0);
+      const auto cs1 = edgeStars.get(i, 1);
       neighbors[offsets[cs0] + neighborsId[cs0]] = cs1;
       neighborsId[cs0]++;
       neighbors[offsets[cs1] + neighborsId[cs1]] = cs0;
@@ -73,7 +57,7 @@ int TwoSkeleton::buildCellNeighborsFromEdges(const SimplexId &vertexNumber,
   // fill FlatJaggedArray struct
   cellNeighbors.setData(std::move(neighbors), std::move(offsets));
 
-  printMsg("Built " + to_string(cellNumber) + " cell neighbors", 1,
+  printMsg("Built " + std::to_string(cellNumber) + " cell neighbors", 1,
            t.getElapsedTime(), 1);
 
   return 0;
@@ -167,7 +151,7 @@ int TwoSkeleton::buildCellNeighborsFromVertices(
   // convert to a FlatJaggedArray
   cellNeighbors.fillFrom(neighbors);
 
-  printMsg("Built " + to_string(cellNumber) + " cell neighbors", 1,
+  printMsg("Built " + std::to_string(cellNumber) + " cell neighbors", 1,
            t.getElapsedTime(), threadNumber_);
 
   return 0;
@@ -177,7 +161,7 @@ int TwoSkeleton::buildEdgeTriangles(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
   FlatJaggedArray &edgeTriangleList,
-  std::vector<std::array<SimplexId, 2>> *edgeList,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   std::vector<std::array<SimplexId, 3>> *triangleEdgeList) const {
 
   // check the consistency of the variables -- to adapt
@@ -186,32 +170,18 @@ int TwoSkeleton::buildEdgeTriangles(
     return -1;
 #endif
 
-  auto localEdgeList = edgeList;
-  vector<std::array<SimplexId, 2>> defaultEdgeList{};
-  if(!localEdgeList) {
-    localEdgeList = &defaultEdgeList;
-  }
-
-  OneSkeleton oneSkeleton;
-  oneSkeleton.setDebugLevel(debugLevel_);
-  oneSkeleton.setThreadNumber(threadNumber_);
-
-  // now do the pre-computation
-  if(localEdgeList->empty()) {
-    oneSkeleton.buildEdgeList(vertexNumber, cellArray, localEdgeList);
-  }
-
   auto localTriangleEdgeList = triangleEdgeList;
-  vector<std::array<SimplexId, 3>> defaultTriangleEdgeList{};
+  std::vector<std::array<SimplexId, 3>> defaultTriangleEdgeList{};
   if(!localTriangleEdgeList) {
     localTriangleEdgeList = &defaultTriangleEdgeList;
   }
 
   if(localTriangleEdgeList->empty()) {
-    buildTriangleEdgeList(vertexNumber, cellArray, *localTriangleEdgeList);
+    buildTriangleEdgeList(
+      vertexNumber, cellArray, *localTriangleEdgeList, edgeList);
   }
 
-  const auto edgeNumber{localEdgeList->size()};
+  const auto edgeNumber{edgeList.size()};
 
   std::vector<SimplexId> offsets(edgeNumber + 1);
   // number of neighbors processed per vertex
@@ -251,7 +221,7 @@ int TwoSkeleton::buildEdgeTriangles(
   // fill FlatJaggedArray struct
   edgeTriangleList.setData(std::move(edgeTriangles), std::move(offsets));
 
-  printMsg("Built " + to_string(edgeNumber) + " edge triangles", 1,
+  printMsg("Built " + std::to_string(edgeNumber) + " edge triangles", 1,
            t.getElapsedTime(), threadNumber_);
 
   return 0;
@@ -260,9 +230,9 @@ int TwoSkeleton::buildEdgeTriangles(
 int TwoSkeleton::buildTriangleList(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<std::array<SimplexId, 3>> *triangleList,
+  std::vector<std::array<SimplexId, 3>> *triangleList,
   FlatJaggedArray *triangleStars,
-  vector<std::array<SimplexId, 4>> *cellTriangleList) const {
+  std::vector<std::array<SimplexId, 4>> *cellTriangleList) const {
 
   Timer t;
 
@@ -415,8 +385,8 @@ int TwoSkeleton::buildTriangleList(
     triangleStars->setData(std::move(triangleSt), std::move(offsets));
   }
 
-  printMsg(
-    "Built " + to_string(nTriangles) + " triangles", 1, t.getElapsedTime(), 1);
+  printMsg("Built " + std::to_string(nTriangles) + " triangles", 1,
+           t.getElapsedTime(), 1);
   // ethaneDiolMedium.vtu, 70Mtets, hal9000 (12coresHT)// 1 thread: 58.5631 s//
   // 24 threads: 87.5816 s (~) ethaneDiol.vtu, 8.7Mtets, vger (2coresHT) - no
   // tet adj// 1 thread: 5.7427 s// 4 threads: 9.14764 s (~)
@@ -430,26 +400,12 @@ int TwoSkeleton::buildTriangleList(
 int TwoSkeleton::buildTriangleEdgeList(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
-  vector<std::array<SimplexId, 3>> &triangleEdgeList,
+  std::vector<std::array<SimplexId, 3>> &triangleEdgeList,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   FlatJaggedArray *vertexEdgeList,
-  vector<std::array<SimplexId, 2>> *edgeList,
-  vector<std::array<SimplexId, 3>> *triangleList,
+  std::vector<std::array<SimplexId, 3>> *triangleList,
   FlatJaggedArray *triangleStarList,
-  vector<std::array<SimplexId, 4>> *cellTriangleList) const {
-
-  auto localEdgeList = edgeList;
-  vector<std::array<SimplexId, 2>> defaultEdgeList{};
-  if(!localEdgeList) {
-    localEdgeList = &defaultEdgeList;
-  }
-
-  if(!localEdgeList->size()) {
-    OneSkeleton oneSkeleton;
-    oneSkeleton.setDebugLevel(debugLevel_);
-    oneSkeleton.setThreadNumber(threadNumber_);
-
-    oneSkeleton.buildEdgeList(vertexNumber, cellArray, localEdgeList);
-  }
+  std::vector<std::array<SimplexId, 4>> *cellTriangleList) const {
 
   auto localVertexEdgeList = vertexEdgeList;
   FlatJaggedArray defaultVertexEdgeList{};
@@ -464,7 +420,7 @@ int TwoSkeleton::buildTriangleEdgeList(
     zeroSkeleton.setThreadNumber(threadNumber_);
 
     zeroSkeleton.buildVertexEdges(
-      vertexNumber, (*localEdgeList), (*localVertexEdgeList));
+      vertexNumber, edgeList, (*localVertexEdgeList));
   }
 
   // NOTE:
@@ -472,7 +428,7 @@ int TwoSkeleton::buildTriangleEdgeList(
   // can compute them for free optionally.
 
   auto localTriangleList = triangleList;
-  vector<std::array<SimplexId, 3>> defaultTriangleList{};
+  std::vector<std::array<SimplexId, 3>> defaultTriangleList{};
   if(!localTriangleList) {
     localTriangleList = &defaultTriangleList;
   }
@@ -511,14 +467,14 @@ int TwoSkeleton::buildTriangleEdgeList(
 
   SimplexId triangleNumber = localTriangleList->size();
 
-  printMsg("Built " + to_string(triangleNumber) + " triangle edges", 1,
+  printMsg("Built " + std::to_string(triangleNumber) + " triangle edges", 1,
            tm.getElapsedTime(), threadNumber_);
 
   return 0;
 }
 
 int TwoSkeleton::buildTriangleLinks(
-  const vector<std::array<SimplexId, 3>> &triangleList,
+  const std::vector<std::array<SimplexId, 3>> &triangleList,
   const FlatJaggedArray &triangleStars,
   const CellArray &cellArray,
   FlatJaggedArray &triangleLinks) const {
@@ -582,7 +538,7 @@ int TwoSkeleton::buildTriangleLinks(
 
 int TwoSkeleton::buildVertexTriangles(
   const SimplexId &vertexNumber,
-  const vector<std::array<SimplexId, 3>> &triangleList,
+  const std::vector<std::array<SimplexId, 3>> &triangleList,
   FlatJaggedArray &vertexTriangles) const {
 
   Timer tm;

--- a/core/base/skeleton/TwoSkeleton.h
+++ b/core/base/skeleton/TwoSkeleton.h
@@ -13,8 +13,7 @@
 #pragma once
 
 // base code includes
-#include <OneSkeleton.h>
-#include <Wrapper.h>
+#include <Debug.h>
 #include <ZeroSkeleton.h>
 
 #include <algorithm>
@@ -49,7 +48,7 @@ namespace ttk {
     int buildCellNeighborsFromEdges(const SimplexId &vertexNumber,
                                     const CellArray &cellArray,
                                     FlatJaggedArray &cellNeighbors,
-                                    FlatJaggedArray *edgeStars = nullptr) const;
+                                    const FlatJaggedArray &edgeStars) const;
 
     /// Compute the list of cell-neighbors of each cell of a 2D triangulation
     /// (unspecified behavior if the input mesh is not a triangulation).
@@ -86,14 +85,9 @@ namespace ttk {
     /// std::vector will be equal to the number of edges in the triangulation.
     /// Each entry will be a std::vector listing the triangle identifiers for
     /// each triangle connected to the entry's edge.
-    /// \param edgeList Optional output edge list (list of std::pairs of vertex
-    /// identifiers). If nullptr, the function will compute this list anyway and
-    /// free the related memory upon return. If not nullptr but pointing to an
-    /// empty std::vector, the function will fill this empty std::vector (useful
-    /// if this list needs to be used later on by the calling program). If not
-    /// nullptr but pointing to a non-empty std::vector, this function will use
-    /// this std::vector as internal edge list. If this std::vector is not empty
-    /// but incorrect, the behavior is unspecified.
+    /// \param edgeList Edge list (list of std::pairs of vertex
+    /// identifiers). If this std::vector is not empty but incorrect,
+    /// the behavior is unspecified.
     /// \param triangleEdgeList Optional output triangle edge list (list of
     /// std::vectors of edges identifiers per triangle). If nullptr, the
     /// function will compute this list anyway and free the related memory upon
@@ -103,12 +97,13 @@ namespace ttk {
     /// a non-empty std::vector, this function will use this std::vector as
     /// internal edge list. If this std::vector is not empty but incorrect, the
     /// behavior is unspecified.
-    int buildEdgeTriangles(
-      const SimplexId &vertexNumber,
-      const CellArray &cellArray,
-      FlatJaggedArray &edgeTriangleList,
-      std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,
-      std::vector<std::array<SimplexId, 3>> *triangleEdgeList = nullptr) const;
+    int
+      buildEdgeTriangles(const SimplexId &vertexNumber,
+                         const CellArray &cellArray,
+                         FlatJaggedArray &edgeTriangleList,
+                         const std::vector<std::array<SimplexId, 2>> &edgeList,
+                         std::vector<std::array<SimplexId, 3>> *triangleEdgeList
+                         = nullptr) const;
 
     /// Compute the list of triangles of a triangulation represented by a
     /// vtkUnstructuredGrid object. Unspecified behavior if the input mesh is
@@ -138,6 +133,9 @@ namespace ttk {
     /// std::vector will be equal to the number of triangles in the
     /// triangulation. Each entry will be a std::vector listing the edge
     /// identifiers for each edge connected to the entry's triangle.
+    /// \param edgeList Edge list (list of std::pairs of vertex
+    /// identifiers). If this std::vector is not empty but incorrect,
+    /// the behavior is unspecified.
     /// \param vertexEdgeList Optional output vertex edge list (list of edge
     /// identifiers for each vertex). If nullptr, the function will compute this
     /// list anyway and free the related memory upon return. If not nullptr but
@@ -147,14 +145,6 @@ namespace ttk {
     /// std::vector, this function will use this std::vector as internal vertex
     /// edge list. If this std::vector is not empty but incorrect, the behavior
     /// is unspecified.
-    /// \param edgeList Optional output edge list (list of std::pairs of vertex
-    /// identifiers). If nullptr, the function will compute this list anyway and
-    /// free the related memory upon return. If not nullptr but pointing to an
-    /// empty std::vector, the function will fill this empty std::vector (useful
-    /// if this list needs to be used later on by the calling program). If not
-    /// nullptr but pointing to a non-empty std::vector, this function will use
-    /// this std::vector as internal edge list. If this std::vector is not empty
-    /// but incorrect, the behavior is unspecified.
     /// \param triangleList Optional output triangle list (list of std::vectors
     /// of vertex identifiers). If nullptr, the function will compute this list
     /// anyway and free the related memory upon return. If not nullptr but
@@ -187,8 +177,8 @@ namespace ttk {
       const SimplexId &vertexNumber,
       const CellArray &cellArray,
       std::vector<std::array<SimplexId, 3>> &triangleEdgeList,
+      const std::vector<std::array<SimplexId, 2>> &edgeList,
       FlatJaggedArray *vertexEdgeList = nullptr,
-      std::vector<std::array<SimplexId, 2>> *edgeList = nullptr,
       std::vector<std::array<SimplexId, 3>> *triangleList = nullptr,
       FlatJaggedArray *triangleStarList = nullptr,
       std::vector<std::array<SimplexId, 4>> *cellTriangleList = nullptr) const;

--- a/core/base/skeleton/TwoSkeleton.h
+++ b/core/base/skeleton/TwoSkeleton.h
@@ -45,8 +45,7 @@ namespace ttk {
     /// internal vertex star list. If this std::vector is not empty but
     /// incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildCellNeighborsFromEdges(const SimplexId &vertexNumber,
-                                    const CellArray &cellArray,
+    int buildCellNeighborsFromEdges(const CellArray &cellArray,
                                     FlatJaggedArray &cellNeighbors,
                                     const FlatJaggedArray &edgeStars) const;
 

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -1,7 +1,5 @@
-#include <OneSkeleton.h>
 #include <ZeroSkeleton.h>
 
-using namespace std;
 using namespace ttk;
 
 ZeroSkeleton::ZeroSkeleton() {
@@ -10,7 +8,7 @@ ZeroSkeleton::ZeroSkeleton() {
 
 int ZeroSkeleton::buildVertexEdges(
   const SimplexId &vertexNumber,
-  const vector<std::array<SimplexId, 2>> &edgeList,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   FlatJaggedArray &vertexEdges) const {
 
   std::vector<SimplexId> offsets(vertexNumber + 1);
@@ -60,8 +58,8 @@ int ZeroSkeleton::buildVertexEdges(
 // 2D cells (triangles)
 int ZeroSkeleton::buildVertexLinks(
   const FlatJaggedArray &vertexStars,
-  const vector<std::array<SimplexId, 3>> &cellEdges,
-  const vector<std::array<SimplexId, 2>> &edgeList,
+  const std::vector<std::array<SimplexId, 3>> &cellEdges,
+  const std::vector<std::array<SimplexId, 2>> &edgeList,
   FlatJaggedArray &vertexLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -117,8 +115,8 @@ int ZeroSkeleton::buildVertexLinks(
 // 3D cells (tetrahedron)
 int ZeroSkeleton::buildVertexLinks(
   const FlatJaggedArray &vertexStars,
-  const vector<std::array<SimplexId, 4>> &cellTriangles,
-  const vector<std::array<SimplexId, 3>> &triangleList,
+  const std::vector<std::array<SimplexId, 4>> &cellTriangles,
+  const std::vector<std::array<SimplexId, 3>> &triangleList,
   FlatJaggedArray &vertexLinks) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -176,31 +174,18 @@ int ZeroSkeleton::buildVertexNeighbors(
   const SimplexId &vertexNumber,
   const CellArray &cellArray,
   FlatJaggedArray &vertexNeighbors,
-  vector<std::array<SimplexId, 2>> *edgeList) const {
+  const std::vector<std::array<SimplexId, 2>> &edgeList) const {
 
   std::vector<SimplexId> offsets(vertexNumber + 1);
   // number of neighbors processed per vertex
   std::vector<SimplexId> neighborsId(vertexNumber);
-
-  auto localEdgeList = edgeList;
-  vector<std::array<SimplexId, 2>> defaultEdgeList{};
-  if(!localEdgeList) {
-    localEdgeList = &defaultEdgeList;
-  }
-
-  if(!localEdgeList->size()) {
-    OneSkeleton osk;
-    osk.setDebugLevel(debugLevel_);
-    osk.setThreadNumber(threadNumber_);
-    osk.buildEdgeList(vertexNumber, cellArray, localEdgeList);
-  }
 
   Timer t;
 
   printMsg("Building vertex neighbors", 0, 0, 1, ttk::debug::LineMode::REPLACE);
 
   // store number of neighbors per vertex
-  for(const auto &e : *localEdgeList) {
+  for(const auto &e : edgeList) {
     offsets[e[0] + 1]++;
     offsets[e[1] + 1]++;
   }
@@ -214,7 +199,7 @@ int ZeroSkeleton::buildVertexNeighbors(
   std::vector<SimplexId> neighbors(offsets.back());
 
   // fill flat neighbors vector using offsets and neighbors count vectors
-  for(const auto &e : *localEdgeList) {
+  for(const auto &e : edgeList) {
     neighbors[offsets[e[0]] + neighborsId[e[0]]] = e[1];
     neighborsId[e[0]]++;
     neighbors[offsets[e[1]] + neighborsId[e[1]]] = e[0];
@@ -283,7 +268,7 @@ int ZeroSkeleton::buildVertexStars(const SimplexId &vertexNumber,
 
   if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
     for(size_t i = 0; i < vertexStars.subvectorsNumber(); i++) {
-      stringstream msg;
+      std::stringstream msg;
       msg << "Vertex #" << i << " (" << vertexStars.size(i) << " cell(s)): ";
       for(SimplexId j = 0; j < vertexStars.size(i); j++) {
         msg << " " << vertexStars.get(i, j);

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -172,7 +172,6 @@ int ZeroSkeleton::buildVertexLinks(
 
 int ZeroSkeleton::buildVertexNeighbors(
   const SimplexId &vertexNumber,
-  const CellArray &cellArray,
   FlatJaggedArray &vertexNeighbors,
   const std::vector<std::array<SimplexId, 2>> &edgeList) const {
 

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -88,19 +88,14 @@ namespace ttk {
     /// std::vector will be equal to the number of vertices in the mesh. Each
     /// entry will be std::vector listing the vertex identifiers of the entry's
     /// vertex' neighbors.
-    /// \param edgeList Optional list of edges. If NULL, the function will
-    /// compute this list anyway and free the related memory upon return. If not
-    /// NULL but pointing to an empty std::vector, the function will fill this
-    /// empty std::vector (useful if this list needs to be used later on by the
-    /// calling program). If not NULL but pointing to a non-empty std::vector,
-    /// this function will use this std::vector as internal edge list. If this
-    /// std::vector is not empty but incorrect, the behavior is unspecified.
+    /// \param edgeList List of edges. If this std::vector is not
+    /// empty but incorrect, the behavior is unspecified.
     /// \return Returns 0 upon success, negative values otherwise.
-    int buildVertexNeighbors(const SimplexId &vertexNumber,
-                             const CellArray &cellArray,
-                             FlatJaggedArray &vertexNeighbors,
-                             std::vector<std::array<SimplexId, 2>> *edgeList
-                             = NULL) const;
+    int buildVertexNeighbors(
+      const SimplexId &vertexNumber,
+      const CellArray &cellArray,
+      FlatJaggedArray &vertexNeighbors,
+      const std::vector<std::array<SimplexId, 2>> &edgeList) const;
 
     /// Compute the star of each vertex of a triangulation. Unspecified
     /// behavior if the input mesh is not a valid triangulation.

--- a/core/base/skeleton/ZeroSkeleton.h
+++ b/core/base/skeleton/ZeroSkeleton.h
@@ -93,7 +93,6 @@ namespace ttk {
     /// \return Returns 0 upon success, negative values otherwise.
     int buildVertexNeighbors(
       const SimplexId &vertexNumber,
-      const CellArray &cellArray,
       FlatJaggedArray &vertexNeighbors,
       const std::vector<std::array<SimplexId, 2>> &edgeList) const;
 


### PR DESCRIPTION
The  `OneSkeleton::buildEdgeList` method has been templated in #593 with the dataset dimension as template parameter to unify implementations for 2D and 3D datasets. 

However, using the wrong template call can lead to segfault: if a filter calls `preconditionVertexNeighbors` followed by `preconditionEdgeStars` on a 3D tetrahedron dataset for instance, `preconditionVertexNeighbors` will initialize the `edgeList` in the skeleton module, skipping the call to `preconditionEdges` in the AbstractTriangulation. The latter call to `preconditionEdgeStars` will segfault due to the wrong default parameter when calling `OneSkeleton::buildEdgeList` in `ExplicitTriangulation::preconditionEdgeStarsInternal`.

While getting to this segfault may seem hard, just applying ScalarFieldSmoother then DiscreteGradient on any 3D tetrahedron dataset is enough to trigger it.

To fix this issue, this PR reworks the handling of the `OneSkeleton::buildEdgeList` calls in the skeleton and ExplicitTriangulation modules:
* the `buildEdgeList` method has been refactored not to accept optional parameters. This may increase performance (no more null pointer checks in the main loop) at the expense of memory: calling buildEdgeList will now compute and keep in memory the edgeList, the edgeStarsList and the cellEdgesList even though the latter are not used,
* intra-skeleton module calls to `buildEdgeList` were replaced by calls to `preconditionEdgesInternal` in ExplicitTriangulation and passing the edgeList from there,
* `buildEdgeList` calls in the ExplicitTriangulation module were replaced with `preconditionEdgesInternal` calls, which dispatch calls to `buildEdgeList` according to the dataset dimension.

In the end, the calls to `buildEdgeList` have been reduced to `ExplicitTriangulation::preconditionEdgesInternal`, pointers to edgeList, edgeStarsList and cellEdgesList have been replaced with references (and calls to `preconditionEdgesInternal`).

And since TTK filters are sometimes used on 1D datasets (in ttk-data/morseMolecule.psvm, GeometrySmoother is applied on 1D separatrices), this PR also enables the support of 1D datasets in the ExplicitTriangulation (at least the bits necessary for the DiscreteGradient and the ttk-data states to run normally).

No changes detected in the ttk-data states.

Enjoy,
Pierre