### PR TITLE
[planarGraphLayout] fix merge tree layout matching cost

### DIFF
--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -380,7 +380,7 @@ public:
     vtkMatching->GetCellData()->AddArray(matchingType);
     vtkMatching->GetCellData()->AddArray(matchPers);
     vtkMatching->GetCellData()->AddArray(matchingID);
-    // vtkMatching->GetCellData()->AddArray(costArray);
+    vtkMatching->GetCellData()->AddArray(costArray);
     vtkMatching->GetCellData()->AddArray(tree1NodeIdField);
     vtkMatching->GetCellData()->AddArray(tree2NodeIdField);
     if(allBaryPercentMatch.size() != 0)


### PR DESCRIPTION
This PR removes the comment indicator of the line adding the cost to each cell in the matching output with merge trees.

Otherwise, the cost field will not appears..