### PR TITLE
[mergeTreeTemporalReduction] add module

### DIFF
--- a/core/base/mergeTreeTemporalReductionDecoding/CMakeLists.txt
+++ b/core/base/mergeTreeTemporalReductionDecoding/CMakeLists.txt
@@ -4,7 +4,5 @@ ttk_add_base_library(mergeTreeTemporalReductionDecoding
   HEADERS
     MergeTreeTemporalReductionDecoding.h
   DEPENDS
-    triangulation
-    ftmTree
     mergeTreeClustering
 )

--- a/core/base/mergeTreeTemporalReductionDecoding/CMakeLists.txt
+++ b/core/base/mergeTreeTemporalReductionDecoding/CMakeLists.txt
@@ -1,0 +1,10 @@
+ttk_add_base_library(mergeTreeTemporalReductionDecoding
+  SOURCES
+    MergeTreeTemporalReductionDecoding.cpp
+  HEADERS
+    MergeTreeTemporalReductionDecoding.h
+  DEPENDS
+    triangulation
+    ftmTree
+    mergeTreeClustering
+)

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.cpp
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.cpp
@@ -1,0 +1,6 @@
+#include <MergeTreeTemporalReductionDecoding.h>
+
+ttk::MergeTreeTemporalReductionDecoding::MergeTreeTemporalReductionDecoding() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("MergeTreeTemporalReductionDecoding");
+}

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -16,7 +16,6 @@
 
 // ttk common includes
 #include <Debug.h>
-#include <Triangulation.h>
 
 #include <FTMTreeUtils.h>
 #include <MergeTreeBarycenter.h>

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -1,0 +1,184 @@
+/// \ingroup base
+/// \class ttk::MergeTreeTemporalReductionDecoding
+/// \author Mathieu Pont (mathieu.pont@lip6.fr)
+/// \date 2021.
+///
+/// This module defines the %MergeTreeTemporalReductionDecoding class that
+/// computes the reconstruction of a reduced sequence of merge trees.
+///
+
+#pragma once
+
+// ttk common includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+#include <FTMTreeUtils.h>
+#include <MergeTreeBarycenter.h>
+#include <MergeTreeBase.h>
+#include <MergeTreeDistance.h>
+
+namespace ttk {
+
+  /**
+   * The MergeTreeTemporalReductionDecoding class provides methods to compute
+   * the reconstruction of a reduced sequence of merge trees.
+   */
+  class MergeTreeTemporalReductionDecoding : virtual public Debug,
+                                             public MergeTreeBase {
+  protected:
+    std::vector<double> finalDistances_, distancesToKeyFrames_;
+
+  public:
+    MergeTreeTemporalReductionDecoding();
+
+    template <class dataType>
+    dataType computeDistance(
+      MergeTree<dataType> &mTree1,
+      MergeTree<dataType> &mTree2,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching) {
+      MergeTreeDistance mergeTreeDistance;
+      mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeDistance.setEpsilonTree1(epsilonTree1_);
+      mergeTreeDistance.setEpsilonTree2(epsilonTree2_);
+      mergeTreeDistance.setEpsilon2Tree1(epsilon2Tree1_);
+      mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
+      mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
+      mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
+      mergeTreeDistance.setProgressiveComputation(progressiveComputation_);
+      mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
+      mergeTreeDistance.setParallelize(parallelize_);
+      mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
+      mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeDistance.setNormalizedWassersteinReg(normalizedWassersteinReg_);
+      mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
+      mergeTreeDistance.setKeepSubtree(keepSubtree_);
+      mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
+      mergeTreeDistance.setThreadNumber(this->threadNumber_);
+      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDebugLevel(2);
+      mergeTreeDistance.setPreprocess(false);
+      mergeTreeDistance.setPostprocess(false);
+      // mergeTreeDistance.setIsCalled(true);
+
+      dataType distance
+        = mergeTreeDistance.execute<dataType>(mTree1, mTree2, matching);
+
+      return distance;
+    }
+
+    template <class dataType>
+    dataType computeDistance(MergeTree<dataType> &mTree1,
+                             MergeTree<dataType> &mTree2) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching;
+      return computeDistance<dataType>(mTree1, mTree2, matching);
+    }
+
+    template <class dataType>
+    MergeTree<dataType> computeBarycenter(MergeTree<dataType> &mTree1,
+                                          MergeTree<dataType> &mTree2,
+                                          double alpha) {
+      MergeTreeBarycenter mergeTreeBarycenter;
+      mergeTreeBarycenter.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeBarycenter.setEpsilonTree1(epsilonTree1_);
+      mergeTreeBarycenter.setEpsilonTree2(epsilonTree2_);
+      mergeTreeBarycenter.setEpsilon2Tree1(epsilon2Tree1_);
+      mergeTreeBarycenter.setEpsilon2Tree2(epsilon2Tree2_);
+      mergeTreeBarycenter.setEpsilon3Tree1(epsilon3Tree1_);
+      mergeTreeBarycenter.setEpsilon3Tree2(epsilon3Tree2_);
+      mergeTreeBarycenter.setProgressiveComputation(progressiveComputation_);
+      mergeTreeBarycenter.setBranchDecomposition(branchDecomposition_);
+      mergeTreeBarycenter.setParallelize(parallelize_);
+      mergeTreeBarycenter.setPersistenceThreshold(persistenceThreshold_);
+      mergeTreeBarycenter.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeBarycenter.setNormalizedWassersteinReg(
+        normalizedWassersteinReg_);
+      mergeTreeBarycenter.setRescaledWasserstein(rescaledWasserstein_);
+      mergeTreeBarycenter.setKeepSubtree(keepSubtree_);
+      mergeTreeBarycenter.setUseMinMaxPair(useMinMaxPair_);
+      mergeTreeBarycenter.setThreadNumber(this->threadNumber_);
+      mergeTreeBarycenter.setAlpha(alpha);
+      mergeTreeBarycenter.setDebugLevel(2);
+      mergeTreeBarycenter.setPreprocess(false);
+      mergeTreeBarycenter.setPostprocess(false);
+      // mergeTreeBarycenter.setIsCalled(true);
+
+      std::vector<MergeTree<dataType>> intermediateTrees;
+      intermediateTrees.push_back(mTree1);
+      intermediateTrees.push_back(mTree2);
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        outputMatchingBarycenter(2);
+      MergeTree<dataType> barycenter;
+      mergeTreeBarycenter.execute<dataType>(
+        intermediateTrees, outputMatchingBarycenter, barycenter);
+      return barycenter;
+    }
+
+    template <class dataType>
+    void execute(
+      std::vector<MergeTree<dataType>> &mTrees,
+      std::vector<std::tuple<double, int, int, int, int>> &coefs,
+      std::vector<MergeTree<dataType>> &allMT,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &allMatching) {
+      Timer t_tempSub;
+
+      // --- Preprocessing
+      treesNodeCorr_ = std::vector<std::vector<int>>(mTrees.size());
+      for(unsigned int i = 0; i < mTrees.size(); ++i) {
+        preprocessingPipeline<dataType>(
+          mTrees[i], epsilonTree2_, epsilon2Tree2_, epsilon3Tree2_,
+          branchDecomposition_, useMinMaxPair_, cleanTree_, treesNodeCorr_[i]);
+      }
+      printTreesStats<dataType>(mTrees);
+
+      // --- Execute
+      distancesToKeyFrames_ = std::vector<double>(coefs.size() * 2);
+      int index = 0;
+      size_t cpt = 0;
+      while(cpt < coefs.size()) {
+        while(cpt < coefs.size() and std::get<2>(coefs[cpt]) <= index) {
+          double alpha = std::get<0>(coefs[cpt]);
+          int index1 = std::get<1>(coefs[cpt]);
+          int index2 = std::get<2>(coefs[cpt]);
+          MergeTree<dataType> tree = computeBarycenter<dataType>(
+            mTrees[index1], mTrees[index2], alpha);
+          allMT.push_back(tree);
+          // distancesToKeyFrames_[cpt*2] =
+          // computeDistance<dataType>(mTrees[index1], tree);
+          // distancesToKeyFrames_[cpt*2+1] = computeDistance<dataType>(tree,
+          // mTrees[index2]);
+          ++cpt;
+        }
+        allMT.push_back(mTrees[index]);
+        ++index;
+      }
+
+      allMatching = std::vector<
+        std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>(allMT.size()
+                                                                   - 1);
+      finalDistances_ = std::vector<double>(allMT.size() - 1);
+      for(unsigned int i = 0; i < allMT.size() - 1; ++i)
+        finalDistances_[i]
+          = computeDistance<dataType>(allMT[i], allMT[i + 1], allMatching[i]);
+
+      // --- Postprocessing
+      for(unsigned int i = 0; i < allMT.size(); ++i)
+        postprocessingPipeline<dataType>(&(allMT[i].tree));
+      for(unsigned int i = 0; i < mTrees.size(); ++i)
+        postprocessingPipeline<dataType>(&(mTrees[i].tree));
+
+      // --- Print results
+      std::stringstream ss, ss2, ss3;
+      ss << "input size    = " << mTrees.size();
+      printMsg(ss.str());
+      ss2 << "output size   = " << allMT.size();
+      printMsg(ss2.str());
+      ss3 << "reconstructed : " << allMT.size() - mTrees.size();
+      printMsg(ss3.str());
+      printMsg("Decoding", 1, t_tempSub.getElapsedTime(), this->threadNumber_);
+    }
+
+  }; // MergeTreeTemporalReductionDecoding class
+
+} // namespace ttk

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -6,6 +6,11 @@
 /// This module defines the %MergeTreeTemporalReductionDecoding class that
 /// computes the reconstruction of a reduced sequence of merge trees.
 ///
+/// \b Related \b publication \n
+/// "Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+/// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+/// Proc. of IEEE VIS 2021.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2021
 
 #pragma once
 

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -149,10 +149,10 @@ namespace ttk {
           MergeTree<dataType> tree = computeBarycenter<dataType>(
             mTrees[index1], mTrees[index2], alpha);
           allMT.push_back(tree);
-          // distancesToKeyFrames_[cpt*2] =
-          // computeDistance<dataType>(mTrees[index1], tree);
-          // distancesToKeyFrames_[cpt*2+1] = computeDistance<dataType>(tree,
-          // mTrees[index2]);
+          distancesToKeyFrames_[cpt * 2]
+            = computeDistance<dataType>(mTrees[index1], tree);
+          distancesToKeyFrames_[cpt * 2 + 1]
+            = computeDistance<dataType>(tree, mTrees[index2]);
           ++cpt;
         }
         allMT.push_back(mTrees[index]);

--- a/core/base/mergeTreeTemporalReductionEncoding/CMakeLists.txt
+++ b/core/base/mergeTreeTemporalReductionEncoding/CMakeLists.txt
@@ -1,0 +1,10 @@
+ttk_add_base_library(mergeTreeTemporalReductionEncoding
+  SOURCES
+    MergeTreeTemporalReductionEncoding.cpp
+  HEADERS
+    MergeTreeTemporalReductionEncoding.h
+  DEPENDS
+    triangulation
+    ftmTree
+    mergeTreeClustering
+)

--- a/core/base/mergeTreeTemporalReductionEncoding/CMakeLists.txt
+++ b/core/base/mergeTreeTemporalReductionEncoding/CMakeLists.txt
@@ -4,7 +4,5 @@ ttk_add_base_library(mergeTreeTemporalReductionEncoding
   HEADERS
     MergeTreeTemporalReductionEncoding.h
   DEPENDS
-    triangulation
-    ftmTree
     mergeTreeClustering
 )

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.cpp
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.cpp
@@ -1,0 +1,6 @@
+#include <MergeTreeTemporalReductionEncoding.h>
+
+ttk::MergeTreeTemporalReductionEncoding::MergeTreeTemporalReductionEncoding() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("MergeTreeTemporalReductionEncoding");
+}

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -16,7 +16,6 @@
 
 // ttk common includes
 #include <Debug.h>
-#include <Triangulation.h>
 
 #include <FTMTreeUtils.h>
 #include <MergeTreeBarycenter.h>

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -1,0 +1,398 @@
+/// \ingroup base
+/// \class ttk::MergeTreeTemporalReductionEncoding
+/// \author Mathieu Pont (mathieu.pont@lip6.fr)
+/// \date 2021.
+///
+/// This module defines the %MergeTreeTemporalReductionEncoding class that
+/// computes a temporal reduction of a sequence of merge trees.
+///
+
+#pragma once
+
+// ttk common includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+#include <FTMTreeUtils.h>
+#include <MergeTreeBarycenter.h>
+#include <MergeTreeBase.h>
+#include <MergeTreeDistance.h>
+
+namespace ttk {
+
+  /**
+   * The MergeTreeTemporalReductionEncoding class provides methods to compute
+   * a temporal reduction of a sequence of merge trees.
+   */
+  class MergeTreeTemporalReductionEncoding : virtual public Debug,
+                                             public MergeTreeBase {
+  protected:
+    double removalPercentage_ = 50.;
+    bool useL2Distance_ = false;
+    std::vector<std::vector<double>> fieldL2_;
+    bool useCustomTimeVariable_ = false;
+    std::vector<double> timeVariable_;
+
+  public:
+    MergeTreeTemporalReductionEncoding();
+
+    void setRemovalPercentage(double rs) {
+      removalPercentage_ = rs;
+    }
+
+    void setUseL2Distance(bool useL2) {
+      useL2Distance_ = useL2;
+    }
+
+    template <class dataType>
+    dataType computeL2Distance(std::vector<dataType> &img1,
+                               std::vector<dataType> &img2,
+                               bool emptyFieldDistance = false) {
+      size_t noPoints = img1.size();
+
+      std::vector<dataType> secondField = img2;
+      if(emptyFieldDistance)
+        secondField = std::vector<dataType>(noPoints, 0);
+
+      dataType distance = 0;
+
+      for(size_t i = 0; i < noPoints; ++i)
+        distance += std::pow((img1[i] - secondField[i]), 2);
+
+      distance = std::sqrt(distance);
+
+      return distance;
+    }
+
+    template <class dataType>
+    std::vector<dataType> computeL2Barycenter(std::vector<dataType> &img1,
+                                              std::vector<dataType> &img2,
+                                              double alpha) {
+
+      size_t noPoints = img1.size();
+
+      std::vector<dataType> barycenter(noPoints);
+      for(size_t i = 0; i < noPoints; ++i)
+        barycenter[i] = alpha * img1[i] * (1 - alpha) * img2[i];
+
+      return barycenter;
+    }
+
+    template <class dataType>
+    dataType computeDistance(MergeTree<dataType> &mTree1,
+                             MergeTree<dataType> &mTree2,
+                             bool emptyTreeDistance = false) {
+      MergeTreeDistance mergeTreeDistance;
+      mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeDistance.setEpsilonTree1(epsilonTree1_);
+      mergeTreeDistance.setEpsilonTree2(epsilonTree2_);
+      mergeTreeDistance.setEpsilon2Tree1(epsilon2Tree1_);
+      mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
+      mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
+      mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
+      mergeTreeDistance.setProgressiveComputation(progressiveComputation_);
+      mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
+      mergeTreeDistance.setParallelize(parallelize_);
+      mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
+      mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeDistance.setNormalizedWassersteinReg(normalizedWassersteinReg_);
+      mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
+      mergeTreeDistance.setKeepSubtree(keepSubtree_);
+      mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
+      mergeTreeDistance.setThreadNumber(this->threadNumber_);
+      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDebugLevel(2);
+      mergeTreeDistance.setPreprocess(false);
+      mergeTreeDistance.setPostprocess(false);
+      // mergeTreeDistance.setIsCalled(true);
+      mergeTreeDistance.setOnlyEmptyTreeDistance(emptyTreeDistance);
+
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching;
+      dataType distance
+        = mergeTreeDistance.execute<dataType>(mTree1, mTree2, matching);
+
+      return distance;
+    }
+
+    template <class dataType>
+    MergeTree<dataType> computeBarycenter(MergeTree<dataType> &mTree1,
+                                          MergeTree<dataType> &mTree2,
+                                          double alpha) {
+      MergeTreeBarycenter mergeTreeBarycenter;
+      mergeTreeBarycenter.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeBarycenter.setEpsilonTree1(epsilonTree1_);
+      mergeTreeBarycenter.setEpsilonTree2(epsilonTree2_);
+      mergeTreeBarycenter.setEpsilon2Tree1(epsilon2Tree1_);
+      mergeTreeBarycenter.setEpsilon2Tree2(epsilon2Tree2_);
+      mergeTreeBarycenter.setEpsilon3Tree1(epsilon3Tree1_);
+      mergeTreeBarycenter.setEpsilon3Tree2(epsilon3Tree2_);
+      mergeTreeBarycenter.setProgressiveComputation(progressiveComputation_);
+      mergeTreeBarycenter.setBranchDecomposition(branchDecomposition_);
+      mergeTreeBarycenter.setParallelize(parallelize_);
+      mergeTreeBarycenter.setPersistenceThreshold(persistenceThreshold_);
+      mergeTreeBarycenter.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeBarycenter.setNormalizedWassersteinReg(
+        normalizedWassersteinReg_);
+      mergeTreeBarycenter.setRescaledWasserstein(rescaledWasserstein_);
+      mergeTreeBarycenter.setKeepSubtree(keepSubtree_);
+      mergeTreeBarycenter.setUseMinMaxPair(useMinMaxPair_);
+      mergeTreeBarycenter.setThreadNumber(this->threadNumber_);
+      mergeTreeBarycenter.setAlpha(alpha);
+      mergeTreeBarycenter.setDebugLevel(2);
+      mergeTreeBarycenter.setPreprocess(false);
+      mergeTreeBarycenter.setPostprocess(false);
+      // mergeTreeBarycenter.setIsCalled(true);
+
+      std::vector<MergeTree<dataType>> intermediateTrees;
+      intermediateTrees.push_back(mTree1);
+      intermediateTrees.push_back(mTree2);
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        outputMatchingBarycenter(2);
+      MergeTree<dataType> barycenter;
+      mergeTreeBarycenter.execute<dataType>(
+        intermediateTrees, outputMatchingBarycenter, barycenter);
+      return barycenter;
+    }
+
+    double computeAlpha(int index1, int middleIndex, int index2) {
+      index1 = timeVariable_[index1];
+      middleIndex = timeVariable_[middleIndex];
+      index2 = timeVariable_[index2];
+      return 1 - ((double)middleIndex - index1) / (index2 - index1);
+    }
+
+    template <class dataType>
+    void
+      temporalSubsampling(std::vector<MergeTree<dataType>> &mTrees,
+                          std::vector<int> &removed,
+                          std::vector<MergeTree<dataType>> &barycenters,
+                          std::vector<std::vector<dataType>> &barycentersL2) {
+      std::vector<bool> treeRemoved(mTrees.size(), false);
+
+      int toRemoved = mTrees.size() * removalPercentage_ / 100.;
+      toRemoved = std::min(toRemoved, (int)(mTrees.size() - 3));
+
+      std::vector<std::vector<dataType>> images(fieldL2_.size());
+      for(size_t i = 0; i < fieldL2_.size(); ++i)
+        for(size_t j = 0; j < fieldL2_[i].size(); ++j)
+          images[i].push_back(static_cast<dataType>(fieldL2_[i][j]));
+
+      for(int iter = 0; iter < toRemoved; ++iter) {
+        dataType bestCost = std::numeric_limits<dataType>::max();
+        int bestMiddleIndex = -1;
+        MergeTree<dataType> bestBarycenter;
+        std::vector<std::tuple<MergeTree<dataType>, int>> bestBarycentersOnPath;
+        std::vector<dataType> bestBarycenterL2;
+        std::vector<std::tuple<std::vector<dataType>, int>>
+          bestBarycentersL2OnPath;
+
+        // Compute barycenter for each pair of trees
+        printMsg("Compute barycenter for each pair of trees",
+                 debug::Priority::VERBOSE);
+        unsigned int index1 = 0, index2 = 0;
+        while(index2 != mTrees.size() - 1) {
+
+          // Get index in the middle
+          int middleIndex = index1 + 1;
+          while(treeRemoved[middleIndex])
+            ++middleIndex;
+
+          // Get second index
+          index2 = middleIndex + 1;
+          while(treeRemoved[index2])
+            ++index2;
+
+          // Compute barycenter
+          printMsg("Compute barycenter", debug::Priority::VERBOSE);
+          double alpha = computeAlpha(index1, middleIndex, index2);
+          MergeTree<dataType> barycenter;
+          std::vector<dataType> barycenterL2;
+          if(not useL2Distance_)
+            barycenter = computeBarycenter<dataType>(
+              mTrees[index1], mTrees[index2], alpha);
+          else
+            barycenterL2 = computeL2Barycenter<dataType>(
+              images[index1], images[index2], alpha);
+
+          // - Compute cost
+          // Compute distance with middleIndex
+          printMsg(
+            "Compute distance with middleIndex", debug::Priority::VERBOSE);
+          dataType cost;
+          if(not useL2Distance_)
+            cost = computeDistance<dataType>(barycenter, mTrees[middleIndex]);
+          else
+            cost
+              = computeL2Distance<dataType>(barycenterL2, images[middleIndex]);
+
+          // Compute distances of previously removed trees on the path
+          printMsg("Compute distances of previously removed trees",
+                   debug::Priority::VERBOSE);
+          std::vector<std::tuple<MergeTree<dataType>, int>> barycentersOnPath;
+          std::vector<std::tuple<std::vector<dataType>, int>>
+            barycentersL2OnPath;
+          for(unsigned int i = 0; i < 2; ++i) {
+            int toReach = (i == 0 ? index1 : index2);
+            int offset = (i == 0 ? -1 : 1);
+            int tIndex = middleIndex + offset;
+            while(tIndex != toReach) {
+
+              // Compute barycenter
+              double alphaT = computeAlpha(index1, tIndex, index2);
+              MergeTree<dataType> barycenterP;
+              std::vector<dataType> barycenterPL2;
+              if(not useL2Distance_)
+                barycenterP = computeBarycenter<dataType>(
+                  mTrees[index1], mTrees[index2], alphaT);
+              else
+                barycenterPL2 = computeL2Barycenter<dataType>(
+                  images[index1], images[index2], alphaT);
+
+              // Compute distance
+              dataType costP;
+              if(not useL2Distance_)
+                costP = computeDistance<dataType>(barycenterP, mTrees[tIndex]);
+              else
+                costP
+                  = computeL2Distance<dataType>(barycenterPL2, images[tIndex]);
+
+              // Save results
+              if(not useL2Distance_)
+                barycentersOnPath.push_back(
+                  std::make_tuple(barycenterP, tIndex));
+              else
+                barycentersL2OnPath.push_back(
+                  std::make_tuple(barycenterPL2, tIndex));
+              cost += costP;
+              tIndex += offset;
+            }
+          }
+
+          if(cost < bestCost) {
+            bestCost = cost;
+            bestMiddleIndex = middleIndex;
+            if(not useL2Distance_) {
+              bestBarycenter = barycenter;
+              bestBarycentersOnPath = barycentersOnPath;
+            } else {
+              bestBarycenterL2 = barycenterL2;
+              bestBarycentersL2OnPath = barycentersL2OnPath;
+            }
+          }
+
+          // Go to the next index
+          index1 = middleIndex;
+        }
+
+        // Removed the tree with the lowest cost
+        printMsg(
+          "Removed the tree with the lowest cost", debug::Priority::VERBOSE);
+        removed.push_back(bestMiddleIndex);
+        treeRemoved[bestMiddleIndex] = true;
+        if(not useL2Distance_) {
+          barycenters[bestMiddleIndex] = bestBarycenter;
+          for(auto &tup : bestBarycentersOnPath)
+            barycenters[std::get<1>(tup)] = std::get<0>(tup);
+        } else {
+          barycentersL2[bestMiddleIndex] = bestBarycenterL2;
+          for(auto &tup : bestBarycentersL2OnPath)
+            barycentersL2[std::get<1>(tup)] = std::get<0>(tup);
+        }
+      }
+    }
+
+    template <class dataType>
+    std::vector<int> execute(std::vector<MergeTree<dataType>> &mTrees,
+                             std::vector<double> &emptyTreeDistances,
+                             std::vector<MergeTree<dataType>> &allMT) {
+      Timer t_tempSub;
+
+      // --- Preprocessing
+      if(not useL2Distance_) {
+        treesNodeCorr_ = std::vector<std::vector<int>>(mTrees.size());
+        for(unsigned int i = 0; i < mTrees.size(); ++i) {
+          preprocessingPipeline<dataType>(mTrees[i], epsilonTree2_,
+                                          epsilon2Tree2_, epsilon3Tree2_,
+                                          branchDecomposition_, useMinMaxPair_,
+                                          cleanTree_, treesNodeCorr_[i]);
+        }
+        printTreesStats<dataType>(mTrees);
+      }
+
+      // --- Execute
+      std::vector<MergeTree<dataType>> barycenters(mTrees.size());
+      std::vector<std::vector<dataType>> barycentersL2(mTrees.size());
+      std::vector<int> removed;
+      if(not useCustomTimeVariable_) {
+        timeVariable_.clear();
+        for(size_t i = 0; i < mTrees.size(); ++i)
+          timeVariable_.push_back(i);
+      }
+      temporalSubsampling<dataType>(
+        mTrees, removed, barycenters, barycentersL2);
+
+      // --- Concatenate all trees/L2Images
+      std::vector<std::vector<dataType>> images(fieldL2_.size());
+      for(size_t i = 0; i < fieldL2_.size(); ++i)
+        for(size_t j = 0; j < fieldL2_[i].size(); ++j)
+          images[i].push_back(static_cast<dataType>(fieldL2_[i][j]));
+
+      for(auto &mt : mTrees)
+        allMT.push_back(mt);
+      std::vector<bool> removedB(mTrees.size(), false);
+      for(auto r : removed)
+        removedB[r] = true;
+      for(unsigned int i = 0; i < barycenters.size(); ++i)
+        if(removedB[i]) {
+          if(not useL2Distance_)
+            allMT.push_back(barycenters[i]);
+          else
+            images.push_back(barycentersL2[i]);
+        }
+
+      // --- Compute empty tree distances
+      unsigned int distMatSize
+        = (not useL2Distance_ ? allMT.size() : images.size());
+      for(unsigned int i = 0; i < distMatSize; ++i) {
+        dataType distance;
+        if(not useL2Distance_)
+          distance = computeDistance<dataType>(allMT[i], allMT[i], true);
+        else
+          distance = computeL2Distance<dataType>(images[i], images[i], true);
+        emptyTreeDistances.push_back(distance);
+      }
+
+      // --- Postprocessing
+      if(not useL2Distance_) {
+        for(unsigned int i = 0; i < allMT.size(); ++i)
+          postprocessingPipeline<dataType>(&(allMT[i].tree));
+        for(unsigned int i = 0; i < mTrees.size(); ++i)
+          postprocessingPipeline<dataType>(&(mTrees[i].tree));
+      }
+
+      // --- Print results
+      std::stringstream ss, ss2, ss3;
+      ss << "input size    = " << mTrees.size();
+      printMsg(ss.str());
+      ss2 << "output size   = "
+          << mTrees.size() - (distMatSize - mTrees.size());
+      printMsg(ss2.str());
+      ss3 << "removed       : ";
+      for(unsigned int i = 0; i < removed.size(); ++i) {
+        auto r = removed[i];
+        ss3 << r;
+        if(i < removed.size() - 1)
+          ss3 << ", ";
+      }
+      printMsg(ss3.str());
+
+      sort(removed.begin(), removed.end());
+
+      printMsg("Encoding", 1, t_tempSub.getElapsedTime(), this->threadNumber_);
+
+      return removed;
+    }
+
+  }; // MergeTreeTemporalReductionEncoding class
+
+} // namespace ttk

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -6,6 +6,11 @@
 /// This module defines the %MergeTreeTemporalReductionEncoding class that
 /// computes a temporal reduction of a sequence of merge trees.
 ///
+/// \b Related \b publication \n
+/// "Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+/// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+/// Proc. of IEEE VIS 2021.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2021
 
 #pragma once
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/CMakeLists.txt
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttk.module
@@ -8,5 +8,4 @@ DEPENDS
   mergeTreeTemporalReductionDecoding
   ttkAlgorithm
   ttkPlanarGraphLayout
-  ftmTree
   

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttk.module
@@ -1,0 +1,12 @@
+NAME
+  ttkMergeTreeTemporalReductionDecoding
+SOURCES
+  ttkMergeTreeTemporalReductionDecoding.cpp
+HEADERS
+  ttkMergeTreeTemporalReductionDecoding.h
+DEPENDS
+  mergeTreeTemporalReductionDecoding
+  ttkAlgorithm
+  ttkPlanarGraphLayout
+  ftmTree
+  

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -1,0 +1,392 @@
+#include <ttkMergeTreeTemporalReductionDecoding.h>
+
+#include <ttkFTMTreeUtils.h>
+#include <ttkMergeTreeVisualization.h>
+
+#include <vtkInformation.h>
+
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+// A VTK macro that enables the instantiation of this class via ::New()
+// You do not have to modify this
+vtkStandardNewMacro(ttkMergeTreeTemporalReductionDecoding);
+
+/**
+ * Implement the filter constructor and destructor in the cpp file.
+ *
+ * The constructor has to specify the number of input and output ports
+ * with the functions SetNumberOfInputPorts and SetNumberOfOutputPorts,
+ * respectively. It should also set default values for all filter
+ * parameters.
+ *
+ * The destructor is usually empty unless you want to manage memory
+ * explicitly, by for example allocating memory on the heap that needs
+ * to be freed when the filter is destroyed.
+ */
+ttkMergeTreeTemporalReductionDecoding::ttkMergeTreeTemporalReductionDecoding() {
+  this->SetNumberOfInputPorts(2);
+  this->SetNumberOfOutputPorts(2);
+}
+
+ttkMergeTreeTemporalReductionDecoding::
+  ~ttkMergeTreeTemporalReductionDecoding() {
+}
+
+/**
+ * Specify the required input data type of each input port
+ *
+ * This method specifies the required input object data types of the
+ * filter by adding the vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE() key to
+ * the port information.
+ */
+int ttkMergeTreeTemporalReductionDecoding::FillInputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+  } else if(port == 1) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+  } else
+    return 0;
+  return 1;
+}
+
+/**
+ * Specify the data object type of each output port
+ *
+ * This method specifies in the port information object the data type of the
+ * corresponding output objects. It is possible to either explicitly
+ * specify a type by adding a vtkDataObject::DATA_TYPE_NAME() key:
+ *
+ *      info->Set( vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid" );
+ *
+ * or to pass a type of an input port to an output port by adding the
+ * ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT() key (see below).
+ *
+ * Note: prior to the execution of the RequestData method the pipeline will
+ * initialize empty output data objects based on this information.
+ */
+int ttkMergeTreeTemporalReductionDecoding::FillOutputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0 or port == 1) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkMultiBlockDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Pass VTK data to the base code and convert base code output to VTK
+ *
+ * This method is called during the pipeline execution to update the
+ * already initialized output data objects based on the given input
+ * data objects and filter parameters.
+ *
+ * Note:
+ *     1) The passed input data objects are validated based on the information
+ *        provided by the FillInputPortInformation method.
+ *     2) The output objects are already initialized based on the information
+ *        provided by the FillOutputPortInformation method.
+ */
+int ttkMergeTreeTemporalReductionDecoding::RequestData(
+  vtkInformation *ttkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector) {
+  // ------------------------------------------------------------------------------------
+  // --- Get input object from input vector
+  // ------------------------------------------------------------------------------------
+  printMsg("Get input object from input vector", debug::Priority::VERBOSE);
+  auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+  auto table = vtkTable::GetData(inputVector[1], 0);
+
+  // ------------------------------------------------------------------------------------
+  // --- Load blocks
+  // ------------------------------------------------------------------------------------
+  printMsg("Load Blocks", debug::Priority::VERBOSE);
+  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  loadBlocks(inputTrees, blocks);
+  printMsg("Load Blocks done.", debug::Priority::VERBOSE);
+  int dataTypeInt
+    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
+        ->GetPointData()
+        ->GetArray("Scalar")
+        ->GetDataType();
+
+  // If we have already computed once but the input has changed
+  if(treesNodes.size() != 0 and inputTrees[0]->GetBlock(0) != treesNodes[0])
+    resetDataVisualization();
+
+  std::vector<std::tuple<double, int, int, int, int>> coefs;
+  int totalInputs = inputTrees.size() + table->GetNumberOfRows();
+  std::vector<bool> interpolatedTrees(totalInputs, false);
+  for(int i = 0; i < table->GetNumberOfRows(); ++i) {
+    double alpha = vtkDataArray::SafeDownCast(table->GetColumnByName("Alpha"))
+                     ->GetTuple1(i);
+    int index1R = vtkDataArray::SafeDownCast(table->GetColumnByName("Index1_R"))
+                    ->GetTuple1(i);
+    int index2R = vtkDataArray::SafeDownCast(table->GetColumnByName("Index2_R"))
+                    ->GetTuple1(i);
+    int index1 = vtkDataArray::SafeDownCast(table->GetColumnByName("Index1"))
+                   ->GetTuple1(i);
+    int index2 = vtkDataArray::SafeDownCast(table->GetColumnByName("Index2"))
+                   ->GetTuple1(i);
+
+    coefs.push_back(std::make_tuple(alpha, index1R, index2R, index1, index2));
+    for(int j = index1 + 1; j < index2; ++j)
+      interpolatedTrees[j] = true;
+  }
+
+  int res = 0;
+  switch(dataTypeInt) {
+    vtkTemplateMacro(
+      res = run<VTK_TT>(outputVector, inputTrees, coefs, interpolatedTrees););
+  }
+  return res;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionDecoding::run(
+  vtkInformationVector *outputVector,
+  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<std::tuple<double, int, int, int, int>> &coefs,
+  std::vector<bool> &interpolatedTrees) {
+  if(not isDataVisualizationFilled())
+    runCompute<dataType>(inputTrees, coefs);
+  runOutput<dataType>(outputVector, inputTrees, coefs, interpolatedTrees);
+  return 1;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionDecoding::runCompute(
+  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<std::tuple<double, int, int, int, int>> &coefs) {
+  // ------------------------------------------------------------------------------------
+  // --- Construct trees
+  // ------------------------------------------------------------------------------------
+  printMsg("Construct trees", debug::Priority::VERBOSE);
+
+  const int numInputs = inputTrees.size();
+
+  setDataVisualization(numInputs);
+
+  std::vector<MergeTree<dataType>> intermediateMTrees(numInputs);
+  constructTrees<dataType>(
+    inputTrees, intermediateMTrees, treesNodes, treesArcs, treesSegmentation);
+
+  // ------------------------------------------------------------------------------------
+  // --- Call base
+  // ------------------------------------------------------------------------------------
+  printMsg("Call base", debug::Priority::VERBOSE);
+
+  std::vector<MergeTree<dataType>> allMT_T;
+
+  execute<dataType>(intermediateMTrees, coefs, allMT_T, allMatching);
+  treesNodeCorrMesh = getTreesNodeCorr();
+
+  for(size_t i = 0; i < allMT_T.size(); ++i) {
+    MergeTree<double> tree;
+    mergeTreeTemplateToDouble<dataType>(allMT_T[i], tree);
+    intermediateSTrees.push_back(tree);
+  }
+
+  return 1;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionDecoding::runOutput(
+  vtkInformationVector *outputVector,
+  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<std::tuple<double, int, int, int, int>> &coefs,
+  std::vector<bool> &interpolatedTrees) {
+  // ------------------------------------------------------------------------------------
+  // --- Create output
+  // ------------------------------------------------------------------------------------
+  auto output_sequence = vtkMultiBlockDataSet::GetData(outputVector, 0);
+  auto output_matchings = vtkMultiBlockDataSet::GetData(outputVector, 1);
+
+  // ------------------------------------------
+  // --- Trees
+  // -----------------------------------------
+  std::vector<vtkUnstructuredGrid *> treesNodesT;
+  std::vector<vtkUnstructuredGrid *> treesArcsT;
+  std::vector<vtkDataSet *> treesSegmentationT;
+  std::vector<std::vector<int>> treesNodeCorrMeshT;
+  std::vector<vtkMultiBlockDataSet *> inputTreesT;
+  int index = 0;
+  size_t cpt = 0;
+  while(cpt < coefs.size()) {
+    while(cpt < coefs.size() and std::get<2>(coefs[cpt]) <= index) {
+      treesNodesT.push_back(nullptr);
+      treesArcsT.push_back(nullptr);
+      treesSegmentationT.push_back(nullptr);
+      treesNodeCorrMeshT.push_back(std::vector<int>());
+      inputTreesT.push_back(nullptr);
+      ++cpt;
+    }
+    treesNodesT.push_back(treesNodes[index]);
+    treesArcsT.push_back(treesArcs[index]);
+    treesSegmentationT.push_back(treesSegmentation[index]);
+    treesNodeCorrMeshT.push_back(treesNodeCorrMesh[index]);
+    inputTreesT.push_back(inputTrees[index]);
+    ++index;
+  }
+  treesNodes.swap(treesNodesT);
+  treesArcs.swap(treesArcsT);
+  treesSegmentation.swap(treesSegmentationT);
+  treesNodeCorrMesh.swap(treesNodeCorrMeshT);
+  inputTrees.swap(inputTreesT);
+
+  std::vector<MergeTree<dataType>> intermediateMTrees;
+  mergeTreesDoubleToTemplate<dataType>(intermediateSTrees, intermediateMTrees);
+  std::vector<FTMTree_MT *> trees;
+  mergeTreeToFTMTree<dataType>(intermediateMTrees, trees);
+  output_sequence->SetNumberOfBlocks(intermediateMTrees.size());
+  double prevXMax = 0;
+  bool OutputSegmentation = false;
+  std::vector<std::vector<SimplexId>> nodeCorr(intermediateMTrees.size());
+  int cptInterpolatedTree = 0;
+  for(size_t i = 0; i < intermediateMTrees.size(); ++i) {
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock1
+      = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+
+    ttkMergeTreeVisualization visuMaker;
+    visuMaker.setPlanarLayout(PlanarLayout);
+    visuMaker.setBranchDecompositionPlanarLayout(
+      BranchDecompositionPlanarLayout);
+    visuMaker.setRescaleTreesIndividually(RescaleTreesIndividually);
+    visuMaker.setOutputSegmentation(OutputSegmentation);
+    visuMaker.setDimensionSpacing(DimensionSpacing);
+    visuMaker.setDimensionToShift(DimensionToShift);
+    visuMaker.setImportantPairs(ImportantPairs);
+    visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
+    visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
+    visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+    // visuMaker.setShiftMode(3); // Double Line
+    visuMaker.setShiftMode(2); // Line
+    visuMaker.setVtkOutputNode(vtkOutputNode1);
+    visuMaker.setVtkOutputArc(vtkOutputArc1);
+    visuMaker.setVtkOutputSegmentation(vtkOutputSegmentation1);
+    visuMaker.setTreesNodes(treesNodes);
+    visuMaker.setTreesNodeCorrMesh(treesNodeCorrMesh);
+    visuMaker.setTreesSegmentation(treesSegmentation);
+    visuMaker.setInterpolatedTrees(interpolatedTrees);
+    visuMaker.setPrintTreeId(i);
+    visuMaker.setPrintClusterId(0);
+    visuMaker.setPrevXMaxOffset(prevXMax);
+    visuMaker.setDebugLevel(this->debugLevel_);
+    visuMaker.makeTreesOutput<dataType>(trees);
+    prevXMax = visuMaker.getPrevXMax();
+    nodeCorr[i] = visuMaker.getNodeCorr()[i];
+
+    // Field data
+    if(inputTrees[i] != nullptr)
+      vtkBlock1->GetFieldData()->ShallowCopy(inputTrees[i]->GetFieldData());
+
+    // Construct multiblock
+    vtkBlock1->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
+    vtkBlock1->SetBlock(0, vtkOutputNode1);
+    vtkBlock1->SetBlock(1, vtkOutputArc1);
+    if(OutputSegmentation)
+      vtkBlock1->SetBlock(2, vtkOutputSegmentation1);
+
+    // Field data
+    if(interpolatedTrees[i]) {
+      // Distance previous key frame
+      vtkNew<vtkDoubleArray> vtkDistancePreviousKey{};
+      vtkDistancePreviousKey->SetName("DistancePreviousKeyFrame");
+      vtkDistancePreviousKey->SetNumberOfTuples(1);
+      vtkDistancePreviousKey->SetTuple1(
+        0, distancesToKeyFrames_[cptInterpolatedTree * 2]);
+      vtkBlock1->GetFieldData()->AddArray(vtkDistancePreviousKey);
+      // Distance next key frame
+      vtkNew<vtkDoubleArray> vtkDistanceNextKey{};
+      vtkDistanceNextKey->SetName("DistanceNextKeyFrame");
+      vtkDistanceNextKey->SetNumberOfTuples(1);
+      vtkDistanceNextKey->SetTuple1(
+        0, distancesToKeyFrames_[cptInterpolatedTree * 2 + 1]);
+      vtkBlock1->GetFieldData()->AddArray(vtkDistanceNextKey);
+      // Index previous key frame
+      vtkNew<vtkIntArray> vtkIndexPreviousKey{};
+      vtkIndexPreviousKey->SetName("IndexPreviousKeyFrame");
+      vtkIndexPreviousKey->SetNumberOfTuples(1);
+      vtkIndexPreviousKey->SetTuple1(
+        0, std::get<3>(coefs[cptInterpolatedTree]));
+      vtkBlock1->GetFieldData()->AddArray(vtkIndexPreviousKey);
+      // Index previous key frame
+      vtkNew<vtkIntArray> vtkIndexNextKey{};
+      vtkIndexNextKey->SetName("IndexNextKeyFrame");
+      vtkIndexNextKey->SetNumberOfTuples(1);
+      vtkIndexNextKey->SetTuple1(0, std::get<4>(coefs[cptInterpolatedTree]));
+      vtkBlock1->GetFieldData()->AddArray(vtkIndexNextKey);
+      // Increment interpolated tree counter
+      ++cptInterpolatedTree;
+    }
+
+    // Add to all multiblocks
+    output_sequence->SetBlock(i, vtkBlock1);
+  }
+
+  // -----------------------------------------
+  // --- Matching
+  // -----------------------------------------
+  output_matchings->SetNumberOfBlocks(intermediateMTrees.size() - 1);
+  for(size_t i = 0; i < intermediateMTrees.size() - 1; ++i) {
+    // Declare vtk objects
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputMatching
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1
+      = vtkUnstructuredGrid::SafeDownCast(
+        vtkMultiBlockDataSet::SafeDownCast(output_sequence->GetBlock(i))
+          ->GetBlock(0));
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode2
+      = vtkUnstructuredGrid::SafeDownCast(
+        vtkMultiBlockDataSet::SafeDownCast(output_sequence->GetBlock(i + 1))
+          ->GetBlock(0));
+    std::vector<std::vector<SimplexId>> nodeCorrTemp;
+    nodeCorrTemp.push_back(nodeCorr[i]);
+    nodeCorrTemp.push_back(nodeCorr[i + 1]);
+
+    // Fill vtk objects
+    ttkMergeTreeVisualization visuMakerMatching;
+    visuMakerMatching.setVtkOutputMatching(vtkOutputMatching);
+    visuMakerMatching.setOutputMatching(allMatching[i]);
+    visuMakerMatching.setVtkOutputNode1(vtkOutputNode2);
+    visuMakerMatching.setVtkOutputNode2(vtkOutputNode1);
+    visuMakerMatching.setNodeCorr1(nodeCorrTemp);
+    visuMakerMatching.setDebugLevel(this->debugLevel_);
+
+    visuMakerMatching.makeMatchingOutput<dataType>(trees[i], trees[i + 1]);
+
+    // Field data
+    vtkNew<vtkDoubleArray> vtkDistance{};
+    vtkDistance->SetName("Distance");
+    vtkDistance->SetNumberOfTuples(1);
+    vtkDistance->SetTuple1(0, finalDistances_[i]);
+    vtkOutputMatching->GetFieldData()->AddArray(vtkDistance);
+
+    // Construct multiblock
+    output_matchings->SetBlock(i, vtkOutputMatching);
+  }
+
+  // -----------------------------------------
+  treesNodes.swap(treesNodesT);
+  treesArcs.swap(treesArcsT);
+  treesSegmentation.swap(treesSegmentationT);
+  treesNodeCorrMesh.swap(treesNodeCorrMeshT);
+  inputTrees.swap(inputTreesT);
+
+  return 1;
+}

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -1,0 +1,205 @@
+/// \ingroup vtk
+/// \class ttkMergeTreeTemporalReductionDecoding
+/// \author Mathieu Pont (mathieu.pont@lip6.fr)
+/// \date 2021.
+///
+/// \brief TTK VTK-filter that wraps the ttk::MergeTreeTemporalReductionDecoding
+/// module.
+///
+/// This VTK filter uses the ttk::MergeTreeTemporalReductionDecoding module to
+/// compute the reconstruction of a reduced sequence of merge trees.
+///
+/// \param Input vtkMultiBlockDataSet Key frames.
+/// \param Input vtkTable Interpolation coefficients.
+/// \param Output vtkMultiBlockDataSet Input trees
+///
+/// See the corresponding standalone program for a usage example:
+///   - standalone/MergeTreeTemporalReductionDecoding/main.cpp
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::MergeTreeTemporalReductionDecoding
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkMergeTreeTemporalReductionDecodingModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+
+/* Note on including VTK modules
+ *
+ * Each VTK module that you include a header from needs to be specified in this
+ * module's vtk.module file, either in the DEPENDS or PRIVATE_DEPENDS (if the
+ * header is included in the cpp file only) sections.
+ *
+ * In order to find the corresponding module, check its location within the VTK
+ * source code. The VTK module name is composed of the path to the header. You
+ * can also find the module name within the vtk.module file located in the same
+ * directory as the header file.
+ *
+ * For example, vtkSphereSource.h is located in directory VTK/Filters/Sources/,
+ * so its corresponding VTK module is called VTK::FiltersSources. In this case,
+ * the vtk.module file would need to be extended to
+ *
+ * NAME
+ *   ttkMergeTreeTemporalReductionDecoding
+ * DEPENDS
+ *   ttkAlgorithm
+ *   VTK::FiltersSources
+ */
+
+// TTK Base Includes
+#include <MergeTreeTemporalReductionDecoding.h>
+
+// VTK Includes
+#include <vtkMultiBlockDataSet.h>
+#include <vtkUnstructuredGrid.h>
+
+class TTKMERGETREETEMPORALREDUCTIONDECODING_EXPORT
+  ttkMergeTreeTemporalReductionDecoding
+  : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
+  ,
+    protected ttk::MergeTreeTemporalReductionDecoding // and we inherit from the
+                                                      // base class
+{
+private:
+  // Output options
+  bool OutputTrees = true;
+  bool PlanarLayout = false;
+  bool BranchDecompositionPlanarLayout = false;
+  double BranchSpacing = 1.;
+  bool RescaleTreesIndividually = false;
+  double DimensionSpacing = 1.;
+  int DimensionToShift = 0;
+  double ImportantPairs = 50.;
+  double ImportantPairsSpacing = 1.;
+  double NonImportantPairsSpacing = 1.;
+  double NonImportantPairsProximity = 0.05;
+
+  // ----------------------
+  // Data for visualization
+  // ----------------------
+  // Trees
+  std::vector<vtkUnstructuredGrid *> treesNodes;
+  std::vector<vtkUnstructuredGrid *> treesArcs;
+  std::vector<vtkDataSet *> treesSegmentation;
+  // Output
+  std::vector<std::vector<int>> treesNodeCorrMesh;
+  std::vector<MergeTree<double>> intermediateSTrees;
+  std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+    allMatching;
+
+  void setDataVisualization(int numInputs) {
+    // Trees
+    treesNodes = std::vector<vtkUnstructuredGrid *>(numInputs);
+    treesArcs = std::vector<vtkUnstructuredGrid *>(numInputs);
+    treesSegmentation = std::vector<vtkDataSet *>(numInputs);
+  }
+
+  void resetDataVisualization() {
+    setDataVisualization(0);
+    treesNodeCorrMesh = std::vector<std::vector<int>>();
+    intermediateSTrees = std::vector<MergeTree<double>>();
+    allMatching = std::vector<
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>();
+  }
+
+  bool isDataVisualizationFilled() {
+    return treesNodeCorrMesh.size() != 0 and intermediateSTrees.size() != 0
+           and allMatching.size() != 0;
+  }
+
+public:
+  /**
+   * Automatically generate getters and setters of filter
+   * parameters via vtkMacros.
+   */
+  // Output Options
+  vtkSetMacro(OutputTrees, bool);
+  vtkGetMacro(OutputTrees, bool);
+
+  vtkSetMacro(PlanarLayout, bool);
+  vtkGetMacro(PlanarLayout, bool);
+
+  vtkSetMacro(BranchDecompositionPlanarLayout, bool);
+  vtkGetMacro(BranchDecompositionPlanarLayout, bool);
+
+  vtkSetMacro(BranchSpacing, double);
+  vtkGetMacro(BranchSpacing, double);
+
+  vtkSetMacro(RescaleTreesIndividually, bool);
+  vtkGetMacro(RescaleTreesIndividually, bool);
+
+  vtkSetMacro(DimensionSpacing, double);
+  vtkGetMacro(DimensionSpacing, double);
+
+  vtkSetMacro(DimensionToShift, int);
+  vtkGetMacro(DimensionToShift, int);
+
+  vtkSetMacro(ImportantPairs, double);
+  vtkGetMacro(ImportantPairs, double);
+
+  vtkSetMacro(ImportantPairsSpacing, double);
+  vtkGetMacro(ImportantPairsSpacing, double);
+
+  vtkSetMacro(NonImportantPairsSpacing, double);
+  vtkGetMacro(NonImportantPairsSpacing, double);
+
+  vtkSetMacro(NonImportantPairsProximity, double);
+  vtkGetMacro(NonImportantPairsProximity, double);
+
+  /**
+   * This static method and the macro below are VTK conventions on how to
+   * instantiate VTK objects. You don't have to modify this.
+   */
+  static ttkMergeTreeTemporalReductionDecoding *New();
+  vtkTypeMacro(ttkMergeTreeTemporalReductionDecoding, ttkAlgorithm);
+
+protected:
+  /**
+   * Implement the filter constructor and destructor
+   * (see cpp file)
+   */
+  ttkMergeTreeTemporalReductionDecoding();
+  ~ttkMergeTreeTemporalReductionDecoding() override;
+
+  /**
+   * Specify the input data type of each input port
+   * (see cpp file)
+   */
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Specify the data object type of each output port
+   * (see cpp file)
+   */
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Pass VTK data to the base code and convert base code output to VTK
+   * (see cpp file)
+   */
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+  template <class dataType>
+  int run(vtkInformationVector *outputVector,
+          std::vector<vtkMultiBlockDataSet *> &inputTrees,
+          std::vector<std::tuple<double, int, int, int, int>> &coefs,
+          std::vector<bool> &interpolatedTrees);
+
+  template <class dataType>
+  int runCompute(std::vector<vtkMultiBlockDataSet *> &inputTrees,
+                 std::vector<std::tuple<double, int, int, int, int>> &coefs);
+
+  template <class dataType>
+  int runOutput(vtkInformationVector *outputVector,
+                std::vector<vtkMultiBlockDataSet *> &inputTrees,
+                std::vector<std::tuple<double, int, int, int, int>> &coefs,
+                std::vector<bool> &interpolatedTrees);
+};

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -21,6 +21,12 @@
 ///
 /// \sa ttk::MergeTreeTemporalReductionDecoding
 /// \sa ttkAlgorithm
+///
+/// \b Related \b publication \n
+/// "Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+/// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+/// Proc. of IEEE VIS 2021.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2021
 
 #pragma once
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/vtk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkMergeTreeTemporalReductionDecoding
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/CMakeLists.txt
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttk.module
@@ -8,6 +8,4 @@ HEADERS
 DEPENDS
   mergeTreeTemporalReductionEncoding
   ttkAlgorithm
-  ttkFTMTree
   ttkPlanarGraphLayout
-  dimensionReduction

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttk.module
@@ -1,0 +1,13 @@
+NAME
+  ttkMergeTreeTemporalReductionEncoding
+SOURCES
+  ttkMergeTreeTemporalReductionEncoding.cpp
+HEADERS
+  ttkMergeTreeTemporalReductionEncoding.h
+  ttkMergeTreeTemporalReductionUtils.h
+DEPENDS
+  mergeTreeTemporalReductionEncoding
+  ttkAlgorithm
+  ttkFTMTree
+  ttkPlanarGraphLayout
+  dimensionReduction

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -1,0 +1,378 @@
+#include <ttkMergeTreeTemporalReductionEncoding.h>
+
+#include <ttkFTMTreeUtils.h>
+#include <ttkMergeTreeVisualization.h>
+
+#include <vtkInformation.h>
+
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkImageData.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkResampleToImage.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+// A VTK macro that enables the instantiation of this class via ::New()
+// You do not have to modify this
+vtkStandardNewMacro(ttkMergeTreeTemporalReductionEncoding);
+
+/**
+ * The constructor has to specify the number of input and output ports
+ * with the functions SetNumberOfInputPorts and SetNumberOfOutputPorts,
+ * respectively. It should also set default values for all filter
+ * parameters.
+ *
+ * The destructor is usually empty unless you want to manage memory
+ * explicitly, by for example allocating memory on the heap that needs
+ * to be freed when the filter is destroyed.
+ */
+ttkMergeTreeTemporalReductionEncoding::ttkMergeTreeTemporalReductionEncoding() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(2);
+}
+
+ttkMergeTreeTemporalReductionEncoding::
+  ~ttkMergeTreeTemporalReductionEncoding() {
+}
+
+/**
+ * This method specifies the required input object data types of the
+ * filter by adding the vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE() key to
+ * the port information.
+ */
+int ttkMergeTreeTemporalReductionEncoding::FillInputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * This method specifies in the port information object the data type of the
+ * corresponding output objects. It is possible to either explicitly
+ * specify a type by adding a vtkDataObject::DATA_TYPE_NAME() key:
+ *
+ *      info->Set( vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid" );
+ *
+ * or to pass a type of an input port to an output port by adding the
+ * ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT() key (see below).
+ *
+ * Note: prior to the execution of the RequestData method the pipeline will
+ * initialize empty output data objects based on this information.
+ */
+int ttkMergeTreeTemporalReductionEncoding::FillOutputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkMultiBlockDataSet");
+  } else if(port == 1) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
+  } else
+    return 0;
+  return 1;
+}
+
+/**
+ * This method is called during the pipeline execution to update the
+ * already initialized output data objects based on the given input
+ * data objects and filter parameters.
+ *
+ * Note:
+ *     1) The passed input data objects are validated based on the information
+ *        provided by the FillInputPortInformation method.
+ *     2) The output objects are already initialized based on the information
+ *        provided by the FillOutputPortInformation method.
+ */
+int ttkMergeTreeTemporalReductionEncoding::RequestData(
+  vtkInformation *ttkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector) {
+  // ------------------------------------------------------------------------------------
+  // --- Get input object from input vector
+  // ------------------------------------------------------------------------------------
+  printMsg("Get input object from input vector", debug::Priority::VERBOSE);
+  auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+
+  // ------------------------------------------------------------------------------------
+  // --- Load blocks
+  // ------------------------------------------------------------------------------------
+  printMsg("Load blocks", debug::Priority::VERBOSE);
+  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  loadBlocks(inputTrees, blocks);
+  printMsg("Load blocks done.", debug::Priority::VERBOSE);
+  int dataTypeInt
+    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
+        ->GetPointData()
+        ->GetArray("Scalar")
+        ->GetDataType();
+
+  // If we have already computed once but the input has changed
+  if(treesNodes.size() != 0 and inputTrees[0]->GetBlock(0) != treesNodes[0])
+    resetDataVisualization();
+
+  // Run
+  int res = 0;
+  switch(dataTypeInt) {
+    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees););
+  }
+  return res;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionEncoding::run(
+  vtkInformationVector *outputVector,
+  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  if(not isDataVisualizationFilled())
+    runCompute<dataType>(inputTrees);
+  runOutput<dataType>(outputVector, inputTrees);
+  return 1;
+}
+
+std::vector<vtkSmartPointer<vtkDataSet>>
+  preprocessSegmentation(std::vector<vtkDataSet *> &treesSegmentation,
+                         bool doResampleToImage = false) {
+  std::vector<vtkSmartPointer<vtkDataSet>> images;
+  for(unsigned int i = 0; i < treesSegmentation.size(); ++i) {
+    if(doResampleToImage) {
+      auto seg = treesSegmentation[i];
+      // auto gridSeg = vtkUnstructuredGrid::SafeDownCast(seg);
+      auto resampleFilter = vtkSmartPointer<vtkResampleToImage>::New();
+      resampleFilter->SetInputDataObject(seg);
+      resampleFilter->SetUseInputBounds(true);
+      // resampleFilter->SetSamplingDimensions(100, 100, 100);
+      resampleFilter->Update();
+      auto resampleFilterOut = resampleFilter->GetOutput();
+      // images.push_back(resampleFilterOut);
+      vtkSmartPointer<vtkDataSet> image = vtkSmartPointer<vtkImageData>::New();
+      image->DeepCopy(resampleFilterOut);
+      images.push_back(image);
+    } else {
+      vtkSmartPointer<vtkDataSet> image;
+      image.TakeReference(treesSegmentation[i]);
+      images.push_back(image);
+    }
+  }
+  return images;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionEncoding::runCompute(
+  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  // ------------------------------------------------------------------------------------
+  // --- Construct trees
+  // ------------------------------------------------------------------------------------
+  printMsg("Construct trees", debug::Priority::VERBOSE);
+
+  const int numInputs = inputTrees.size();
+
+  setDataVisualization(numInputs);
+
+  std::vector<MergeTree<dataType>> intermediateMTrees(numInputs);
+  constructTrees<dataType>(
+    inputTrees, intermediateMTrees, treesNodes, treesArcs, treesSegmentation);
+
+  // L2 distance preprocessing
+  if(useL2Distance_) {
+    auto images = preprocessSegmentation(treesSegmentation, DoResampleToImage);
+    fieldL2_ = std::vector<std::vector<double>>(images.size());
+    for(size_t i = 0; i < images.size(); ++i) {
+      auto array = images[i]->GetPointData()->GetArray("Scalars");
+      for(vtkIdType j = 0; j < array->GetNumberOfTuples(); ++j)
+        fieldL2_[i].push_back(static_cast<double>(array->GetTuple1(j)));
+    }
+  }
+
+  // Load time variable if needed
+  timeVariable_.clear();
+  if(useCustomTimeVariable_) {
+    timeVariable_ = std::vector<double>(inputTrees.size());
+    for(size_t i = 0; i < inputTrees.size(); ++i) {
+      for(int j = 0; j < 3; ++j) {
+        if(j != 2 or inputTrees[i]->GetNumberOfBlocks() > 2) {
+          auto array = inputTrees[i]->GetBlock(j)->GetFieldData()->GetArray(
+            TimeVariableName.c_str());
+          if(array) {
+            timeVariable_[i] = array->GetTuple1(0);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------------------------
+  // --- Call base
+  // ------------------------------------------------------------------------------------
+  printMsg("Call base", debug::Priority::VERBOSE);
+
+  std::vector<MergeTree<dataType>> allMT_T;
+
+  removed = execute<dataType>(intermediateMTrees, emptyTreeDistances, allMT_T);
+  treesNodeCorrMesh = getTreesNodeCorr();
+
+  int indexRemoved = 0;
+  for(size_t i = 0; i < intermediateMTrees.size(); ++i) {
+    if((int)i != removed[indexRemoved]) {
+      MergeTree<double> keyFrame;
+      mergeTreeTemplateToDouble<dataType>(intermediateMTrees[i], keyFrame);
+      keyFrames.push_back(keyFrame);
+    } else
+      ++indexRemoved;
+  }
+
+  return 1;
+}
+
+template <class dataType>
+int ttkMergeTreeTemporalReductionEncoding::runOutput(
+  vtkInformationVector *outputVector,
+  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  // ------------------------------------------------------------------------------------
+  // --- Create output
+  // ------------------------------------------------------------------------------------
+  auto output_keyFrames = vtkMultiBlockDataSet::GetData(outputVector, 0);
+  auto output_table = vtkTable::GetData(outputVector, 1);
+
+  // ------------------------------------------
+  // --- Trees output
+  // -----------------------------------------
+  std::vector<int> keyFramesIndex;
+  int indexRemoved = 0;
+  for(size_t i = 0; i < inputTrees.size(); ++i)
+    if((int)i != removed[indexRemoved]) {
+      keyFramesIndex.push_back(i);
+    } else
+      ++indexRemoved;
+
+  std::vector<vtkUnstructuredGrid *> treesNodesT;
+  std::vector<vtkUnstructuredGrid *> treesArcsT;
+  std::vector<vtkDataSet *> treesSegmentationT;
+  std::vector<std::vector<int>> treesNodeCorrMeshT;
+  std::vector<vtkMultiBlockDataSet *> inputTreesT;
+  for(size_t i = 0; i < keyFramesIndex.size(); ++i) {
+    treesNodesT.push_back(treesNodes[keyFramesIndex[i]]);
+    treesArcsT.push_back(treesArcs[keyFramesIndex[i]]);
+    treesSegmentationT.push_back(treesSegmentation[keyFramesIndex[i]]);
+    treesNodeCorrMeshT.push_back(treesNodeCorrMesh[keyFramesIndex[i]]);
+    inputTreesT.push_back(inputTrees[keyFramesIndex[i]]);
+  }
+  treesNodes.swap(treesNodesT);
+  treesArcs.swap(treesArcsT);
+  treesSegmentation.swap(treesSegmentationT);
+  treesNodeCorrMesh.swap(treesNodeCorrMeshT);
+  inputTrees.swap(inputTreesT);
+
+  std::vector<MergeTree<dataType>> keyFramesT;
+  mergeTreesDoubleToTemplate<dataType>(keyFrames, keyFramesT);
+  std::vector<FTMTree_MT *> keyFramesTree;
+  mergeTreeToFTMTree<dataType>(keyFramesT, keyFramesTree);
+  output_keyFrames->SetNumberOfBlocks(keyFramesT.size());
+  double prevXMax = 0;
+  for(size_t i = 0; i < keyFramesT.size(); ++i) {
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation1
+      = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock1
+      = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+
+    ttkMergeTreeVisualization visuMaker;
+    visuMaker.setPlanarLayout(PlanarLayout);
+    visuMaker.setBranchDecompositionPlanarLayout(
+      BranchDecompositionPlanarLayout);
+    visuMaker.setRescaleTreesIndividually(RescaleTreesIndividually);
+    visuMaker.setOutputSegmentation(OutputSegmentation);
+    visuMaker.setDimensionSpacing(DimensionSpacing);
+    visuMaker.setDimensionToShift(DimensionToShift);
+    visuMaker.setImportantPairs(ImportantPairs);
+    visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
+    visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
+    visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+    // visuMaker.setShiftMode(3); // Double Line
+    visuMaker.setShiftMode(2); // Line
+    visuMaker.setVtkOutputNode(vtkOutputNode1);
+    visuMaker.setVtkOutputArc(vtkOutputArc1);
+    visuMaker.setVtkOutputSegmentation(vtkOutputSegmentation1);
+    visuMaker.setTreesNodes(treesNodes);
+    visuMaker.setTreesNodeCorrMesh(treesNodeCorrMesh);
+    visuMaker.setTreesSegmentation(treesSegmentation);
+    // visuMaker.setInterpolatedTrees(interpolatedTrees);
+    visuMaker.setPrintTreeId(i);
+    visuMaker.setPrintClusterId(0);
+    visuMaker.setPrevXMaxOffset(prevXMax);
+    visuMaker.setDebugLevel(this->debugLevel_);
+    visuMaker.makeTreesOutput<dataType>(keyFramesTree);
+    prevXMax = visuMaker.getPrevXMax();
+
+    // Field data
+    vtkBlock1->GetFieldData()->ShallowCopy(inputTrees[i]->GetFieldData());
+
+    // Construct multiblock
+    vtkBlock1->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
+    vtkBlock1->SetBlock(0, vtkOutputNode1);
+    vtkBlock1->SetBlock(1, vtkOutputArc1);
+    if(OutputSegmentation)
+      vtkBlock1->SetBlock(2, vtkOutputSegmentation1);
+
+    output_keyFrames->SetBlock(i, vtkBlock1);
+  }
+
+  // ------------------------------------------
+  // --- Table
+  // ------------------------------------------
+  vtkNew<vtkIntArray> treeIds{};
+  treeIds->SetName("treeID");
+  treeIds->SetNumberOfTuples(removed.size());
+  vtkNew<vtkDoubleArray> coef{};
+  coef->SetName("Alpha");
+  coef->SetNumberOfTuples(removed.size());
+  vtkNew<vtkIntArray> index1Id{};
+  index1Id->SetName("Index1");
+  index1Id->SetNumberOfTuples(removed.size());
+  vtkNew<vtkIntArray> index2Id{};
+  index2Id->SetName("Index2");
+  index2Id->SetNumberOfTuples(removed.size());
+  vtkNew<vtkIntArray> index1IdR{};
+  index1IdR->SetName("Index1_R");
+  index1IdR->SetNumberOfTuples(removed.size());
+  vtkNew<vtkIntArray> index2IdR{};
+  index2IdR->SetName("Index2_R");
+  index2IdR->SetNumberOfTuples(removed.size());
+  int keyFrameCpt = 0;
+  for(size_t i = 0; i < removed.size(); ++i) {
+    while(removed[i] > keyFramesIndex[keyFrameCpt])
+      ++keyFrameCpt;
+    int index1 = keyFramesIndex[keyFrameCpt - 1];
+    int index2 = keyFramesIndex[keyFrameCpt];
+    double alpha = computeAlpha(index1, removed[i], index2);
+    coef->SetTuple1(i, alpha);
+    index1Id->SetTuple1(i, index1);
+    index2Id->SetTuple1(i, index2);
+    treeIds->SetTuple1(i, removed[i]);
+    index1IdR->SetTuple1(i, keyFrameCpt - 1);
+    index2IdR->SetTuple1(i, keyFrameCpt);
+  }
+  output_table->AddColumn(treeIds);
+  output_table->AddColumn(coef);
+  output_table->AddColumn(index1Id);
+  output_table->AddColumn(index2Id);
+  output_table->AddColumn(index1IdR);
+  output_table->AddColumn(index2IdR);
+
+  // ------------------------------------------
+  treesNodes.swap(treesNodesT);
+  treesArcs.swap(treesArcsT);
+  treesSegmentation.swap(treesSegmentationT);
+  treesNodeCorrMesh.swap(treesNodeCorrMeshT);
+  inputTrees.swap(inputTreesT);
+
+  return 1;
+}

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -70,8 +70,6 @@ private:
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
 
-  bool TemporalSubsamplingMDS = false;
-
   // ----------------------
   // Data for visualization
   // ----------------------

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -21,6 +21,12 @@
 ///
 /// \sa ttk::MergeTreeTemporalReductionEncoding
 /// \sa ttkAlgorithm
+///
+/// \b Related \b publication \n
+/// "Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+/// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+/// Proc. of IEEE VIS 2021.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2021
 
 #pragma once
 

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -1,0 +1,302 @@
+/// \ingroup vtk
+/// \class ttkMergeTreeTemporalReductionEncoding
+/// \author Mathieu Pont (mathieu.pont@lip6.fr)
+/// \date 2021.
+///
+/// \brief TTK VTK-filter that wraps the ttk::MergeTreeTemporalReductionEncoding
+/// module.
+///
+/// This VTK filter uses the ttk::MergeTreeTemporalReductionEncoding module to
+/// compute a temporal reduction of a sequence of merge trees.
+///
+/// \param Input vtkMultiBlockDataSet Input trees
+/// \param Output vtkMultiBlockDataSet Key frames.
+/// \param Output vtkTable Interpolation coefficients.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::MergeTreeTemporalReductionEncoding
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkMergeTreeTemporalReductionEncodingModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkUnstructuredGrid.h>
+
+// TTK Base Includes
+#include <MergeTreeTemporalReductionEncoding.h>
+
+class TTKMERGETREETEMPORALREDUCTIONENCODING_EXPORT
+  ttkMergeTreeTemporalReductionEncoding
+  : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
+  ,
+    protected ttk::MergeTreeTemporalReductionEncoding // and we inherit from the
+                                                      // base class
+{
+private:
+  // Execution options
+  std::string TimeVariableName{""};
+
+  // Input Options
+  bool DoResampleToImage = false;
+
+  // Output options
+  double DistanceAxisStretch = 1.;
+  bool OutputTrees = true;
+  bool OutputSegmentation = false;
+  bool PlanarLayout = false;
+  bool BranchDecompositionPlanarLayout = false;
+  double BranchSpacing = 1.;
+  bool RescaleTreesIndividually = false;
+  double DimensionSpacing = 1.;
+  int DimensionToShift = 0;
+  double ImportantPairs = 50.;
+  double ImportantPairsSpacing = 1.;
+  double NonImportantPairsSpacing = 1.;
+  double NonImportantPairsProximity = 0.05;
+
+  bool TemporalSubsamplingMDS = false;
+
+  // ----------------------
+  // Data for visualization
+  // ----------------------
+  // Trees
+  std::vector<vtkUnstructuredGrid *> treesNodes;
+  std::vector<vtkUnstructuredGrid *> treesArcs;
+  std::vector<vtkDataSet *> treesSegmentation;
+  // Output
+  std::vector<std::vector<int>> treesNodeCorrMesh;
+  std::vector<double> emptyTreeDistances;
+  std::vector<MergeTree<double>> keyFrames;
+  std::vector<int> removed;
+
+  void setDataVisualization(int numInputs) {
+    // Trees
+    treesNodes = std::vector<vtkUnstructuredGrid *>(numInputs);
+    treesArcs = std::vector<vtkUnstructuredGrid *>(numInputs);
+    treesSegmentation = std::vector<vtkDataSet *>(numInputs);
+  }
+
+  void resetDataVisualization() {
+    setDataVisualization(0);
+    treesNodeCorrMesh = std::vector<std::vector<int>>();
+    emptyTreeDistances = std::vector<double>();
+    keyFrames = std::vector<MergeTree<double>>();
+    removed = std::vector<int>();
+  }
+
+  bool isDataVisualizationFilled() {
+    return treesNodeCorrMesh.size() != 0 and keyFrames.size() != 0
+           and emptyTreeDistances.size() != 0 and removed.size() != 0;
+  }
+
+public:
+  /**
+   * Automatically generate getters and setters of filter
+   * parameters via vtkMacros.
+   */
+  // Input Options
+  void SetEpsilon1UseFarthestSaddle(bool epsilon1UseFarthestSaddle) {
+    epsilon1UseFarthestSaddle_ = epsilon1UseFarthestSaddle;
+    Modified();
+    resetDataVisualization();
+  }
+  bool GetEpsilon1UseFarthestSaddle() {
+    return epsilon1UseFarthestSaddle_;
+  }
+
+  void SetEpsilonTree1(double epsilonTree1) {
+    epsilonTree1_ = epsilonTree1;
+    Modified();
+    resetDataVisualization();
+  }
+  double SetEpsilonTree1() {
+    return epsilonTree1_;
+  }
+
+  void SetEpsilon2Tree1(double epsilon2Tree1) {
+    epsilon2Tree1_ = epsilon2Tree1;
+    Modified();
+    resetDataVisualization();
+  }
+  double SetEpsilon2Tree1() {
+    return epsilon2Tree1_;
+  }
+
+  void SetEpsilon3Tree1(double epsilon3Tree1) {
+    epsilon3Tree1_ = epsilon3Tree1;
+    Modified();
+    resetDataVisualization();
+  }
+  double SetEpsilon3Tree1() {
+    return epsilon3Tree1_;
+  }
+
+  void SetPersistenceThreshold(double persistenceThreshold) {
+    persistenceThreshold_ = persistenceThreshold;
+    Modified();
+    resetDataVisualization();
+  }
+  double SetPersistenceThreshold() {
+    return persistenceThreshold_;
+  }
+
+  void SetUseMinMaxPair(bool useMinMaxPair) {
+    useMinMaxPair_ = useMinMaxPair;
+    Modified();
+    resetDataVisualization();
+  }
+  bool SetUseMinMaxPair() {
+    return useMinMaxPair_;
+  }
+
+  void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
+    deleteMultiPersPairs_ = deleteMultiPersPairs;
+    Modified();
+    resetDataVisualization();
+  }
+  bool SetDeleteMultiPersPairs() {
+    return deleteMultiPersPairs_;
+  }
+
+  // Execution Options
+  void SetAssignmentSolver(int assignmentSolver) {
+    assignmentSolverID_ = assignmentSolver;
+    Modified();
+    resetDataVisualization();
+  }
+  int GetAssignmentSolver() {
+    return assignmentSolverID_;
+  }
+
+  void SetRemovalPercentage(double removePerc) {
+    removalPercentage_ = removePerc;
+    Modified();
+    resetDataVisualization();
+  }
+  double GetRemovalPercentage() {
+    return removalPercentage_;
+  }
+
+  void SetUseL2Distance(double useL2) {
+    useL2Distance_ = useL2;
+    Modified();
+    resetDataVisualization();
+  }
+  double GetUseL2Distance() {
+    return useL2Distance_;
+  }
+
+  void SetUseCustomTimeVariable(bool useCustomTime) {
+    useCustomTimeVariable_ = useCustomTime;
+    Modified();
+    resetDataVisualization();
+  }
+  bool GetUseCustomTimeVariable() {
+    return useCustomTimeVariable_;
+  }
+
+  void SetTimeVariableName(
+    int idx, int port, int connection, int fieldAssociation, const char *name) {
+    SetInputArrayToProcess(idx, port, connection, fieldAssociation, name);
+    TimeVariableName = std::string(name);
+    Modified();
+    resetDataVisualization();
+  }
+  vtkGetMacro(TimeVariableName, std::string);
+
+  // Output Options
+  vtkSetMacro(OutputTrees, bool);
+  vtkGetMacro(OutputTrees, bool);
+
+  vtkSetMacro(OutputSegmentation, bool);
+  vtkGetMacro(OutputSegmentation, bool);
+
+  vtkSetMacro(PlanarLayout, bool);
+  vtkGetMacro(PlanarLayout, bool);
+
+  vtkSetMacro(BranchDecompositionPlanarLayout, bool);
+  vtkGetMacro(BranchDecompositionPlanarLayout, bool);
+
+  vtkSetMacro(BranchSpacing, double);
+  vtkGetMacro(BranchSpacing, double);
+
+  vtkSetMacro(RescaleTreesIndividually, bool);
+  vtkGetMacro(RescaleTreesIndividually, bool);
+
+  vtkSetMacro(DimensionSpacing, double);
+  vtkGetMacro(DimensionSpacing, double);
+
+  vtkSetMacro(DimensionToShift, int);
+  vtkGetMacro(DimensionToShift, int);
+
+  vtkSetMacro(ImportantPairs, double);
+  vtkGetMacro(ImportantPairs, double);
+
+  vtkSetMacro(ImportantPairsSpacing, double);
+  vtkGetMacro(ImportantPairsSpacing, double);
+
+  vtkSetMacro(NonImportantPairsSpacing, double);
+  vtkGetMacro(NonImportantPairsSpacing, double);
+
+  vtkSetMacro(NonImportantPairsProximity, double);
+  vtkGetMacro(NonImportantPairsProximity, double);
+
+  vtkSetMacro(DistanceAxisStretch, double);
+  vtkGetMacro(DistanceAxisStretch, double);
+
+  /**
+   * This static method and the macro below are VTK conventions on how to
+   * instantiate VTK objects. You don't have to modify this.
+   */
+  static ttkMergeTreeTemporalReductionEncoding *New();
+  vtkTypeMacro(ttkMergeTreeTemporalReductionEncoding, ttkAlgorithm);
+
+protected:
+  /**
+   * Implement the filter constructor and destructor
+   * (see cpp file)
+   */
+  ttkMergeTreeTemporalReductionEncoding();
+  ~ttkMergeTreeTemporalReductionEncoding() override;
+
+  /**
+   * Specify the input data type of each input port
+   * (see cpp file)
+   */
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Specify the data object type of each output port
+   * (see cpp file)
+   */
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Pass VTK data to the base code and convert base code output to VTK
+   * (see cpp file)
+   */
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+  template <class dataType>
+  int run(vtkInformationVector *outputVector,
+          std::vector<vtkMultiBlockDataSet *> &inputTrees);
+
+  template <class dataType>
+  int runCompute(std::vector<vtkMultiBlockDataSet *> &inputTrees);
+
+  template <class dataType>
+  int runOutput(vtkInformationVector *outputVector,
+                std::vector<vtkMultiBlockDataSet *> &inputTrees);
+};

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
@@ -1,37 +1,23 @@
 /// \ingroup base
 /// \class vtk::ttkMergeTreeTemporalReductionUtils
 /// \author Mathieu Pont (mathieu.pont@lip6.fr)
+/// \date 2021.
 ///
 
 #ifndef _TTKMERGETREETEMPORALREDUCTIONUTILS_H
 #define _TTKMERGETREETEMPORALREDUCTIONUTILS_H
 
-//#include <ttkUtils.h>
-#include <FTMStructures.h>
-#include <FTMTree.h>
 #include <FTMTreeUtils.h>
 
-#include <vtkCellType.h>
-
-#include <vtkAppendFilter.h>
-#include <vtkCellArray.h>
-#include <vtkCellData.h>
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkFloatArray.h>
-#include <vtkIntArray.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
-
-//#include <ttkMacros.h>
-#include <DimensionReduction.h>
+#include <vtkPointData.h>
+#include <vtkCellData.h>
 
 using namespace ttk;
 using namespace ftm;
 
 // -------------------------------------------------------------------------------------
-// Temporal Subsampling MDS
+// Temporal Subsampling
 // -------------------------------------------------------------------------------------
 template <class dataType>
 void makeTemporalSubsamplingOutput(
@@ -195,45 +181,6 @@ void makeTemporalSubsamplingOutput(
   vtkArcs->GetCellData()->AddArray(pathId);
   vtkArcs->GetCellData()->AddArray(arcId);
   vtkOutputArc1->ShallowCopy(vtkArcs);
-}
-
-template <class dataType>
-void makeTemporalSubsamplingMDSOutput(
-  std::vector<MergeTree<dataType>> &intermediateMTrees,
-  std::vector<std::vector<double>> &distanceMatrix,
-  std::vector<MergeTree<dataType>> &allMT,
-  std::vector<int> removed,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
-  bool metricMDS) {
-  // Call DimensionReduction filter
-  std::vector<std::vector<double>> embedding{};
-  std::vector<double> inputData;
-  for(int i = 0; i < (int)distanceMatrix.size(); ++i)
-    for(int j = 0; j < (int)distanceMatrix.size(); ++j)
-      inputData.push_back(distanceMatrix[i][j]);
-
-  DimensionReduction dimensionReduction;
-  dimensionReduction.setInputModulePath("default");
-  dimensionReduction.setInputModuleName("dimensionReduction");
-  dimensionReduction.setInputFunctionName("doIt");
-  dimensionReduction.setInputMatrixDimensions(
-    distanceMatrix.size(), distanceMatrix.size());
-  dimensionReduction.setInputMatrix(inputData.data());
-  dimensionReduction.setInputMethod(2);
-  dimensionReduction.setInputNumberOfComponents(2);
-  dimensionReduction.setInputNumberOfNeighbors(5);
-  dimensionReduction.setInputIsDeterministic(false);
-  // mds_Metric, mds_Init, mds_MaxIteration, mds_Verbose, mds_Epsilon,
-  // InputIsADistanceMatrix
-  dimensionReduction.setMDSParameters(metricMDS, 4, 300, 0, 0.001, true);
-  dimensionReduction.setOutputComponents(&embedding);
-  int errorCode = dimensionReduction.execute();
-
-  // Create output
-  makeTemporalSubsamplingOutput<dataType>(intermediateMTrees, embedding, allMT,
-                                          removed, vtkOutputNode1,
-                                          vtkOutputArc1);
 }
 
 template <class dataType>

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
@@ -9,9 +9,9 @@
 
 #include <FTMTreeUtils.h>
 
-#include <vtkUnstructuredGrid.h>
-#include <vtkPointData.h>
 #include <vtkCellData.h>
+#include <vtkPointData.h>
+#include <vtkUnstructuredGrid.h>
 
 using namespace ttk;
 using namespace ftm;

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
@@ -1,0 +1,266 @@
+/// \ingroup base
+/// \class vtk::ttkMergeTreeTemporalReductionUtils
+/// \author Mathieu Pont (mathieu.pont@lip6.fr)
+///
+
+#ifndef _TTKMERGETREETEMPORALREDUCTIONUTILS_H
+#define _TTKMERGETREETEMPORALREDUCTIONUTILS_H
+
+//#include <ttkUtils.h>
+#include <FTMStructures.h>
+#include <FTMTree.h>
+#include <FTMTreeUtils.h>
+
+#include <vtkCellType.h>
+
+#include <vtkAppendFilter.h>
+#include <vtkCellArray.h>
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkFloatArray.h>
+#include <vtkIntArray.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
+
+//#include <ttkMacros.h>
+#include <DimensionReduction.h>
+
+using namespace ttk;
+using namespace ftm;
+
+// -------------------------------------------------------------------------------------
+// Temporal Subsampling MDS
+// -------------------------------------------------------------------------------------
+template <class dataType>
+void makeTemporalSubsamplingOutput(
+  std::vector<MergeTree<dataType>> &intermediateMTrees,
+  std::vector<std::vector<double>> &embedding,
+  std::vector<MergeTree<dataType>> &allMT,
+  std::vector<int> removed,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
+  bool displayRemoved = false) {
+  auto fullSize = intermediateMTrees.size() + removed.size();
+  std::vector<SimplexId> nodeSimplexId(fullSize);
+  vtkNew<vtkIntArray> treeId{};
+  treeId->SetName("TreeId");
+  vtkNew<vtkIntArray> nodePathId{};
+  nodePathId->SetName("NodePathId");
+  vtkNew<vtkIntArray> pathId{};
+  pathId->SetName("PathId");
+  vtkNew<vtkIntArray> nodeRemoved{};
+  nodeRemoved->SetName("isNodeRemoved");
+  vtkNew<vtkIntArray> nodeId{};
+  nodeId->SetName("NodeId");
+  vtkNew<vtkIntArray> arcId{};
+  arcId->SetName("ArcId");
+
+  vtkSmartPointer<vtkUnstructuredGrid> vtkArcs
+    = vtkSmartPointer<vtkUnstructuredGrid>::New();
+  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  for(unsigned int i = 0; i < embedding[0].size(); ++i) {
+    if(not displayRemoved and i >= intermediateMTrees.size())
+      continue;
+
+    // Next point
+    double point[3] = {embedding[0][i], embedding[1][i], 0};
+    nodeSimplexId[i] = points->InsertNextPoint(point);
+
+    // Add TreeID field
+    int index = i;
+    if(i >= intermediateMTrees.size())
+      index = removed[i - intermediateMTrees.size()];
+    treeId->InsertNextTuple1(index);
+
+    // Add NodePathId field
+    int thisPathId = (i < intermediateMTrees.size() ? 0 : 1);
+    nodePathId->InsertNextTuple1(thisPathId);
+
+    // Add NodeId
+    nodeId->InsertNextTuple1(i);
+
+    // Add cell
+    if(i > 0 and i < intermediateMTrees.size()) {
+      vtkIdType pointIds[2];
+      pointIds[0] = nodeSimplexId[i - 1];
+      pointIds[1] = nodeSimplexId[i];
+      vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds);
+
+      // Add PathId field
+      pathId->InsertNextTuple1(0);
+
+      // Add Arc Id
+      arcId->InsertNextTuple1(i);
+    }
+  }
+
+  if(displayRemoved) {
+    for(unsigned int i = 0; i < removed.size(); ++i) {
+      int index = removed[i];
+      // First cell
+      if(i == 0) {
+        vtkIdType pointIds[2];
+        pointIds[0] = nodeSimplexId[index - 1];
+        pointIds[1] = nodeSimplexId[intermediateMTrees.size() + i];
+        vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds);
+        pathId->InsertNextTuple1(1);
+
+        if(removed[i + 1] != index + 1) {
+          vtkIdType pointIds2[2];
+          pointIds2[0] = nodeSimplexId[intermediateMTrees.size() + i];
+          pointIds2[1] = nodeSimplexId[index + 1];
+          vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds2);
+          pathId->InsertNextTuple1(1);
+        }
+      }
+      // Between cell
+      if(i > 0 and i < removed.size() - 1) {
+        vtkIdType pointIds[2];
+        int prevIndex
+          = (removed[i - 1] == index - 1 ? intermediateMTrees.size() + i - 1
+                                         : index - 1);
+        pointIds[0] = nodeSimplexId[prevIndex];
+        pointIds[1] = nodeSimplexId[intermediateMTrees.size() + i];
+        vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds);
+        pathId->InsertNextTuple1(1);
+
+        vtkIdType pointIds2[2];
+        int nextvIndex
+          = (removed[i + 1] == index + 1 ? intermediateMTrees.size() + i + 1
+                                         : index + 1);
+        pointIds2[0] = nodeSimplexId[intermediateMTrees.size() + i];
+        pointIds2[1] = nodeSimplexId[nextvIndex];
+        vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds2);
+        pathId->InsertNextTuple1(1);
+      }
+      // End cell
+      if(i == removed.size() - 1) {
+        vtkIdType pointIds[2];
+        pointIds[0] = nodeSimplexId[intermediateMTrees.size() + i];
+        pointIds[1] = nodeSimplexId[index + 1];
+        vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds);
+        pathId->InsertNextTuple1(1);
+
+        if(removed[i - 1] != index - 1) {
+          vtkIdType pointIds2[2];
+          pointIds2[0] = nodeSimplexId[index - 1];
+          pointIds2[1] = nodeSimplexId[intermediateMTrees.size() + i];
+          vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds2);
+          pathId->InsertNextTuple1(1);
+        }
+      }
+    }
+  } else {
+    for(unsigned int i = 0; i < removed.size(); ++i) {
+      int before = removed[i] - 1;
+      int index = i - 1;
+      if(i > 0)
+        while(before == removed[index]) {
+          before = removed[index] - 1;
+          --index;
+        }
+
+      int after = removed[i] + 1;
+      index = i + 1;
+      if(i < removed.size() - 1)
+        while(after == removed[index]) {
+          after = removed[index] + 1;
+          ++index;
+        }
+
+      vtkIdType pointIds[2];
+      pointIds[0] = nodeSimplexId[before];
+      pointIds[1] = nodeSimplexId[after];
+      vtkArcs->InsertNextCell(VTK_LINE, 2, pointIds);
+      pathId->InsertNextTuple1(1);
+      arcId->InsertNextTuple1(intermediateMTrees.size() + i);
+    }
+  }
+
+  for(unsigned int i = 0; i < fullSize; ++i)
+    nodeRemoved->InsertNextTuple1(0);
+  for(unsigned int i = 0; i < removed.size(); ++i) {
+    nodeRemoved->SetTuple1(removed[i], 1);
+    nodeRemoved->SetTuple1(intermediateMTrees.size() + i, 1);
+  }
+
+  vtkOutputNode1->SetPoints(points);
+  vtkOutputNode1->GetPointData()->AddArray(treeId);
+  vtkOutputNode1->GetPointData()->AddArray(nodePathId);
+  vtkOutputNode1->GetPointData()->AddArray(nodeRemoved);
+  vtkOutputNode1->GetPointData()->AddArray(nodeId);
+  vtkArcs->SetPoints(points);
+  vtkArcs->GetCellData()->AddArray(pathId);
+  vtkArcs->GetCellData()->AddArray(arcId);
+  vtkOutputArc1->ShallowCopy(vtkArcs);
+}
+
+template <class dataType>
+void makeTemporalSubsamplingMDSOutput(
+  std::vector<MergeTree<dataType>> &intermediateMTrees,
+  std::vector<std::vector<double>> &distanceMatrix,
+  std::vector<MergeTree<dataType>> &allMT,
+  std::vector<int> removed,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
+  bool metricMDS) {
+  // Call DimensionReduction filter
+  std::vector<std::vector<double>> embedding{};
+  std::vector<double> inputData;
+  for(int i = 0; i < (int)distanceMatrix.size(); ++i)
+    for(int j = 0; j < (int)distanceMatrix.size(); ++j)
+      inputData.push_back(distanceMatrix[i][j]);
+
+  DimensionReduction dimensionReduction;
+  dimensionReduction.setInputModulePath("default");
+  dimensionReduction.setInputModuleName("dimensionReduction");
+  dimensionReduction.setInputFunctionName("doIt");
+  dimensionReduction.setInputMatrixDimensions(
+    distanceMatrix.size(), distanceMatrix.size());
+  dimensionReduction.setInputMatrix(inputData.data());
+  dimensionReduction.setInputMethod(2);
+  dimensionReduction.setInputNumberOfComponents(2);
+  dimensionReduction.setInputNumberOfNeighbors(5);
+  dimensionReduction.setInputIsDeterministic(false);
+  // mds_Metric, mds_Init, mds_MaxIteration, mds_Verbose, mds_Epsilon,
+  // InputIsADistanceMatrix
+  dimensionReduction.setMDSParameters(metricMDS, 4, 300, 0, 0.001, true);
+  dimensionReduction.setOutputComponents(&embedding);
+  int errorCode = dimensionReduction.execute();
+
+  // Create output
+  makeTemporalSubsamplingOutput<dataType>(intermediateMTrees, embedding, allMT,
+                                          removed, vtkOutputNode1,
+                                          vtkOutputArc1);
+}
+
+template <class dataType>
+void makeTemporalSubsamplingETDOutput(
+  std::vector<MergeTree<dataType>> &intermediateMTrees,
+  std::vector<double> &emptyTreeDistances,
+  std::vector<MergeTree<dataType>> &allMT,
+  std::vector<int> removed,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
+  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
+  double DistanceAxisStretch) {
+  std::vector<std::vector<double>> embedding(2);
+  for(int i = 0; i < (int)intermediateMTrees.size() + (int)removed.size();
+      ++i) {
+    double y = emptyTreeDistances[i] * DistanceAxisStretch;
+    double x = i;
+    if(i >= (int)intermediateMTrees.size())
+      x = removed[i - (int)intermediateMTrees.size()];
+
+    embedding[0].push_back(x);
+    embedding[1].push_back(y);
+  }
+
+  // Create output
+  makeTemporalSubsamplingOutput<dataType>(intermediateMTrees, embedding, allMT,
+                                          removed, vtkOutputNode1,
+                                          vtkOutputArc1);
+}
+
+#endif

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/vtk.module
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkMergeTreeTemporalReductionEncoding
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -6,7 +6,14 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy name="ttkMergeTreeTemporalReductionDecoding" class="ttkMergeTreeTemporalReductionDecoding" label="TTK MergeTreeTemporalReductionDecoding">
-      <Documentation long_help="MergeTreeTemporalReductionDecoding Long" short_help="MergeTreeTemporalReductionDecoding Short">This filter is a well documented ttk example filter that computes for each vertex of a vtkDataSet the average scalar value of itself and its neighbors.</Documentation>
+      <Documentation long_help="MergeTreeTemporalReductionDecoding Long" short_help="MergeTreeTemporalReductionDecoding Short">
+This VTK filter uses the ttk::MergeTreeTemporalReductionDecoding module to compute the reconstruction of a reduced sequence of merge trees.
+\b Related \b publication \n
+"Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+Proc. of IEEE VIS 2021.\n
+IEEE Transactions on Visualization and Computer Graphics, 2021
+      </Documentation>
 
       <!-- INPUT DATA OBJECTS -->
       <InputProperty

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -255,7 +255,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
 
       <!-- MENU CATEGORY -->
       <Hints>
-        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+        <ShowInMenu category="TTK - Time-varying Scalar Data" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
+<!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
+<!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ttkMergeTreeTemporalReductionDecoding" class="ttkMergeTreeTemporalReductionDecoding" label="TTK MergeTreeTemporalReductionDecoding">
+      <Documentation long_help="MergeTreeTemporalReductionDecoding Long" short_help="MergeTreeTemporalReductionDecoding Short">This filter is a well documented ttk example filter that computes for each vertex of a vtkDataSet the average scalar value of itself and its neighbors.</Documentation>
+
+      <!-- INPUT DATA OBJECTS -->
+      <InputProperty
+          name="Key Frames"
+          port_index="0"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkMultiBlockDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Merge trees to process.
+        </Documentation>
+      </InputProperty>
+
+      <InputProperty
+          name="Metadata"
+          port_index="1"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkTable"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Encoding metadata.
+        </Documentation>
+      </InputProperty>
+
+      <!-- INPUT PARAMETER WIDGETS -->
+               <!-- Output options -->
+                
+                <IntVectorProperty
+                name="OutputTrees"
+                command="SetOutputTrees"
+                label="Output Trees"
+                number_of_elements="1"
+                default_values="1">
+                  <Documentation>
+                    Display output trees. 
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="DimensionSpacing"
+                command="SetDimensionSpacing"
+                label="Dimension Spacing"
+                number_of_elements="1"
+                default_values="1.0">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="OutputTrees"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <IntVectorProperty
+                name="PlanarLayout"
+                command="SetPlanarLayout"
+                label="Planar Layout"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="OutputTrees"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    Display trees in a plane or in the original domain.
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="BranchDecompositionPlanarLayout"
+                command="SetBranchDecompositionPlanarLayout"
+                label="Branch Decomposition Planar Layout"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="BranchSpacing"
+                command="SetBranchSpacing"
+                label="Branch Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="BranchDecompositionPlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="ImportantPairs"
+                command="SetImportantPairs"
+                label="Important Pairs (%)"
+                number_of_elements="1"
+                default_values="50">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="ImportantPairsSpacing"
+                command="SetImportantPairsSpacing"
+                label="Important Pairs Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="NonImportantPairsSpacing"
+                command="SetNonImportantPairsSpacing"
+                label="Non Important Pairs Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="NonImportantPairsProximity"
+                command="SetNonImportantPairsProximity"
+                label="Non Important Pairs Proximity"
+                number_of_elements="1"
+                default_values="0.05">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="1" />
+                </DoubleVectorProperty>
+                
+                <IntVectorProperty
+                name="RescaleTreesIndividually"
+                command="SetRescaleTreesIndividually"
+                label="Rescale Trees Individually"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    Rescale trees individually. If enabled, the trees will have the same size, it can be interesting to use to individually analyze trees but the comparison between trees given their size will be biased.
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty> 
+                
+            <PropertyGroup panel_widget="Line" label="Output options">
+              <Property name="OutputTrees"/>
+              <Property name="DimensionSpacing"/>
+              <Property name="PlanarLayout"/>
+              <Property name="BranchDecompositionPlanarLayout"/>
+              <Property name="BranchSpacing"/>
+              <Property name="ImportantPairs"/>
+              <Property name="ImportantPairsSpacing"/>
+              <Property name="NonImportantPairsSpacing"/>
+              <Property name="NonImportantPairsProximity"/>
+              <Property name="RescaleTreesIndividually"/>
+            </PropertyGroup>
+
+            <!-- OUTPUT PARAMETER WIDGETS -->
+                <OutputPort name="Reconstructed Sequence" index="0" id="port0" />
+                <OutputPort name="Matching" index="1" id="port1" />
+
+      <!-- DEBUG -->
+      ${DEBUG_WIDGETS}
+
+      <!-- MENU CATEGORY -->
+      <Hints>
+        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -453,7 +453,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
 
       <!-- MENU CATEGORY -->
       <Hints>
-        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+        <ShowInMenu category="TTK - Time-varying Scalar Data" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- TODO 11: Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- Add widgets to the ParaView UI that control the member variables of the vtk filter -->
 <!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
 <!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
 <!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
@@ -7,7 +7,12 @@
   <ProxyGroup name="filters">
     <SourceProxy name="ttkMergeTreeTemporalReductionEncoding" class="ttkMergeTreeTemporalReductionEncoding" label="TTK MergeTreeTemporalReductionEncoding">
       <Documentation long_help="MergeTreeTemporalReductionEncoding Long" short_help="MergeTreeTemporalReductionEncoding Short">
-          TODO
+This VTK filter uses the ttk::MergeTreeTemporalReductionEncoding module to compute a temporal reduction of a sequence of merge trees.
+\b Related \b publication \n
+"Wasserstein Distances, Geodesics and Barycenters of Merge Trees" \n
+Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
+Proc. of IEEE VIS 2021.\n
+IEEE Transactions on Visualization and Computer Graphics, 2021
       </Documentation>
 
       <!-- INPUT DATA OBJECTS -->

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- TODO 11: Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
+<!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
+<!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ttkMergeTreeTemporalReductionEncoding" class="ttkMergeTreeTemporalReductionEncoding" label="TTK MergeTreeTemporalReductionEncoding">
+      <Documentation long_help="MergeTreeTemporalReductionEncoding Long" short_help="MergeTreeTemporalReductionEncoding Short">
+          TODO
+      </Documentation>
+
+      <!-- INPUT DATA OBJECTS -->
+      <InputProperty
+          name="Input"
+          port_index="0"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkMultiBlockDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1" attribute_type="field">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Merge trees to process.
+        </Documentation>
+      </InputProperty>
+
+           <!-- INPUT PARAMETER WIDGETS -->
+                <!-- Execution options -->
+                <DoubleVectorProperty
+                name="RemovalPercentage"
+                command="SetRemovalPercentage"
+                label="Removal Percentage"
+                number_of_elements="1"
+                default_values="50">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty> 
+      
+                <IntVectorProperty
+                name="AssignmentSolver"
+                label="Assignment Solver"
+                command="SetAssignmentSolver"
+                number_of_elements="1"
+                default_values="0">
+                <EnumerationDomain name="enum">
+                    <Entry value="0" text="Auction"/>
+                    <Entry value="1" text="Exhaustive Search"/>
+                    <Entry value="2" text="Munkres"/>
+                </EnumerationDomain>
+                  <Documentation>
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="UseCustomTimeVariable"
+                command="SetUseCustomTimeVariable"
+                label="Use custom time variable"
+                number_of_elements="1"
+                default_values="0">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <StringVectorProperty
+                    name="TimeVariableName"
+                    command="SetTimeVariableName"
+                    label="Time Variable"
+                    element_types="0 0 0 0 2"
+                    number_of_elements="5"
+                    default_values="0"
+                    animateable="0"
+                    >
+                  <Hints>
+                    <PropertyWidgetDecorator type="GenericDecorator"
+                                            mode="visibility"
+                                            property="UseCustomTimeVariable"
+                                            value="1" />
+                  </Hints>
+                  <ArrayListDomain
+                      name="array_list"
+                      default_values="0">
+                    <RequiredProperties>
+                      <Property name="Input" function="Input" />
+                    </RequiredProperties>
+                  </ArrayListDomain>
+                  <Documentation>
+                    Select the input string array.
+                  </Documentation>
+                </StringVectorProperty>
+                
+                <IntVectorProperty
+                name="UseL2Distance"
+                command="SetUseL2Distance"
+                label="Use L2 distance"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <!-- Input options -->                
+                <IntVectorProperty
+                name="DeleteMultiPersPairs"
+                command="SetDeleteMultiPersPairs"
+                label="Delete Multi Pers. Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="Epsilon1UseFarthestSaddle"
+                command="SetEpsilon1UseFarthestSaddle"
+                label="Epsilon1 Use Farthest Saddle"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="EpsilonTree1"
+                command="SetEpsilonTree1"
+                label="Epsilon 1 (%)"
+                number_of_elements="1"
+                default_values="5">
+                  <Documentation>
+                    Merge saddle points (in a bottom-up manner) having their difference in function value below epsilon times the biggest difference in function value.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>   
+                
+                <DoubleVectorProperty
+                name="Epsilon2Tree1"
+                command="SetEpsilon2Tree1"
+                label="Epsilon 2 (%)"
+                number_of_elements="1"
+                default_values="95"
+                panel_visibility="advanced">
+                  <Hints>
+
+                  </Hints>
+                  <Documentation>
+                    Given a branch decomposition, ascend a pair (by making it children of the parent of its parent) if the ratio between its persistence and the persistence of its parent is above epsilon2. A high value will ascend only pairs having a close persistence to their parent, more epsilon2 is low more the pairs having a distant persistence to their parent will also be ascended.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>   
+                
+                <DoubleVectorProperty
+                name="Epsilon3Tree1"
+                command="SetEpsilon3Tree1"
+                label="Epsilon 3 (%)"
+                number_of_elements="1"
+                default_values="90"
+                panel_visibility="advanced">
+                  <Hints>
+
+                  </Hints>
+                  <Documentation>
+                    Will apply the processing of Epsilon2 only for the pairs having a ratio between their persistence and the maximum persistence inferior to epsilon3. A low value will apply the processing of Epsilon2 only to the small persistence pairs, more epsilon3 is high more the pairs having a high persistence will also be processed.
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="PersistenceThreshold"
+                command="SetPersistenceThreshold"
+                label="Persistence Threshold (%)"
+                number_of_elements="1"
+                default_values="0">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>  
+                
+                <!-- Output options -->
+                
+                <IntVectorProperty
+                name="OutputTrees"
+                command="SetOutputTrees"
+                label="Output Trees"
+                number_of_elements="1"
+                default_values="1">
+                  <Documentation>
+                    Display output trees. 
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="DimensionSpacing"
+                command="SetDimensionSpacing"
+                label="Dimension Spacing"
+                number_of_elements="1"
+                default_values="1.0">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="OutputTrees"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <IntVectorProperty
+                name="PlanarLayout"
+                command="SetPlanarLayout"
+                label="Planar Layout"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="OutputTrees"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    Display trees in a plane or in the original domain.
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="BranchDecompositionPlanarLayout"
+                command="SetBranchDecompositionPlanarLayout"
+                label="Branch Decomposition Planar Layout"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="BranchSpacing"
+                command="SetBranchSpacing"
+                label="Branch Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="BranchDecompositionPlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="ImportantPairs"
+                command="SetImportantPairs"
+                label="Important Pairs (%)"
+                number_of_elements="1"
+                default_values="50">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="ImportantPairsSpacing"
+                command="SetImportantPairsSpacing"
+                label="Important Pairs Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="NonImportantPairsSpacing"
+                command="SetNonImportantPairsSpacing"
+                label="Non Important Pairs Spacing"
+                number_of_elements="1"
+                default_values="1">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+                
+                <DoubleVectorProperty
+                name="NonImportantPairsProximity"
+                command="SetNonImportantPairsProximity"
+                label="Non Important Pairs Proximity"
+                number_of_elements="1"
+                default_values="0.05">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="1" />
+                </DoubleVectorProperty>
+                
+                <IntVectorProperty
+                name="RescaleTreesIndividually"
+                command="SetRescaleTreesIndividually"
+                label="Rescale Trees Individually"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="1" />
+                  </Hints>
+                  <Documentation>
+                    Rescale trees individually. If enabled, the trees will have the same size, it can be interesting to use to individually analyze trees but the comparison between trees given their size will be biased.
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="OutputSegmentation"
+                command="SetOutputSegmentation"
+                label="Output Segmentation"
+                number_of_elements="1"
+                default_values="0">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="OutputTrees"
+                                           value="1" />
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                           mode="visibility"
+                                           property="PlanarLayout"
+                                           value="0" />
+                  </Hints>
+                  <Documentation>
+                    Display output segmentation. Be careful, it can consume a lot of memory since some segmentations must be copied (to shift them).
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>  
+                
+                <DoubleVectorProperty
+                name="DistanceAxisStretch"
+                command="SetDistanceAxisStretch"
+                label="Distance Axis Stretch"
+                number_of_elements="1"
+                default_values="1.0">
+                  <Hints>
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </DoubleVectorProperty>
+            
+            <PropertyGroup panel_widget="Line" label="Execution options">
+              <Property name="RemovalPercentage"/>
+              <Property name="AssignmentSolver"/>
+              <Property name="UseCustomTimeVariable"/>
+              <Property name="TimeVariableName"/>
+              <Property name="UseL2Distance"/>
+            </PropertyGroup>
+            
+            <PropertyGroup panel_widget="Line" label="Input options">
+              <Property name="DeleteMultiPersPairs"/>
+              <Property name="Epsilon1UseFarthestSaddle"/>
+              <Property name="EpsilonTree1"/>
+              <Property name="Epsilon2Tree1"/>
+              <Property name="Epsilon3Tree1"/>
+              <Property name="PersistenceThreshold"/>
+            </PropertyGroup>
+                
+            <PropertyGroup panel_widget="Line" label="Output options">
+              <Property name="OutputTrees"/>
+              <Property name="DimensionSpacing"/>
+              <Property name="PlanarLayout"/>
+              <Property name="BranchDecompositionPlanarLayout"/>
+              <Property name="BranchSpacing"/>
+              <Property name="ImportantPairs"/>
+              <Property name="ImportantPairsSpacing"/>
+              <Property name="NonImportantPairsSpacing"/>
+              <Property name="NonImportantPairsProximity"/>
+              <Property name="RescaleTreesIndividually"/>
+              <Property name="OutputSegmentation"/>
+              <Property name="DistanceAxisStretch"/>
+            </PropertyGroup>
+
+            <!-- OUTPUT PARAMETER WIDGETS -->
+                <OutputPort name="Key Frames" index="0" id="port0" />
+                <OutputPort name="Metadata" index="1" id="port1" />
+
+      <!-- DEBUG -->
+      ${DEBUG_WIDGETS}
+
+      <!-- MENU CATEGORY -->
+      <Hints>
+        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
This PR adds the temporal reduction module for merge trees.

It allows to subsampling a sequence of merge trees by greedily remove trees in the original sequence that can be accurately reconstructed with the geodesic computation.

Best.