### PR TITLE
Add new FlattenMultiBlock module

### DIFF
--- a/core/vtk/ttkFlattenMultiBlock/CMakeLists.txt
+++ b/core/vtk/ttkFlattenMultiBlock/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkFlattenMultiBlock/ttk.module
+++ b/core/vtk/ttkFlattenMultiBlock/ttk.module
@@ -1,0 +1,8 @@
+NAME
+  ttkFlattenMultiBlock
+SOURCES
+  ttkFlattenMultiBlock.cpp
+HEADERS
+  ttkFlattenMultiBlock.h
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkFlattenMultiBlock/ttkFlattenMultiBlock.cpp
+++ b/core/vtk/ttkFlattenMultiBlock/ttkFlattenMultiBlock.cpp
@@ -1,0 +1,89 @@
+#include <ttkFlattenMultiBlock.h>
+
+#include <vtkFieldData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkMultiBlockDataSet.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkUnsignedIntArray.h>
+
+vtkStandardNewMacro(ttkFlattenMultiBlock);
+
+ttkFlattenMultiBlock::ttkFlattenMultiBlock() {
+  this->setDebugMsgPrefix("FlattenMultiBlock");
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkFlattenMultiBlock::FillInputPortInformation(int port,
+                                                   vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkFlattenMultiBlock::FillOutputPortInformation(int port,
+                                                    vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkMultiBlockDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkFlattenMultiBlock::RequestData(vtkInformation *ttkNotUsed(request),
+                                      vtkInformationVector **inputVector,
+                                      vtkInformationVector *outputVector) {
+
+  // Get input data (pointer to vtkDataObject, parent block id)
+  std::vector<std::pair<vtkDataObject *, size_t>> blocks{};
+
+  auto input = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+
+  // Sanity check
+  if(input == nullptr || input->GetNumberOfBlocks() == 0) {
+    this->printErr("No input block");
+    return 0;
+  }
+
+  for(size_t i = 0; i < input->GetNumberOfBlocks(); ++i) {
+    const auto topLvlBlock
+      = vtkMultiBlockDataSet::SafeDownCast(input->GetBlock(i));
+    if(topLvlBlock == nullptr) {
+      continue;
+    }
+    for(size_t j = 0; j < topLvlBlock->GetNumberOfBlocks(); ++j) {
+      blocks.emplace_back(topLvlBlock->GetBlock(j), i);
+    }
+  }
+
+  auto outputFlatBlocks = vtkMultiBlockDataSet::GetData(outputVector);
+
+  // Sanity check
+  if(blocks.empty()) {
+    this->printWrn("Not a hierarchy of vtkMultiBlockDataSet");
+    outputFlatBlocks->ShallowCopy(input);
+    return 1;
+  }
+
+  // Set output
+  outputFlatBlocks->SetNumberOfBlocks(blocks.size());
+
+  for(size_t i = 0; i < blocks.size(); ++i) {
+    // Set flattened blocks
+    outputFlatBlocks->SetBlock(i, blocks[i].first);
+
+    // Set FieldData
+    vtkNew<vtkUnsignedIntArray> blockId{};
+    blockId->SetName("ParentBlockId");
+    blockId->SetNumberOfTuples(1);
+    blockId->SetTuple1(0, blocks[i].second);
+
+    blocks[i].first->GetFieldData()->AddArray(blockId);
+  }
+
+  return 1;
+}

--- a/core/vtk/ttkFlattenMultiBlock/ttkFlattenMultiBlock.h
+++ b/core/vtk/ttkFlattenMultiBlock/ttkFlattenMultiBlock.h
@@ -1,0 +1,31 @@
+/// \ingroup vtk
+/// \class ttkFlattenMultiBlock
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date September 2021
+///
+/// \brief TTK processing package for flattening the top-level
+/// hierarchy of a tree vtkMultiBlockDataSet structure.
+
+#pragma once
+
+#include <ttkFlattenMultiBlockModule.h>
+
+#include <ttkAlgorithm.h>
+
+class TTKFLATTENMULTIBLOCK_EXPORT ttkFlattenMultiBlock : public ttkAlgorithm {
+
+public:
+  static ttkFlattenMultiBlock *New();
+
+  vtkTypeMacro(ttkFlattenMultiBlock, ttkAlgorithm);
+
+protected:
+  ttkFlattenMultiBlock();
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+};

--- a/core/vtk/ttkFlattenMultiBlock/vtk.module
+++ b/core/vtk/ttkFlattenMultiBlock/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkFlattenMultiBlock
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/FlattenMultiBlock.xml
+++ b/paraview/xmls/FlattenMultiBlock.xml
@@ -1,0 +1,42 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkFlattenMultiBlock"
+        class="ttkFlattenMultiBlock"
+        label="TTK FlattenMultiBlock">
+      <Documentation
+          long_help="Flatten vtkMultiBlockDataSet of vtkMultiBlockDataSet."
+          shorthelp="Flatten vtkMultiBlockDataSet."
+          >
+        This filter flattens the top-level hierarchy of a tree
+        vtkMultiBlockDataSet structure.
+
+        The main use-case is to flatten a "Group Datasets" of several
+        vtkMultiBlockDataSets.
+      </Documentation>
+
+      <InputProperty
+          name="Input"
+          command="AddInputConnection"
+          clean_command="RemoveAllInputs"
+          multiple_input="1">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkMultiBlockDataSet"/>
+        </DataTypeDomain>
+        <Documentation>
+          Hierarchy of vtkMultiBlockDataSet to process.
+        </Documentation>
+      </InputProperty>
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
This PR adds a new TTK filter that flattens one level of a vtkMultiBlockDataSet hierarchy.

It can be used on the (Group Dataset of) Clustered Diagrams and Cluster Centroids output of the PersistenceDiagramClustering module to bring input diagrams and centroids into the same MultiBlockDataSet.

The old parent block is identified as a Field Data array, named "ParentBlockId", attached to every block.

Enjoy,
Pierre

