### PR TITLE
[mergeTreeClustering] fix join/split mixture coefficient

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -310,6 +310,7 @@ int ttkMergeTreeClustering::runCompute(
       mergeTreeClustering.setDeleteMultiPersPairs(DeleteMultiPersPairs);
       mergeTreeClustering.setEpsilon1UseFarthestSaddle(
         Epsilon1UseFarthestSaddle);
+      mergeTreeClustering.setMixtureCoefficient(JoinSplitMixtureCoefficient);
       mergeTreeClustering.setThreadNumber(this->threadNumber_);
       mergeTreeClustering.setDebugLevel(this->debugLevel_);
 


### PR DESCRIPTION
The GUI parameter allowing to controls the weight of join or split tree in the clustering algorithm of the MergeTreeClustering filter is not correctly given to the base code. 

Hence, at that moment, changing this parameter in the GUI does not change anything. This PR fixes this problem.