### PR TITLE
PersistenceDiagramClustering: Fix log, compatibility with FlattenMultiBlock

### DIFF
--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -2273,7 +2273,7 @@ void PDClustering<dataType>::setBidderDiagrams() {
         b.setPositionInAuction(bidders.size());
         bidders.addBidder(b);
         if(b.isDiagonal() || b.x_ == b.y_) {
-          std::cout << "Diagonal point in diagram !!!" << std::endl;
+          this->printMsg("Diagonal point in diagram", debug::Priority::DETAIL);
         }
       }
       bidder_diagrams_min_.push_back(bidders);
@@ -2297,7 +2297,7 @@ void PDClustering<dataType>::setBidderDiagrams() {
         b.setPositionInAuction(bidders.size());
         bidders.addBidder(b);
         if(b.isDiagonal() || b.x_ == b.y_) {
-          std::cout << "Diagonal point in diagram !!!" << std::endl;
+          this->printMsg("Diagonal point in diagram", debug::Priority::DETAIL);
         }
       }
       bidder_diagrams_saddle_.push_back(bidders);
@@ -2321,7 +2321,7 @@ void PDClustering<dataType>::setBidderDiagrams() {
         b.setPositionInAuction(bidders.size());
         bidders.addBidder(b);
         if(b.isDiagonal() || b.x_ == b.y_) {
-          std::cout << "Diagonal point in diagram !!!" << std::endl;
+          this->printMsg("Diagonal point in diagram", debug::Priority::DETAIL);
         }
       }
       bidder_diagrams_max_.push_back(bidders);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -490,12 +490,6 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
     vtkNew<vtkUnstructuredGrid> vtu{};
     vtu->ShallowCopy(diags[i]);
 
-    vtkNew<vtkIntArray> diagId{};
-    diagId->SetName("DiagramID");
-    diagId->SetNumberOfTuples(vtu->GetNumberOfPoints());
-    diagId->Fill(i);
-    vtu->GetPointData()->AddArray(diagId);
-
     vtkNew<vtkIntArray> clusterId{};
     clusterId->SetName("ClusterID");
     clusterId->SetNumberOfComponents(1);
@@ -558,6 +552,12 @@ void ttkPersistenceDiagramClustering::outputCentroids(
   for(size_t i = 0; i < final_centroids.size(); ++i) {
     vtkNew<vtkUnstructuredGrid> vtu{};
     this->diagramToVTU(vtu, final_centroids[i], i, this->max_dimension_total_);
+
+    vtkNew<vtkIntArray> cid{};
+    cid->SetName("ClusterId");
+    cid->SetNumberOfTuples(1);
+    cid->SetTuple1(0, i);
+    vtu->GetFieldData()->AddArray(cid);
 
     if(dm == DISPLAY::STARS && spacing > 0) {
       // shift centroid along the X axis


### PR DESCRIPTION
This PR reduces the scope of a warning message in the base layer of the PersistenceDiagramClustering module.

Furthermore, the output diagrams and centroids format has been reworked for both to be compatible with FlattenMultiBlock (no more segfault when applying PersistenceDiagramDistanceMatrix after FlattenMultiBlock). The "DiagramID" point data array has been removed from the Clustered Diagrams output (diagrams are now in individual blocks and can be filtered with Extract Block/TTKExtract) and the "ClusterId" field data has been added to the Cluster Centroids outputs.

No change in the two ttk-data states using PersistenceDiagramClustering.

Enjoy,
Pierre