### PR TITLE
[planarLayout] merge tree min and max number of important pairs

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -400,6 +400,8 @@ int ttkMergeTreeClustering::runOutput(
       visuMaker.setDimensionSpacing(DimensionSpacing);
       visuMaker.setDimensionToShift(DimensionToShift);
       visuMaker.setImportantPairs(ImportantPairs);
+      visuMaker.setMaximumImportantPairs(MaximumImportantPairs);
+      visuMaker.setMinimumImportantPairs(MinimumImportantPairs);
       visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
       visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
       visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
@@ -522,6 +524,8 @@ int ttkMergeTreeClustering::runOutput(
           visuMaker.setDimensionSpacing(DimensionSpacing);
           visuMaker.setDimensionToShift(DimensionToShift);
           visuMaker.setImportantPairs(ImportantPairs);
+          visuMaker.setMaximumImportantPairs(MaximumImportantPairs);
+          visuMaker.setMinimumImportantPairs(MinimumImportantPairs);
           visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
           visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
           visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
@@ -585,6 +589,8 @@ int ttkMergeTreeClustering::runOutput(
         visuMakerBary.setDimensionSpacing(DimensionSpacing);
         visuMakerBary.setDimensionToShift(DimensionToShift);
         visuMakerBary.setImportantPairs(ImportantPairs);
+        visuMakerBary.setMaximumImportantPairs(MaximumImportantPairs);
+        visuMakerBary.setMinimumImportantPairs(MinimumImportantPairs);
         visuMakerBary.setImportantPairsSpacing(ImportantPairsSpacing);
         visuMakerBary.setNonImportantPairsSpacing(NonImportantPairsSpacing);
         visuMakerBary.setNonImportantPairsProximity(NonImportantPairsProximity);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -87,6 +87,8 @@ private:
   double DimensionSpacing = 1.;
   int DimensionToShift = 0;
   double ImportantPairs = 50.;
+  int MaximumImportantPairs = 0;
+  int MinimumImportantPairs = 0;
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
@@ -322,6 +324,12 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
+  
+  vtkSetMacro(MaximumImportantPairs, int);
+  vtkGetMacro(MaximumImportantPairs, int);
+  
+  vtkSetMacro(MinimumImportantPairs, int);
+  vtkGetMacro(MinimumImportantPairs, int);
 
   vtkSetMacro(ImportantPairsSpacing, double);
   vtkGetMacro(ImportantPairsSpacing, double);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -324,10 +324,10 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
-  
+
   vtkSetMacro(MaximumImportantPairs, int);
   vtkGetMacro(MaximumImportantPairs, int);
-  
+
   vtkSetMacro(MinimumImportantPairs, int);
   vtkGetMacro(MinimumImportantPairs, int);
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -271,6 +271,8 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
     visuMaker.setDimensionSpacing(DimensionSpacing);
     visuMaker.setDimensionToShift(DimensionToShift);
     visuMaker.setImportantPairs(ImportantPairs);
+    visuMaker.setMaximumImportantPairs(MaximumImportantPairs);
+    visuMaker.setMinimumImportantPairs(MinimumImportantPairs);
     visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
     visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
     visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -150,10 +150,10 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
-  
+
   vtkSetMacro(MaximumImportantPairs, int);
   vtkGetMacro(MaximumImportantPairs, int);
-  
+
   vtkSetMacro(MinimumImportantPairs, int);
   vtkGetMacro(MinimumImportantPairs, int);
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -82,6 +82,8 @@ private:
   double DimensionSpacing = 1.;
   int DimensionToShift = 0;
   double ImportantPairs = 50.;
+  int MaximumImportantPairs = 0;
+  int MinimumImportantPairs = 0;
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
@@ -148,6 +150,12 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
+  
+  vtkSetMacro(MaximumImportantPairs, int);
+  vtkGetMacro(MaximumImportantPairs, int);
+  
+  vtkSetMacro(MinimumImportantPairs, int);
+  vtkGetMacro(MinimumImportantPairs, int);
 
   vtkSetMacro(ImportantPairsSpacing, double);
   vtkGetMacro(ImportantPairsSpacing, double);

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -293,6 +293,8 @@ int ttkMergeTreeTemporalReductionEncoding::runOutput(
     visuMaker.setDimensionSpacing(DimensionSpacing);
     visuMaker.setDimensionToShift(DimensionToShift);
     visuMaker.setImportantPairs(ImportantPairs);
+    visuMaker.setMaximumImportantPairs(MaximumImportantPairs);
+    visuMaker.setMinimumImportantPairs(MinimumImportantPairs);
     visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
     visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
     visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -247,10 +247,10 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
-  
+
   vtkSetMacro(MaximumImportantPairs, int);
   vtkGetMacro(MaximumImportantPairs, int);
-  
+
   vtkSetMacro(MinimumImportantPairs, int);
   vtkGetMacro(MinimumImportantPairs, int);
 

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -66,6 +66,8 @@ private:
   double DimensionSpacing = 1.;
   int DimensionToShift = 0;
   double ImportantPairs = 50.;
+  int MaximumImportantPairs = 0;
+  int MinimumImportantPairs = 0;
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
@@ -245,6 +247,12 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
+  
+  vtkSetMacro(MaximumImportantPairs, int);
+  vtkGetMacro(MaximumImportantPairs, int);
+  
+  vtkSetMacro(MinimumImportantPairs, int);
+  vtkGetMacro(MinimumImportantPairs, int);
 
   vtkSetMacro(ImportantPairsSpacing, double);
   vtkGetMacro(ImportantPairsSpacing, double);

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -113,10 +113,10 @@ public:
   void setShiftMode(int mode) {
     ShiftMode = mode;
   }
-  void setMaximumImportantPairs(int maxPairs){
+  void setMaximumImportantPairs(int maxPairs) {
     MaximumImportantPairs = maxPairs;
   }
-  void setMinimumImportantPairs(int minPairs){
+  void setMinimumImportantPairs(int minPairs) {
     MinimumImportantPairs = minPairs;
   }
 
@@ -606,21 +606,25 @@ public:
 
         // Manage important pairs threshold
         importantPairs_ = importantPairsOriginal;
-        if(MaximumImportantPairs > 0 or MinimumImportantPairs > 0){
+        if(MaximumImportantPairs > 0 or MinimumImportantPairs > 0) {
           std::vector<std::tuple<ftm::idNode, ftm::idNode, dataType>> pairs;
           trees[i]->getPersistencePairsFromTree(pairs, false);
           if(MaximumImportantPairs > 0) {
-            double tempThreshold = 0.999*std::get<2>(pairs[pairs.size()-MaximumImportantPairs]) / std::get<2>(pairs[pairs.size()-1]);
+            double tempThreshold
+              = 0.999 * std::get<2>(pairs[pairs.size() - MaximumImportantPairs])
+                / std::get<2>(pairs[pairs.size() - 1]);
             tempThreshold *= 100;
             importantPairs_ = std::max(importantPairs_, tempThreshold);
           }
           if(MinimumImportantPairs > 0) {
-            double tempThreshold = 0.999*std::get<2>(pairs[pairs.size()-MinimumImportantPairs]) / std::get<2>(pairs[pairs.size()-1]);
+            double tempThreshold
+              = 0.999 * std::get<2>(pairs[pairs.size() - MinimumImportantPairs])
+                / std::get<2>(pairs[pairs.size() - 1]);
             tempThreshold *= 100;
             importantPairs_ = std::min(importantPairs_, tempThreshold);
           }
         }
-        
+
         // Get is interpolated tree (temporal subsampling)
         bool isInterpolatedTree = false;
         if(interpolatedTrees.size() != 0)

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -38,6 +38,8 @@ private:
   int DimensionToShift = 0;
   bool OutputSegmentation = false;
   int ShiftMode = 0; // 0: Star ; 1: Star Barycenter ; 2: Line ; 3: Double Line
+  int MaximumImportantPairs = 0;
+  int MinimumImportantPairs = 0;
 
   // Offset
   int iSampleOffset = 0;
@@ -110,6 +112,12 @@ public:
   }
   void setShiftMode(int mode) {
     ShiftMode = mode;
+  }
+  void setMaximumImportantPairs(int maxPairs){
+    MaximumImportantPairs = maxPairs;
+  }
+  void setMinimumImportantPairs(int minPairs){
+    MinimumImportantPairs = minPairs;
   }
 
   // Offset
@@ -552,6 +560,7 @@ public:
     // Iterate through all clusters
     // --------------------------------------------------------
     printMsg("Iterate through all clusters", debug::Priority::VERBOSE);
+    double importantPairsOriginal = importantPairs_;
     for(int c = 0; c < NumberOfBarycenters; ++c) {
 
       // Get radius
@@ -595,6 +604,23 @@ public:
                and (c != printClusterId or i != printTreeId)))
           continue;
 
+        // Manage important pairs threshold
+        importantPairs_ = importantPairsOriginal;
+        if(MaximumImportantPairs > 0 or MinimumImportantPairs > 0){
+          std::vector<std::tuple<ftm::idNode, ftm::idNode, dataType>> pairs;
+          trees[i]->getPersistencePairsFromTree(pairs, false);
+          if(MaximumImportantPairs > 0) {
+            double tempThreshold = 0.999*std::get<2>(pairs[pairs.size()-MaximumImportantPairs]) / std::get<2>(pairs[pairs.size()-1]);
+            tempThreshold *= 100;
+            importantPairs_ = std::max(importantPairs_, tempThreshold);
+          }
+          if(MinimumImportantPairs > 0) {
+            double tempThreshold = 0.999*std::get<2>(pairs[pairs.size()-MinimumImportantPairs]) / std::get<2>(pairs[pairs.size()-1]);
+            tempThreshold *= 100;
+            importantPairs_ = std::min(importantPairs_, tempThreshold);
+          }
+        }
+        
         // Get is interpolated tree (temporal subsampling)
         bool isInterpolatedTree = false;
         if(interpolatedTrees.size() != 0)

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -174,6 +174,8 @@ int ttkPlanarGraphLayout::mergeTreePlanarLayoutCallTemplate(
   visuMaker.setBranchDecompositionPlanarLayout(BranchDecompositionPlanarLayout);
   visuMaker.setBranchSpacing(BranchSpacing);
   visuMaker.setImportantPairs(ImportantPairs);
+  visuMaker.setMaximumImportantPairs(MaximumImportantPairs);
+  visuMaker.setMinimumImportantPairs(MinimumImportantPairs);
   visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
   visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
   visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -71,6 +71,8 @@ private:
   bool BranchDecompositionPlanarLayout = false;
   double BranchSpacing = 1.;
   double ImportantPairs = 10.; // important pairs threshold
+  int MaximumImportantPairs = 0;
+  int MinimumImportantPairs = 0;
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 0.1;
   double NonImportantPairsProximity = 0.05;
@@ -106,6 +108,12 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
+  
+  vtkSetMacro(MaximumImportantPairs, int);
+  vtkGetMacro(MaximumImportantPairs, int);
+  
+  vtkSetMacro(MinimumImportantPairs, int);
+  vtkGetMacro(MinimumImportantPairs, int);
 
   vtkSetMacro(ImportantPairsSpacing, double);
   vtkGetMacro(ImportantPairsSpacing, double);

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -108,10 +108,10 @@ public:
 
   vtkSetMacro(ImportantPairs, double);
   vtkGetMacro(ImportantPairs, double);
-  
+
   vtkSetMacro(MaximumImportantPairs, int);
   vtkGetMacro(MaximumImportantPairs, int);
-  
+
   vtkSetMacro(MinimumImportantPairs, int);
   vtkGetMacro(MinimumImportantPairs, int);
 

--- a/paraview/xmls/MergeTreeClustering.xml
+++ b/paraview/xmls/MergeTreeClustering.xml
@@ -613,6 +613,42 @@
                   <DoubleRangeDomain name="range" min="0" max="100" />
                 </DoubleVectorProperty>
                 
+                <IntVectorProperty
+                name="MaximumImportantPairs"
+                command="SetMaximumImportantPairs"
+                label="Maximum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="PlanarLayout"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="MinimumImportantPairs"
+                command="SetMinimumImportantPairs"
+                label="Minimum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="InputIsAMergeTree"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
                 <DoubleVectorProperty
                 name="ImportantPairsSpacing"
                 command="SetImportantPairsSpacing"
@@ -735,6 +771,8 @@
               <Property name="BranchDecompositionPlanarLayout"/>
               <Property name="BranchSpacing"/>
               <Property name="ImportantPairs"/>
+              <Property name="MaximumImportantPairs"/>
+              <Property name="MinimumImportantPairs"/>
               <Property name="ImportantPairsSpacing"/>
               <Property name="NonImportantPairsSpacing"/>
               <Property name="NonImportantPairsProximity"/>

--- a/paraview/xmls/MergeTreeClustering.xml
+++ b/paraview/xmls/MergeTreeClustering.xml
@@ -641,7 +641,7 @@
                   <Hints>
                   <PropertyWidgetDecorator type="GenericDecorator"
                                           mode="visibility"
-                                          property="InputIsAMergeTree"
+                                          property="PlanarLayout"
                                           value="1" />
                   </Hints>
                   <Documentation>

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -190,7 +190,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                   <Hints>
                   <PropertyWidgetDecorator type="GenericDecorator"
                                           mode="visibility"
-                                          property="InputIsAMergeTree"
+                                          property="PlanarLayout"
                                           value="1" />
                   </Hints>
                   <Documentation>

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -162,6 +162,42 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                   <DoubleRangeDomain name="range" min="0" max="100" />
                 </DoubleVectorProperty>
                 
+                <IntVectorProperty
+                name="MaximumImportantPairs"
+                command="SetMaximumImportantPairs"
+                label="Maximum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="PlanarLayout"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="MinimumImportantPairs"
+                command="SetMinimumImportantPairs"
+                label="Minimum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="InputIsAMergeTree"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
                 <DoubleVectorProperty
                 name="ImportantPairsSpacing"
                 command="SetImportantPairsSpacing"
@@ -240,6 +276,8 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
               <Property name="BranchDecompositionPlanarLayout"/>
               <Property name="BranchSpacing"/>
               <Property name="ImportantPairs"/>
+              <Property name="MaximumImportantPairs"/>
+              <Property name="MinimumImportantPairs"/>
               <Property name="ImportantPairsSpacing"/>
               <Property name="NonImportantPairsSpacing"/>
               <Property name="NonImportantPairsProximity"/>

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -334,7 +334,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                   <Hints>
                   <PropertyWidgetDecorator type="GenericDecorator"
                                           mode="visibility"
-                                          property="InputIsAMergeTree"
+                                          property="PlanarLayout"
                                           value="1" />
                   </Hints>
                   <Documentation>

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -306,6 +306,42 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                   <DoubleRangeDomain name="range" min="0" max="100" />
                 </DoubleVectorProperty>
                 
+                <IntVectorProperty
+                name="MaximumImportantPairs"
+                command="SetMaximumImportantPairs"
+                label="Maximum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="PlanarLayout"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
+                <IntVectorProperty
+                name="MinimumImportantPairs"
+                command="SetMinimumImportantPairs"
+                label="Minimum Number of Important Pairs"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="GenericDecorator"
+                                          mode="visibility"
+                                          property="InputIsAMergeTree"
+                                          value="1" />
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                </IntVectorProperty>
+                
                 <DoubleVectorProperty
                 name="ImportantPairsSpacing"
                 command="SetImportantPairsSpacing"
@@ -436,6 +472,8 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
               <Property name="BranchDecompositionPlanarLayout"/>
               <Property name="BranchSpacing"/>
               <Property name="ImportantPairs"/>
+              <Property name="MaximumImportantPairs"/>
+              <Property name="MinimumImportantPairs"/>
               <Property name="ImportantPairsSpacing"/>
               <Property name="NonImportantPairsSpacing"/>
               <Property name="NonImportantPairsProximity"/>

--- a/paraview/xmls/PlanarGraphLayout.xml
+++ b/paraview/xmls/PlanarGraphLayout.xml
@@ -111,6 +111,42 @@ TODO
               <DoubleRangeDomain name="range" min="0" max="100" />
             </DoubleVectorProperty>
             
+            <IntVectorProperty
+            name="MaximumImportantPairs"
+            command="SetMaximumImportantPairs"
+            label="Maximum Number of Important Pairs"
+            number_of_elements="1"
+            default_values="0"
+            panel_visibility="advanced">
+              <Hints>
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="InputIsAMergeTree"
+                                       value="1" />
+              </Hints>
+              <Documentation>
+                
+              </Documentation>
+            </IntVectorProperty>
+            
+            <IntVectorProperty
+            name="MinimumImportantPairs"
+            command="SetMinimumImportantPairs"
+            label="Minimum Number of Important Pairs"
+            number_of_elements="1"
+            default_values="0"
+            panel_visibility="advanced">
+              <Hints>
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="InputIsAMergeTree"
+                                       value="1" />
+              </Hints>
+              <Documentation>
+                
+              </Documentation>
+            </IntVectorProperty>
+            
             <DoubleVectorProperty
             name="ImportantPairsSpacing"
             command="SetImportantPairsSpacing"
@@ -302,6 +338,8 @@ TODO
                 <Property name="BranchDecompositionPlanarLayout"/>
                 <Property name="BranchSpacing"/>
                 <Property name="ImportantPairs"/>
+                <Property name="MaximumImportantPairs"/>
+                <Property name="MinimumImportantPairs"/>
                 <Property name="ImportantPairsSpacing"/>
                 <Property name="NonImportantPairsSpacing"/>
                 <Property name="NonImportantPairsProximity"/>


### PR DESCRIPTION
The most important parameter of the merge tree planar layout is the important pairs threshold that allows to consider as "important" the pairs having a persistence above this threshold (they will be much more visible).

However, when many trees are present, this threshold (in percentage) can be complicated to use to have a good planar layout for all trees (the same threshold can give a very high number of important pairs for a tree but very few for another one).

To tackle this problem we can add two parameters (in advanced) than bound the minimum and maximum number of possible important pairs for all trees. Hence ensuring that the planar layout of all trees are not too much imbalanced.

(in a future PR, the (planar layout) parameters in common in the merge tree filters will be merged)