### PR TITLE
[mergeTreeClustering] fix compatibility with FlattenMultiBlock

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -620,7 +620,7 @@ int ttkMergeTreeClustering::runOutput(
         vtkClusterAssignment->SetNumberOfTuples(1);
         vtkClusterAssignment->SetTuple1(0, c);
         vtkBlock2->GetFieldData()->AddArray(vtkClusterAssignment);
-        
+
         // Construct multiblock
         vtkBlock2->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
         vtkBlock2->SetBlock(0, vtkOutputNode2);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -573,6 +573,8 @@ int ttkMergeTreeClustering::runOutput(
           = vtkSmartPointer<vtkUnstructuredGrid>::New();
         vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation2
           = vtkSmartPointer<vtkUnstructuredGrid>::New();
+        vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock2
+          = vtkSmartPointer<vtkMultiBlockDataSet>::New();
 
         // Fill vtk objects
         ttkMergeTreeVisualization visuMakerBary;
@@ -612,9 +614,14 @@ int ttkMergeTreeClustering::runOutput(
         auto allBaryPercentMatchT = visuMakerBary.getAllBaryPercentMatch();
         allBaryPercentMatch[c] = allBaryPercentMatchT[c];
 
+        // Field data
+        vtkNew<vtkDoubleArray> vtkClusterAssignment{};
+        vtkClusterAssignment->SetName("ClusterAssignment");
+        vtkClusterAssignment->SetNumberOfTuples(1);
+        vtkClusterAssignment->SetTuple1(0, c);
+        vtkBlock2->GetFieldData()->AddArray(vtkClusterAssignment);
+        
         // Construct multiblock
-        vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock2
-          = vtkSmartPointer<vtkMultiBlockDataSet>::New();
         vtkBlock2->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
         vtkBlock2->SetBlock(0, vtkOutputNode2);
         vtkBlock2->SetBlock(1, vtkOutputArc2);


### PR DESCRIPTION
As in #658 the MergeTreeClustering filter followed by a FlattenMultiBlock and a MergeTreeDistanceMatrix can cause a segmentation fault.

This is because the clustered trees will have a cluster ID field data and not the centroids tree (hence making an error while copying this field data in the distance matrix).

As in #658, this PR fixes the problem by adding the cluster ID to the centroids.