### PR TITLE
GitHubActions: Replace TTK-ParaView cache with release assets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,12 @@ on:
     branches:
       - 'dev'
 
+
+env:
+  PV_TAG: v5.9.1-headless
+  PV_REPO: topology-tool-kit/ttk-paraview
+
+
 jobs:
 
 
@@ -93,6 +99,7 @@ jobs:
           libboost-system-dev \
           libeigen3-dev \
           libgraphviz-dev \
+          libosmesa-dev \
           libsqlite3-dev \
           graphviz \
           python3-sklearn \
@@ -101,13 +108,13 @@ jobs:
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
-        repo: "topology-tool-kit/ttk-paraview"
-        version: "tags/v5.8.1"
-        file: "ttk-paraview-ubuntu-20.04.deb"
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
+        file: "ttk-paraview-headless-ubuntu-20.04.deb"
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview-headless-ubuntu-20.04.deb
 
     - name: Create & configure TTK build directory
       run: |
@@ -162,6 +169,7 @@ jobs:
           libboost-system-dev \
           libeigen3-dev \
           libgraphviz-dev \
+          libosmesa-dev \
           libsqlite3-dev \
           graphviz \
           python3-sklearn \
@@ -170,13 +178,13 @@ jobs:
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
-        repo: "topology-tool-kit/ttk-paraview"
-        version: "tags/v5.8.1"
-        file: "ttk-paraview-ubuntu-20.04.deb"
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
+        file: "ttk-paraview-headless-ubuntu-20.04.deb"
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview-headless-ubuntu-20.04.deb
 
     - name: Create & configure TTK build directory
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,21 +31,6 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout TTK source code
 
-    - name: Cache ttk-paraview package
-      uses: actions/cache@v2
-      id: cache-ttk-paraview
-      with:
-        path: "ttk-paraview/build/ttk-paraview.deb"
-        key: ttk-paraview-${{ matrix.os }}
-
-    - uses: actions/checkout@v2
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      with:
-        repository: "topology-tool-kit/ttk-paraview"
-        ref: "5.9.0"
-        path: "ttk-paraview"
-      name: Checkout TTK-ParaView source code
-
     - name: Install Ubuntu dependencies
       run: |
         sudo apt update
@@ -74,37 +59,16 @@ jobs:
         key: ccache-${{ matrix.os }}-${{ github.sha }}
         restore-keys: ccache-${{ matrix.os }}
 
-    - name: Create & configure ParaView build directory
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      run: |
-        cd ttk-paraview
-        mkdir build && cd build
-        cmake \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_INSTALL_PREFIX=/usr \
-          -DPARAVIEW_PYTHON_SITE_PACKAGES_SUFFIX=lib/python3/dist-packages \
-          -DPARAVIEW_USE_QT=OFF \
-          -DVTK_USE_X=OFF \
-          -DVTK_OPENGL_HAS_OSMESA=ON \
-          -GNinja \
-          ..
-
-    - name: Build ParaView
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      run: |
-        cd ttk-paraview/build
-        cmake --build . --parallel
-
-    - name: Create ParaView package
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      run: |
-        cd ttk-paraview/build
-        cpack -G DEB
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+      name: Fetch TTK-ParaView headless Debian package
+      with:
+        repo: "pierre-guillou/paraview-ttk"
+        version: "tags/5.9.1-headless"
+        file: "ttk-paraview-headless-${{ matrix.os }}.deb"
 
     - name: Install ParaView .deb
       run: |
-        cd ttk-paraview/build
-        sudo apt install ./ttk-paraview.deb
+        sudo apt install ./ttk-paraview-headless-${{ matrix.os }}.deb
 
     - name: Create & configure TTK build directory
       run: |
@@ -194,52 +158,13 @@ jobs:
       run: |
         ccache -M 128M && ccache -c
 
-    - name: Cache ttk-paraview package
-      uses: actions/cache@v2
-      id: cache-ttk-paraview
-      with:
-        path: "ttk-paraview/build/ttk-paraview.tar.gz"
-        key: ttk-paraview-macos
-
-    - uses: actions/checkout@v2
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      with:
-        repository: "topology-tool-kit/ttk-paraview"
-        ref: "5.9.0"
-        path: "ttk-paraview"
-      name: Checkout TTK-ParaView source code
-
-    - name: Create & configure ParaView build directory
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
+    - name: Fetch TTK-ParaView headless macOS binary archive
       run: |
-        # switch to Xcode 11 since Xcode 12 breaks the ParaView build
-        sudo xcode-select -s "/Applications/Xcode_11.7.app"
-        cd ttk-paraview
-        mkdir build && cd build
-        cmake \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DPARAVIEW_USE_QT=OFF \
-          -DPython3_ROOT_DIR=$(brew --prefix python) \
-          -GNinja \
-          ..
-
-    - name: Build ParaView
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      run: |
-        cd ttk-paraview/build
-        cmake --build . --parallel
-        sudo cmake --build . --target install
-
-    - name: Create ParaView package
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      run: |
-        cd ttk-paraview/build
-        sudo cpack -G TGZ
+        wget https://github.com/pierre-guillou/paraview-ttk/releases/download/5.9.1-headless/ttk-paraview-headless.tar.gz
 
     - name: Install ParaView
       run: |
-        cd ttk-paraview/build
-        tar xzvf ttk-paraview.tar.gz
+        tar xzvf ttk-paraview-headless.tar.gz
         sudo cp -r ttk-paraview/* /usr/local
 
     - name: Create & configure TTK build directory
@@ -283,21 +208,6 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout TTK source code
 
-    - name: Cache ttk-paraview package
-      uses: actions/cache@v2
-      id: cache-ttk-paraview
-      with:
-        path: "ttk-paraview/build/ttk-paraview.exe"
-        key: ttk-paraview-${{ runner.os }}
-
-    - uses: actions/checkout@v2
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      with:
-        repository: "topology-tool-kit/ttk-paraview"
-        ref: "5.9.0"
-        path: "ttk-paraview"
-      name: Checkout TTK-ParaView source code
-
     - uses: s-weigand/setup-conda@v1
 
     - name: Install dependencies with conda
@@ -310,41 +220,16 @@ jobs:
       run: |
         rm -rf C:/hostedtoolcache/windows/Python
 
-    - name: Create & configure ParaView build directory
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      shell: cmd
+    - name: Fetch TTK-ParaView headless Windows installer
       run: |
-        call "%VCVARS%"
-        cd ttk-paraview
-        mkdir build
-        cd build
-        cmake ^
-          -DPARAVIEW_USE_QT=OFF ^
-          -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
-          -DCMAKE_BUILD_TYPE=Release ^
-          -GNinja ^
-          ..
-
-    - name: Build ParaView
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        call "%VCVARS%"
-        cd ttk-paraview/build
-        cmake --build . --config Release --parallel
-
-    - name: Create ParaView package
-      if: steps.cache-ttk-paraview.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd ttk-paraview/build
-        cpack -G NSIS64
+        Invoke-WebRequest `
+        -OutFile ttk-paraview-headless.exe `
+        -Uri https://github.com/pierre-guillou/paraview-ttk/releases/download/5.9.1-headless/ttk-paraview-headless.exe
 
     - name: Install ParaView
       shell: cmd
       run: |
-        cd ttk-paraview/build
-        ttk-paraview.exe /S
+        ttk-paraview-headless.exe /S
 
     - name: Create & configure TTK build directory
       shell: cmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,12 @@ on:
     branches:
       - 'dev'
 
-jobs:
+env:
+  PV_REPO: topology-tool-kit/ttk-paraview
+  PV_TAG: v5.9.1-headless
 
+
+jobs:
 
   # ------------------#
   # Test Ubuntu build #
@@ -67,8 +71,8 @@ jobs:
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       name: Fetch TTK-ParaView headless Debian package
       with:
-        repo: "pierre-guillou/paraview-ttk"
-        version: "tags/5.9.1-headless"
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-headless-${{ matrix.os }}.deb"
 
     - name: Install ParaView .deb
@@ -164,7 +168,7 @@ jobs:
 
     - name: Fetch TTK-ParaView headless macOS binary archive
       run: |
-        wget https://github.com/pierre-guillou/paraview-ttk/releases/download/5.9.1-headless/ttk-paraview-headless.tar.gz
+        wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.tar.gz
 
     - name: Install ParaView
       run: |
@@ -228,7 +232,7 @@ jobs:
       run: |
         Invoke-WebRequest `
         -OutFile ttk-paraview-headless.exe `
-        -Uri https://github.com/pierre-guillou/paraview-ttk/releases/download/5.9.1-headless/ttk-paraview-headless.exe
+        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.exe
 
     - name: Install ParaView
       shell: cmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       name: Fetch archived ccache
       with:
-        repo: "pierre-guillou/ttk"
+        repo: "topology-tool-kit/ttk"
         version: "tags/ccache"
         file: "ttk-ccache-${{ matrix.os }}.tar.gz"
 
@@ -158,7 +158,7 @@ jobs:
 
     - name: Fetch archived ccache
       run: |
-        wget https://github.com/pierre-guillou/ttk/releases/download/ccache/ttk-ccache-macOS.tar.gz
+        wget https://github.com/topology-tool-kit/ttk/releases/download/ccache/ttk-ccache-macOS.tar.gz
 
     - name: Decompress ccache archive
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,17 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - name: Cache object files with ccache
-      uses: actions/cache@v2
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+      name: Fetch archived ccache
       with:
-        path: /home/runner/.ccache
-        key: ccache-${{ matrix.os }}-${{ github.sha }}
-        restore-keys: ccache-${{ matrix.os }}
+        repo: "pierre-guillou/ttk"
+        version: "tags/ccache"
+        file: "ttk-ccache-${{ matrix.os }}.tar.gz"
+
+    - name: Decompress ccache archive
+      run: |
+        tar xzf ttk-ccache-${{ matrix.os }}.tar.gz
+        mv .ccache /home/runner/
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
       name: Fetch TTK-ParaView headless Debian package
@@ -147,16 +152,15 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - name: Cache object files with ccache
-      uses: actions/cache@v2
-      with:
-        path: /Users/runner/work/ttk/.ccache
-        key: ccache-macos-${{ github.sha }}
-        restore-keys: ccache-macos
-
-    - name: Reduce ccache cache size
+    - name: Fetch archived ccache
       run: |
-        ccache -M 128M && ccache -c
+        wget https://github.com/pierre-guillou/ttk/releases/download/ccache/ttk-ccache-macOS.tar.gz
+
+    - name: Decompress ccache archive
+      run: |
+        tar xzf ttk-ccache-macOS.tar.gz
+        rm -rf /Users/runner/work/ttk/.ccache
+        mv .ccache /Users/runner/work/ttk/
 
     - name: Fetch TTK-ParaView headless macOS binary archive
       run: |
@@ -164,7 +168,7 @@ jobs:
 
     - name: Install ParaView
       run: |
-        tar xzvf ttk-paraview-headless.tar.gz
+        tar xzf ttk-paraview-headless.tar.gz
         sudo cp -r ttk-paraview/* /usr/local
 
     - name: Create & configure TTK build directory


### PR DESCRIPTION
This PR replaces the cache used in the "test_build" GitHub Actions workflow with release assets.

The last PRs on the TTK repositories showed that the GitHub Actions cache scope is restricted to a branch and PRs that target it. Since the CI is not triggered after the merge but only when PRs are opened, this means that currently no cache is associated with the "dev" branch.

Another workaround would be to enable this workflow on push events on the "dev" branch. However, this might have an impact on forks of the reference repository with "dev" branches, triggering sometimes unwanted CI pipelines. Besides, in case of a cache miss during a PR, a second cache miss would also occur after the merge because the PR-triggered workflow cache is associated to the PR branch, not the "dev" branch. The current version, by using Release Assets instead of cache, solves those two shortcomings.

Enjoy,
Pierre