### PR TITLE
Using CMake Targets for Eigen includes

### DIFF
--- a/core/base/eigenField/CMakeLists.txt
+++ b/core/base/eigenField/CMakeLists.txt
@@ -11,7 +11,7 @@ ttk_add_base_library(eigenField
 
 if(TTK_ENABLE_SPECTRA)
   target_compile_definitions(eigenField PRIVATE TTK_ENABLE_EIGEN)
-  target_include_directories(eigenField SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_link_libraries(eigenField PRIVATE Eigen3::Eigen)
   target_compile_definitions(eigenField PRIVATE TTK_ENABLE_SPECTRA)
   target_link_libraries(eigenField PRIVATE Spectra::Spectra)
 endif()

--- a/core/base/harmonicField/CMakeLists.txt
+++ b/core/base/harmonicField/CMakeLists.txt
@@ -11,5 +11,5 @@ ttk_add_base_library(harmonicField
 
 if(TTK_ENABLE_EIGEN)
   target_compile_definitions(harmonicField PRIVATE TTK_ENABLE_EIGEN)
-  target_include_directories(harmonicField SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_link_libraries(harmonicField PRIVATE Eigen3::Eigen)
 endif()

--- a/core/base/laplacian/CMakeLists.txt
+++ b/core/base/laplacian/CMakeLists.txt
@@ -10,5 +10,5 @@ ttk_add_base_library(laplacian
 
 if(TTK_ENABLE_EIGEN)
   target_compile_definitions(laplacian PRIVATE TTK_ENABLE_EIGEN)
-  target_include_directories(laplacian SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIR})
+  target_link_libraries(laplacian PRIVATE Eigen3::Eigen)
 endif()


### PR DESCRIPTION
Uses the CMake target Eigen3::Eigen to link to the Eigen library.

Requires CMake 3.0 (or later).