### PR TITLE
nullptr check in GetVoidPointer; new util function SliceArray

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -234,9 +234,10 @@ void *ttkUtils::GetVoidPointer(vtkPoints *points, vtkIdType start) {
   return GetVoidPointer(points->GetData(), start);
 }
 
-vtkSmartPointer<vtkDataArray> ttkUtils::SliceArray(vtkDataArray *array,
-                                                   vtkIdType idx) {
-  auto slicedArray = vtkSmartPointer<vtkDataArray>::Take(array->NewInstance());
+vtkSmartPointer<vtkAbstractArray> ttkUtils::SliceArray(vtkAbstractArray *array,
+                                                       vtkIdType idx) {
+  auto slicedArray
+    = vtkSmartPointer<vtkAbstractArray>::Take(array->NewInstance());
   slicedArray->SetName(array->GetName());
   slicedArray->SetNumberOfComponents(array->GetNumberOfComponents());
   slicedArray->SetNumberOfTuples(1);

--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -219,6 +219,9 @@ vtkSmartPointer<vtkDoubleArray>
 /// the old GetVoidPointer in vtkDataArray
 void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
   void *outPtr = nullptr;
+  if(array == nullptr)
+    return outPtr;
+
   switch(array->GetDataType()) {
     vtkTemplateMacro(
       auto *aosArray = vtkAOSDataArrayTemplate<VTK_TT>::FastDownCast(array);
@@ -229,6 +232,16 @@ void *ttkUtils::GetVoidPointer(vtkDataArray *array, vtkIdType start) {
 
 void *ttkUtils::GetVoidPointer(vtkPoints *points, vtkIdType start) {
   return GetVoidPointer(points->GetData(), start);
+}
+
+vtkSmartPointer<vtkDataArray> ttkUtils::SliceArray(vtkDataArray *array,
+                                                   vtkIdType idx) {
+  auto slicedArray = vtkSmartPointer<vtkDataArray>::Take(array->NewInstance());
+  slicedArray->SetName(array->GetName());
+  slicedArray->SetNumberOfComponents(array->GetNumberOfComponents());
+  slicedArray->SetNumberOfTuples(1);
+  slicedArray->SetTuple(0, idx, array);
+  return slicedArray;
 }
 
 void *ttkUtils::WriteVoidPointer(vtkDataArray *array,

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -60,6 +60,9 @@ public:
     return static_cast<DT *>(ttkUtils::GetVoidPointer(array, start));
   }
 
+  static vtkSmartPointer<vtkDataArray> SliceArray(vtkDataArray *array,
+                                                  vtkIdType idx);
+
   static void *
     WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);
   static void *

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -60,8 +60,8 @@ public:
     return static_cast<DT *>(ttkUtils::GetVoidPointer(array, start));
   }
 
-  static vtkSmartPointer<vtkDataArray> SliceArray(vtkDataArray *array,
-                                                  vtkIdType idx);
+  static vtkSmartPointer<vtkAbstractArray> SliceArray(vtkAbstractArray *array,
+                                                      vtkIdType idx);
 
   static void *
     WriteVoidPointer(vtkDataArray *array, vtkIdType start, vtkIdType numValues);


### PR DESCRIPTION
Hi Julien,
this PR adds a sanity check in `ttkUtils::GetVoidPointer` to prevent a segfault when a `nullptr` is passed to  the function. This is convenient, because now one can write:
```
auto arrayData = ttkUtils::GetPointer<double>(somePointData->GetArray("Test"));
if(!arrayData)
  return ERROR;
```
Before one had to first check if the array exists, and then feed it into the `GetVoidPointer` method. Otherwise a seg fault would occur.

I also added a new Utils function called `SliceArray` which takes a `srcArray` and a `tupleIdx` as input. The function then creates a new `dstArray` with the same name and number of components, but the new array only contains the tuple at the specified index. This is convenient for many Cinema related stuff.

Best
Jonas