### PR TITLE
DiscreteGradient: Fix simplexes comparisons in priority queues

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -59,8 +59,8 @@ namespace ttk {
 
       // if cell has been paired with another in current lower star
       bool paired_{false};
-      // lower vertices in current lower star (1 for edges, 2 for triangles, 3
-      // for tetras)
+      // (order field value on) lower vertices in current lower star
+      // (1 for edges, 2 for triangles, 3 for tetras)
       const std::array<SimplexId, 3> lowVerts_{};
       // indices of faces (cells of dimensions dim_ - 1) in lower star
       // structure, only applicable for triangles (2 edge faces)  and tetras (3

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -57,8 +57,6 @@ namespace ttk {
         : Cell{dim, id}, lowVerts_{lowVerts}, faces_{faces} {
       }
 
-      // if cell has been paired with another in current lower star
-      bool paired_{false};
       // (order field value on) lower vertices in current lower star
       // (1 for edges, 2 for triangles, 3 for tetras)
       const std::array<SimplexId, 3> lowVerts_{};
@@ -66,6 +64,8 @@ namespace ttk {
       // structure, only applicable for triangles (2 edge faces)  and tetras (3
       // triangle faces)
       const std::array<uint8_t, 3> faces_{};
+      // if cell has been paired with another in current lower star
+      bool paired_{false};
     };
 
     /**

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1974,56 +1974,37 @@ int DiscreteGradient::processLowerStars(
   // Comparison function for Cells inside priority queues
   const auto orderCells = [&](const CellExt &a, const CellExt &b) -> bool {
     if(a.dim_ == b.dim_) {
-      // there should be a shared facet between the two cells
-      // compare the vertices not in the shared facet
+      // compare the last non common vertex inserted in the filtration
       if(a.dim_ == 1) {
         return offsets[a.lowVerts_[0]] > offsets[b.lowVerts_[0]];
 
       } else if(a.dim_ == 2) {
-        const auto &m0 = a.lowVerts_[0];
-        const auto &m1 = a.lowVerts_[1];
-        const auto &n0 = b.lowVerts_[0];
-        const auto &n1 = b.lowVerts_[1];
-
-        if(m0 == n0) {
-          return offsets[m1] > offsets[n1];
-        } else if(m0 == n1) {
-          return offsets[m1] > offsets[n0];
-        } else if(m1 == n0) {
-          return offsets[m0] > offsets[n1];
-        } else if(m1 == n1) {
-          return offsets[m0] > offsets[n0];
-        }
+        std::array<SimplexId, 2> m{
+          offsets[a.lowVerts_[0]],
+          offsets[a.lowVerts_[1]],
+        };
+        std::array<SimplexId, 2> n{
+          offsets[b.lowVerts_[0]],
+          offsets[b.lowVerts_[1]],
+        };
+        std::sort(m.begin(), m.end());
+        std::sort(n.begin(), n.end());
+        return m > n;
 
       } else if(a.dim_ == 3) {
-        SimplexId m{-1}, n{-1};
-
-        const auto &m0 = a.lowVerts_[0];
-        const auto &m1 = a.lowVerts_[1];
-        const auto &m2 = a.lowVerts_[2];
-        const auto &n0 = b.lowVerts_[0];
-        const auto &n1 = b.lowVerts_[1];
-        const auto &n2 = b.lowVerts_[2];
-
-        // extract vertex of a not in b
-        if(m0 != n0 && m0 != n1 && m0 != n2) {
-          m = m0;
-        } else if(m1 != n0 && m1 != n1 && m1 != n2) {
-          m = m1;
-        } else if(m2 != n0 && m2 != n1 && m2 != n2) {
-          m = m2;
-        }
-
-        // extract vertex of b not in a
-        if(n0 != m0 && n0 != m1 && n0 != m2) {
-          n = n0;
-        } else if(n1 != m0 && n1 != m1 && n1 != m2) {
-          n = n1;
-        } else if(n2 != m0 && n2 != m1 && n2 != m2) {
-          n = n2;
-        }
-
-        return offsets[m] > offsets[n];
+        std::array<SimplexId, 3> m{
+          offsets[a.lowVerts_[0]],
+          offsets[a.lowVerts_[1]],
+          offsets[a.lowVerts_[2]],
+        };
+        std::array<SimplexId, 3> n{
+          offsets[b.lowVerts_[0]],
+          offsets[b.lowVerts_[1]],
+          offsets[b.lowVerts_[2]],
+        };
+        std::sort(m.begin(), m.end());
+        std::sort(n.begin(), n.end());
+        return m > n;
       }
     } else {
       // the cell of greater dimension should contain the cell of

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1796,8 +1796,11 @@ inline void
           lowVerts[0] = offsets[v0];
           lowVerts[1] = offsets[v1];
         }
-        std::sort(lowVerts.rbegin(), lowVerts.rend());
-        if(offsets[a] > lowVerts[0] && offsets[a] > lowVerts[1]) {
+        // higher order vertex first
+        if(lowVerts[0] < lowVerts[1]) {
+          std::swap(lowVerts[0], lowVerts[1]);
+        }
+        if(offsets[a] > lowVerts[0]) { // triangle in lowerStar
           uint8_t j{}, k{};
           // store edges indices of current triangle
           std::array<uint8_t, 3> faces{};
@@ -1873,18 +1876,23 @@ inline void
           lowVerts[1] = offsets[v1];
           lowVerts[2] = offsets[v2];
         }
-        std::sort(lowVerts.rbegin(), lowVerts.rend());
-        if(offsets[a] > lowVerts[0] && offsets[a] > lowVerts[1]
-           && offsets[a] > lowVerts[2]) {
+        if(offsets[a] > *std::max_element(
+             lowVerts.begin(), lowVerts.end())) { // tetra in lowerStar
+
+          // higher order vertex first
+          std::sort(lowVerts.rbegin(), lowVerts.rend());
+
           uint8_t j{}, k{};
           // store triangles indices of current tetra
           std::array<uint8_t, 3> faces{};
           for(const auto &t : ls[2]) {
-            if((t.lowVerts_[0] == lowVerts[0] || t.lowVerts_[0] == lowVerts[1]
-                || t.lowVerts_[0] == lowVerts[2])
-               && (t.lowVerts_[1] == lowVerts[0]
-                   || t.lowVerts_[1] == lowVerts[1]
-                   || t.lowVerts_[1] == lowVerts[2])) {
+            // lowVerts & t.lowVerts are ordered, no need to check if
+            // t.lowVerts[0] == lowVerts[2] or t.lowVerts[1] == lowVerts[0]
+            if((t.lowVerts_[0] == lowVerts[0]
+                && (t.lowVerts_[1] == lowVerts[1]
+                    || t.lowVerts_[1] == lowVerts[2]))
+               || (t.lowVerts_[0] == lowVerts[1]
+                   && t.lowVerts_[1] == lowVerts[2])) {
               faces[k++] = j;
             }
             j++;

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -59,14 +59,12 @@ int ttkDimensionReduction::RequestData(vtkInformation *ttkNotUsed(request),
     const SimplexId numberOfRows = input->GetNumberOfRows();
     const SimplexId numberOfColumns = ScalarFields.size();
 
-#ifndef TTK_ENABLE_KAMIKAZE
     if(numberOfRows <= 0 || numberOfColumns <= 0) {
       this->printErr("input matrix has invalid dimensions (rows: "
                      + std::to_string(numberOfRows)
                      + ", columns: " + std::to_string(numberOfColumns) + ")");
-      return -1;
+      return 0;
     }
-#endif
 
     std::vector<double> inputData;
     std::vector<vtkAbstractArray *> arrays;

--- a/core/vtk/ttkDistanceField/ttkDistanceField.cpp
+++ b/core/vtk/ttkDistanceField/ttkDistanceField.cpp
@@ -47,70 +47,44 @@ int ttkDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
   vtkPointSet *sources = vtkPointSet::GetData(inputVector[1]);
   vtkDataSet *output = vtkDataSet::GetData(outputVector);
 
-  ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(domain);
-  this->preconditionTriangulation(triangulation);
-  Modified();
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!triangulation) {
-    this->printErr("wrong triangulation.");
-    return -1;
+  auto triangulation = ttkAlgorithm::GetTriangulation(domain);
+  if(triangulation == nullptr) {
+    this->printErr("Wrong triangulation.");
+    return 0;
   }
-#endif
+
+  this->preconditionTriangulation(triangulation);
 
   std::vector<ttk::SimplexId> idSpareStorage{};
   auto *identifiers = this->GetIdentifierArrayPtr(ForceInputVertexScalarField,
                                                   0, ttk::VertexScalarFieldName,
                                                   sources, idSpareStorage);
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!identifiers) {
-    printErr("wrong identifiers.");
-    return -2;
+  if(identifiers == nullptr) {
+    printErr("Wrong identifiers.");
+    return 0;
   }
-#endif
 
   const int numberOfPointsInDomain = domain->GetNumberOfPoints();
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!numberOfPointsInDomain) {
-    printErr("domain has no points.");
-    return -3;
+  if(numberOfPointsInDomain == 0) {
+    printErr("Domain has no points.");
+    return 0;
   }
-#endif
 
   const int numberOfPointsInSources = sources->GetNumberOfPoints();
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!numberOfPointsInSources) {
-    printErr("sources have no points.");
-    return -4;
+  if(numberOfPointsInSources == 0) {
+    printErr("Sources have no points.");
+    return 0;
   }
-#endif
 
   vtkNew<ttkSimplexIdTypeArray> origin{};
-  if(origin) {
-    origin->SetNumberOfComponents(1);
-    origin->SetNumberOfTuples(numberOfPointsInDomain);
-    origin->SetName(ttk::VertexScalarFieldName);
-  }
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  else {
-    printErr("ttkSimplexIdTypeArray allocation problem.");
-    return -5;
-  }
-#endif
+  origin->SetNumberOfComponents(1);
+  origin->SetNumberOfTuples(numberOfPointsInDomain);
+  origin->SetName(ttk::VertexScalarFieldName);
 
   vtkNew<ttkSimplexIdTypeArray> seg{};
-  if(seg) {
-    seg->SetNumberOfComponents(1);
-    seg->SetNumberOfTuples(numberOfPointsInDomain);
-    seg->SetName("SeedIdentifier");
-  }
-#ifndef TTK_ENABLE_KAMIKAZE
-  else {
-    printErr("ttkSimplexIdTypeArray allocation problem.");
-    return -6;
-  }
-#endif
+  seg->SetNumberOfComponents(1);
+  seg->SetNumberOfTuples(numberOfPointsInDomain);
+  seg->SetName("SeedIdentifier");
 
   this->setVertexNumber(numberOfPointsInDomain);
   this->setSourceNumber(numberOfPointsInSources);
@@ -123,17 +97,10 @@ int ttkDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
   switch(static_cast<DistanceType>(OutputScalarFieldType)) {
     case DistanceType::Float:
       distanceScalars = vtkFloatArray::New();
-      if(distanceScalars) {
-        distanceScalars->SetNumberOfComponents(1);
-        distanceScalars->SetNumberOfTuples(numberOfPointsInDomain);
-        distanceScalars->SetName(OutputScalarFieldName.data());
-      }
-#ifndef TTK_ENABLE_KAMIKAZE
-      else {
-        printErr("vtkFloatArray allocation problem.");
-        return -7;
-      }
-#endif
+      distanceScalars->SetNumberOfComponents(1);
+      distanceScalars->SetNumberOfTuples(numberOfPointsInDomain);
+      distanceScalars->SetName(OutputScalarFieldName.data());
+
       this->setOutputScalarFieldPointer(
         ttkUtils::GetVoidPointer(distanceScalars));
       ttkTemplateMacro(
@@ -143,17 +110,10 @@ int ttkDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
 
     case DistanceType::Double:
       distanceScalars = vtkDoubleArray::New();
-      if(distanceScalars) {
-        distanceScalars->SetNumberOfComponents(1);
-        distanceScalars->SetNumberOfTuples(numberOfPointsInDomain);
-        distanceScalars->SetName(OutputScalarFieldName.data());
-      }
-#ifndef TTK_ENABLE_KAMIKAZE
-      else {
-        printErr("vtkDoubleArray allocation problem.");
-        return -8;
-      }
-#endif
+      distanceScalars->SetNumberOfComponents(1);
+      distanceScalars->SetNumberOfTuples(numberOfPointsInDomain);
+      distanceScalars->SetName(OutputScalarFieldName.data());
+
       this->setOutputScalarFieldPointer(
         ttkUtils::GetVoidPointer(distanceScalars));
 
@@ -163,17 +123,15 @@ int ttkDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
       break;
 
     default:
-#ifndef TTK_ENABLE_KAMIKAZE
-      printErr("Scalar field type problem.");
-      return -9;
-#endif
+      printErr("Invalid scalar field type.");
+      return 0;
       break;
   }
 
   // something wrong in baseCode
-  if(ret) {
+  if(ret != 0) {
     printErr("DistanceField.execute() error code : " + std::to_string(ret));
-    return -10;
+    return 0;
   }
 
   // update result
@@ -183,5 +141,5 @@ int ttkDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
   output->GetPointData()->AddArray(seg);
   distanceScalars->Delete();
 
-  return !ret;
+  return 1;
 }


### PR DESCRIPTION
This PR fixes the simplexes comparison order when filling the priority queues of the processLowerStar algorithm in the DiscreteGradient. Currently, comparing simplexes of dimension > 1 in a lower star do not take the filtration order into account. This should be fixed in this PR with the following changes:
* for each simplex in a lower star, instead of storing the lower vertices, we store their order value sorted in decreasing order (the higher order value first). -1 values are used to fill missing vertex order values for edges and triangles. Comparing two simplexes becomes a simple lexicographic comparison between two `std::array`s.

This change causes, however, some modifications in the ttk-data states. 1manifoldLearning, 2manifoldLearning, morseMolecule, morseSmaleQuadrangulation, tectonicPuzzle and tribute (all states that call the Morse-Smale complex and display 2-saddles, maxima or ascending 1-separatrices) are slightly affected.

Also included in this PR:
* an extended use of the `firstprivate` clause in the MorseSmaleComplex (3D). It improves performance (+8/10% when computing saddle connectors + 2-separatrices) compared to a shared vector between threads in which each thread access its own element,
* DimensionReduction now exits with an helpful error message when the input matrix has 0 rows or columns,
* DistanceField does not segfault anymore when the input dataset is not a valid triangulation (preconditionTriangulation now called after checking triangulation != nullptr).

Those last changes do not affect the ttk-data states.

Enjoy,
Pierre