### PR TITLE
GitHub Actions: Fix packaging for ParaView >= 5.9.0, generate ccache archives for CI

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -1,0 +1,211 @@
+name: store_ccache
+
+on:
+  push:
+    branch-ignore:
+      - '*'
+    tags:
+      - 'ccache'
+
+env:
+  PV_TAG: v5.9.1-headless
+  PV_REPO: topology-tool-kit/ttk-paraview
+
+jobs:
+
+  # -------#
+  # Ubuntu #
+  # -------#
+  ccache-ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+    steps:
+
+    - uses: actions/checkout@v2
+      name: Checkout TTK source code
+
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt update
+        # TTK dependencies
+        sudo apt install -y \
+          ccache \
+          g++-11 \
+          libboost-system-dev \
+          libeigen3-dev \
+          libgraphviz-dev \
+          libosmesa-dev \
+          libsqlite3-dev \
+          graphviz \
+          ninja-build \
+          zlib1g-dev \
+          dpkg-dev
+        sudo python3 -m pip install scikit-learn
+
+    - name: Install optional dependencies
+      uses: ./.github/actions/install-deps-unix
+
+    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+      name: Fetch TTK-ParaView headless Debian package
+      with:
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
+        file: "ttk-paraview-headless-${{ matrix.os }}.deb"
+
+    - name: Install ParaView .deb
+      run: |
+        sudo apt install ./ttk-paraview-headless-${{ matrix.os }}.deb
+
+    - name: Create & configure TTK build directory
+      run: |
+        mkdir build
+        cd build
+        CC=gcc-11 CXX=g++-11 cmake \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
+          -DTTK_BUILD_VTK_WRAPPERS=TRUE \
+          -DTTK_BUILD_STANDALONE_APPS=TRUE \
+          -DTTK_ENABLE_KAMIKAZE=TRUE \
+          -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
+          -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          -GNinja \
+          $GITHUB_WORKSPACE
+
+    - name: Build TTK
+      run: |
+        cd build
+        cmake --build . --parallel
+
+    - name: Archive cache
+      run: |
+        cd /home/runner
+        tar czf ttk-ccache.tar.gz .ccache
+
+    - name: Upload ccache archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-ccache-${{ matrix.os }}
+        path: /home/runner/ttk-ccache.tar.gz
+
+
+  # ------#
+  # macOS #
+  # ------#
+  ccache-macos:
+    runs-on: macos-latest
+    env:
+      CCACHE_DIR: /Users/runner/work/ttk/.ccache
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK source code
+
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /usr/local/Frameworks/Python.framework
+
+    - name: Install macOS dependencies
+      run: |
+        # ParaView dependencies
+        brew install --cask xquartz
+        brew install wget libomp ninja python
+        # TTK dependencies
+        brew install boost eigen graphviz numpy embree ccache
+        python3 -m pip install scikit-learn
+        # prepend ccache to system path
+        echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
+
+    - name: Install optional dependencies
+      uses: ./.github/actions/install-deps-unix
+
+    - name: Fetch TTK-ParaView headless macOS binary archive
+      run: |
+        wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.tar.gz
+
+    - name: Install ParaView
+      run: |
+        tar xzf ttk-paraview-headless.tar.gz
+        sudo cp -r ttk-paraview/* /usr/local
+
+    - name: Create & configure TTK build directory
+      run: |
+        mkdir build
+        cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DPython3_ROOT_DIR=$(brew --prefix python) \
+          -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
+          -DTTK_BUILD_VTK_WRAPPERS=TRUE \
+          -DTTK_BUILD_STANDALONE_APPS=TRUE \
+          -DTTK_ENABLE_KAMIKAZE=TRUE \
+          -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
+          -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          -GNinja \
+          $GITHUB_WORKSPACE
+
+    - name: Build TTK
+      run: |
+        cd build
+        cmake --build . --parallel
+
+    - name: Archive cache
+      run: |
+        cd /Users/runner/work/ttk
+        tar czf ttk-ccache.tar.gz .ccache
+
+    - name: Upload ccache archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-ccache-macOS
+        path: /Users/runner/work/ttk/ttk-ccache.tar.gz
+
+  # --------------------- #
+  # Upload release assets #
+  # --------------------- #
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [ccache-ubuntu, ccache-macos]
+    steps:
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+    - name: Fetch all uploaded artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Upload Ubuntu Bionic .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ccache-ubuntu-18.04/ttk-ccache.tar.gz
+        asset_name: ttk-ccache-ubuntu-18.04.tar.gz
+
+    - name: Upload Ubuntu Focal .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ccache-ubuntu-20.04/ttk-ccache.tar.gz
+        asset_name: ttk-ccache-ubuntu-20.04.tar.gz
+
+    - name: Upload .pkg as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ccache-macOS/ttk-ccache.tar.gz
+        asset_name: ttk-ccache-macOS.tar.gz

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,20 +15,21 @@ on:
       - '*.*.*'
       - 'pack*'
 
+env:
+  PV_TAG: v5.9.1
+  PV_REPO: topology-tool-kit/ttk-paraview
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build-linux:
-    # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+  # -------------#
+  # Build Ubuntu #
+  # -------------#
+  build-linux:
+    runs-on: ubuntu-20.04
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
 
     - name: Install Ubuntu dependencies
       run: |
@@ -39,6 +40,7 @@ jobs:
           libeigen3-dev \
           libgraphviz-dev \
           libsqlite3-dev \
+          libgl1-mesa-dev \
           graphviz \
           python3-sklearn \
           zlib1g-dev \
@@ -48,14 +50,15 @@ jobs:
       uses: ./.github/actions/install-deps-unix
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
+      name: Fetch TTK-ParaView package
       with:
-        repo: "topology-tool-kit/ttk-paraview"
-        version: "tags/v5.8.1"
-        file: "ttk-paraview-${{ matrix.os }}.deb"
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
+        file: "ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb"
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-${{ matrix.os }}.deb
+        sudo apt install ./ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb
 
     - name: Create & configure TTK build directory
       run: |
@@ -76,7 +79,8 @@ jobs:
     - name: Build TTK
       run: |
         cd build
-        make -j$(nproc)
+        # not enough RAM to build in parallel (or with ninja)
+        cmake --build .
 
     - name: Package TTK & update package informations
       run: |
@@ -89,72 +93,75 @@ jobs:
         # modify control file, remove libgcc-s1 dependency
         sed 's/libgcc-s1[^,]*, //g' -i tmp/DEBIAN/control
         # build updated deb package
-        dpkg -b tmp ttk-${{ matrix.os }}.deb
+        dpkg -b tmp ttk-ubuntu-20.04.deb
 
     - name: Upload TTK .deb package
       uses: actions/upload-artifact@v2
       with:
-        name: ttk-${{ matrix.os }}.deb
-        path: build/ttk-${{ matrix.os }}.deb
+        name: ttk-ubuntu-20.04.deb
+        path: build/ttk-ubuntu-20.04.deb
 
+  # ------------#
+  # Test Ubuntu #
+  # ------------#
   test-linux:
     needs: build-linux
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
 
     - uses: dsaltares/fetch-gh-release-asset@0.0.5
+      name: Fetch TTK-ParaView package
       with:
-        repo: "topology-tool-kit/ttk-paraview"
-        version: "tags/v5.8.1"
-        file: "ttk-paraview-${{ matrix.os }}.deb"
+        repo: "${{ env.PV_REPO }}"
+        version: "tags/${{ env.PV_TAG }}"
+        file: "ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb"
 
     - name: Fetch TTK .deb artifact
       uses: actions/download-artifact@v2
       with:
-        name: ttk-${{ matrix.os }}.deb
+        name: ttk-ubuntu-20.04.deb
 
     - name: Install generated .deb packages
       run: |
         sudo apt update
-        sudo apt install ./ttk-paraview-${{ matrix.os }}.deb
-        sudo apt install ./ttk-${{ matrix.os }}.deb
+        sudo apt install ./ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb
+        sudo apt install ./ttk-ubuntu-20.04.deb
 
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 
+
+  # ------------#
+  # Build macOS #
+  # ------------#
   build-macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /usr/local/Frameworks/Python.framework
 
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp mesa glew qt
+        brew install wget libomp mesa glew qt@5 ninja python
         # TTK dependencies
         brew install boost eigen graphviz embree
-        python -m pip install scikit-learn
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
+        python3 -m pip install scikit-learn
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - name: Fetch & install ttk-paraview
+    - name: Fetch & install TTK-ParaView
       run: |
-        wget https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.pkg
-        sudo installer -pkg ttk-paraview.pkg -target /
+        wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.pkg
+        sudo installer -pkg ttk-paraview-${{ env.PV_TAG }}.pkg -target /
 
     - name: Create & configure TTK build directory
       run: |
@@ -162,7 +169,7 @@ jobs:
         cd build
         cmake \
           -DCMAKE_BUILD_TYPE=Release \
-          -DQt5_DIR=$(brew --prefix qt)/lib/cmake/Qt5 \
+          -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
           -DPython3_FIND_STRATEGY=LOCATION \
           -DPython3_ROOT_DIR=$(python -c "import sys; print(sys.prefix)") \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
@@ -172,12 +179,13 @@ jobs:
           -DTTK_ENABLE_DOUBLE_TEMPLATING=TRUE \
           -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
           -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          -GNinja \
           $GITHUB_WORKSPACE
 
     - name: Build TTK
       run: |
         cd build
-        make -j$(sysctl -n hw.physicalcpu)
+        cmake --build . --parallel
 
     - name: Package TTK
       run: |
@@ -190,32 +198,32 @@ jobs:
         name: ttk.pkg
         path: build/ttk.pkg
 
+  # -----------#
+  # Test macOS #
+  # -----------#
   test-macos:
     needs: build-macos
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /usr/local/Frameworks/Python.framework
 
-    - name: Install macOS run-time dependencies
+    - name: Install macOS dependencies
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp mesa glew qt
+        brew install wget libomp mesa glew qt@5 ninja python
         # TTK dependencies
-        brew install boost graphviz embree
-        python -m pip install scikit-learn
+        brew install boost eigen graphviz embree
+        python3 -m pip install scikit-learn
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
-
-    - name: Fetch ttk-paraview
+    - name: Fetch TTK-ParaView
       run: |
-        wget https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.pkg
+        wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.pkg
 
     - name: Fetch TTK .pkg artifact
       uses: actions/download-artifact@v2
@@ -224,7 +232,7 @@ jobs:
 
     - name: Install .pkg packages
       run: |
-        sudo installer -pkg ttk-paraview.pkg -target /
+        sudo installer -pkg ttk-paraview-${{ env.PV_TAG }}.pkg -target /
         sudo installer -pkg ttk.pkg -target /
 
     - name: Test TTK examples
@@ -233,20 +241,20 @@ jobs:
         cd $GITHUB_WORKSPACE/examples/c++
         mkdir build && cd build
         cmake ..
-        make
+        cmake --build . --parallel
         ./ttkExample-c++ -i ../../data/inputData.off
         # VTK layer
-        export CMAKE_PREFIX_PATH=$(brew --prefix qt)/lib/cmake:$CMAKE_PREFIX_PATH
+        export CMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake:$CMAKE_PREFIX_PATH
         cd $GITHUB_WORKSPACE/examples/vtk-c++
         mkdir build &&  cd build
         cmake ..
-        make
+        cmake --build . --parallel
         ./ttkExample-vtk-c++ -i ../../data/inputData.vtu
         # pure Python
-        export PYTHONPATH=/Applications/lib/python3.8/site-packages
+        export PYTHONPATH=/Applications/lib/python3.9/site-packages
         export DYLD_LIBRARY_PATH=/Applications/lib:$DYLD_LIBRARY_PATH
         cd $GITHUB_WORKSPACE/examples/python
-        python example.py ../data/inputData.vtu
+        python3 example.py ../data/inputData.vtu
         # pvpython
         export PATH=/Applications/bin:$PATH
         cd $GITHUB_WORKSPACE/examples/pvpython
@@ -255,23 +263,33 @@ jobs:
         cd $GITHUB_WORKSPACE
         ttkHelloWorldCmd -i examples/data/inputData.vtu
 
+
+  # --------------#
+  # Build Windows #
+  # --------------#
   build-windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
+
     - uses: s-weigand/setup-conda@v1
 
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c anaconda qt boost
-        conda install -c conda-forge eigen=3.3.8 spectralib zfp scikit-learn openmp embree3
+        conda install -c conda-forge qt boost eigen spectralib zfp scikit-learn openmp graphviz
 
-    - name: Fetch ParaView installer
+    - name: Remove hosted Python
+      shell: bash
+      run: |
+        rm -rf C:/hostedtoolcache/windows/Python
+
+    - name: Fetch TTK-ParaView installer
       run: |
         Invoke-WebRequest `
         -OutFile ttk-paraview.exe `
-        -Uri https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.exe
+        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
 
     - name: Install ParaView .exe
       shell: cmd
@@ -284,7 +302,7 @@ jobs:
           -OutFile vc_redist.x64.exe `
           -Uri https://aka.ms/vs/16/release/vc_redist.x64.exe
 
-    - name: Configure TTK
+    - name: Create & configure TTK build directory
       shell: cmd
       run: |
         set CONDA_ROOT="C:\Miniconda"
@@ -326,24 +344,33 @@ jobs:
         name: ttk.exe
         path: build/ttk.exe
 
+  # -------------#
+  # Test Windows #
+  # -------------#
   test-windows:
     needs: build-windows
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+      name: Checkout TTK source code
+
     - uses: s-weigand/setup-conda@v1
 
-    - name: Install run-time dependencies with conda
+    - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c anaconda qt boost
-        conda install -c conda-forge zfp scikit-learn openmp embree3
+        conda install -c conda-forge qt boost eigen spectralib zfp scikit-learn openmp graphviz
 
-    - name: Fetch ParaView installer
+    - name: Remove hosted Python
+      shell: bash
+      run: |
+        rm -rf C:/hostedtoolcache/windows/Python
+
+    - name: Fetch TTK-ParaView installer
       run: |
         Invoke-WebRequest `
         -OutFile ttk-paraview.exe `
-        -Uri https://github.com/topology-tool-kit/ttk-paraview/releases/download/v5.8.1/ttk-paraview.exe
+        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
 
     - name: Fetch TTK .exe artifact
       uses: actions/download-artifact@v2
@@ -400,6 +427,9 @@ jobs:
         pvpython.exe example.py ../data/inputData.vtu
 
 
+  # ---------------#
+  # Create release #
+  # ---------------#
   create-release:
     runs-on: ubuntu-latest
     needs: [test-linux, test-macos, test-windows]
@@ -418,14 +448,6 @@ jobs:
 
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v2
-
-    - name: Upload Ubuntu Bionic .deb as Release Asset
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.ref }}
-        file: ttk-ubuntu-18.04.deb/ttk-ubuntu-18.04.deb
-        asset_name: ttk-$tag-ubuntu-18.04.deb
 
     - name: Upload Ubuntu Focal .deb as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
   set(CPACK_RESOURCE_FILE_README ${PROJECT_BINARY_DIR}/Readme.txt)
 endif()
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-  "ttk-paraview (= 5.8.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev")
+  "ttk-paraview (= 5.9.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev, libgl1-mesa-dev")
 # autogenerate dependency information
 set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 # package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -1,0 +1,221 @@
+name: build_headless_packages
+
+on:
+  push:
+    branch-ignore:
+      - '*'
+    tags:
+      - 'v?\d+.\d+.\d+-headless'
+
+jobs:
+
+  # ------ #
+  # Ubuntu #
+  # ------ #
+  build-ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK-ParaView source code
+
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt update
+        # TTK-ParaView dependencies
+        sudo apt install -y \
+          g++-11 \
+          libosmesa-dev \
+          ninja-build \
+          dpkg-dev
+
+    - name: Create & configure ParaView build directory
+      run: |
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DPARAVIEW_PYTHON_SITE_PACKAGES_SUFFIX=lib/python3/dist-packages \
+          -DPARAVIEW_USE_QT=OFF \
+          -DVTK_USE_X=OFF \
+          -DVTK_OPENGL_HAS_OSMESA=ON \
+          -GNinja \
+          ..
+
+    - name: Build ParaView
+      run: |
+        cd build
+        cmake --build . --parallel
+
+    - name: Create ParaView package
+      run: |
+        cd build
+        cpack -G DEB
+
+    - name: Upload Debian package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview-headless-${{ matrix.os }}
+        path: build/ttk-paraview.deb
+
+  # ----- #
+  # macOS #
+  # ----- #
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK-ParaView source code
+
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /usr/local/Frameworks/Python.framework
+
+    - name: Install macOS dependencies
+      run: |
+        # ParaView dependencies
+        brew install --cask xquartz
+        brew install wget libomp ninja python
+
+    - name: Create & configure ParaView build directory
+      run: |
+        # switch to Xcode 11 since Xcode 12 breaks the ParaView build
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPARAVIEW_USE_QT=OFF \
+          -DPython3_ROOT_DIR=$(brew --prefix python) \
+          -GNinja \
+          ..
+
+    - name: Build ParaView
+      run: |
+        cd build
+        cmake --build . --parallel
+        sudo cmake --build . --target install
+
+    - name: Create ParaView package
+      run: |
+        cd build
+        sudo cpack -G TGZ
+
+    - name: Upload compressed binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview-headless-macOS
+        path: build/ttk-paraview.tar.gz
+
+
+  # ------- #
+  # Windows #
+  # ------- #
+  build-windows:
+    runs-on: windows-latest
+    env:
+      CONDA_ROOT: C:\Miniconda
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK-ParaView source code
+
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install dependencies with conda
+      shell: bash
+      run: |
+        conda install -c conda-forge glew
+
+    - name: Remove hosted Python
+      shell: bash
+      run: |
+        rm -rf C:/hostedtoolcache/windows/Python
+
+    - name: Create & configure ParaView build directory
+      shell: cmd
+      run: |
+        call "%VCVARS%"
+        mkdir build
+        cd build
+        cmake ^
+          -DPARAVIEW_USE_QT=OFF ^
+          -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -GNinja ^
+          ..
+
+    - name: Build ParaView
+      shell: cmd
+      run: |
+        call "%VCVARS%"
+        cd build
+        cmake --build . --config Release --parallel
+
+    - name: Create ParaView package
+      shell: bash
+      run: |
+        cd build
+        cpack -G NSIS64
+
+    - name: Upload install executable
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview-headless-windows
+        path: build/ttk-paraview.exe
+
+
+  # --------------------- #
+  # Upload release assets #
+  # --------------------- #
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-ubuntu, build-macos, build-windows]
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Fetch all uploaded artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Upload Ubuntu Bionic .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-headless-ubuntu-18.04/ttk-paraview.deb
+        asset_name: ttk-paraview-headless-ubuntu-18.04.deb
+
+    - name: Upload Ubuntu Focal .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-headless-ubuntu-20.04/ttk-paraview.deb
+        asset_name: ttk-paraview-headless-ubuntu-20.04.deb
+
+    - name: Upload .tar.gz as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-headless-macOS/ttk-paraview.tar.gz
+        asset_name: ttk-paraview-headless.tar.gz
+
+    - name: Upload .exe as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-headless-windows/ttk-paraview.exe
+        asset_name: ttk-paraview-headless.exe

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -1,0 +1,229 @@
+# This is a basic workflow to help you get started with Actions
+
+name: packaging
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branch-ignore:
+      - '*'
+    tags:
+      - 'v?\d+.\d+.\d+'
+      - 'dev*'
+      - 'pack*'
+
+jobs:
+
+  # ------ #
+  # Ubuntu #
+  # ------ #
+  build-linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt update
+        # ParaView dependencies
+        sudo apt install -y \
+          qt5-default \
+          qttools5-dev \
+          qtxmlpatterns5-dev-tools \
+          libqt5x11extras5-dev \
+          libqt5svg5-dev \
+          libgl1-mesa-dev \
+          libxcursor-dev \
+          ninja-build \
+          dpkg-dev
+
+    - name: Configure ParaView build
+      run: |
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr \
+          -DPARAVIEW_PYTHON_SITE_PACKAGES_SUFFIX=lib/python3/dist-packages \
+          -GNinja \
+          $GITHUB_WORKSPACE
+
+    - name: Build patched ParaView
+      run: |
+        cd build
+        cmake --build . --parallel
+
+    - name: Create package
+      run: |
+        cd build
+        cpack -G DEB
+
+    - name: Update package informations
+      run: |
+        cd build
+        # unpack deb package to access control file
+        mkdir tmp
+        dpkg-deb -x ttk-paraview.deb tmp
+        dpkg-deb --control ttk-paraview.deb tmp/DEBIAN
+        # modify control file, remove libgcc-s1 dependency
+        sed 's/libgcc-s1[^,]*, //g' -i tmp/DEBIAN/control
+        # build updated deb package
+        dpkg -b tmp ttk-paraview.deb.new
+        # replace old package with new
+        mv ttk-paraview.deb.new ttk-paraview.deb
+
+    - name: Upload .deb package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview-ubuntu-20.04.deb
+        path: build/ttk-paraview.deb
+
+
+  # ----- #
+  # macOS #
+  # ----- #
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /usr/local/Frameworks/Python.framework
+
+    - name: Install macOS dependencies
+      run: |
+        brew install --cask xquartz
+        brew install wget libomp mesa glew boost qt@5 ninja python
+
+    - name: Configure ParaView build
+      run: |
+        # switch to Xcode 11 since Xcode 12 breaks the ParaView build
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+        mkdir build && cd build
+        cmake \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/Applications \
+          -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+          -DPython3_ROOT_DIR=$(brew --prefix python) \
+          -GNinja \
+          $GITHUB_WORKSPACE
+
+    - name: Build patched ParaView
+      run: |
+        cd build
+        cmake --build . --parallel
+
+    - name: Create package
+      run: |
+        cd build
+        cpack -G productbuild
+
+    - name: Upload .pgk package
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview.pkg
+        path: build/ttk-paraview.pkg
+
+
+  # ------- #
+  # Windows #
+  # ------- #
+  build-windows:
+    runs-on: windows-latest
+    env:
+      CONDA_ROOT: C:\Miniconda
+      VCVARS: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK-ParaView source code
+
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install dependencies with conda
+      shell: bash
+      run: |
+        conda install -c conda-forge qt
+
+    - name: Remove hosted Python
+      shell: bash
+      run: |
+        rm -rf C:/hostedtoolcache/windows/Python
+
+    - name: Configure ParaView build
+      shell: cmd
+      run: |
+        call "%VCVARS%"
+        mkdir build
+        cd build
+        cmake ^
+          -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -GNinja ^
+          ..
+
+    - name: Build patched ParaView
+      shell: cmd
+      run: |
+        call "%VCVARS%"
+        cd build
+        cmake --build . --config Release --parallel
+
+    - name: Create package
+      shell: bash
+      run: |
+        cd build
+        cpack -G NSIS64
+
+    - name: Upload .exe installer
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-paraview.exe
+        path: build/ttk-paraview.exe
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-macos, build-windows]
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Fetch all uploaded artifacts
+      uses: actions/download-artifact@v2
+
+    - name: Upload Ubuntu Focal .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-ubuntu-20.04.deb/ttk-paraview.deb
+        asset_name: ttk-paraview-$tag-ubuntu-20.04.deb
+
+    - name: Upload .pkg as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview.pkg/ttk-paraview.pkg
+        asset_name: ttk-paraview-$tag.pkg
+
+    - name: Upload .exe as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview.exe/ttk-paraview.exe
+        asset_name: ttk-paraview-$tag.exe

--- a/paraview/patch/patch-paraview-5.9.1.sh
+++ b/paraview/patch/patch-paraview-5.9.1.sh
@@ -97,7 +97,8 @@ $PATCH_BIN -p1 \
 $PATCH_BIN -p1 \
   < "${PATCH_DIR}/paraview-5.9.0-gcc11-missing-includes.patch"
 mkdir -p .github/workflows/
-cp ${PATCH_DIR}/main.yml .github/workflows
+cp ${PATCH_DIR}/package.yml .github/workflows
+cp ${PATCH_DIR}/headless.yml .github/workflows
 
 echo "Finished patching."
 


### PR DESCRIPTION
This PR updates the packaging workflow to be compatible with ParaView >= 5.9.0. It complements https://github.com/topology-tool-kit/ttk-paraview/pull/3 on the TTK side while also importing the modified ttk-paraview GitHub Actions workflows inside paraview/patch.

The packaging workflow has been modified as follows:
* only Ubuntu 20.04 is supported (since ParaView 5.9 is not compatible anymore with Ubuntu 18.04)
* the embree in Ubuntu 20.04 repositories (3.3) is too old to work with TTK (which needs >= 3.4)
* a new dependency to `libgl1-mesa-dev` on Ubuntu, needed by some ParaView headers
* the macOS job uses brew's Python and Qt 5 is explicitly selected
* the Windows job uses conda's Python and every dependency is pulled from the conda-forge repository (including graphviz but except embree)
To generate packages, make sure that a v5.9.1 release exists in the topology-tool-kit/ttk-paraview repository, then push a tag matching the regular expressions `v*`, `*-*-*` or `*.*.*`.

A new workflow to generate ccache archives to speed up the ttk-data CI is also included. This workflow bypasses the GitHub Action cache by using Release Assets as a permanent object storage. Only Ubuntu and macOS jobs will benefit from it since object caching is not working (yet?) on Windows. This should further reduce the CI from about 1h to 40min (the bottleneck being the Windows compilation of TTK) when used with the headless packages generated by https://github.com/topology-tool-kit/ttk-paraview/pull/3 (see https://github.com/topology-tool-kit/ttk/pull/661 for an example usage). The ccache archive is generated by pushing a tag named "ccache". It should be manually refreshed every time the Ubuntu job takes more time than the Windows one. Once generated on this repository, I will modify https://github.com/topology-tool-kit/ttk/pull/661 to use it.

Enjoy,
Pierre
