### PR TITLE
Make IdentifierRandomizer platform-independant

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -32,7 +32,6 @@ jobs:
         # TTK dependencies
         sudo apt install -y \
           ccache \
-          g++-11 \
           libboost-system-dev \
           libeigen3-dev \
           libgraphviz-dev \
@@ -62,7 +61,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        CC=gcc-11 CXX=g++-11 cmake \
+        cmake \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_INSTALL_PREFIX=/usr \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
         # TTK dependencies
         sudo apt install -y \
           ccache \
-          g++-11 \
           libboost-system-dev \
           libeigen3-dev \
           libgraphviz-dev \
@@ -83,7 +82,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        CC=gcc-11 CXX=g++-11 cmake \
+        cmake \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_INSTALL_PREFIX=/usr \

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -13,6 +13,7 @@ ttk_add_base_library(common
         OrderDisambiguation.h
         Os.h
         ProgramBase.h
+        Shuffle.h
         Timer.h
         Wrapper.h
         )

--- a/core/base/common/Shuffle.h
+++ b/core/base/common/Shuffle.h
@@ -1,0 +1,19 @@
+#include <cstdlib>
+#include <vector>
+
+namespace ttk {
+  /**
+   * @brief Platform-independant alternative to std::shuffle
+   * implementing the Fisher-Yates shuffle algorithm
+   *
+   * @param[in,out] toShuffle Vector of elements to be shuffled
+   * @param[in] rng Random number generator
+   */
+  template <typename T, typename U>
+  void shuffle(std::vector<T> &toShuffle, U &&rng) {
+    for(size_t i = toShuffle.size() - 1; i >= 1; i--) {
+      const auto j = rng() % i;
+      std::swap(toShuffle[i], toShuffle[j]);
+    }
+  }
+} // namespace ttk

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -1,4 +1,4 @@
-#include "BaseClass.h"
+#include <Shuffle.h>
 #include <ttkIdentifierRandomizer.h>
 
 #include <vtkCellData.h>
@@ -42,14 +42,6 @@ int ttkIdentifierRandomizer::FillOutputPortInformation(int port,
   return 0;
 }
 
-template <typename T, typename U>
-void fisher_yates_shuffle(std::vector<T> &toShuffle, U &&rng) {
-  for(size_t i = toShuffle.size() - 1; i >= 1; i--) {
-    const auto j = rng() % i;
-    std::swap(toShuffle[i], toShuffle[j]);
-  }
-}
-
 template <typename T>
 int shuffleScalarFieldValues(const T *const inputField,
                              T *const outputField,
@@ -73,7 +65,7 @@ int shuffleScalarFieldValues(const T *const inputField,
   random_engine.seed(seed);
   // use the Fisher-Yates algorithm instead of std::shuffle, whose
   // results are platform-dependent
-  fisher_yates_shuffle(shuffledValues, random_engine);
+  ttk::shuffle(shuffledValues, random_engine);
 
   // link original value to shuffled value correspondance
   std::map<T, T> originalToShuffledValues{};

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -42,6 +42,14 @@ int ttkIdentifierRandomizer::FillOutputPortInformation(int port,
   return 0;
 }
 
+template <typename T, typename U>
+void fisher_yates_shuffle(std::vector<T> &toShuffle, U &&rng) {
+  for(size_t i = toShuffle.size() - 1; i >= 1; i--) {
+    const auto j = rng() % i;
+    std::swap(toShuffle[i], toShuffle[j]);
+  }
+}
+
 template <typename T>
 int shuffleScalarFieldValues(const T *const inputField,
                              T *const outputField,
@@ -63,7 +71,9 @@ int shuffleScalarFieldValues(const T *const inputField,
   // shuffle them using the seed
   std::mt19937 random_engine{};
   random_engine.seed(seed);
-  std::shuffle(shuffledValues.begin(), shuffledValues.end(), random_engine);
+  // use the Fisher-Yates algorithm instead of std::shuffle, whose
+  // results are platform-dependent
+  fisher_yates_shuffle(shuffledValues, random_engine);
 
   // link original value to shuffled value correspondance
   std::map<T, T> originalToShuffledValues{};


### PR DESCRIPTION
This PR replaces the usage of `std::shuffle` inside IdentifierRandomizer with a custom implementation of a well-known algorithm, the [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle).

This ensures that the IdentifierRandomizer output is the same on all supported platforms (Linux, macOS and Windows). As it happens, `std::shuffle` results are platform-dependant.

As a consequence, the dependency to GCC11 in the Ubuntu VM of the test workflow is lifted.

Enjoy,
Pierre