### PR TITLE
MergeTree filters fixes

### DIFF
--- a/core/base/assignmentSolver/AssignmentAuction.h
+++ b/core/base/assignmentSolver/AssignmentAuction.h
@@ -14,9 +14,10 @@
 #ifndef _ASSIGNMENTAUCTION_H
 #define _ASSIGNMENTAUCTION_H
 
-#include <Debug.h>
-
 #include "AssignmentSolver.h"
+
+#include <limits>
+#include <queue>
 
 namespace ttk {
 
@@ -134,7 +135,7 @@ namespace ttk {
 
   template <typename dataType>
   void AssignmentAuction<dataType>::initEpsilon() {
-    if(epsilon == -1) {
+    if(epsilon == -1.0) {
       dataType maxValue
         = getMaxValue<dataType>(this->costMatrix, this->balancedAssignment);
       // int tRowSize = this->balancedAssignment ? this->rowSize :
@@ -142,12 +143,12 @@ namespace ttk {
       // this->balancedAssignment ? this->colSize :
       // (this->rowSize-1)+(this->colSize-1); epsilon = maxValue *
       // std::min(tRowSize, tColSize)/2;
-      epsilon = maxValue / 4;
+      epsilon = maxValue / 4.0;
       // epsilon = std::pow(maxValue, 2)/4;
       // epsilon += *std::max_element(goodPrices.begin(), goodPrices.end());
       // epsilon += getSecondMinValueVector(goodPrices);
-      if(epsilon == 0)
-        epsilon = 1;
+      if(epsilon == 0.0)
+        epsilon = 1.0;
       epsilon
         /= ((epsilonDiviserMultiplier == 0) ? 1 : epsilonDiviserMultiplier * 5);
     }

--- a/core/base/assignmentSolver/AssignmentExhaustive.h
+++ b/core/base/assignmentSolver/AssignmentExhaustive.h
@@ -22,6 +22,9 @@
 #include "AssignmentSolver.h"
 
 #include <iterator>
+#include <limits>
+#include <map>
+#include <queue>
 #include <set>
 
 namespace ttk {
@@ -105,8 +108,7 @@ namespace ttk {
                 // TODO there is probably be a better way to avoid duplicates
                 std::sort(elemVec.begin() + min_dim, elemVec.end());
                 std::string new_string = vectorToString(elemVec);
-                auto it2 = std::find(
-                  unasgnAdded.begin(), unasgnAdded.end(), new_string);
+                auto it2 = unasgnAdded.find(new_string);
                 if(it2 == unasgnAdded.end()) {
                   unasgnAdded.insert(vectorToString(elemVec));
                   allAsgn.push_back(elemVec);

--- a/core/base/ftmTree/FTMDataTypes.h
+++ b/core/base/ftmTree/FTMDataTypes.h
@@ -21,6 +21,14 @@
 #include <set>
 #include <tuple>
 
+// untied OpenMP tasks are causing segfaults in MergeTreeClustering when
+// compiled with Clang
+#ifdef __clang__
+#define UNTIED()
+#else
+#define UNTIED() untied
+#endif
+
 namespace ttk {
   namespace ftm {
     // Types

--- a/core/base/ftmTree/FTMTree_CT_Template.h
+++ b/core/base/ftmTree/FTMTree_CT_Template.h
@@ -52,13 +52,13 @@ namespace ttk {
         {
           if(tt == TreeType::Join || bothMT) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task untied if(threadNumber_ > 1)
+#pragma omp task UNTIED() if(threadNumber_ > 1)
 #endif
             jt_->build(mesh, tt == TreeType::Contour);
           }
           if(tt == TreeType::Split || bothMT) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task untied if(threadNumber_ > 1)
+#pragma omp task UNTIED() if(threadNumber_ > 1)
 #endif
             st_->build(mesh, tt == TreeType::Contour);
           }

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -880,7 +880,7 @@ namespace ttk {
       MergeTree() : MergeTree(emptyScalars(), emptyParams()) {
       }
 
-      MergeTree(ftm::Scalars scalarsT, ftm::Params paramsT)
+      MergeTree(const ftm::Scalars &scalarsT, ftm::Params paramsT)
         : scalars(scalarsT), params(paramsT),
           tree(&params, &scalars, params.treeType) {
         tree.makeAlloc();
@@ -889,7 +889,7 @@ namespace ttk {
         scalars.values = (void *)(scalarsValues.data());
       }
 
-      MergeTree(ftm::Scalars scalarsT,
+      MergeTree(const ftm::Scalars &scalarsT,
                 std::vector<dataType> scalarValuesT,
                 ftm::Params paramsT)
         : scalars(scalarsT), scalarsValues(scalarValuesT), params(paramsT),

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -185,7 +185,7 @@ namespace ttk {
         (*mt_data_.ufs)[v] = new AtomicUF(v);
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task untied OPTIONAL_PRIORITY(isPrior())
+#pragma omp task UNTIED() OPTIONAL_PRIORITY(isPrior())
 #endif
         arcGrowth(mesh, v, n);
       }

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -870,9 +870,9 @@ namespace ttk {
           int decrement = multiplier * pairs.size() / 10;
           int thresholdIndex = pairs.size() - noPairs - std::max(decrement, 2);
           thresholdIndex = std::max(thresholdIndex, 0);
-          dataType persistence = std::get<2>(pairs[thresholdIndex]);
+          const double persistence = std::get<2>(pairs[thresholdIndex]);
           persistenceThreshold
-            = persistence / std::get<2>(pairs[pairs.size() - 1]) * 100;
+            = persistence / std::get<2>(pairs.back()) * 100.0;
           if(thresholdIndex == 0) {
             persistenceThreshold = 0.;
             ++noTreesUnscaled;

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -12,9 +12,6 @@
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
 
-#ifndef _MERGETREEBARYCENTER_H
-#define _MERGETREEBARYCENTER_H
-
 #pragma once
 
 #include <random>
@@ -192,10 +189,10 @@ namespace ttk {
 
     template <class dataType>
     void initBarycenterTree(std::vector<ftm::FTMTree_MT *> &trees,
-                            MergeTree<dataType> &baryTree,
+                            ftm::MergeTree<dataType> &baryTree,
                             bool distMinimizer = true) {
       int bestIndex = getBestInitTreeIndex<dataType>(trees, distMinimizer);
-      baryTree = copyMergeTree<dataType>(trees[bestIndex], true);
+      baryTree = ftm::copyMergeTree<dataType>(trees[bestIndex], true);
     }
 
     // ----------------------------------------
@@ -203,7 +200,7 @@ namespace ttk {
     // ----------------------------------------
     template <class dataType>
     ftm::idNode getNodesAndScalarsToAdd(
-      MergeTree<dataType> &ttkNotUsed(mTree1),
+      ftm::MergeTree<dataType> &ttkNotUsed(mTree1),
       ftm::idNode nodeId1,
       ftm::FTMTree_MT *tree2,
       ftm::idNode nodeId2,
@@ -238,7 +235,7 @@ namespace ttk {
 
     template <class dataType>
     void addNodes(
-      MergeTree<dataType> &mTree1,
+      ftm::MergeTree<dataType> &mTree1,
       int noTrees,
       std::vector<std::tuple<ftm::idNode, ftm::idNode, int>> &nodesToProcess,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode>>>
@@ -266,7 +263,7 @@ namespace ttk {
 
     template <class dataType>
     void updateNodesAndScalars(
-      MergeTree<dataType> &mTree1,
+      ftm::MergeTree<dataType> &mTree1,
       int noTrees,
       std::vector<std::tuple<ftm::idNode, ftm::idNode, int>> &nodesToProcess,
       std::vector<dataType> &newScalarsVector,
@@ -275,9 +272,9 @@ namespace ttk {
       ftm::FTMTree_MT *tree1 = &(mTree1.tree);
 
       // Create new tree
-      MergeTree<dataType> mTreeNew
-        = createEmptyMergeTree<dataType>(newScalarsVector.size());
-      setTreeScalars<dataType>(mTreeNew, newScalarsVector);
+      ftm::MergeTree<dataType> mTreeNew
+        = ftm::createEmptyMergeTree<dataType>(newScalarsVector.size());
+      ftm::setTreeScalars<dataType>(mTreeNew, newScalarsVector);
       ftm::FTMTree_MT *treeNew = &(mTreeNew.tree);
 
       // Copy the old tree structure
@@ -293,7 +290,7 @@ namespace ttk {
     template <class dataType>
     void updateBarycenterTreeStructure(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &matchings) {
       ftm::FTMTree_MT *baryTree = &(baryMergeTree.tree);
@@ -358,7 +355,7 @@ namespace ttk {
         ftm::idNode nodeCpt = baryTree->getNumberOfNodes();
         std::vector<std::tuple<ftm::idNode, ftm::idNode, int>> nodesToProcess;
         std::vector<dataType> newScalarsVector;
-        getTreeScalars<dataType>(baryMergeTree, newScalarsVector);
+        ftm::getTreeScalars<dataType>(baryMergeTree, newScalarsVector);
         for(unsigned int i = 0; i < nodesToAdd.size(); ++i) {
           for(auto node : nodesToAdd[i]) {
             ftm::idNode parent
@@ -448,7 +445,7 @@ namespace ttk {
 
     template <class dataType>
     std::tuple<dataType, dataType>
-      interpolation(MergeTree<dataType> &baryMergeTree,
+      interpolation(ftm::MergeTree<dataType> &baryMergeTree,
                     ftm::idNode nodeId,
                     std::vector<dataType> &newScalarsVector,
                     std::vector<ftm::FTMTree_MT *> &trees,
@@ -538,7 +535,7 @@ namespace ttk {
       interpolationAdded(ftm::FTMTree_MT *tree,
                          ftm::idNode nodeId,
                          double alpha,
-                         MergeTree<dataType> &baryMergeTree,
+                         ftm::MergeTree<dataType> &baryMergeTree,
                          ftm::idNode nodeB,
                          std::vector<dataType> &newScalarsVector) {
       ftm::FTMTree_MT *baryTree = &(baryMergeTree.tree);
@@ -586,7 +583,7 @@ namespace ttk {
     }
 
     template <class dataType>
-    void purgeBarycenter(MergeTree<dataType> &baryMergeTree,
+    void purgeBarycenter(ftm::MergeTree<dataType> &baryMergeTree,
                          std::vector<std::vector<ftm::idNode>> &baryMatching,
                          std::vector<ftm::FTMTree_MT *> &trees,
                          std::vector<double> &alphas) {
@@ -639,7 +636,7 @@ namespace ttk {
     template <class dataType>
     void updateBarycenterTreeScalars(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<double> &alphas,
       int indexAddedNodes,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
@@ -703,7 +700,7 @@ namespace ttk {
       persistenceThresholding<dataType>(
         &(baryMergeTree.tree), 0, deletedNodesT);
       if(not isCalled_)
-        cleanMergeTree<dataType>(baryMergeTree);
+        ftm::cleanMergeTree<dataType>(baryMergeTree);
     }
 
     int getNumberOfRoots(ftm::FTMTree_MT *tree) {
@@ -716,7 +713,7 @@ namespace ttk {
     template <class dataType>
     void updateBarycenterTree(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<double> &alphas,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &matchings) {
@@ -770,7 +767,7 @@ namespace ttk {
     template <class dataType>
     void computeOneDistance(
       ftm::FTMTree_MT *tree,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching,
       dataType &distance) {
       computeOneDistance<dataType>(
@@ -779,8 +776,8 @@ namespace ttk {
 
     template <class dataType>
     void computeOneDistance(
-      MergeTree<dataType> &baryMergeTree,
-      MergeTree<dataType> &baryMergeTree2,
+      ftm::MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree2,
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching,
       dataType &distance) {
       computeOneDistance<dataType>(
@@ -790,7 +787,7 @@ namespace ttk {
     template <class dataType>
     void assignment(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &matchings,
       std::vector<dataType> &distances) {
@@ -803,7 +800,7 @@ namespace ttk {
     template <class dataType>
     void assignmentPara(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &matchings,
       std::vector<dataType> &distances) {
@@ -822,7 +819,7 @@ namespace ttk {
     template <class dataType>
     void assignmentTask(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &matchings,
       std::vector<dataType> &distances) {
@@ -844,7 +841,7 @@ namespace ttk {
     template <class dataType>
     unsigned int
       persistenceScaling(std::vector<ftm::FTMTree_MT *> &trees,
-                         std::vector<MergeTree<dataType>> &mergeTrees,
+                         std::vector<ftm::MergeTree<dataType>> &mergeTrees,
                          std::vector<ftm::FTMTree_MT *> &oriTrees,
                          int iterationNumber,
                          std::vector<std::vector<ftm::idNode>> &deletedNodes) {
@@ -879,11 +876,12 @@ namespace ttk {
           }
         }
         if(persistenceThreshold != 0.) {
-          MergeTree<dataType> mt = copyMergeTree<dataType>(oriTrees[i]);
+          ftm::MergeTree<dataType> mt
+            = ftm::copyMergeTree<dataType>(oriTrees[i]);
           persistenceThresholding<dataType>(
             &(mt.tree), persistenceThreshold, deletedNodes[i]);
           if(mergeTrees.size() == 0)
-            mergeTrees = std::vector<MergeTree<dataType>>(oriTrees.size());
+            mergeTrees = std::vector<ftm::MergeTree<dataType>>(oriTrees.size());
           mergeTrees[i] = mt;
           trees[i] = &(mt.tree);
         } else {
@@ -920,7 +918,7 @@ namespace ttk {
     template <class dataType>
     void computeBarycenter(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<double> &alphas,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &finalMatchings) {
@@ -930,7 +928,7 @@ namespace ttk {
 
       // Persistence scaling
       std::vector<ftm::FTMTree_MT *> oriTrees;
-      std::vector<MergeTree<dataType>> scaledMergeTrees;
+      std::vector<ftm::MergeTree<dataType>> scaledMergeTrees;
       std::vector<std::vector<ftm::idNode>> deletedNodes;
       if(progressiveBarycenter_) {
         oriTrees.insert(oriTrees.end(), trees.begin(), trees.end());
@@ -1049,11 +1047,11 @@ namespace ttk {
 
     template <class dataType>
     void execute(
-      std::vector<MergeTree<dataType>> &trees,
+      std::vector<ftm::MergeTree<dataType>> &trees,
       std::vector<double> &alphas,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &finalMatchings,
-      MergeTree<dataType> &baryMergeTree) {
+      ftm::MergeTree<dataType> &baryMergeTree) {
       // --- Preprocessing
       if(preprocess_) {
         treesNodeCorr_ = std::vector<std::vector<int>>(trees.size());
@@ -1067,7 +1065,7 @@ namespace ttk {
 
       // --- Init barycenter
       std::vector<ftm::FTMTree_MT *> treesT;
-      mergeTreeToFTMTree<dataType>(trees, treesT);
+      ftm::mergeTreeToFTMTree<dataType>(trees, treesT);
       initBarycenterTree<dataType>(treesT, baryMergeTree);
 
       // --- Execute
@@ -1092,10 +1090,10 @@ namespace ttk {
 
     template <class dataType>
     void execute(
-      std::vector<MergeTree<dataType>> &trees,
+      std::vector<ftm::MergeTree<dataType>> &trees,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &finalMatchings,
-      MergeTree<dataType> &baryMergeTree) {
+      ftm::MergeTree<dataType> &baryMergeTree) {
       std::vector<double> alphas;
       if(trees.size() != 2) {
         for(unsigned int i = 0; i < trees.size(); ++i)
@@ -1112,7 +1110,7 @@ namespace ttk {
     // Postprocessing
     // ----------------------------------------
     template <class dataType>
-    void fixMergedRootOriginBarycenter(MergeTree<dataType> &barycenter) {
+    void fixMergedRootOriginBarycenter(ftm::MergeTree<dataType> &barycenter) {
       if(not barycenter.tree.isFullMerge())
         return;
 
@@ -1124,7 +1122,7 @@ namespace ttk {
       // Verify that scalars are consistent
       ftm::idNode treeRoot = tree->getRoot();
       std::vector<dataType> newScalarsVector;
-      getTreeScalars<dataType>(tree, newScalarsVector);
+      ftm::getTreeScalars<dataType>(tree, newScalarsVector);
       bool isJT = tree->isJoinTree<dataType>();
       if((isJT and tree->getValue<dataType>(maxIndex) > oldOriginValue)
          or (not isJT
@@ -1142,7 +1140,7 @@ namespace ttk {
     template <class dataType>
     void verifyBarycenterTwoTrees(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &finalMatchings,
       std::vector<dataType> distances) {
@@ -1234,5 +1232,3 @@ namespace ttk {
   }; // MergeTreeBarycenter class
 
 } // namespace ttk
-
-#endif

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -825,8 +825,8 @@ namespace ttk {
       std::vector<dataType> &distances) {
       for(unsigned int i = 0; i < trees.size(); ++i)
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(i) \
-  untied shared(baryMergeTree, matchings, distances)
+#pragma omp task firstprivate(i) UNTIED() \
+  shared(baryMergeTree, matchings, distances)
 #endif
         computeOneDistance<dataType>(
           trees[i], baryMergeTree, matchings[i], distances[i]);

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -296,8 +296,8 @@ public:
       queue.pop();
       ftm::idNode nodeParent = tree->getParentSafe(node);
       if(!tree->isRoot(node)) {
-        dataType nodePers = tree->getNodePersistence<dataType>(node);
-        dataType nodeParentPers
+        const double nodePers = tree->getNodePersistence<dataType>(node);
+        const double nodeParentPers
           = tree->getNodePersistence<dataType>(nodeParent);
         if(nodePers / nodeParentPers > epsilon2
            and nodePers / maxPers < epsilon3)

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -940,10 +940,11 @@ public:
     ftm::FTMTree_MT *tree2,
     std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching) {
     std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
-      realOutputMatching;
-    for(auto tup : outputMatching)
-      realOutputMatching.push_back(
-        std::make_tuple(std::get<0>(tup), std::get<1>(tup), 0));
+      realOutputMatching(outputMatching.size());
+    for(size_t i = 0; i < outputMatching.size(); ++i) {
+      const auto &tup{outputMatching[i]};
+      realOutputMatching[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+    }
 
     convertBranchDecompositionMatching<dataType>(
       tree1, tree2, realOutputMatching);
@@ -1328,10 +1329,12 @@ public:
 
   void printMatching(
     std::vector<std::tuple<ftm::idNode, ftm::idNode>> &matchings) {
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matchingsT;
-    for(auto tup : matchings)
-      matchingsT.push_back(
-        std::make_tuple(std::get<0>(tup), std::get<1>(tup), 0));
+    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matchingsT(
+      matchings.size());
+    for(size_t i = 0; i < matchings.size(); ++i) {
+      const auto &tup{matchings[i]};
+      matchingsT[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+    }
     printMatching(matchingsT);
   }
 

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -9,8 +9,7 @@
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
 
-#ifndef _MERGETREEBASE_H
-#define _MERGETREEBASE_H
+#pragma once
 
 #include <AssignmentSolver.h>
 #include <FTMNode.h>
@@ -20,1409 +19,1419 @@
 
 #include "MergeTreeUtils.h"
 
-using namespace ttk;
+namespace ttk {
 
-class MergeTreeBase : virtual public Debug {
-protected:
-  int assignmentSolverID_ = 0;
-  bool epsilon1UseFarthestSaddle_ = false;
-  double epsilonTree1_ = 5;
-  double epsilonTree2_ = 5;
-  double epsilon2Tree1_ = 95;
-  double epsilon2Tree2_ = 95;
-  double epsilon3Tree1_ = 100;
-  double epsilon3Tree2_ = 100;
-  double persistenceThreshold_ = 0;
-  bool barycenterMergeTree_ = false;
-  bool useMinMaxPair_ = true;
-  bool deleteMultiPersPairs_ = false;
+  class MergeTreeBase : virtual public Debug {
+  protected:
+    int assignmentSolverID_ = 0;
+    bool epsilon1UseFarthestSaddle_ = false;
+    double epsilonTree1_ = 5;
+    double epsilonTree2_ = 5;
+    double epsilon2Tree1_ = 95;
+    double epsilon2Tree2_ = 95;
+    double epsilon3Tree1_ = 100;
+    double epsilon3Tree2_ = 100;
+    double persistenceThreshold_ = 0;
+    bool barycenterMergeTree_ = false;
+    bool useMinMaxPair_ = true;
+    bool deleteMultiPersPairs_ = false;
 
-  bool branchDecomposition_ = true;
-  int wassersteinPower_ = 2;
-  bool normalizedWasserstein_ = true;
-  bool keepSubtree_ = false;
+    bool branchDecomposition_ = true;
+    int wassersteinPower_ = 2;
+    bool normalizedWasserstein_ = true;
+    bool keepSubtree_ = false;
 
-  bool distanceSquared_ = true;
-  bool useFullMerge_ = false;
+    bool distanceSquared_ = true;
+    bool useFullMerge_ = false;
 
-  // Old
-  bool progressiveComputation_ = false;
-  bool rescaledWasserstein_ = false;
-  double normalizedWassersteinReg_ = 0.;
-  bool parallelize_ = true;
-  int nodePerTask_ = 32;
-  bool cleanTree_ = true;
+    // Old
+    bool progressiveComputation_ = false;
+    bool rescaledWasserstein_ = false;
+    double normalizedWassersteinReg_ = 0.;
+    bool parallelize_ = true;
+    int nodePerTask_ = 32;
+    bool cleanTree_ = true;
 
-  // Clean correspondence
-  std::vector<std::vector<int>> treesNodeCorr_;
+    // Clean correspondence
+    std::vector<std::vector<int>> treesNodeCorr_;
 
-public:
-  MergeTreeBase() {
-    this->setDebugMsgPrefix(
-      "MergeTreeBase"); // inherited from Debug: prefix will be printed
-                        // at the beginning of every msg
-  }
-
-  void setAssignmentSolver(int assignmentSolver) {
-    assignmentSolverID_ = assignmentSolver;
-  }
-
-  void setEpsilon1UseFarthestSaddle(bool b) {
-    epsilon1UseFarthestSaddle_ = b;
-  }
-
-  void setEpsilonTree1(double epsilon) {
-    epsilonTree1_ = epsilon;
-  }
-
-  void setEpsilonTree2(double epsilon) {
-    epsilonTree2_ = epsilon;
-  }
-
-  void setEpsilon2Tree1(double epsilon) {
-    epsilon2Tree1_ = epsilon;
-  }
-
-  void setEpsilon2Tree2(double epsilon) {
-    epsilon2Tree2_ = epsilon;
-  }
-
-  void setEpsilon3Tree1(double epsilon) {
-    epsilon3Tree1_ = epsilon;
-  }
-
-  void setEpsilon3Tree2(double epsilon) {
-    epsilon3Tree2_ = epsilon;
-  }
-
-  void setPersistenceThreshold(double pt) {
-    persistenceThreshold_ = pt;
-  }
-
-  void setParallelize(bool para) {
-    parallelize_ = para;
-  }
-
-  void setNodePerTask(int npt) {
-    nodePerTask_ = npt;
-  }
-
-  void setBranchDecomposition(bool useBD) {
-    branchDecomposition_ = useBD;
-  }
-
-  void setNormalizedWasserstein(bool normalizedWasserstein) {
-    normalizedWasserstein_ = normalizedWasserstein;
-  }
-
-  void setRescaledWasserstein(bool rescaledWasserstein) {
-    rescaledWasserstein_ = rescaledWasserstein;
-  }
-
-  void setNormalizedWassersteinReg(double normalizedWassersteinReg) {
-    normalizedWassersteinReg_ = normalizedWassersteinReg;
-  }
-
-  void setKeepSubtree(bool keepSubtree) {
-    keepSubtree_ = keepSubtree;
-  }
-
-  void setProgressiveComputation(bool progressive) {
-    progressiveComputation_ = progressive;
-    /*if(progressiveComputation_)
-      Preprocess = false;*/
-  }
-
-  void setBarycenterMergeTree(bool imt) {
-    barycenterMergeTree_ = imt;
-  }
-
-  void setDistanceSquared(bool distanceSquared) {
-    distanceSquared_ = distanceSquared;
-  }
-
-  void setUseMinMaxPair(bool useMinMaxPair) {
-    useMinMaxPair_ = useMinMaxPair;
-  }
-
-  void setDeleteMultiPersPairs(bool deleteMultiPersPairsT) {
-    deleteMultiPersPairs_ = deleteMultiPersPairsT;
-  }
-
-  void setCleanTree(bool clean) {
-    cleanTree_ = clean;
-  }
-
-  std::vector<std::vector<int>> getTreesNodeCorr() {
-    return treesNodeCorr_;
-  }
-
-  // --------------------------------------------------------------------------------
-  // Tree Preprocessing
-  // --------------------------------------------------------------------------------
-  // Epsilon 1 processing
-  template <class dataType>
-  void mergeSaddle(ftm::FTMTree_MT *tree,
-                   double epsilon,
-                   std::vector<std::vector<ftm::idNode>> &treeNodeMerged,
-                   bool mergeByPersistence = false) {
-    bool fullMerge = (epsilon == 100);
-    fullMerge &= useFullMerge_;
-
-    if(mergeByPersistence)
-      computePersistencePairs<dataType>(
-        tree); // need to have the pairing (if merge by persistence)
-
-    // Compute epsilon value
-    dataType maxValue = tree->getValue<dataType>(0);
-    dataType minValue = tree->getValue<dataType>(0);
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
-      if(!tree->isRoot(i) and !tree->isLeaf(i)) {
-        dataType iValue = tree->getValue<dataType>(i);
-        if(mergeByPersistence) {
-          maxValue = (maxValue < iValue) ? iValue : maxValue;
-          minValue = (minValue > iValue) ? iValue : minValue;
-        } else {
-          ftm::idNode parent = tree->getParentSafe(i);
-          dataType parentValue = tree->getValue<dataType>(parent);
-          dataType tempMax = std::max(iValue, parentValue);
-          dataType tempMin = std::min(iValue, parentValue);
-          if((tempMax - tempMin) > (maxValue - minValue)) {
-            maxValue = tempMax;
-            minValue = tempMin;
-          }
-        }
-      }
+  public:
+    MergeTreeBase() {
+      this->setDebugMsgPrefix(
+        "MergeTreeBase"); // inherited from Debug: prefix will be printed
+                          // at the beginning of every msg
     }
-    double epsilonOri = epsilon;
-    epsilon = (maxValue - minValue) * epsilon / 100;
 
-    // For Farthest Saddle option
-    if(epsilon1UseFarthestSaddle_)
-      epsilon = tree->getMaximumPersistence<dataType>() * epsilonOri / 100;
-    bool isJT = tree->isJoinTree<dataType>();
-    auto isFarthest = [&](ftm::idNode a, ftm::idNode b) {
-      return (isJT
-              and tree->getValue<dataType>(a) > tree->getValue<dataType>(b))
-             or (not isJT
-                 and tree->getValue<dataType>(a) < tree->getValue<dataType>(b));
-    };
-    std::vector<ftm::idNode> farthestSaddle(tree->getNumberOfNodes());
-    for(unsigned int i = 0; i < farthestSaddle.size(); ++i)
-      farthestSaddle[i] = i;
-
-    // --- Merge saddle
-    // Create stack
-    std::stack<int> nodeStack;
-    std::queue<ftm::idNode> queue;
-    queue.emplace(tree->getRoot());
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-      nodeStack.emplace(node);
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue.emplace(child);
+    void setAssignmentSolver(int assignmentSolver) {
+      assignmentSolverID_ = assignmentSolver;
     }
-    // Iterate through nodes
-    while(!nodeStack.empty()) {
-      ftm::idNode nodeId = nodeStack.top();
-      nodeStack.pop();
-      if(!tree->isRoot(nodeId) and !tree->isLeaf(nodeId)) {
-        ftm::idNode parentNodeId = tree->getParentSafe(nodeId);
-        dataType nodeValue = tree->getValue<dataType>(nodeId);
-        if(epsilon1UseFarthestSaddle_)
-          nodeValue = tree->getValue<dataType>(farthestSaddle[nodeId]);
-        dataType parentNodeValue = tree->getValue<dataType>(parentNodeId);
-        dataType diffValue = std::max(nodeValue, parentNodeValue)
-                             - std::min(nodeValue, parentNodeValue);
-        if(diffValue <= epsilon) {
-          ftm::idNode nodeIdToDelete, nodeIdToKeep;
+
+    void setEpsilon1UseFarthestSaddle(bool b) {
+      epsilon1UseFarthestSaddle_ = b;
+    }
+
+    void setEpsilonTree1(double epsilon) {
+      epsilonTree1_ = epsilon;
+    }
+
+    void setEpsilonTree2(double epsilon) {
+      epsilonTree2_ = epsilon;
+    }
+
+    void setEpsilon2Tree1(double epsilon) {
+      epsilon2Tree1_ = epsilon;
+    }
+
+    void setEpsilon2Tree2(double epsilon) {
+      epsilon2Tree2_ = epsilon;
+    }
+
+    void setEpsilon3Tree1(double epsilon) {
+      epsilon3Tree1_ = epsilon;
+    }
+
+    void setEpsilon3Tree2(double epsilon) {
+      epsilon3Tree2_ = epsilon;
+    }
+
+    void setPersistenceThreshold(double pt) {
+      persistenceThreshold_ = pt;
+    }
+
+    void setParallelize(bool para) {
+      parallelize_ = para;
+    }
+
+    void setNodePerTask(int npt) {
+      nodePerTask_ = npt;
+    }
+
+    void setBranchDecomposition(bool useBD) {
+      branchDecomposition_ = useBD;
+    }
+
+    void setNormalizedWasserstein(bool normalizedWasserstein) {
+      normalizedWasserstein_ = normalizedWasserstein;
+    }
+
+    void setRescaledWasserstein(bool rescaledWasserstein) {
+      rescaledWasserstein_ = rescaledWasserstein;
+    }
+
+    void setNormalizedWassersteinReg(double normalizedWassersteinReg) {
+      normalizedWassersteinReg_ = normalizedWassersteinReg;
+    }
+
+    void setKeepSubtree(bool keepSubtree) {
+      keepSubtree_ = keepSubtree;
+    }
+
+    void setProgressiveComputation(bool progressive) {
+      progressiveComputation_ = progressive;
+      /*if(progressiveComputation_)
+        Preprocess = false;*/
+    }
+
+    void setBarycenterMergeTree(bool imt) {
+      barycenterMergeTree_ = imt;
+    }
+
+    void setDistanceSquared(bool distanceSquared) {
+      distanceSquared_ = distanceSquared;
+    }
+
+    void setUseMinMaxPair(bool useMinMaxPair) {
+      useMinMaxPair_ = useMinMaxPair;
+    }
+
+    void setDeleteMultiPersPairs(bool deleteMultiPersPairsT) {
+      deleteMultiPersPairs_ = deleteMultiPersPairsT;
+    }
+
+    void setCleanTree(bool clean) {
+      cleanTree_ = clean;
+    }
+
+    std::vector<std::vector<int>> getTreesNodeCorr() {
+      return treesNodeCorr_;
+    }
+
+    // --------------------------------------------------------------------------------
+    // Tree Preprocessing
+    // --------------------------------------------------------------------------------
+    // Epsilon 1 processing
+    template <class dataType>
+    void mergeSaddle(ftm::FTMTree_MT *tree,
+                     double epsilon,
+                     std::vector<std::vector<ftm::idNode>> &treeNodeMerged,
+                     bool mergeByPersistence = false) {
+      bool fullMerge = (epsilon == 100);
+      fullMerge &= useFullMerge_;
+
+      if(mergeByPersistence)
+        ftm::computePersistencePairs<dataType>(
+          tree); // need to have the pairing (if merge by persistence)
+
+      // Compute epsilon value
+      dataType maxValue = tree->getValue<dataType>(0);
+      dataType minValue = tree->getValue<dataType>(0);
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
+        if(!tree->isRoot(i) and !tree->isLeaf(i)) {
+          dataType iValue = tree->getValue<dataType>(i);
           if(mergeByPersistence) {
-            auto birthDeath1 = tree->getBirthDeath<dataType>(nodeId);
-            auto birthDeath2 = tree->getBirthDeath<dataType>(parentNodeId);
-            dataType pers1
-              = std::get<1>(birthDeath1) - std::get<0>(birthDeath1);
-            dataType pers2
-              = std::get<1>(birthDeath2) - std::get<0>(birthDeath2);
-            nodeIdToDelete = (pers1 > pers2) ? parentNodeId : nodeId;
-            nodeIdToKeep = (pers1 > pers2) ? nodeId : parentNodeId;
-            if(nodeIdToDelete == parentNodeId)
-              nodeStack.emplace(nodeId);
+            maxValue = (maxValue < iValue) ? iValue : maxValue;
+            minValue = (minValue > iValue) ? iValue : minValue;
           } else {
-            nodeIdToDelete = nodeId;
-            nodeIdToKeep = parentNodeId;
+            ftm::idNode parent = tree->getParentSafe(i);
+            dataType parentValue = tree->getValue<dataType>(parent);
+            dataType tempMax = std::max(iValue, parentValue);
+            dataType tempMin = std::min(iValue, parentValue);
+            if((tempMax - tempMin) > (maxValue - minValue)) {
+              maxValue = tempMax;
+              minValue = tempMin;
+            }
           }
-          // Manage nodeMerged vector of vector
-          for(auto node : treeNodeMerged[nodeIdToDelete]) {
-            treeNodeMerged[nodeIdToKeep].push_back(node);
-            if(isFarthest(farthestSaddle[nodeIdToKeep],
-                          tree->getNode(node)->getOrigin()))
-              farthestSaddle[nodeIdToKeep] = tree->getNode(node)->getOrigin();
-          }
-          treeNodeMerged[nodeIdToKeep].push_back(
-            tree->getNode(nodeIdToDelete)->getOrigin());
-          if(isFarthest(farthestSaddle[nodeIdToKeep], nodeIdToDelete))
-            farthestSaddle[nodeIdToKeep] = nodeIdToDelete;
-          treeNodeMerged[nodeIdToDelete].clear();
-          // Delete node
-          tree->deleteNode(nodeIdToDelete);
         }
       }
-    }
+      double epsilonOri = epsilon;
+      epsilon = (maxValue - minValue) * epsilon / 100;
 
-    if(fullMerge) {
-      auto root = tree->getRoot();
-      tree->getNode(root)->setOrigin(root);
-    }
-  }
+      // For Farthest Saddle option
+      if(epsilon1UseFarthestSaddle_)
+        epsilon = tree->getMaximumPersistence<dataType>() * epsilonOri / 100;
+      bool isJT = tree->isJoinTree<dataType>();
+      auto isFarthest = [&](ftm::idNode a, ftm::idNode b) {
+        return (isJT
+                and tree->getValue<dataType>(a) > tree->getValue<dataType>(b))
+               or (not isJT
+                   and tree->getValue<dataType>(a)
+                         < tree->getValue<dataType>(b));
+      };
+      std::vector<ftm::idNode> farthestSaddle(tree->getNumberOfNodes());
+      for(unsigned int i = 0; i < farthestSaddle.size(); ++i)
+        farthestSaddle[i] = i;
 
-  // Epsilon 2 and 3 processing
-  template <class dataType>
-  void persistenceMerging(ftm::FTMTree_MT *tree,
-                          double epsilon2,
-                          double epsilon3 = 100) {
-    bool fullMerge = (epsilon2 == 0);
-    fullMerge &= useFullMerge_;
-    epsilon2 /= 100;
-    epsilon3 /= 100;
-    dataType maxPers = tree->getMaximumPersistence<dataType>();
-
-    std::queue<ftm::idNode> queue;
-    queue.emplace(tree->getRoot());
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-      ftm::idNode nodeParent = tree->getParentSafe(node);
-      if(!tree->isRoot(node)) {
-        const double nodePers = tree->getNodePersistence<dataType>(node);
-        const double nodeParentPers
-          = tree->getNodePersistence<dataType>(nodeParent);
-        if(nodePers / nodeParentPers > epsilon2
-           and nodePers / maxPers < epsilon3)
-          tree->setParent(node, tree->getParentSafe(nodeParent));
+      // --- Merge saddle
+      // Create stack
+      std::stack<int> nodeStack;
+      std::queue<ftm::idNode> queue;
+      queue.emplace(tree->getRoot());
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        nodeStack.emplace(node);
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(auto child : children)
+          queue.emplace(child);
       }
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue.emplace(child);
-    }
+      // Iterate through nodes
+      while(!nodeStack.empty()) {
+        ftm::idNode nodeId = nodeStack.top();
+        nodeStack.pop();
+        if(!tree->isRoot(nodeId) and !tree->isLeaf(nodeId)) {
+          ftm::idNode parentNodeId = tree->getParentSafe(nodeId);
+          dataType nodeValue = tree->getValue<dataType>(nodeId);
+          if(epsilon1UseFarthestSaddle_)
+            nodeValue = tree->getValue<dataType>(farthestSaddle[nodeId]);
+          dataType parentNodeValue = tree->getValue<dataType>(parentNodeId);
+          dataType diffValue = std::max(nodeValue, parentNodeValue)
+                               - std::min(nodeValue, parentNodeValue);
+          if(diffValue <= epsilon) {
+            ftm::idNode nodeIdToDelete, nodeIdToKeep;
+            if(mergeByPersistence) {
+              auto birthDeath1 = tree->getBirthDeath<dataType>(nodeId);
+              auto birthDeath2 = tree->getBirthDeath<dataType>(parentNodeId);
+              dataType pers1
+                = std::get<1>(birthDeath1) - std::get<0>(birthDeath1);
+              dataType pers2
+                = std::get<1>(birthDeath2) - std::get<0>(birthDeath2);
+              nodeIdToDelete = (pers1 > pers2) ? parentNodeId : nodeId;
+              nodeIdToKeep = (pers1 > pers2) ? nodeId : parentNodeId;
+              if(nodeIdToDelete == parentNodeId)
+                nodeStack.emplace(nodeId);
+            } else {
+              nodeIdToDelete = nodeId;
+              nodeIdToKeep = parentNodeId;
+            }
+            // Manage nodeMerged vector of vector
+            for(auto node : treeNodeMerged[nodeIdToDelete]) {
+              treeNodeMerged[nodeIdToKeep].push_back(node);
+              if(isFarthest(farthestSaddle[nodeIdToKeep],
+                            tree->getNode(node)->getOrigin()))
+                farthestSaddle[nodeIdToKeep] = tree->getNode(node)->getOrigin();
+            }
+            treeNodeMerged[nodeIdToKeep].push_back(
+              tree->getNode(nodeIdToDelete)->getOrigin());
+            if(isFarthest(farthestSaddle[nodeIdToKeep], nodeIdToDelete))
+              farthestSaddle[nodeIdToKeep] = nodeIdToDelete;
+            treeNodeMerged[nodeIdToDelete].clear();
+            // Delete node
+            tree->deleteNode(nodeIdToDelete);
+          }
+        }
+      }
 
-    if(fullMerge) {
-      auto root = tree->getRoot();
-      if(tree->getNode(root)->getOrigin() != (int)root) {
-        tree->setParent(tree->getNode(root)->getOrigin(), root);
+      if(fullMerge) {
+        auto root = tree->getRoot();
         tree->getNode(root)->setOrigin(root);
       }
     }
-  }
 
-  template <class dataType>
-  void persistenceThresholding(ftm::FTMTree_MT *tree,
-                               double persistenceThresholdT,
-                               std::vector<ftm::idNode> &deletedNodes) {
-    dataType threshold
-      = persistenceThresholdT / 100 * tree->getMaximumPersistence<dataType>();
+    // Epsilon 2 and 3 processing
+    template <class dataType>
+    void persistenceMerging(ftm::FTMTree_MT *tree,
+                            double epsilon2,
+                            double epsilon3 = 100) {
+      bool fullMerge = (epsilon2 == 0);
+      fullMerge &= useFullMerge_;
+      epsilon2 /= 100;
+      epsilon3 /= 100;
+      dataType maxPers = tree->getMaximumPersistence<dataType>();
 
-    dataType secondMax = tree->getSecondMaximumPersistence<dataType>();
-    if(threshold >= secondMax)
-      threshold = 0.99 * secondMax;
+      std::queue<ftm::idNode> queue;
+      queue.emplace(tree->getRoot());
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        ftm::idNode nodeParent = tree->getParentSafe(node);
+        if(!tree->isRoot(node)) {
+          const double nodePers = tree->getNodePersistence<dataType>(node);
+          const double nodeParentPers
+            = tree->getNodePersistence<dataType>(nodeParent);
+          if(nodePers / nodeParentPers > epsilon2
+             and nodePers / maxPers < epsilon3)
+            tree->setParent(node, tree->getParentSafe(nodeParent));
+        }
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(auto child : children)
+          queue.emplace(child);
+      }
 
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
-      dataType nodePers = tree->getNodePersistence<dataType>(i);
-      if((nodePers == 0 or nodePers <= threshold
-          or not tree->isNodeOriginDefined(i))
-         and !tree->isRoot(i)) {
-        tree->deleteNode(i);
-        deletedNodes.push_back(i);
-        ftm::idNode nodeOrigin = tree->getNode(i)->getOrigin();
-        if(tree->isNodeOriginDefined(i)
-           and tree->getNode(nodeOrigin)->getOrigin() == (int)i) {
-          tree->deleteNode(nodeOrigin);
-          deletedNodes.push_back(nodeOrigin);
+      if(fullMerge) {
+        auto root = tree->getRoot();
+        if(tree->getNode(root)->getOrigin() != (int)root) {
+          tree->setParent(tree->getNode(root)->getOrigin(), root);
+          tree->getNode(root)->setOrigin(root);
         }
       }
     }
-  }
 
-  template <class dataType>
-  void persistenceThresholding(ftm::FTMTree_MT *tree,
-                               std::vector<ftm::idNode> &deletedNodes) {
-    persistenceThresholding<dataType>(
-      tree, persistenceThreshold_, deletedNodes);
-  }
+    template <class dataType>
+    void persistenceThresholding(ftm::FTMTree_MT *tree,
+                                 double persistenceThresholdT,
+                                 std::vector<ftm::idNode> &deletedNodes) {
+      dataType threshold
+        = persistenceThresholdT / 100 * tree->getMaximumPersistence<dataType>();
 
-  template <class dataType>
-  void verifyOrigins(ftm::FTMTree_MT *tree) {
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-      if(not tree->isNodeAlone(i) and not tree->isNodeOriginDefined(i)) {
-        std::stringstream ss;
-        std::vector<idNode> children;
-        tree->getChildren(i, children);
-        ss << i << " has no origin (scalar=" << tree->getValue<dataType>(i)
-           << ", noChildren=" << children.size()
-           << ", parent=" << tree->getParentSafe(i) << ")";
-        printMsg(ss.str());
-        if(!tree->isRoot(i))
+      dataType secondMax = tree->getSecondMaximumPersistence<dataType>();
+      if(threshold >= secondMax)
+        threshold = 0.99 * secondMax;
+
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
+        dataType nodePers = tree->getNodePersistence<dataType>(i);
+        if((nodePers == 0 or nodePers <= threshold
+            or not tree->isNodeOriginDefined(i))
+           and !tree->isRoot(i)) {
           tree->deleteNode(i);
-        else {
-          std::stringstream ss2;
-          ss2 << "the root has no origin!";
-          printErr(ss2.str());
+          deletedNodes.push_back(i);
+          ftm::idNode nodeOrigin = tree->getNode(i)->getOrigin();
+          if(tree->isNodeOriginDefined(i)
+             and tree->getNode(nodeOrigin)->getOrigin() == (int)i) {
+            tree->deleteNode(nodeOrigin);
+            deletedNodes.push_back(nodeOrigin);
+          }
         }
       }
-  }
+    }
 
-  template <class dataType>
-  void preprocessTree(ftm::FTMTree_MT *tree,
-                      double epsilon,
-                      std::vector<std::vector<ftm::idNode>> &treeNodeMerged) {
-    // Manage inconsistent critical points
-    // Critical points with same scalar value than parent
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-      if(!tree->isNodeAlone(i) and !tree->isRoot(i)
-         and tree->getValue<dataType>(tree->getParentSafe(i))
-               == tree->getValue<dataType>(i))
-        tree->deleteNode(i);
-    // Valence 2 nodes
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-      if(tree->getNode(i)->getNumberOfUpSuperArcs() == 1
-         and tree->getNode(i)->getNumberOfDownSuperArcs() == 1)
-        tree->deleteNode(i);
+    template <class dataType>
+    void persistenceThresholding(ftm::FTMTree_MT *tree,
+                                 std::vector<ftm::idNode> &deletedNodes) {
+      persistenceThresholding<dataType>(
+        tree, persistenceThreshold_, deletedNodes);
+    }
 
-    // Compute persistence pairs
-    auto pairs = computePersistencePairs<dataType>(tree);
-    // Verify pairs
-    verifyOrigins<dataType>(tree);
+    template <class dataType>
+    void verifyOrigins(ftm::FTMTree_MT *tree) {
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(not tree->isNodeAlone(i) and not tree->isNodeOriginDefined(i)) {
+          std::stringstream ss;
+          std::vector<ftm::idNode> children;
+          tree->getChildren(i, children);
+          ss << i << " has no origin (scalar=" << tree->getValue<dataType>(i)
+             << ", noChildren=" << children.size()
+             << ", parent=" << tree->getParentSafe(i) << ")";
+          printMsg(ss.str());
+          if(!tree->isRoot(i))
+            tree->deleteNode(i);
+          else {
+            std::stringstream ss2;
+            ss2 << "the root has no origin!";
+            printErr(ss2.str());
+          }
+        }
+    }
 
-    // Delete null persistence pairs and persistence thresholding
-    std::vector<ftm::idNode> deletedNodes;
-    persistenceThresholding<dataType>(tree, deletedNodes);
+    template <class dataType>
+    void preprocessTree(ftm::FTMTree_MT *tree,
+                        double epsilon,
+                        std::vector<std::vector<ftm::idNode>> &treeNodeMerged) {
+      // Manage inconsistent critical points
+      // Critical points with same scalar value than parent
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(!tree->isNodeAlone(i) and !tree->isRoot(i)
+           and tree->getValue<dataType>(tree->getParentSafe(i))
+                 == tree->getValue<dataType>(i))
+          tree->deleteNode(i);
+      // Valence 2 nodes
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(tree->getNode(i)->getNumberOfUpSuperArcs() == 1
+           and tree->getNode(i)->getNumberOfDownSuperArcs() == 1)
+          tree->deleteNode(i);
 
-    // Merge saddle points according epsilon
-    if(epsilon != 0)
-      mergeSaddle<dataType>(tree, epsilon, treeNodeMerged);
-  }
+      // Compute persistence pairs
+      auto pairs = ftm::computePersistencePairs<dataType>(tree);
+      // Verify pairs
+      verifyOrigins<dataType>(tree);
 
-  template <class dataType>
-  ftm::FTMTree_MT *computeBranchDecomposition(
-    ftm::FTMTree_MT *tree,
-    std::vector<std::vector<ftm::idNode>> &treeNodeMerged) {
-    ftm::FTMTree_MT *treeNew = tree;
+      // Delete null persistence pairs and persistence thresholding
+      std::vector<ftm::idNode> deletedNodes;
+      persistenceThresholding<dataType>(tree, deletedNodes);
 
-    ftm::idNode root = treeNew->getRoot();
+      // Merge saddle points according epsilon
+      if(epsilon != 0)
+        mergeSaddle<dataType>(tree, epsilon, treeNodeMerged);
+    }
 
-    // Manage when there is only one pair
-    if(tree->isThereOnlyOnePersistencePair()) {
-      ftm::idNode rootOrigin = treeNew->getNode(root)->getOrigin();
-      treeNew->getNode(rootOrigin)->setOrigin(rootOrigin);
+    template <class dataType>
+    ftm::FTMTree_MT *computeBranchDecomposition(
+      ftm::FTMTree_MT *tree,
+      std::vector<std::vector<ftm::idNode>> &treeNodeMerged) {
+      ftm::FTMTree_MT *treeNew = tree;
+
+      ftm::idNode root = treeNew->getRoot();
+
+      // Manage when there is only one pair
+      if(tree->isThereOnlyOnePersistencePair()) {
+        ftm::idNode rootOrigin = treeNew->getNode(root)->getOrigin();
+        treeNew->getNode(rootOrigin)->setOrigin(rootOrigin);
+        return treeNew;
+      }
+
+      // Manage multi persistence pairing
+      std::vector<std::vector<ftm::idNode>> treeMultiPers;
+      tree->getMultiPersOriginsVectorFromTree(treeMultiPers);
+
+      // General case
+      std::vector<bool> nodeDone(tree->getNumberOfNodes(), false);
+      std::queue<ftm::idNode> queueNodes;
+      queueNodes.emplace(root);
+      while(!queueNodes.empty()) {
+        ftm::idNode node = queueNodes.front();
+        queueNodes.pop();
+        ftm::idNode nodeOrigin = treeNew->getNode(node)->getOrigin();
+        if(node == nodeOrigin
+           or treeNew->getNodeLevel(node) > treeNew->getNodeLevel(nodeOrigin))
+          continue;
+
+        // Init vector with all origins
+        std::vector<std::tuple<ftm::idNode, int>> vecOrigins;
+        for(auto nodeMergedOrigin : treeNodeMerged[node]) {
+          vecOrigins.push_back(std::make_tuple(nodeMergedOrigin, 0));
+          for(auto multiPersOrigin :
+              treeMultiPers[tree->getNode(nodeMergedOrigin)->getOrigin()])
+            vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
+        }
+        if(not tree->isNodeMerged(node))
+          for(auto multiPersOrigin : treeMultiPers[node])
+            vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
+        vecOrigins.push_back(std::make_tuple(nodeOrigin, 2));
+
+        bool splitRoot = (vecOrigins.size() != 1 and treeNew->isRoot(node));
+        splitRoot = false; // disabled
+
+        // Process each origin
+        for(auto stackTuple : vecOrigins) {
+          ftm::idNode nodeOriginT = std::get<0>(stackTuple);
+          int nodeOriginTID = std::get<1>(stackTuple);
+          if(nodeDone[nodeOriginT]
+             and nodeDone[tree->getNode(nodeOriginT)->getOrigin()])
+            continue;
+          nodeDone[nodeOriginT] = true;
+          nodeDone[tree->getNode(nodeOriginT)->getOrigin()] = true;
+
+          // Manage new parent
+          ftm::idNode newParent = node;
+          // - if merged node
+          if(nodeOriginTID == 0) {
+            newParent = treeNew->getNode(nodeOriginT)->getOrigin();
+            treeNew->setParent(newParent, treeNew->getParentSafe(node));
+            // - if multi pers node or nodeOrigin and splitRoot
+          } else if(nodeOriginTID == 1 or (nodeOriginTID == 2 and splitRoot)) {
+            newParent = nodeOriginT;
+          }
+
+          // Set nodes in the branch as childrens of the node
+          ftm::idNode parentNodeOrigin = treeNew->getParentSafe(nodeOriginT);
+          while(parentNodeOrigin != node) {
+            ftm::idNode oldParentNodeOrigin
+              = treeNew->getParentSafe(parentNodeOrigin);
+            treeNew->setParent(parentNodeOrigin, newParent);
+            parentNodeOrigin = oldParentNodeOrigin;
+          }
+
+          if(nodeOriginTID == 1 or (nodeOriginTID == 2 and splitRoot))
+            treeNew->setParent(newParent, treeNew->getParentSafe(node));
+          else // if(nodeOriginTID != 1) // if not a multi pers node
+            // Delete the other node of the pair
+            treeNew->deleteNode(nodeOriginT);
+          if(nodeOriginTID == 2 and splitRoot)
+            tree->getNode(node)->setOrigin(node);
+
+          // Push childrens of the node to the stack to process them
+          std::vector<ftm::idNode> childrenNode;
+          treeNew->getChildren(newParent, childrenNode);
+          for(ftm::idNode children : childrenNode)
+            if(!treeNew->isLeaf(children))
+              queueNodes.emplace(children);
+        }
+      }
+
+      // Verify inconsistency
+      // verifyBranchDecompositionInconsistency<dataType>(treeNew);
+
       return treeNew;
     }
 
-    // Manage multi persistence pairing
-    std::vector<std::vector<ftm::idNode>> treeMultiPers;
-    tree->getMultiPersOriginsVectorFromTree(treeMultiPers);
-
-    // General case
-    std::vector<bool> nodeDone(tree->getNumberOfNodes(), false);
-    std::queue<ftm::idNode> queueNodes;
-    queueNodes.emplace(root);
-    while(!queueNodes.empty()) {
-      ftm::idNode node = queueNodes.front();
-      queueNodes.pop();
-      ftm::idNode nodeOrigin = treeNew->getNode(node)->getOrigin();
-      if(node == nodeOrigin
-         or treeNew->getNodeLevel(node) > treeNew->getNodeLevel(nodeOrigin))
-        continue;
-
-      // Init vector with all origins
-      std::vector<std::tuple<ftm::idNode, int>> vecOrigins;
-      for(auto nodeMergedOrigin : treeNodeMerged[node]) {
-        vecOrigins.push_back(std::make_tuple(nodeMergedOrigin, 0));
-        for(auto multiPersOrigin :
-            treeMultiPers[tree->getNode(nodeMergedOrigin)->getOrigin()])
-          vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
-      }
-      if(not tree->isNodeMerged(node))
-        for(auto multiPersOrigin : treeMultiPers[node])
-          vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
-      vecOrigins.push_back(std::make_tuple(nodeOrigin, 2));
-
-      bool splitRoot = (vecOrigins.size() != 1 and treeNew->isRoot(node));
-      splitRoot = false; // disabled
-
-      // Process each origin
-      for(auto stackTuple : vecOrigins) {
-        ftm::idNode nodeOriginT = std::get<0>(stackTuple);
-        int nodeOriginTID = std::get<1>(stackTuple);
-        if(nodeDone[nodeOriginT]
-           and nodeDone[tree->getNode(nodeOriginT)->getOrigin()])
-          continue;
-        nodeDone[nodeOriginT] = true;
-        nodeDone[tree->getNode(nodeOriginT)->getOrigin()] = true;
-
-        // Manage new parent
-        ftm::idNode newParent = node;
-        // - if merged node
-        if(nodeOriginTID == 0) {
-          newParent = treeNew->getNode(nodeOriginT)->getOrigin();
-          treeNew->setParent(newParent, treeNew->getParentSafe(node));
-          // - if multi pers node or nodeOrigin and splitRoot
-        } else if(nodeOriginTID == 1 or (nodeOriginTID == 2 and splitRoot)) {
-          newParent = nodeOriginT;
-        }
-
-        // Set nodes in the branch as childrens of the node
-        ftm::idNode parentNodeOrigin = treeNew->getParentSafe(nodeOriginT);
-        while(parentNodeOrigin != node) {
-          ftm::idNode oldParentNodeOrigin
-            = treeNew->getParentSafe(parentNodeOrigin);
-          treeNew->setParent(parentNodeOrigin, newParent);
-          parentNodeOrigin = oldParentNodeOrigin;
-        }
-
-        if(nodeOriginTID == 1 or (nodeOriginTID == 2 and splitRoot))
-          treeNew->setParent(newParent, treeNew->getParentSafe(node));
-        else // if(nodeOriginTID != 1) // if not a multi pers node
-          // Delete the other node of the pair
-          treeNew->deleteNode(nodeOriginT);
-        if(nodeOriginTID == 2 and splitRoot)
-          tree->getNode(node)->setOrigin(node);
-
-        // Push childrens of the node to the stack to process them
-        std::vector<ftm::idNode> childrenNode;
-        treeNew->getChildren(newParent, childrenNode);
-        for(ftm::idNode children : childrenNode)
-          if(!treeNew->isLeaf(children))
-            queueNodes.emplace(children);
-      }
+    template <class dataType>
+    ftm::idNode getMergedRootOrigin(ftm::FTMTree_MT *tree) {
+      ftm::idNode treeRoot = tree->getRoot();
+      bool isJt = tree->isJoinTree<dataType>();
+      ftm::idNode mergedRootOrigin = treeRoot;
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(tree->getNode(i)->getOrigin() == (int)treeRoot and i != treeRoot)
+          if((isJt
+              and tree->getValue<dataType>(i)
+                    < tree->getValue<dataType>(mergedRootOrigin))
+             or (not isJt
+                 and tree->getValue<dataType>(i)
+                       > tree->getValue<dataType>(mergedRootOrigin)))
+            mergedRootOrigin = i;
+      return mergedRootOrigin;
     }
 
-    // Verify inconsistency
-    // verifyBranchDecompositionInconsistency<dataType>(treeNew);
-
-    return treeNew;
-  }
-
-  template <class dataType>
-  ftm::idNode getMergedRootOrigin(ftm::FTMTree_MT *tree) {
-    ftm::idNode treeRoot = tree->getRoot();
-    bool isJt = tree->isJoinTree<dataType>();
-    ftm::idNode mergedRootOrigin = treeRoot;
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-      if(tree->getNode(i)->getOrigin() == (int)treeRoot and i != treeRoot)
-        if((isJt
-            and tree->getValue<dataType>(i)
-                  < tree->getValue<dataType>(mergedRootOrigin))
-           or (not isJt
-               and tree->getValue<dataType>(i)
-                     > tree->getValue<dataType>(mergedRootOrigin)))
-          mergedRootOrigin = i;
-    return mergedRootOrigin;
-  }
-
-  template <class dataType>
-  void dontUseMinMaxPair(ftm::FTMTree_MT *tree) {
-    ftm::idNode treeRoot = tree->getRoot();
-    // Full merge case, search for the origin
-    if(tree->getNode(treeRoot)->getOrigin() == (int)treeRoot) {
-      ftm::idNode nodeIdToDelete = getMergedRootOrigin<dataType>(tree);
-      if(nodeIdToDelete != treeRoot
-         and not tree->isNodeIdInconsistent(nodeIdToDelete)) {
-        if(tree->isThereOnlyOnePersistencePair())
-          tree->getNode(nodeIdToDelete)->setOrigin(nodeIdToDelete);
-        else
-          tree->deleteNode(nodeIdToDelete);
-      }
-      // Classic case
-    } else {
-      ftm::idNode rootOrigin = tree->getNode(treeRoot)->getOrigin();
-      if(tree->isThereOnlyOnePersistencePair())
-        tree->getNode(rootOrigin)->setOrigin(rootOrigin);
-      else
-        tree->deleteNode(rootOrigin);
-    }
-
-    tree->getNode(treeRoot)->setOrigin(treeRoot);
-  }
-
-  void verifyPairsTree(ftm::FTMTree_MT *tree) {
-    int cptBug = 0;
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
-      if(not tree->isNodeOriginDefined(i)) {
-        std::stringstream ss;
-        ss << i << " _ " << tree->getNode(i)->getOrigin() << " / "
-           << tree->getNumberOfNodes();
-        printMsg(ss.str());
-        if(tree->isNodeAlone(i))
-          printMsg("alone");
-        cptBug++;
-      }
-    }
-    std::stringstream ss;
-    ss << cptBug;
-    printMsg(ss.str());
-  }
-
-  template <class dataType>
-  void deleteMultiPersPairs(ftm::FTMTree_MT *tree, bool useBD) {
-    auto multiPersOrigins = tree->getMultiPersOrigins<dataType>(useBD);
-    for(auto origin : multiPersOrigins)
-      tree->deleteNode(origin);
-  }
-
-  template <class dataType>
-  ftm::FTMTree_MT *preprocessingPipeline(MergeTree<dataType> &mTree,
-                                         double epsilonTree,
-                                         double epsilon2Tree,
-                                         double epsilon3Tree,
-                                         bool branchDecompositionT,
-                                         bool useMinMaxPairT,
-                                         bool cleanTreeT,
-                                         std::vector<int> &nodeCorr) {
-    Timer t_proc;
-
-    FTMTree_MT *tree = &(mTree.tree);
-
-    std::vector<std::vector<ftm::idNode>> treeNodeMerged(
-      tree->getNumberOfNodes());
-
-    preprocessTree<dataType>(tree, epsilonTree, treeNodeMerged);
-    ftm::FTMTree_MT *treeOld = tree;
-
-    // verifyPairsTree(tree);
-    if(branchDecompositionT)
-      tree = computeBranchDecomposition<dataType>(tree, treeNodeMerged);
-
-    if(deleteMultiPersPairs_)
-      deleteMultiPersPairs<dataType>(tree, branchDecompositionT);
-
-    // verifyPairsTree(tree);
-    if(not useMinMaxPairT)
-      dontUseMinMaxPair<dataType>(tree);
-
-    if(branchDecompositionT)
-      persistenceMerging<dataType>(tree, epsilon2Tree, epsilon3Tree);
-
-    if(cleanTreeT) {
-      cleanMergeTree<dataType>(mTree, nodeCorr, branchDecompositionT);
-      tree = &(mTree.tree);
-      reverseNodeCorr(tree, nodeCorr);
-    }
-
-    if(tree->getNumberOfRoot() != 1) {
-      printErr("preprocessingPipeline tree->getNumberOfRoot() != 1");
-    }
-
-    // verifyPairsTree(tree);
-    auto t_preproc_time = t_proc.getElapsedTime();
-    std::stringstream ss;
-    ss << "TIME PREPROC.   = " << t_preproc_time;
-    printMsg(ss.str(), debug::Priority::DETAIL);
-
-    return treeOld;
-  }
-
-  void reverseNodeCorr(ftm::FTMTree_MT *tree, std::vector<int> &nodeCorr) {
-    std::vector<int> newNodeCorr(tree->getNumberOfNodes());
-    for(unsigned int i = 0; i < nodeCorr.size(); ++i)
-      if(nodeCorr[i] >= 0 && nodeCorr[i] < (int)newNodeCorr.size())
-        newNodeCorr[nodeCorr[i]] = i;
-    nodeCorr = newNodeCorr;
-  }
-
-  // --------------------------------------------------------------------------------
-  // Tree Postprocessing
-  // --------------------------------------------------------------------------------
-  template <class dataType>
-  std::tuple<int, dataType> fixMergedRootOrigin(ftm::FTMTree_MT *tree) {
-    if(not tree->isFullMerge())
-      return std::make_tuple(-1, -1);
-
-    // Get node of the min max pair
-    dataType maxPers = 0;
-    int maxIndex = -1;
-    for(unsigned int j = 0; j < tree->getNumberOfNodes(); ++j) {
-      if(not tree->isNodeAlone(j)) {
-        dataType nodePers = tree->getNodePersistence<dataType>(j);
-        if(nodePers > maxPers) {
-          maxPers = nodePers;
-          maxIndex = j;
-        }
-      }
-    }
-
-    // Link node of the min max pair with the root
-    ftm::idNode treeRoot = tree->getRoot();
-    dataType oldOriginValue
-      = tree->getValue<dataType>(tree->getNode(maxIndex)->getOrigin());
-    tree->getNode(maxIndex)->setOrigin(treeRoot);
-
-    return std::make_tuple(maxIndex, oldOriginValue);
-  }
-
-  template <class dataType>
-  void branchDecompositionToTree(ftm::FTMTree_MT *tree) {
-    ftm::idNode treeRoot = tree->getRoot();
-
-    // One pair case
-    if(tree->isThereOnlyOnePersistencePair()) {
-      idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
-      tree->getNode(treeRootOrigin)->setOrigin(treeRoot);
-      return;
-    }
-
-    // Manage full merge and dontuseMinMaxPair_
-    bool isFM = tree->isFullMerge();
-    if(isFM) {
-      ftm::idNode mergedRootOrigin = getMergedRootOrigin<dataType>(tree);
-      if(not tree->isNodeIdInconsistent(mergedRootOrigin)
-         and mergedRootOrigin != treeRoot)
-        tree->getNode(treeRoot)->setOrigin(mergedRootOrigin);
-      else {
-        printErr("branchDecompositionToTree mergedRootOrigin inconsistent");
-      }
-    }
-
-    // Some functions
-    bool isJT = tree->isJoinTree<dataType>();
-    auto comp = [&](const std::tuple<ftm::idNode, dataType> &a,
-                    const std::tuple<ftm::idNode, dataType> &b) {
-      return isJT ? std::get<1>(a) > std::get<1>(b)
-                  : std::get<1>(a) < std::get<1>(b);
-    };
-    auto getIndexNotMultiPers = [&](int index, ftm::FTMTree_MT *treeT,
-                                    std::vector<ftm::idNode> &children) {
-      while(treeT->isMultiPersPair(children[index]))
-        --index;
-      index = std::max(0, index);
-      return index;
-    };
-
-    // Branch Decomposition To Tree
-    std::vector<std::tuple<ftm::idNode, ftm::idNode>> nodeParent;
-    std::queue<ftm::idNode> queue;
-    queue.emplace(treeRoot);
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-      auto nodeOrigin = tree->getNode(node)->getOrigin();
-      if(tree->isLeaf(node)) {
-        if(tree->isNodeAlone(nodeOrigin)) {
-          if(not isFM)
-            nodeParent.push_back(std::make_tuple(nodeOrigin, node));
+    template <class dataType>
+    void dontUseMinMaxPair(ftm::FTMTree_MT *tree) {
+      ftm::idNode treeRoot = tree->getRoot();
+      // Full merge case, search for the origin
+      if(tree->getNode(treeRoot)->getOrigin() == (int)treeRoot) {
+        ftm::idNode nodeIdToDelete = getMergedRootOrigin<dataType>(tree);
+        if(nodeIdToDelete != treeRoot
+           and not tree->isNodeIdInconsistent(nodeIdToDelete)) {
+          if(tree->isThereOnlyOnePersistencePair())
+            tree->getNode(nodeIdToDelete)->setOrigin(nodeIdToDelete);
           else
-            nodeParent.push_back(std::make_tuple(node, nodeOrigin));
-        } else if(tree->isMultiPersPair(node)) {
-          nodeParent.push_back(std::make_tuple(node, nodeOrigin));
+            tree->deleteNode(nodeIdToDelete);
         }
-        continue;
-      }
-
-      // Get children and sort them by scalar values
-      std::vector<ftm::idNode> childrenOri;
-      tree->getChildren(node, childrenOri);
-      std::vector<ftm::idNode> children = childrenOri;
-      std::vector<std::tuple<ftm::idNode, dataType>> childrenScalars;
-      for(unsigned int i = 0; i < children.size(); ++i) {
-        if(isFM and (int) children[i] != nodeOrigin)
-          children[i] = tree->getNode(children[i])->getOrigin();
-        childrenScalars.push_back(
-          std::make_tuple(children[i], tree->getValue<dataType>(children[i])));
-      }
-      std::sort(std::begin(childrenScalars), std::end(childrenScalars), comp);
-      children.clear();
-      for(unsigned int i = 0; i < childrenScalars.size(); ++i)
-        children.push_back(std::get<0>(childrenScalars[i]));
-
-      // Get new parent of children
-      for(unsigned int i = 1; i < children.size(); ++i) {
-        if(tree->isMultiPersPair(children[i]))
-          continue;
-        int index = getIndexNotMultiPers(i - 1, tree, children);
-        nodeParent.push_back(std::make_tuple(children[i], children[index]));
-      }
-
-      bool multiPersPair = tree->getNode(nodeOrigin)->getOrigin() != (int)node;
-      if(not multiPersPair) {
-        if(not isFM) {
-          int index = getIndexNotMultiPers(children.size() - 1, tree, children);
-          nodeParent.push_back(std::make_tuple(nodeOrigin, children[index]));
-        } else
-          nodeParent.push_back(std::make_tuple(children[0], node));
+        // Classic case
       } else {
-        // std::cout << "branchDecompositionToTree multiPersPair" << std::endl;
-        nodeParent.push_back(std::make_tuple(children[0], nodeOrigin));
-        int index = getIndexNotMultiPers(children.size() - 1, tree, children);
-        nodeParent.push_back(std::make_tuple(node, children[index]));
+        ftm::idNode rootOrigin = tree->getNode(treeRoot)->getOrigin();
+        if(tree->isThereOnlyOnePersistencePair())
+          tree->getNode(rootOrigin)->setOrigin(rootOrigin);
+        else
+          tree->deleteNode(rootOrigin);
       }
 
-      // Push children to the queue
-      for(auto child : childrenOri)
-        queue.emplace(child);
+      tree->getNode(treeRoot)->setOrigin(treeRoot);
     }
 
-    // Set new parents for each node
-    for(auto nodeParentT : nodeParent)
-      tree->setParent(std::get<0>(nodeParentT), std::get<1>(nodeParentT));
-
-    // Verify that the tree is correct
-    for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-      if(tree->getNode(i)->getNumberOfDownSuperArcs() == 1
-         and tree->getNode(i)->getNumberOfUpSuperArcs() == 1) {
-        tree->printTree();
-        std::stringstream ss;
-        ss << i << " _ " << tree->getNode(i)->getOrigin();
-        printMsg(ss.str());
-        printErr("1 up arc and 1 down arc");
+    void verifyPairsTree(ftm::FTMTree_MT *tree) {
+      int cptBug = 0;
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
+        if(not tree->isNodeOriginDefined(i)) {
+          std::stringstream ss;
+          ss << i << " _ " << tree->getNode(i)->getOrigin() << " / "
+             << tree->getNumberOfNodes();
+          printMsg(ss.str());
+          if(tree->isNodeAlone(i))
+            printMsg("alone");
+          cptBug++;
+        }
       }
-  }
+      std::stringstream ss;
+      ss << cptBug;
+      printMsg(ss.str());
+    }
 
-  // For not branch decomposition tree
-  template <class dataType>
-  void putBackMergedNodes(ftm::FTMTree_MT *tree) {
-    bool isJT = tree->isJoinTree<dataType>();
-    std::queue<ftm::idNode> queue;
-    queue.emplace(tree->getRoot());
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-      ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-      if(!tree->isLeaf(node)) {
+    template <class dataType>
+    void deleteMultiPersPairs(ftm::FTMTree_MT *tree, bool useBD) {
+      auto multiPersOrigins = tree->getMultiPersOrigins<dataType>(useBD);
+      for(auto origin : multiPersOrigins)
+        tree->deleteNode(origin);
+    }
+
+    template <class dataType>
+    ftm::FTMTree_MT *preprocessingPipeline(ftm::MergeTree<dataType> &mTree,
+                                           double epsilonTree,
+                                           double epsilon2Tree,
+                                           double epsilon3Tree,
+                                           bool branchDecompositionT,
+                                           bool useMinMaxPairT,
+                                           bool cleanTreeT,
+                                           std::vector<int> &nodeCorr) {
+      Timer t_proc;
+
+      ftm::FTMTree_MT *tree = &(mTree.tree);
+
+      std::vector<std::vector<ftm::idNode>> treeNodeMerged(
+        tree->getNumberOfNodes());
+
+      preprocessTree<dataType>(tree, epsilonTree, treeNodeMerged);
+      ftm::FTMTree_MT *treeOld = tree;
+
+      // verifyPairsTree(tree);
+      if(branchDecompositionT)
+        tree = computeBranchDecomposition<dataType>(tree, treeNodeMerged);
+
+      if(deleteMultiPersPairs_)
+        deleteMultiPersPairs<dataType>(tree, branchDecompositionT);
+
+      // verifyPairsTree(tree);
+      if(not useMinMaxPairT)
+        dontUseMinMaxPair<dataType>(tree);
+
+      if(branchDecompositionT)
+        persistenceMerging<dataType>(tree, epsilon2Tree, epsilon3Tree);
+
+      if(cleanTreeT) {
+        ftm::cleanMergeTree<dataType>(mTree, nodeCorr, branchDecompositionT);
+        tree = &(mTree.tree);
+        reverseNodeCorr(tree, nodeCorr);
+      }
+
+      if(tree->getNumberOfRoot() != 1) {
+        printErr("preprocessingPipeline tree->getNumberOfRoot() != 1");
+      }
+
+      // verifyPairsTree(tree);
+      auto t_preproc_time = t_proc.getElapsedTime();
+      std::stringstream ss;
+      ss << "TIME PREPROC.   = " << t_preproc_time;
+      printMsg(ss.str(), debug::Priority::DETAIL);
+
+      return treeOld;
+    }
+
+    void reverseNodeCorr(ftm::FTMTree_MT *tree, std::vector<int> &nodeCorr) {
+      std::vector<int> newNodeCorr(tree->getNumberOfNodes());
+      for(unsigned int i = 0; i < nodeCorr.size(); ++i)
+        if(nodeCorr[i] >= 0 && nodeCorr[i] < (int)newNodeCorr.size())
+          newNodeCorr[nodeCorr[i]] = i;
+      nodeCorr = newNodeCorr;
+    }
+
+    // --------------------------------------------------------------------------------
+    // Tree Postprocessing
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    std::tuple<int, dataType> fixMergedRootOrigin(ftm::FTMTree_MT *tree) {
+      if(not tree->isFullMerge())
+        return std::make_tuple(-1, -1);
+
+      // Get node of the min max pair
+      dataType maxPers = 0;
+      int maxIndex = -1;
+      for(unsigned int j = 0; j < tree->getNumberOfNodes(); ++j) {
+        if(not tree->isNodeAlone(j)) {
+          dataType nodePers = tree->getNodePersistence<dataType>(j);
+          if(nodePers > maxPers) {
+            maxPers = nodePers;
+            maxIndex = j;
+          }
+        }
+      }
+
+      // Link node of the min max pair with the root
+      ftm::idNode treeRoot = tree->getRoot();
+      dataType oldOriginValue
+        = tree->getValue<dataType>(tree->getNode(maxIndex)->getOrigin());
+      tree->getNode(maxIndex)->setOrigin(treeRoot);
+
+      return std::make_tuple(maxIndex, oldOriginValue);
+    }
+
+    template <class dataType>
+    void branchDecompositionToTree(ftm::FTMTree_MT *tree) {
+      ftm::idNode treeRoot = tree->getRoot();
+
+      // One pair case
+      if(tree->isThereOnlyOnePersistencePair()) {
+        ftm::idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
+        tree->getNode(treeRootOrigin)->setOrigin(treeRoot);
+        return;
+      }
+
+      // Manage full merge and dontuseMinMaxPair_
+      bool isFM = tree->isFullMerge();
+      if(isFM) {
+        ftm::idNode mergedRootOrigin = getMergedRootOrigin<dataType>(tree);
+        if(not tree->isNodeIdInconsistent(mergedRootOrigin)
+           and mergedRootOrigin != treeRoot)
+          tree->getNode(treeRoot)->setOrigin(mergedRootOrigin);
+        else {
+          printErr("branchDecompositionToTree mergedRootOrigin inconsistent");
+        }
+      }
+
+      // Some functions
+      bool isJT = tree->isJoinTree<dataType>();
+      auto comp = [&](const std::tuple<ftm::idNode, dataType> &a,
+                      const std::tuple<ftm::idNode, dataType> &b) {
+        return isJT ? std::get<1>(a) > std::get<1>(b)
+                    : std::get<1>(a) < std::get<1>(b);
+      };
+      auto getIndexNotMultiPers = [&](int index, ftm::FTMTree_MT *treeT,
+                                      std::vector<ftm::idNode> &children) {
+        while(treeT->isMultiPersPair(children[index]))
+          --index;
+        index = std::max(0, index);
+        return index;
+      };
+
+      // Branch Decomposition To Tree
+      std::vector<std::tuple<ftm::idNode, ftm::idNode>> nodeParent;
+      std::queue<ftm::idNode> queue;
+      queue.emplace(treeRoot);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        auto nodeOrigin = tree->getNode(node)->getOrigin();
+        if(tree->isLeaf(node)) {
+          if(tree->isNodeAlone(nodeOrigin)) {
+            if(not isFM)
+              nodeParent.push_back(std::make_tuple(nodeOrigin, node));
+            else
+              nodeParent.push_back(std::make_tuple(node, nodeOrigin));
+          } else if(tree->isMultiPersPair(node)) {
+            nodeParent.push_back(std::make_tuple(node, nodeOrigin));
+          }
+          continue;
+        }
+
+        // Get children and sort them by scalar values
+        std::vector<ftm::idNode> childrenOri;
+        tree->getChildren(node, childrenOri);
+        std::vector<ftm::idNode> children = childrenOri;
+        std::vector<std::tuple<ftm::idNode, dataType>> childrenScalars;
+        for(unsigned int i = 0; i < children.size(); ++i) {
+          if(isFM and (int) children[i] != nodeOrigin)
+            children[i] = tree->getNode(children[i])->getOrigin();
+          childrenScalars.push_back(std::make_tuple(
+            children[i], tree->getValue<dataType>(children[i])));
+        }
+        std::sort(std::begin(childrenScalars), std::end(childrenScalars), comp);
+        children.clear();
+        for(unsigned int i = 0; i < childrenScalars.size(); ++i)
+          children.push_back(std::get<0>(childrenScalars[i]));
+
+        // Get new parent of children
+        for(unsigned int i = 1; i < children.size(); ++i) {
+          if(tree->isMultiPersPair(children[i]))
+            continue;
+          int index = getIndexNotMultiPers(i - 1, tree, children);
+          nodeParent.push_back(std::make_tuple(children[i], children[index]));
+        }
+
+        bool multiPersPair
+          = tree->getNode(nodeOrigin)->getOrigin() != (int)node;
+        if(not multiPersPair) {
+          if(not isFM) {
+            int index
+              = getIndexNotMultiPers(children.size() - 1, tree, children);
+            nodeParent.push_back(std::make_tuple(nodeOrigin, children[index]));
+          } else
+            nodeParent.push_back(std::make_tuple(children[0], node));
+        } else {
+          // std::cout << "branchDecompositionToTree multiPersPair" <<
+          // std::endl;
+          nodeParent.push_back(std::make_tuple(children[0], nodeOrigin));
+          int index = getIndexNotMultiPers(children.size() - 1, tree, children);
+          nodeParent.push_back(std::make_tuple(node, children[index]));
+        }
+
+        // Push children to the queue
+        for(auto child : childrenOri)
+          queue.emplace(child);
+      }
+
+      // Set new parents for each node
+      for(auto nodeParentT : nodeParent)
+        tree->setParent(std::get<0>(nodeParentT), std::get<1>(nodeParentT));
+
+      // Verify that the tree is correct
+      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+        if(tree->getNode(i)->getNumberOfDownSuperArcs() == 1
+           and tree->getNode(i)->getNumberOfUpSuperArcs() == 1) {
+          tree->printTree();
+          std::stringstream ss;
+          ss << i << " _ " << tree->getNode(i)->getOrigin();
+          printMsg(ss.str());
+          printErr("1 up arc and 1 down arc");
+        }
+    }
+
+    // For not branch decomposition tree
+    template <class dataType>
+    void putBackMergedNodes(ftm::FTMTree_MT *tree) {
+      bool isJT = tree->isJoinTree<dataType>();
+      std::queue<ftm::idNode> queue;
+      queue.emplace(tree->getRoot());
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+        if(!tree->isLeaf(node)) {
+          std::vector<ftm::idNode> children;
+          tree->getChildren(node, children);
+          std::vector<ftm::idNode> lowestNodes;
+          ftm::idNode branchOrigin = nodeOrigin;
+          for(auto child : children) {
+            ftm::idNode lowestNode = tree->getLowestNode<dataType>(child);
+            lowestNodes.push_back(lowestNode);
+            ftm::idNode lowestNodeOrigin
+              = tree->getNode(lowestNode)->getOrigin();
+            if(not tree->isNodeAlone(lowestNodeOrigin)
+               and lowestNodeOrigin != node)
+              branchOrigin = lowestNode;
+          }
+          for(size_t i = 0; i < children.size(); ++i) {
+            ftm::idNode lowestNodeOrigin
+              = tree->getNode(lowestNodes[i])->getOrigin();
+            if(branchOrigin == lowestNodes[i] or lowestNodeOrigin == node)
+              continue;
+            dataType lowestNodeOriginVal
+              = tree->getValue<dataType>(lowestNodeOrigin);
+            ftm::idNode branchOriginT = branchOrigin;
+            ftm::idNode branchRoot = tree->getNode(branchOrigin)->getOrigin();
+            while(branchRoot != branchOriginT) {
+              dataType val
+                = tree->getValue<dataType>(tree->getParentSafe(branchOriginT));
+              if((val > lowestNodeOriginVal and isJT)
+                 or (val < lowestNodeOriginVal and not isJT))
+                break;
+              branchOriginT = tree->getParentSafe(branchOriginT);
+            }
+            tree->setParent(
+              lowestNodeOrigin, tree->getParentSafe(branchOriginT));
+            tree->setParent(branchOriginT, lowestNodeOrigin);
+            tree->setParent(children[i], lowestNodeOrigin);
+          }
+        }
         std::vector<ftm::idNode> children;
         tree->getChildren(node, children);
-        std::vector<ftm::idNode> lowestNodes;
-        ftm::idNode branchOrigin = nodeOrigin;
-        for(auto child : children) {
-          ftm::idNode lowestNode = tree->getLowestNode<dataType>(child);
-          lowestNodes.push_back(lowestNode);
-          ftm::idNode lowestNodeOrigin = tree->getNode(lowestNode)->getOrigin();
-          if(not tree->isNodeAlone(lowestNodeOrigin)
-             and lowestNodeOrigin != node)
-            branchOrigin = lowestNode;
-        }
-        for(size_t i = 0; i < children.size(); ++i) {
-          ftm::idNode lowestNodeOrigin
-            = tree->getNode(lowestNodes[i])->getOrigin();
-          if(branchOrigin == lowestNodes[i] or lowestNodeOrigin == node)
-            continue;
-          dataType lowestNodeOriginVal
-            = tree->getValue<dataType>(lowestNodeOrigin);
-          ftm::idNode branchOriginT = branchOrigin;
-          ftm::idNode branchRoot = tree->getNode(branchOrigin)->getOrigin();
-          while(branchRoot != branchOriginT) {
-            dataType val
-              = tree->getValue<dataType>(tree->getParentSafe(branchOriginT));
-            if((val > lowestNodeOriginVal and isJT)
-               or (val < lowestNodeOriginVal and not isJT))
-              break;
-            branchOriginT = tree->getParentSafe(branchOriginT);
-          }
-          tree->setParent(lowestNodeOrigin, tree->getParentSafe(branchOriginT));
-          tree->setParent(branchOriginT, lowestNodeOrigin);
-          tree->setParent(children[i], lowestNodeOrigin);
-        }
+        for(auto child : children)
+          queue.emplace(child);
       }
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue.emplace(child);
     }
-  }
 
-  template <class dataType>
-  void postprocessingPipeline(ftm::FTMTree_MT *tree) {
-    // TODO fix dont use min max pair
-    if(not branchDecomposition_ or not useMinMaxPair_)
-      fixMergedRootOrigin<dataType>(tree);
-    if(branchDecomposition_)
-      branchDecompositionToTree<dataType>(tree);
-    else
-      putBackMergedNodes<dataType>(tree);
-  }
+    template <class dataType>
+    void postprocessingPipeline(ftm::FTMTree_MT *tree) {
+      // TODO fix dont use min max pair
+      if(not branchDecomposition_ or not useMinMaxPair_)
+        fixMergedRootOrigin<dataType>(tree);
+      if(branchDecomposition_)
+        branchDecompositionToTree<dataType>(tree);
+      else
+        putBackMergedNodes<dataType>(tree);
+    }
 
-  // --------------------------------------------------------------------------------
-  // Output Matching
-  // --------------------------------------------------------------------------------
-  template <class dataType>
-  void computeMatching(
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
-    std::vector<std::vector<std::vector<std::tuple<int, int>>>>
-      &forestBackTable,
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &outputMatching,
-    int startR,
-    int startC) {
-    std::queue<std::tuple<int, int, bool>> backQueue;
-    backQueue.emplace(std::make_tuple(startR, startC, true));
-    while(!backQueue.empty()) {
-      std::tuple<int, int, bool> elem = backQueue.front();
-      backQueue.pop();
-      bool useTreeTable = std::get<2>(elem);
-      int i = std::get<0>(elem);
-      int j = std::get<1>(elem);
+    // --------------------------------------------------------------------------------
+    // Output Matching
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    void computeMatching(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
+      std::vector<std::vector<std::vector<std::tuple<int, int>>>>
+        &forestBackTable,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &outputMatching,
+      int startR,
+      int startC) {
+      std::queue<std::tuple<int, int, bool>> backQueue;
+      backQueue.emplace(std::make_tuple(startR, startC, true));
+      while(!backQueue.empty()) {
+        std::tuple<int, int, bool> elem = backQueue.front();
+        backQueue.pop();
+        bool useTreeTable = std::get<2>(elem);
+        int i = std::get<0>(elem);
+        int j = std::get<1>(elem);
 
-      if(useTreeTable) {
-        int tupleI = std::get<0>(treeBackTable[i][j]);
-        int tupleJ = std::get<1>(treeBackTable[i][j]);
-        if(tupleI != 0 && tupleJ != 0) {
-          useTreeTable = (tupleI != i || tupleJ != j);
-          backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
-          if(not useTreeTable) { // We have matched i and j
-            ftm::idNode tree1Node = tupleI - 1;
-            ftm::idNode tree2Node = tupleJ - 1;
-            double cost = 0;
-            dataType costT
-              = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
-            cost = static_cast<double>(costT);
-            outputMatching.push_back(
-              std::make_tuple(tree1Node, tree2Node, cost));
-          }
-        }
-      } else {
-        for(std::tuple<int, int> forestBackElem : forestBackTable[i][j]) {
-          int tupleI = std::get<0>(forestBackElem);
-          int tupleJ = std::get<1>(forestBackElem);
+        if(useTreeTable) {
+          int tupleI = std::get<0>(treeBackTable[i][j]);
+          int tupleJ = std::get<1>(treeBackTable[i][j]);
           if(tupleI != 0 && tupleJ != 0) {
-            useTreeTable = (tupleI != i && tupleJ != j);
+            useTreeTable = (tupleI != i || tupleJ != j);
             backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
+            if(not useTreeTable) { // We have matched i and j
+              ftm::idNode tree1Node = tupleI - 1;
+              ftm::idNode tree2Node = tupleJ - 1;
+              double cost = 0;
+              dataType costT
+                = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
+              cost = static_cast<double>(costT);
+              outputMatching.push_back(
+                std::make_tuple(tree1Node, tree2Node, cost));
+            }
+          }
+        } else {
+          for(std::tuple<int, int> forestBackElem : forestBackTable[i][j]) {
+            int tupleI = std::get<0>(forestBackElem);
+            int tupleJ = std::get<1>(forestBackElem);
+            if(tupleI != 0 && tupleJ != 0) {
+              useTreeTable = (tupleI != i && tupleJ != j);
+              backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
+            }
           }
         }
       }
     }
-  }
 
-  template <class dataType>
-  void convertBranchDecompositionMatching(
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &outputMatching) {
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> toAdd;
-    for(auto mTuple : outputMatching) {
-      ftm::idNode node1 = std::get<0>(mTuple);
-      ftm::idNode node2 = std::get<1>(mTuple);
-      double cost = std::get<2>(mTuple);
-      ftm::idNode node1Origin = tree1->getNode(node1)->getOrigin();
-      ftm::idNode node2Origin = tree2->getNode(node2)->getOrigin();
+    template <class dataType>
+    void convertBranchDecompositionMatching(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
+        &outputMatching) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> toAdd;
+      for(auto mTuple : outputMatching) {
+        ftm::idNode node1 = std::get<0>(mTuple);
+        ftm::idNode node2 = std::get<1>(mTuple);
+        double cost = std::get<2>(mTuple);
+        ftm::idNode node1Origin = tree1->getNode(node1)->getOrigin();
+        ftm::idNode node2Origin = tree2->getNode(node2)->getOrigin();
 
-      int node1Level = tree1->getNodeLevel(node1);
-      int node1OriginLevel = tree1->getNodeLevel(node1Origin);
-      int node2Level = tree2->getNodeLevel(node2);
-      int node2OriginLevel = tree2->getNodeLevel(node2Origin);
+        int node1Level = tree1->getNodeLevel(node1);
+        int node1OriginLevel = tree1->getNodeLevel(node1Origin);
+        int node2Level = tree2->getNodeLevel(node2);
+        int node2OriginLevel = tree2->getNodeLevel(node2Origin);
 
-      ftm::idNode node1Higher
-        = (node1Level > node1OriginLevel) ? node1 : node1Origin;
-      ftm::idNode node1Lower
-        = (node1Level > node1OriginLevel) ? node1Origin : node1;
-      ftm::idNode node2Higher
-        = (node2Level > node2OriginLevel) ? node2 : node2Origin;
-      ftm::idNode node2Lower
-        = (node2Level > node2OriginLevel) ? node2Origin : node2;
+        ftm::idNode node1Higher
+          = (node1Level > node1OriginLevel) ? node1 : node1Origin;
+        ftm::idNode node1Lower
+          = (node1Level > node1OriginLevel) ? node1Origin : node1;
+        ftm::idNode node2Higher
+          = (node2Level > node2OriginLevel) ? node2 : node2Origin;
+        ftm::idNode node2Lower
+          = (node2Level > node2OriginLevel) ? node2Origin : node2;
 
-      if(((tree1->isRoot(node1Higher) and tree1->isFullMerge())
-          or (tree2->isRoot(node2Higher) and tree2->isFullMerge())))
-        continue;
+        if(((tree1->isRoot(node1Higher) and tree1->isFullMerge())
+            or (tree2->isRoot(node2Higher) and tree2->isFullMerge())))
+          continue;
 
-      if(!tree1->isNodeAlone(node1Higher) and !tree2->isNodeAlone(node2Higher))
-        toAdd.push_back(std::make_tuple(node1Higher, node2Higher, cost));
-      if(!tree1->isNodeAlone(node1Lower) and !tree2->isNodeAlone(node2Lower))
-        toAdd.push_back(std::make_tuple(node1Lower, node2Lower, cost));
-    }
-    outputMatching.clear();
-    outputMatching.insert(outputMatching.end(), toAdd.begin(), toAdd.end());
-  }
-
-  template <class dataType>
-  void convertBranchDecompositionMatching(
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching) {
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
-      realOutputMatching(outputMatching.size());
-    for(size_t i = 0; i < outputMatching.size(); ++i) {
-      const auto &tup{outputMatching[i]};
-      realOutputMatching[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+        if(!tree1->isNodeAlone(node1Higher)
+           and !tree2->isNodeAlone(node2Higher))
+          toAdd.push_back(std::make_tuple(node1Higher, node2Higher, cost));
+        if(!tree1->isNodeAlone(node1Lower) and !tree2->isNodeAlone(node2Lower))
+          toAdd.push_back(std::make_tuple(node1Lower, node2Lower, cost));
+      }
+      outputMatching.clear();
+      outputMatching.insert(outputMatching.end(), toAdd.begin(), toAdd.end());
     }
 
-    convertBranchDecompositionMatching<dataType>(
-      tree1, tree2, realOutputMatching);
+    template <class dataType>
+    void convertBranchDecompositionMatching(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
+        realOutputMatching(outputMatching.size());
+      for(size_t i = 0; i < outputMatching.size(); ++i) {
+        const auto &tup{outputMatching[i]};
+        realOutputMatching[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+      }
 
-    outputMatching.clear();
-    for(auto tup : realOutputMatching)
-      outputMatching.push_back(
-        std::make_tuple(std::get<0>(tup), std::get<1>(tup)));
-  }
+      convertBranchDecompositionMatching<dataType>(
+        tree1, tree2, realOutputMatching);
 
-  template <class dataType>
-  void identifyRealMatching(
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching,
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, bool>> &realMatching) {
-    for(std::tuple<ftm::idNode, ftm::idNode> mTuple : outputMatching) {
-      ftm::idNode tree1Node = std::get<0>(mTuple);
-      ftm::idNode tree2Node = std::get<1>(mTuple);
-      dataType relabelCostVal
-        = relabelCostOnly<dataType>(tree1, tree1Node, tree2, tree2Node);
-      dataType deleteInsertCostVal = deleteCost<dataType>(tree1, tree1Node)
-                                     + insertCost<dataType>(tree2, tree2Node);
-      bool isRealMatching = (relabelCostVal <= deleteInsertCostVal);
-      realMatching.push_back(
-        std::make_tuple(tree1Node, tree2Node, isRealMatching));
+      outputMatching.clear();
+      for(auto tup : realOutputMatching)
+        outputMatching.push_back(
+          std::make_tuple(std::get<0>(tup), std::get<1>(tup)));
     }
-  }
 
-  // --------------------------------------------------------------------------------
-  // Edit Costs
-  // --------------------------------------------------------------------------------
-  template <class dataType>
-  dataType computeDistance(
-    dataType x1, dataType x2, dataType y1, dataType y2, double power = 2) {
-    if(power <= 0)
-      return std::max(std::abs((double)(x1 - y1)), std::abs((double)(x2 - y2)));
-    else
-      return std::pow(std::abs((double)(x1 - y1)), power)
-             + std::pow(std::abs((double)(x2 - y2)), power);
-  }
-
-  template <class dataType>
-  dataType regularizationCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
-    dataType shiftMin1 = getMinMaxLocal<dataType>(tree, nodeId);
-    dataType shiftMax1 = getMinMaxLocal<dataType>(tree, nodeId, false);
-    return computeDistance<dataType>(
-      shiftMin1, 0, shiftMax1, 0, wassersteinPower_);
-  }
-
-  template <class dataType>
-  dataType deleteCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
-    dataType cost = 0;
-    dataType newMin = 0.0, newMax = 1.0;
-    if(normalizedWasserstein_ and rescaledWasserstein_) {
-      auto newMinMax = getNewMinMax<dataType>(tree, nodeId, tree, nodeId);
-      newMin = std::get<0>(newMinMax);
-      newMax = std::get<1>(newMinMax);
+    template <class dataType>
+    void identifyRealMatching(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, bool>> &realMatching) {
+      for(std::tuple<ftm::idNode, ftm::idNode> mTuple : outputMatching) {
+        ftm::idNode tree1Node = std::get<0>(mTuple);
+        ftm::idNode tree2Node = std::get<1>(mTuple);
+        dataType relabelCostVal
+          = relabelCostOnly<dataType>(tree1, tree1Node, tree2, tree2Node);
+        dataType deleteInsertCostVal = deleteCost<dataType>(tree1, tree1Node)
+                                       + insertCost<dataType>(tree2, tree2Node);
+        bool isRealMatching = (relabelCostVal <= deleteInsertCostVal);
+        realMatching.push_back(
+          std::make_tuple(tree1Node, tree2Node, isRealMatching));
+      }
     }
-    // Get birth/death
-    auto birthDeath
-      = normalizedWasserstein_
-          ? getNormalizedBirthDeath<dataType>(tree, nodeId, newMin, newMax)
-          : tree->getBirthDeath<dataType>(nodeId);
-    dataType birth = std::get<0>(birthDeath);
-    dataType death = std::get<1>(birthDeath);
-    dataType projec = (birth + death) / 2;
-    // Compute delete cost
-    cost = computeDistance<dataType>(
-      birth, death, projec, projec, wassersteinPower_);
-    // Divide cost by two if not branch decomposition and not merged
-    /*if(! branchDecomposition_ and ! tree->isNodeMerged(nodeId))
-      cost /= 2;*/
-    // Regularize
-    if(normalizedWasserstein_ and normalizedWassersteinReg_ != 0)
-      cost += normalizedWassersteinReg_
-              * regularizationCost<dataType>(tree, nodeId);
 
-    return cost;
-  }
-
-  template <class dataType>
-  dataType insertCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
-    return deleteCost<dataType>(tree, nodeId);
-  }
-
-  template <class dataType>
-  dataType regularizationCost2(ftm::FTMTree_MT *tree1,
-                               ftm::idNode nodeId1,
-                               ftm::FTMTree_MT *tree2,
-                               ftm::idNode nodeId2) {
-    dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
-    dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
-    dataType shiftMin2 = getMinMaxLocal<dataType>(tree2, nodeId2);
-    dataType shiftMax2 = getMinMaxLocal<dataType>(tree2, nodeId2, false);
-    return computeDistance<dataType>(
-      shiftMin1, shiftMax1, shiftMin2, shiftMax2, wassersteinPower_);
-  }
-
-  template <class dataType>
-  dataType relabelCostOnly(ftm::FTMTree_MT *tree1,
-                           ftm::idNode nodeId1,
-                           ftm::FTMTree_MT *tree2,
-                           ftm::idNode nodeId2) {
-    dataType cost = 0;
-    dataType newMin = 0.0, newMax = 1.0;
-    if(normalizedWasserstein_ and rescaledWasserstein_) {
-      auto newMinMax = getNewMinMax<dataType>(tree1, nodeId1, tree2, nodeId2);
-      newMin = std::get<0>(newMinMax);
-      newMax = std::get<1>(newMinMax);
+    // --------------------------------------------------------------------------------
+    // Edit Costs
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    dataType computeDistance(
+      dataType x1, dataType x2, dataType y1, dataType y2, double power = 2) {
+      if(power <= 0)
+        return std::max(
+          std::abs((double)(x1 - y1)), std::abs((double)(x2 - y2)));
+      else
+        return std::pow(std::abs((double)(x1 - y1)), power)
+               + std::pow(std::abs((double)(x2 - y2)), power);
     }
-    // Get birth/death of the first tree
-    auto birthDeath1
-      = normalizedWasserstein_
-          ? getNormalizedBirthDeath<dataType>(tree1, nodeId1, newMin, newMax)
-          : tree1->getBirthDeath<dataType>(nodeId1);
-    dataType birth1 = std::get<0>(birthDeath1);
-    dataType death1 = std::get<1>(birthDeath1);
-    // Get birth/death of the second tree
-    auto birthDeath2
-      = normalizedWasserstein_
-          ? getNormalizedBirthDeath<dataType>(tree2, nodeId2, newMin, newMax)
-          : tree2->getBirthDeath<dataType>(nodeId2);
-    dataType birth2 = std::get<0>(birthDeath2);
-    dataType death2 = std::get<1>(birthDeath2);
-    // Compute relabel cost
-    cost = computeDistance<dataType>(
-      birth1, death1, birth2, death2, wassersteinPower_);
-    // Divide cost by two if not branch decomposition and not merged
-    /*bool merged = isNodeMerged(tree1, nodeId1) or isNodeMerged(tree2,
-    nodeId2); if(! branchDecomposition_ and ! merged) cost /= 2;*/
-    // Regularize
-    if(normalizedWasserstein_ and normalizedWassersteinReg_ != 0)
-      cost += normalizedWassersteinReg_
-              * regularizationCost2<dataType>(tree1, nodeId1, tree2, nodeId2);
 
-    return cost;
-  }
+    template <class dataType>
+    dataType regularizationCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
+      dataType shiftMin1 = getMinMaxLocal<dataType>(tree, nodeId);
+      dataType shiftMax1 = getMinMaxLocal<dataType>(tree, nodeId, false);
+      return computeDistance<dataType>(
+        shiftMin1, 0, shiftMax1, 0, wassersteinPower_);
+    }
 
-  template <class dataType>
-  dataType relabelCost(ftm::FTMTree_MT *tree1,
-                       ftm::idNode nodeId1,
-                       ftm::FTMTree_MT *tree2,
-                       ftm::idNode nodeId2) {
-    // Full merge case and only one persistence pair case
-    if(tree1->getNode(nodeId1)->getOrigin() == (int)nodeId1
-       or tree2->getNode(nodeId2)->getOrigin() == (int)nodeId2)
-      return 0;
+    template <class dataType>
+    dataType deleteCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
+      dataType cost = 0;
+      dataType newMin = 0.0, newMax = 1.0;
+      if(normalizedWasserstein_ and rescaledWasserstein_) {
+        auto newMinMax = getNewMinMax<dataType>(tree, nodeId, tree, nodeId);
+        newMin = std::get<0>(newMinMax);
+        newMax = std::get<1>(newMinMax);
+      }
+      // Get birth/death
+      auto birthDeath
+        = normalizedWasserstein_
+            ? getNormalizedBirthDeath<dataType>(tree, nodeId, newMin, newMax)
+            : tree->getBirthDeath<dataType>(nodeId);
+      dataType birth = std::get<0>(birthDeath);
+      dataType death = std::get<1>(birthDeath);
+      dataType projec = (birth + death) / 2;
+      // Compute delete cost
+      cost = computeDistance<dataType>(
+        birth, death, projec, projec, wassersteinPower_);
+      // Divide cost by two if not branch decomposition and not merged
+      /*if(! branchDecomposition_ and ! tree->isNodeMerged(nodeId))
+        cost /= 2;*/
+      // Regularize
+      if(normalizedWasserstein_ and normalizedWassersteinReg_ != 0)
+        cost += normalizedWassersteinReg_
+                * regularizationCost<dataType>(tree, nodeId);
 
-    // Compute relabel cost
-    dataType cost = relabelCostOnly<dataType>(tree1, nodeId1, tree2, nodeId2);
-    // Compute deleteInsert cost
-    dataType deleteInsertCost = deleteCost<dataType>(tree1, nodeId1)
-                                + insertCost<dataType>(tree2, nodeId2);
+      return cost;
+    }
 
-    if(keepSubtree_ and deleteInsertCost < cost)
-      cost = deleteInsertCost;
+    template <class dataType>
+    dataType insertCost(ftm::FTMTree_MT *tree, ftm::idNode nodeId) {
+      return deleteCost<dataType>(tree, nodeId);
+    }
 
-    return cost;
-  }
+    template <class dataType>
+    dataType regularizationCost2(ftm::FTMTree_MT *tree1,
+                                 ftm::idNode nodeId1,
+                                 ftm::FTMTree_MT *tree2,
+                                 ftm::idNode nodeId2) {
+      dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
+      dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
+      dataType shiftMin2 = getMinMaxLocal<dataType>(tree2, nodeId2);
+      dataType shiftMax2 = getMinMaxLocal<dataType>(tree2, nodeId2, false);
+      return computeDistance<dataType>(
+        shiftMin1, shiftMax1, shiftMin2, shiftMax2, wassersteinPower_);
+    }
 
-  // --------------------------------------------------------------------------------
-  // Edit Distance Dynamic Programming Equations
-  // --------------------------------------------------------------------------------
-  template <class dataType>
-  void computeEquation8(ftm::FTMTree_MT *tree1,
-                        ftm::idNode nodeI,
-                        int i,
-                        std::vector<std::vector<dataType>> &treeTable,
-                        std::vector<std::vector<dataType>> &forestTable) {
-    std::vector<ftm::idNode> children;
-    tree1->getChildren(nodeI, children);
-    forestTable[i][0] = 0;
-    for(ftm::idNode child : children)
-      forestTable[i][0] += treeTable[child + 1][0];
-  }
+    template <class dataType>
+    dataType relabelCostOnly(ftm::FTMTree_MT *tree1,
+                             ftm::idNode nodeId1,
+                             ftm::FTMTree_MT *tree2,
+                             ftm::idNode nodeId2) {
+      dataType cost = 0;
+      dataType newMin = 0.0, newMax = 1.0;
+      if(normalizedWasserstein_ and rescaledWasserstein_) {
+        auto newMinMax = getNewMinMax<dataType>(tree1, nodeId1, tree2, nodeId2);
+        newMin = std::get<0>(newMinMax);
+        newMax = std::get<1>(newMinMax);
+      }
+      // Get birth/death of the first tree
+      auto birthDeath1
+        = normalizedWasserstein_
+            ? getNormalizedBirthDeath<dataType>(tree1, nodeId1, newMin, newMax)
+            : tree1->getBirthDeath<dataType>(nodeId1);
+      dataType birth1 = std::get<0>(birthDeath1);
+      dataType death1 = std::get<1>(birthDeath1);
+      // Get birth/death of the second tree
+      auto birthDeath2
+        = normalizedWasserstein_
+            ? getNormalizedBirthDeath<dataType>(tree2, nodeId2, newMin, newMax)
+            : tree2->getBirthDeath<dataType>(nodeId2);
+      dataType birth2 = std::get<0>(birthDeath2);
+      dataType death2 = std::get<1>(birthDeath2);
+      // Compute relabel cost
+      cost = computeDistance<dataType>(
+        birth1, death1, birth2, death2, wassersteinPower_);
+      // Divide cost by two if not branch decomposition and not merged
+      /*bool merged = isNodeMerged(tree1, nodeId1) or isNodeMerged(tree2,
+      nodeId2); if(! branchDecomposition_ and ! merged) cost /= 2;*/
+      // Regularize
+      if(normalizedWasserstein_ and normalizedWassersteinReg_ != 0)
+        cost += normalizedWassersteinReg_
+                * regularizationCost2<dataType>(tree1, nodeId1, tree2, nodeId2);
 
-  template <class dataType>
-  void computeEquation9(ftm::FTMTree_MT *tree1,
-                        ftm::idNode nodeI,
-                        int i,
-                        std::vector<std::vector<dataType>> &treeTable,
-                        std::vector<std::vector<dataType>> &forestTable) {
-    treeTable[i][0] = forestTable[i][0] + deleteCost<dataType>(tree1, nodeI);
-  }
+      return cost;
+    }
 
-  template <class dataType>
-  void computeEquation10(ftm::FTMTree_MT *tree2,
-                         ftm::idNode nodeJ,
-                         int j,
-                         std::vector<std::vector<dataType>> &treeTable,
-                         std::vector<std::vector<dataType>> &forestTable) {
-    std::vector<ftm::idNode> children;
-    tree2->getChildren(nodeJ, children);
-    forestTable[0][j] = 0;
-    for(ftm::idNode child : children)
-      forestTable[0][j] += treeTable[0][child + 1];
-  }
+    template <class dataType>
+    dataType relabelCost(ftm::FTMTree_MT *tree1,
+                         ftm::idNode nodeId1,
+                         ftm::FTMTree_MT *tree2,
+                         ftm::idNode nodeId2) {
+      // Full merge case and only one persistence pair case
+      if(tree1->getNode(nodeId1)->getOrigin() == (int)nodeId1
+         or tree2->getNode(nodeId2)->getOrigin() == (int)nodeId2)
+        return 0;
 
-  template <class dataType>
-  void computeEquation11(ftm::FTMTree_MT *tree2,
-                         ftm::idNode nodeJ,
-                         int j,
-                         std::vector<std::vector<dataType>> &treeTable,
-                         std::vector<std::vector<dataType>> &forestTable) {
-    treeTable[0][j] = forestTable[0][j] + insertCost<dataType>(tree2, nodeJ);
-  }
+      // Compute relabel cost
+      dataType cost = relabelCostOnly<dataType>(tree1, nodeId1, tree2, nodeId2);
+      // Compute deleteInsert cost
+      dataType deleteInsertCost = deleteCost<dataType>(tree1, nodeId1)
+                                  + insertCost<dataType>(tree2, nodeId2);
 
-  // Compute first or second term of equation 12 or 13
-  template <class dataType>
-  std::tuple<dataType, ftm::idNode>
-    computeTerm1_2(std::vector<ftm::idNode> &childrens,
-                   int ind,
-                   std::vector<std::vector<dataType>> &table,
-                   bool computeTerm1) {
-    dataType tempMin = (childrens.size() == 0)
-                         ? ((computeTerm1) ? table[ind][0] : table[0][ind])
-                         : std::numeric_limits<dataType>::max();
-    ftm::idNode bestIdNode = 0;
-    for(ftm::idNode children : childrens) {
-      children += 1;
-      dataType temp;
-      if(computeTerm1) {
-        temp = table[ind][children] - table[0][children];
+      if(keepSubtree_ and deleteInsertCost < cost)
+        cost = deleteInsertCost;
+
+      return cost;
+    }
+
+    // --------------------------------------------------------------------------------
+    // Edit Distance Dynamic Programming Equations
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    void computeEquation8(ftm::FTMTree_MT *tree1,
+                          ftm::idNode nodeI,
+                          int i,
+                          std::vector<std::vector<dataType>> &treeTable,
+                          std::vector<std::vector<dataType>> &forestTable) {
+      std::vector<ftm::idNode> children;
+      tree1->getChildren(nodeI, children);
+      forestTable[i][0] = 0;
+      for(ftm::idNode child : children)
+        forestTable[i][0] += treeTable[child + 1][0];
+    }
+
+    template <class dataType>
+    void computeEquation9(ftm::FTMTree_MT *tree1,
+                          ftm::idNode nodeI,
+                          int i,
+                          std::vector<std::vector<dataType>> &treeTable,
+                          std::vector<std::vector<dataType>> &forestTable) {
+      treeTable[i][0] = forestTable[i][0] + deleteCost<dataType>(tree1, nodeI);
+    }
+
+    template <class dataType>
+    void computeEquation10(ftm::FTMTree_MT *tree2,
+                           ftm::idNode nodeJ,
+                           int j,
+                           std::vector<std::vector<dataType>> &treeTable,
+                           std::vector<std::vector<dataType>> &forestTable) {
+      std::vector<ftm::idNode> children;
+      tree2->getChildren(nodeJ, children);
+      forestTable[0][j] = 0;
+      for(ftm::idNode child : children)
+        forestTable[0][j] += treeTable[0][child + 1];
+    }
+
+    template <class dataType>
+    void computeEquation11(ftm::FTMTree_MT *tree2,
+                           ftm::idNode nodeJ,
+                           int j,
+                           std::vector<std::vector<dataType>> &treeTable,
+                           std::vector<std::vector<dataType>> &forestTable) {
+      treeTable[0][j] = forestTable[0][j] + insertCost<dataType>(tree2, nodeJ);
+    }
+
+    // Compute first or second term of equation 12 or 13
+    template <class dataType>
+    std::tuple<dataType, ftm::idNode>
+      computeTerm1_2(std::vector<ftm::idNode> &childrens,
+                     int ind,
+                     std::vector<std::vector<dataType>> &table,
+                     bool computeTerm1) {
+      dataType tempMin = (childrens.size() == 0)
+                           ? ((computeTerm1) ? table[ind][0] : table[0][ind])
+                           : std::numeric_limits<dataType>::max();
+      ftm::idNode bestIdNode = 0;
+      for(ftm::idNode children : childrens) {
+        children += 1;
+        dataType temp;
+        if(computeTerm1) {
+          temp = table[ind][children] - table[0][children];
+        } else {
+          temp = table[children][ind] - table[children][0];
+        }
+        if(temp < tempMin) {
+          tempMin = temp;
+          bestIdNode = children;
+        }
+      }
+      return std::make_tuple(tempMin, bestIdNode);
+    }
+
+    template <class dataType>
+    void computeEquation12(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      int i,
+      int j,
+      ftm::idNode nodeI,
+      ftm::idNode nodeJ,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable,
+      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
+      std::vector<ftm::idNode> &children1,
+      std::vector<ftm::idNode> &children2) {
+      dataType treeTerm1, treeTerm2, treeTerm3;
+      std::tuple<dataType, ftm::idNode> treeCoTerm1, treeCoTerm2;
+      // Term 1
+      treeCoTerm1 = computeTerm1_2<dataType>(children2, i, treeTable, true);
+      treeTerm1 = treeTable[0][j] + std::get<0>(treeCoTerm1);
+
+      // Term 2
+      treeCoTerm2 = computeTerm1_2<dataType>(children1, j, treeTable, false);
+      treeTerm2 = treeTable[i][0] + std::get<0>(treeCoTerm2);
+
+      // Term 3
+      treeTerm3
+        = forestTable[i][j] + relabelCost<dataType>(tree1, nodeI, tree2, nodeJ);
+
+      // Compute table value
+      treeTable[i][j] = keepSubtree_
+                          ? std::min(std::min(treeTerm1, treeTerm2), treeTerm3)
+                          : treeTerm3;
+
+      // Add backtracking information
+      if(treeTable[i][j] == treeTerm3) {
+        treeBackTable[i][j] = std::make_tuple(i, j);
+      } else if(treeTable[i][j] == treeTerm2) {
+        treeBackTable[i][j] = std::make_tuple(std::get<1>(treeCoTerm2), j);
       } else {
-        temp = table[children][ind] - table[children][0];
-      }
-      if(temp < tempMin) {
-        tempMin = temp;
-        bestIdNode = children;
+        treeBackTable[i][j] = std::make_tuple(i, std::get<1>(treeCoTerm1));
       }
     }
-    return std::make_tuple(tempMin, bestIdNode);
-  }
 
-  template <class dataType>
-  void computeEquation12(
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    int i,
-    int j,
-    ftm::idNode nodeI,
-    ftm::idNode nodeJ,
-    std::vector<std::vector<dataType>> &treeTable,
-    std::vector<std::vector<dataType>> &forestTable,
-    std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
-    std::vector<ftm::idNode> &children1,
-    std::vector<ftm::idNode> &children2) {
-    dataType treeTerm1, treeTerm2, treeTerm3;
-    std::tuple<dataType, ftm::idNode> treeCoTerm1, treeCoTerm2;
-    // Term 1
-    treeCoTerm1 = computeTerm1_2<dataType>(children2, i, treeTable, true);
-    treeTerm1 = treeTable[0][j] + std::get<0>(treeCoTerm1);
-
-    // Term 2
-    treeCoTerm2 = computeTerm1_2<dataType>(children1, j, treeTable, false);
-    treeTerm2 = treeTable[i][0] + std::get<0>(treeCoTerm2);
-
-    // Term 3
-    treeTerm3
-      = forestTable[i][j] + relabelCost<dataType>(tree1, nodeI, tree2, nodeJ);
-
-    // Compute table value
-    treeTable[i][j] = keepSubtree_
-                        ? std::min(std::min(treeTerm1, treeTerm2), treeTerm3)
-                        : treeTerm3;
-
-    // Add backtracking information
-    if(treeTable[i][j] == treeTerm3) {
-      treeBackTable[i][j] = std::make_tuple(i, j);
-    } else if(treeTable[i][j] == treeTerm2) {
-      treeBackTable[i][j] = std::make_tuple(std::get<1>(treeCoTerm2), j);
-    } else {
-      treeBackTable[i][j] = std::make_tuple(i, std::get<1>(treeCoTerm1));
-    }
-  }
-
-  // --------------------------------------------------------------------------------
-  // Assignment Problem Functions
-  // --------------------------------------------------------------------------------
-  template <class dataType>
-  dataType
-    postprocessAssignment(std::vector<asgnMatchingTuple> &matchings,
-                          std::vector<ftm::idNode> &children1,
-                          std::vector<ftm::idNode> &children2,
-                          std::vector<std::tuple<int, int>> &forestAssignment) {
-    dataType cost = 0;
-    for(asgnMatchingTuple mTuple : matchings) {
-      cost += std::get<2>(mTuple);
-      if(std::get<0>(mTuple) >= (int)children1.size()
-         || std::get<1>(mTuple) >= (int)children2.size())
-        continue;
-      int tableId1 = children1[std::get<0>(mTuple)] + 1;
-      int tableId2 = children2[std::get<1>(mTuple)] + 1;
-      forestAssignment.push_back(std::make_tuple(tableId1, tableId2));
-    }
-    return cost;
-  }
-
-  // --------------------------------------------------------------------------------
-  // Utils
-  // --------------------------------------------------------------------------------
-  void printTreesStats(std::vector<ftm::FTMTree_MT *> &trees) {
-    int avgNodes = 0, avgNodesT = 0;
-    double avgDepth = 0;
-    for(unsigned int i = 0; i < trees.size(); ++i) {
-      auto noNodesT = trees[i]->getNumberOfNodes();
-      auto noNodes = trees[i]->getRealNumberOfNodes();
-      avgNodes += noNodes;
-      avgNodesT += noNodesT;
-      avgDepth += trees[i]->getTreeDepth();
-    }
-    avgNodes /= trees.size();
-    avgNodesT /= trees.size();
-    avgDepth /= trees.size();
-    std::stringstream ss;
-    ss << trees.size() << " trees average [node: " << avgNodes << " / "
-       << avgNodesT << ", depth: " << avgDepth << "]";
-    printMsg(ss.str());
-  }
-
-  template <class dataType>
-  void printTreesStats(std::vector<MergeTree<dataType>> &trees) {
-    std::vector<ftm::FTMTree_MT *> treesT;
-    mergeTreeToFTMTree<dataType>(trees, treesT);
-    printTreesStats(treesT);
-  }
-
-  template <class dataType>
-  void printTableVector(std::vector<std::vector<dataType>> &table) {
-    std::streamsize ssize = std::cout.precision();
-    std::stringstream ss;
-    ss << "      ";
-    for(unsigned int j = 0; j < table[0].size(); ++j)
-      ss << j - 1 << "    ";
-    printMsg(ss.str());
-    ss.str("");
-    ss.clear();
-    for(unsigned int i = 0; i < table.size(); ++i) {
-      ss << std::setw(3) << std::setfill('0') << std::internal << i - 1
-         << " | ";
-      for(unsigned int j = 0; j < table[0].size(); ++j) {
-        ss << std::fixed << std::setprecision(2) << table[i][j] << " ";
+    // --------------------------------------------------------------------------------
+    // Assignment Problem Functions
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    dataType postprocessAssignment(
+      std::vector<asgnMatchingTuple> &matchings,
+      std::vector<ftm::idNode> &children1,
+      std::vector<ftm::idNode> &children2,
+      std::vector<std::tuple<int, int>> &forestAssignment) {
+      dataType cost = 0;
+      for(asgnMatchingTuple mTuple : matchings) {
+        cost += std::get<2>(mTuple);
+        if(std::get<0>(mTuple) >= (int)children1.size()
+           || std::get<1>(mTuple) >= (int)children2.size())
+          continue;
+        int tableId1 = children1[std::get<0>(mTuple)] + 1;
+        int tableId2 = children2[std::get<1>(mTuple)] + 1;
+        forestAssignment.push_back(std::make_tuple(tableId1, tableId2));
       }
-      printMsg(ss.str());
-      printMsg("");
+      return cost;
     }
-    std::cout.precision(ssize);
-    printMsg(debug::Separator::L2);
-  }
 
-  template <class dataType>
-  void printTable(dataType *table, int nRows, int nCols) {
-    std::vector<std::vector<dataType>> vec(nRows, std::vector<dataType>());
-    for(int i = 0; i < nRows; ++i)
-      for(int j = 0; j < nCols; ++j)
-        vec[i].push_back(table[i * nCols + j]);
-    printTableVector<dataType>(vec);
-  }
-
-  void printMatching(std::vector<asgnMatchingTuple> &matchings) {
-    printMsg(debug::Separator::L2);
-    for(asgnMatchingTuple mTuple : matchings) {
+    // --------------------------------------------------------------------------------
+    // Utils
+    // --------------------------------------------------------------------------------
+    void printTreesStats(std::vector<ftm::FTMTree_MT *> &trees) {
+      int avgNodes = 0, avgNodesT = 0;
+      double avgDepth = 0;
+      for(unsigned int i = 0; i < trees.size(); ++i) {
+        auto noNodesT = trees[i]->getNumberOfNodes();
+        auto noNodes = trees[i]->getRealNumberOfNodes();
+        avgNodes += noNodes;
+        avgNodesT += noNodesT;
+        avgDepth += trees[i]->getTreeDepth();
+      }
+      avgNodes /= trees.size();
+      avgNodesT /= trees.size();
+      avgDepth /= trees.size();
       std::stringstream ss;
-      ss << std::get<0>(mTuple) << " - " << std::get<1>(mTuple) << " - "
-         << std::get<2>(mTuple);
+      ss << trees.size() << " trees average [node: " << avgNodes << " / "
+         << avgNodesT << ", depth: " << avgDepth << "]";
       printMsg(ss.str());
     }
-    printMsg(debug::Separator::L2);
-  }
 
-  void printMatching(
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings) {
-    printMsg(debug::Separator::L2);
-    for(auto mTuple : matchings) {
+    template <class dataType>
+    void printTreesStats(std::vector<ftm::MergeTree<dataType>> &trees) {
+      std::vector<ftm::FTMTree_MT *> treesT;
+      ftm::mergeTreeToFTMTree<dataType>(trees, treesT);
+      printTreesStats(treesT);
+    }
+
+    template <class dataType>
+    void printTableVector(std::vector<std::vector<dataType>> &table) {
+      std::streamsize ssize = std::cout.precision();
       std::stringstream ss;
-      ss << std::get<0>(mTuple) << " - " << std::get<1>(mTuple);
+      ss << "      ";
+      for(unsigned int j = 0; j < table[0].size(); ++j)
+        ss << j - 1 << "    ";
       printMsg(ss.str());
+      ss.str("");
+      ss.clear();
+      for(unsigned int i = 0; i < table.size(); ++i) {
+        ss << std::setw(3) << std::setfill('0') << std::internal << i - 1
+           << " | ";
+        for(unsigned int j = 0; j < table[0].size(); ++j) {
+          ss << std::fixed << std::setprecision(2) << table[i][j] << " ";
+        }
+        printMsg(ss.str());
+        printMsg("");
+      }
+      std::cout.precision(ssize);
+      printMsg(debug::Separator::L2);
     }
-    printMsg(debug::Separator::L2);
-  }
 
-  void printMatching(
-    std::vector<std::tuple<ftm::idNode, ftm::idNode>> &matchings) {
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matchingsT(
-      matchings.size());
-    for(size_t i = 0; i < matchings.size(); ++i) {
-      const auto &tup{matchings[i]};
-      matchingsT[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+    template <class dataType>
+    void printTable(dataType *table, int nRows, int nCols) {
+      std::vector<std::vector<dataType>> vec(nRows, std::vector<dataType>());
+      for(int i = 0; i < nRows; ++i)
+        for(int j = 0; j < nCols; ++j)
+          vec[i].push_back(table[i * nCols + j]);
+      printTableVector<dataType>(vec);
     }
-    printMatching(matchingsT);
-  }
 
-  template <class dataType>
-  void printPairs(
-    std::vector<std::tuple<SimplexId, SimplexId, dataType>> &treePairs) {
-    for(auto pair : treePairs) {
+    void printMatching(std::vector<asgnMatchingTuple> &matchings) {
+      printMsg(debug::Separator::L2);
+      for(asgnMatchingTuple mTuple : matchings) {
+        std::stringstream ss;
+        ss << std::get<0>(mTuple) << " - " << std::get<1>(mTuple) << " - "
+           << std::get<2>(mTuple);
+        printMsg(ss.str());
+      }
+      printMsg(debug::Separator::L2);
+    }
+
+    void printMatching(
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings) {
+      printMsg(debug::Separator::L2);
+      for(auto mTuple : matchings) {
+        std::stringstream ss;
+        ss << std::get<0>(mTuple) << " - " << std::get<1>(mTuple);
+        printMsg(ss.str());
+      }
+      printMsg(debug::Separator::L2);
+    }
+
+    void printMatching(
+      std::vector<std::tuple<ftm::idNode, ftm::idNode>> &matchings) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matchingsT(
+        matchings.size());
+      for(size_t i = 0; i < matchings.size(); ++i) {
+        const auto &tup{matchings[i]};
+        matchingsT[i] = {std::get<0>(tup), std::get<1>(tup), 0.0};
+      }
+      printMatching(matchingsT);
+    }
+
+    template <class dataType>
+    void printPairs(
+      std::vector<std::tuple<SimplexId, SimplexId, dataType>> &treePairs) {
+      for(auto pair : treePairs) {
+        std::stringstream ss;
+        ss << std::get<0>(pair) << " _ " << std::get<1>(pair) << " _ "
+           << std::get<2>(pair);
+        printMsg(ss.str());
+      }
+      printMsg(debug::Separator::L2);
+    }
+
+    template <class dataType>
+    void printOutputMatching(
+      std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching,
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      bool computeCosts = true) {
+      dataType cost = 0;
+      std::vector<bool> tree1Done(tree1->getNumberOfNodes(), false);
+      std::vector<bool> tree2Done(tree2->getNumberOfNodes(), false);
       std::stringstream ss;
-      ss << std::get<0>(pair) << " _ " << std::get<1>(pair) << " _ "
-         << std::get<2>(pair);
-      printMsg(ss.str());
-    }
-    printMsg(debug::Separator::L2);
-  }
+      for(std::tuple<ftm::idNode, ftm::idNode> matching : outputMatching) {
+        ftm::idNode node0 = std::get<0>(matching);
+        ftm::idNode node1 = std::get<1>(matching);
+        ftm::idNode node0Origin = tree1->getNode(node0)->getOrigin();
+        ftm::idNode node1Origin = tree2->getNode(node1)->getOrigin();
+        ss << node0 << " - " << node1 << " _ [ ";
+        ss << "f(" << node0 << ")=" << tree1->getValue<dataType>(node0)
+           << " _ ";
+        ss << "g(" << node1 << ")=" << tree2->getValue<dataType>(node1) << " ]"
+           << " _ [ ";
+        ss << "f(" << node0Origin
+           << ")=" << tree1->getValue<dataType>(node0Origin) << " _ ";
+        ss << "g(" << node1Origin
+           << ")=" << tree2->getValue<dataType>(node1Origin) << " ] ";
 
-  template <class dataType>
-  void printOutputMatching(
-    std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching,
-    ftm::FTMTree_MT *tree1,
-    ftm::FTMTree_MT *tree2,
-    bool computeCosts = true) {
-    dataType cost = 0;
-    std::vector<bool> tree1Done(tree1->getNumberOfNodes(), false);
-    std::vector<bool> tree2Done(tree2->getNumberOfNodes(), false);
-    std::stringstream ss;
-    for(std::tuple<ftm::idNode, ftm::idNode> matching : outputMatching) {
-      ftm::idNode node0 = std::get<0>(matching);
-      ftm::idNode node1 = std::get<1>(matching);
-      ftm::idNode node0Origin = tree1->getNode(node0)->getOrigin();
-      ftm::idNode node1Origin = tree2->getNode(node1)->getOrigin();
-      ss << node0 << " - " << node1 << " _ [ ";
-      ss << "f(" << node0 << ")=" << tree1->getValue<dataType>(node0) << " _ ";
-      ss << "g(" << node1 << ")=" << tree2->getValue<dataType>(node1) << " ]"
-         << " _ [ ";
-      ss << "f(" << node0Origin
-         << ")=" << tree1->getValue<dataType>(node0Origin) << " _ ";
-      ss << "g(" << node1Origin
-         << ")=" << tree2->getValue<dataType>(node1Origin) << " ] ";
-
-      if(computeCosts) {
-        dataType tempCost = relabelCost<dataType>(tree1, node0, tree2, node1);
-        dataType tempCost2
-          = relabelCostOnly<dataType>(tree1, node0, tree2, node1);
-        ss << "cost = " << tempCost << " (" << tempCost2 << ")" << std::endl;
-        cost += tempCost;
-      } else
-        ss << std::endl;
-      tree1Done[node0] = true;
-      tree2Done[node1] = true;
-    }
-
-    for(unsigned int i = 0; i < tree1->getNumberOfNodes(); ++i)
-      if(not tree1Done[i] and not tree1->isNodeAlone(i)) {
-        ftm::idNode nodeOrigin = tree1->getNode(i)->getOrigin();
-        ss << "T1 " << i << " _ [ f(" << i
-           << ") = " << tree1->getValue<dataType>(i);
-        ss << "_ f(" << nodeOrigin
-           << ") = " << tree1->getValue<dataType>(nodeOrigin);
-        ss << "]";
         if(computeCosts) {
-          dataType tempCost = deleteCost<dataType>(tree1, i);
-          ss << " _ cost = " << tempCost << std::endl;
+          dataType tempCost = relabelCost<dataType>(tree1, node0, tree2, node1);
+          dataType tempCost2
+            = relabelCostOnly<dataType>(tree1, node0, tree2, node1);
+          ss << "cost = " << tempCost << " (" << tempCost2 << ")" << std::endl;
           cost += tempCost;
         } else
           ss << std::endl;
+        tree1Done[node0] = true;
+        tree2Done[node1] = true;
       }
-    for(unsigned int i = 0; i < tree2->getNumberOfNodes(); ++i)
-      if(not tree2Done[i] and not tree2->isNodeAlone(i)) {
-        ftm::idNode nodeOrigin = tree2->getNode(i)->getOrigin();
-        ss << "T2 " << i << " _ [ g(" << i
-           << ") = " << tree2->getValue<dataType>(i);
-        ss << "_ g(" << nodeOrigin
-           << ") = " << tree2->getValue<dataType>(nodeOrigin);
-        ss << "]";
-        if(computeCosts) {
-          dataType tempCost = deleteCost<dataType>(tree2, i);
-          ss << " _ cost = " << tempCost << std::endl;
-          cost += tempCost;
-        } else
-          ss << std::endl;
-      }
-    if(computeCosts)
-      ss << "total cost = " << cost << " (" << std::sqrt(cost) << ")"
-         << std::endl;
 
-    printMsg(ss.str());
-    printMsg(debug::Separator::L2);
-  }
-}; // MergeTreeBase class
+      for(unsigned int i = 0; i < tree1->getNumberOfNodes(); ++i)
+        if(not tree1Done[i] and not tree1->isNodeAlone(i)) {
+          ftm::idNode nodeOrigin = tree1->getNode(i)->getOrigin();
+          ss << "T1 " << i << " _ [ f(" << i
+             << ") = " << tree1->getValue<dataType>(i);
+          ss << "_ f(" << nodeOrigin
+             << ") = " << tree1->getValue<dataType>(nodeOrigin);
+          ss << "]";
+          if(computeCosts) {
+            dataType tempCost = deleteCost<dataType>(tree1, i);
+            ss << " _ cost = " << tempCost << std::endl;
+            cost += tempCost;
+          } else
+            ss << std::endl;
+        }
+      for(unsigned int i = 0; i < tree2->getNumberOfNodes(); ++i)
+        if(not tree2Done[i] and not tree2->isNodeAlone(i)) {
+          ftm::idNode nodeOrigin = tree2->getNode(i)->getOrigin();
+          ss << "T2 " << i << " _ [ g(" << i
+             << ") = " << tree2->getValue<dataType>(i);
+          ss << "_ g(" << nodeOrigin
+             << ") = " << tree2->getValue<dataType>(nodeOrigin);
+          ss << "]";
+          if(computeCosts) {
+            dataType tempCost = deleteCost<dataType>(tree2, i);
+            ss << " _ cost = " << tempCost << std::endl;
+            cost += tempCost;
+          } else
+            ss << std::endl;
+        }
+      if(computeCosts)
+        ss << "total cost = " << cost << " (" << std::sqrt(cost) << ")"
+           << std::endl;
 
-#endif
+      printMsg(ss.str());
+      printMsg(debug::Separator::L2);
+    }
+  }; // MergeTreeBase class
+
+} // namespace ttk

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -14,9 +14,6 @@
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
 
-#ifndef _MERGETREECLUSTERING_H
-#define _MERGETREECLUSTERING_H
-
 #define treesMatchingVector \
   std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
 #define matchingVector std::vector<treesMatchingVector>
@@ -58,7 +55,7 @@ namespace ttk {
     std::vector<int> bestCentroid_, oldBestCentroid_;
     std::vector<double> bestDistance_;
     std::vector<bool> recompute_;
-    std::vector<MergeTree<dataType2>> oldCentroids_, oldCentroids2_;
+    std::vector<ftm::MergeTree<dataType2>> oldCentroids_, oldCentroids2_;
 
     // Clean correspondence
     std::vector<std::vector<int>> trees2NodeCorr_;
@@ -98,21 +95,22 @@ namespace ttk {
     void initCentroids(
       std::vector<ftm::FTMTree_MT *> &trees,
       std::vector<ftm::FTMTree_MT *> &trees2,
-      std::vector<std::vector<MergeTree<dataType>>> &allCentroids) {
-      allCentroids = std::vector<std::vector<MergeTree<dataType>>>(
-        2, std::vector<MergeTree<dataType>>(noCentroids_));
+      std::vector<std::vector<ftm::MergeTree<dataType>>> &allCentroids) {
+      allCentroids = std::vector<std::vector<ftm::MergeTree<dataType>>>(
+        2, std::vector<ftm::MergeTree<dataType>>(noCentroids_));
       std::vector<dataType> distances(
         trees.size(), std::numeric_limits<dataType>::max());
       for(unsigned int i = 0; i < noCentroids_; ++i) {
         int bestIndex = -1;
         if(i == 0) {
           bestIndex = getBestInitTreeIndex<dataType>(trees, trees2, false);
-          allCentroids[0][i] = copyMergeTree<dataType>(trees[bestIndex], true);
-          cleanMergeTree<dataType>(allCentroids[0][i]);
+          allCentroids[0][i]
+            = ftm::copyMergeTree<dataType>(trees[bestIndex], true);
+          ftm::cleanMergeTree<dataType>(allCentroids[0][i]);
           if(trees2.size() != 0) {
             allCentroids[1][i]
-              = copyMergeTree<dataType>(trees2[bestIndex], true);
-            cleanMergeTree<dataType>(allCentroids[1][i]);
+              = ftm::copyMergeTree<dataType>(trees2[bestIndex], true);
+            ftm::cleanMergeTree<dataType>(allCentroids[1][i]);
           }
         } else {
           // Create vector of probabilities
@@ -136,12 +134,13 @@ namespace ttk {
             bestIndex = distribution(generator);
           }
           // Create new centroid
-          allCentroids[0][i] = copyMergeTree<dataType>(trees[bestIndex], true);
-          cleanMergeTree<dataType>(allCentroids[0][i]);
+          allCentroids[0][i]
+            = ftm::copyMergeTree<dataType>(trees[bestIndex], true);
+          ftm::cleanMergeTree<dataType>(allCentroids[0][i]);
           if(trees2.size() != 0) {
             allCentroids[1][i]
-              = copyMergeTree<dataType>(trees2[bestIndex], true);
-            cleanMergeTree<dataType>(allCentroids[1][i]);
+              = ftm::copyMergeTree<dataType>(trees2[bestIndex], true);
+            ftm::cleanMergeTree<dataType>(allCentroids[1][i]);
           }
         }
 
@@ -169,7 +168,7 @@ namespace ttk {
 
     template <class dataType>
     void initNewCentroid(std::vector<ftm::FTMTree_MT *> &trees,
-                         MergeTree<dataType> &centroid) {
+                         ftm::MergeTree<dataType> &centroid) {
       int bestIndex = -1;
       dataType bestValue = std::numeric_limits<dataType>::lowest();
       for(unsigned int i = 0; i < bestDistance_.size(); ++i) {
@@ -178,18 +177,18 @@ namespace ttk {
           bestIndex = bestCentroid_[i];
         }
       }
-      centroid = copyMergeTree<dataType>(trees[bestIndex], true);
-      cleanMergeTree<dataType>(centroid);
+      centroid = ftm::copyMergeTree<dataType>(trees[bestIndex], true);
+      ftm::cleanMergeTree<dataType>(centroid);
     }
 
     template <class dataType>
-    void
-      assignmentCentroidsNaive(std::vector<ftm::FTMTree_MT *> &trees,
-                               std::vector<MergeTree<dataType>> &centroids,
-                               std::vector<std::tuple<int, int>> &assignmentC,
-                               std::vector<dataType> &bestDistanceT,
-                               std::vector<ftm::FTMTree_MT *> &trees2,
-                               std::vector<MergeTree<dataType>> &centroids2) {
+    void assignmentCentroidsNaive(
+      std::vector<ftm::FTMTree_MT *> &trees,
+      std::vector<ftm::MergeTree<dataType>> &centroids,
+      std::vector<std::tuple<int, int>> &assignmentC,
+      std::vector<dataType> &bestDistanceT,
+      std::vector<ftm::FTMTree_MT *> &trees2,
+      std::vector<ftm::MergeTree<dataType>> &centroids2) {
       std::vector<int> bestCentroidT(trees.size(), -1);
 
 #ifdef TTK_ENABLE_OPENMP
@@ -223,7 +222,7 @@ namespace ttk {
 
     template <class dataType>
     void getCentroidsDistanceMatrix(
-      std::vector<MergeTree<dataType>> &centroids,
+      std::vector<ftm::MergeTree<dataType>> &centroids,
       std::vector<std::vector<double>> &distanceMatrix) {
       std::vector<ftm::FTMTree_MT *> trees(centroids.size());
       for(size_t i = 0; i < centroids.size(); ++i) {
@@ -243,7 +242,7 @@ namespace ttk {
     template <class dataType>
     void initAcceleratedKMeansVectors(
       std::vector<ftm::FTMTree_MT *> &trees,
-      std::vector<MergeTree<dataType>> &centroids,
+      std::vector<ftm::MergeTree<dataType>> &centroids,
       std::vector<ftm::FTMTree_MT *> &ttkNotUsed(trees2)) {
       lowerBound_ = std::vector<std::vector<double>>(
         trees.size(), std::vector<double>(centroids.size(), 0));
@@ -257,10 +256,11 @@ namespace ttk {
     }
 
     template <class dataType>
-    void initAcceleratedKMeans(std::vector<ftm::FTMTree_MT *> &trees,
-                               std::vector<MergeTree<dataType>> &centroids,
-                               std::vector<ftm::FTMTree_MT *> &trees2,
-                               std::vector<MergeTree<dataType>> &centroids2) {
+    void
+      initAcceleratedKMeans(std::vector<ftm::FTMTree_MT *> &trees,
+                            std::vector<ftm::MergeTree<dataType>> &centroids,
+                            std::vector<ftm::FTMTree_MT *> &trees2,
+                            std::vector<ftm::MergeTree<dataType>> &centroids2) {
       acceleratedInitialized_ = true;
       std::vector<std::tuple<int, int>> assignmentC;
       std::vector<dataType> bestDistanceT(
@@ -276,21 +276,21 @@ namespace ttk {
     }
 
     template <class dataType>
-    void copyCentroids(std::vector<MergeTree<dataType>> &centroids,
-                       std::vector<MergeTree<dataType>> &oldCentroids) {
+    void copyCentroids(std::vector<ftm::MergeTree<dataType>> &centroids,
+                       std::vector<ftm::MergeTree<dataType>> &oldCentroids) {
       oldCentroids.clear();
       for(unsigned int i = 0; i < centroids.size(); ++i)
-        oldCentroids.push_back(copyMergeTree<dataType>(centroids[i]));
+        oldCentroids.push_back(ftm::copyMergeTree<dataType>(centroids[i]));
     }
 
     template <class dataType>
     void assignmentCentroidsAccelerated(
       std::vector<ftm::FTMTree_MT *> &trees,
-      std::vector<MergeTree<dataType>> &centroids,
+      std::vector<ftm::MergeTree<dataType>> &centroids,
       std::vector<std::tuple<int, int>> &assignmentC,
       std::vector<dataType> &bestDistanceT,
       std::vector<ftm::FTMTree_MT *> &trees2,
-      std::vector<MergeTree<dataType>> &centroids2) {
+      std::vector<ftm::MergeTree<dataType>> &centroids2) {
       if(not acceleratedInitialized_) {
         initAcceleratedKMeans<dataType>(trees, centroids, trees2, centroids2);
       } else {
@@ -418,12 +418,13 @@ namespace ttk {
     }
 
     template <class dataType>
-    void assignmentCentroids(std::vector<ftm::FTMTree_MT *> &trees,
-                             std::vector<MergeTree<dataType>> &centroids,
-                             std::vector<std::tuple<int, int>> &assignmentC,
-                             std::vector<dataType> &bestDistanceT,
-                             std::vector<ftm::FTMTree_MT *> &trees2,
-                             std::vector<MergeTree<dataType>> &centroids2) {
+    void
+      assignmentCentroids(std::vector<ftm::FTMTree_MT *> &trees,
+                          std::vector<ftm::MergeTree<dataType>> &centroids,
+                          std::vector<std::tuple<int, int>> &assignmentC,
+                          std::vector<dataType> &bestDistanceT,
+                          std::vector<ftm::FTMTree_MT *> &trees2,
+                          std::vector<ftm::MergeTree<dataType>> &centroids2) {
       oldBestCentroid_ = bestCentroid_;
       if(normalizedWasserstein_ and rescaledWasserstein_)
         assignmentCentroidsNaive<dataType>(
@@ -434,15 +435,15 @@ namespace ttk {
     }
 
     template <class dataType>
-    void
-      finalAssignmentCentroids(std::vector<ftm::FTMTree_MT *> &trees,
-                               std::vector<MergeTree<dataType>> &centroids,
-                               matchingVector &matchingsC,
-                               std::vector<std::tuple<int, int>> &assignmentC,
-                               std::vector<dataType> &bestDistanceT,
-                               std::vector<ftm::FTMTree_MT *> &trees2,
-                               std::vector<MergeTree<dataType>> &centroids2,
-                               matchingVector &matchingsC2) {
+    void finalAssignmentCentroids(
+      std::vector<ftm::FTMTree_MT *> &trees,
+      std::vector<ftm::MergeTree<dataType>> &centroids,
+      matchingVector &matchingsC,
+      std::vector<std::tuple<int, int>> &assignmentC,
+      std::vector<dataType> &bestDistanceT,
+      std::vector<ftm::FTMTree_MT *> &trees2,
+      std::vector<ftm::MergeTree<dataType>> &centroids2,
+      matchingVector &matchingsC2) {
       int noC = centroids.size();
       std::vector<std::vector<ftm::FTMTree_MT *>> assignedTrees(noC),
         assignedTrees2(noC);
@@ -503,7 +504,7 @@ namespace ttk {
 
     template <class dataType>
     bool updateCentroids(std::vector<ftm::FTMTree_MT *> &trees,
-                         std::vector<MergeTree<dataType>> &centroids,
+                         std::vector<ftm::MergeTree<dataType>> &centroids,
                          std::vector<double> &alphas,
                          std::vector<std::tuple<int, int>> &assignmentC) {
       bool oneCentroidUpdated = false;
@@ -536,8 +537,8 @@ namespace ttk {
                   lowerBound_[t][i] = 0;
               } else if(assignedTrees[i].size() == 1) {
                 centroids[i]
-                  = copyMergeTree<dataType>(assignedTrees[i][0], true);
-                cleanMergeTree<dataType>(centroids[i]);
+                  = ftm::copyMergeTree<dataType>(assignedTrees[i][0], true);
+                ftm::cleanMergeTree<dataType>(centroids[i]);
               } else if(not samePreviousAssignment(
                           i)) { // Do not update if same previous assignment
                 oneCentroidUpdated = true;
@@ -553,7 +554,7 @@ namespace ttk {
                 std::vector<ftm::idNode> deletedNodesT;
                 persistenceThresholding<dataType>(
                   &(centroids[i].tree), 0, deletedNodesT);
-                cleanMergeTree<dataType>(centroids[i]);
+                ftm::cleanMergeTree<dataType>(centroids[i]);
               }
 #ifdef TTK_ENABLE_OPENMP
             } // pragma omp task
@@ -570,7 +571,7 @@ namespace ttk {
     template <class dataType>
     void computeOneBarycenter(
       std::vector<ftm::FTMTree_MT *> &trees,
-      MergeTree<dataType> &baryMergeTree,
+      ftm::MergeTree<dataType> &baryMergeTree,
       std::vector<double> &alphas,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &finalMatchings) {
@@ -602,12 +603,12 @@ namespace ttk {
     // ----------------------------------------
     template <class dataType>
     void computeCentroids(std::vector<ftm::FTMTree_MT *> &trees,
-                          std::vector<MergeTree<dataType>> &centroids,
+                          std::vector<ftm::MergeTree<dataType>> &centroids,
                           matchingVector &outputMatching,
                           std::vector<double> &alphas,
                           std::vector<int> &clusteringAssignment,
                           std::vector<ftm::FTMTree_MT *> &trees2,
-                          std::vector<MergeTree<dataType>> &centroids2,
+                          std::vector<ftm::MergeTree<dataType>> &centroids2,
                           matchingVector &outputMatching2) {
       Timer t_clust;
 
@@ -712,13 +713,13 @@ namespace ttk {
     }
 
     template <class dataType>
-    void execute(std::vector<MergeTree<dataType>> &trees,
+    void execute(std::vector<ftm::MergeTree<dataType>> &trees,
                  matchingVector &outputMatching,
                  std::vector<double> &alphas,
                  std::vector<int> &clusteringAssignment,
-                 std::vector<MergeTree<dataType>> &trees2,
+                 std::vector<ftm::MergeTree<dataType>> &trees2,
                  matchingVector &outputMatching2,
-                 std::vector<MergeTree<dataType>> &centroids) {
+                 std::vector<ftm::MergeTree<dataType>> &centroids) {
       // --- Preprocessing
       // std::vector<ftm::FTMTree_MT*> oldTrees, oldTrees2;
       treesNodeCorr_ = std::vector<std::vector<int>>(trees.size());
@@ -728,15 +729,15 @@ namespace ttk {
         preprocessingClustering<dataType>(trees2, trees2NodeCorr_, false);
       }
       std::vector<ftm::FTMTree_MT *> treesT;
-      mergeTreeToFTMTree<dataType>(trees, treesT);
+      ftm::mergeTreeToFTMTree<dataType>(trees, treesT);
       std::vector<ftm::FTMTree_MT *> treesT2;
-      mergeTreeToFTMTree<dataType>(trees2, treesT2);
+      ftm::mergeTreeToFTMTree<dataType>(trees2, treesT2);
 
       // --- Init centroids
-      std::vector<std::vector<MergeTree<dataType>>> allCentroids;
+      std::vector<std::vector<ftm::MergeTree<dataType>>> allCentroids;
       initCentroids<dataType>(treesT, treesT2, allCentroids);
       centroids = allCentroids[0];
-      std::vector<MergeTree<dataType>> centroids2;
+      std::vector<ftm::MergeTree<dataType>> centroids2;
       if(trees2.size() != 0)
         centroids2 = allCentroids[1];
       /*for(unsigned int i = 0; i < centroids.size(); ++i){
@@ -768,12 +769,12 @@ namespace ttk {
     }
 
     template <class dataType>
-    void execute(std::vector<MergeTree<dataType>> &trees,
+    void execute(std::vector<ftm::MergeTree<dataType>> &trees,
                  matchingVector &outputMatching,
                  std::vector<int> &clusteringAssignment,
-                 std::vector<MergeTree<dataType>> &trees2,
+                 std::vector<ftm::MergeTree<dataType>> &trees2,
                  matchingVector &outputMatching2,
-                 std::vector<MergeTree<dataType>> &centroids) {
+                 std::vector<ftm::MergeTree<dataType>> &centroids) {
       if(trees2.size() != 0)
         printMsg("Use join and split trees");
 
@@ -786,12 +787,12 @@ namespace ttk {
     }
 
     template <class dataType>
-    void execute(std::vector<MergeTree<dataType>> &trees,
+    void execute(std::vector<ftm::MergeTree<dataType>> &trees,
                  matchingVector &outputMatching,
                  std::vector<int> &clusteringAssignment,
-                 std::vector<MergeTree<dataType>> &centroids) {
-      std::vector<MergeTree<dataType>> trees2
-        = std::vector<MergeTree<dataType>>();
+                 std::vector<ftm::MergeTree<dataType>> &centroids) {
+      std::vector<ftm::MergeTree<dataType>> trees2
+        = std::vector<ftm::MergeTree<dataType>>();
       matchingVector outputMatching2 = matchingVector();
       execute<dataType>(trees, outputMatching, clusteringAssignment, trees2,
                         outputMatching2, centroids);
@@ -801,7 +802,7 @@ namespace ttk {
     // Preprocessing
     // ----------------------------------------
     template <class dataType>
-    void preprocessingClustering(std::vector<MergeTree<dataType>> &trees,
+    void preprocessingClustering(std::vector<ftm::MergeTree<dataType>> &trees,
                                  std::vector<std::vector<int>> &nodeCorr,
                                  bool useMinMaxPairT = true) {
       for(unsigned int i = 0; i < trees.size(); ++i) {
@@ -819,22 +820,22 @@ namespace ttk {
     // ----------------------------------------
     template <class dataType>
     void fixMergedRootOriginClustering(
-      std::vector<MergeTree<dataType>> &centroids) {
+      std::vector<ftm::MergeTree<dataType>> &centroids) {
       for(unsigned int i = 0; i < centroids.size(); ++i)
         fixMergedRootOriginBarycenter<dataType>(centroids[i]);
     }
 
     template <class dataType>
     void updateNodesAndScalars(
-      MergeTree<dataType> &mTree1,
+      ftm::MergeTree<dataType> &mTree1,
       std::vector<dataType> &newScalarsVector,
       std::vector<std::tuple<ftm::idNode, bool>> &origins) {
       ftm::FTMTree_MT *tree1 = &(mTree1.tree);
 
       // Create new tree
-      MergeTree<dataType> mTreeNew
-        = createEmptyMergeTree<dataType>(newScalarsVector.size());
-      setTreeScalars<dataType>(mTreeNew, newScalarsVector);
+      ftm::MergeTree<dataType> mTreeNew
+        = ftm::createEmptyMergeTree<dataType>(newScalarsVector.size());
+      ftm::setTreeScalars<dataType>(mTreeNew, newScalarsVector);
       ftm::FTMTree_MT *treeNew = &(mTreeNew.tree);
 
       // Copy the old tree structure
@@ -858,8 +859,8 @@ namespace ttk {
 
     // TODO manage if join tree?
     template <class dataType>
-    void putBackMinMaxPair(std::vector<MergeTree<dataType>> &centroids,
-                           std::vector<MergeTree<dataType>> &centroids2) {
+    void putBackMinMaxPair(std::vector<ftm::MergeTree<dataType>> &centroids,
+                           std::vector<ftm::MergeTree<dataType>> &centroids2) {
       for(unsigned int i = 0; i < centroids2.size(); ++i) {
         // Get min max pair
         ftm::FTMTree_MT *centroidITree = &(centroids[i].tree);
@@ -871,7 +872,7 @@ namespace ttk {
         // Update tree
         ftm::idNode root2 = centroids2[i].tree.getRoot();
         std::vector<dataType> newScalarsVector
-          = getTreeScalars<dataType>(centroids2[i]);
+          = ftm::getTreeScalars<dataType>(centroids2[i]);
         newScalarsVector[root2] = newMax;
         newScalarsVector.push_back(newMin);
         std::vector<std::tuple<ftm::idNode, bool>> origins;
@@ -882,10 +883,11 @@ namespace ttk {
     }
 
     template <class dataType>
-    void postprocessingClustering(std::vector<MergeTree<dataType>> &trees,
-                                  std::vector<MergeTree<dataType>> &centroids,
-                                  matchingVector &outputMatching,
-                                  std::vector<int> &clusteringAssignment) {
+    void
+      postprocessingClustering(std::vector<ftm::MergeTree<dataType>> &trees,
+                               std::vector<ftm::MergeTree<dataType>> &centroids,
+                               matchingVector &outputMatching,
+                               std::vector<int> &clusteringAssignment) {
       for(unsigned int i = 0; i < trees.size(); ++i)
         postprocessingPipeline<dataType>(&(trees[i].tree));
       for(unsigned int i = 0; i < centroids.size(); ++i)
@@ -900,5 +902,3 @@ namespace ttk {
   }; // MergeTreeClustering class
 
 } // namespace ttk
-
-#endif

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -225,9 +225,10 @@ namespace ttk {
     void getCentroidsDistanceMatrix(
       std::vector<MergeTree<dataType>> &centroids,
       std::vector<std::vector<double>> &distanceMatrix) {
-      std::vector<ftm::FTMTree_MT *> trees;
-      for(MergeTree<dataType> &centroid : centroids)
-        trees.push_back(&(centroid.tree));
+      std::vector<ftm::FTMTree_MT *> trees(centroids.size());
+      for(size_t i = 0; i < centroids.size(); ++i) {
+        trees[i] = &(centroids[i].tree);
+      }
       getDistanceMatrix<dataType>(trees, distanceMatrix);
     }
 

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -482,7 +482,7 @@ namespace ttk {
 
     void matchingCorrespondence(treesMatchingVector &matchingT,
                                 std::vector<int> &nodeCorr,
-                                std::vector<int> assignedTreesIndex) {
+                                std::vector<int> &assignedTreesIndex) {
       for(int i : assignedTreesIndex) {
         std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> newMatching;
         for(auto tup : matchingT[i])

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -12,9 +12,6 @@
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
 
-#ifndef _MERGETREEDISTANCE_H
-#define _MERGETREEDISTANCE_H
-
 #pragma once
 
 #include <stack>
@@ -259,8 +256,8 @@ namespace ttk {
     // ----------------------------------------
     template <class dataType>
     dataType
-      computeDistance(FTMTree_MT *tree1,
-                      FTMTree_MT *tree2,
+      computeDistance(ftm::FTMTree_MT *tree1,
+                      ftm::FTMTree_MT *tree2,
                       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
                         &outputMatching) {
       // ---------------------
@@ -316,8 +313,8 @@ namespace ttk {
 
     template <class dataType>
     dataType computeDistance(
-      FTMTree_MT *tree1,
-      FTMTree_MT *tree2,
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
       std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching) {
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
         realOutputMatching;
@@ -330,8 +327,8 @@ namespace ttk {
     }
 
     template <class dataType>
-    dataType execute(MergeTree<dataType> &mTree1,
-                     MergeTree<dataType> &mTree2,
+    dataType execute(ftm::MergeTree<dataType> &mTree1,
+                     ftm::MergeTree<dataType> &mTree2,
                      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
                        &outputMatching) {
       Memory m;
@@ -348,11 +345,11 @@ namespace ttk {
       // ---------------------
       // ----- Preprocessing
       // --------------------
-      MergeTree<dataType> tree1Ori = mTree1;
-      MergeTree<dataType> tree2Ori = mTree2;
+      ftm::MergeTree<dataType> tree1Ori = mTree1;
+      ftm::MergeTree<dataType> tree2Ori = mTree2;
       if(saveTree_) {
-        mTree1 = copyMergeTree<dataType>(mTree1);
-        mTree2 = copyMergeTree<dataType>(mTree2);
+        mTree1 = ftm::copyMergeTree<dataType>(mTree1);
+        mTree2 = ftm::copyMergeTree<dataType>(mTree2);
         tree1 = &(mTree1.tree);
         tree2 = &(mTree2.tree);
       }
@@ -415,8 +412,8 @@ namespace ttk {
 
     template <class dataType>
     dataType execute(
-      MergeTree<dataType> &tree1,
-      MergeTree<dataType> &tree2,
+      ftm::MergeTree<dataType> &tree1,
+      ftm::MergeTree<dataType> &tree2,
       std::vector<std::tuple<ftm::idNode, ftm::idNode>> &outputMatching) {
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
         realOutputMatching;
@@ -555,12 +552,12 @@ namespace ttk {
       int ttkNotUsed(nCols)) {
       std::vector<int> tree1NodeChildSize, tree2NodeChildSize;
       for(unsigned int i = 0; i < tree1->getNumberOfNodes(); ++i) {
-        std::vector<idNode> children;
+        std::vector<ftm::idNode> children;
         tree1->getChildren(i, children);
         tree1NodeChildSize.push_back(children.size());
       }
       for(unsigned int j = 0; j < tree2->getNumberOfNodes(); ++j) {
-        std::vector<idNode> children;
+        std::vector<ftm::idNode> children;
         tree2->getChildren(j, children);
         tree2NodeChildSize.push_back(children.size());
       }
@@ -1126,7 +1123,7 @@ namespace ttk {
     }
 
     template <class dataType>
-    void verifyMergeTreeStructure(FTMTree_MT *tree) {
+    void verifyMergeTreeStructure(ftm::FTMTree_MT *tree) {
       bool problem = false;
 
       bool isJT = tree->isJoinTree<dataType>();
@@ -1153,7 +1150,7 @@ namespace ttk {
           problem |= thisProblem;
         }
 
-        std::vector<idNode> children;
+        std::vector<ftm::idNode> children;
         tree->getChildren(node, children);
         for(auto c : children)
           queue.emplace(c);
@@ -1220,5 +1217,3 @@ namespace ttk {
   }; // MergeTreeDistance class
 
 } // namespace ttk
-
-#endif

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -703,9 +703,9 @@ namespace ttk {
           taskQueue.emplace(nodeT);
         }
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(taskQueue, nodeT)                         \
-  untied shared(treeTable, forestTable, treeBackTable, forestBackTable, \
-                treeChildDone, treeNodeDone) if(isTree1)
+#pragma omp task firstprivate(taskQueue, nodeT) UNTIED()         \
+  shared(treeTable, forestTable, treeBackTable, forestBackTable, \
+         treeChildDone, treeNodeDone) if(isTree1)
         {
 #endif
           ftm::FTMTree_MT *treeT = (isTree1) ? tree1 : tree2;
@@ -857,9 +857,9 @@ namespace ttk {
         treeQueue.pop();
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(nodeT)                                    \
-  untied shared(treeTable, forestTable, treeBackTable, forestBackTable, \
-                treeChildDone, treeNodeDone)
+#pragma omp task firstprivate(nodeT) UNTIED()                    \
+  shared(treeTable, forestTable, treeBackTable, forestBackTable, \
+         treeChildDone, treeNodeDone)
         {
 #endif
           while((int)nodeT != -1) {
@@ -959,7 +959,8 @@ namespace ttk {
           treeQueue.pop();
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(nodeT) \
-  untied // shared(treeTable, forestTable)//, treeBackTable, forestBackTable)
+  UNTIED() // shared(treeTable, forestTable)//, treeBackTable,
+           // forestBackTable)
           {
 #endif
             std::stringstream ss;
@@ -1058,7 +1059,7 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(nodeT) \
-  untied // shared(treeTable, forestTable, treeBackTable, forestBackTable)
+  UNTIED() // shared(treeTable, forestTable, treeBackTable, forestBackTable)
           {
 #endif
             while(static_cast<int>(nodeT) != -1) {

--- a/core/base/mergeTreeClustering/MergeTreeUtils.h
+++ b/core/base/mergeTreeClustering/MergeTreeUtils.h
@@ -4,220 +4,220 @@
 /// \date 2021.
 ///
 
-#ifndef _MERGETREEUTILS_H
-#define _MERGETREEUTILS_H
+#pragma once
 
 #include <FTMTreeUtils.h>
 #include <stack>
 
-using namespace ttk;
-using namespace ftm;
+namespace ttk {
 
-template <class dataType>
-bool isDeathHigher(ftm::FTMTree_MT *tree1,
-                   ftm::idNode tree1Node,
-                   ftm::FTMTree_MT *tree2,
-                   ftm::idNode tree2Node) {
-  dataType tree1NodeDeath
-    = std::get<1>(tree1->getBirthDeath<dataType>(tree1Node));
-  dataType tree2NodeDeath
-    = std::get<1>(tree2->getBirthDeath<dataType>(tree2Node));
-  return tree1NodeDeath > tree2NodeDeath;
-}
-
-// --------------------
-// Normalized Wasserstein
-// --------------------
-
-template <class dataType>
-dataType getMinMaxLocal(ftm::FTMTree_MT *tree,
-                        ftm::idNode nodeId,
-                        bool getMin = true) {
-  auto nodeIdParent = tree->getParentSafe(nodeId);
-
-  if(tree->notNeedToNormalize(nodeId))
-    return getMin ? 0.0 : 1.0;
-
-  // General case
-  std::tuple<dataType, dataType> birthDeath
-    = tree->getBirthDeath<dataType>(nodeIdParent);
-
-  // Verify inconsistency
-  if(tree->isParentInconsistent<dataType>(nodeId)) {
-    // printErr("inconsistency");
-    // if(tree->getNumberOfNodes() < 1000)
-    tree->printTree();
-    // printPairsFromTree<dataType>(tree, true);
-    tree->printNode2<dataType>(nodeId);
-    tree->printNode2<dataType>(nodeIdParent);
+  template <class dataType>
+  bool isDeathHigher(ftm::FTMTree_MT *tree1,
+                     ftm::idNode tree1Node,
+                     ftm::FTMTree_MT *tree2,
+                     ftm::idNode tree2Node) {
+    dataType tree1NodeDeath
+      = std::get<1>(tree1->getBirthDeath<dataType>(tree1Node));
+    dataType tree2NodeDeath
+      = std::get<1>(tree2->getBirthDeath<dataType>(tree2Node));
+    return tree1NodeDeath > tree2NodeDeath;
   }
 
-  return getMin ? std::get<0>(birthDeath) : std::get<1>(birthDeath);
-}
+  // --------------------
+  // Normalized Wasserstein
+  // --------------------
 
-template <class dataType>
-std::tuple<dataType, dataType> getMinMaxLocalT(ftm::FTMTree_MT *tree,
-                                               ftm::idNode nodeId) {
-  dataType min = getMinMaxLocal<dataType>(tree, nodeId);
-  dataType max = getMinMaxLocal<dataType>(tree, nodeId, false);
-  return std::make_tuple(min, max);
-}
+  template <class dataType>
+  dataType getMinMaxLocal(ftm::FTMTree_MT *tree,
+                          ftm::idNode nodeId,
+                          bool getMin = true) {
+    auto nodeIdParent = tree->getParentSafe(nodeId);
 
-template <class dataType>
-std::tuple<double, double> getNormalizedBirthDeathDouble(ftm::FTMTree_MT *tree,
+    if(tree->notNeedToNormalize(nodeId))
+      return getMin ? 0.0 : 1.0;
+
+    // General case
+    std::tuple<dataType, dataType> birthDeath
+      = tree->getBirthDeath<dataType>(nodeIdParent);
+
+    // Verify inconsistency
+    if(tree->isParentInconsistent<dataType>(nodeId)) {
+      // printErr("inconsistency");
+      // if(tree->getNumberOfNodes() < 1000)
+      tree->printTree();
+      // printPairsFromTree<dataType>(tree, true);
+      tree->printNode2<dataType>(nodeId);
+      tree->printNode2<dataType>(nodeIdParent);
+    }
+
+    return getMin ? std::get<0>(birthDeath) : std::get<1>(birthDeath);
+  }
+
+  template <class dataType>
+  std::tuple<dataType, dataType> getMinMaxLocalT(ftm::FTMTree_MT *tree,
+                                                 ftm::idNode nodeId) {
+    dataType min = getMinMaxLocal<dataType>(tree, nodeId);
+    dataType max = getMinMaxLocal<dataType>(tree, nodeId, false);
+    return std::make_tuple(min, max);
+  }
+
+  template <class dataType>
+  std::tuple<double, double>
+    getNormalizedBirthDeathDouble(ftm::FTMTree_MT *tree,
+                                  ftm::idNode nodeId,
+                                  dataType newMin = 0.0,
+                                  dataType newMax = 1.0) {
+    auto birthDeath = tree->getBirthDeath<dataType>(nodeId);
+    double birth = std::get<0>(birthDeath);
+    double death = std::get<1>(birthDeath);
+    dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
+    dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
+    birth = (newMax - newMin) * (birth - shiftMin)
+            / (shiftMax - shiftMin); // + newMin;
+    death = (newMax - newMin) * (death - shiftMin)
+            / (shiftMax - shiftMin); // + newMin;
+    return std::make_tuple(birth, death);
+  }
+
+  template <class dataType>
+  std::tuple<dataType, dataType> getNormalizedBirthDeath(ftm::FTMTree_MT *tree,
                                                          ftm::idNode nodeId,
                                                          dataType newMin = 0.0,
                                                          dataType newMax
                                                          = 1.0) {
-  auto birthDeath = tree->getBirthDeath<dataType>(nodeId);
-  double birth = std::get<0>(birthDeath);
-  double death = std::get<1>(birthDeath);
-  dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
-  dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
-  birth = (newMax - newMin) * (birth - shiftMin)
-          / (shiftMax - shiftMin); // + newMin;
-  death = (newMax - newMin) * (death - shiftMin)
-          / (shiftMax - shiftMin); // + newMin;
-  return std::make_tuple(birth, death);
-}
-
-template <class dataType>
-std::tuple<dataType, dataType> getNormalizedBirthDeath(ftm::FTMTree_MT *tree,
-                                                       ftm::idNode nodeId,
-                                                       dataType newMin = 0.0,
-                                                       dataType newMax = 1.0) {
-  auto birthDeath = tree->getBirthDeath<dataType>(nodeId);
-  dataType birth = std::get<0>(birthDeath);
-  dataType death = std::get<1>(birthDeath);
-  dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
-  dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
-  birth = (newMax - newMin) * (birth - shiftMin)
-          / (shiftMax - shiftMin); // + newMin;
-  death = (newMax - newMin) * (death - shiftMin)
-          / (shiftMax - shiftMin); // + newMin;
-  return std::make_tuple(birth, death);
-}
-
-// --------------------
-// Rescaled Wasserstein (old)
-// --------------------
-
-template <class dataType>
-std::tuple<dataType, dataType> getNewMinMax(ftm::FTMTree_MT *tree1,
-                                            ftm::idNode nodeId1,
-                                            ftm::FTMTree_MT *tree2,
-                                            ftm::idNode nodeId2) {
-  dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
-  dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
-  dataType shiftMin2 = getMinMaxLocal<dataType>(tree2, nodeId2);
-  dataType shiftMax2 = getMinMaxLocal<dataType>(tree2, nodeId2, false);
-  return std::make_tuple(
-    (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
-}
-
-template <class dataType>
-std::tuple<dataType, dataType> getRescaledBirthDeath(ftm::FTMTree_MT *tree1,
-                                                     ftm::idNode nodeId1,
-                                                     ftm::FTMTree_MT *tree2,
-                                                     ftm::idNode nodeId2) {
-  auto newMinMax = getNewMinMax<dataType>(tree1, nodeId1, tree2, nodeId2);
-  return getNormalizedBirthDeath<dataType>(
-    tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
-}
-
-template <class dataType>
-dataType getMinMaxLocalFromVector(ftm::FTMTree_MT *tree,
-                                  ftm::idNode nodeId,
-                                  std::vector<dataType> &scalarsVector,
-                                  bool getMin = true) {
-  auto nodeIdParent = tree->getParentSafe(nodeId);
-
-  if(tree->notNeedToNormalize(nodeId))
-    return getMin ? 0.0 : 1.0;
-
-  // General case
-  dataType death = scalarsVector[nodeIdParent];
-  dataType birth = scalarsVector[tree->getNode(nodeIdParent)->getOrigin()];
-  if(death < birth) {
-    dataType temp = death;
-    death = birth;
-    birth = temp;
+    auto birthDeath = tree->getBirthDeath<dataType>(nodeId);
+    dataType birth = std::get<0>(birthDeath);
+    dataType death = std::get<1>(birthDeath);
+    dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
+    dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
+    birth = (newMax - newMin) * (birth - shiftMin)
+            / (shiftMax - shiftMin); // + newMin;
+    death = (newMax - newMin) * (death - shiftMin)
+            / (shiftMax - shiftMin); // + newMin;
+    return std::make_tuple(birth, death);
   }
 
-  return getMin ? birth : death;
-}
+  // --------------------
+  // Rescaled Wasserstein (old)
+  // --------------------
 
-template <class dataType>
-std::tuple<dataType, dataType>
-  getMinMaxLocalFromVectorT(ftm::FTMTree_MT *tree,
-                            ftm::idNode nodeId,
-                            std::vector<dataType> &scalarsVector) {
-  dataType min
-    = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector);
-  dataType max
-    = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector, false);
-  return std::make_tuple(min, max);
-}
+  template <class dataType>
+  std::tuple<dataType, dataType> getNewMinMax(ftm::FTMTree_MT *tree1,
+                                              ftm::idNode nodeId1,
+                                              ftm::FTMTree_MT *tree2,
+                                              ftm::idNode nodeId2) {
+    dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
+    dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
+    dataType shiftMin2 = getMinMaxLocal<dataType>(tree2, nodeId2);
+    dataType shiftMax2 = getMinMaxLocal<dataType>(tree2, nodeId2, false);
+    return std::make_tuple(
+      (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
+  }
 
-template <class dataType>
-std::tuple<dataType, dataType>
-  getNewMinMaxFromVector(ftm::FTMTree_MT *tree1,
-                         ftm::idNode nodeId1,
-                         ftm::FTMTree_MT *tree2,
-                         ftm::idNode nodeId2,
-                         std::vector<dataType> &scalarsVector) {
-  dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
-  dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
-  dataType shiftMin2
-    = getMinMaxLocalFromVector<dataType>(tree2, nodeId2, scalarsVector);
-  dataType shiftMax2
-    = getMinMaxLocalFromVector<dataType>(tree2, nodeId2, scalarsVector, false);
-  return std::make_tuple(
-    (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
-}
+  template <class dataType>
+  std::tuple<dataType, dataType> getRescaledBirthDeath(ftm::FTMTree_MT *tree1,
+                                                       ftm::idNode nodeId1,
+                                                       ftm::FTMTree_MT *tree2,
+                                                       ftm::idNode nodeId2) {
+    auto newMinMax = getNewMinMax<dataType>(tree1, nodeId1, tree2, nodeId2);
+    return getNormalizedBirthDeath<dataType>(
+      tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
+  }
 
-template <class dataType>
-std::tuple<dataType, dataType>
-  getRescaledBirthDeathFromVector(ftm::FTMTree_MT *tree1,
-                                  ftm::idNode nodeId1,
-                                  ftm::FTMTree_MT *tree2,
-                                  ftm::idNode nodeId2,
-                                  std::vector<dataType> &scalarsVector) {
-  auto newMinMax = getNewMinMaxFromVector<dataType>(
-    tree1, nodeId1, tree2, nodeId2, scalarsVector);
-  return getNormalizedBirthDeath<dataType>(
-    tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
-}
+  template <class dataType>
+  dataType getMinMaxLocalFromVector(ftm::FTMTree_MT *tree,
+                                    ftm::idNode nodeId,
+                                    std::vector<dataType> &scalarsVector,
+                                    bool getMin = true) {
+    auto nodeIdParent = tree->getParentSafe(nodeId);
 
-// --------------------
-// Testing
-// --------------------
-template <class dataType>
-ftm::FTMTree_MT *
-  makeFakeTree(dataType *nodesScalar,
-               std::vector<SimplexId> &nodes,
-               std::vector<std::tuple<ftm::idNode, ftm::idNode>> &arcs) {
-  // Init Scalars
-  ftm::Scalars *scalars = new ftm::Scalars();
-  scalars->size = nodes.size();
-  scalars->values = (void *)nodesScalar;
+    if(tree->notNeedToNormalize(nodeId))
+      return getMin ? 0.0 : 1.0;
 
-  // Init Tree
-  ftm::Params *params = new ftm::Params();
-  // ftm::FTMTree_MT *tree = new ftm::FTMTree_MT(params, nullptr, scalars,
-  // ftm::Join_Split);
-  ftm::FTMTree_MT *tree = new ftm::FTMTree_MT(params, scalars, ftm::Join_Split);
-  tree->makeAlloc();
+    // General case
+    dataType death = scalarsVector[nodeIdParent];
+    dataType birth = scalarsVector[tree->getNode(nodeIdParent)->getOrigin()];
+    if(death < birth) {
+      dataType temp = death;
+      death = birth;
+      birth = temp;
+    }
 
-  // Add Nodes
-  for(auto i : nodes)
-    tree->makeNode(i);
+    return getMin ? birth : death;
+  }
 
-  // Add Arcs
-  for(std::tuple<ftm::idNode, ftm::idNode> arc : arcs)
-    tree->makeSuperArc(std::get<0>(arc), std::get<1>(arc)); // (down, Up)
+  template <class dataType>
+  std::tuple<dataType, dataType>
+    getMinMaxLocalFromVectorT(ftm::FTMTree_MT *tree,
+                              ftm::idNode nodeId,
+                              std::vector<dataType> &scalarsVector) {
+    dataType min
+      = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector);
+    dataType max
+      = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector, false);
+    return std::make_tuple(min, max);
+  }
 
-  return tree;
-}
+  template <class dataType>
+  std::tuple<dataType, dataType>
+    getNewMinMaxFromVector(ftm::FTMTree_MT *tree1,
+                           ftm::idNode nodeId1,
+                           ftm::FTMTree_MT *tree2,
+                           ftm::idNode nodeId2,
+                           std::vector<dataType> &scalarsVector) {
+    dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
+    dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
+    dataType shiftMin2
+      = getMinMaxLocalFromVector<dataType>(tree2, nodeId2, scalarsVector);
+    dataType shiftMax2 = getMinMaxLocalFromVector<dataType>(
+      tree2, nodeId2, scalarsVector, false);
+    return std::make_tuple(
+      (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
+  }
 
-#endif
+  template <class dataType>
+  std::tuple<dataType, dataType>
+    getRescaledBirthDeathFromVector(ftm::FTMTree_MT *tree1,
+                                    ftm::idNode nodeId1,
+                                    ftm::FTMTree_MT *tree2,
+                                    ftm::idNode nodeId2,
+                                    std::vector<dataType> &scalarsVector) {
+    auto newMinMax = getNewMinMaxFromVector<dataType>(
+      tree1, nodeId1, tree2, nodeId2, scalarsVector);
+    return getNormalizedBirthDeath<dataType>(
+      tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
+  }
+
+  // --------------------
+  // Testing
+  // --------------------
+  template <class dataType>
+  ftm::FTMTree_MT *
+    makeFakeTree(dataType *nodesScalar,
+                 std::vector<SimplexId> &nodes,
+                 std::vector<std::tuple<ftm::idNode, ftm::idNode>> &arcs) {
+    // Init Scalars
+    ftm::Scalars *scalars = new ftm::Scalars();
+    scalars->size = nodes.size();
+    scalars->values = (void *)nodesScalar;
+
+    // Init Tree
+    ftm::Params *params = new ftm::Params();
+    // ftm::FTMTree_MT *tree = new ftm::FTMTree_MT(params, nullptr, scalars,
+    // ftm::Join_Split);
+    ftm::FTMTree_MT *tree
+      = new ftm::FTMTree_MT(params, scalars, ftm::Join_Split);
+    tree->makeAlloc();
+
+    // Add Nodes
+    for(auto i : nodes)
+      tree->makeNode(i);
+
+    // Add Arcs
+    for(std::tuple<ftm::idNode, ftm::idNode> arc : arcs)
+      tree->makeSuperArc(std::get<0>(arc), std::get<1>(arc)); // (down, Up)
+
+    return tree;
+  }
+
+} // namespace ttk

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -62,7 +62,7 @@ namespace ttk {
                          std::vector<std::vector<double>> &distanceMatrix) {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(i) untied shared(distanceMatrix)
+#pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix)
         {
 #endif
           std::stringstream stream;

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -5,10 +5,6 @@
 ///
 /// This VTK filter uses the ttk::MergeTreeDistanceMatrix module to compute the
 /// distance matrix of a group of merge trees.
-///
-
-#ifndef _MERGETREEDISTANCEMATRIX_H
-#define _MERGETREEDISTANCEMATRIX_H
 
 #pragma once
 
@@ -41,13 +37,13 @@ namespace ttk {
      * Implementation of the algorithm.
      */
     template <class dataType>
-    void execute(std::vector<MergeTree<dataType>> trees,
+    void execute(std::vector<ftm::MergeTree<dataType>> &trees,
                  std::vector<std::vector<double>> &distanceMatrix) {
       executePara<dataType>(trees, distanceMatrix);
     }
 
     template <class dataType>
-    void executePara(std::vector<MergeTree<dataType>> trees,
+    void executePara(std::vector<ftm::MergeTree<dataType>> &trees,
                      std::vector<std::vector<double>> &distanceMatrix) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel num_threads(this->threadNumber_)
@@ -62,7 +58,7 @@ namespace ttk {
     }
 
     template <class dataType>
-    void executeParaImpl(std::vector<MergeTree<dataType>> trees,
+    void executeParaImpl(std::vector<ftm::MergeTree<dataType>> &trees,
                          std::vector<std::vector<double>> &distanceMatrix) {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
@@ -116,5 +112,3 @@ namespace ttk {
   }; // MergeTreeDistanceMatrix class
 
 } // namespace ttk
-
-#endif

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -38,8 +38,8 @@ namespace ttk {
 
     template <class dataType>
     dataType computeDistance(
-      MergeTree<dataType> &mTree1,
-      MergeTree<dataType> &mTree2,
+      ftm::MergeTree<dataType> &mTree1,
+      ftm::MergeTree<dataType> &mTree2,
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching) {
       MergeTreeDistance mergeTreeDistance;
       mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
@@ -72,16 +72,16 @@ namespace ttk {
     }
 
     template <class dataType>
-    dataType computeDistance(MergeTree<dataType> &mTree1,
-                             MergeTree<dataType> &mTree2) {
+    dataType computeDistance(ftm::MergeTree<dataType> &mTree1,
+                             ftm::MergeTree<dataType> &mTree2) {
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching;
       return computeDistance<dataType>(mTree1, mTree2, matching);
     }
 
     template <class dataType>
-    MergeTree<dataType> computeBarycenter(MergeTree<dataType> &mTree1,
-                                          MergeTree<dataType> &mTree2,
-                                          double alpha) {
+    ftm::MergeTree<dataType> computeBarycenter(ftm::MergeTree<dataType> &mTree1,
+                                               ftm::MergeTree<dataType> &mTree2,
+                                               double alpha) {
       MergeTreeBarycenter mergeTreeBarycenter;
       mergeTreeBarycenter.setAssignmentSolver(assignmentSolverID_);
       mergeTreeBarycenter.setEpsilonTree1(epsilonTree1_);
@@ -107,12 +107,12 @@ namespace ttk {
       mergeTreeBarycenter.setPostprocess(false);
       // mergeTreeBarycenter.setIsCalled(true);
 
-      std::vector<MergeTree<dataType>> intermediateTrees;
+      std::vector<ftm::MergeTree<dataType>> intermediateTrees;
       intermediateTrees.push_back(mTree1);
       intermediateTrees.push_back(mTree2);
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         outputMatchingBarycenter(2);
-      MergeTree<dataType> barycenter;
+      ftm::MergeTree<dataType> barycenter;
       mergeTreeBarycenter.execute<dataType>(
         intermediateTrees, outputMatchingBarycenter, barycenter);
       return barycenter;
@@ -120,9 +120,9 @@ namespace ttk {
 
     template <class dataType>
     void execute(
-      std::vector<MergeTree<dataType>> &mTrees,
+      std::vector<ftm::MergeTree<dataType>> &mTrees,
       std::vector<std::tuple<double, int, int, int, int>> &coefs,
-      std::vector<MergeTree<dataType>> &allMT,
+      std::vector<ftm::MergeTree<dataType>> &allMT,
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         &allMatching) {
       Timer t_tempSub;
@@ -145,7 +145,7 @@ namespace ttk {
           double alpha = std::get<0>(coefs[cpt]);
           int index1 = std::get<1>(coefs[cpt]);
           int index2 = std::get<2>(coefs[cpt]);
-          MergeTree<dataType> tree = computeBarycenter<dataType>(
+          ftm::MergeTree<dataType> tree = computeBarycenter<dataType>(
             mTrees[index1], mTrees[index2], alpha);
           allMT.push_back(tree);
           distancesToKeyFrames_[cpt * 2]

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -83,8 +83,8 @@ namespace ttk {
     }
 
     template <class dataType>
-    dataType computeDistance(MergeTree<dataType> &mTree1,
-                             MergeTree<dataType> &mTree2,
+    dataType computeDistance(ftm::MergeTree<dataType> &mTree1,
+                             ftm::MergeTree<dataType> &mTree2,
                              bool emptyTreeDistance = false) {
       MergeTreeDistance mergeTreeDistance;
       mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
@@ -119,9 +119,9 @@ namespace ttk {
     }
 
     template <class dataType>
-    MergeTree<dataType> computeBarycenter(MergeTree<dataType> &mTree1,
-                                          MergeTree<dataType> &mTree2,
-                                          double alpha) {
+    ftm::MergeTree<dataType> computeBarycenter(ftm::MergeTree<dataType> &mTree1,
+                                               ftm::MergeTree<dataType> &mTree2,
+                                               double alpha) {
       MergeTreeBarycenter mergeTreeBarycenter;
       mergeTreeBarycenter.setAssignmentSolver(assignmentSolverID_);
       mergeTreeBarycenter.setEpsilonTree1(epsilonTree1_);
@@ -147,12 +147,12 @@ namespace ttk {
       mergeTreeBarycenter.setPostprocess(false);
       // mergeTreeBarycenter.setIsCalled(true);
 
-      std::vector<MergeTree<dataType>> intermediateTrees;
+      std::vector<ftm::MergeTree<dataType>> intermediateTrees;
       intermediateTrees.push_back(mTree1);
       intermediateTrees.push_back(mTree2);
       std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
         outputMatchingBarycenter(2);
-      MergeTree<dataType> barycenter;
+      ftm::MergeTree<dataType> barycenter;
       mergeTreeBarycenter.execute<dataType>(
         intermediateTrees, outputMatchingBarycenter, barycenter);
       return barycenter;
@@ -167,9 +167,9 @@ namespace ttk {
 
     template <class dataType>
     void
-      temporalSubsampling(std::vector<MergeTree<dataType>> &mTrees,
+      temporalSubsampling(std::vector<ftm::MergeTree<dataType>> &mTrees,
                           std::vector<int> &removed,
-                          std::vector<MergeTree<dataType>> &barycenters,
+                          std::vector<ftm::MergeTree<dataType>> &barycenters,
                           std::vector<std::vector<dataType>> &barycentersL2) {
       std::vector<bool> treeRemoved(mTrees.size(), false);
 
@@ -184,8 +184,9 @@ namespace ttk {
       for(int iter = 0; iter < toRemoved; ++iter) {
         dataType bestCost = std::numeric_limits<dataType>::max();
         int bestMiddleIndex = -1;
-        MergeTree<dataType> bestBarycenter;
-        std::vector<std::tuple<MergeTree<dataType>, int>> bestBarycentersOnPath;
+        ftm::MergeTree<dataType> bestBarycenter;
+        std::vector<std::tuple<ftm::MergeTree<dataType>, int>>
+          bestBarycentersOnPath;
         std::vector<dataType> bestBarycenterL2;
         std::vector<std::tuple<std::vector<dataType>, int>>
           bestBarycentersL2OnPath;
@@ -209,7 +210,7 @@ namespace ttk {
           // Compute barycenter
           printMsg("Compute barycenter", debug::Priority::VERBOSE);
           double alpha = computeAlpha(index1, middleIndex, index2);
-          MergeTree<dataType> barycenter;
+          ftm::MergeTree<dataType> barycenter;
           std::vector<dataType> barycenterL2;
           if(not useL2Distance_)
             barycenter = computeBarycenter<dataType>(
@@ -232,7 +233,8 @@ namespace ttk {
           // Compute distances of previously removed trees on the path
           printMsg("Compute distances of previously removed trees",
                    debug::Priority::VERBOSE);
-          std::vector<std::tuple<MergeTree<dataType>, int>> barycentersOnPath;
+          std::vector<std::tuple<ftm::MergeTree<dataType>, int>>
+            barycentersOnPath;
           std::vector<std::tuple<std::vector<dataType>, int>>
             barycentersL2OnPath;
           for(unsigned int i = 0; i < 2; ++i) {
@@ -243,7 +245,7 @@ namespace ttk {
 
               // Compute barycenter
               double alphaT = computeAlpha(index1, tIndex, index2);
-              MergeTree<dataType> barycenterP;
+              ftm::MergeTree<dataType> barycenterP;
               std::vector<dataType> barycenterPL2;
               if(not useL2Distance_)
                 barycenterP = computeBarycenter<dataType>(
@@ -306,9 +308,9 @@ namespace ttk {
     }
 
     template <class dataType>
-    std::vector<int> execute(std::vector<MergeTree<dataType>> &mTrees,
+    std::vector<int> execute(std::vector<ftm::MergeTree<dataType>> &mTrees,
                              std::vector<double> &emptyTreeDistances,
-                             std::vector<MergeTree<dataType>> &allMT) {
+                             std::vector<ftm::MergeTree<dataType>> &allMT) {
       Timer t_tempSub;
 
       // --- Preprocessing
@@ -324,7 +326,7 @@ namespace ttk {
       }
 
       // --- Execute
-      std::vector<MergeTree<dataType>> barycenters(mTrees.size());
+      std::vector<ftm::MergeTree<dataType>> barycenters(mTrees.size());
       std::vector<std::vector<dataType>> barycentersL2(mTrees.size());
       std::vector<int> removed;
       if(not useCustomTimeVariable_) {

--- a/core/base/planarGraphLayout/MergeTreeVisualization.h
+++ b/core/base/planarGraphLayout/MergeTreeVisualization.h
@@ -109,7 +109,7 @@ public:
       queue.pop();
       idNode nodeOrigin = tree->getNode(node)->getOrigin();
 
-      dataType nodePers = tree->getNodePersistence<dataType>(node);
+      const double nodePers = tree->getNodePersistence<dataType>(node);
       retVec[treeSimplexId[nodeOrigin] * 2] = 0;
       retVec[treeSimplexId[nodeOrigin] * 2 + 1]
         = nodePers / rootPers * (rootYmax - rootYmin) + rootYmin;
@@ -391,8 +391,8 @@ public:
     float rootYmin = std::min(rootY, rootOriginY);
     float rootYmax = std::max(rootY, rootOriginY);
     auto rootBirthDeath = tree->getBirthDeath<dataType>(treeRoot);
-    dataType rootBirth = std::get<0>(rootBirthDeath);
-    dataType rootDeath = std::get<1>(rootBirthDeath);
+    const double rootBirth = std::get<0>(rootBirthDeath);
+    const double rootDeath = std::get<1>(rootBirthDeath);
     for(size_t i = 0; i < tree->getNumberOfNodes(); ++i) {
       retVec[treeSimplexId[i] * 2 + 1]
         = (tree->getValue<dataType>(i) - rootBirth) / (rootDeath - rootBirth);
@@ -438,7 +438,7 @@ public:
       if(tree->isLeaf(node)) {
         float nodeDiff = (retVec[treeSimplexId[node] * 2]
                           - retVec[treeSimplexId[nodeOrigin] * 2]);
-        int sign = nodeDiff / std::abs(nodeDiff);
+        const auto sign = nodeDiff / std::abs(nodeDiff);
         auto inc = sign * nodePers / rootPers * (rootYmax - rootYmin) / 2;
         retVec[treeSimplexId[node] * 2]
           = retVec[treeSimplexId[nodeOrigin] * 2] + inc;

--- a/core/base/planarGraphLayout/MergeTreeVisualization.h
+++ b/core/base/planarGraphLayout/MergeTreeVisualization.h
@@ -4,10 +4,6 @@
 /// \date 2021.
 ///
 /// Visualization module for merge trees.
-///
-
-#ifndef _MERGETREEVISUALIZATION_H
-#define _MERGETREEVISUALIZATION_H
 
 #pragma once
 
@@ -15,888 +11,900 @@
 
 #include <stack>
 
-using namespace ttk;
-using namespace ftm;
+namespace ttk {
 
-class MergeTreeVisualization : virtual public Debug {
-protected:
-  // Visualization parameters
-  bool branchDecompositionPlanarLayout_ = false;
-  double branchSpacing_ = 1.;
-  bool rescaleTreesIndividually_ = false;
-  double importantPairs_ = 50.; // important pairs threshold
-  double importantPairsSpacing_ = 1.;
-  double nonImportantPairsSpacing_ = 1.;
-  double nonImportantPairsProximity_ = 0.05;
+  class MergeTreeVisualization : virtual public Debug {
+  protected:
+    // Visualization parameters
+    bool branchDecompositionPlanarLayout_ = false;
+    double branchSpacing_ = 1.;
+    bool rescaleTreesIndividually_ = false;
+    double importantPairs_ = 50.; // important pairs threshold
+    double importantPairsSpacing_ = 1.;
+    double nonImportantPairsSpacing_ = 1.;
+    double nonImportantPairsProximity_ = 0.05;
 
-public:
-  MergeTreeVisualization() = default;
-  virtual ~MergeTreeVisualization() = default;
+  public:
+    MergeTreeVisualization() = default;
+    virtual ~MergeTreeVisualization() = default;
 
-  // ==========================================================================
-  // Getter / Setter
-  // ==========================================================================
-  // Visualization parameters
-  void setBranchDecompositionPlanarLayout(bool b) {
-    branchDecompositionPlanarLayout_ = b;
-  }
-  void setBranchSpacing(double d) {
-    branchSpacing_ = d;
-  }
-  void setRescaleTreesIndividually(bool b) {
-    rescaleTreesIndividually_ = b;
-  }
-  void setImportantPairs(double d) {
-    importantPairs_ = d;
-  }
-  void setImportantPairsSpacing(double d) {
-    importantPairsSpacing_ = d;
-  }
-  void setNonImportantPairsSpacing(double d) {
-    nonImportantPairsSpacing_ = d;
-  }
-  void setNonImportantPairsProximity(double d) {
-    nonImportantPairsProximity_ = d;
-  }
+    // ==========================================================================
+    // Getter / Setter
+    // ==========================================================================
+    // Visualization parameters
+    void setBranchDecompositionPlanarLayout(bool b) {
+      branchDecompositionPlanarLayout_ = b;
+    }
+    void setBranchSpacing(double d) {
+      branchSpacing_ = d;
+    }
+    void setRescaleTreesIndividually(bool b) {
+      rescaleTreesIndividually_ = b;
+    }
+    void setImportantPairs(double d) {
+      importantPairs_ = d;
+    }
+    void setImportantPairsSpacing(double d) {
+      importantPairsSpacing_ = d;
+    }
+    void setNonImportantPairsSpacing(double d) {
+      nonImportantPairsSpacing_ = d;
+    }
+    void setNonImportantPairsProximity(double d) {
+      nonImportantPairsProximity_ = d;
+    }
 
-  // ==========================================================================
-  // Planar Layout
-  // ==========================================================================
-  // TODO manage multi pers pairs
-  template <class dataType>
-  void treePlanarLayoutBDImpl(
-    FTMTree_MT *tree,
-    std::vector<float> &retVec,
-    std::vector<LongSimplexId> &treeSimplexId,
-    std::vector<idNode> &ttkNotUsed(branching),
-    std::vector<std::vector<ftm::idNode>> &nodeBranching) {
-    idNode treeRoot = tree->getRoot();
-    idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
-    float rootY = retVec[treeSimplexId[treeRoot] * 2 + 1];
-    float rootOriginY = retVec[treeSimplexId[treeRootOrigin] * 2 + 1];
-    float rootYmin = std::min(rootY, rootOriginY);
-    float rootYmax = std::max(rootY, rootOriginY);
-    dataType rootPers = tree->getNodePersistence<dataType>(treeRoot);
-    std::vector<std::tuple<float, float>> allNodeSpanX(
-      tree->getNumberOfNodes());
-    std::vector<std::tuple<float, float>> allNodeImportantSpanX(
-      tree->getNumberOfNodes());
+    // ==========================================================================
+    // Planar Layout
+    // ==========================================================================
+    // TODO manage multi pers pairs
+    template <class dataType>
+    void treePlanarLayoutBDImpl(
+      ftm::FTMTree_MT *tree,
+      std::vector<float> &retVec,
+      std::vector<LongSimplexId> &treeSimplexId,
+      std::vector<ftm::idNode> &ttkNotUsed(branching),
+      std::vector<std::vector<ftm::idNode>> &nodeBranching) {
+      ftm::idNode treeRoot = tree->getRoot();
+      ftm::idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
+      float rootY = retVec[treeSimplexId[treeRoot] * 2 + 1];
+      float rootOriginY = retVec[treeSimplexId[treeRootOrigin] * 2 + 1];
+      float rootYmin = std::min(rootY, rootOriginY);
+      float rootYmax = std::max(rootY, rootOriginY);
+      dataType rootPers = tree->getNodePersistence<dataType>(treeRoot);
+      std::vector<std::tuple<float, float>> allNodeSpanX(
+        tree->getNumberOfNodes());
+      std::vector<std::tuple<float, float>> allNodeImportantSpanX(
+        tree->getNumberOfNodes());
 
-    // Compute gap
-    float nonImportantPairsGap
-      = (rootYmax - rootYmin) * 0.05 * nonImportantPairsSpacing_;
-    float importantPairsGap
-      = std::max(nonImportantPairsGap, (float)importantPairsSpacing_);
+      // Compute gap
+      float nonImportantPairsGap
+        = (rootYmax - rootYmin) * 0.05 * nonImportantPairsSpacing_;
+      float importantPairsGap
+        = std::max(nonImportantPairsGap, (float)importantPairsSpacing_);
 
-    // Some functions
-    auto compLowerPers = [&](const ftm::idNode a, const ftm::idNode b) {
-      return tree->getNodePersistence<dataType>(a)
-             < tree->getNodePersistence<dataType>(b);
-    };
-    auto compEqUpperPers = [&](const ftm::idNode a, const ftm::idNode b) {
-      return not compLowerPers(a, b);
-    };
+      // Some functions
+      auto compLowerPers = [&](const ftm::idNode a, const ftm::idNode b) {
+        return tree->getNodePersistence<dataType>(a)
+               < tree->getNodePersistence<dataType>(b);
+      };
+      auto compEqUpperPers = [&](const ftm::idNode a, const ftm::idNode b) {
+        return not compLowerPers(a, b);
+      };
 
-    // Go
-    std::vector<ftm::idNode> leaves;
-    tree->getLeavesFromTree(leaves);
-    std::sort(leaves.begin(), leaves.end(), compLowerPers);
-    std::queue<ftm::idNode> queue;
-    for(auto node : leaves)
-      queue.emplace(node);
-    while(!queue.empty()) {
-      idNode node = queue.front();
-      queue.pop();
-      idNode nodeOrigin = tree->getNode(node)->getOrigin();
+      // Go
+      std::vector<ftm::idNode> leaves;
+      tree->getLeavesFromTree(leaves);
+      std::sort(leaves.begin(), leaves.end(), compLowerPers);
+      std::queue<ftm::idNode> queue;
+      for(auto node : leaves)
+        queue.emplace(node);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
 
-      const double nodePers = tree->getNodePersistence<dataType>(node);
-      retVec[treeSimplexId[nodeOrigin] * 2] = 0;
-      retVec[treeSimplexId[nodeOrigin] * 2 + 1]
-        = nodePers / rootPers * (rootYmax - rootYmin) + rootYmin;
+        const double nodePers = tree->getNodePersistence<dataType>(node);
+        retVec[treeSimplexId[nodeOrigin] * 2] = 0;
+        retVec[treeSimplexId[nodeOrigin] * 2 + 1]
+          = nodePers / rootPers * (rootYmax - rootYmin) + rootYmin;
 
-      // Positioning nodes in the branch
-      if(tree->isBranchOrigin(nodeOrigin)) {
-        float prevX = 0;
-        std::vector<idNode> nodeBranchingVector;
-        for(size_t i = 1; i < nodeBranching[nodeOrigin].size(); ++i)
-          nodeBranchingVector.push_back(nodeBranching[nodeOrigin][i]);
-        std::sort(nodeBranchingVector.begin(), nodeBranchingVector.end(),
-                  compEqUpperPers);
+        // Positioning nodes in the branch
+        if(tree->isBranchOrigin(nodeOrigin)) {
+          float prevX = 0;
+          std::vector<ftm::idNode> nodeBranchingVector;
+          for(size_t i = 1; i < nodeBranching[nodeOrigin].size(); ++i)
+            nodeBranchingVector.push_back(nodeBranching[nodeOrigin][i]);
+          std::sort(nodeBranchingVector.begin(), nodeBranchingVector.end(),
+                    compEqUpperPers);
 
-        // Iterate through each node of the branch
-        int lastIndexImportant = -1;
-        for(size_t i = 0; i < nodeBranchingVector.size(); ++i) {
-          idNode nodeBranchingI = nodeBranchingVector[i];
+          // Iterate through each node of the branch
+          int lastIndexImportant = -1;
+          for(size_t i = 0; i < nodeBranchingVector.size(); ++i) {
+            ftm::idNode nodeBranchingI = nodeBranchingVector[i];
 
-          // Get old node span X
-          float oldMin = std::get<0>(allNodeSpanX[nodeBranchingI]);
-          float oldMax = std::get<1>(allNodeSpanX[nodeBranchingI]);
+            // Get old node span X
+            float oldMin = std::get<0>(allNodeSpanX[nodeBranchingI]);
+            float oldMax = std::get<1>(allNodeSpanX[nodeBranchingI]);
 
-          // Get x spacing
-          float nodeSpacing = 0;
-          if(i > 0) {
+            // Get x spacing
+            float nodeSpacing = 0;
+            if(i > 0) {
+              if(tree->isImportantPair<dataType>(
+                   nodeBranchingVector[i], importantPairs_)) {
+                nodeSpacing = importantPairsGap;
+              } else if(tree->isImportantPair<dataType>(
+                          nodeBranchingVector[i - 1], importantPairs_)) {
+                nodeSpacing = nonImportantPairsProximity_;
+                // prevX =
+              } else {
+                nodeSpacing = nonImportantPairsGap;
+              }
+            } else if(not tree->isImportantPair<dataType>(
+                        nodeBranchingVector[i], importantPairs_)
+                      and tree->isImportantPair<dataType>(
+                        nodeOrigin, importantPairs_))
+              nodeSpacing = nonImportantPairsProximity_;
+            float newMin = prevX + nodeSpacing;
+            float shiftX = newMin - oldMin;
+
+            // Set y coordinate according difference in persistence
+            dataType nodeBranchingIPers
+              = tree->getNodePersistence<dataType>(nodeBranchingI);
+            float shiftY = nodeBranchingIPers * branchSpacing_;
+            float diffY = retVec[treeSimplexId[nodeBranchingI] * 2 + 1];
+            retVec[treeSimplexId[nodeBranchingI] * 2 + 1]
+              = retVec[treeSimplexId[nodeOrigin] * 2 + 1] - shiftY;
+            diffY = retVec[treeSimplexId[nodeBranchingI] * 2 + 1] - diffY;
+
+            // Shift this branch
+            std::queue<ftm::idNode> queueBranching;
+            queueBranching.emplace(nodeBranchingI);
+            while(!queueBranching.empty()) {
+              ftm::idNode nodeBranchOrigin = queueBranching.front();
+              queueBranching.pop();
+              retVec[treeSimplexId[nodeBranchOrigin] * 2] += shiftX;
+              if(nodeBranchOrigin != nodeBranchingI)
+                retVec[treeSimplexId[nodeBranchOrigin] * 2 + 1] += diffY;
+              if(tree->isBranchOrigin(nodeBranchOrigin))
+                for(auto nodeB : nodeBranching[nodeBranchOrigin])
+                  queueBranching.emplace(nodeB);
+            }
+
+            // Update node span X
+            allNodeSpanX[nodeBranchingI]
+              = std::make_tuple(oldMin + shiftX, oldMax + shiftX);
+            float oldMinImp
+              = std::get<0>(allNodeImportantSpanX[nodeBranchingI]);
+            float oldMaxImp
+              = std::get<1>(allNodeImportantSpanX[nodeBranchingI]);
+            allNodeImportantSpanX[nodeBranchingI]
+              = std::make_tuple(oldMinImp + shiftX, oldMaxImp + shiftX);
+
+            // Update x base for next iteration
+            prevX = std::get<1>(allNodeSpanX[nodeBranchingI]);
             if(tree->isImportantPair<dataType>(
                  nodeBranchingVector[i], importantPairs_)) {
-              nodeSpacing = importantPairsGap;
-            } else if(tree->isImportantPair<dataType>(
-                        nodeBranchingVector[i - 1], importantPairs_)) {
-              nodeSpacing = nonImportantPairsProximity_;
-              // prevX =
-            } else {
-              nodeSpacing = nonImportantPairsGap;
+              lastIndexImportant = i;
+              prevX = std::get<1>(allNodeImportantSpanX[nodeBranchingI]);
+              if(i < nodeBranchingVector.size() - 1
+                 and not tree->isImportantPair<dataType>(
+                   nodeBranchingVector[i + 1], importantPairs_)) {
+                float spanMin
+                  = std::get<0>(allNodeSpanX[nodeBranchingVector[0]]);
+                float spanMax
+                  = std::get<1>(allNodeImportantSpanX
+                                  [nodeBranchingVector[lastIndexImportant]]);
+                prevX = (spanMin + spanMax) / 2;
+              }
             }
-          } else if(not tree->isImportantPair<dataType>(
-                      nodeBranchingVector[i], importantPairs_)
-                    and tree->isImportantPair<dataType>(
-                      nodeOrigin, importantPairs_))
-            nodeSpacing = nonImportantPairsProximity_;
-          float newMin = prevX + nodeSpacing;
-          float shiftX = newMin - oldMin;
-
-          // Set y coordinate according difference in persistence
-          dataType nodeBranchingIPers
-            = tree->getNodePersistence<dataType>(nodeBranchingI);
-          float shiftY = nodeBranchingIPers * branchSpacing_;
-          float diffY = retVec[treeSimplexId[nodeBranchingI] * 2 + 1];
-          retVec[treeSimplexId[nodeBranchingI] * 2 + 1]
-            = retVec[treeSimplexId[nodeOrigin] * 2 + 1] - shiftY;
-          diffY = retVec[treeSimplexId[nodeBranchingI] * 2 + 1] - diffY;
-
-          // Shift this branch
-          std::queue<idNode> queueBranching;
-          queueBranching.emplace(nodeBranchingI);
-          while(!queueBranching.empty()) {
-            idNode nodeBranchOrigin = queueBranching.front();
-            queueBranching.pop();
-            retVec[treeSimplexId[nodeBranchOrigin] * 2] += shiftX;
-            if(nodeBranchOrigin != nodeBranchingI)
-              retVec[treeSimplexId[nodeBranchOrigin] * 2 + 1] += diffY;
-            if(tree->isBranchOrigin(nodeBranchOrigin))
-              for(auto nodeB : nodeBranching[nodeBranchOrigin])
-                queueBranching.emplace(nodeB);
-          }
+          } // end for nodeBranching
 
           // Update node span X
-          allNodeSpanX[nodeBranchingI]
-            = std::make_tuple(oldMin + shiftX, oldMax + shiftX);
-          float oldMinImp = std::get<0>(allNodeImportantSpanX[nodeBranchingI]);
-          float oldMaxImp = std::get<1>(allNodeImportantSpanX[nodeBranchingI]);
-          allNodeImportantSpanX[nodeBranchingI]
-            = std::make_tuple(oldMinImp + shiftX, oldMaxImp + shiftX);
+          float spanMin = std::get<0>(allNodeSpanX[nodeBranchingVector[0]]);
+          if(lastIndexImportant != -1) {
+            float spanMaxImp = std::get<1>(
+              allNodeImportantSpanX[nodeBranchingVector[lastIndexImportant]]);
+            allNodeImportantSpanX[nodeOrigin]
+              = std::make_tuple(spanMin, spanMaxImp);
+          } else {
+            allNodeImportantSpanX[nodeOrigin] = std::make_tuple(0, 0);
+            spanMin = 0;
+          }
+          float spanMax = std::get<1>(
+            allNodeSpanX[nodeBranchingVector[nodeBranchingVector.size() - 1]]);
+          allNodeSpanX[nodeOrigin] = std::make_tuple(spanMin, spanMax);
+        } else {
+          allNodeSpanX[nodeOrigin] = std::make_tuple(0, 0);
+          allNodeImportantSpanX[nodeOrigin] = std::make_tuple(0, 0);
+        }
 
-          // Update x base for next iteration
-          prevX = std::get<1>(allNodeSpanX[nodeBranchingI]);
-          if(tree->isImportantPair<dataType>(
-               nodeBranchingVector[i], importantPairs_)) {
-            lastIndexImportant = i;
-            prevX = std::get<1>(allNodeImportantSpanX[nodeBranchingI]);
-            if(i < nodeBranchingVector.size() - 1
-               and not tree->isImportantPair<dataType>(
-                 nodeBranchingVector[i + 1], importantPairs_)) {
-              float spanMin = std::get<0>(allNodeSpanX[nodeBranchingVector[0]]);
-              float spanMax = std::get<1>(
-                allNodeImportantSpanX[nodeBranchingVector[lastIndexImportant]]);
-              prevX = (spanMin + spanMax) / 2;
+        // Positioning of this node x coordinate
+        float spanMin = std::get<0>(allNodeImportantSpanX[nodeOrigin]);
+        float spanMax = std::get<1>(allNodeImportantSpanX[nodeOrigin]);
+        retVec[treeSimplexId[nodeOrigin] * 2] = (spanMin + spanMax) / 2;
+      }
+
+      // Copy coordinates of nodeOrigin
+      for(auto node : leaves)
+        queue.emplace(node);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+        retVec[treeSimplexId[node] * 2] = retVec[treeSimplexId[nodeOrigin] * 2];
+        retVec[treeSimplexId[node] * 2 + 1]
+          = retVec[treeSimplexId[nodeOrigin] * 2 + 1];
+      }
+    }
+
+    // TODO manage multi pers pairs
+    template <class dataType>
+    void treePlanarLayoutImpl(
+      ftm::FTMTree_MT *tree,
+      std::tuple<double, double, double, double, double, double> oldBounds,
+      double ttkNotUsed(refPersistence),
+      std::vector<float> &retVec) {
+      printMsg(debug::Separator::L1, debug::Priority::VERBOSE);
+      printMsg("Planar Layout", debug::Priority::VERBOSE);
+
+      // ----------------------------------------------------
+      // Init internal parameters
+      // ----------------------------------------------------
+      Timer t_init;
+      printMsg("Init internal parameters", debug::Priority::VERBOSE);
+
+      auto nPoints = tree->getRealNumberOfNodes();
+      int outNumberOfPoints = nPoints * 2;
+      retVec = std::vector<float>(outNumberOfPoints);
+
+      int cptNode = 0;
+      std::vector<LongSimplexId> treeSimplexId(tree->getNumberOfNodes());
+      std::vector<ftm::idNode> branching;
+      std::vector<int> branchingID;
+      std::vector<std::vector<ftm::idNode>> nodeBranching;
+      tree->getTreeBranching(branching, branchingID, nodeBranching);
+
+      std::stringstream ss;
+      ss << "INIT            = " << t_init.getElapsedTime();
+      printMsg(ss.str(), debug::Priority::VERBOSE);
+
+      // ----------------------------------------------------
+      // Iterate through tree
+      // ----------------------------------------------------
+      Timer t_iterate;
+      printMsg("Iterate through tree", debug::Priority::VERBOSE);
+
+      std::queue<ftm::idNode> queue;
+      ftm::idNode treeRoot = tree->getRoot();
+      ftm::idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
+      queue.emplace(treeRoot);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+
+        // Get and insert point
+        treeSimplexId[node] = cptNode;
+        ++cptNode;
+
+        // Push children to the queue
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(size_t i = 0; i < children.size(); ++i) {
+          auto child = children[i];
+          queue.emplace(child);
+        }
+      }
+
+      std::stringstream ss2;
+      ss2 << "ITERATE TREE    = " << t_iterate.getElapsedTime();
+      printMsg(ss2.str(), debug::Priority::VERBOSE);
+
+      // ----------------------------------------------------
+      // Prepositioning coordinates
+      // ----------------------------------------------------
+      std::queue<ftm::idNode> queue2;
+      queue2.emplace(treeRoot);
+      while(!queue2.empty()) {
+        ftm::idNode node = queue2.front();
+        queue2.pop();
+
+        retVec[treeSimplexId[node] * 2]
+          = tree->getValue<dataType>(branching[node]);
+        retVec[treeSimplexId[node] * 2 + 1] = tree->getValue<dataType>(node);
+
+        // Push children to the queue
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(auto child : children)
+          queue2.emplace(child);
+      }
+
+      // ----------------------------------------------------
+      // Rescale coordinates
+      // ----------------------------------------------------
+      Timer t_rescale;
+      printMsg("Rescale coordinates ", debug::Priority::VERBOSE);
+
+      float x_min, y_min, x_max, y_max;
+      x_min = std::numeric_limits<float>::max();
+      y_min = std::numeric_limits<float>::max();
+      x_max = std::numeric_limits<float>::lowest();
+      y_max = std::numeric_limits<float>::lowest();
+      for(int i = 0; i < outNumberOfPoints; i += 2) {
+        x_min = std::min(x_min, retVec[i]);
+        x_max = std::max(x_max, retVec[i]);
+        y_min = std::min(y_min, retVec[i + 1]);
+        y_max = std::max(y_max, retVec[i + 1]);
+      }
+      auto newBounds = std::make_tuple(x_min, x_max, y_min, y_max, 0, 0);
+
+      // TODO correctly manage diff and offset if rescaleTreesIndividually_
+      double diff = std::max((std::get<1>(oldBounds) - std::get<0>(oldBounds)),
+                             (std::get<3>(oldBounds) - std::get<2>(oldBounds)));
+      double offset = std::max(std::get<0>(oldBounds), std::get<2>(oldBounds));
+      if(not rescaleTreesIndividually_) {
+        // diff *= getNodePersistence<dataType>(tree, treeRoot) /
+        // refPersistence;
+        diff = tree->getNodePersistence<dataType>(treeRoot);
+        offset = tree->getBirth<dataType>(treeRoot);
+      }
+
+      for(int i = 0; i < outNumberOfPoints; i += 2) {
+        auto divisor1
+          = std::get<1>(newBounds) - std::get<0>(newBounds); // (x_max - x_min)
+        divisor1 = (divisor1 == 0 ? 1 : divisor1);
+        auto divisor2
+          = std::get<3>(newBounds) - std::get<2>(newBounds); // (y_max - y_min)
+        divisor2 = (divisor2 == 0 ? 1 : divisor2);
+
+        // x coordinate
+        retVec[i] = (retVec[i] - std::get<0>(newBounds)) / divisor1;
+        retVec[i] = retVec[i] * diff / 2 + offset;
+
+        // y coordinate
+        retVec[i + 1] = (retVec[i + 1] - std::get<2>(newBounds)) / divisor2;
+        retVec[i + 1] = retVec[i + 1] * diff + offset;
+      }
+
+      std::stringstream ss3;
+      ss3 << "RESCALE COORD.  = " << t_rescale.getElapsedTime();
+      printMsg(ss3.str(), debug::Priority::VERBOSE);
+
+      // ----------------------------------------------------
+      // Call Branch Decomposition Planar Layout if asked
+      // ----------------------------------------------------
+      if(branchDecompositionPlanarLayout_) {
+        treePlanarLayoutBDImpl<dataType>(
+          tree, retVec, treeSimplexId, branching, nodeBranching);
+        return;
+      }
+
+      // ----------------------------------------------------
+      // Move nodes given scalars
+      // ----------------------------------------------------
+      Timer t_move;
+      printMsg("Move nodes given scalars", debug::Priority::VERBOSE);
+
+      float rootY = retVec[treeSimplexId[treeRoot] * 2 + 1];
+      float rootOriginY = retVec[treeSimplexId[treeRootOrigin] * 2 + 1];
+      float rootYmin = std::min(rootY, rootOriginY);
+      float rootYmax = std::max(rootY, rootOriginY);
+      auto rootBirthDeath = tree->getBirthDeath<dataType>(treeRoot);
+      const double rootBirth = std::get<0>(rootBirthDeath);
+      const double rootDeath = std::get<1>(rootBirthDeath);
+      for(size_t i = 0; i < tree->getNumberOfNodes(); ++i) {
+        retVec[treeSimplexId[i] * 2 + 1]
+          = (tree->getValue<dataType>(i) - rootBirth) / (rootDeath - rootBirth);
+        retVec[treeSimplexId[i] * 2 + 1]
+          = retVec[treeSimplexId[i] * 2 + 1] * (rootYmax - rootYmin) + rootYmin;
+      }
+
+      std::stringstream ss4;
+      ss4 << "MOVE SCALAR     = " << t_move.getElapsedTime();
+      printMsg(ss4.str(), debug::Priority::VERBOSE);
+
+      // ----------------------------------------------------
+      // Scale pairs given persistence
+      // ----------------------------------------------------
+      Timer t_scale;
+      printMsg("Scale pairs given persistence", debug::Priority::VERBOSE);
+
+      dataType rootPers = tree->getNodePersistence<dataType>(treeRoot);
+
+      std::vector<ftm::idNode> leaves;
+      tree->getLeavesFromTree(leaves);
+      auto compLowerPers = [&](const ftm::idNode a, const ftm::idNode b) {
+        return tree->getNodePersistence<dataType>(a)
+               < tree->getNodePersistence<dataType>(b);
+      };
+      std::sort(leaves.begin(), leaves.end(), compLowerPers);
+      std::stack<ftm::idNode> stack;
+      for(auto node : leaves)
+        stack.emplace(node);
+      std::vector<bool> nodeDone(tree->getNumberOfNodes(), false);
+      while(!stack.empty()) {
+        ftm::idNode node = stack.top();
+        stack.pop();
+        nodeDone[node] = true;
+
+        if(node == treeRoot or node == treeRootOrigin
+           or tree->isNodeAlone(node))
+          continue;
+
+        dataType nodePers = tree->getNodePersistence<dataType>(node);
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+
+        // Manage leaf
+        if(tree->isLeaf(node)) {
+          float nodeDiff = (retVec[treeSimplexId[node] * 2]
+                            - retVec[treeSimplexId[nodeOrigin] * 2]);
+          const auto sign = nodeDiff / std::abs(nodeDiff);
+          auto inc = sign * nodePers / rootPers * (rootYmax - rootYmin) / 2;
+          retVec[treeSimplexId[node] * 2]
+            = retVec[treeSimplexId[nodeOrigin] * 2] + inc;
+
+          // Push nodes in the branch to the stack
+          ftm::idNode nodeParent = tree->getParentSafe(node);
+          ftm::idNode oldNodeParent = -1;
+          while(nodeParent != nodeOrigin) {
+            if(not nodeDone[nodeParent])
+              stack.emplace(nodeParent);
+            else
+              break;
+            oldNodeParent = nodeParent;
+            nodeParent = tree->getParentSafe(nodeParent);
+            if(oldNodeParent == nodeParent) {
+              std::stringstream ss5;
+              ss5 << "treePlanarLayoutImpl oldNodeParent == nodeParent";
+              printMsg(ss5.str(), debug::Priority::VERBOSE);
+              break;
             }
           }
-        } // end for nodeBranching
-
-        // Update node span X
-        float spanMin = std::get<0>(allNodeSpanX[nodeBranchingVector[0]]);
-        if(lastIndexImportant != -1) {
-          float spanMaxImp = std::get<1>(
-            allNodeImportantSpanX[nodeBranchingVector[lastIndexImportant]]);
-          allNodeImportantSpanX[nodeOrigin]
-            = std::make_tuple(spanMin, spanMaxImp);
-        } else {
-          allNodeImportantSpanX[nodeOrigin] = std::make_tuple(0, 0);
-          spanMin = 0;
         }
-        float spanMax = std::get<1>(
-          allNodeSpanX[nodeBranchingVector[nodeBranchingVector.size() - 1]]);
-        allNodeSpanX[nodeOrigin] = std::make_tuple(spanMin, spanMax);
-      } else {
-        allNodeSpanX[nodeOrigin] = std::make_tuple(0, 0);
-        allNodeImportantSpanX[nodeOrigin] = std::make_tuple(0, 0);
-      }
 
-      // Positioning of this node x coordinate
-      float spanMin = std::get<0>(allNodeImportantSpanX[nodeOrigin]);
-      float spanMax = std::get<1>(allNodeImportantSpanX[nodeOrigin]);
-      retVec[treeSimplexId[nodeOrigin] * 2] = (spanMin + spanMax) / 2;
-    }
-
-    // Copy coordinates of nodeOrigin
-    for(auto node : leaves)
-      queue.emplace(node);
-    while(!queue.empty()) {
-      idNode node = queue.front();
-      queue.pop();
-      idNode nodeOrigin = tree->getNode(node)->getOrigin();
-      retVec[treeSimplexId[node] * 2] = retVec[treeSimplexId[nodeOrigin] * 2];
-      retVec[treeSimplexId[node] * 2 + 1]
-        = retVec[treeSimplexId[nodeOrigin] * 2 + 1];
-    }
-  }
-
-  // TODO manage multi pers pairs
-  template <class dataType>
-  void treePlanarLayoutImpl(
-    FTMTree_MT *tree,
-    std::tuple<double, double, double, double, double, double> oldBounds,
-    double ttkNotUsed(refPersistence),
-    std::vector<float> &retVec) {
-    printMsg(debug::Separator::L1, debug::Priority::VERBOSE);
-    printMsg("Planar Layout", debug::Priority::VERBOSE);
-
-    // ----------------------------------------------------
-    // Init internal parameters
-    // ----------------------------------------------------
-    Timer t_init;
-    printMsg("Init internal parameters", debug::Priority::VERBOSE);
-
-    auto nPoints = tree->getRealNumberOfNodes();
-    int outNumberOfPoints = nPoints * 2;
-    retVec = std::vector<float>(outNumberOfPoints);
-
-    int cptNode = 0;
-    std::vector<LongSimplexId> treeSimplexId(tree->getNumberOfNodes());
-    std::vector<idNode> branching;
-    std::vector<int> branchingID;
-    std::vector<std::vector<ftm::idNode>> nodeBranching;
-    tree->getTreeBranching(branching, branchingID, nodeBranching);
-
-    std::stringstream ss;
-    ss << "INIT            = " << t_init.getElapsedTime();
-    printMsg(ss.str(), debug::Priority::VERBOSE);
-
-    // ----------------------------------------------------
-    // Iterate through tree
-    // ----------------------------------------------------
-    Timer t_iterate;
-    printMsg("Iterate through tree", debug::Priority::VERBOSE);
-
-    std::queue<idNode> queue;
-    ftm::idNode treeRoot = tree->getRoot();
-    ftm::idNode treeRootOrigin = tree->getNode(treeRoot)->getOrigin();
-    queue.emplace(treeRoot);
-    while(!queue.empty()) {
-      idNode node = queue.front();
-      queue.pop();
-
-      // Get and insert point
-      treeSimplexId[node] = cptNode;
-      ++cptNode;
-
-      // Push children to the queue
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(size_t i = 0; i < children.size(); ++i) {
-        auto child = children[i];
-        queue.emplace(child);
-      }
-    }
-
-    std::stringstream ss2;
-    ss2 << "ITERATE TREE    = " << t_iterate.getElapsedTime();
-    printMsg(ss2.str(), debug::Priority::VERBOSE);
-
-    // ----------------------------------------------------
-    // Prepositioning coordinates
-    // ----------------------------------------------------
-    std::queue<idNode> queue2;
-    queue2.emplace(treeRoot);
-    while(!queue2.empty()) {
-      idNode node = queue2.front();
-      queue2.pop();
-
-      retVec[treeSimplexId[node] * 2]
-        = tree->getValue<dataType>(branching[node]);
-      retVec[treeSimplexId[node] * 2 + 1] = tree->getValue<dataType>(node);
-
-      // Push children to the queue
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue2.emplace(child);
-    }
-
-    // ----------------------------------------------------
-    // Rescale coordinates
-    // ----------------------------------------------------
-    Timer t_rescale;
-    printMsg("Rescale coordinates ", debug::Priority::VERBOSE);
-
-    float x_min, y_min, x_max, y_max;
-    x_min = std::numeric_limits<float>::max();
-    y_min = std::numeric_limits<float>::max();
-    x_max = std::numeric_limits<float>::lowest();
-    y_max = std::numeric_limits<float>::lowest();
-    for(int i = 0; i < outNumberOfPoints; i += 2) {
-      x_min = std::min(x_min, retVec[i]);
-      x_max = std::max(x_max, retVec[i]);
-      y_min = std::min(y_min, retVec[i + 1]);
-      y_max = std::max(y_max, retVec[i + 1]);
-    }
-    auto newBounds = std::make_tuple(x_min, x_max, y_min, y_max, 0, 0);
-
-    // TODO correctly manage diff and offset if rescaleTreesIndividually_
-    double diff = std::max((std::get<1>(oldBounds) - std::get<0>(oldBounds)),
-                           (std::get<3>(oldBounds) - std::get<2>(oldBounds)));
-    double offset = std::max(std::get<0>(oldBounds), std::get<2>(oldBounds));
-    if(not rescaleTreesIndividually_) {
-      // diff *= getNodePersistence<dataType>(tree, treeRoot) / refPersistence;
-      diff = tree->getNodePersistence<dataType>(treeRoot);
-      offset = tree->getBirth<dataType>(treeRoot);
-    }
-
-    for(int i = 0; i < outNumberOfPoints; i += 2) {
-      auto divisor1
-        = std::get<1>(newBounds) - std::get<0>(newBounds); // (x_max - x_min)
-      divisor1 = (divisor1 == 0 ? 1 : divisor1);
-      auto divisor2
-        = std::get<3>(newBounds) - std::get<2>(newBounds); // (y_max - y_min)
-      divisor2 = (divisor2 == 0 ? 1 : divisor2);
-
-      // x coordinate
-      retVec[i] = (retVec[i] - std::get<0>(newBounds)) / divisor1;
-      retVec[i] = retVec[i] * diff / 2 + offset;
-
-      // y coordinate
-      retVec[i + 1] = (retVec[i + 1] - std::get<2>(newBounds)) / divisor2;
-      retVec[i + 1] = retVec[i + 1] * diff + offset;
-    }
-
-    std::stringstream ss3;
-    ss3 << "RESCALE COORD.  = " << t_rescale.getElapsedTime();
-    printMsg(ss3.str(), debug::Priority::VERBOSE);
-
-    // ----------------------------------------------------
-    // Call Branch Decomposition Planar Layout if asked
-    // ----------------------------------------------------
-    if(branchDecompositionPlanarLayout_) {
-      treePlanarLayoutBDImpl<dataType>(
-        tree, retVec, treeSimplexId, branching, nodeBranching);
-      return;
-    }
-
-    // ----------------------------------------------------
-    // Move nodes given scalars
-    // ----------------------------------------------------
-    Timer t_move;
-    printMsg("Move nodes given scalars", debug::Priority::VERBOSE);
-
-    float rootY = retVec[treeSimplexId[treeRoot] * 2 + 1];
-    float rootOriginY = retVec[treeSimplexId[treeRootOrigin] * 2 + 1];
-    float rootYmin = std::min(rootY, rootOriginY);
-    float rootYmax = std::max(rootY, rootOriginY);
-    auto rootBirthDeath = tree->getBirthDeath<dataType>(treeRoot);
-    const double rootBirth = std::get<0>(rootBirthDeath);
-    const double rootDeath = std::get<1>(rootBirthDeath);
-    for(size_t i = 0; i < tree->getNumberOfNodes(); ++i) {
-      retVec[treeSimplexId[i] * 2 + 1]
-        = (tree->getValue<dataType>(i) - rootBirth) / (rootDeath - rootBirth);
-      retVec[treeSimplexId[i] * 2 + 1]
-        = retVec[treeSimplexId[i] * 2 + 1] * (rootYmax - rootYmin) + rootYmin;
-    }
-
-    std::stringstream ss4;
-    ss4 << "MOVE SCALAR     = " << t_move.getElapsedTime();
-    printMsg(ss4.str(), debug::Priority::VERBOSE);
-
-    // ----------------------------------------------------
-    // Scale pairs given persistence
-    // ----------------------------------------------------
-    Timer t_scale;
-    printMsg("Scale pairs given persistence", debug::Priority::VERBOSE);
-
-    dataType rootPers = tree->getNodePersistence<dataType>(treeRoot);
-
-    std::vector<ftm::idNode> leaves;
-    tree->getLeavesFromTree(leaves);
-    auto compLowerPers = [&](const ftm::idNode a, const ftm::idNode b) {
-      return tree->getNodePersistence<dataType>(a)
-             < tree->getNodePersistence<dataType>(b);
-    };
-    std::sort(leaves.begin(), leaves.end(), compLowerPers);
-    std::stack<ftm::idNode> stack;
-    for(auto node : leaves)
-      stack.emplace(node);
-    std::vector<bool> nodeDone(tree->getNumberOfNodes(), false);
-    while(!stack.empty()) {
-      ftm::idNode node = stack.top();
-      stack.pop();
-      nodeDone[node] = true;
-
-      if(node == treeRoot or node == treeRootOrigin or tree->isNodeAlone(node))
-        continue;
-
-      dataType nodePers = tree->getNodePersistence<dataType>(node);
-      ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-
-      // Manage leaf
-      if(tree->isLeaf(node)) {
-        float nodeDiff = (retVec[treeSimplexId[node] * 2]
-                          - retVec[treeSimplexId[nodeOrigin] * 2]);
-        const auto sign = nodeDiff / std::abs(nodeDiff);
-        auto inc = sign * nodePers / rootPers * (rootYmax - rootYmin) / 2;
-        retVec[treeSimplexId[node] * 2]
-          = retVec[treeSimplexId[nodeOrigin] * 2] + inc;
-
-        // Push nodes in the branch to the stack
-        ftm::idNode nodeParent = tree->getParentSafe(node);
-        ftm::idNode oldNodeParent = -1;
-        while(nodeParent != nodeOrigin) {
-          if(not nodeDone[nodeParent])
-            stack.emplace(nodeParent);
-          else
-            break;
-          oldNodeParent = nodeParent;
-          nodeParent = tree->getParentSafe(nodeParent);
-          if(oldNodeParent == nodeParent) {
-            std::stringstream ss5;
-            ss5 << "treePlanarLayoutImpl oldNodeParent == nodeParent";
-            printMsg(ss5.str(), debug::Priority::VERBOSE);
-            break;
-          }
+        // Manage saddle
+        if(not tree->isLeaf(node) and not tree->isRoot(node)) {
+          float branchY
+            = retVec[treeSimplexId[tree->getNode(branching[node])->getOrigin()]
+                     * 2];
+          retVec[treeSimplexId[node] * 2] = branchY;
         }
       }
 
-      // Manage saddle
-      if(not tree->isLeaf(node) and not tree->isRoot(node)) {
-        float branchY
-          = retVec[treeSimplexId[tree->getNode(branching[node])->getOrigin()]
-                   * 2];
-        retVec[treeSimplexId[node] * 2] = branchY;
-      }
-    }
+      std::stringstream ss5;
+      ss5 << "SCALE PERS.     = " << t_scale.getElapsedTime();
+      printMsg(ss5.str(), debug::Priority::VERBOSE);
 
-    std::stringstream ss5;
-    ss5 << "SCALE PERS.     = " << t_scale.getElapsedTime();
-    printMsg(ss5.str(), debug::Priority::VERBOSE);
+      // ----------------------------------------------------
+      // Branches positionning and avoid edges crossing
+      // ----------------------------------------------------
+      Timer t_avoid;
+      printMsg("Avoid edges crossing", debug::Priority::VERBOSE);
 
-    // ----------------------------------------------------
-    // Branches positionning and avoid edges crossing
-    // ----------------------------------------------------
-    Timer t_avoid;
-    printMsg("Avoid edges crossing", debug::Priority::VERBOSE);
+      bool isJT = tree->isJoinTree<dataType>();
+      auto compValue = [&](const ftm::idNode a, const ftm::idNode b) {
+        return (isJT
+                  ? tree->getValue<dataType>(a) < tree->getValue<dataType>(b)
+                  : tree->getValue<dataType>(a) > tree->getValue<dataType>(b));
+      };
+      std::vector<std::tuple<float, float, float, float>> allBranchBounds(
+        tree->getNumberOfNodes());
+      std::vector<std::vector<ftm::idNode>> allBranchOrigins(
+        tree->getNumberOfNodes());
+      std::vector<int> allBranchOriginsSize(tree->getNumberOfNodes());
+      std::queue<ftm::idNode> queueCrossing;
 
-    bool isJT = tree->isJoinTree<dataType>();
-    auto compValue = [&](const ftm::idNode a, const ftm::idNode b) {
-      return (isJT ? tree->getValue<dataType>(a) < tree->getValue<dataType>(b)
-                   : tree->getValue<dataType>(a) > tree->getValue<dataType>(b));
-    };
-    std::vector<std::tuple<float, float, float, float>> allBranchBounds(
-      tree->getNumberOfNodes());
-    std::vector<std::vector<ftm::idNode>> allBranchOrigins(
-      tree->getNumberOfNodes());
-    std::vector<int> allBranchOriginsSize(tree->getNumberOfNodes());
-    std::queue<ftm::idNode> queueCrossing;
-
-    // ----- Get important and non-important pairs gap and store saddle nodes of
-    // each branch
-    int maxSize = std::numeric_limits<int>::lowest();
-    for(auto leaf : leaves)
-      queueCrossing.emplace(leaf);
-    while(!queueCrossing.empty()) {
-      ftm::idNode node = queueCrossing.front();
-      queueCrossing.pop();
-      ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-
-      // Get saddle nodes in the branch
-      std::tuple<std::vector<ftm::idNode>, std::vector<ftm::idNode>>
-        tupBranchOrigins;
-      tree->getBranchOriginsFromThisBranch(nodeOrigin, tupBranchOrigins);
-      allBranchOrigins[nodeOrigin] = std::get<0>(tupBranchOrigins);
-      std::vector<ftm::idNode> nonBranchOrigins = std::get<1>(tupBranchOrigins);
-      allBranchOrigins[nodeOrigin].insert(allBranchOrigins[nodeOrigin].end(),
-                                          nonBranchOrigins.begin(),
-                                          nonBranchOrigins.end());
-      std::sort(allBranchOrigins[nodeOrigin].begin(),
-                allBranchOrigins[nodeOrigin].end(), compValue);
-      allBranchOriginsSize[nodeOrigin] = allBranchOrigins[nodeOrigin].size();
-
-      // Get sizes of sub-branches if they are non-important
-      for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
-        ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
-        bool isSubBranchImportant
-          = tree->isImportantPair<dataType>(branchNodeOrigin, importantPairs_);
-        if(not isSubBranchImportant)
-          allBranchOriginsSize[nodeOrigin]
-            += allBranchOriginsSize[branchNodeOrigin];
-      }
-
-      if(tree->isImportantPair<dataType>(nodeOrigin, importantPairs_))
-        maxSize = std::max(maxSize, allBranchOriginsSize[nodeOrigin]);
-    }
-    double nonImportantPairsGap
-      = (rootYmax - rootYmin) * 0.005 * nonImportantPairsSpacing_;
-    double importantPairsGap = (maxSize)*nonImportantPairsGap * 1.05;
-    bool customimportantPairsSpacing_
-      = importantPairsGap < importantPairsSpacing_;
-    if(customimportantPairsSpacing_)
-      importantPairsGap = importantPairsSpacing_;
-
-    // ----- Positioning of branches and avoid conflict
-    for(auto leaf : leaves)
-      queueCrossing.emplace(leaf);
-    while(!queueCrossing.empty()) {
-      ftm::idNode node = queueCrossing.front();
-      queueCrossing.pop();
-      ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-
-      // Prepositioning of branches
-      // auto restrictedBounds = getBranchBounds(retVec, treeSimplexId,
-      // branching, tree, nodeOrigin, true);
-      auto restrictedBounds = std::make_tuple(
-        retVec[treeSimplexId[node] * 2], retVec[treeSimplexId[node] * 2], 0, 0);
-      for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
-        ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
-        ftm::idNode branchNode = tree->getNode(branchNodeOrigin)->getOrigin();
-
-        bool isSubBranchImportant
-          = tree->isImportantPair<dataType>(branchNodeOrigin, importantPairs_);
-        bool toLeft = not isSubBranchImportant;
-
-        // float branchNodeOriginXmin =
-        // std::get<0>(allBranchBounds[branchNodeOrigin]);
-        float branchNodeOriginXmax
-          = std::get<1>(allBranchBounds[branchNodeOrigin]);
-        float shift
-          = toLeft ? std::get<0>(restrictedBounds) - branchNodeOriginXmax :
-                   // std::get<1>(restrictedBounds) - branchNodeOriginXmin;
-              std::get<1>(restrictedBounds)
-                - retVec[treeSimplexId[branchNode] * 2];
-        shift += (toLeft ? -1 : 1)
-                 * (isSubBranchImportant ? importantPairsGap
-                                         : nonImportantPairsGap);
-        // shift += (toLeft ? -1 : 1) * nonImportantPairsGap;
-        shiftBranchBounds(retVec, treeSimplexId, branching, allBranchBounds,
-                          allBranchOrigins[branchNodeOrigin], tree,
-                          branchNodeOrigin, shift);
-      }
-
-      // Shift a branch if conflict with another one
-      for(size_t i = 1; i < allBranchOrigins[nodeOrigin].size(); ++i) {
-        ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
-        ftm::idNode branchNode = tree->getNode(branchNodeOrigin)->getOrigin();
-        for(size_t j = 0; j < i; ++j) {
-          auto first = allBranchBounds[branchNodeOrigin];
-          ftm::idNode previousBranchNodeOrigin
-            = allBranchOrigins[nodeOrigin][j];
-          auto second = allBranchBounds[previousBranchNodeOrigin];
-
-          bool branchConflict = isConflictingBranchAndBound(
-            first, second, tree, previousBranchNodeOrigin, retVec,
-            treeSimplexId);
-          if(isConflictingBounds(first, second) or branchConflict) {
-
-            // Get left or right orientation given the branch
-            int lastIndex = nodeBranching[branchNodeOrigin].size() - 1;
-            bool isLeft
-              = (retVec
-                   [treeSimplexId[nodeBranching[branchNodeOrigin][lastIndex]]
-                    * 2]
-                 //< retVec[treeSimplexId[nodeOrigin]*2]);
-                 < retVec[treeSimplexId[node] * 2]);
-
-            // Get shift
-            float branchNodeOriginXmax = std::get<1>(first);
-            float previousbranchNodeOriginXmin = std::get<0>(second);
-            // float branchNodeOriginXmin = std::get<0>(first);
-            float previousbranchNodeOriginXmax = std::get<1>(second);
-            float shift
-              = isLeft ? previousbranchNodeOriginXmin - branchNodeOriginXmax :
-                       // previousbranchNodeOriginXmax - branchNodeOriginXmin;
-                  previousbranchNodeOriginXmax
-                    - retVec[treeSimplexId[branchNode] * 2];
-            bool isSubBranchImportant = tree->isImportantPair<dataType>(
-              branchNodeOrigin, importantPairs_);
-            shift += (isLeft ? -1 : 1)
-                     * (isSubBranchImportant ? importantPairsGap
-                                             : nonImportantPairsGap);
-            // shift += (isLeft ? -1 : 1) * nonImportantPairsGap;
-
-            // Shift bounds
-            shiftBranchBounds(retVec, treeSimplexId, branching, allBranchBounds,
-                              allBranchOrigins[branchNodeOrigin], tree,
-                              branchNodeOrigin, shift);
-          }
-        }
-      } // end for
-
-      // TODO optimize get branch bounds by using results previously computed
-      // Get branch x and y bounds
-      allBranchBounds[nodeOrigin]
-        = getBranchBounds(retVec, treeSimplexId, branching, tree, nodeOrigin);
-    } // end while
-
-    // ----- Correction of important/non-important pairs gap
-    // TODO the gap between important pairs can be higher than the minimum gap
-    // needed to avoid conflict. The gap is computed using the maximum number of
-    // non-important pairs attached to an inmportant pairs Unfortunately the
-    // real gap can only be computed here, after the conflicts has been avoided.
-    // The maximum real gap must be calculated and propagated to all important
-    // branches and we also need to manage to avoid conflict with this new gap.
-    // Get real gap
-    double realImportantPairsGap = std::numeric_limits<double>::lowest();
-    /*if(customimportantPairsSpacing_)
-      realImportantPairsGap = importantPairsGap;
-    else{
+      // ----- Get important and non-important pairs gap and store saddle nodes
+      // of each branch
+      int maxSize = std::numeric_limits<int>::lowest();
       for(auto leaf : leaves)
         queueCrossing.emplace(leaf);
-      while(!queueCrossing.empty()){
+      while(!queueCrossing.empty()) {
         ftm::idNode node = queueCrossing.front();
         queueCrossing.pop();
         ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-        //if(isRoot(tree, nodeOrigin)) continue; // TODO manage root gap and gap
-    for the others
 
-        bool isBranchImportant = isImportantPair<dataType>(tree, nodeOrigin,
-    importantPairs_); if(not isBranchImportant) continue;
+        // Get saddle nodes in the branch
+        std::tuple<std::vector<ftm::idNode>, std::vector<ftm::idNode>>
+          tupBranchOrigins;
+        tree->getBranchOriginsFromThisBranch(nodeOrigin, tupBranchOrigins);
+        allBranchOrigins[nodeOrigin] = std::get<0>(tupBranchOrigins);
+        std::vector<ftm::idNode> nonBranchOrigins
+          = std::get<1>(tupBranchOrigins);
+        allBranchOrigins[nodeOrigin].insert(allBranchOrigins[nodeOrigin].end(),
+                                            nonBranchOrigins.begin(),
+                                            nonBranchOrigins.end());
+        std::sort(allBranchOrigins[nodeOrigin].begin(),
+                  allBranchOrigins[nodeOrigin].end(), compValue);
+        allBranchOriginsSize[nodeOrigin] = allBranchOrigins[nodeOrigin].size();
 
-        double gap = retVec[treeSimplexId[node]*2] -
-    std::get<0>(allBranchBounds[nodeOrigin]); realImportantPairsGap =
-    std::max(gap, realImportantPairsGap);
-      }
-      realImportantPairsGap *= 1.05;
-    }*/
-    realImportantPairsGap = importantPairsGap;
-
-    // Shift given real gap
-    for(auto leaf : leaves)
-      queueCrossing.emplace(leaf);
-    while(!queueCrossing.empty()) {
-      ftm::idNode node = queueCrossing.front();
-      queueCrossing.pop();
-      ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
-
-      bool isBranchImportant
-        = tree->isImportantPair<dataType>(nodeOrigin, importantPairs_);
-      if(not isBranchImportant)
-        continue;
-
-      for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
-        ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
-        bool isSubBranchImportant
-          = tree->isImportantPair<dataType>(branchNodeOrigin, importantPairs_);
-        double shift = 0;
-        if(not isSubBranchImportant) {
-          double gap = retVec[treeSimplexId[node] * 2]
-                       - std::get<0>(allBranchBounds[nodeOrigin]);
-          shift = -(realImportantPairsGap - gap) * nonImportantPairsProximity_;
-        } else {
-          shift = -(
-            importantPairsGap
-            - realImportantPairsGap); // TODO multi shift depending on conflict
+        // Get sizes of sub-branches if they are non-important
+        for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
+          ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
+          bool isSubBranchImportant = tree->isImportantPair<dataType>(
+            branchNodeOrigin, importantPairs_);
+          if(not isSubBranchImportant)
+            allBranchOriginsSize[nodeOrigin]
+              += allBranchOriginsSize[branchNodeOrigin];
         }
-        shiftBranchBounds(retVec, treeSimplexId, branching, allBranchBounds,
-                          allBranchOrigins[branchNodeOrigin], tree,
-                          branchNodeOrigin, shift);
+
+        if(tree->isImportantPair<dataType>(nodeOrigin, importantPairs_))
+          maxSize = std::max(maxSize, allBranchOriginsSize[nodeOrigin]);
       }
+      double nonImportantPairsGap
+        = (rootYmax - rootYmin) * 0.005 * nonImportantPairsSpacing_;
+      double importantPairsGap = (maxSize)*nonImportantPairsGap * 1.05;
+      bool customimportantPairsSpacing_
+        = importantPairsGap < importantPairsSpacing_;
+      if(customimportantPairsSpacing_)
+        importantPairsGap = importantPairsSpacing_;
+
+      // ----- Positioning of branches and avoid conflict
+      for(auto leaf : leaves)
+        queueCrossing.emplace(leaf);
+      while(!queueCrossing.empty()) {
+        ftm::idNode node = queueCrossing.front();
+        queueCrossing.pop();
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+
+        // Prepositioning of branches
+        // auto restrictedBounds = getBranchBounds(retVec, treeSimplexId,
+        // branching, tree, nodeOrigin, true);
+        auto restrictedBounds
+          = std::make_tuple(retVec[treeSimplexId[node] * 2],
+                            retVec[treeSimplexId[node] * 2], 0, 0);
+        for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
+          ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
+          ftm::idNode branchNode = tree->getNode(branchNodeOrigin)->getOrigin();
+
+          bool isSubBranchImportant = tree->isImportantPair<dataType>(
+            branchNodeOrigin, importantPairs_);
+          bool toLeft = not isSubBranchImportant;
+
+          // float branchNodeOriginXmin =
+          // std::get<0>(allBranchBounds[branchNodeOrigin]);
+          float branchNodeOriginXmax
+            = std::get<1>(allBranchBounds[branchNodeOrigin]);
+          float shift
+            = toLeft ? std::get<0>(restrictedBounds) - branchNodeOriginXmax :
+                     // std::get<1>(restrictedBounds) - branchNodeOriginXmin;
+                std::get<1>(restrictedBounds)
+                  - retVec[treeSimplexId[branchNode] * 2];
+          shift += (toLeft ? -1 : 1)
+                   * (isSubBranchImportant ? importantPairsGap
+                                           : nonImportantPairsGap);
+          // shift += (toLeft ? -1 : 1) * nonImportantPairsGap;
+          shiftBranchBounds(retVec, treeSimplexId, branching, allBranchBounds,
+                            allBranchOrigins[branchNodeOrigin], tree,
+                            branchNodeOrigin, shift);
+        }
+
+        // Shift a branch if conflict with another one
+        for(size_t i = 1; i < allBranchOrigins[nodeOrigin].size(); ++i) {
+          ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
+          ftm::idNode branchNode = tree->getNode(branchNodeOrigin)->getOrigin();
+          for(size_t j = 0; j < i; ++j) {
+            auto first = allBranchBounds[branchNodeOrigin];
+            ftm::idNode previousBranchNodeOrigin
+              = allBranchOrigins[nodeOrigin][j];
+            auto second = allBranchBounds[previousBranchNodeOrigin];
+
+            bool branchConflict = isConflictingBranchAndBound(
+              first, second, tree, previousBranchNodeOrigin, retVec,
+              treeSimplexId);
+            if(isConflictingBounds(first, second) or branchConflict) {
+
+              // Get left or right orientation given the branch
+              int lastIndex = nodeBranching[branchNodeOrigin].size() - 1;
+              bool isLeft
+                = (retVec
+                     [treeSimplexId[nodeBranching[branchNodeOrigin][lastIndex]]
+                      * 2]
+                   //< retVec[treeSimplexId[nodeOrigin]*2]);
+                   < retVec[treeSimplexId[node] * 2]);
+
+              // Get shift
+              float branchNodeOriginXmax = std::get<1>(first);
+              float previousbranchNodeOriginXmin = std::get<0>(second);
+              // float branchNodeOriginXmin = std::get<0>(first);
+              float previousbranchNodeOriginXmax = std::get<1>(second);
+              float shift
+                = isLeft ? previousbranchNodeOriginXmin - branchNodeOriginXmax :
+                         // previousbranchNodeOriginXmax - branchNodeOriginXmin;
+                    previousbranchNodeOriginXmax
+                      - retVec[treeSimplexId[branchNode] * 2];
+              bool isSubBranchImportant = tree->isImportantPair<dataType>(
+                branchNodeOrigin, importantPairs_);
+              shift += (isLeft ? -1 : 1)
+                       * (isSubBranchImportant ? importantPairsGap
+                                               : nonImportantPairsGap);
+              // shift += (isLeft ? -1 : 1) * nonImportantPairsGap;
+
+              // Shift bounds
+              shiftBranchBounds(retVec, treeSimplexId, branching,
+                                allBranchBounds,
+                                allBranchOrigins[branchNodeOrigin], tree,
+                                branchNodeOrigin, shift);
+            }
+          }
+        } // end for
+
+        // TODO optimize get branch bounds by using results previously computed
+        // Get branch x and y bounds
+        allBranchBounds[nodeOrigin]
+          = getBranchBounds(retVec, treeSimplexId, branching, tree, nodeOrigin);
+      } // end while
+
+      // ----- Correction of important/non-important pairs gap
+      // TODO the gap between important pairs can be higher than the minimum gap
+      // needed to avoid conflict. The gap is computed using the maximum number
+      // of non-important pairs attached to an inmportant pairs Unfortunately
+      // the real gap can only be computed here, after the conflicts has been
+      // avoided. The maximum real gap must be calculated and propagated to all
+      // important branches and we also need to manage to avoid conflict with
+      // this new gap. Get real gap
+      double realImportantPairsGap = std::numeric_limits<double>::lowest();
+      /*if(customimportantPairsSpacing_)
+        realImportantPairsGap = importantPairsGap;
+      else{
+        for(auto leaf : leaves)
+          queueCrossing.emplace(leaf);
+        while(!queueCrossing.empty()){
+          ftm::idNode node = queueCrossing.front();
+          queueCrossing.pop();
+          ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+          //if(isRoot(tree, nodeOrigin)) continue; // TODO manage root gap and
+      gap for the others
+
+          bool isBranchImportant = isImportantPair<dataType>(tree, nodeOrigin,
+      importantPairs_); if(not isBranchImportant) continue;
+
+          double gap = retVec[treeSimplexId[node]*2] -
+      std::get<0>(allBranchBounds[nodeOrigin]); realImportantPairsGap =
+      std::max(gap, realImportantPairsGap);
+        }
+        realImportantPairsGap *= 1.05;
+      }*/
+      realImportantPairsGap = importantPairsGap;
+
+      // Shift given real gap
+      for(auto leaf : leaves)
+        queueCrossing.emplace(leaf);
+      while(!queueCrossing.empty()) {
+        ftm::idNode node = queueCrossing.front();
+        queueCrossing.pop();
+        ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
+
+        bool isBranchImportant
+          = tree->isImportantPair<dataType>(nodeOrigin, importantPairs_);
+        if(not isBranchImportant)
+          continue;
+
+        for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
+          ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
+          bool isSubBranchImportant = tree->isImportantPair<dataType>(
+            branchNodeOrigin, importantPairs_);
+          double shift = 0;
+          if(not isSubBranchImportant) {
+            double gap = retVec[treeSimplexId[node] * 2]
+                         - std::get<0>(allBranchBounds[nodeOrigin]);
+            shift
+              = -(realImportantPairsGap - gap) * nonImportantPairsProximity_;
+          } else {
+            shift = -(importantPairsGap
+                      - realImportantPairsGap); // TODO multi shift depending on
+                                                // conflict
+          }
+          shiftBranchBounds(retVec, treeSimplexId, branching, allBranchBounds,
+                            allBranchOrigins[branchNodeOrigin], tree,
+                            branchNodeOrigin, shift);
+        }
+      }
+
+      std::stringstream ss6;
+      ss6 << "AVOID CROSSING  = " << t_avoid.getElapsedTime();
+      printMsg(ss6.str(), debug::Priority::VERBOSE);
+      printMsg(debug::Separator::L2, debug::Priority::VERBOSE);
     }
 
-    std::stringstream ss6;
-    ss6 << "AVOID CROSSING  = " << t_avoid.getElapsedTime();
-    printMsg(ss6.str(), debug::Priority::VERBOSE);
-    printMsg(debug::Separator::L2, debug::Priority::VERBOSE);
-  }
-
-  template <class dataType>
-  void treePlanarLayout(
-    FTMTree_MT *tree,
-    std::tuple<double, double, double, double, double, double> oldBounds,
-    double refPersistence,
-    std::vector<float> &res) {
-    treePlanarLayoutImpl<dataType>(tree, oldBounds, refPersistence, res);
-  }
-
-  // ==========================================================================
-  // Bounds Utils
-  // ==========================================================================
-  void printTuple(std::tuple<float, float, float, float> tup) {
-    printMsg(debug::Separator::L2, debug::Priority::VERBOSE);
-    std::stringstream ss;
-    ss << std::get<0>(tup) << " _ " << std::get<1>(tup) << " _ "
-       << std::get<2>(tup) << " _ " << std::get<3>(tup) << " _ ";
-    printMsg(ss.str(), debug::Priority::VERBOSE);
-  }
-
-  // Branchroot must be a non-leaf node
-  std::tuple<float, float, float, float>
-    getBranchBounds(std::vector<float> &retVec,
-                    std::vector<LongSimplexId> &treeSimplexId,
-                    std::vector<ftm::idNode> &branching,
-                    FTMTree_MT *tree,
-                    ftm::idNode branchRoot,
-                    bool restricted = false) {
-    float x_min = std::numeric_limits<float>::max();
-    float y_min = std::numeric_limits<float>::max();
-    float x_max = std::numeric_limits<float>::lowest();
-    float y_max = std::numeric_limits<float>::lowest();
-
-    std::queue<ftm::idNode> queue;
-    queue.emplace(branchRoot);
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-
-      // Skip if we go in the branch in which is branchRoot
-      if(branching[node] != branchRoot
-         and tree->getParentSafe(node) == branchRoot and node != branchRoot)
-        continue;
-
-      // Skip if restricted
-      if(restricted and !tree->isLeaf(node) and branching[node] != branchRoot
-         and node != branchRoot)
-        continue;
-
-      y_min = std::min(y_min, retVec[treeSimplexId[node] * 2 + 1]);
-      y_max = std::max(y_max, retVec[treeSimplexId[node] * 2 + 1]);
-      if(node != branchRoot) {
-        x_min = std::min(x_min, retVec[treeSimplexId[node] * 2]);
-        x_max = std::max(x_max, retVec[treeSimplexId[node] * 2]);
-      }
-
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue.emplace(child);
+    template <class dataType>
+    void treePlanarLayout(
+      ftm::FTMTree_MT *tree,
+      std::tuple<double, double, double, double, double, double> oldBounds,
+      double refPersistence,
+      std::vector<float> &res) {
+      treePlanarLayoutImpl<dataType>(tree, oldBounds, refPersistence, res);
     }
 
-    return std::make_tuple(x_min, x_max, y_min, y_max);
-  }
-
-  bool
-    isConflictingBoundsXOneWay(std::tuple<float, float, float, float> first,
-                               std::tuple<float, float, float, float> second) {
-    return (std::get<0>(first) <= std::get<0>(second)
-            and std::get<0>(second) <= std::get<1>(first))
-           or (std::get<0>(first) <= std::get<1>(second)
-               and std::get<1>(second) <= std::get<1>(first));
-  }
-
-  bool isConflictingBoundsX(std::tuple<float, float, float, float> first,
-                            std::tuple<float, float, float, float> second) {
-    return isConflictingBoundsXOneWay(first, second)
-           or isConflictingBoundsXOneWay(second, first);
-  }
-
-  bool
-    isConflictingBoundsYOneWay(std::tuple<float, float, float, float> first,
-                               std::tuple<float, float, float, float> second) {
-    return (std::get<2>(first) <= std::get<2>(second)
-            and std::get<2>(second) <= std::get<3>(first))
-           or (std::get<2>(first) <= std::get<3>(second)
-               and std::get<3>(second) <= std::get<3>(first));
-  }
-
-  bool isConflictingBoundsY(std::tuple<float, float, float, float> first,
-                            std::tuple<float, float, float, float> second) {
-    return isConflictingBoundsYOneWay(first, second)
-           or isConflictingBoundsYOneWay(second, first);
-  }
-
-  bool isConflictingBounds(std::tuple<float, float, float, float> first,
-                           std::tuple<float, float, float, float> second) {
-    return isConflictingBoundsX(first, second)
-           and isConflictingBoundsY(first, second);
-  }
-
-  bool
-    isConflictingBranchAndBound(std::tuple<float, float, float, float> first,
-                                std::tuple<float, float, float, float> second,
-                                FTMTree_MT *tree,
-                                ftm::idNode branchNodeOrigin,
-                                std::vector<float> &retVec,
-                                std::vector<LongSimplexId> &treeSimplexId) {
-    float xBranchNodeOrigin = retVec[treeSimplexId[branchNodeOrigin] * 2];
-    float xBranchNode
-      = retVec[treeSimplexId[tree->getNode(branchNodeOrigin)->getOrigin()] * 2];
-    float myMin = std::min(xBranchNode, xBranchNodeOrigin);
-    float myMax = std::max(xBranchNode, xBranchNodeOrigin);
-    auto branchBounds = std::make_tuple(myMin, myMax, 0, 0);
-    return isConflictingBoundsX(first, branchBounds)
-           and isConflictingBoundsY(first, second);
-  }
-
-  std::tuple<float, float, float, float>
-    shiftBranchBoundsTuple(std::tuple<float, float, float, float> branchBound,
-                           float realShift) {
-    return std::make_tuple(std::get<0>(branchBound) + realShift,
-                           std::get<1>(branchBound) + realShift,
-                           std::get<2>(branchBound), std::get<3>(branchBound));
-  }
-
-  void shiftBranchBounds(
-    std::vector<float> &retVec,
-    std::vector<LongSimplexId> &treeSimplexId,
-    std::vector<ftm::idNode> &branching,
-    std::vector<std::tuple<float, float, float, float>> &allBranchBounds,
-    std::vector<ftm::idNode> &branchOrigins,
-    FTMTree_MT *tree,
-    ftm::idNode branchRoot,
-    float shift) {
-    std::queue<ftm::idNode> queue;
-    queue.emplace(branchRoot);
-    while(!queue.empty()) {
-      ftm::idNode node = queue.front();
-      queue.pop();
-
-      if(branching[node] != branchRoot
-         and tree->getParentSafe(node) == branchRoot and node != branchRoot)
-        continue;
-
-      if(node != branchRoot)
-        retVec[treeSimplexId[node] * 2] += shift;
-
-      std::vector<idNode> children;
-      tree->getChildren(node, children);
-      for(auto child : children)
-        queue.emplace(child);
+    // ==========================================================================
+    // Bounds Utils
+    // ==========================================================================
+    void printTuple(std::tuple<float, float, float, float> tup) {
+      printMsg(debug::Separator::L2, debug::Priority::VERBOSE);
+      std::stringstream ss;
+      ss << std::get<0>(tup) << " _ " << std::get<1>(tup) << " _ "
+         << std::get<2>(tup) << " _ " << std::get<3>(tup) << " _ ";
+      printMsg(ss.str(), debug::Priority::VERBOSE);
     }
-    allBranchBounds[branchRoot]
-      = shiftBranchBoundsTuple(allBranchBounds[branchRoot], shift);
-    for(auto node : branchOrigins)
-      allBranchBounds[node]
-        = shiftBranchBoundsTuple(allBranchBounds[node], shift);
-  }
 
-  void tupleToVector(
-    std::tuple<double, double, double, double, double, double> &tup,
-    std::vector<double> &vec) {
-    vec = std::vector<double>{std::get<0>(tup), std::get<1>(tup),
-                              std::get<2>(tup), std::get<3>(tup),
-                              std::get<4>(tup), std::get<5>(tup)};
-  }
+    // Branchroot must be a non-leaf node
+    std::tuple<float, float, float, float>
+      getBranchBounds(std::vector<float> &retVec,
+                      std::vector<LongSimplexId> &treeSimplexId,
+                      std::vector<ftm::idNode> &branching,
+                      ftm::FTMTree_MT *tree,
+                      ftm::idNode branchRoot,
+                      bool restricted = false) {
+      float x_min = std::numeric_limits<float>::max();
+      float y_min = std::numeric_limits<float>::max();
+      float x_max = std::numeric_limits<float>::lowest();
+      float y_max = std::numeric_limits<float>::lowest();
 
-  std::tuple<double, double, double, double, double, double>
-    vectorToTuple(std::vector<double> &vec) {
-    return std::make_tuple(vec[0], vec[1], vec[2], vec[3], vec[4], vec[5]);
-  }
+      std::queue<ftm::idNode> queue;
+      queue.emplace(branchRoot);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
 
-  std::tuple<double, double, double, double, double, double> getMaximalBounds(
-    std::vector<std::tuple<double, double, double, double, double, double>>
-      &allBounds,
-    std::vector<int> &clusteringAssignmentT,
-    int clusterID) {
-    double x_min = std::numeric_limits<double>::max();
-    double y_min = std::numeric_limits<double>::max();
-    double z_min = std::numeric_limits<double>::max();
-    double x_max = std::numeric_limits<double>::lowest();
-    double y_max = std::numeric_limits<double>::lowest();
-    double z_max = std::numeric_limits<double>::lowest();
-    for(size_t i = 0; i < allBounds.size(); ++i)
-      if(clusteringAssignmentT[i] == clusterID) {
-        x_min = std::min(x_min, std::get<0>(allBounds[i]));
-        x_max = std::max(x_max, std::get<1>(allBounds[i]));
-        y_min = std::min(y_min, std::get<2>(allBounds[i]));
-        y_max = std::max(y_max, std::get<3>(allBounds[i]));
-        z_min = std::min(z_min, std::get<4>(allBounds[i]));
-        z_max = std::max(z_max, std::get<5>(allBounds[i]));
+        // Skip if we go in the branch in which is branchRoot
+        if(branching[node] != branchRoot
+           and tree->getParentSafe(node) == branchRoot and node != branchRoot)
+          continue;
+
+        // Skip if restricted
+        if(restricted and !tree->isLeaf(node) and branching[node] != branchRoot
+           and node != branchRoot)
+          continue;
+
+        y_min = std::min(y_min, retVec[treeSimplexId[node] * 2 + 1]);
+        y_max = std::max(y_max, retVec[treeSimplexId[node] * 2 + 1]);
+        if(node != branchRoot) {
+          x_min = std::min(x_min, retVec[treeSimplexId[node] * 2]);
+          x_max = std::max(x_max, retVec[treeSimplexId[node] * 2]);
+        }
+
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(auto child : children)
+          queue.emplace(child);
       }
-    return std::make_tuple(x_min, x_max, y_min, y_max, z_min, z_max);
-  }
-};
 
-#endif
+      return std::make_tuple(x_min, x_max, y_min, y_max);
+    }
+
+    bool isConflictingBoundsXOneWay(
+      std::tuple<float, float, float, float> first,
+      std::tuple<float, float, float, float> second) {
+      return (std::get<0>(first) <= std::get<0>(second)
+              and std::get<0>(second) <= std::get<1>(first))
+             or (std::get<0>(first) <= std::get<1>(second)
+                 and std::get<1>(second) <= std::get<1>(first));
+    }
+
+    bool isConflictingBoundsX(std::tuple<float, float, float, float> first,
+                              std::tuple<float, float, float, float> second) {
+      return isConflictingBoundsXOneWay(first, second)
+             or isConflictingBoundsXOneWay(second, first);
+    }
+
+    bool isConflictingBoundsYOneWay(
+      std::tuple<float, float, float, float> first,
+      std::tuple<float, float, float, float> second) {
+      return (std::get<2>(first) <= std::get<2>(second)
+              and std::get<2>(second) <= std::get<3>(first))
+             or (std::get<2>(first) <= std::get<3>(second)
+                 and std::get<3>(second) <= std::get<3>(first));
+    }
+
+    bool isConflictingBoundsY(std::tuple<float, float, float, float> first,
+                              std::tuple<float, float, float, float> second) {
+      return isConflictingBoundsYOneWay(first, second)
+             or isConflictingBoundsYOneWay(second, first);
+    }
+
+    bool isConflictingBounds(std::tuple<float, float, float, float> first,
+                             std::tuple<float, float, float, float> second) {
+      return isConflictingBoundsX(first, second)
+             and isConflictingBoundsY(first, second);
+    }
+
+    bool
+      isConflictingBranchAndBound(std::tuple<float, float, float, float> first,
+                                  std::tuple<float, float, float, float> second,
+                                  ftm::FTMTree_MT *tree,
+                                  ftm::idNode branchNodeOrigin,
+                                  std::vector<float> &retVec,
+                                  std::vector<LongSimplexId> &treeSimplexId) {
+      float xBranchNodeOrigin = retVec[treeSimplexId[branchNodeOrigin] * 2];
+      float xBranchNode
+        = retVec[treeSimplexId[tree->getNode(branchNodeOrigin)->getOrigin()]
+                 * 2];
+      float myMin = std::min(xBranchNode, xBranchNodeOrigin);
+      float myMax = std::max(xBranchNode, xBranchNodeOrigin);
+      auto branchBounds = std::make_tuple(myMin, myMax, 0, 0);
+      return isConflictingBoundsX(first, branchBounds)
+             and isConflictingBoundsY(first, second);
+    }
+
+    std::tuple<float, float, float, float>
+      shiftBranchBoundsTuple(std::tuple<float, float, float, float> branchBound,
+                             float realShift) {
+      return std::make_tuple(std::get<0>(branchBound) + realShift,
+                             std::get<1>(branchBound) + realShift,
+                             std::get<2>(branchBound),
+                             std::get<3>(branchBound));
+    }
+
+    void shiftBranchBounds(
+      std::vector<float> &retVec,
+      std::vector<LongSimplexId> &treeSimplexId,
+      std::vector<ftm::idNode> &branching,
+      std::vector<std::tuple<float, float, float, float>> &allBranchBounds,
+      std::vector<ftm::idNode> &branchOrigins,
+      ftm::FTMTree_MT *tree,
+      ftm::idNode branchRoot,
+      float shift) {
+      std::queue<ftm::idNode> queue;
+      queue.emplace(branchRoot);
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+
+        if(branching[node] != branchRoot
+           and tree->getParentSafe(node) == branchRoot and node != branchRoot)
+          continue;
+
+        if(node != branchRoot)
+          retVec[treeSimplexId[node] * 2] += shift;
+
+        std::vector<ftm::idNode> children;
+        tree->getChildren(node, children);
+        for(auto child : children)
+          queue.emplace(child);
+      }
+      allBranchBounds[branchRoot]
+        = shiftBranchBoundsTuple(allBranchBounds[branchRoot], shift);
+      for(auto node : branchOrigins)
+        allBranchBounds[node]
+          = shiftBranchBoundsTuple(allBranchBounds[node], shift);
+    }
+
+    void tupleToVector(
+      std::tuple<double, double, double, double, double, double> &tup,
+      std::vector<double> &vec) {
+      vec = std::vector<double>{std::get<0>(tup), std::get<1>(tup),
+                                std::get<2>(tup), std::get<3>(tup),
+                                std::get<4>(tup), std::get<5>(tup)};
+    }
+
+    std::tuple<double, double, double, double, double, double>
+      vectorToTuple(std::vector<double> &vec) {
+      return std::make_tuple(vec[0], vec[1], vec[2], vec[3], vec[4], vec[5]);
+    }
+
+    std::tuple<double, double, double, double, double, double> getMaximalBounds(
+      std::vector<std::tuple<double, double, double, double, double, double>>
+        &allBounds,
+      std::vector<int> &clusteringAssignmentT,
+      int clusterID) {
+      double x_min = std::numeric_limits<double>::max();
+      double y_min = std::numeric_limits<double>::max();
+      double z_min = std::numeric_limits<double>::max();
+      double x_max = std::numeric_limits<double>::lowest();
+      double y_max = std::numeric_limits<double>::lowest();
+      double z_max = std::numeric_limits<double>::lowest();
+      for(size_t i = 0; i < allBounds.size(); ++i)
+        if(clusteringAssignmentT[i] == clusterID) {
+          x_min = std::min(x_min, std::get<0>(allBounds[i]));
+          x_max = std::max(x_max, std::get<1>(allBounds[i]));
+          y_min = std::min(y_min, std::get<2>(allBounds[i]));
+          y_max = std::max(y_max, std::get<3>(allBounds[i]));
+          z_min = std::min(z_min, std::get<4>(allBounds[i]));
+          z_max = std::max(z_max, std::get<5>(allBounds[i]));
+        }
+      return std::make_tuple(x_min, x_max, y_min, y_max, z_min, z_max);
+    }
+  };
+
+} // namespace ttk

--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -93,14 +93,12 @@ namespace ttk {
 
       inline int init(std::vector<LocalFTM> &ftmTree, Params params) {
         idSuperArc nbArcs = 0;
-        idSuperArc nbNodes = 0;
         idSuperArc samplePoints = 0;
         SimplexId nbVerts = 0;
 
         for(auto &t : ftmTree) {
           FTMTree_MT *tree = t.tree.getTree(params.treeType);
           nbArcs += tree->getNumberOfSuperArcs();
-          nbNodes += tree->getNumberOfNodes();
           samplePoints
             += params.samplingLvl >= 0
                  ? tree->getNumberOfNodes() + (nbArcs * params.samplingLvl)

--- a/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
@@ -33,9 +33,9 @@ namespace ttk {
       vtkSmartPointer<vtkDataArray> nodesScalar
         = treeNodes->GetPointData()->GetArray("Scalar"); // 1: Scalar
       scalars.size = nodesScalar->GetNumberOfTuples();
-      std::vector<dataType> scalarsValues;
+      std::vector<dataType> scalarsValues(nodesScalar->GetNumberOfTuples());
       for(int i = 0; i < nodesScalar->GetNumberOfTuples(); ++i)
-        scalarsValues.push_back(nodesScalar->GetTuple1(i));
+        scalarsValues[i] = nodesScalar->GetTuple1(i);
       // scalars.values = ttkUtils::GetVoidPointer(nodesScalar);
       scalars.values = (void *)(scalarsValues.data());
 

--- a/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
@@ -5,9 +5,6 @@
 ///
 /// Utils function for manipulating FTMTree class
 
-#ifndef _TTKFTMTREEUTILS_H
-#define _TTKFTMTREEUTILS_H
-
 #pragma once
 
 #include <FTMTree.h>
@@ -86,8 +83,8 @@ namespace ttk {
       return mergeTree;
     }
 
-    void loadBlocks(std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                    vtkMultiBlockDataSet *blocks) {
+    inline void loadBlocks(std::vector<vtkMultiBlockDataSet *> &inputTrees,
+                           vtkMultiBlockDataSet *blocks) {
       if(blocks != nullptr) {
         inputTrees.resize(blocks->GetNumberOfBlocks());
         for(size_t i = 0; i < inputTrees.size(); ++i) {
@@ -131,5 +128,3 @@ namespace ttk {
     }
   } // namespace ftm
 } // namespace ttk
-
-#endif

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -1,11 +1,11 @@
-#include <ttkMergeTreeClustering.h>
-//#include <ttkUtils.h>
 #include <FTMStructures.h>
 #include <FTMTree.h>
 #include <FTMTreeUtils.h>
 #include <MergeTreeUtils.h>
 #include <MergeTreeVisualization.h>
 #include <ttkFTMTreeUtils.h>
+#include <ttkMacros.h>
+#include <ttkMergeTreeClustering.h>
 #include <ttkMergeTreeVisualization.h>
 
 #include <vtkDataObject.h> // For port information

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -107,19 +107,21 @@ private:
   // Data for visualization
   // ----------------------
   // Trees
-  std::vector<MergeTree<double>> intermediateSTrees, intermediateSTrees2;
+  std::vector<ttk::ftm::MergeTree<double>> intermediateSTrees,
+    intermediateSTrees2;
   std::vector<vtkUnstructuredGrid *> treesNodes, treesNodes2;
   std::vector<vtkUnstructuredGrid *> treesArcs, treesArcs2;
   std::vector<vtkDataSet *> treesSegmentation, treesSegmentation2;
 
   // Matching
-  std::vector<std::tuple<idNode, idNode, double>> outputMatching;
-  std::vector<
-    std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>
+  std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>
+    outputMatching;
+  std::vector<std::vector<
+    std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>>>
     outputMatchingBarycenter, outputMatchingBarycenter2;
 
   // Barycenter
-  std::vector<MergeTree<double>> barycentersS;
+  std::vector<ttk::ftm::MergeTree<double>> barycentersS;
   std::vector<int> clusteringAssignment;
 
   // Node correspondence
@@ -130,8 +132,8 @@ private:
 
   void setDataVisualization(int numInputs, int numInputs2) {
     // Trees
-    intermediateSTrees = std::vector<MergeTree<double>>(numInputs);
-    intermediateSTrees2 = std::vector<MergeTree<double>>(numInputs2);
+    intermediateSTrees = std::vector<ttk::ftm::MergeTree<double>>(numInputs);
+    intermediateSTrees2 = std::vector<ttk::ftm::MergeTree<double>>(numInputs2);
     treesNodes = std::vector<vtkUnstructuredGrid *>(numInputs);
     treesNodes2 = std::vector<vtkUnstructuredGrid *>(numInputs2);
     treesArcs = std::vector<vtkUnstructuredGrid *>(numInputs);
@@ -140,20 +142,23 @@ private:
     treesSegmentation2 = std::vector<vtkDataSet *>(numInputs2);
 
     // Matching
-    outputMatchingBarycenter = std::vector<
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>(
+    outputMatchingBarycenter = std::vector<std::vector<
+      std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>>>(
       NumberOfBarycenters,
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>(
+      std::vector<
+        std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>>(
         numInputs));
 
-    outputMatchingBarycenter2 = std::vector<
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>(
+    outputMatchingBarycenter2 = std::vector<std::vector<
+      std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>>>(
       NumberOfBarycenters,
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>(
+      std::vector<
+        std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, double>>>(
         numInputs2));
 
     // Barycenter
-    barycentersS = std::vector<MergeTree<double>>(NumberOfBarycenters);
+    barycentersS
+      = std::vector<ttk::ftm::MergeTree<double>>(NumberOfBarycenters);
     clusteringAssignment = std::vector<int>(numInputs, 0);
   }
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -15,6 +15,9 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
+using namespace ttk;
+using namespace ttk::ftm;
+
 // A VTK macro that enables the instantiation of this class via ::New()
 // You do not have to modify this
 vtkStandardNewMacro(ttkMergeTreeTemporalReductionDecoding);

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -73,6 +73,8 @@ class TTKMERGETREETEMPORALREDUCTIONDECODING_EXPORT
                                                       // base class
 {
 private:
+  using idNode = ttk::ftm::idNode;
+
   // Output options
   bool OutputTrees = true;
   bool PlanarLayout = false;
@@ -97,9 +99,8 @@ private:
   std::vector<vtkDataSet *> treesSegmentation;
   // Output
   std::vector<std::vector<int>> treesNodeCorrMesh;
-  std::vector<MergeTree<double>> intermediateSTrees;
-  std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
-    allMatching;
+  std::vector<ttk::ftm::MergeTree<double>> intermediateSTrees;
+  std::vector<std::vector<std::tuple<idNode, idNode, double>>> allMatching;
 
   void setDataVisualization(int numInputs) {
     // Trees
@@ -111,9 +112,9 @@ private:
   void resetDataVisualization() {
     setDataVisualization(0);
     treesNodeCorrMesh = std::vector<std::vector<int>>();
-    intermediateSTrees = std::vector<MergeTree<double>>();
-    allMatching = std::vector<
-      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>();
+    intermediateSTrees = std::vector<ttk::ftm::MergeTree<double>>();
+    allMatching
+      = std::vector<std::vector<std::tuple<idNode, idNode, double>>>();
   }
 
   bool isDataVisualizationFilled() {

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -17,6 +17,9 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
+using namespace ttk;
+using namespace ttk::ftm;
+
 // A VTK macro that enables the instantiation of this class via ::New()
 // You do not have to modify this
 vtkStandardNewMacro(ttkMergeTreeTemporalReductionEncoding);
@@ -102,7 +105,7 @@ int ttkMergeTreeTemporalReductionEncoding::RequestData(
   // ------------------------------------------------------------------------------------
   // --- Load blocks
   // ------------------------------------------------------------------------------------
-  printMsg("Load blocks", debug::Priority::VERBOSE);
+  printMsg("Load blocks", ttk::debug::Priority::VERBOSE);
   std::vector<vtkMultiBlockDataSet *> inputTrees;
   loadBlocks(inputTrees, blocks);
   printMsg("Load blocks done.", debug::Priority::VERBOSE);

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -184,7 +184,7 @@ int ttkMergeTreeTemporalReductionEncoding::runCompute(
     for(size_t i = 0; i < images.size(); ++i) {
       auto array = images[i]->GetPointData()->GetArray("Scalars");
       for(vtkIdType j = 0; j < array->GetNumberOfTuples(); ++j)
-        fieldL2_[i].push_back(static_cast<double>(array->GetTuple1(j)));
+        fieldL2_[i].push_back(array->GetTuple1(j));
     }
   }
 

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -65,7 +65,7 @@ private:
   // Output
   std::vector<std::vector<int>> treesNodeCorrMesh;
   std::vector<double> emptyTreeDistances;
-  std::vector<MergeTree<double>> keyFrames;
+  std::vector<ttk::ftm::MergeTree<double>> keyFrames;
   std::vector<int> removed;
 
   void setDataVisualization(int numInputs) {
@@ -79,7 +79,7 @@ private:
     setDataVisualization(0);
     treesNodeCorrMesh = std::vector<std::vector<int>>();
     emptyTreeDistances = std::vector<double>();
-    keyFrames = std::vector<MergeTree<double>>();
+    keyFrames = std::vector<ttk::ftm::MergeTree<double>>();
     removed = std::vector<int>();
   }
 

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionUtils.h
@@ -4,8 +4,7 @@
 /// \date 2021.
 ///
 
-#ifndef _TTKMERGETREETEMPORALREDUCTIONUTILS_H
-#define _TTKMERGETREETEMPORALREDUCTIONUTILS_H
+#pragma once
 
 #include <FTMTreeUtils.h>
 
@@ -13,23 +12,21 @@
 #include <vtkPointData.h>
 #include <vtkUnstructuredGrid.h>
 
-using namespace ttk;
-using namespace ftm;
-
 // -------------------------------------------------------------------------------------
 // Temporal Subsampling
 // -------------------------------------------------------------------------------------
 template <class dataType>
 void makeTemporalSubsamplingOutput(
-  std::vector<MergeTree<dataType>> &intermediateMTrees,
-  std::vector<std::vector<double>> &embedding,
-  std::vector<MergeTree<dataType>> &allMT,
-  std::vector<int> removed,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
-  bool displayRemoved = false) {
+  const std::vector<ttk::ftm::MergeTree<dataType>> &intermediateMTrees,
+  const std::vector<std::vector<double>> &embedding,
+  const std::vector<ttk::ftm::MergeTree<dataType>> &ttkNotUsed(allMT),
+  const std::vector<int> &removed,
+  vtkUnstructuredGrid *const vtkOutputNode1,
+  vtkUnstructuredGrid *const vtkOutputArc1,
+  const bool displayRemoved = false) {
+
   auto fullSize = intermediateMTrees.size() + removed.size();
-  std::vector<SimplexId> nodeSimplexId(fullSize);
+  std::vector<ttk::SimplexId> nodeSimplexId(fullSize);
   vtkNew<vtkIntArray> treeId{};
   treeId->SetName("TreeId");
   vtkNew<vtkIntArray> nodePathId{};
@@ -43,9 +40,8 @@ void makeTemporalSubsamplingOutput(
   vtkNew<vtkIntArray> arcId{};
   arcId->SetName("ArcId");
 
-  vtkSmartPointer<vtkUnstructuredGrid> vtkArcs
-    = vtkSmartPointer<vtkUnstructuredGrid>::New();
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkUnstructuredGrid> vtkArcs{};
+  vtkNew<vtkPoints> points{};
   for(unsigned int i = 0; i < embedding[0].size(); ++i) {
     if(not displayRemoved and i >= intermediateMTrees.size())
       continue;
@@ -185,20 +181,20 @@ void makeTemporalSubsamplingOutput(
 
 template <class dataType>
 void makeTemporalSubsamplingETDOutput(
-  std::vector<MergeTree<dataType>> &intermediateMTrees,
-  std::vector<double> &emptyTreeDistances,
-  std::vector<MergeTree<dataType>> &allMT,
-  std::vector<int> removed,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc1,
-  double DistanceAxisStretch) {
-  std::vector<std::vector<double>> embedding(2);
-  for(int i = 0; i < (int)intermediateMTrees.size() + (int)removed.size();
-      ++i) {
+  const std::vector<ttk::ftm::MergeTree<dataType>> &intermediateMTrees,
+  const std::vector<double> &emptyTreeDistances,
+  const std::vector<ttk::ftm::MergeTree<dataType>> &allMT,
+  const std::vector<int> removed,
+  vtkUnstructuredGrid *const vtkOutputNode1,
+  vtkUnstructuredGrid *const vtkOutputArc1,
+  const double DistanceAxisStretch) {
+
+  std::array<std::vector<double>, 2> embedding{};
+  for(size_t i = 0; i < intermediateMTrees.size() + removed.size(); ++i) {
     double y = emptyTreeDistances[i] * DistanceAxisStretch;
     double x = i;
-    if(i >= (int)intermediateMTrees.size())
-      x = removed[i - (int)intermediateMTrees.size()];
+    if(i >= intermediateMTrees.size())
+      x = removed[i - intermediateMTrees.size()];
 
     embedding[0].push_back(x);
     embedding[1].push_back(y);
@@ -209,5 +205,3 @@ void makeTemporalSubsamplingETDOutput(
                                           removed, vtkOutputNode1,
                                           vtkOutputArc1);
 }
-
-#endif

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -4,7 +4,6 @@
 /// \date 2021.
 ///
 /// Visualization module for merge trees.
-///
 
 #pragma once
 
@@ -23,8 +22,13 @@
 #include <vtkPoints.h>
 #include <vtkUnstructuredGrid.h>
 
-class ttkMergeTreeVisualization : public MergeTreeVisualization {
+class ttkMergeTreeVisualization : public ttk::MergeTreeVisualization {
 private:
+  // redefine types
+  using idNode = ttk::ftm::idNode;
+  using SimplexId = ttk::SimplexId;
+  using FTMTree_MT = ttk::ftm::FTMTree_MT;
+
   // Visualization parameters
   bool PlanarLayout = false;
   double DimensionSpacing = 1.;
@@ -57,8 +61,7 @@ private:
 
   // Clustering output
   std::vector<int> clusteringAssignment;
-  std::vector<
-    std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>
+  std::vector<std::vector<std::vector<std::tuple<idNode, idNode, double>>>>
     outputMatchingBarycenter;
 
   // Barycenter output
@@ -169,8 +172,7 @@ public:
     clusteringAssignment = asgn;
   }
   void setOutputMatchingBarycenter(
-    std::vector<
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>
+    std::vector<std::vector<std::vector<std::tuple<idNode, idNode, double>>>>
       &matching) {
     outputMatchingBarycenter = matching;
   }
@@ -217,13 +219,11 @@ public:
     vtkOutputMatching = vtkMatching;
   }
   void setOutputMatching(
-    std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching) {
+    std::vector<std::tuple<idNode, idNode, double>> &matching) {
     outputMatchingBarycenter = std::vector<
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>>(
-      1);
+      std::vector<std::vector<std::tuple<idNode, idNode, double>>>>(1);
     outputMatchingBarycenter[0]
-      = std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>(
-        1);
+      = std::vector<std::vector<std::tuple<idNode, idNode, double>>>(1);
     outputMatchingBarycenter[0][0] = matching;
   }
 
@@ -281,7 +281,8 @@ public:
     matchingPercentMatch->SetName("MatchingPercentMatch");
 
     // Iterate through clusters and trees
-    printMsg("// Iterate through clusters and trees", debug::Priority::VERBOSE);
+    printMsg(
+      "// Iterate through clusters and trees", ttk::debug::Priority::VERBOSE);
     int count = 0;
     for(int c = 0; c < NumberOfBarycenters; ++c) {
       for(int i = 0; i < numInputs; ++i) {
@@ -293,8 +294,8 @@ public:
         for(std::tuple<idNode, idNode, double> match :
             outputMatchingBarycenter[c][i]) {
           vtkIdType pointIds[2];
-          ftm::idNode tree1NodeId = std::get<0>(match);
-          ftm::idNode tree2NodeId = std::get<1>(match);
+          idNode tree1NodeId = std::get<0>(match);
+          idNode tree2NodeId = std::get<1>(match);
           double cost = std::get<2>(match);
           FTMTree_MT *tree1;
           FTMTree_MT *tree2 = trees[i];
@@ -305,7 +306,7 @@ public:
             tree1 = barycenters[c];
 
           // Get first point
-          printMsg("// Get first point", debug::Priority::VERBOSE);
+          printMsg("// Get first point", ttk::debug::Priority::VERBOSE);
           SimplexId pointToGet1 = clusteringOutput ? nodeCorr2[c][tree1NodeId]
                                                    : nodeCorr1[0][tree1NodeId];
           double *point1 = vtkOutputNode2->GetPoints()->GetPoint(pointToGet1);
@@ -313,7 +314,7 @@ public:
           pointIds[0] = nextPointId1;
 
           // Get second point
-          printMsg("// Get second point", debug::Priority::VERBOSE);
+          printMsg("// Get second point", ttk::debug::Priority::VERBOSE);
           SimplexId pointToGet2 = clusteringOutput ? nodeCorr1[i][tree2NodeId]
                                                    : nodeCorr1[1][tree2NodeId];
           double *point2 = vtkOutputNode1->GetPoints()->GetPoint(pointToGet2);
@@ -321,17 +322,19 @@ public:
           pointIds[1] = nextPointId2;
 
           // Add cell
-          printMsg("// Add cell", debug::Priority::VERBOSE);
+          printMsg("// Add cell", ttk::debug::Priority::VERBOSE);
           vtkMatching->InsertNextCell(VTK_LINE, 2, pointIds);
 
           // Add arc matching percentage
-          printMsg("// Add arc matching percentage", debug::Priority::VERBOSE);
+          printMsg(
+            "// Add arc matching percentage", ttk::debug::Priority::VERBOSE);
           if(allBaryPercentMatch.size() != 0)
             matchingPercentMatch->InsertNextTuple1(
               allBaryPercentMatch[c][tree1NodeId]);
 
           // Add tree1 and tree2 node ids
-          printMsg("// Add tree1 and tree2 node ids", debug::Priority::VERBOSE);
+          printMsg(
+            "// Add tree1 and tree2 node ids", ttk::debug::Priority::VERBOSE);
           tree1NodeIdField->InsertNextTuple1(pointToGet1);
           tree2NodeIdField->InsertNextTuple1(pointToGet2);
 
@@ -339,7 +342,7 @@ public:
           matchingID->InsertNextTuple1(count);
 
           // Add matching type
-          printMsg("// Add matching type", debug::Priority::VERBOSE);
+          printMsg("// Add matching type", ttk::debug::Priority::VERBOSE);
           int thisType = 0;
           int tree1NodeDown
             = tree1->getNode(tree1NodeId)->getNumberOfDownSuperArcs();
@@ -361,7 +364,8 @@ public:
           matchingType->InsertNextTuple1(thisType);
 
           // Add mean matched persistence
-          printMsg("// Add mean matched persistence", debug::Priority::VERBOSE);
+          printMsg(
+            "// Add mean matched persistence", ttk::debug::Priority::VERBOSE);
           double tree1Pers = tree1->getNodePersistence<dataType>(tree1NodeId);
           double tree2Pers = tree2->getNodePersistence<dataType>(tree2NodeId);
           double meanPersistence = (tree1Pers + tree2Pers) / 2;
@@ -422,7 +426,7 @@ public:
       = std::max(NumberOfBarycenters, 1); // to always enter the outer loop
 
     // Bounds
-    printMsg("Bounds and branching", debug::Priority::VERBOSE);
+    printMsg("Bounds and branching", ttk::debug::Priority::VERBOSE);
     std::vector<std::tuple<double, double, double, double, double, double>>
       allBounds(numInputs);
     for(int i = 0; i < numInputs; ++i) {
@@ -446,7 +450,7 @@ public:
     }
     std::vector<std::tuple<double, double, double, double, double, double>>
       allBaryBounds(barycenters.size());
-    std::vector<std::vector<ftm::idNode>> allBaryBranching(barycenters.size());
+    std::vector<std::vector<idNode>> allBaryBranching(barycenters.size());
     std::vector<std::vector<int>> allBaryBranchingID(barycenters.size());
     for(size_t c = 0; c < barycenters.size(); ++c) {
       allBaryBounds[c] = getMaximalBounds(allBounds, clusteringAssignment, c);
@@ -460,7 +464,7 @@ public:
     // ----------------------------------------------------------------------
     // Make Trees Output
     // ----------------------------------------------------------------------
-    printMsg("--- Make Trees Output", debug::Priority::VERBOSE);
+    printMsg("--- Make Trees Output", ttk::debug::Priority::VERBOSE);
     std::vector<FTMTree_MT *> treesOri(trees);
     if(ShiftMode == 1) { // Star Barycenter
       trees.clear();
@@ -547,12 +551,12 @@ public:
     // --------------------------------------------------------
     // Iterate through all clusters
     // --------------------------------------------------------
-    printMsg("Iterate through all clusters", debug::Priority::VERBOSE);
+    printMsg("Iterate through all clusters", ttk::debug::Priority::VERBOSE);
     double importantPairsOriginal = importantPairs_;
     for(int c = 0; c < NumberOfBarycenters; ++c) {
 
       // Get radius
-      printMsg("// Get radius", debug::Priority::VERBOSE);
+      printMsg("// Get radius", ttk::debug::Priority::VERBOSE);
       double delta_max = std::numeric_limits<double>::lowest();
       int noSample = 0 + noSampleOffset;
       for(int i = 0; i < numInputsOri; ++i) {
@@ -578,8 +582,8 @@ public:
       // ------------------------------------------
       // Iterate through all trees of this cluster
       // ------------------------------------------
-      printMsg(
-        "Iterate through all trees of this cluster", debug::Priority::VERBOSE);
+      printMsg("Iterate through all trees of this cluster",
+               ttk::debug::Priority::VERBOSE);
       for(int i = 0; i < numInputs; ++i) {
         if(clusteringAssignment[i] != c)
           continue;
@@ -595,7 +599,7 @@ public:
         // Manage important pairs threshold
         importantPairs_ = importantPairsOriginal;
         if(MaximumImportantPairs > 0 or MinimumImportantPairs > 0) {
-          std::vector<std::tuple<ftm::idNode, ftm::idNode, dataType>> pairs;
+          std::vector<std::tuple<idNode, idNode, dataType>> pairs;
           trees[i]->getPersistencePairsFromTree(pairs, false);
           if(MaximumImportantPairs > 0) {
             double tempThreshold
@@ -620,13 +624,13 @@ public:
         foundOneInterpolatedTree |= isInterpolatedTree;
 
         // Get branching
-        printMsg("// Get branching", debug::Priority::VERBOSE);
-        std::vector<ftm::idNode> treeBranching;
+        printMsg("// Get branching", ttk::debug::Priority::VERBOSE);
+        std::vector<idNode> treeBranching;
         std::vector<int> treeBranchingID;
         trees[i]->getTreeBranching(treeBranching, treeBranchingID);
 
         // Get shift
-        printMsg("// Get shift", debug::Priority::VERBOSE);
+        printMsg("// Get shift", ttk::debug::Priority::VERBOSE);
         double angle = 360.0 / noSample * iSample;
         double pi = 3.14159265359;
         double diff_x = 0, diff_y = 0;
@@ -658,7 +662,7 @@ public:
         }
 
         // Get dimension shift
-        printMsg("// Get dimension shift", debug::Priority::VERBOSE);
+        printMsg("// Get dimension shift", ttk::debug::Priority::VERBOSE);
         double diff_z = PlanarLayout ? 0 : -std::get<4>(allBounds[i]);
         // TODO DimensionToShift for Planar Layout
         if(not PlanarLayout)
@@ -671,7 +675,7 @@ public:
           }
 
         // Planar layout
-        printMsg("// Planar Layout", debug::Priority::VERBOSE);
+        printMsg("// Planar Layout", ttk::debug::Priority::VERBOSE);
         std::vector<float> layout;
         if(PlanarLayout) {
           double refPersistence;
@@ -686,21 +690,20 @@ public:
         }
 
         // Internal arrays
-        printMsg("// Internal arrays", debug::Priority::VERBOSE);
+        printMsg("// Internal arrays", ttk::debug::Priority::VERBOSE);
         int cptNode = 0;
         nodeCorr[i] = std::vector<SimplexId>(trees[i]->getNumberOfNodes());
         std::vector<SimplexId> treeSimplexId(trees[i]->getNumberOfNodes());
         std::vector<SimplexId> treeDummySimplexId(trees[i]->getNumberOfNodes());
         std::vector<SimplexId> layoutCorr(trees[i]->getNumberOfNodes());
-        std::vector<ftm::idNode> treeMatching(trees[i]->getNumberOfNodes(), -1);
+        std::vector<idNode> treeMatching(trees[i]->getNumberOfNodes(), -1);
         if(clusteringOutput)
           for(auto match : outputMatchingBarycenter[c][i])
             treeMatching[std::get<1>(match)] = std::get<0>(match);
         // _ m[i][j] contains the node in treesOri[j] matched to the node i in
         // the barycenter
-        std::vector<std::vector<ftm::idNode>> baryMatching(
-          trees[i]->getNumberOfNodes(),
-          std::vector<ftm::idNode>(numInputsOri, -1));
+        std::vector<std::vector<idNode>> baryMatching(
+          trees[i]->getNumberOfNodes(), std::vector<idNode>(numInputsOri, -1));
         if(ShiftMode == 1) {
           for(size_t j = 0; j < outputMatchingBarycenter[c].size(); ++j)
             for(auto match : outputMatchingBarycenter[c][j])
@@ -712,7 +715,7 @@ public:
         // ----------------------------
         // Tree traversal
         // ----------------------------
-        printMsg("// Tree traversal", debug::Priority::VERBOSE);
+        printMsg("// Tree traversal", ttk::debug::Priority::VERBOSE);
         std::queue<idNode> queue;
         queue.emplace(trees[i]->getRoot());
         while(!queue.empty()) {
@@ -721,7 +724,8 @@ public:
           idNode nodeOrigin = trees[i]->getNode(node)->getOrigin();
 
           // Push children to the queue
-          printMsg("// Push children to the queue", debug::Priority::VERBOSE);
+          printMsg(
+            "// Push children to the queue", ttk::debug::Priority::VERBOSE);
           std::vector<idNode> children;
           trees[i]->getChildren(node, children);
           for(auto child : children)
@@ -730,7 +734,7 @@ public:
           // --------------
           // Insert point
           // --------------
-          printMsg("// Get and insert point", debug::Priority::VERBOSE);
+          printMsg("// Get and insert point", ttk::debug::Priority::VERBOSE);
           int nodeMesh = -1;
           int nodeMeshTreeIndex = -1;
           double noMatched = 0.0;
@@ -793,12 +797,13 @@ public:
           // --------------
           // Insert cell connecting parent
           // --------------
-          printMsg("// Add cell connecting parent", debug::Priority::VERBOSE);
+          printMsg(
+            "// Add cell connecting parent", ttk::debug::Priority::VERBOSE);
           if(!trees[i]->isRoot(node)) {
             vtkIdType pointIds[2];
             pointIds[0] = treeSimplexId[node];
 
-            ftm::idNode nodeParent = trees[i]->getParentSafe(node);
+            idNode nodeParent = trees[i]->getParentSafe(node);
             // TODO too many dummy cells are created
             bool dummyCell = PlanarLayout
                              and not branchDecompositionPlanarLayout_
@@ -833,7 +838,8 @@ public:
                   allBaryPercentMatch[c][allBaryBranching[c][node]]);
 
               // Add branch bary ID
-              printMsg("// Push arc bary branch id", debug::Priority::VERBOSE);
+              printMsg(
+                "// Push arc bary branch id", ttk::debug::Priority::VERBOSE);
               if(clusteringOutput and ShiftMode != 1) {
                 int tBranchID = -1;
                 if(treeMatching[node] < allBaryBranchingID[c].size()) {
@@ -854,7 +860,8 @@ public:
               downNodeId->InsertNextTuple1(treeSimplexId[node]);
 
               // Add arc persistence
-              printMsg("// Push arc persistence", debug::Priority::VERBOSE);
+              printMsg(
+                "// Push arc persistence", ttk::debug::Priority::VERBOSE);
               idNode nodeToGetPers = treeBranching[node];
               if(PlanarLayout and branchDecompositionPlanarLayout_)
                 nodeToGetPers = node;
@@ -911,7 +918,7 @@ public:
             scalar->InsertNextTuple1(trees[i]->getValue<dataType>(node));
 
             // Add criticalType
-            printMsg("// Add criticalType", debug::Priority::VERBOSE);
+            printMsg("// Add criticalType", ttk::debug::Priority::VERBOSE);
             int criticalTypeT = -1;
             if(not isInterpolatedTree) {
               if(ShiftMode == 1) {
@@ -939,7 +946,8 @@ public:
             }
 
             // Add node branch bary id
-            printMsg("// Add node bary branch id", debug::Priority::VERBOSE);
+            printMsg(
+              "// Add node bary branch id", ttk::debug::Priority::VERBOSE);
             if(clusteringOutput and ShiftMode != 1) {
               int tBranchID = -1;
               if(treeMatching[node] < allBaryBranchingID[c].size()) {
@@ -958,7 +966,7 @@ public:
             branchNodeID->InsertNextTuple1(tBranchID);
 
             // Add node persistence
-            printMsg("// Push node persistence", debug::Priority::VERBOSE);
+            printMsg("// Push node persistence", ttk::debug::Priority::VERBOSE);
             persistenceNode->InsertNextTuple1(
               trees[i]->getNodePersistence<dataType>(node));
 
@@ -992,13 +1000,13 @@ public:
             pointCount++;
           }
 
-          printMsg("end loop", debug::Priority::VERBOSE);
+          printMsg("end loop", ttk::debug::Priority::VERBOSE);
         } // end tree traversal
 
         // --------------
         // Manage segmentation
         // --------------
-        printMsg("// Shift segmentation", debug::Priority::VERBOSE);
+        printMsg("// Shift segmentation", ttk::debug::Priority::VERBOSE);
         if(OutputSegmentation and not PlanarLayout) {
           vtkNew<vtkUnstructuredGrid> iTreesSegmentationCopy{};
           iTreesSegmentationCopy->DeepCopy(treesSegmentation[i]);
@@ -1023,7 +1031,7 @@ public:
       persistenceBaryArc->InsertNextTuple1(0);
 
     // --- Add VTK arrays to output
-    printMsg("// Add VTK arrays to output", debug::Priority::VERBOSE);
+    printMsg("// Add VTK arrays to output", ttk::debug::Priority::VERBOSE);
     // Manage node output
     vtkOutputNode->SetPoints(points);
     vtkOutputNode->GetPointData()->AddArray(criticalType);

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -8,11 +8,9 @@
 
 #pragma once
 
+#include <FTMTree.h>
 #include <MergeTreeVisualization.h>
 
-#include <FTMTree.h>
-
-#include <Debug.h>
 #include <ttkAlgorithm.h>
 
 // VTK Includes
@@ -24,11 +22,6 @@
 #include <vtkPointData.h>
 #include <vtkPoints.h>
 #include <vtkUnstructuredGrid.h>
-
-#include <stack>
-
-using namespace ttk;
-using namespace ftm;
 
 class ttkMergeTreeVisualization : public MergeTreeVisualization {
 private:
@@ -75,15 +68,14 @@ private:
   std::vector<bool> interpolatedTrees;
 
   // Output
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode;
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputArc;
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation;
+  vtkUnstructuredGrid *vtkOutputNode{};
+  vtkUnstructuredGrid *vtkOutputArc{};
+  vtkUnstructuredGrid *vtkOutputSegmentation{};
 
   // Matching output
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1,
-    vtkOutputNode2; // input data
+  vtkUnstructuredGrid *vtkOutputNode1{}, *vtkOutputNode2{}; // input data
   std::vector<std::vector<SimplexId>> nodeCorr1, nodeCorr2;
-  vtkSmartPointer<vtkUnstructuredGrid> vtkOutputMatching; // output
+  vtkUnstructuredGrid *vtkOutputMatching{}; // output
 
   // Filled by the algorithm
   std::vector<std::vector<SimplexId>> nodeCorr;
@@ -198,22 +190,21 @@ public:
   }
 
   // Output
-  void setVtkOutputNode(vtkSmartPointer<vtkUnstructuredGrid> vtkNode) {
+  void setVtkOutputNode(vtkUnstructuredGrid *vtkNode) {
     vtkOutputNode = vtkNode;
   }
-  void setVtkOutputArc(vtkSmartPointer<vtkUnstructuredGrid> vtkArc) {
+  void setVtkOutputArc(vtkUnstructuredGrid *vtkArc) {
     vtkOutputArc = vtkArc;
   }
-  void setVtkOutputSegmentation(
-    vtkSmartPointer<vtkUnstructuredGrid> vtkSegmentation) {
+  void setVtkOutputSegmentation(vtkUnstructuredGrid *vtkSegmentation) {
     vtkOutputSegmentation = vtkSegmentation;
   }
 
   // Matching output
-  void setVtkOutputNode1(vtkSmartPointer<vtkUnstructuredGrid> vtkNode1) {
+  void setVtkOutputNode1(vtkUnstructuredGrid *vtkNode1) {
     vtkOutputNode1 = vtkNode1;
   }
-  void setVtkOutputNode2(vtkSmartPointer<vtkUnstructuredGrid> vtkNode2) {
+  void setVtkOutputNode2(vtkUnstructuredGrid *vtkNode2) {
     vtkOutputNode2 = vtkNode2;
   }
   void setNodeCorr1(std::vector<std::vector<SimplexId>> &nodeCorrT) {
@@ -222,7 +213,7 @@ public:
   void setNodeCorr2(std::vector<std::vector<SimplexId>> &nodeCorrT) {
     nodeCorr2 = nodeCorrT;
   }
-  void setVtkOutputMatching(vtkSmartPointer<vtkUnstructuredGrid> vtkMatching) {
+  void setVtkOutputMatching(vtkUnstructuredGrid *vtkMatching) {
     vtkOutputMatching = vtkMatching;
   }
   void setOutputMatching(
@@ -269,9 +260,8 @@ public:
     if(not clusteringOutput)
       numInputs = 1;
 
-    vtkSmartPointer<vtkUnstructuredGrid> vtkMatching
-      = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    vtkSmartPointer<vtkPoints> pointsM = vtkSmartPointer<vtkPoints>::New();
+    vtkNew<vtkUnstructuredGrid> vtkMatching{};
+    vtkNew<vtkPoints> pointsM{};
 
     // Fields
     vtkNew<vtkIntArray> matchingID{};
@@ -482,9 +472,8 @@ public:
       numInputs = trees.size();
     }
     // - Declare VTK arrays
-    vtkSmartPointer<vtkUnstructuredGrid> vtkArcs
-      = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+    vtkNew<vtkUnstructuredGrid> vtkArcs{};
+    vtkNew<vtkPoints> points{};
 
     // Node fields
     vtkNew<vtkIntArray> criticalType{};
@@ -545,8 +534,7 @@ public:
     persistenceBaryArc->SetName("PersistenceBarycenter");
 
     // Segmentation
-    vtkSmartPointer<vtkAppendFilter> appendFilter
-      = vtkSmartPointer<vtkAppendFilter>::New();
+    vtkNew<vtkAppendFilter> appendFilter{};
 
     // Internal data
     int cellCount = 0;
@@ -1012,8 +1000,7 @@ public:
         // --------------
         printMsg("// Shift segmentation", debug::Priority::VERBOSE);
         if(OutputSegmentation and not PlanarLayout) {
-          auto iTreesSegmentationCopy
-            = vtkSmartPointer<vtkUnstructuredGrid>::New();
+          vtkNew<vtkUnstructuredGrid> iTreesSegmentationCopy{};
           iTreesSegmentationCopy->DeepCopy(treesSegmentation[i]);
           auto iVkOutputSegmentationTemp
             = vtkUnstructuredGrid::SafeDownCast(iTreesSegmentationCopy);

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -157,11 +157,11 @@ int ttkPlanarGraphLayout::mergeTreePlanarLayoutCallTemplate(
   vtkUnstructuredGrid *treeNodes,
   vtkUnstructuredGrid *treeArcs,
   vtkUnstructuredGrid *output) {
-  MergeTree<dataType> mergeTree = makeTree<dataType>(treeNodes, treeArcs);
-  FTMTree_MT *tree = &(mergeTree.tree);
+  auto mergeTree = ttk::ftm::makeTree<dataType>(treeNodes, treeArcs);
+  ttk::ftm::FTMTree_MT *tree = &(mergeTree.tree);
   // tree->printTree2();
 
-  computePersistencePairs<dataType>(tree);
+  ttk::ftm::computePersistencePairs<dataType>(tree);
 
   std::vector<std::vector<int>> treeNodeCorrMesh(1);
   treeNodeCorrMesh[0] = std::vector<int>(tree->getNumberOfNodes());


### PR DESCRIPTION
This PR fixes some compiler/style issues in the FTMTree/PlanarGraphLayout/MergeTreeClustering/MergeTreeDistanceMatrix/MergeTreeTemporalReduction/AssignmentSolver modules.

The following changes have been performed:
* removing the `using namespace` directives from header files, as it propagate to every source file that includes it,
* using double variables to avoid integer divisions in templated code,
* replacing copies or inefficient allocations with more performant code,
* placing base code in the `ttk` namespace.

Most of these issues were detected using the `clang-tidy` linter tool.

No change detected in the relevant ttk-data state files.

Enjoy,
Pierre