### PR TITLE
Fix static analysis warnings

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2396,12 +2396,13 @@ namespace ttk {
     /**
      * Compute the barycenter of the points of the given edge identifier.
      */
-    inline int getEdgeIncenter(SimplexId edgeId, float incenter[3]) const {
-      SimplexId vertexId[2];
+    inline int getEdgeIncenter(const SimplexId edgeId,
+                               float incenter[3]) const {
+      std::array<SimplexId, 2> vertexId{};
       getEdgeVertex(edgeId, 0, vertexId[0]);
       getEdgeVertex(edgeId, 1, vertexId[1]);
 
-      float p[6];
+      std::array<float, 6> p{};
       getVertexPoint(vertexId[0], p[0], p[1], p[2]);
       getVertexPoint(vertexId[1], p[3], p[4], p[5]);
 
@@ -2415,10 +2416,10 @@ namespace ttk {
     /**
      * Compute the incenter of the points of the given triangle identifier.
      */
-    inline int getTriangleIncenter(SimplexId triangleId,
+    inline int getTriangleIncenter(const SimplexId triangleId,
                                    float incenter[3]) const {
 
-      SimplexId vertexId[3];
+      std::array<SimplexId, 3> vertexId{};
       if(getDimensionality() == 2) {
         getCellVertex(triangleId, 0, vertexId[0]);
         getCellVertex(triangleId, 1, vertexId[1]);
@@ -2429,15 +2430,15 @@ namespace ttk {
         getTriangleVertex(triangleId, 2, vertexId[2]);
       }
 
-      float p[9];
+      std::array<float, 9> p{};
       getVertexPoint(vertexId[0], p[0], p[1], p[2]);
       getVertexPoint(vertexId[1], p[3], p[4], p[5]);
       getVertexPoint(vertexId[2], p[6], p[7], p[8]);
 
-      float d[3];
-      d[0] = Geometry::distance(p + 3, p + 6);
-      d[1] = Geometry::distance(p, p + 6);
-      d[2] = Geometry::distance(p, p + 3);
+      std::array<float, 3> d{};
+      d[0] = Geometry::distance(&p[3], &p[6]);
+      d[1] = Geometry::distance(&p[0], &p[6]);
+      d[2] = Geometry::distance(&p[0], &p[3]);
       const float sum = d[0] + d[1] + d[2];
 
       d[0] = d[0] / sum;
@@ -2455,16 +2456,17 @@ namespace ttk {
      * Compute the barycenter of the incenters of the triangles of the given
        tetra identifier.
      */
-    inline int getTetraIncenter(SimplexId tetraId, float incenter[3]) const {
+    inline int getTetraIncenter(const SimplexId tetraId,
+                                float incenter[3]) const {
       incenter[0] = 0.0f;
       incenter[1] = 0.0f;
       incenter[2] = 0.0f;
 
-      float p[3];
+      std::array<float, 3> p{};
       for(int i = 0; i < 4; ++i) {
         SimplexId triangleId;
         getCellTriangle(tetraId, i, triangleId);
-        getTriangleIncenter(triangleId, p);
+        getTriangleIncenter(triangleId, p.data());
         incenter[0] += p[0];
         incenter[1] += p[1];
         incenter[2] += p[2];
@@ -2480,8 +2482,9 @@ namespace ttk {
     /**
      * Compute the geometric barycenter of a given cell.
      */
-    inline int
-      getCellIncenter(SimplexId cellid, int dim, float incenter[3]) const {
+    inline int getCellIncenter(const SimplexId cellid,
+                               const int dim,
+                               float incenter[3]) const {
       switch(dim) {
         case 0:
           getVertexPoint(cellid, incenter[0], incenter[1], incenter[2]);

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -207,7 +207,6 @@ namespace ttk {
         if((size_t)i >= treeData_.superArcs.size()) {
           std::cout << "[Merge Tree] get superArc on bad id :" << i;
           std::cout << " / " << treeData_.superArcs.size() << std::endl;
-          return nullptr;
         }
 #endif
         return &(treeData_.superArcs[i]);

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -286,8 +286,12 @@ namespace ttk {
     int flush();
 
     inline const Arc *getArc(const int &arcId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((arcId < 0) || (arcId >= (int)arcList_.size()))
-        return NULL;
+        this->printErr("Out-of-bounds access in getArc: element "
+                       + std::to_string(arcId) + " in list of size "
+                       + std::to_string(arcList_.size()));
+#endif // !TTK_ENABLE_KAMIKAZE
       return &(arcList_[arcId]);
     }
 
@@ -299,37 +303,53 @@ namespace ttk {
     }
 
     inline const Node *getNode(const int &nodeId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((nodeId < 0) || (nodeId >= (int)nodeList_.size()))
-        return NULL;
+        this->printErr("Out-of-bounds access in getNode: element "
+                       + std::to_string(nodeId) + " in list of size "
+                       + std::to_string(nodeList_.size()));
+#endif // !TTK_ENABLE_KAMIKAZE
       return &(nodeList_[nodeId]);
     }
 
     inline const Node *getNodeDownNeighbor(const Node *n,
                                            const int &neighborId) const {
-      if(!n)
-        return NULL;
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(n == nullptr)
+        this->printErr("Nullptr dereference in getNodeDownNeighbor");
+#endif // !TTK_ENABLE_KAMIKAZE
       return getNodeDownNeighbor(n - &(nodeList_[0]), neighborId);
     }
 
     inline const Node *getNodeDownNeighbor(const int &nodeId,
                                            const int &neighborId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((nodeId < 0) || (nodeId >= (int)nodeList_.size()))
-        return NULL;
+        this->printErr("Out-of-bounds access in getNodeDownNeighbor: element "
+                       + std::to_string(nodeId) + " in list of size "
+                       + std::to_string(nodeList_.size()));
+#endif // !TTK_ENABLE_KAMIKAZE
       return &(nodeList_[arcList_[nodeList_[nodeId].getDownArcId(neighborId)]
                            .getDownNodeId()]);
     }
 
     inline const Node *getNodeUpNeighbor(const Node *n,
                                          const int &neighborId) const {
-      if(!n)
-        return NULL;
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(n == nullptr)
+        this->printErr("Nullptr dereference in getNodeUpNeighbor");
+#endif // !TTK_ENABLE_KAMIKAZE
       return getNodeUpNeighbor(n - &(nodeList_[0]), neighborId);
     }
 
     inline const Node *getNodeUpNeighbor(const int &nodeId,
                                          const int &neighborId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((nodeId < 0) || (nodeId >= (int)nodeList_.size()))
-        return NULL;
+        this->printErr("Out-of-bounds access in getNodeUpNeighbor: element "
+                       + std::to_string(nodeId) + " in list of size "
+                       + std::to_string(nodeList_.size()));
+#endif // !TTK_ENABLE_KAMIKAZE
       return &(nodeList_[arcList_[nodeList_[nodeId].getUpArcId(neighborId)]
                            .getUpNodeId()]);
     }
@@ -376,8 +396,12 @@ namespace ttk {
       = nullptr) const;
 
     inline const SuperArc *getSuperArc(const int &superArcId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((superArcId < 0) || (superArcId >= (int)superArcList_.size()))
-        return NULL;
+        this->printErr("Out-of-bounds access in getSuperArc: element "
+                       + std::to_string(superArcId) + " in list of size "
+                       + std::to_string(superArcList_.size()));
+#endif // !TTK_ENABLE_KAMIKAZE
       return &(superArcList_[superArcId]);
     }
 
@@ -396,17 +420,26 @@ namespace ttk {
     }
 
     inline const SuperArc *getVertexSuperArc(const int &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
-        return NULL;
+        this->printErr("Out-of-bounds access in getVertexSuperArc: element "
+                       + std::to_string(vertexId) + " in list of size "
+                       + std::to_string(vertexNumber_));
       if(vertex2superArc_[vertexId] == -1)
-        return NULL;
+        this->printErr("Invalid super arc id for vertex "
+                       + std::to_string(vertexId));
+#endif // !TTK_ENABLE_KAMIKAZE
 
       return &(superArcList_[vertex2superArc_[vertexId]]);
     }
 
     inline int getVertexSuperArcId(const int &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
-        return -1;
+        this->printErr("Out-of-bounds access in getVertexSuperArcId: element "
+                       + std::to_string(vertexId) + " in list of size "
+                       + std::to_string(vertexNumber_));
+#endif // !TTK_ENABLE_KAMIKAZE
       return vertex2superArc_[vertexId];
     }
 

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -379,7 +379,6 @@ namespace ttk {
         if(i >= mt_data_.superArcs->size()) {
           std::cout << "[Merge Tree] get superArc on bad id :" << i;
           std::cout << " / " << mt_data_.superArcs->size() << std::endl;
-          return nullptr;
         }
 #endif
         return &((*mt_data_.superArcs)[i]);
@@ -390,7 +389,6 @@ namespace ttk {
         if(i >= mt_data_.superArcs->size()) {
           std::cout << "[Merge Tree] get superArc on bad id :" << i;
           std::cout << " / " << mt_data_.superArcs->size() << std::endl;
-          return nullptr;
         }
 #endif
         return &((*mt_data_.superArcs)[i]);

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -158,7 +158,8 @@ namespace ttk {
 
     template <typename Type>
     idSuperArc DynGraphNode<Type>::findRootArc(void) const {
-      return findRoot()->corArc_;
+      const auto root = findRoot();
+      return root != nullptr ? root->corArc_ : -1;
     }
 
     template <typename Type>

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -624,7 +624,7 @@ namespace ttk {
 
         segment.resize(propagation->segmentSize);
         IT segmentIndex = 0;
-        {
+        if(propagation->segmentSize > 0) {
           std::vector<IT> queue(propagation->segmentSize);
           IT queueIndex = 0;
 
@@ -701,7 +701,7 @@ namespace ttk {
           return 0;
 
         // print status
-        if(this->debugLevel_ < 4) {
+        if(this->debugLevel_ < 4 || nPropagations == 0) {
           this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
         } else {
 
@@ -944,7 +944,7 @@ namespace ttk {
             = std::numeric_limits<IT>::max();
         }
 
-        if(this->debugLevel_ < 4) {
+        if(this->debugLevel_ < 4 || nPropagations == 0) {
           this->printMsg("Computing Local Order of Segments ("
                            + std::to_string(nPropagations) + ")",
                          1, timer.getElapsedTime(), this->threadNumber_);

--- a/core/base/meshGraph/MeshGraph.h
+++ b/core/base/meshGraph/MeshGraph.h
@@ -477,7 +477,7 @@ int ttk::MeshGraph::execute2(
       IT no1 = n1 * 6;
 
       size_t q2 = q + i * outputPointsSubdivisonOffset;
-      for(float j = 1; j <= nSubdivisions; j++) {
+      for(size_t j = 1; j <= nSubdivisions; j++) {
         computeBezierPoint(no0, no1, q2, j / nSubdivisionsP1);
         computeBezierPoint(no0 + 3, no1 + 3, q2 + 3, j / nSubdivisionsP1);
 

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -315,7 +315,8 @@ int ttk::PersistenceDiagram::executePersistentSimplex(
     } else if(p.type == 1) {
       CTDiagram.emplace_back(
         p.birth, CriticalType::Saddle1, death,
-        isFinite ? CriticalType::Saddle2 : CriticalType::Local_maximum,
+        (isFinite && dim == 3) ? CriticalType::Saddle2
+                               : CriticalType::Local_maximum,
         inputScalars[death] - inputScalars[p.birth], p.type);
     } else if(p.type == 2) {
       CTDiagram.emplace_back(

--- a/core/base/rangeDrivenOctree/RangeDrivenOctree.h
+++ b/core/base/rangeDrivenOctree/RangeDrivenOctree.h
@@ -174,7 +174,7 @@ int ttk::RangeDrivenOctree::build(
         vertexId = cell[j];
       }
 
-      float p[3];
+      std::array<float, 3> p{};
       if(triangulation) {
         triangulation->getVertexPoint(vertexId, p[0], p[1], p[2]);
       } else {
@@ -236,7 +236,7 @@ int ttk::RangeDrivenOctree::build(
   for(SimplexId i = 0; i < vertexNumber_; i++) {
 
     // domain one
-    float p[3];
+    std::array<float, 3> p{};
     if(triangulation) {
       triangulation->getVertexPoint(i, p[0], p[1], p[2]);
     } else {

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.cpp
@@ -176,6 +176,9 @@ int ttkCinemaDarkroomShader::InitRenderer(vtkImageData *outputImage) {
     this->RenderWindow->OffScreenRenderingOn();
 
     auto windowAsOGL = vtkOpenGLRenderWindow::SafeDownCast(this->RenderWindow);
+    if(windowAsOGL == nullptr) {
+      return 0;
+    }
     windowAsOGL->SetSize(dim[0], dim[1]);
     windowAsOGL->Initialize();
 

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.cpp
@@ -261,7 +261,7 @@ bool Class::postprocess() {
   }
   const vtkIdType cinfosSize = cinfoCounter;
 
-  auto cinfosBufVtk = reinterpret_cast<vtkIdType *>(cinfosBuf);
+  vtkIdType *cinfosBufVtk{};
   if(!std::is_same<ttk::SimplexId, vtkIdType>::value) { // unlikely
     // Actually a warning would be in order-
     // what if conversion is not possible (e.g. too large indices)?
@@ -269,6 +269,8 @@ bool Class::postprocess() {
     for(ttk::SimplexId i = 0; i < cinfosSize; ++i)
       cinfosBufVtk[i] = vtkIdType(cinfosBuf[i]);
     delete[] cinfosBuf;
+  } else {
+    cinfosBufVtk = reinterpret_cast<vtkIdType *>(cinfosBuf);
   }
 
   auto cells = vtkSmartPointer<vtkCellArray>::New();

--- a/core/vtk/ttkStableManifoldPersistence/ttkStableManifoldPersistence.cpp
+++ b/core/vtk/ttkStableManifoldPersistence/ttkStableManifoldPersistence.cpp
@@ -112,6 +112,13 @@ int ttkStableManifoldPersistence::AttachPersistence(vtkDataSet *output) const {
     output->GetCellData()->AddArray(persistenceArray);
     output->GetCellData()->AddArray(pairTypeArray);
   } else {
+
+    if((IsUnstable && descendingManifoldArray == nullptr)
+       || ascendingManifoldArray == nullptr) {
+      this->printErr("Missing array");
+      return -4;
+    }
+
     int vertexNumber = output->GetNumberOfPoints();
 
     persistenceArray->SetNumberOfTuples(vertexNumber);

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -62,16 +62,9 @@ public:
 
 protected:
   ttkTrackingFromOverlap() {
-    SetLabelFieldName("RegionId");
-
-    UseAllCores = false;
-
     SetNumberOfInputPorts(1);
     SetNumberOfOutputPorts(1);
   }
-
-  bool UseAllCores;
-  int ThreadNumber;
 
   int reset();
 
@@ -120,7 +113,7 @@ protected:
 
 private:
   int LabelDataType;
-  std::string LabelFieldName;
+  std::string LabelFieldName{"RegionId"};
 
   vtkSmartPointer<vtkMultiBlockDataSet> previousIterationData;
 

--- a/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
+++ b/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
@@ -367,8 +367,8 @@ int ttkWebSocketIO::SendVtkDataObject(vtkDataObject *object) {
       "Serializing vtkDataObject", 0.4, 0, ttk::debug::LineMode::REPLACE);
 
     // send points if last input is a vtkPointSet
-    if(block->IsA("vtkPointSet")) {
-      auto blockAsPS = vtkPointSet::SafeDownCast(block);
+    auto blockAsPS = vtkPointSet::SafeDownCast(block);
+    if(blockAsPS != nullptr) {
       auto points = blockAsPS->GetPoints();
       this->queueMessage(
         "{"
@@ -382,7 +382,7 @@ int ttkWebSocketIO::SendVtkDataObject(vtkDataObject *object) {
         + ","
           "\"nComponents\": 3"
           "}");
-      if(blockAsPS->GetNumberOfPoints() > 0)
+      if(blockAsPS->GetNumberOfPoints() > 0 && points != nullptr)
         switch(points->GetDataType()) {
           vtkTemplateMacro(this->queueMessage(
             blockAsPS->GetNumberOfPoints() * sizeof(VTK_TT) * 3,


### PR DESCRIPTION
This PR fixes some warnings detected either by GCC with the `-Wnull-dereference` flag enabled or by Clang's Static Analyzer. Those fixes includes:
* replacing C arrays with zero-initialized `std::array`s in the Triangulation modules to avoid garbage values,
* avoid returning `nullptr`s in ContourTree and FTMTree, with (helpful?) message errors in non KAMIKAZE mode,
*  adding more checks to avoid segfaults or divisions by zero.

This also reduces the number of warnings in the `check_code / lint-code` CI job.

No change observed in the ttk-data states files.

Enjoy,
Pierre
