### PR TITLE
Add new Persistence Diagram backend

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -495,7 +495,9 @@ jobs:
 # VTK 9, no rendering
 
 - job:
-  condition: true
+  # disable Windows job as it runs longer than the 1h maximum timeout
+  # (and is redundant with the Windows GitHub Action test CI)
+  condition: false
   displayName: Windows-VTK
   strategy:
     matrix:

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -15,5 +15,6 @@ ttk_add_base_library(common
         ProgramBase.h
         Shuffle.h
         Timer.h
+        VisitedMask.h
         Wrapper.h
         )

--- a/core/base/common/VisitedMask.h
+++ b/core/base/common/VisitedMask.h
@@ -1,0 +1,64 @@
+/// \ingroup base
+/// \class ttk::VisitedMask
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date November 2021.
+
+#pragma once
+
+#include <DataTypes.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace ttk {
+
+  /**
+   * @brief Auto-cleaning re-usable graph propagations data structure
+   *
+   * This structure stores two vector references. The first vector
+   * maps the nodes of a graph to a boolean (true if the node is
+   * visited, false if not). The second reference points to a vector
+   * that contains the visited nodes indices. Using RAII, the boolean
+   * vector is cleaned using the indices vector when this structure
+   * goes out of scope. See @ref
+   * ttk::MorseSmaleComplex3D::getSaddleConnectors for an example use.
+   *
+   */
+  struct VisitedMask {
+    std::vector<bool> &isVisited_;
+    std::vector<SimplexId> &visitedIds_;
+
+    VisitedMask(std::vector<bool> &isVisited,
+                std::vector<SimplexId> &visitedIds)
+      : isVisited_{isVisited}, visitedIds_{visitedIds} {
+    }
+
+    ~VisitedMask() {
+      // use RAII to clean & reset referenced vectors
+      for(const auto id : this->visitedIds_) {
+        this->isVisited_[id] = false;
+      }
+      // set size to 0 but keep allocated memory
+      this->visitedIds_.clear();
+    }
+
+    inline void insert(const SimplexId id) {
+      this->isVisited_[id] = true;
+      this->visitedIds_.emplace_back(id);
+    }
+
+    inline bool remove(const SimplexId id) {
+      if(!this->isVisited_[id]) {
+        return false;
+      }
+      const auto it
+        = std::find(this->visitedIds_.begin(), this->visitedIds_.end(), id);
+      if(it != this->visitedIds_.end()) {
+        this->visitedIds_.erase(it);
+      }
+      this->isVisited_[id] = false;
+      return true;
+    }
+  };
+
+} // namespace ttk

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -19,6 +19,7 @@
 #include <FTMTree.h>
 #include <Geometry.h>
 #include <Triangulation.h>
+#include <VisitedMask.h>
 
 #include <algorithm>
 #include <array>
@@ -272,28 +273,6 @@ namespace ttk {
         }
 
         return (vpathId1 < vpathId2);
-      }
-    };
-
-    struct VisitedMask {
-      std::vector<bool> &isVisited_;
-      std::vector<SimplexId> &visitedIds_;
-
-      VisitedMask(std::vector<bool> &isVisited,
-                  std::vector<SimplexId> &visitedIds)
-        : isVisited_{isVisited}, visitedIds_{visitedIds} {
-      }
-      ~VisitedMask() {
-        // use RAII to clean & reset referenced vectors
-        for(const auto id : this->visitedIds_) {
-          this->isVisited_[id] = false;
-        }
-        // set size to 0 but keep allocated memory
-        this->visitedIds_.clear();
-      }
-      void insert(SimplexId id) {
-        this->isVisited_[id] = true;
-        this->visitedIds_.emplace_back(id);
       }
     };
 

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -17,12 +17,12 @@
 #include <DiscreteGradient.h>
 
 using ttk::SimplexId;
+using ttk::VisitedMask;
 using ttk::dcg::Cell;
 using ttk::dcg::CellExt;
 using ttk::dcg::CriticalPoint;
 using ttk::dcg::DiscreteGradient;
 using ttk::dcg::SaddleSaddleVPathComparator;
-using ttk::dcg::VisitedMask;
 using ttk::dcg::VPath;
 
 template <typename dataType, typename triangulationType>

--- a/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
+++ b/core/base/morseSmaleComplex3D/MorseSmaleComplex3D.h
@@ -875,7 +875,7 @@ int ttk::MorseSmaleComplex3D::getSaddleConnectors(
     const auto &s2{saddles2[i]};
 
     std::set<SimplexId> saddles1{};
-    dcg::VisitedMask mask{isVisited, visitedTriangles};
+    VisitedMask mask{isVisited, visitedTriangles};
     discreteGradient_.getDescendingWall(
       s2, mask, triangulation, nullptr, &saddles1);
 
@@ -962,7 +962,7 @@ int ttk::MorseSmaleComplex3D::getAscendingSeparatrices2(
     const Cell &saddle1 = criticalPoints[saddleIndex];
 
     std::vector<Cell> wall;
-    dcg::VisitedMask mask{isVisited, visitedEdges};
+    VisitedMask mask{isVisited, visitedEdges};
     discreteGradient_.getAscendingWall(
       saddle1, mask, triangulation, &wall, &separatricesSaddles[i]);
 
@@ -1013,7 +1013,7 @@ int ttk::MorseSmaleComplex3D::getDescendingSeparatrices2(
     const Cell &saddle2 = criticalPoints[saddleIndex];
 
     std::vector<Cell> wall;
-    dcg::VisitedMask mask{isVisited, visitedTriangles};
+    VisitedMask mask{isVisited, visitedTriangles};
     discreteGradient_.getDescendingWall(
       saddle2, mask, triangulation, &wall, &separatricesSaddles[i]);
 

--- a/core/base/persistenceDiagram/CMakeLists.txt
+++ b/core/base/persistenceDiagram/CMakeLists.txt
@@ -7,5 +7,6 @@ ttk_add_base_library(persistenceDiagram
     discreteGradient
     triangulation
     ftmTreePP
+    persistentSimplexPairs
     progressiveTopology
     )

--- a/core/base/persistentSimplexPairs/CMakeLists.txt
+++ b/core/base/persistentSimplexPairs/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(persistentSimplexPairs
+  SOURCES
+    PersistentSimplexPairs.cpp
+  HEADERS
+    PersistentSimplexPairs.h
+  DEPENDS
+    triangulation
+)

--- a/core/base/persistentSimplexPairs/PersistentSimplexPairs.cpp
+++ b/core/base/persistentSimplexPairs/PersistentSimplexPairs.cpp
@@ -1,0 +1,98 @@
+#include <PersistentSimplexPairs.h>
+
+ttk::PersistentSimplexPairs::PersistentSimplexPairs() {
+  this->setDebugMsgPrefix("PersistentSimplexPairs");
+}
+
+ttk::SimplexId ttk::PersistentSimplexPairs::eliminateBoundaries(
+  const Simplex &c,
+  VisitedMask &boundary,
+  const std::vector<SimplexId> &filtOrder,
+  const std::vector<Simplex> &partners) const {
+
+  this->addCellBoundary(c, boundary);
+
+  while(!boundary.visitedIds_.empty()) {
+    // youngest cell on boundary
+    const auto tau{*std::max_element(
+      boundary.visitedIds_.begin(), boundary.visitedIds_.end(),
+      [&filtOrder, &c, this](const SimplexId a, const SimplexId b) {
+        return filtOrder[getCellId(c.dim_ - 1, a)]
+               < filtOrder[getCellId(c.dim_ - 1, b)];
+      })};
+    const auto &partnerTau{partners[getCellId(c.dim_ - 1, tau)]};
+    if(partnerTau.dim_ == -1 || partnerTau.id_ == -1) {
+      return tau;
+    }
+    addCellBoundary(partnerTau, boundary);
+  }
+
+  return -1;
+}
+
+int ttk::PersistentSimplexPairs::pairCells(
+  std::vector<PersistencePair> &pairs,
+  std::array<std::vector<bool>, 3> &boundaries,
+  const std::vector<Simplex> &filtration,
+  const std::vector<SimplexId> &filtOrder) const {
+
+  // for VisitedMask
+  std::vector<SimplexId> visitedIds{};
+  // paired simplices
+  std::vector<Simplex> partners(filtration.size());
+
+  Timer tm{};
+
+  for(const auto &c : filtration) {
+
+    // skip vertices
+    if(c.dim_ == 0) {
+      continue;
+    }
+
+    // store the boundary cells
+    VisitedMask vm{boundaries[c.dim_ - 1], visitedIds};
+
+    const auto partner = eliminateBoundaries(c, vm, filtOrder, partners);
+    if(partner != -1) {
+      const auto &pc{filtration[filtOrder[getCellId(c.dim_ - 1, partner)]]};
+      partners[c.cellId_] = pc;
+      partners[pc.cellId_] = c;
+
+      // only record pairs with non-null persistence
+      if(c.vertsOrder_[0] != pc.vertsOrder_[0]) {
+        pairs.emplace_back(partner, c.id_, c.dim_ - 1);
+      }
+    }
+  }
+
+  const auto nRegPairs{pairs.size()};
+
+  this->printMsg("Computed " + std::to_string(nRegPairs) + " regular pair"
+                   + (nRegPairs > 1 ? "s" : ""),
+                 1.0, tm.getElapsedTime(), 1);
+
+  // get infinite pairs
+  for(SimplexId i = 0; i < this->nVerts_; ++i) {
+    if(partners[i].id_ == -1) {
+      pairs.emplace_back(i, -1, 0);
+    }
+  }
+  for(SimplexId i = 0; i < this->nEdges_; ++i) {
+    if(partners[i + this->nVerts_].id_ == -1) {
+      pairs.emplace_back(i, -1, 1);
+    }
+  }
+  for(SimplexId i = 0; i < this->nTri_; ++i) {
+    if(partners[i + this->nVerts_ + this->nEdges_].id_ == -1) {
+      pairs.emplace_back(i, -1, 2);
+    }
+  }
+
+  const auto nInfPairs{pairs.size() - nRegPairs};
+
+  this->printMsg("Detected " + std::to_string(nInfPairs) + " infinite pair"
+                 + (nInfPairs > 1 ? "s" : ""));
+
+  return 0;
+}

--- a/core/base/persistentSimplexPairs/PersistentSimplexPairs.cpp
+++ b/core/base/persistentSimplexPairs/PersistentSimplexPairs.cpp
@@ -78,14 +78,18 @@ int ttk::PersistentSimplexPairs::pairCells(
       pairs.emplace_back(i, -1, 0);
     }
   }
-  for(SimplexId i = 0; i < this->nEdges_; ++i) {
-    if(partners[i + this->nVerts_].id_ == -1) {
-      pairs.emplace_back(i, -1, 1);
+  if(this->nTri_ > 0) {
+    for(SimplexId i = 0; i < this->nEdges_; ++i) {
+      if(partners[i + this->nVerts_].id_ == -1) {
+        pairs.emplace_back(i, -1, 1);
+      }
     }
   }
-  for(SimplexId i = 0; i < this->nTri_; ++i) {
-    if(partners[i + this->nVerts_ + this->nEdges_].id_ == -1) {
-      pairs.emplace_back(i, -1, 2);
+  if(this->nTetra_ > 0) {
+    for(SimplexId i = 0; i < this->nTri_; ++i) {
+      if(partners[i + this->nVerts_ + this->nEdges_].id_ == -1) {
+        pairs.emplace_back(i, -1, 2);
+      }
     }
   }
 

--- a/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
+++ b/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
@@ -1,0 +1,284 @@
+/// \ingroup base
+/// \class ttk::PersistentSimplexPairs
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date November 2021.
+///
+/// \brief Textbook algorithm to find persistence pairs.
+///
+/// This algorithm is described in "Algorithm and Theory of
+/// Computation Handbook (Second Edition) - Special Topics and
+/// Techniques" by Atallah and Blanton on page 97.
+
+#pragma once
+
+#include <AbstractTriangulation.h>
+#include <Debug.h>
+#include <VisitedMask.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace ttk {
+
+  class PersistentSimplexPairs : virtual public Debug {
+  public:
+    PersistentSimplexPairs();
+
+    struct PersistencePair {
+      /** first (lower) vertex id */
+      SimplexId birth;
+      /** second (higher) vertex id */
+      SimplexId death;
+      /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
+      SimplexId type;
+
+      PersistencePair(SimplexId b, SimplexId d, SimplexId t)
+        : birth{b}, death{d}, type{t} {
+      }
+    };
+
+    /**
+     * @brief Preprocess all the required connectivity requests on the
+     * triangulation.
+     */
+    inline void preconditionTriangulation(AbstractTriangulation *const data) {
+      if(data != nullptr) {
+        const auto dim = data->getDimensionality();
+        data->preconditionEdges();
+        if(dim == 2) {
+          data->preconditionCellEdges();
+        } else if(dim == 3) {
+          data->preconditionTriangles();
+          data->preconditionTriangleEdges();
+          data->preconditionCellTriangles();
+        }
+        this->nVerts_ = data->getNumberOfVertices();
+        this->nEdges_ = data->getNumberOfEdges();
+        this->nTri_ = dim > 1 ? data->getNumberOfTriangles() : 0;
+        this->nTetra_ = dim > 2 ? data->getNumberOfCells() : 0;
+      }
+    }
+
+    /**
+     * @brief Compute the persistence pairs from the triangulation
+     * simplicial complex
+     */
+    template <typename triangulationType>
+    int computePersistencePairs(std::vector<PersistencePair> &pairs,
+                                const SimplexId *const orderField,
+                                const triangulationType &triangulation) const;
+
+  private:
+    struct Simplex {
+      SimplexId dim_{-1}; // dimension
+      SimplexId id_{-1}; // id in triangulation (overlap between dimensions)
+      SimplexId cellId_{-1}; // cell id (unique)
+      // face (triangulation) indices
+      std::array<SimplexId, 4> faceIds_{-1, -1, -1, -1};
+      // order on vertices, sorted in descending order
+      std::array<SimplexId, 4> vertsOrder_{-1, -1, -1, -1};
+
+      friend bool operator<(const Simplex &lhs, const Simplex &rhs) {
+        return lhs.vertsOrder_ < rhs.vertsOrder_;
+      }
+
+      void fillVert(const SimplexId v, const SimplexId *const offset) {
+        this->dim_ = 0;
+        this->id_ = v;
+        this->cellId_ = v;
+        this->vertsOrder_[0] = offset[v];
+      }
+
+      template <typename triangulationType>
+      void fillEdge(const SimplexId e,
+                    const SimplexId c,
+                    const SimplexId *const offset,
+                    const triangulationType &triangulation) {
+        this->dim_ = 1;
+        this->id_ = e;
+        this->cellId_ = c;
+        triangulation.getEdgeVertex(e, 0, this->faceIds_[0]);
+        triangulation.getEdgeVertex(e, 1, this->faceIds_[1]);
+        this->vertsOrder_[0] = offset[this->faceIds_[0]];
+        this->vertsOrder_[1] = offset[this->faceIds_[1]];
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+
+      template <typename triangulationType>
+      void fillTriangle(const SimplexId t,
+                        const SimplexId c,
+                        const SimplexId *const offset,
+                        const triangulationType &triangulation) {
+        this->dim_ = 2;
+        this->id_ = t;
+        this->cellId_ = c;
+        triangulation.getTriangleEdge(t, 0, this->faceIds_[0]);
+        triangulation.getTriangleEdge(t, 1, this->faceIds_[1]);
+        triangulation.getTriangleEdge(t, 2, this->faceIds_[2]);
+        triangulation.getTriangleVertex(t, 0, this->vertsOrder_[0]);
+        triangulation.getTriangleVertex(t, 1, this->vertsOrder_[1]);
+        triangulation.getTriangleVertex(t, 2, this->vertsOrder_[2]);
+        this->vertsOrder_[0] = offset[this->vertsOrder_[0]];
+        this->vertsOrder_[1] = offset[this->vertsOrder_[1]];
+        this->vertsOrder_[2] = offset[this->vertsOrder_[2]];
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+
+      template <typename triangulationType>
+      void fillTetra(const SimplexId T,
+                     const SimplexId c,
+                     const SimplexId *const offset,
+                     const triangulationType &triangulation) {
+        this->dim_ = 3;
+        this->id_ = T;
+        this->cellId_ = c;
+        triangulation.getCellTriangle(T, 0, this->faceIds_[0]);
+        triangulation.getCellTriangle(T, 1, this->faceIds_[1]);
+        triangulation.getCellTriangle(T, 2, this->faceIds_[2]);
+        triangulation.getCellTriangle(T, 3, this->faceIds_[3]);
+        triangulation.getCellVertex(T, 0, this->vertsOrder_[0]);
+        triangulation.getCellVertex(T, 1, this->vertsOrder_[1]);
+        triangulation.getCellVertex(T, 2, this->vertsOrder_[2]);
+        triangulation.getCellVertex(T, 3, this->vertsOrder_[3]);
+        this->vertsOrder_[0] = offset[this->vertsOrder_[0]];
+        this->vertsOrder_[1] = offset[this->vertsOrder_[1]];
+        this->vertsOrder_[2] = offset[this->vertsOrder_[2]];
+        this->vertsOrder_[3] = offset[this->vertsOrder_[3]];
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+    };
+
+    template <typename triangulationType>
+    std::vector<Simplex>
+      computeFiltrationOrder(const SimplexId *const offset,
+                             const triangulationType &triangulation) const;
+
+    inline void addCellBoundary(const Simplex &c, VisitedMask &boundary) const {
+      for(SimplexId i = 0; i < c.dim_ + 1; ++i) {
+        const auto f{c.faceIds_[i]};
+        if(!boundary.isVisited_[f]) {
+          boundary.insert(f);
+        } else {
+          boundary.remove(f);
+        }
+      }
+    }
+
+    inline SimplexId getCellId(const SimplexId cdim,
+                               const SimplexId cid) const {
+      if(cdim == 0) {
+        return cid;
+      } else if(cdim == 1) {
+        return cid + this->nVerts_;
+      } else if(cdim == 2) {
+        return cid + this->nVerts_ + this->nEdges_;
+      } else if(cdim == 3) {
+        return cid + this->nVerts_ + this->nEdges_ + this->nTri_;
+      }
+      return -1;
+    }
+
+    SimplexId eliminateBoundaries(const Simplex &c,
+                                  VisitedMask &boundary,
+                                  const std::vector<SimplexId> &filtOrder,
+                                  const std::vector<Simplex> &partners) const;
+
+    int pairCells(std::vector<PersistencePair> &pairs,
+                  std::array<std::vector<bool>, 3> &boundaries,
+                  const std::vector<Simplex> &filtration,
+                  const std::vector<SimplexId> &filtOrder) const;
+
+    SimplexId nVerts_{0};
+    SimplexId nEdges_{0};
+    SimplexId nTri_{0};
+    SimplexId nTetra_{0};
+  };
+
+} // namespace ttk
+
+template <typename triangulationType>
+int ttk::PersistentSimplexPairs::computePersistencePairs(
+  std::vector<ttk::PersistentSimplexPairs::PersistencePair> &pairs,
+  const SimplexId *const orderField,
+  const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  // every simplex in the triangulation, sorted by filtration
+  const auto filtration
+    = this->computeFiltrationOrder(orderField, triangulation);
+
+  std::array<std::vector<bool>, 3> boundaries{};
+  boundaries[0].resize(this->nVerts_, false);
+  boundaries[1].resize(this->nEdges_, false);
+  boundaries[2].resize(this->nTri_, false);
+
+  // simplex id -> filtration order
+  std::vector<SimplexId> filtOrder(filtration.size());
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < filtration.size(); ++i) {
+    filtOrder[filtration[i].cellId_] = i;
+  }
+
+  this->pairCells(pairs, boundaries, filtration, filtOrder);
+
+  this->printMsg(
+    "Computed " + std::to_string(pairs.size()) + " persistence pairs", 1.0,
+    tm.getElapsedTime(), 1);
+
+  return 0;
+}
+
+template <typename triangulationType>
+std::vector<ttk::PersistentSimplexPairs::Simplex>
+  ttk::PersistentSimplexPairs::computeFiltrationOrder(
+    const SimplexId *const offset,
+    const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  std::vector<Simplex> res(this->nVerts_ + this->nEdges_ + this->nTri_
+                           + this->nTetra_);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < this->nVerts_; ++i) {
+    res[i].fillVert(i, offset);
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < this->nEdges_; ++i) {
+    const auto o = this->nVerts_ + i;
+    res[o].fillEdge(i, o, offset, triangulation);
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < this->nTri_; ++i) {
+    const auto o = this->nVerts_ + this->nEdges_ + i;
+    res[o].fillTriangle(i, o, offset, triangulation);
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < this->nTetra_; ++i) {
+    const auto o = this->nVerts_ + this->nEdges_ + this->nTri_ + i;
+    res[o].fillTetra(i, o, offset, triangulation);
+  }
+
+  PSORT(this->threadNumber_)(res.begin(), res.end());
+
+  this->printMsg(
+    "Computed filtration order", 1.0, tm.getElapsedTime(), this->threadNumber_);
+
+  return res;
+}

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -1,4 +1,3 @@
-
 <ServerManagerConfiguration>
   <!-- This is the server manager configuration XML. It defines the interface to
        our new filter. As a rule of thumb, try to locate the configuration for
@@ -6,62 +5,68 @@
        that matches your filter and then model your xml on it -->
   <ProxyGroup name="filters">
     <SourceProxy
-      name="ttkPersistenceDiagram"
-      class="ttkPersistenceDiagram"
-      label="TTK PersistenceDiagram">
+        name="ttkPersistenceDiagram"
+        class="ttkPersistenceDiagram"
+        label="TTK PersistenceDiagram">
       <Documentation
-        long_help="TTK plugin for the computation of persistence diagrams."
-        short_help="TTK plugin for the computation of persistence diagrams.">
+          long_help="TTK plugin for the computation of persistence diagrams."
+          short_help="TTK plugin for the computation of persistence diagrams.">
         TTK plugin for the computation of persistence diagrams.
 
-This plugin computes the persistence diagram of the extremum-saddle pairs
-of an input scalar field. The X-coordinate of each pair corresponds to its
-birth, while its smallest and highest Y-coordinates correspond to its birth
-and death respectively.
+        This plugin computes the persistence diagram of the extremum-saddle pairs
+        of an input scalar field. The X-coordinate of each pair corresponds to its
+        birth, while its smallest and highest Y-coordinates correspond to its birth
+        and death respectively.
 
-In practice, the diagram is represented by a vtkUnstructuredGrid. Each
-vertex of this mesh represent a critical point of the input data. It is
-associated with point data (vertexId, critical type). Each vertical edge
-of this mesh represent a persistence pair. It is associated with cell data
-(persistence of the pair, critical index of the extremum of the pair).
-The diagonal of the diagram can be filtered out by considering its
-PairIdentifier value (set at -1).
+        In practice, the diagram is represented by a vtkUnstructuredGrid. Each
+        vertex of this mesh represent a critical point of the input data. It is
+        associated with point data (vertexId, critical type). Each vertical edge
+        of this mesh represent a persistence pair. It is associated with cell data
+        (persistence of the pair, critical index of the extremum of the pair).
+        The diagonal of the diagram can be filtered out by considering its
+        PairIdentifier value (set at -1).
 
-Persistence diagrams are useful and stable concise representations of the
-topological features of a data-set. It is useful to fine-tune persistence
-thresholds for topological simplification or for fast similarity
-estimations for instance.
+        Persistence diagrams are useful and stable concise representations of the
+        topological features of a data-set. It is useful to fine-tune persistence
+        thresholds for topological simplification or for fast similarity
+        estimations for instance.
 
-Two backends are available for the computation of the persistence diagram:
+        Three backends are available for the computation of the persistence diagram:
 
-1) FTM
+        1) FTM
 
-Related publication:
-'Task-based Augmented Merge Trees with Fibonacci Heaps',
-Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny,
-Proc. of IEEE LDAV 2017.
+        Related publication:
+        'Task-based Augmented Merge Trees with Fibonacci Heaps',
+        Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny,
+        Proc. of IEEE LDAV 2017.
 
-2) A progressive approach
+        2) A progressive approach
 
-Related publication:
-'A Progressive Approach to Scalar Field Topology'
-Jules Vidal, Pierre Guillou, Julien Tierny
-IEEE Transaction on Visualization and Computer Graphics, 2021
+        Related publication:
+        'A Progressive Approach to Scalar Field Topology'
+        Jules Vidal, Pierre Guillou, Julien Tierny
+        IEEE Transaction on Visualization and Computer Graphics, 2021
 
-This approach necessitates the input data to be defined on an implicit regular grid.
-It processes the data using a multiresolution hierarchical
-representation in a coarse-to-fine fashion.
-Set both the Start and End resolution levels to -1 to execute in
-non-progressive mode on the finest level, i.e. the original grid.
+        This approach necessitates the input data to be defined on an implicit regular grid.
+        It processes the data using a multiresolution hierarchical
+        representation in a coarse-to-fine fashion.
+        Set both the Start and End resolution levels to -1 to execute in
+        non-progressive mode on the finest level, i.e. the original grid.
 
+        3) Persistent Simplex
 
-See also ContourForests, PersistenceCurve, ScalarFieldCriticalPoints,
-TopologicalSimplification.
+        This is a textbook (and very slow) algorithm, described in
+        "Algorithm and Theory of Computation Handbook (Second Edition)
+        - Special Topics and Techniques" by Atallah and Blanton on
+        page 97.
+
+        See also ContourForests, PersistenceCurve, ScalarFieldCriticalPoints,
+        TopologicalSimplification.
       </Documentation>
 
       <InputProperty
-        name="Input"
-        command="SetInputConnection">
+          name="Input"
+          command="SetInputConnection">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>
           <Group name="filters"/>
@@ -79,17 +84,17 @@ TopologicalSimplification.
         </Documentation>
       </InputProperty>
 
-      <StringVectorProperty 
-        name="ScalarFieldNew" 
-        label="Scalar Field" 
-        command="SetInputArrayToProcess" 
-        element_types="0 0 0 0 2" 
-        number_of_elements="5" 
-        default_values="0"
-        >
+      <StringVectorProperty
+          name="ScalarFieldNew"
+          label="Scalar Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
+          >
         <ArrayListDomain
-          name="array_list"
-          default_values="0">
+            name="array_list"
+            default_values="0">
           <RequiredProperties>
             <Property name="Input" function="Input" />
           </RequiredProperties>
@@ -100,41 +105,41 @@ TopologicalSimplification.
       </StringVectorProperty>
 
       <IntVectorProperty
-         name="ForceInputOffsetScalarField"
-         command="SetForceInputOffsetScalarField"
-         label="Force Input Offset Field"
-         number_of_elements="1"
-         panel_visibility="advanced"
-         default_values="0">
+          name="ForceInputOffsetScalarField"
+          command="SetForceInputOffsetScalarField"
+          label="Force Input Offset Field"
+          number_of_elements="1"
+          panel_visibility="advanced"
+          default_values="0">
         <BooleanDomain name="bool"/>
-         <Documentation>
+        <Documentation>
           Check this box to force the usage of a specific input scalar field
           as vertex offset (used to disambiguate flat plateaus).
-         </Documentation>
+        </Documentation>
       </IntVectorProperty>
 
-      <StringVectorProperty 
-        name="InputOffsetScalarFieldNameNew" 
-        label="Input Offset Field" 
-        command="SetInputArrayToProcess" 
-        element_types="0 0 0 0 2" 
-        number_of_elements="5" 
-        default_values="1"
-        panel_visibility="advanced"
-        >
+      <StringVectorProperty
+          name="InputOffsetScalarFieldNameNew"
+          label="Input Offset Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="1"
+          panel_visibility="advanced"
+          >
         <ArrayListDomain
-          name="array_list"
-					default_values="1"
-                    >
+            name="array_list"
+            default_values="1"
+            >
           <RequiredProperties>
             <Property name="Input" function="Input" />
           </RequiredProperties>
         </ArrayListDomain>
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="ForceInputOffsetScalarField"
-            value="1" />
+                                   mode="visibility"
+                                   property="ForceInputOffsetScalarField"
+                                   value="1" />
         </Hints>
         <Documentation>
           Select the input offset field (used to disambiguate flat plateaus).
@@ -146,11 +151,12 @@ TopologicalSimplification.
           label="Backend"
           command="SetBackEnd"
           number_of_elements="1"
-         default_values="0" 
+         default_values="0"
          panel_visibility="advanced" >
-		 <EnumerationDomain name="enum">
+         <EnumerationDomain name="enum">
           <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
           <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
+          <Entry value="2" text="Persistent Simplex"/>
         </EnumerationDomain>
         <Documentation>
             Backend for the computation of the persistence diagram.
@@ -163,7 +169,7 @@ TopologicalSimplification.
          label="Start resolution level"
          command="SetStartingResolutionLevel"
          number_of_elements="1"
-         default_values="0" 
+         default_values="0"
          panel_visibility="advanced" >
         <IntRangeDomain name="range" min="-1" max="100" />
         <Hints>
@@ -183,7 +189,7 @@ TopologicalSimplification.
          label="End resolution level"
          command="SetStoppingResolutionLevel"
          number_of_elements="1"
-         default_values="-1" 
+         default_values="-1"
          panel_visibility="advanced" >
         <IntRangeDomain name="range" min="-1" max="100" />
         <Hints>
@@ -231,7 +237,7 @@ TopologicalSimplification.
                                    value="1" />
         </Hints>
         <Documentation>
-          Maximal time of computation for the progressive computation. 
+          Maximal time of computation for the progressive computation.
           Set 0 for no time limit.
         </Documentation>
       </DoubleVectorProperty>
@@ -249,17 +255,17 @@ TopologicalSimplification.
                                    value="0" />
         </Hints>
         <BooleanDomain name="bool"/>
-         <Documentation>
+        <Documentation>
           Add saddle-saddle pairs in the diagram (SLOW!).
-         </Documentation>
+        </Documentation>
       </IntVectorProperty>
 
       <IntVectorProperty name="ShowInsideDomain"
-        label="Embed in Domain"
-        command="SetShowInsideDomain"
-        number_of_elements="1"
-        default_values="0"
-        panel_visibility="default">
+                         label="Embed in Domain"
+                         command="SetShowInsideDomain"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="default">
         <BooleanDomain name="bool"/>
         <Documentation>
           Embed the persistence pairs in the domain.
@@ -268,13 +274,16 @@ TopologicalSimplification.
 
       <PropertyGroup panel_widget="Line" label="Input options">
           <Property name="ScalarFieldNew" />
-	      <Property name="ForceInputOffsetScalarField"/>
-	      <Property name="InputOffsetScalarFieldNameNew"/>
+          <Property name="ForceInputOffsetScalarField"/>
+          <Property name="InputOffsetScalarFieldNameNew"/>
         <Property name="BackEnd" />
         <Property name="StartingResolutionLevel" />
         <Property name="StoppingResolutionLevel" />
         <Property name="IsResumable" />
         <Property name="TimeLimit" />
+        <Property name="ScalarFieldNew" />
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="InputOffsetScalarFieldNameNew"/>
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -44,7 +44,9 @@ int main(int argc, char **argv) {
     parser.setArgument("a", &inputArrayNames, "Input array names", true);
     parser.setArgument(
       "o", &outputPathPrefix, "Output file prefix (no extension)", true);
-    parser.setArgument("B", &backEnd, "Method (0:FTM, 1: progressive)", true);
+    parser.setArgument("B", &backEnd,
+                       "Method (0: FTM, 1: progressive, 2: persistent simplex)",
+                       true);
     parser.setArgument("S", &startingRL,
                        "Starting Resolution Level for progressive "
                        "multiresolution scheme (-1: finest level)",


### PR DESCRIPTION
This PR adds a new Persistence Diagram backend named "Persistent Simplex Pairs". This algorithm is described in "Algorithm and Theory of Computation Handbook (Second Edition) - Special Topics and Techniques" by Atallah and Blanton on page 97.

Since I used the `VisitedMask` data structure from the `DiscreteGradient` module, this structure has been moved in the `common` module.

This algorithm is very slow - 4 to 5 orders of magnitudes slower than FTM. However, it computes saddle-saddle and infinite pairs.

Enjoy,
Pierre