### PR TITLE
TriangulationRequests: Support multiple indices

### DIFF
--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.cpp
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.cpp
@@ -2,11 +2,13 @@
 #include <ttkTriangulationRequest.h>
 #include <ttkUtils.h>
 
+#include <vtkCellData.h>
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
+#include <vtkSignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
 vtkStandardNewMacro(ttkTriangulationRequest);
@@ -48,6 +50,12 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
 
   vtkNew<vtkPoints> points{};
   vtkNew<vtkUnstructuredGrid> cells{};
+  vtkNew<ttkSimplexIdTypeArray> cellIds{};
+  cellIds->SetNumberOfComponents(1);
+  cellIds->SetName("CellId");
+  vtkNew<vtkSignedCharArray> cellDims{};
+  cellDims->SetNumberOfComponents(1);
+  cellDims->SetName("CellDimension");
 
   using ttk::SimplexId;
 
@@ -90,6 +98,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
     }
 
     cells->InsertNextCell(VTK_LINE, 2, pointIds);
+    cellIds->InsertNextTuple1(edgeId);
+    cellDims->InsertNextTuple1(1);
 
     return 0;
   };
@@ -116,6 +126,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
     }
 
     cells->InsertNextCell(VTK_TRIANGLE, 3, pointIds);
+    cellIds->InsertNextTuple1(triangleId);
+    cellDims->InsertNextTuple1(2);
 
     return 0;
   };
@@ -139,6 +151,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
     }
 
     cells->InsertNextCell(VTK_TETRA, 4, pointIds);
+    cellIds->InsertNextTuple1(tetraId);
+    cellDims->InsertNextTuple1(3);
 
     return 0;
   };
@@ -208,6 +222,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
           case Vertex: {
             const auto vid = addVertex(si);
             cells->InsertNextCell(VTK_VERTEX, 1, &vid);
+            cellIds->InsertNextTuple1(vid);
+            cellDims->InsertNextTuple1(0);
           } break;
 
           case Edge:
@@ -434,6 +450,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
   }
 
   cells->SetPoints(points);
+  cells->GetCellData()->AddArray(cellIds);
+  cells->GetCellData()->AddArray(cellDims);
 
   output->ShallowCopy(cells);
 

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.cpp
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.cpp
@@ -76,15 +76,15 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
     if(vertexId == -1)
       return vtkIdType(-1);
 
-    float p[3];
+    std::array<float, 3> p{};
     triangulation->getVertexPoint(vertexId, p[0], p[1], p[2]);
     vertices.push_back(vertexId);
-    return points->InsertNextPoint(p);
+    return points->InsertNextPoint(p.data());
   };
 
   auto addEdge = [&](const SimplexId edgeId) {
-    vtkIdType pointIds[2];
-    SimplexId vertexIds[2];
+    std::array<vtkIdType, 2> pointIds{};
+    std::array<SimplexId, 2> vertexIds{};
 
     for(int i = 0; i < 2; ++i) {
       triangulation->getEdgeVertex(edgeId, i, vertexIds[i]);
@@ -100,7 +100,7 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
         pointIds[i] = isVisited[vertexId];
     }
 
-    cells->InsertNextCell(VTK_LINE, 2, pointIds);
+    cells->InsertNextCell(VTK_LINE, 2, pointIds.data());
     cellIds->InsertNextTuple1(edgeId);
     cellDims->InsertNextTuple1(1);
 
@@ -108,8 +108,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
   };
 
   auto addTriangle = [&](const SimplexId triangleId) {
-    vtkIdType pointIds[3];
-    SimplexId vertexIds[3];
+    std::array<vtkIdType, 3> pointIds{};
+    std::array<SimplexId, 3> vertexIds{};
 
     for(int i = 0; i < 3; ++i) {
       if(dimensionality == 3)
@@ -128,7 +128,7 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
         pointIds[i] = isVisited[vertexId];
     }
 
-    cells->InsertNextCell(VTK_TRIANGLE, 3, pointIds);
+    cells->InsertNextCell(VTK_TRIANGLE, 3, pointIds.data());
     cellIds->InsertNextTuple1(triangleId);
     cellDims->InsertNextTuple1(2);
 
@@ -136,8 +136,8 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
   };
 
   auto addTetra = [&](const SimplexId tetraId) {
-    vtkIdType pointIds[4];
-    SimplexId vertexIds[4];
+    std::array<vtkIdType, 4> pointIds{};
+    std::array<SimplexId, 4> vertexIds{};
 
     for(int i = 0; i < 4; ++i) {
       triangulation->getCellVertex(tetraId, i, vertexIds[i]);
@@ -153,7 +153,7 @@ int ttkTriangulationRequest::RequestData(vtkInformation *ttkNotUsed(request),
         pointIds[i] = isVisited[vertexId];
     }
 
-    cells->InsertNextCell(VTK_TETRA, 4, pointIds);
+    cells->InsertNextCell(VTK_TETRA, 4, pointIds.data());
     cellIds->InsertNextTuple1(tetraId);
     cellDims->InsertNextTuple1(3);
 

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -24,6 +24,7 @@
 // ttk code includes
 #include <Triangulation.h>
 #include <ttkAlgorithm.h>
+#include <ttkMacros.h>
 
 // VTK Module
 #include <ttkTriangulationRequestModule.h>
@@ -32,51 +33,47 @@ class TTKTRIANGULATIONREQUEST_EXPORT ttkTriangulationRequest
   : public ttkAlgorithm {
 
 public:
-  enum Simplex { Vertex = 0, Edge, Triangle, Tetra };
-
-  enum Request {
-    ComputeSimplex = 0,
-    ComputeFacet,
-    ComputeCofacet,
-    ComputeStar,
-    ComputeLink
+  enum class SIMPLEX {
+    VERTEX = 0,
+    EDGE = 1,
+    TRIANGLE = 2,
+    TETRA = 3,
+  };
+  enum class REQUEST {
+    COMPUTE_SIMPLEX = 0,
+    COMPUTE_FACET = 1,
+    COMPUTE_COFACET = 2,
+    COMPUTE_STAR = 3,
+    COMPUTE_LINK = 4,
   };
 
   static ttkTriangulationRequest *New();
-  vtkTypeMacro(ttkTriangulationRequest, ttkAlgorithm)
+  vtkTypeMacro(ttkTriangulationRequest, ttkAlgorithm);
 
-    vtkSetMacro(SimplexType, int);
-  vtkGetMacro(SimplexType, int);
+  ttkSetEnumMacro(SimplexType, SIMPLEX);
+  vtkGetEnumMacro(SimplexType, SIMPLEX);
 
   vtkSetMacro(SimplexIdentifier, const std::string &);
   vtkGetMacro(SimplexIdentifier, std::string);
 
-  vtkSetMacro(RequestType, int);
-  vtkGetMacro(RequestType, int);
+  ttkSetEnumMacro(RequestType, REQUEST);
+  vtkGetEnumMacro(RequestType, REQUEST);
 
   vtkSetMacro(KeepAllDataArrays, bool);
   vtkGetMacro(KeepAllDataArrays, bool);
 
 protected:
-  ttkTriangulationRequest() {
-    SetNumberOfInputPorts(1);
-    SetNumberOfOutputPorts(1);
-    this->setDebugMsgPrefix("TriangulationRequest");
-  }
-
-  ~ttkTriangulationRequest() override{};
+  ttkTriangulationRequest();
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
-
   int FillOutputPortInformation(int port, vtkInformation *info) override;
-
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
 
 private:
-  int SimplexType{0};
+  SIMPLEX SimplexType{};
+  REQUEST RequestType{};
   std::string SimplexIdentifier{0};
-  int RequestType{0};
   bool KeepAllDataArrays{true};
 };

--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -48,8 +48,8 @@ public:
     vtkSetMacro(SimplexType, int);
   vtkGetMacro(SimplexType, int);
 
-  vtkSetMacro(SimplexIdentifier, int);
-  vtkGetMacro(SimplexIdentifier, int);
+  vtkSetMacro(SimplexIdentifier, const std::string &);
+  vtkGetMacro(SimplexIdentifier, std::string);
 
   vtkSetMacro(RequestType, int);
   vtkGetMacro(RequestType, int);
@@ -76,7 +76,7 @@ protected:
 
 private:
   int SimplexType{0};
-  int SimplexIdentifier{0};
+  std::string SimplexIdentifier{0};
   int RequestType{0};
   bool KeepAllDataArrays{true};
 };

--- a/paraview/xmls/TriangulationRequest.xml
+++ b/paraview/xmls/TriangulationRequest.xml
@@ -46,16 +46,16 @@
         </Documentation>
       </IntVectorProperty>
 
-      <IntVectorProperty name="SimplexIdentifier"
-        label="Simplex identifier"
+      <StringVectorProperty name="SimplexIdentifier"
+        label="Simplex identifiers"
         command="SetSimplexIdentifier"
         number_of_elements="1"
         default_values="0"
         panel_visibility="default">
         <Documentation>
-          Output simplex identifier.
+          Output simplex identifiers (comma-separated list).
         </Documentation>
-      </IntVectorProperty>
+      </StringVectorProperty>
 
       <IntVectorProperty name="KeepAllDataArrays"
         label="Keep All Data Arrays"


### PR DESCRIPTION
With this PR, users can pass comma and/or space separated list of indices to TriangulationRequests.
A pre-processing step removes the duplicates, negative & out-of-bounds values. After this step, if the list is empty, the filter aborts.

Additionally, new CellData arrays were added to display the indices and the dimensions (similarly to the DiscreteGradient/MorseSmaleComplex critical points). The filter also makes use of Jonas' vtkGetEnumMacro/ttkSetEnumMacro.

Enjoy,
Pierre