### PR TITLE
Add links to examples documentation

### DIFF
--- a/core/vtk/ttkEigenField/ttkEigenField.h
+++ b/core/vtk/ttkEigenField/ttkEigenField.h
@@ -26,6 +26,12 @@
 ///
 /// \sa ttkHarmonicField
 /// \sa ttk::EigenField
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.h
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.h
@@ -18,6 +18,15 @@
 /// See the related ParaView example state files for usage examples within a
 /// VTK pipeline.
 ///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
+///
+
 #pragma once
 
 // VTK includes -- to adapt

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -51,14 +51,24 @@
 /// \sa ttk::MorseSmaleComplex
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/morseMolecule/">
-/// Morse molecule example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
 ///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseMolecule/">Morse
+///   molecule example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.h
+++ b/core/vtk/ttkMorseSmaleQuadrangulation/ttkMorseSmaleQuadrangulation.h
@@ -22,6 +22,12 @@
 /// \sa ttkFTMTree
 /// \sa ttkIdentifiers
 /// \sa ttk::MorseSmaleQuadrangulation
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -61,13 +61,22 @@
 ///   - <a href="https://topology-tool-kit.github.io/examples/ctBones/">CT Bones
 ///   example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
-/// example</a> \n
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions//">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
 ///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.h
+++ b/core/vtk/ttkQuadrangulationSubdivision/ttkQuadrangulationSubdivision.h
@@ -22,6 +22,12 @@
 /// \sa ttkFTMTree
 /// \sa ttkIdentifiers
 /// \sa ttk::QuadrangulationSubdivision
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.h
@@ -25,6 +25,13 @@
 /// \sa vtkCellDataConverter
 /// \sa vtkPointDataConverter
 /// \sa vtkScalarFieldSmoother
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///
+
 #pragma once
 
 // VTK Module

--- a/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
+++ b/core/vtk/ttkTopologicalCompression/ttkTopologicalCompression.h
@@ -26,6 +26,12 @@
 /// within a VTK pipeline.
 ///
 /// \sa ttk::TopologicalCompression
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/">Persistence-Driven
+///   Compression example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -5,6 +5,12 @@
 ///
 /// \brief VTK-filter that wraps the topologicalCompressionWriter processing
 /// package.
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/">Persistence-Driven
+///   Compression example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -5,6 +5,12 @@
 ///
 /// \brief VTK-filter that wraps the topologicalCompressionWriter processing
 /// package.
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/">Persistence-Driven
+///   Compression example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -58,13 +58,22 @@
 ///   - <a href="https://topology-tool-kit.github.io/examples/ctBones/">CT Bones
 ///   example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
-/// example</a> \n
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
 ///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
 ///
 
 #pragma once

--- a/paraview/xmls/EigenField.xml
+++ b/paraview/xmls/EigenField.xml
@@ -13,6 +13,11 @@
         "Spectral surface quadrangulation"
         Shen Dong, Peer-Timo Bremer, Michael Garland, Valerio Pascucci, John C. Hart
         SIGGRAPH 2006
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/IdentifierRandomizer.xml
+++ b/paraview/xmls/IdentifierRandomizer.xml
@@ -14,6 +14,13 @@
         short_help="TTK identifierRandomizer plugin.">
        TTK filter to shuflle ids randomly. Useful to reduce the number of neighbor
        regions with close ids.
+
+       Online examples:
+
+       - https://topology-tool-kit.github.io/examples/imageProcessing/
+
+        - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
+
      </Documentation>
      <InputProperty
         name="Input"

--- a/paraview/xmls/MorseSmaleComplex.xml
+++ b/paraview/xmls/MorseSmaleComplex.xml
@@ -32,6 +32,12 @@
 
         - https://topology-tool-kit.github.io/examples/persistenceClustering0/
         
+        - https://topology-tool-kit.github.io/examples/imageProcessing/
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
+        - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
+
       </Documentation>
       <InputProperty
         name="Input"

--- a/paraview/xmls/MorseSmaleQuadrangulation.xml
+++ b/paraview/xmls/MorseSmaleQuadrangulation.xml
@@ -9,6 +9,11 @@
           short_help="TTK plugin for Morse-Smale quadrangulation.">
         This plugin outputs a very raw quadrangulation from a
         Morse-Smale Complex of a triangular surfacic mesh.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -69,12 +69,17 @@
 
         - https://topology-tool-kit.github.io/examples/dragon/
 
-        - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
+        - https://topology-tool-kit.github.io/examples/imageProcessing/
 
-        - https://topology-tool-kit.github.io/examples/persistenceClustering0/
+        - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
 
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
+        - https://topology-tool-kit.github.io/examples/persistenceClustering0/
+
+        - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
 
       </Documentation>
 

--- a/paraview/xmls/QuadrangulationSubdivision.xml
+++ b/paraview/xmls/QuadrangulationSubdivision.xml
@@ -9,6 +9,11 @@
           short_help="TTK plugin for surface quadrangulation.">
         This plugin outputs a very raw quadrangulation from a
         Morse-Smale Complex of a triangular surfacic mesh.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/ScalarFieldNormalizer.xml
+++ b/paraview/xmls/ScalarFieldNormalizer.xml
@@ -13,6 +13,11 @@
         long_help="TTK plugin that normalizes an input scalar field."
         short_help="TTK plugin that normalizes an input scalar field.">
           TTK plugin that normalizes an input scalar field.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
      </Documentation>
      <InputProperty
         name="Input"

--- a/paraview/xmls/TopologicalCompression.xml
+++ b/paraview/xmls/TopologicalCompression.xml
@@ -13,6 +13,11 @@
           long_help="TTK topologicalCompression plugin."
           short_help="TTK topologicalCompression plugin.">
         TTK topologicalCompression plugin documentation.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/
+
       </Documentation>
 
         <InputProperty

--- a/paraview/xmls/TopologicalCompressionReader.xml
+++ b/paraview/xmls/TopologicalCompressionReader.xml
@@ -8,6 +8,11 @@
           long_help="TTK topologicalCompressionReader plugin."
           short_help="Read a .ttk file.">
         This plugin specifies the file name for the TTK reader.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/
+
       </Documentation>
       <StringVectorProperty
               name="FileName"

--- a/paraview/xmls/TopologicalCompressionWriter.xml
+++ b/paraview/xmls/TopologicalCompressionWriter.xml
@@ -9,6 +9,11 @@
           long_help="TTK topologicalCompressionWriter plugin."
           short_help="TTK topologicalCompressionWriter plugin.">
         TTK topologicalCompression plugin documentation.
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistenceDrivenCompression/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/TopologicalSimplification.xml
+++ b/paraview/xmls/TopologicalSimplification.xml
@@ -47,11 +47,17 @@ Identifiers.
 
         - https://topology-tool-kit.github.io/examples/dragon/
 
+        - https://topology-tool-kit.github.io/examples/imageProcessing/
+
         - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
 
         - https://topology-tool-kit.github.io/examples/persistenceClustering0/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
+
+        - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
+
+        - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
 
       </Documentation>
 


### PR DESCRIPTION
This PR adds HTML links in the doxygen documentation of the VTK layer and in the corresponding XML files to the imageProcessing and the morseSmaleQuadrangulation examples.

This completes https://github.com/topology-tool-kit/ttk-data/pull/88 and https://github.com/topology-tool-kit/ttk-data/pull/93.

This might cause some conflicts with other PRs though...

Enjoy,
Pierre

