### PR TITLE
Merge Tree Temporal Reduction example links

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -11,7 +11,10 @@
 ///   - <a href="https://topology-tool-kit.github.io/examples/ctBones/">CT Bones
 ///   example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
-///   example</a>
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge
+///   Tree Temporal Reduction</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -27,6 +27,11 @@
 /// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge
+///   Tree Temporal Reduction</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -27,6 +27,11 @@
 /// Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.\n
 /// Proc. of IEEE VIS 2021.\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge
+///   Tree Temporal Reduction</a> \n
 
 #pragma once
 

--- a/paraview/xmls/FTMTree.xml
+++ b/paraview/xmls/FTMTree.xml
@@ -42,6 +42,8 @@
         - https://topology-tool-kit.github.io/examples/dragon/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
+        
+        - https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/
 
             </Documentation>
 

--- a/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionDecoding.xml
@@ -18,6 +18,9 @@ Related publication:
 Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.
 Proc. of IEEE VIS 2021.
 IEEE Transactions on Visualization and Computer Graphics, 2021
+
+Online examples:
+- https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/
       </Documentation>
 
       <!-- INPUT DATA OBJECTS -->

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -20,6 +20,9 @@ Related publication:
 Mathieu Pont, Jules Vidal, Julie Delon, Julien Tierny.
 Proc. of IEEE VIS 2021.
 IEEE Transactions on Visualization and Computer Graphics, 2021
+
+Online examples:
+- https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/
       </Documentation>
 
       <!-- INPUT DATA OBJECTS -->


### PR DESCRIPTION
This PR adds links to the documentation of the related filters of the MergeTreeTemporalReduction example.