### PR TITLE
Doxygen: expand VTK macros

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,6 +2,10 @@ add_subdirectory(base)
 
 if(TTK_BUILD_DOCUMENTATION)
   if(DOXYGEN_FOUND)
+    set(DOXYGEN_INCLUDE_DIRS)
+    if(TARGET VTK::CommonCore)
+      get_target_property(DOXYGEN_INCLUDE_DIRS VTK::CommonCore INTERFACE_INCLUDE_DIRECTORIES)
+    endif()
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ttk.doxygen
       ${CMAKE_CURRENT_BINARY_DIR}/ttk.doxygen)
     add_custom_target(doc

--- a/core/ttk.doxygen
+++ b/core/ttk.doxygen
@@ -2000,7 +2000,14 @@ PREDEFINED  = "vtkSetMacro(name,type)= \
                    static int IsTypeOf(const char *type); \
                    virtual int IsA(const char *type); \
                    static thisClass* SafeDownCast(vtkObject *o);" \
-               "VTK_LEGACY(x)= x"
+               "VTK_LEGACY(x)= x" \
+               "vtkSetEnumMacro(name, enumType)= \
+                   virtual void Set##name (enumType);" \
+               "vtkGetEnumMacro(name, enumType)=\
+                   virtual enumType Get##name () const;" \
+               "ttkSetEnumMacro(name, enumType)= \
+                   virtual void Set##name (int _arg); \
+                   virtual void Set##name (enumType);"
 
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/core/ttk.doxygen
+++ b/core/ttk.doxygen
@@ -1893,7 +1893,7 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES the includes files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -1925,7 +1925,83 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+# from ParaView/Utilities/Doxygen/doxyfile.in:
+PREDEFINED  = "vtkSetMacro(name,type)= \
+                 virtual void Set##name (type);" \
+              "vtkGetMacro(name,type)= \
+                 virtual type Get##name ();" \
+              "vtkSetStringMacro(name)= \
+                 virtual void Set##name (const char*);" \
+              "vtkGetStringMacro(name)= \
+                 virtual char* Get##name ();" \
+              "vtkSetClampMacro(name,type,min,max)= \
+                 virtual void Set##name (type);" \
+              "vtkSetObjectMacro(name,type)= \
+                 virtual void Set##name (type*);" \
+              "vtkGetObjectMacro(name,type)= \
+                 virtual type *Get##name ();" \
+              "vtkBooleanMacro(name,type)= \
+                 virtual void name##On (); \
+                 virtual void name##Off ();" \
+              "vtkSetVector2Macro(name,type)= \
+                 virtual void Set##name (type, type); \
+                 void Set##name (type [2]);" \
+              "vtkGetVector2Macro(name,type)= \
+                 virtual type *Get##name (); \
+                 virtual void Get##name (type &, type &); \
+                 virtual void Get##name (type [2]);" \
+              "vtkSetVector3Macro(name,type)= \
+                 virtual void Set##name (type, type, type); \
+                 virtual void Set##name (type [3]);" \
+              "vtkGetVector3Macro(name,type)= \
+                 virtual type *Get##name (); \
+                 virtual void Get##name (type &, type &, type &); \
+                 virtual void Get##name (type [3]);" \
+              "vtkSetVector4Macro(name,type)= \
+                 virtual void Set##name (type, type, type, type); \
+                 virtual void Set##name (type [4]);" \
+              "vtkGetVector4Macro(name,type)= \
+                 virtual type *Get##name (); \
+                 virtual void Get##name (type &, type &, type &, type &); \
+                 virtual void Get##name (type [4]);" \
+               "vtkSetVector6Macro(name,type)= \
+                 virtual void Set##name (type, type, type, type, \
+                                         type, type); \
+                 virtual void Set##name (type [6]);" \
+               "vtkGetVector6Macro(name,type)= \
+                  virtual type *Get##name (); \
+                  virtual void Get##name (type &, type &, type &, \
+                                          type &, type &, type &); \
+                  virtual void Get##name (type [6]);" \
+               "vtkSetVectorMacro(name,type,count)= \
+                  virtual void Set##name(type data[]);" \
+               "vtkGetVectorMacro(name,type,count)= \
+                   virtual type *Get##name (); \
+                   virtual void Get##name(type data[##count]);" \
+               "vtkWorldCoordinateMacro(name)= \
+                   virtual vtkCoordinate *Get##name##Coordinate (); \
+                   virtual void Set##name(float x[3]); \
+                   virtual void Set##name(float x, float y, float z); \
+                   virtual float *Get##name();" \
+               "vtkViewportCoordinateMacro(name)= \
+                   virtual vtkCoordinate *Get##name##Coordinate (); \
+                   virtual void Set##name(float x[2]); \
+                   virtual void Set##name(float x, float y); \
+                   virtual float *Get##name();" \
+               "vtkTypeMacro(thisClass,superclass)= \
+                   typedef superclass Superclass; \
+                   virtual const char *GetClassName(); \
+                   static int IsTypeOf(const char *type); \
+                   virtual int IsA(const char *type); \
+                   static thisClass* SafeDownCast(vtkObject *o);" \
+               "vtkTypeMacro(thisClass,superclass)= \
+                   typedef superclass Superclass; \
+                   virtual const char *GetClassName(); \
+                   static int IsTypeOf(const char *type); \
+                   virtual int IsA(const char *type); \
+                   static thisClass* SafeDownCast(vtkObject *o);" \
+               "VTK_LEGACY(x)= x"
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/core/ttk.doxygen
+++ b/core/ttk.doxygen
@@ -1885,7 +1885,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -1907,7 +1907,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = @DOXYGEN_INCLUDE_DIRS@
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the


### PR DESCRIPTION
This PR grabs the include directory from `VTK::CommonCore` if available, and lets doxygen expand the `vtkGetMacro`/`vtkSetMacro` in the docs.

I think it is a bit nicer to have `GetXYZ`, `SetXYZ` instead of `vtkGetMacro(XYZ)` etc.