### PR TITLE
Cleanup some cmake files a bit

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -1,6 +1,23 @@
+# --- Prerequisites
+
 set(CMAKE_CXX_STANDARD 11)
 
-# --- Options
+# --- Global Options
+
+option(TTK_BUILD_VTK_WRAPPERS "Build the TTK VTK Wrappers" ON)
+cmake_dependent_option(TTK_BUILD_PARAVIEW_PLUGINS "Build the TTK ParaView Plugins" ON "TTK_BUILD_VTK_WRAPPERS" OFF)
+option(TTK_BUILD_STANDALONE_APPS "Build the TTK Standalone Applications" ON)
+option(TTK_WHITELIST_MODE "Explicitely enable each filter" OFF)
+mark_as_advanced(TTK_WHITELIST_MODE BUILD_SHARED_LIBS)
+
+# This option allows library to be built dynamic
+# like the TopologyToolKit.so file for paraview
+option(BUILD_SHARED_LIBS "Build TTK as shared lib" ON)
+
+if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)
+  message(WARNING "Can't build standalones without the VTK wrappers: disable")
+  set(TTK_BUILD_STANDALONE_APPS OFF CACHE BOOL "Build the cmd and gui commands" FORCE)
+endif()
 
 # Set a default build type if none was specified
 get_property(generator_is_multi_config GLOBAL
@@ -21,7 +38,7 @@ set(TTK_CELL_ARRAY_LAYOUT "SingleArray" CACHE STRING "Layout for the cell array.
 set_property(CACHE TTK_CELL_ARRAY_LAYOUT PROPERTY STRINGS "SingleArray" "OffsetAndConnectivity")
 mark_as_advanced(TTK_CELL_ARRAY_LAYOUT)
 
-# issue #605 
+# issue #605
 # workaround https://gitlab.kitware.com/paraview/paraview/-/issues/20324
 option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 if (TTK_ENABLE_MPI)
@@ -107,18 +124,22 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0
   "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
+# mandatory packages
+
 find_package(Boost REQUIRED)
 if(Boost_FOUND)
   message(STATUS "Found Boost ${Boost_VERSION} (${Boost_INCLUDE_DIR})")
 endif()
 
+# optional pakages
+
 find_package(ZLIB QUIET)
-if(NOT ZLIB_FOUND)
-  option(TTK_ENABLE_ZLIB "Enable Zlib support" OFF)
-  message(STATUS "Zlib not found, disabling Zlib support in TTK.")
-else()
+if(ZLIB_FOUND)
   option(TTK_ENABLE_ZLIB "Enable Zlib support" ON)
   message(STATUS "Found Zlib ${ZLIB_VERSION_STRING} (${ZLIB_LIBRARIES})")
+else()
+  option(TTK_ENABLE_ZLIB "Enable Zlib support" OFF)
+  message(STATUS "Zlib not found, disabling Zlib support in TTK.")
 endif()
 
 find_package(EMBREE 3.4 QUIET)
@@ -130,7 +151,6 @@ else()
   message(STATUS "EMBREE library not found, disabling embree support in TTK.")
 endif()
 
-# GraphViz
 find_package(Graphviz QUIET)
 if(Graphviz_FOUND)
   option(TTK_ENABLE_GRAPHVIZ "Enable GraphViz support" ON)
@@ -139,9 +159,7 @@ else()
   option(TTK_ENABLE_GRAPHVIZ "Enable GraphViz support" OFF)
   message(STATUS "GraphViz not found, disabling GraphViz support in TTK.")
 endif()
-# End GraphViz
 
-# FindSQLite3 supported since CMake 3.14
 find_package(SQLite3 QUIET)
 if(SQLite3_FOUND)
   option(TTK_ENABLE_SQLITE3 "Enable SQLITE3 support" ON)
@@ -245,12 +263,12 @@ endif()
 
 
 find_package(WEBSOCKETPP QUIET)
-if(NOT WEBSOCKETPP_FOUND)
-  option(TTK_ENABLE_WEBSOCKETPP "Enable WebSocketIO module" OFF)
-  message(STATUS "WebSocketPP not found, disabling WebSocketIO module in TTK.")
-else()
+if(WEBSOCKETPP_FOUND)
   option(TTK_ENABLE_WEBSOCKETPP "Enable WebSocketIO module" ON)
   message(STATUS "Found WebSocketPP ${WEBSOCKETPP_VERSION} (${WEBSOCKETPP_INCLUDE_DIR}), enabling WebSocketIO module in TTK.")
+else()
+  option(TTK_ENABLE_WEBSOCKETPP "Enable WebSocketIO module" OFF)
+  message(STATUS "WebSocketPP not found, disabling WebSocketIO module in TTK.")
 endif()
 
 # --- Install path

--- a/CMake/cpack_config.cmake
+++ b/CMake/cpack_config.cmake
@@ -1,0 +1,45 @@
+set(CPACK_PACKAGE_NAME "TTK")
+set(CPACK_PACKAGE_FILE_NAME "ttk")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The Topology ToolKit")
+set(CPACK_PACKAGE_VERSION_MAJOR ${TTK_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${TTK_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${TTK_VERSION_PATCH})
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_CONTACT "Julien Tierny <julien.tierny@sorbonne-universite.fr>")
+set(CPACK_PACKAGE_VENDOR "CNRS, Sorbonne University and contributors")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://topology-tool-kit.github.io/")
+if(NOT APPLE)
+  set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
+  set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+else()
+  # macOS needs license & readme files ending with .txt
+  configure_file(LICENSE License.txt COPYONLY)
+  configure_file(README.md Readme.txt COPYONLY)
+  set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_BINARY_DIR}/License.txt)
+  set(CPACK_RESOURCE_FILE_README ${PROJECT_BINARY_DIR}/Readme.txt)
+endif()
+set(CPACK_DEBIAN_PACKAGE_DEPENDS
+  "ttk-paraview (= 5.9.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev, libgl1-mesa-dev")
+# autogenerate dependency information
+set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+# package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK")
+# let the installer uninstall previous installations on Windows
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+# generate components, fix productbuild packaging for macOS
+if(APPLE)
+  set(CPACK_COMPONENTS_ALL Unspecified python development)
+endif()
+# embed Visual C++ redistribuable for Windows + set environment variables
+if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe")
+  install(FILES "${CMAKE_SOURCE_DIR}/scripts/set_windows_env_vars.ps1" DESTINATION bin)
+  install(PROGRAMS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe" DESTINATION bin)
+  set(CPACK_VERBATIM_VARIABLES TRUE)
+  list(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\" install'
+      ExecWait '$INSTDIR\\bin\\vc_redist.x64.exe /passive /norestart'
+      Delete '$INSTDIR\\bin\\vc_redist.x64.exe' ")
+  list(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\"' ")
+endif()
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,69 +8,11 @@ endif()
 
 include(CMakeDependentOption)
 
-option(TTK_BUILD_VTK_WRAPPERS "Build the TTK VTK Wrappers" ON)
-cmake_dependent_option(TTK_BUILD_PARAVIEW_PLUGINS "Build the TTK ParaView Plugins" ON "TTK_BUILD_VTK_WRAPPERS" OFF)
-option(TTK_BUILD_STANDALONE_APPS "Build the TTK Standalone Applications" ON)
-option(TTK_WHITELIST_MODE "Explicitely enable each filter" OFF)
-mark_as_advanced(TTK_WHITELIST_MODE BUILD_SHARED_LIBS)
+# options & dependencies
+include(CMake/config.cmake)
 
-# This option allows library to be built dynamic
-# like the TopologyToolKit.so file for paraview
-option(BUILD_SHARED_LIBS "Build TTK as shared lib" ON)
-
-set(CPACK_PACKAGE_NAME "TTK")
-set(CPACK_PACKAGE_FILE_NAME "ttk")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The Topology ToolKit")
-set(CPACK_PACKAGE_VERSION_MAJOR ${TTK_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${TTK_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${TTK_VERSION_PATCH})
-set(CPACK_GENERATOR "DEB")
-set(CPACK_PACKAGE_CONTACT "Julien Tierny <julien.tierny@sorbonne-universite.fr>")
-set(CPACK_PACKAGE_VENDOR "CNRS, Sorbonne University and contributors")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://topology-tool-kit.github.io/")
-if(NOT APPLE)
-  set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
-  set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
-else()
-  # macOS needs license & readme files ending with .txt
-  configure_file(LICENSE License.txt COPYONLY)
-  configure_file(README.md Readme.txt COPYONLY)
-  set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_BINARY_DIR}/License.txt)
-  set(CPACK_RESOURCE_FILE_README ${PROJECT_BINARY_DIR}/Readme.txt)
-endif()
-set(CPACK_DEBIAN_PACKAGE_DEPENDS
-  "ttk-paraview (= 5.9.1), python3-sklearn, libboost-system-dev, python3-dev, libgraphviz-dev, libsqlite3-dev, libgl1-mesa-dev")
-# autogenerate dependency information
-set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-# package will be installed under %ProgramFiles%\${CPACK_PACKAGE_INSTALL_DIRECTORY} on Windows
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "TTK")
-# let the installer uninstall previous installations on Windows
-set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-# generate components, fix productbuild packaging for macOS
-if(APPLE)
-  set(CPACK_COMPONENTS_ALL Unspecified python development)
-endif()
-# embed Visual C++ redistribuable for Windows + set environment variables
-if(WIN32 AND EXISTS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe")
-  install(FILES "${CMAKE_SOURCE_DIR}/scripts/set_windows_env_vars.ps1" DESTINATION bin)
-  install(PROGRAMS "${CMAKE_SOURCE_DIR}/vc_redist.x64.exe" DESTINATION bin)
-  set(CPACK_VERBATIM_VARIABLES TRUE)
-  list(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\" install'
-      ExecWait '$INSTDIR\\bin\\vc_redist.x64.exe /passive /norestart'
-      Delete '$INSTDIR\\bin\\vc_redist.x64.exe' ")
-  list(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-    " ExecWait 'powershell -ExecutionPolicy Bypass -File \"$INSTDIR\\bin\\set_windows_env_vars.ps1\"' ")
-endif()
-include(CPack)
-
-if(TTK_BUILD_STANDALONE_APPS AND NOT TTK_BUILD_VTK_WRAPPERS)
-  message(WARNING "Can't build standalones without the VTK wrappers: disable")
-  set(TTK_BUILD_STANDALONE_APPS OFF CACHE BOOL "Build the cmd and gui commands" FORCE)
-endif()
-
-# find dependencies
-include(config.cmake)
+# cmake packaging
+include(CMake/cpack_config.cmake)
 
 # Use folder as configured by the distribution
 include(GNUInstallDirs)


### PR DESCRIPTION
Dear Julien,

This MR improves a bit the CMake structure of TTK, trying to keep the main CMakeList lighter.

There is still a point that could be improved; if a user set a
TTK_ENABLE_... to true and the package is not found, CMake still configure
and then the compilation fails. A simple workaround is to add
find_package(... REQUIRED) in the variable is ON for each package.
It should not be costly as it will reuse existing variable for the find
and it will handle unfound packages properly.
Do you want me to handle this in this PR ?

Best,
Charles

