### PR TITLE
Add links to documentation for morsePersistence

### DIFF
--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -56,6 +56,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
+///   example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -69,9 +69,9 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n
-///   - <a 
-///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
-///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -35,8 +35,9 @@
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
 /// example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
-///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
 ///
 
 #ifndef _TTK_PERSISTENCECURVE_H

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -34,7 +34,9 @@
 ///
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
-/// example</a>
+/// example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
+///   example</a> \n
 ///
 
 #ifndef _TTK_PERSISTENCECURVE_H

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -65,6 +65,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions//">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
+///   example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -77,9 +77,9 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n
-///   - <a 
-///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
-///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
@@ -41,6 +41,11 @@
 ///
 /// \sa vtkGeometrySmoother
 /// \sa ttk::ScalarFieldSmoother
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
+///   example</a> \n
+
 #ifndef _TTK_SCALAR_FIELD_SMOOTHER_H
 #define _TTK_SCALAR_FIELD_SMOOTHER_H
 

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
@@ -43,8 +43,9 @@
 /// \sa ttk::ScalarFieldSmoother
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
-///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
 
 #ifndef _TTK_SCALAR_FIELD_SMOOTHER_H
 #define _TTK_SCALAR_FIELD_SMOOTHER_H

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -74,9 +74,9 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n
-///   - <a 
-///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
-///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -62,6 +62,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions//">Karhunen-Love
 ///   Digits 64-Dimensions example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse Persistence 
+///   example</a> \n
 ///
 
 #pragma once

--- a/paraview/xmls/ScalarFieldSmoother.xml
+++ b/paraview/xmls/ScalarFieldSmoother.xml
@@ -17,6 +17,10 @@
         of each vertex.
 
         See also GeometrySmoother.
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/morsePersistence/   
+
       </Documentation>
       <InputProperty
         name="Input"


### PR DESCRIPTION
This Pull Request is part of the Hackathon 2021.
It adds links to the documentation of the morsePersistence example for relevant TTK classes.
Some of the links were already added to .xml files.

