### PR TITLE
ContourTreeAlignment Doxygen Documentation

### DIFF
--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -13,14 +13,14 @@ ContourTree::ContourTree(float *scalars,
                          size_t nEdges,
                          std::vector<std::vector<int>> regions) {
 
-  nodes = std::vector<std::shared_ptr<CTNode>>();
-  arcs = std::vector<std::shared_ptr<CTEdge>>();
+  nodes = std::vector<std::shared_ptr<ttk::cta::CTNode>>();
+  arcs = std::vector<std::shared_ptr<ttk::cta::CTEdge>>();
 
   float minVal = FLT_MAX;
   float maxVal = -FLT_MAX;
 
   for(size_t i = 0; i < nVertices; i++) {
-    std::shared_ptr<CTNode> node(new CTNode);
+    std::shared_ptr<ttk::cta::CTNode> node(new ttk::cta::CTNode);
     node->scalarValue = scalars[i];
     node->edgeList = std::vector<int>();
     node->branchID = -1;
@@ -32,7 +32,7 @@ ContourTree::ContourTree(float *scalars,
   }
   int j = 0;
   for(size_t i = 0; i < nEdges; i++) {
-    std::shared_ptr<CTEdge> edge(new CTEdge);
+    std::shared_ptr<ttk::cta::CTEdge> edge(new ttk::cta::CTEdge);
     edge->area = regionSizes[i];
     edge->segId = segmentationIds[i];
     if(!regions.empty())
@@ -51,14 +51,14 @@ ContourTree::ContourTree(float *scalars,
     j += 2;
   }
 
-  for(const std::shared_ptr<CTNode> &node : nodes) {
+  for(const std::shared_ptr<ttk::cta::CTNode> &node : nodes) {
     if(node->edgeList.size() == 0)
       std::cout << "wtf?\n" << std::flush;
     if(node->edgeList.size() > 1)
       node->type = saddleNode;
     else {
-      std::shared_ptr<CTEdge> edge = arcs[node->edgeList[0]];
-      std::shared_ptr<CTNode> neighbor = nodes[edge->node1Idx] == node
+      std::shared_ptr<ttk::cta::CTEdge> edge = arcs[node->edgeList[0]];
+      std::shared_ptr<ttk::cta::CTNode> neighbor = nodes[edge->node1Idx] == node
                                            ? nodes[edge->node2Idx]
                                            : nodes[edge->node1Idx];
       if(neighbor->scalarValue > node->scalarValue)
@@ -69,7 +69,7 @@ ContourTree::ContourTree(float *scalars,
   }
 
   binary = true;
-  for(const std::shared_ptr<CTNode> &node : nodes) {
+  for(const std::shared_ptr<ttk::cta::CTNode> &node : nodes) {
     if(node->edgeList.size() > 3)
       binary = false;
   }
@@ -78,9 +78,9 @@ ContourTree::ContourTree(float *scalars,
 ContourTree::~ContourTree() {
 }
 
-std::shared_ptr<Tree>
-  ContourTree::computeRootedTree(const std::shared_ptr<CTNode> &node,
-                                 const std::shared_ptr<CTEdge> &parent,
+std::shared_ptr<ttk::cta::Tree>
+  ContourTree::computeRootedTree(const std::shared_ptr<ttk::cta::CTNode> &node,
+                                 const std::shared_ptr<ttk::cta::CTEdge> &parent,
                                  int &id) {
 
   // initialize tree
@@ -110,13 +110,13 @@ std::shared_ptr<Tree>
   // add neighbors to children
   for(size_t i = 0; i < node->edgeList.size(); i++) {
 
-    std::shared_ptr<CTEdge> edge = arcs[node->edgeList[i]];
+    std::shared_ptr<ttk::cta::CTEdge> edge = arcs[node->edgeList[i]];
     if(edge == parent) {
       parentVisited = true;
       continue;
     }
 
-    std::shared_ptr<CTNode> child = nodes[edge->node1Idx] == node
+    std::shared_ptr<ttk::cta::CTNode> child = nodes[edge->node1Idx] == node
                                       ? nodes[edge->node2Idx]
                                       : nodes[edge->node1Idx];
 
@@ -142,9 +142,9 @@ std::shared_ptr<Tree>
   return t;
 }
 
-std::shared_ptr<BinaryTree>
-  ContourTree::computeRootedTree_binary(const std::shared_ptr<CTNode> &node,
-                                        const std::shared_ptr<CTEdge> &parent,
+std::shared_ptr<ttk::cta::BinaryTree>
+  ContourTree::computeRootedTree_binary(const std::shared_ptr<ttk::cta::CTNode> &node,
+                                        const std::shared_ptr<ttk::cta::CTEdge> &parent,
                                         int &id) {
 
   // initialize tree
@@ -156,7 +156,7 @@ std::shared_ptr<BinaryTree>
 
   // set type/label
   t->type = node->type;
-  std::shared_ptr<CTEdge> edge = arcs[node->edgeList[0]];
+  std::shared_ptr<ttk::cta::CTEdge> edge = arcs[node->edgeList[0]];
   int nodeIdx = nodes[edge->node1Idx] == node ? edge->node1Idx : edge->node2Idx;
   t->nodeRefs = std::vector<std::pair<int, int>>();
   t->nodeRefs.push_back(std::make_pair(-1, nodeIdx));
@@ -185,7 +185,7 @@ std::shared_ptr<BinaryTree>
 
     if(edge != parent) {
 
-      std::shared_ptr<CTNode> child = nodes[edge->node1Idx] == node
+      std::shared_ptr<ttk::cta::CTNode> child = nodes[edge->node1Idx] == node
                                         ? nodes[edge->node2Idx]
                                         : nodes[edge->node1Idx];
 
@@ -225,13 +225,13 @@ std::shared_ptr<BinaryTree>
   return t;
 }
 
-std::shared_ptr<BinaryTree> ContourTree::rootAtMax() {
+std::shared_ptr<ttk::cta::BinaryTree> ContourTree::rootAtMax() {
 
   // get global maximum node to build rooted tree from there
   float maxVal = -FLT_MAX;
-  std::shared_ptr<CTNode> globalMax = nullptr;
+  std::shared_ptr<ttk::cta::CTNode> globalMax = nullptr;
 
-  for(const std::shared_ptr<CTNode> &node : nodes) {
+  for(const std::shared_ptr<ttk::cta::CTNode> &node : nodes) {
     if(node->scalarValue > maxVal) {
       globalMax = node;
       maxVal = node->scalarValue;
@@ -243,8 +243,8 @@ std::shared_ptr<BinaryTree> ContourTree::rootAtMax() {
   return computeRootedTree_binary(globalMax, nullptr, id);
 }
 
-std::shared_ptr<BinaryTree>
-  ContourTree::rootAtNode(const std::shared_ptr<CTNode> &root) {
+std::shared_ptr<ttk::cta::BinaryTree>
+  ContourTree::rootAtNode(const std::shared_ptr<ttk::cta::CTNode> &root) {
 
   int id = 1;
 
@@ -389,8 +389,8 @@ std::pair<float, std::vector<int>> ContourTree::pathToMin(int root,
   return std::make_pair(bestVal, path);
 }
 
-std::pair<std::vector<std::shared_ptr<CTNode>>,
-          std::vector<std::shared_ptr<CTEdge>>>
+std::pair<std::vector<std::shared_ptr<ttk::cta::CTNode>>,
+          std::vector<std::shared_ptr<ttk::cta::CTEdge>>>
   ContourTree::getGraph() {
   return std::make_pair(nodes, arcs);
 }

--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -59,8 +59,8 @@ ContourTree::ContourTree(float *scalars,
     else {
       std::shared_ptr<ttk::cta::CTEdge> edge = arcs[node->edgeList[0]];
       std::shared_ptr<ttk::cta::CTNode> neighbor = nodes[edge->node1Idx] == node
-                                           ? nodes[edge->node2Idx]
-                                           : nodes[edge->node1Idx];
+                                                     ? nodes[edge->node2Idx]
+                                                     : nodes[edge->node1Idx];
       if(neighbor->scalarValue > node->scalarValue)
         node->type = minNode;
       else
@@ -78,10 +78,10 @@ ContourTree::ContourTree(float *scalars,
 ContourTree::~ContourTree() {
 }
 
-std::shared_ptr<ttk::cta::Tree>
-  ContourTree::computeRootedTree(const std::shared_ptr<ttk::cta::CTNode> &node,
-                                 const std::shared_ptr<ttk::cta::CTEdge> &parent,
-                                 int &id) {
+std::shared_ptr<ttk::cta::Tree> ContourTree::computeRootedTree(
+  const std::shared_ptr<ttk::cta::CTNode> &node,
+  const std::shared_ptr<ttk::cta::CTEdge> &parent,
+  int &id) {
 
   // initialize tree
   std::shared_ptr<Tree> t(new Tree);
@@ -117,8 +117,8 @@ std::shared_ptr<ttk::cta::Tree>
     }
 
     std::shared_ptr<ttk::cta::CTNode> child = nodes[edge->node1Idx] == node
-                                      ? nodes[edge->node2Idx]
-                                      : nodes[edge->node1Idx];
+                                                ? nodes[edge->node2Idx]
+                                                : nodes[edge->node1Idx];
 
     std::shared_ptr<Tree> childTree = computeRootedTree(child, edge, id);
 
@@ -142,10 +142,10 @@ std::shared_ptr<ttk::cta::Tree>
   return t;
 }
 
-std::shared_ptr<ttk::cta::BinaryTree>
-  ContourTree::computeRootedTree_binary(const std::shared_ptr<ttk::cta::CTNode> &node,
-                                        const std::shared_ptr<ttk::cta::CTEdge> &parent,
-                                        int &id) {
+std::shared_ptr<ttk::cta::BinaryTree> ContourTree::computeRootedTree_binary(
+  const std::shared_ptr<ttk::cta::CTNode> &node,
+  const std::shared_ptr<ttk::cta::CTEdge> &parent,
+  int &id) {
 
   // initialize tree
   std::shared_ptr<BinaryTree> t(new BinaryTree);
@@ -186,8 +186,8 @@ std::shared_ptr<ttk::cta::BinaryTree>
     if(edge != parent) {
 
       std::shared_ptr<ttk::cta::CTNode> child = nodes[edge->node1Idx] == node
-                                        ? nodes[edge->node2Idx]
-                                        : nodes[edge->node1Idx];
+                                                  ? nodes[edge->node2Idx]
+                                                  : nodes[edge->node1Idx];
 
       std::shared_ptr<BinaryTree> childTree
         = computeRootedTree_binary(child, edge, id);

--- a/core/base/contourTreeAlignment/CTA_contourtree.h
+++ b/core/base/contourTreeAlignment/CTA_contourtree.h
@@ -22,27 +22,29 @@ namespace ttk {
     // Tree Data Structure with arbitrary degree
 
     /**
-       * \ingroup base
-       * @brief Basic tree data structure for a rooted contour tree of unbounded degree.
-       *
-       * This structure represents nodes of a rooted contour tree.
-       * It stores the following node properties:
-       * - critical type
-       * - vertex id
-       * 
-       * It stores the following edge properties (these always refer to its parent edge and are filled with dummy values for the root vertex): 
-       * - persistence
-       * - volume
-       * 
-       * It stores the following meta information for the tree structure:
-       * - height of the subtree rooted in this node
-       * - size of the subtree rooted in this node
-       * - node id
-       * - a vector of pointers to its child nodes.
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::ContourTree
-       */
+     * \ingroup base
+     * @brief Basic tree data structure for a rooted contour tree of unbounded
+     * degree.
+     *
+     * This structure represents nodes of a rooted contour tree.
+     * It stores the following node properties:
+     * - critical type
+     * - vertex id
+     *
+     * It stores the following edge properties (these always refer to its parent
+     * edge and are filled with dummy values for the root vertex):
+     * - persistence
+     * - volume
+     *
+     * It stores the following meta information for the tree structure:
+     * - height of the subtree rooted in this node
+     * - size of the subtree rooted in this node
+     * - node id
+     * - a vector of pointers to its child nodes.
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::ContourTree
+     */
     struct Tree {
       std::vector<std::shared_ptr<Tree>> children;
       Type_Node type;
@@ -58,35 +60,37 @@ namespace ttk {
     // Binary Tree Data Structure
 
     /**
-       * \ingroup base
-       * @brief Basic tree data structure for a rooted contour tree of degree 2 and rooted contour tree alignments of degree 2.
-       *
-       * This structure represents nodes of a rooted contour tree.
-       * 
-       * It stores the following node properties: 
-       * - critical type
-       * - vertex id
-       * 
-       * It stores the following edge properties (these always refer to its parent edge and are filled with dummy values for the root vertex):
-       * - persistence
-       * - area
-       * - volume
-       * - the corresponding segment/region
-       * 
-       * It stores the following meta information for the tree structure:
-       * - height of the subtree rooted in this node
-       * - size of the subtree rooted in this node
-       * - node id and two pointers to its child nodes
-       * 
-       * It stores the following alignment node properties:
-       * - frequency of the node
-       * - a vector of references to matched contour tree nodes
-       * - a vector of references to matched contour tree arcs.
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::ContourTree
-       * \sa ttk::cta::AlignmentTree
-       */
+     * \ingroup base
+     * @brief Basic tree data structure for a rooted contour tree of degree 2
+     * and rooted contour tree alignments of degree 2.
+     *
+     * This structure represents nodes of a rooted contour tree.
+     *
+     * It stores the following node properties:
+     * - critical type
+     * - vertex id
+     *
+     * It stores the following edge properties (these always refer to its parent
+     * edge and are filled with dummy values for the root vertex):
+     * - persistence
+     * - area
+     * - volume
+     * - the corresponding segment/region
+     *
+     * It stores the following meta information for the tree structure:
+     * - height of the subtree rooted in this node
+     * - size of the subtree rooted in this node
+     * - node id and two pointers to its child nodes
+     *
+     * It stores the following alignment node properties:
+     * - frequency of the node
+     * - a vector of references to matched contour tree nodes
+     * - a vector of references to matched contour tree arcs.
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::ContourTree
+     * \sa ttk::cta::AlignmentTree
+     */
     struct BinaryTree {
       std::shared_ptr<BinaryTree> child1;
       std::shared_ptr<BinaryTree> child2;
@@ -113,23 +117,23 @@ namespace ttk {
     struct CTEdge;
 
     /**
-       * \ingroup base
-       * @brief Basic data structure for a node of an unrooted contour tree.
-       *
-       * This structure represents nodes of an unrooted contour tree.
-       * 
-       * It stores the following node properties:
-       * - critical type
-       * - scalar value
-       * - branch id
-       * 
-       * It stores the following information for the tree structure:
-       * - a vector of reference ids to its incident edges.
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::ContourTree
-       * \sa ttk::cta::CTEdge
-       */
+     * \ingroup base
+     * @brief Basic data structure for a node of an unrooted contour tree.
+     *
+     * This structure represents nodes of an unrooted contour tree.
+     *
+     * It stores the following node properties:
+     * - critical type
+     * - scalar value
+     * - branch id
+     *
+     * It stores the following information for the tree structure:
+     * - a vector of reference ids to its incident edges.
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::ContourTree
+     * \sa ttk::cta::CTEdge
+     */
     struct CTNode {
 
       Type_Node type;
@@ -140,25 +144,25 @@ namespace ttk {
     };
 
     /**
-       * \ingroup base
-       * @brief Basic data structure for an edge of an unrooted contour tree.
-       *
-       * This structure represents edges of an unrooted contour tree.
-       * 
-       * It stores the following edge properties:
-       * - persistence
-       * - area
-       * - volume
-       * - segmentation id
-       * - the corresponding segment/region.
-       * 
-       * It stores the following information for the tree structure:
-       * - two reference ids to its incident nodes.
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::ContourTree
-       * \sa ttk::cta::CTNode
-       */
+     * \ingroup base
+     * @brief Basic data structure for an edge of an unrooted contour tree.
+     *
+     * This structure represents edges of an unrooted contour tree.
+     *
+     * It stores the following edge properties:
+     * - persistence
+     * - area
+     * - volume
+     * - segmentation id
+     * - the corresponding segment/region.
+     *
+     * It stores the following information for the tree structure:
+     * - two reference ids to its incident nodes.
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::ContourTree
+     * \sa ttk::cta::CTNode
+     */
     struct CTEdge {
 
       int node1Idx;
@@ -174,31 +178,41 @@ namespace ttk {
     // class for an unrooted contour tree
 
     /**
-       * \ingroup base
-       * @brief Contour %Tree Data Structure for an unrooted contour tree of unbounded degree for internal use from the ttk:ContourTreeAlignment module.
-       *
-       * \author Florian Wetzels <f_wetzels13@cs.uni-kl.de> \date 26.11.2021
-       * 
-       * ToDo
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::CTNode
-       * \sa ttk::cta::CTEdge
-       * \sa ttk::cta::BinaryTree
-       * \sa ttk::cta::Tree
-       */
+     * \ingroup base
+     * @brief Contour %Tree Data Structure for an unrooted contour tree of
+     * unbounded degree for internal use from the ttk:ContourTreeAlignment
+     * module.
+     *
+     * \author Florian Wetzels <f_wetzels13@cs.uni-kl.de> \date 26.11.2021
+     *
+     * ToDo
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::CTNode
+     * \sa ttk::cta::CTEdge
+     * \sa ttk::cta::BinaryTree
+     * \sa ttk::cta::Tree
+     */
     class ContourTree {
 
     public:
-      /// Constructor for internal contour tree class. Constructs graph from vtk style array input.
+      /// Constructor for internal contour tree class. Constructs graph from vtk
+      /// style array input.
       ///
-      /// \param scalar Scalar values of the contour tree nodes. scalars[i] is scalar values of the node of index i.
-      /// \param regionSizes Region size values of the contour tree edges. regionSizes[i] is the number of vertices in the segment associated with the edge of index i.
-      /// \param segmentationIds Segmentation ids of the contour tree edges. segmentationIds[i] is an identifier of the segment associated with the edge of index i.
-      /// \param topology Connectivity information describing the graph stucture. topology[i][0] and topology[i][1] are the indices of the two nodes incident to the edge of index i.
-      /// \param nVertices The number of vertices in the graph and the length of scalar array.
-      /// \param nEdges The number of edges in the graph and the length of regionSizes, segmentationIds and topology arrays.
-      /// \param regions Segments/Regions associated with the edges of the contour tree. regions[i] is a vector of vertex identifiers that belong to the edge of index i.
+      /// \param scalar Scalar values of the contour tree nodes. scalars[i] is
+      /// scalar values of the node of index i. \param regionSizes Region size
+      /// values of the contour tree edges. regionSizes[i] is the number of
+      /// vertices in the segment associated with the edge of index i. \param
+      /// segmentationIds Segmentation ids of the contour tree edges.
+      /// segmentationIds[i] is an identifier of the segment associated with the
+      /// edge of index i. \param topology Connectivity information describing
+      /// the graph stucture. topology[i][0] and topology[i][1] are the indices
+      /// of the two nodes incident to the edge of index i. \param nVertices The
+      /// number of vertices in the graph and the length of scalar array. \param
+      /// nEdges The number of edges in the graph and the length of regionSizes,
+      /// segmentationIds and topology arrays. \param regions Segments/Regions
+      /// associated with the edges of the contour tree. regions[i] is a vector
+      /// of vertex identifiers that belong to the edge of index i.
       ContourTree(float *scalars,
                   int *regionSizes,
                   int *segmentationIds,
@@ -210,17 +224,20 @@ namespace ttk {
       /// Destructor of internal contour tree class.
       ~ContourTree();
 
-      /// Get a rooted binary representation of the contour tree. The root is the vertex of highest scalar value.
+      /// Get a rooted binary representation of the contour tree. The root is
+      /// the vertex of highest scalar value.
       ///
-      /// \pre The contour tree should be binary. If it is not, the rooted tree will not be complete.
-      /// \returns Smartpointer to the binary tree object.
+      /// \pre The contour tree should be binary. If it is not, the rooted tree
+      /// will not be complete. \returns Smartpointer to the binary tree object.
       std::shared_ptr<BinaryTree> rootAtMax();
 
-      /// Get a rooted binary representation of the contour tree. The root is the vertex passed as first argument.
+      /// Get a rooted binary representation of the contour tree. The root is
+      /// the vertex passed as first argument.
       ///
-      /// \pre The contour tree should be binary. If it is not, the rooted tree will not be complete.
-      /// \param root The contour tree node that will be the root of the rooted tree.
-      /// \returns Smartpointer to the binary tree object.
+      /// \pre The contour tree should be binary. If it is not, the rooted tree
+      /// will not be complete. \param root The contour tree node that will be
+      /// the root of the rooted tree. \returns Smartpointer to the binary tree
+      /// object.
       std::shared_ptr<BinaryTree>
         rootAtNode(const std::shared_ptr<CTNode> &root);
 
@@ -229,10 +246,12 @@ namespace ttk {
       /// \returns True if the contour tree is binary, False otherwise.
       bool isBinary();
 
-      /// Computes a branch decomposition of the contour tree and attaches the branch information to the node objects.
+      /// Computes a branch decomposition of the contour tree and attaches the
+      /// branch information to the node objects.
       void computeBranches();
 
-      /// Returns a graph representaiton of the contour tree as node list and edge list.
+      /// Returns a graph representaiton of the contour tree as node list and
+      /// edge list.
       ///
       /// \returns Pair consisting of the node list and the edge list.
       std::pair<std::vector<std::shared_ptr<CTNode>>,

--- a/core/base/contourTreeAlignment/CTA_contourtree.h
+++ b/core/base/contourTreeAlignment/CTA_contourtree.h
@@ -7,87 +7,198 @@
 #include <queue>
 #include <stack>
 
-///=====================================================================================================================
-/// enums and structs for tree data structure
-///=====================================================================================================================
-
-///=====================================================================================================================
-/// node types of a contour tree
-enum Type_Node { minNode, maxNode, saddleNode };
-
-///=====================================================================================================================
-/// basic tree data structure for a rooted contour tree of unbounded degree
-struct Tree {
-  std::vector<std::shared_ptr<Tree>> children;
-  Type_Node type;
-  int vertexId;
-  int id;
-  int size;
-  int height;
-  float scalardistanceParent;
-  float volume;
-};
-
-///=====================================================================================================================
-/// basic tree data structure for a rooted contour tree of degree 2
-struct BinaryTree {
-  std::shared_ptr<BinaryTree> child1;
-  std::shared_ptr<BinaryTree> child2;
-  Type_Node type;
-  int vertexId;
-  int id;
-  int size;
-  int height;
-  float scalardistanceParent;
-  float area;
-  float volume;
-  float scalarValue;
-  std::vector<int> region;
-
-  // for fuzzy trees
-  int freq;
-  std::vector<std::pair<int, int>> nodeRefs;
-  std::vector<std::pair<int, int>> arcRefs;
-};
-
-///=====================================================================================================================
-/// edge data structure for an unrooted contour tree (forward declaration)
-struct CTEdge;
-
-///=====================================================================================================================
-/// node data structure for an unrooted contour tree
-struct CTNode {
-
-  Type_Node type;
-  float scalarValue;
-  int branchID;
-
-  std::vector<int> edgeList;
-};
-
-///=====================================================================================================================
-/// edge data structure for an unrooted contour tree (definition)
-struct CTEdge {
-
-  int node1Idx;
-  int node2Idx;
-  float scalardistance;
-  float area;
-  std::vector<int> region;
-  float volume;
-  int segId;
-};
-
-///=======================================================================================S==============================
-/// class for an unrooted contour tree
-///=====================================================================================================================
-
 namespace ttk {
 
   namespace cta {
+
+    //#####################################################################################################################
+    // enums and structs for tree data structure
+
+    //=====================================================================================================================
+    // node types of a contour tree
+    enum Type_Node { minNode, maxNode, saddleNode };
+
+    //=====================================================================================================================
+    // Tree Data Structure with arbitrary degree
+
+    /**
+       * \ingroup base
+       * @brief Basic tree data structure for a rooted contour tree of unbounded degree.
+       *
+       * This structure represents nodes of a rooted contour tree.
+       * It stores the following node properties:
+       * - critical type
+       * - vertex id
+       * 
+       * It stores the following edge properties (these always refer to its parent edge and are filled with dummy values for the root vertex): 
+       * - persistence
+       * - volume
+       * 
+       * It stores the following meta information for the tree structure:
+       * - height of the subtree rooted in this node
+       * - size of the subtree rooted in this node
+       * - node id
+       * - a vector of pointers to its child nodes.
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::ContourTree
+       */
+    struct Tree {
+      std::vector<std::shared_ptr<Tree>> children;
+      Type_Node type;
+      int vertexId;
+      int id;
+      int size;
+      int height;
+      float scalardistanceParent;
+      float volume;
+    };
+
+    //=====================================================================================================================
+    // Binary Tree Data Structure
+
+    /**
+       * \ingroup base
+       * @brief Basic tree data structure for a rooted contour tree of degree 2 and rooted contour tree alignments of degree 2.
+       *
+       * This structure represents nodes of a rooted contour tree.
+       * 
+       * It stores the following node properties: 
+       * - critical type
+       * - vertex id
+       * 
+       * It stores the following edge properties (these always refer to its parent edge and are filled with dummy values for the root vertex):
+       * - persistence
+       * - area
+       * - volume
+       * - the corresponding segment/region
+       * 
+       * It stores the following meta information for the tree structure:
+       * - height of the subtree rooted in this node
+       * - size of the subtree rooted in this node
+       * - node id and two pointers to its child nodes
+       * 
+       * It stores the following alignment node properties:
+       * - frequency of the node
+       * - a vector of references to matched contour tree nodes
+       * - a vector of references to matched contour tree arcs.
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::ContourTree
+       * \sa ttk::cta::AlignmentTree
+       */
+    struct BinaryTree {
+      std::shared_ptr<BinaryTree> child1;
+      std::shared_ptr<BinaryTree> child2;
+      Type_Node type;
+      int vertexId;
+      int id;
+      int size;
+      int height;
+      float scalardistanceParent;
+      float area;
+      float volume;
+      float scalarValue;
+      std::vector<int> region;
+
+      // for fuzzy trees
+      int freq;
+      std::vector<std::pair<int, int>> nodeRefs;
+      std::vector<std::pair<int, int>> arcRefs;
+    };
+
+    //=====================================================================================================================
+    // Structs for unrooted Contour Tree
+
+    struct CTEdge;
+
+    /**
+       * \ingroup base
+       * @brief Basic data structure for a node of an unrooted contour tree.
+       *
+       * This structure represents nodes of an unrooted contour tree.
+       * 
+       * It stores the following node properties:
+       * - critical type
+       * - scalar value
+       * - branch id
+       * 
+       * It stores the following information for the tree structure:
+       * - a vector of reference ids to its incident edges.
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::ContourTree
+       * \sa ttk::cta::CTEdge
+       */
+    struct CTNode {
+
+      Type_Node type;
+      float scalarValue;
+      int branchID;
+
+      std::vector<int> edgeList;
+    };
+
+    /**
+       * \ingroup base
+       * @brief Basic data structure for an edge of an unrooted contour tree.
+       *
+       * This structure represents edges of an unrooted contour tree.
+       * 
+       * It stores the following edge properties:
+       * - persistence
+       * - area
+       * - volume
+       * - segmentation id
+       * - the corresponding segment/region.
+       * 
+       * It stores the following information for the tree structure:
+       * - two reference ids to its incident nodes.
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::ContourTree
+       * \sa ttk::cta::CTNode
+       */
+    struct CTEdge {
+
+      int node1Idx;
+      int node2Idx;
+      float scalardistance;
+      float area;
+      std::vector<int> region;
+      float volume;
+      int segId;
+    };
+
+    ///#####################################################################################################################
+    // class for an unrooted contour tree
+
+    /**
+       * \ingroup base
+       * @brief Contour %Tree Data Structure for an unrooted contour tree of unbounded degree for internal use from the ttk:ContourTreeAlignment module.
+       *
+       * \author Florian Wetzels <f_wetzels13@cs.uni-kl.de> \date 26.11.2021
+       * 
+       * ToDo
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::CTNode
+       * \sa ttk::cta::CTEdge
+       * \sa ttk::cta::BinaryTree
+       * \sa ttk::cta::Tree
+       */
     class ContourTree {
 
     public:
+      /// Constructor for internal contour tree class. Constructs graph from vtk style array input.
+      ///
+      /// \param scalar Scalar values of the contour tree nodes. scalars[i] is scalar values of the node of index i.
+      /// \param regionSizes Region size values of the contour tree edges. regionSizes[i] is the number of vertices in the segment associated with the edge of index i.
+      /// \param segmentationIds Segmentation ids of the contour tree edges. segmentationIds[i] is an identifier of the segment associated with the edge of index i.
+      /// \param topology Connectivity information describing the graph stucture. topology[i][0] and topology[i][1] are the indices of the two nodes incident to the edge of index i.
+      /// \param nVertices The number of vertices in the graph and the length of scalar array.
+      /// \param nEdges The number of edges in the graph and the length of regionSizes, segmentationIds and topology arrays.
+      /// \param regions Segments/Regions associated with the edges of the contour tree. regions[i] is a vector of vertex identifiers that belong to the edge of index i.
       ContourTree(float *scalars,
                   int *regionSizes,
                   int *segmentationIds,
@@ -95,13 +206,35 @@ namespace ttk {
                   size_t nVertices,
                   size_t nEdges,
                   std::vector<std::vector<int>> regions = {});
+
+      /// Destructor of internal contour tree class.
       ~ContourTree();
 
+      /// Get a rooted binary representation of the contour tree. The root is the vertex of highest scalar value.
+      ///
+      /// \pre The contour tree should be binary. If it is not, the rooted tree will not be complete.
+      /// \returns Smartpointer to the binary tree object.
       std::shared_ptr<BinaryTree> rootAtMax();
+
+      /// Get a rooted binary representation of the contour tree. The root is the vertex passed as first argument.
+      ///
+      /// \pre The contour tree should be binary. If it is not, the rooted tree will not be complete.
+      /// \param root The contour tree node that will be the root of the rooted tree.
+      /// \returns Smartpointer to the binary tree object.
       std::shared_ptr<BinaryTree>
         rootAtNode(const std::shared_ptr<CTNode> &root);
+
+      /// Checks if the maximum node degree is at most 3.
+      ///
+      /// \returns True if the contour tree is binary, False otherwise.
       bool isBinary();
+
+      /// Computes a branch decomposition of the contour tree and attaches the branch information to the node objects.
       void computeBranches();
+
+      /// Returns a graph representaiton of the contour tree as node list and edge list.
+      ///
+      /// \returns Pair consisting of the node list and the edge list.
       std::pair<std::vector<std::shared_ptr<CTNode>>,
                 std::vector<std::shared_ptr<CTEdge>>>
         getGraph();

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -42,9 +42,9 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
       for(const auto &cE : currNode->edgeList) {
 
-        std::shared_ptr<ttk::cta::AlignmentNode> cN = (cE->node1.lock()) == currNode
-                                              ? cE->node2.lock()
-                                              : cE->node1.lock();
+        std::shared_ptr<ttk::cta::AlignmentNode> cN
+          = (cE->node1.lock()) == currNode ? cE->node2.lock()
+                                           : cE->node1.lock();
         if(cN == path[i - 1])
           continue;
         if(cN == path[i + 1])
@@ -192,11 +192,12 @@ bool ttk::ContourTreeAlignment::initialize(
 
   std::shared_ptr<ttk::cta::BinaryTree> t = ct->rootAtMax();
 
-  std::queue<
-    std::pair<std::shared_ptr<ttk::cta::BinaryTree>, std::shared_ptr<ttk::cta::AlignmentNode>>>
+  std::queue<std::pair<std::shared_ptr<ttk::cta::BinaryTree>,
+                       std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<ttk::cta::AlignmentNode> currNode(new ttk::cta::AlignmentNode());
+  std::shared_ptr<ttk::cta::AlignmentNode> currNode(
+    new ttk::cta::AlignmentNode());
   std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
@@ -219,7 +220,8 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -229,7 +231,8 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child1->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -247,7 +250,8 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -257,7 +261,8 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child2->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -290,11 +295,12 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
   std::shared_ptr<ttk::cta::BinaryTree> t = ct->rootAtMax();
 
-  std::queue<
-    std::pair<std::shared_ptr<ttk::cta::BinaryTree>, std::shared_ptr<ttk::cta::AlignmentNode>>>
+  std::queue<std::pair<std::shared_ptr<ttk::cta::BinaryTree>,
+                       std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<ttk::cta::AlignmentNode> currNode(new ttk::cta::AlignmentNode());
+  std::shared_ptr<ttk::cta::AlignmentNode> currNode(
+    new ttk::cta::AlignmentNode());
   std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
@@ -317,7 +323,8 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -327,7 +334,8 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child1->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -350,7 +358,8 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -360,7 +369,8 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child2->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -427,7 +437,8 @@ bool ttk::ContourTreeAlignment::alignTree(
       // compute matching
 
       if((node1->type == ttk::cta::maxNode && node2->type == ttk::cta::maxNode)
-         || (node1->type == ttk::cta::minNode && node2->type == ttk::cta::minNode)) {
+         || (node1->type == ttk::cta::minNode
+             && node2->type == ttk::cta::minNode)) {
 
         std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>> match
           = getAlignmentBinary(t1, t2);
@@ -480,8 +491,10 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 
     // compute matching
 
-    if((alignmentRoot->type == ttk::cta::maxNode && node2->type == ttk::cta::maxNode)
-       || (alignmentRoot->type == ttk::cta::minNode && node2->type == ttk::cta::minNode)) {
+    if((alignmentRoot->type == ttk::cta::maxNode
+        && node2->type == ttk::cta::maxNode)
+       || (alignmentRoot->type == ttk::cta::minNode
+           && node2->type == ttk::cta::minNode)) {
 
       t2 = ct->rootAtNode(node2);
 
@@ -517,16 +530,17 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
   nodes.clear();
   arcs.clear();
 
-  std::queue<
-    std::tuple<std::shared_ptr<ttk::cta::AlignmentTree>, std::shared_ptr<ttk::cta::AlignmentNode>,
-               std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>,
-               std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>>
+  std::queue<std::tuple<std::shared_ptr<ttk::cta::AlignmentTree>,
+                        std::shared_ptr<ttk::cta::AlignmentNode>,
+                        std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>,
+                        std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>>
     q;
 
   std::shared_ptr<ttk::cta::AlignmentNode> currNode;
   std::shared_ptr<ttk::cta::AlignmentTree> currTree;
 
-  currNode = std::shared_ptr<ttk::cta::AlignmentNode>(new ttk::cta::AlignmentNode());
+  currNode
+    = std::shared_ptr<ttk::cta::AlignmentNode>(new ttk::cta::AlignmentNode());
 
   if(res->node1 == nullptr && res->node2 == nullptr) {
     return;
@@ -590,9 +604,9 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
   nodes.push_back(currNode);
 
-  q.push(std::make_tuple(res, currNode,
-                         std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>(),
-                         std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>()));
+  q.push(std::make_tuple(
+    res, currNode, std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>(),
+    std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>()));
 
   while(!q.empty()) {
 
@@ -613,7 +627,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
 
       childNode->freq
         = (currTree->child1->node1 == nullptr ? 0
@@ -673,7 +688,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           std::make_pair((int)contourtrees.size() - 1,
                          currTree->child1->node2->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
 
       if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
@@ -792,7 +808,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
+        new ttk::cta::AlignmentNode());
 
       childNode->freq
         = (currTree->child2->node1 == nullptr ? 0
@@ -852,7 +869,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           std::make_pair((int)contourtrees.size() - 1,
                          currTree->child2->node2->nodeRefs[0].second));
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
+        new ttk::cta::AlignmentEdge());
 
       if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
@@ -1049,7 +1067,8 @@ std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>>
   float dist = alignTreeBinary(t1, t2, memT, memF);
 
   // backtrace through the table to get the alignment
-  std::shared_ptr<ttk::cta::AlignmentTree> res = traceAlignmentTree(t1, t2, memT, memF);
+  std::shared_ptr<ttk::cta::AlignmentTree> res
+    = traceAlignmentTree(t1, t2, memT, memF);
 
   return std::make_pair(dist, res);
 }
@@ -1215,11 +1234,11 @@ float ttk::ContourTreeAlignment::editCost(
   if(t1.get() != nullptr)
     v1 = arcMatchMode == ttk::cta::persistence ? t1->scalardistanceParent
          : arcMatchMode == ttk::cta::area      ? t1->area
-                                     : t1->volume;
+                                               : t1->volume;
   if(t2.get() != nullptr)
     v2 = arcMatchMode == ttk::cta::persistence ? t2->scalardistanceParent
          : arcMatchMode == ttk::cta::area      ? t2->area
-                                     : t2->volume;
+                                               : t2->volume;
 
   if(arcMatchMode == ttk::cta::overlap) {
     // this->printMsg("overlap");
@@ -1297,23 +1316,26 @@ float ttk::ContourTreeAlignment::editCost(
     return FLT_MAX;
 }
 
-std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
-  const std::shared_ptr<ttk::cta::BinaryTree> &t1,
-  const std::shared_ptr<ttk::cta::BinaryTree> &t2,
-  std::vector<std::vector<float>> &memT,
-  std::vector<std::vector<float>> &memF) {
+std::shared_ptr<ttk::cta::AlignmentTree>
+  ttk::ContourTreeAlignment::traceAlignmentTree(
+    const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+    const std::shared_ptr<ttk::cta::BinaryTree> &t2,
+    std::vector<std::vector<float>> &memT,
+    std::vector<std::vector<float>> &memF) {
 
   if(t1 == nullptr)
     return traceNullAlignment(t2, false);
   if(t2 == nullptr)
     return traceNullAlignment(t1, true);
 
-  auto id
-    = [](std::shared_ptr<ttk::cta::BinaryTree> &t) { return t == nullptr ? 0 : t->id; };
+  auto id = [](std::shared_ptr<ttk::cta::BinaryTree> &t) {
+    return t == nullptr ? 0 : t->id;
+  };
 
   if(memT[t1->id][t2->id] == editCost(t1, t2) + memF[t1->id][t2->id]) {
 
-    std::shared_ptr<ttk::cta::AlignmentTree> resNode(new ttk::cta::AlignmentTree);
+    std::shared_ptr<ttk::cta::AlignmentTree> resNode(
+      new ttk::cta::AlignmentTree);
 
     resNode->node1 = t1;
     resNode->node2 = t2;
@@ -1443,7 +1465,8 @@ std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceAlignme
 
   printErr("Alignment computation failed. Traceback of memoization table not "
            "possible.");
-  return std::shared_ptr<ttk::cta::AlignmentTree>(new ttk::cta::AlignmentTree());
+  return std::shared_ptr<ttk::cta::AlignmentTree>(
+    new ttk::cta::AlignmentTree());
 }
 
 std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
@@ -1673,8 +1696,9 @@ std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
   return std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>();
 }
 
-std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceNullAlignment(
-  const std::shared_ptr<ttk::cta::BinaryTree> &t, bool first) {
+std::shared_ptr<ttk::cta::AlignmentTree>
+  ttk::ContourTreeAlignment::traceNullAlignment(
+    const std::shared_ptr<ttk::cta::BinaryTree> &t, bool first) {
 
   if(t == nullptr)
     return nullptr;
@@ -1694,7 +1718,8 @@ std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceNullAli
 =====================================================================================================================
 */
 
-bool ttk::ContourTreeAlignment::isBinary(const std::shared_ptr<ttk::cta::Tree> &t) {
+bool ttk::ContourTreeAlignment::isBinary(
+  const std::shared_ptr<ttk::cta::Tree> &t) {
 
   if(t->children.size() > 2)
     return false;
@@ -1711,14 +1736,16 @@ std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::rootAtNode(
   const std::shared_ptr<ttk::cta::AlignmentNode> &root) {
 
   int id = 1;
-  std::shared_ptr<ttk::cta::BinaryTree> t = computeRootedTree(root, nullptr, id);
+  std::shared_ptr<ttk::cta::BinaryTree> t
+    = computeRootedTree(root, nullptr, id);
   return t;
 }
 
-std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
-  const std::shared_ptr<ttk::cta::AlignmentNode> &node,
-  const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
-  int &id) {
+std::shared_ptr<ttk::cta::BinaryTree>
+  ttk::ContourTreeAlignment::computeRootedTree(
+    const std::shared_ptr<ttk::cta::AlignmentNode> &node,
+    const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
+    int &id) {
 
   std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
 
@@ -1773,8 +1800,11 @@ std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedTr
   return t;
 }
 
-std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
-  const std::shared_ptr<ttk::cta::AlignmentEdge> &arc, bool parent1, int &id) {
+std::shared_ptr<ttk::cta::BinaryTree>
+  ttk::ContourTreeAlignment::computeRootedDualTree(
+    const std::shared_ptr<ttk::cta::AlignmentEdge> &arc,
+    bool parent1,
+    int &id) {
 
   std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
 
@@ -1782,12 +1812,13 @@ std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedDu
   t->area = arc->area;
   t->volume = t->area * t->scalardistanceParent;
   t->freq = arc->freq;
-  t->type
-    = arc->node1.lock()->type == ttk::cta::maxNode || arc->node2.lock()->type == ttk::cta::maxNode
-        ? ttk::cta::maxNode
-      : arc->node1.lock()->type == ttk::cta::minNode || arc->node2.lock()->type == ttk::cta::minNode
-        ? ttk::cta::minNode
-        : ttk::cta::saddleNode;
+  t->type = arc->node1.lock()->type == ttk::cta::maxNode
+                || arc->node2.lock()->type == ttk::cta::maxNode
+              ? ttk::cta::maxNode
+            : arc->node1.lock()->type == ttk::cta::minNode
+                || arc->node2.lock()->type == ttk::cta::minNode
+              ? ttk::cta::minNode
+              : ttk::cta::saddleNode;
   t->child1 = nullptr;
   t->child2 = nullptr;
   t->id = id;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -1,46 +1,48 @@
 #include "ContourTreeAlignment.h"
 
-///=====================================================================================================================
-/// branch decomposition
-///=====================================================================================================================
+/*
+=====================================================================================================================
+ branch decomposition
+=====================================================================================================================
+*/
 
 void ttk::ContourTreeAlignment::computeBranches() {
 
   // find global minimum
-  std::shared_ptr<AlignmentNode> minNode = nodes[0];
+  std::shared_ptr<ttk::cta::AlignmentNode> minNode = nodes[0];
   for(size_t i = 1; i < nodes.size(); i++) {
     if(minNode->scalarValue > nodes[i]->scalarValue)
       minNode = nodes[i];
   }
 
   // find path to global max
-  std::shared_ptr<AlignmentNode> nextNode
+  std::shared_ptr<ttk::cta::AlignmentNode> nextNode
     = minNode->edgeList[0]->node1.lock() == minNode
         ? minNode->edgeList[0]->node2.lock()
         : minNode->edgeList[0]->node1.lock();
-  std::vector<std::shared_ptr<AlignmentNode>> maxPath_
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> maxPath_
     = pathToMax(nextNode, minNode).second;
-  std::vector<std::shared_ptr<AlignmentNode>> maxPath;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> maxPath;
   maxPath.push_back(minNode);
   maxPath.insert(maxPath.end(), maxPath_.begin(), maxPath_.end());
 
   int currID = 0;
   minNode->branchID = 0;
-  std::stack<std::vector<std::shared_ptr<AlignmentNode>>> q;
+  std::stack<std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>> q;
   q.push(maxPath);
 
   while(!q.empty()) {
 
-    std::vector<std::shared_ptr<AlignmentNode>> path = q.top();
+    std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> path = q.top();
     q.pop();
 
     for(size_t i = 1; i < path.size() - 1; i++) {
 
-      std::shared_ptr<AlignmentNode> currNode = path[i];
+      std::shared_ptr<ttk::cta::AlignmentNode> currNode = path[i];
 
       for(const auto &cE : currNode->edgeList) {
 
-        std::shared_ptr<AlignmentNode> cN = (cE->node1.lock()) == currNode
+        std::shared_ptr<ttk::cta::AlignmentNode> cN = (cE->node1.lock()) == currNode
                                               ? cE->node2.lock()
                                               : cE->node1.lock();
         if(cN == path[i - 1])
@@ -49,16 +51,16 @@ void ttk::ContourTreeAlignment::computeBranches() {
           continue;
 
         if(cN->scalarValue > currNode->scalarValue) {
-          std::vector<std::shared_ptr<AlignmentNode>> newPath_
+          std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath_
             = pathToMax(cN, currNode).second;
-          std::vector<std::shared_ptr<AlignmentNode>> newPath;
+          std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath;
           newPath.push_back(currNode);
           newPath.insert(newPath.end(), newPath_.begin(), newPath_.end());
           q.push(newPath);
         } else {
-          std::vector<std::shared_ptr<AlignmentNode>> newPath_
+          std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath_
             = pathToMin(cN, currNode).second;
-          std::vector<std::shared_ptr<AlignmentNode>> newPath;
+          std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath;
           newPath.push_back(currNode);
           newPath.insert(newPath.end(), newPath_.begin(), newPath_.end());
           q.push(newPath);
@@ -70,22 +72,22 @@ void ttk::ContourTreeAlignment::computeBranches() {
 
     for(const auto &cE : path.back()->edgeList) {
 
-      std::shared_ptr<AlignmentNode> cN
+      std::shared_ptr<ttk::cta::AlignmentNode> cN
         = cE->node1.lock() == path.back() ? cE->node2.lock() : cE->node1.lock();
       if(cN == path[path.size() - 2])
         continue;
 
       if(cN->scalarValue > path.back()->scalarValue) {
-        std::vector<std::shared_ptr<AlignmentNode>> newPath_
+        std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath_
           = pathToMax(cN, path.back()).second;
-        std::vector<std::shared_ptr<AlignmentNode>> newPath;
+        std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath;
         newPath.push_back(path.back());
         newPath.insert(newPath.end(), newPath_.begin(), newPath_.end());
         q.push(newPath);
       } else {
-        std::vector<std::shared_ptr<AlignmentNode>> newPath_
+        std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath_
           = pathToMin(cN, path.back()).second;
-        std::vector<std::shared_ptr<AlignmentNode>> newPath;
+        std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> newPath;
         newPath.push_back(path.back());
         newPath.insert(newPath.end(), newPath_.begin(), newPath_.end());
         q.push(newPath);
@@ -97,24 +99,24 @@ void ttk::ContourTreeAlignment::computeBranches() {
   }
 }
 
-std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
+std::pair<float, std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>>
   ttk::ContourTreeAlignment::pathToMax(
-    const std::shared_ptr<AlignmentNode> &root,
-    const std::shared_ptr<AlignmentNode> &parent) {
+    const std::shared_ptr<ttk::cta::AlignmentNode> &root,
+    const std::shared_ptr<ttk::cta::AlignmentNode> &parent) {
 
-  std::vector<std::shared_ptr<AlignmentNode>> path;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> path;
   path.push_back(root);
 
   if(root->edgeList.size() == 1) {
     return std::make_pair(root->scalarValue, path);
   }
 
-  std::vector<std::shared_ptr<AlignmentNode>> bestPath;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> bestPath;
   float bestVal = -FLT_MAX;
 
   for(const auto &cE : root->edgeList) {
 
-    std::shared_ptr<AlignmentNode> nextNode
+    std::shared_ptr<ttk::cta::AlignmentNode> nextNode
       = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
     if(parent == nextNode)
       continue;
@@ -133,24 +135,24 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   return std::make_pair(bestVal, path);
 }
 
-std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
+std::pair<float, std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>>
   ttk::ContourTreeAlignment::pathToMin(
-    const std::shared_ptr<AlignmentNode> &root,
-    const std::shared_ptr<AlignmentNode> &parent) {
+    const std::shared_ptr<ttk::cta::AlignmentNode> &root,
+    const std::shared_ptr<ttk::cta::AlignmentNode> &parent) {
 
-  std::vector<std::shared_ptr<AlignmentNode>> path;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> path;
   path.push_back(root);
 
   if(root->edgeList.size() == 1) {
     return std::make_pair(root->scalarValue, path);
   }
 
-  std::vector<std::shared_ptr<AlignmentNode>> bestPath;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> bestPath;
   float bestVal = FLT_MAX;
 
   for(const auto &cE : root->edgeList) {
 
-    std::shared_ptr<AlignmentNode> nextNode
+    std::shared_ptr<ttk::cta::AlignmentNode> nextNode
       = cE->node1.lock() == root ? cE->node2.lock() : cE->node1.lock();
     if(parent == nextNode)
       continue;
@@ -169,9 +171,11 @@ std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
   return std::make_pair(bestVal, path);
 }
 
-///=====================================================================================================================
-/// iterated aligning
-///=====================================================================================================================
+/*
+=====================================================================================================================
+ iterated aligning
+=====================================================================================================================
+*/
 
 using ttk::cta::ContourTree;
 
@@ -186,14 +190,14 @@ bool ttk::ContourTreeAlignment::initialize(
 
   // compute initial Alignment from initial contourtree
 
-  std::shared_ptr<BinaryTree> t = ct->rootAtMax();
+  std::shared_ptr<ttk::cta::BinaryTree> t = ct->rootAtMax();
 
   std::queue<
-    std::pair<std::shared_ptr<BinaryTree>, std::shared_ptr<AlignmentNode>>>
+    std::pair<std::shared_ptr<ttk::cta::BinaryTree>, std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<AlignmentNode> currNode(new AlignmentNode());
-  std::shared_ptr<BinaryTree> currTree;
+  std::shared_ptr<ttk::cta::AlignmentNode> currNode(new ttk::cta::AlignmentNode());
+  std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
   currNode->type = t->type;
@@ -215,7 +219,7 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -225,7 +229,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child1->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -243,7 +247,7 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -253,7 +257,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child2->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -284,14 +288,14 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
   // compute initial Alignment from initial contourtree
 
-  std::shared_ptr<BinaryTree> t = ct->rootAtMax();
+  std::shared_ptr<ttk::cta::BinaryTree> t = ct->rootAtMax();
 
   std::queue<
-    std::pair<std::shared_ptr<BinaryTree>, std::shared_ptr<AlignmentNode>>>
+    std::pair<std::shared_ptr<ttk::cta::BinaryTree>, std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<AlignmentNode> currNode(new AlignmentNode());
-  std::shared_ptr<BinaryTree> currTree;
+  std::shared_ptr<ttk::cta::AlignmentNode> currNode(new ttk::cta::AlignmentNode());
+  std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
   currNode->type = t->type;
@@ -313,7 +317,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -323,7 +327,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child1->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -346,7 +350,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -356,7 +360,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs.push_back(
         std::make_pair(0, currTree->child2->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -399,13 +403,13 @@ bool ttk::ContourTreeAlignment::alignTree(
 
   // compute optimal alignment between current alignment and new tree
 
-  std::shared_ptr<BinaryTree> t1, t2;
+  std::shared_ptr<ttk::cta::BinaryTree> t1, t2;
 
-  std::shared_ptr<AlignmentTree> res = nullptr;
+  std::shared_ptr<ttk::cta::AlignmentTree> res = nullptr;
   float resVal = FLT_MAX;
 
-  std::vector<std::shared_ptr<AlignmentNode>> nodes1 = nodes;
-  std::vector<std::shared_ptr<CTNode>> nodes2 = ct->getGraph().first;
+  std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> nodes1 = nodes;
+  std::vector<std::shared_ptr<ttk::cta::CTNode>> nodes2 = ct->getGraph().first;
 
   int i = 0;
   int j = 0;
@@ -422,10 +426,10 @@ bool ttk::ContourTreeAlignment::alignTree(
 
       // compute matching
 
-      if((node1->type == maxNode && node2->type == maxNode)
-         || (node1->type == minNode && node2->type == minNode)) {
+      if((node1->type == ttk::cta::maxNode && node2->type == ttk::cta::maxNode)
+         || (node1->type == ttk::cta::minNode && node2->type == ttk::cta::minNode)) {
 
-        std::pair<float, std::shared_ptr<AlignmentTree>> match
+        std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>> match
           = getAlignmentBinary(t1, t2);
 
         if(match.first < resVal) {
@@ -461,12 +465,12 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 
   // compute optimal alignment between current alignment and new tree
 
-  std::shared_ptr<BinaryTree> t1, t2;
+  std::shared_ptr<ttk::cta::BinaryTree> t1, t2;
 
-  std::shared_ptr<AlignmentTree> res = nullptr;
+  std::shared_ptr<ttk::cta::AlignmentTree> res = nullptr;
   float resVal = FLT_MAX;
 
-  std::vector<std::shared_ptr<CTNode>> nodes2 = ct->getGraph().first;
+  std::vector<std::shared_ptr<ttk::cta::CTNode>> nodes2 = ct->getGraph().first;
 
   int i = 0;
 
@@ -476,12 +480,12 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 
     // compute matching
 
-    if((alignmentRoot->type == maxNode && node2->type == maxNode)
-       || (alignmentRoot->type == minNode && node2->type == minNode)) {
+    if((alignmentRoot->type == ttk::cta::maxNode && node2->type == ttk::cta::maxNode)
+       || (alignmentRoot->type == ttk::cta::minNode && node2->type == ttk::cta::minNode)) {
 
       t2 = ct->rootAtNode(node2);
 
-      std::pair<float, std::shared_ptr<AlignmentTree>> match
+      std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>> match
         = getAlignmentBinary(t1, t2);
 
       if(match.first < resVal) {
@@ -508,21 +512,21 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 }
 
 void ttk::ContourTreeAlignment::computeNewAlignmenttree(
-  const std::shared_ptr<AlignmentTree> &res) {
+  const std::shared_ptr<ttk::cta::AlignmentTree> &res) {
 
   nodes.clear();
   arcs.clear();
 
   std::queue<
-    std::tuple<std::shared_ptr<AlignmentTree>, std::shared_ptr<AlignmentNode>,
-               std::vector<std::shared_ptr<AlignmentEdge>>,
-               std::vector<std::shared_ptr<AlignmentEdge>>>>
+    std::tuple<std::shared_ptr<ttk::cta::AlignmentTree>, std::shared_ptr<ttk::cta::AlignmentNode>,
+               std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>,
+               std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>>
     q;
 
-  std::shared_ptr<AlignmentNode> currNode;
-  std::shared_ptr<AlignmentTree> currTree;
+  std::shared_ptr<ttk::cta::AlignmentNode> currNode;
+  std::shared_ptr<ttk::cta::AlignmentTree> currTree;
 
-  currNode = std::shared_ptr<AlignmentNode>(new AlignmentNode());
+  currNode = std::shared_ptr<ttk::cta::AlignmentNode>(new ttk::cta::AlignmentNode());
 
   if(res->node1 == nullptr && res->node2 == nullptr) {
     return;
@@ -533,7 +537,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
   currNode->type = res->node1 == nullptr ? res->node2->type : res->node1->type;
   currNode->branchID = -1;
 
-  if(alignmenttreeType == lastMatchedValue) {
+  if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
     currNode->scalarValue = res->node2 == nullptr ? res->node1->scalarValue
                                                   : res->node2->scalarValue;
@@ -547,7 +551,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
       currNode->nodeRefs.push_back(std::make_pair(
         (int)contourtrees.size() - 1, res->node2->nodeRefs[0].second));
 
-  } else if(alignmenttreeType == averageValues) {
+  } else if(alignmenttreeType == ttk::cta::averageValues) {
 
     currNode->scalarValue = res->node1 == nullptr ? res->node2->scalarValue
                             : res->node2 == nullptr
@@ -587,8 +591,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
   nodes.push_back(currNode);
 
   q.push(std::make_tuple(res, currNode,
-                         std::vector<std::shared_ptr<AlignmentEdge>>(),
-                         std::vector<std::shared_ptr<AlignmentEdge>>()));
+                         std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>(),
+                         std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>()));
 
   while(!q.empty()) {
 
@@ -609,7 +613,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
 
       childNode->freq
         = (currTree->child1->node1 == nullptr ? 0
@@ -623,13 +627,13 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       childNode->branchID = -1;
 
-      if(alignmenttreeType == lastMatchedValue) {
+      if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
         childNode->scalarValue = currTree->child1->node2 == nullptr
                                    ? currTree->child1->node1->scalarValue
                                    : currTree->child1->node2->scalarValue;
 
-      } else if(alignmenttreeType == averageValues) {
+      } else if(alignmenttreeType == ttk::cta::averageValues) {
 
         childNode->scalarValue = currTree->child1->node1 == nullptr
                                    ? currTree->child1->node2->scalarValue
@@ -669,9 +673,9 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           std::make_pair((int)contourtrees.size() - 1,
                          currTree->child1->node2->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
 
-      if(alignmenttreeType == lastMatchedValue) {
+      if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
         childEdge->area = currTree->child1->node2 == nullptr
                             ? currTree->child1->node1->area
@@ -682,7 +686,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
               ? currTree->child1->node1->scalardistanceParent
               : currTree->child1->node2->scalardistanceParent;
 
-      } else if(alignmenttreeType == averageValues) {
+      } else if(alignmenttreeType == ttk::cta::averageValues) {
 
         childEdge->area
           = currTree->child1->node1 == nullptr ? currTree->child1->node2->area
@@ -788,7 +792,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<AlignmentNode> childNode(new AlignmentNode());
+      std::shared_ptr<ttk::cta::AlignmentNode> childNode(new ttk::cta::AlignmentNode());
 
       childNode->freq
         = (currTree->child2->node1 == nullptr ? 0
@@ -802,13 +806,13 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
 
       childNode->branchID = -1;
 
-      if(alignmenttreeType == lastMatchedValue) {
+      if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
         childNode->scalarValue = currTree->child2->node2 == nullptr
                                    ? currTree->child2->node1->scalarValue
                                    : currTree->child2->node2->scalarValue;
 
-      } else if(alignmenttreeType == averageValues) {
+      } else if(alignmenttreeType == ttk::cta::averageValues) {
 
         childNode->scalarValue = currTree->child2->node1 == nullptr
                                    ? currTree->child2->node2->scalarValue
@@ -848,9 +852,9 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           std::make_pair((int)contourtrees.size() - 1,
                          currTree->child2->node2->nodeRefs[0].second));
 
-      std::shared_ptr<AlignmentEdge> childEdge(new AlignmentEdge());
+      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(new ttk::cta::AlignmentEdge());
 
-      if(alignmenttreeType == lastMatchedValue) {
+      if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
         childEdge->area = currTree->child2->node2 == nullptr
                             ? currTree->child2->node1->area
@@ -861,7 +865,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
               ? currTree->child2->node1->scalardistanceParent
               : currTree->child2->node2->scalardistanceParent;
 
-      } else if(alignmenttreeType == averageValues) {
+      } else if(alignmenttreeType == ttk::cta::averageValues) {
 
         childEdge->area
           = currTree->child2->node1 == nullptr ? currTree->child2->node2->area
@@ -963,9 +967,11 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
   }
 }
 
-///=====================================================================================================================
-/// getters and setters
-///=====================================================================================================================
+/*
+=====================================================================================================================
+ getters and setters
+=====================================================================================================================
+*/
 
 int ttk::ContourTreeAlignment::getAlignmentRootIdx() {
   int idx = 0;
@@ -983,12 +989,12 @@ std::vector<std::shared_ptr<ContourTree>>
   return contourtrees;
 }
 
-std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
-                      std::vector<std::shared_ptr<CTEdge>>>>
+std::vector<std::pair<std::vector<std::shared_ptr<ttk::cta::CTNode>>,
+                      std::vector<std::shared_ptr<ttk::cta::CTEdge>>>>
   ttk::ContourTreeAlignment::getGraphs() {
 
-  std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
-                        std::vector<std::shared_ptr<CTEdge>>>>
+  std::vector<std::pair<std::vector<std::shared_ptr<ttk::cta::CTNode>>,
+                        std::vector<std::shared_ptr<ttk::cta::CTEdge>>>>
     trees_simplified;
 
   for(const auto &ct : contourtrees) {
@@ -998,17 +1004,17 @@ std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
   return trees_simplified;
 }
 
-std::pair<std::vector<std::shared_ptr<AlignmentNode>>,
-          std::vector<std::shared_ptr<AlignmentEdge>>>
+std::pair<std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>,
+          std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>
   ttk::ContourTreeAlignment::getAlignmentGraph() {
 
   return std::make_pair(nodes, arcs);
 }
 
-std::shared_ptr<BinaryTree>
+std::shared_ptr<ttk::cta::BinaryTree>
   ttk::ContourTreeAlignment::getAlignmentGraphRooted() {
 
-  std::shared_ptr<AlignmentNode> root = nodes[0];
+  std::shared_ptr<ttk::cta::AlignmentNode> root = nodes[0];
   float maxScalar = FLT_MIN;
   for(const auto &node : nodes) {
 
@@ -1022,14 +1028,16 @@ std::shared_ptr<BinaryTree>
   return rootAtNode(root);
 }
 
-///=====================================================================================================================
-/// aligning two trees
-///=====================================================================================================================
+/*
+=====================================================================================================================
+ aligning two trees
+=====================================================================================================================
+*/
 
-std::pair<float, std::shared_ptr<AlignmentTree>>
+std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>>
   ttk::ContourTreeAlignment::getAlignmentBinary(
-    const std::shared_ptr<BinaryTree> &t1,
-    const std::shared_ptr<BinaryTree> &t2) {
+    const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+    const std::shared_ptr<ttk::cta::BinaryTree> &t2) {
 
   // initialize memoization tables
   std::vector<std::vector<float>> memT(
@@ -1041,14 +1049,14 @@ std::pair<float, std::shared_ptr<AlignmentTree>>
   float dist = alignTreeBinary(t1, t2, memT, memF);
 
   // backtrace through the table to get the alignment
-  std::shared_ptr<AlignmentTree> res = traceAlignmentTree(t1, t2, memT, memF);
+  std::shared_ptr<ttk::cta::AlignmentTree> res = traceAlignmentTree(t1, t2, memT, memF);
 
   return std::make_pair(dist, res);
 }
 
 float ttk::ContourTreeAlignment::alignTreeBinary(
-  const std::shared_ptr<BinaryTree> &t1,
-  const std::shared_ptr<BinaryTree> &t2,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1121,8 +1129,8 @@ float ttk::ContourTreeAlignment::alignTreeBinary(
 }
 
 float ttk::ContourTreeAlignment::alignForestBinary(
-  const std::shared_ptr<BinaryTree> &t1,
-  const std::shared_ptr<BinaryTree> &t2,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1200,20 +1208,20 @@ float ttk::ContourTreeAlignment::alignForestBinary(
 }
 
 float ttk::ContourTreeAlignment::editCost(
-  const std::shared_ptr<BinaryTree> &t1,
-  const std::shared_ptr<BinaryTree> &t2) {
+  const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t2) {
 
   float v1 = 0, v2 = 0;
   if(t1.get() != nullptr)
-    v1 = arcMatchMode == persistence ? t1->scalardistanceParent
-         : arcMatchMode == area      ? t1->area
+    v1 = arcMatchMode == ttk::cta::persistence ? t1->scalardistanceParent
+         : arcMatchMode == ttk::cta::area      ? t1->area
                                      : t1->volume;
   if(t2.get() != nullptr)
-    v2 = arcMatchMode == persistence ? t2->scalardistanceParent
-         : arcMatchMode == area      ? t2->area
+    v2 = arcMatchMode == ttk::cta::persistence ? t2->scalardistanceParent
+         : arcMatchMode == ttk::cta::area      ? t2->area
                                      : t2->volume;
 
-  if(arcMatchMode == overlap) {
+  if(arcMatchMode == ttk::cta::overlap) {
     // this->printMsg("overlap");
     int unionsize = 0;
     int intersectionsize = 0;
@@ -1289,9 +1297,9 @@ float ttk::ContourTreeAlignment::editCost(
     return FLT_MAX;
 }
 
-std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
-  const std::shared_ptr<BinaryTree> &t1,
-  const std::shared_ptr<BinaryTree> &t2,
+std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
+  const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+  const std::shared_ptr<ttk::cta::BinaryTree> &t2,
   std::vector<std::vector<float>> &memT,
   std::vector<std::vector<float>> &memF) {
 
@@ -1301,11 +1309,11 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
     return traceNullAlignment(t1, true);
 
   auto id
-    = [](std::shared_ptr<BinaryTree> &t) { return t == nullptr ? 0 : t->id; };
+    = [](std::shared_ptr<ttk::cta::BinaryTree> &t) { return t == nullptr ? 0 : t->id; };
 
   if(memT[t1->id][t2->id] == editCost(t1, t2) + memF[t1->id][t2->id]) {
 
-    std::shared_ptr<AlignmentTree> resNode(new AlignmentTree);
+    std::shared_ptr<ttk::cta::AlignmentTree> resNode(new ttk::cta::AlignmentTree);
 
     resNode->node1 = t1;
     resNode->node2 = t2;
@@ -1314,7 +1322,7 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
     resNode->height = 0;
     resNode->size = 1;
 
-    std::vector<std::shared_ptr<AlignmentTree>> resChildren
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> resChildren
       = traceAlignmentForest(t1, t2, memT, memF);
 
     if(resChildren.size() > 0)
@@ -1338,11 +1346,11 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
           + memT[id(t1->child1)]
                 [t2->id] /* && t1->type != maxNode && t1->type != minNode */) {
 
-    std::shared_ptr<AlignmentTree> resChild1
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild1
       = traceAlignmentTree(t1->child1, t2, memT, memF);
-    std::shared_ptr<AlignmentTree> resChild2
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t1->child2, true);
-    std::shared_ptr<AlignmentTree> res(new AlignmentTree());
+    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
     res->node1 = t1;
     res->node2 = nullptr;
     res->height = 0;
@@ -1363,11 +1371,11 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
           + memT[id(t1->child2)]
                 [t2->id] /* && t1->type != maxNode && t1->type != minNode */) {
 
-    std::shared_ptr<AlignmentTree> resChild1
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild1
       = traceAlignmentTree(t1->child2, t2, memT, memF);
-    std::shared_ptr<AlignmentTree> resChild2
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t1->child1, true);
-    std::shared_ptr<AlignmentTree> res(new AlignmentTree());
+    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
     res->node1 = t1;
     res->node2 = nullptr;
     res->height = 0;
@@ -1388,11 +1396,11 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
           + memT[t1->id][id(
             t2->child1)] /* && t2->type != maxNode && t2->type != minNode */) {
 
-    std::shared_ptr<AlignmentTree> resChild1
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild1
       = traceAlignmentTree(t1, t2->child1, memT, memF);
-    std::shared_ptr<AlignmentTree> resChild2
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t2->child2, false);
-    std::shared_ptr<AlignmentTree> res(new AlignmentTree());
+    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
     res->node1 = nullptr;
     res->node2 = t2;
     res->height = 0;
@@ -1413,11 +1421,11 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
           + memT[t1->id][id(
             t2->child2)] /* && t2->type != maxNode && t2->type != minNode */) {
 
-    std::shared_ptr<AlignmentTree> resChild1
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild1
       = traceAlignmentTree(t1, t2->child2, memT, memF);
-    std::shared_ptr<AlignmentTree> resChild2
+    std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t2->child1, false);
-    std::shared_ptr<AlignmentTree> res(new AlignmentTree());
+    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
     res->node1 = nullptr;
     res->node2 = t2;
     res->height = 0;
@@ -1435,34 +1443,34 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceAlignmentTree(
 
   printErr("Alignment computation failed. Traceback of memoization table not "
            "possible.");
-  return std::shared_ptr<AlignmentTree>(new AlignmentTree());
+  return std::shared_ptr<ttk::cta::AlignmentTree>(new ttk::cta::AlignmentTree());
 }
 
-std::vector<std::shared_ptr<AlignmentTree>>
+std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
   ttk::ContourTreeAlignment::traceAlignmentForest(
-    const std::shared_ptr<BinaryTree> &t1,
-    const std::shared_ptr<BinaryTree> &t2,
+    const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+    const std::shared_ptr<ttk::cta::BinaryTree> &t2,
     std::vector<std::vector<float>> &memT,
     std::vector<std::vector<float>> &memF) {
 
   if(t1 == nullptr && t2 == nullptr)
-    return std::vector<std::shared_ptr<AlignmentTree>>();
+    return std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>();
   if(t1 == nullptr) {
-    std::vector<std::shared_ptr<AlignmentTree>> res;
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
     if(t2->child1 != nullptr)
       res.push_back(traceNullAlignment(t2->child1, false));
     if(t2->child2 != nullptr)
       res.push_back(traceNullAlignment(t2->child2, false));
   }
   if(t2 == nullptr) {
-    std::vector<std::shared_ptr<AlignmentTree>> res;
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
     if(t1->child1 != nullptr)
       res.push_back(traceNullAlignment(t1->child1, true));
     if(t1->child2 != nullptr)
       res.push_back(traceNullAlignment(t1->child2, true));
   }
 
-  auto id = [](const std::shared_ptr<BinaryTree> &t) {
+  auto id = [](const std::shared_ptr<ttk::cta::BinaryTree> &t) {
     return t == nullptr ? 0 : t->id;
   };
 
@@ -1470,12 +1478,12 @@ std::vector<std::shared_ptr<AlignmentTree>>
      == memT[id(t1->child1)][id(t2->child1)]
           + memT[id(t1->child2)][id(t2->child2)]) {
 
-    std::vector<std::shared_ptr<AlignmentTree>> res;
-    std::shared_ptr<AlignmentTree> res1
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
+    std::shared_ptr<ttk::cta::AlignmentTree> res1
       = traceAlignmentTree(t1->child1, t2->child1, memT, memF);
     if(res1 != nullptr)
       res.push_back(res1);
-    std::shared_ptr<AlignmentTree> res2
+    std::shared_ptr<ttk::cta::AlignmentTree> res2
       = traceAlignmentTree(t1->child2, t2->child2, memT, memF);
     if(res2 != nullptr)
       res.push_back(res2);
@@ -1487,12 +1495,12 @@ std::vector<std::shared_ptr<AlignmentTree>>
      == memT[id(t1->child1)][id(t2->child2)]
           + memT[id(t1->child2)][id(t2->child1)]) {
 
-    std::vector<std::shared_ptr<AlignmentTree>> res;
-    std::shared_ptr<AlignmentTree> res1
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
+    std::shared_ptr<ttk::cta::AlignmentTree> res1
       = traceAlignmentTree(t1->child1, t2->child2, memT, memF);
     if(res1 != nullptr)
       res.push_back(res1);
-    std::shared_ptr<AlignmentTree> res2
+    std::shared_ptr<ttk::cta::AlignmentTree> res2
       = traceAlignmentTree(t1->child2, t2->child1, memT, memF);
     if(res2 != nullptr)
       res.push_back(res2);
@@ -1506,9 +1514,9 @@ std::vector<std::shared_ptr<AlignmentTree>>
 
     if(t1->child1 != nullptr) {
 
-      std::vector<std::shared_ptr<AlignmentTree>> res;
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<AlignmentTree> t(new AlignmentTree);
+      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
       t->node1 = t1->child1;
       t->node2 = nullptr;
 
@@ -1518,7 +1526,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       t->size = 1;
       t->height = 0;
 
-      std::vector<std::shared_ptr<AlignmentTree>> resChildren
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> resChildren
         = traceAlignmentForest(t1->child1, t2, memT, memF);
       if(resChildren.size() > 0)
         t->child1 = resChildren[0];
@@ -1546,9 +1554,9 @@ std::vector<std::shared_ptr<AlignmentTree>>
 
     if(t1->child2 != nullptr) {
 
-      std::vector<std::shared_ptr<AlignmentTree>> res;
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<AlignmentTree> t(new AlignmentTree);
+      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
       t->node1 = t1->child2;
       t->node2 = nullptr;
 
@@ -1558,7 +1566,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       t->size = 1;
       t->height = 0;
 
-      std::vector<std::shared_ptr<AlignmentTree>> resChildren
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> resChildren
         = traceAlignmentForest(t1->child2, t2, memT, memF);
       if(resChildren.size() > 0)
         t->child1 = resChildren[0];
@@ -1586,9 +1594,9 @@ std::vector<std::shared_ptr<AlignmentTree>>
 
     if(t2->child1 != nullptr) {
 
-      std::vector<std::shared_ptr<AlignmentTree>> res;
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<AlignmentTree> t(new AlignmentTree);
+      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
       t->node1 = nullptr;
       t->node2 = t2->child1;
 
@@ -1598,7 +1606,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       t->size = 1;
       t->height = 0;
 
-      std::vector<std::shared_ptr<AlignmentTree>> resChildren
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> resChildren
         = traceAlignmentForest(t1, t2->child1, memT, memF);
       if(resChildren.size() > 0)
         t->child1 = resChildren[0];
@@ -1626,9 +1634,9 @@ std::vector<std::shared_ptr<AlignmentTree>>
 
     if(t2->child2 != nullptr) {
 
-      std::vector<std::shared_ptr<AlignmentTree>> res;
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<AlignmentTree> t(new AlignmentTree);
+      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
       t->node1 = nullptr;
       t->node2 = t2->child2;
 
@@ -1638,7 +1646,7 @@ std::vector<std::shared_ptr<AlignmentTree>>
       t->size = 1;
       t->height = 0;
 
-      std::vector<std::shared_ptr<AlignmentTree>> resChildren
+      std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> resChildren
         = traceAlignmentForest(t1, t2->child2, memT, memF);
       if(resChildren.size() > 0)
         t->child1 = resChildren[0];
@@ -1662,15 +1670,15 @@ std::vector<std::shared_ptr<AlignmentTree>>
 
   printErr("Alignment computation failed. Traceback of memoization table not "
            "possible.");
-  return std::vector<std::shared_ptr<AlignmentTree>>();
+  return std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>();
 }
 
-std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceNullAlignment(
-  const std::shared_ptr<BinaryTree> &t, bool first) {
+std::shared_ptr<ttk::cta::AlignmentTree> ttk::ContourTreeAlignment::traceNullAlignment(
+  const std::shared_ptr<ttk::cta::BinaryTree> &t, bool first) {
 
   if(t == nullptr)
     return nullptr;
-  std::shared_ptr<AlignmentTree> at(new AlignmentTree());
+  std::shared_ptr<ttk::cta::AlignmentTree> at(new ttk::cta::AlignmentTree());
   at->node1 = first ? t : nullptr;
   at->node2 = first ? nullptr : t;
   at->height = t->height;
@@ -1680,11 +1688,13 @@ std::shared_ptr<AlignmentTree> ttk::ContourTreeAlignment::traceNullAlignment(
   return at;
 }
 
-///=====================================================================================================================
-/// helper functions
-///=====================================================================================================================
+/*
+=====================================================================================================================
+ helper functions
+=====================================================================================================================
+*/
 
-bool ttk::ContourTreeAlignment::isBinary(const std::shared_ptr<Tree> &t) {
+bool ttk::ContourTreeAlignment::isBinary(const std::shared_ptr<ttk::cta::Tree> &t) {
 
   if(t->children.size() > 2)
     return false;
@@ -1697,20 +1707,20 @@ bool ttk::ContourTreeAlignment::isBinary(const std::shared_ptr<Tree> &t) {
   }
 }
 
-std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::rootAtNode(
-  const std::shared_ptr<AlignmentNode> &root) {
+std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::rootAtNode(
+  const std::shared_ptr<ttk::cta::AlignmentNode> &root) {
 
   int id = 1;
-  std::shared_ptr<BinaryTree> t = computeRootedTree(root, nullptr, id);
+  std::shared_ptr<ttk::cta::BinaryTree> t = computeRootedTree(root, nullptr, id);
   return t;
 }
 
-std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
-  const std::shared_ptr<AlignmentNode> &node,
-  const std::shared_ptr<AlignmentEdge> &parent,
+std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
+  const std::shared_ptr<ttk::cta::AlignmentNode> &node,
+  const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
   int &id) {
 
-  std::shared_ptr<BinaryTree> t(new BinaryTree);
+  std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
 
   if(parent == nullptr) {
     t->scalardistanceParent = 10000;
@@ -1739,13 +1749,13 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
   t->size = 1;
   t->height = 0;
 
-  std::vector<std::shared_ptr<BinaryTree>> children;
+  std::vector<std::shared_ptr<ttk::cta::BinaryTree>> children;
 
   for(const auto &edge : node->edgeList) {
 
     if(edge != parent) {
 
-      std::shared_ptr<BinaryTree> child = computeRootedTree(
+      std::shared_ptr<ttk::cta::BinaryTree> child = computeRootedTree(
         edge->node1.lock() == node ? edge->node2.lock() : edge->node1.lock(),
         edge, id);
       children.push_back(child);
@@ -1763,21 +1773,21 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedTree(
   return t;
 }
 
-std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
-  const std::shared_ptr<AlignmentEdge> &arc, bool parent1, int &id) {
+std::shared_ptr<ttk::cta::BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
+  const std::shared_ptr<ttk::cta::AlignmentEdge> &arc, bool parent1, int &id) {
 
-  std::shared_ptr<BinaryTree> t(new BinaryTree);
+  std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
 
   t->scalardistanceParent = arc->scalardistance;
   t->area = arc->area;
   t->volume = t->area * t->scalardistanceParent;
   t->freq = arc->freq;
   t->type
-    = arc->node1.lock()->type == maxNode || arc->node2.lock()->type == maxNode
-        ? maxNode
-      : arc->node1.lock()->type == minNode || arc->node2.lock()->type == minNode
-        ? minNode
-        : saddleNode;
+    = arc->node1.lock()->type == ttk::cta::maxNode || arc->node2.lock()->type == ttk::cta::maxNode
+        ? ttk::cta::maxNode
+      : arc->node1.lock()->type == ttk::cta::minNode || arc->node2.lock()->type == ttk::cta::minNode
+        ? ttk::cta::minNode
+        : ttk::cta::saddleNode;
   t->child1 = nullptr;
   t->child2 = nullptr;
   t->id = id;
@@ -1788,16 +1798,16 @@ std::shared_ptr<BinaryTree> ttk::ContourTreeAlignment::computeRootedDualTree(
   t->size = 1;
   t->height = 0;
 
-  std::vector<std::shared_ptr<BinaryTree>> children;
+  std::vector<std::shared_ptr<ttk::cta::BinaryTree>> children;
 
-  std::shared_ptr<AlignmentNode> node
+  std::shared_ptr<ttk::cta::AlignmentNode> node
     = parent1 ? arc->node2.lock() : arc->node1.lock();
 
   for(const auto &edge : node->edgeList) {
 
     if(edge != arc) {
 
-      std::shared_ptr<BinaryTree> child = computeRootedDualTree(
+      std::shared_ptr<ttk::cta::BinaryTree> child = computeRootedDualTree(
         edge, edge->node1.lock() == node ? true : false, id);
       children.push_back(child);
       t->size += child->size;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -207,7 +207,7 @@ namespace ttk {
     /// \param nVertices Vector holding n integers representing the number of nodes of the n input trees.
     /// \param nEdges Vector holding n integers representing the number of edges of the n input trees.
     /// \param segmentations Vector holding n arrays representing the segmentation arrays of the n input trees.
-    /// \param segSizes ToDo: This should be reduntant with regionSizes.
+    /// \param segSizes Vector holding the sizes of the corresponding segmentations array. segSizes[i] should be the size of the number of points in the ith scalar field. This should also be the size of segmentations[i].
     /// \param outputVertices Vector for the alignment node scalars that will be filled by this algorithm. outputVertices[i] should be the scalar value of the ith node in the alignment tree.
     /// \param outputFrequencies Vector for the alignment node frequencies that will be filled by this algorithm. outputFrequencies[i] should be the number of original nodes matched the ith node in the alignment tree.
     /// \param outputVertexIds Vector for the alignment node matching that will be filled by this algorithm. outputVertexIds[i*n+j] should be the id of the vertex from the jth input tree matched in the ith node of the alignment tree.

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -41,31 +41,32 @@
 #include <memory>
 #include <random>
 
-namespace ttk{
+namespace ttk {
 
-  namespace cta{
+  namespace cta {
 
     enum Type_Alignmenttree { averageValues, medianValues, lastMatchedValue };
     // enum Type_Match { matchNodes, matchArcs };
     enum Mode_ArcMatch { persistence, area, volume, overlap };
 
     /**
-       * \ingroup base
-       * @brief Basic tree data structure for an alignment of two rooted binary trees.
-       *
-       * This structure represents nodes of a rooted alignment tree.
-       * 
-       * It stores the following meta information for the tree structure:
-       * - height of the subtree rooted in this node
-       * - size of the subtree rooted in this node
-       * - two pointers to its child nodes
-       * 
-       * It stores the following alignment node properties:
-       * - pointers to the two matched nodes
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::BinaryTree
-       */
+     * \ingroup base
+     * @brief Basic tree data structure for an alignment of two rooted binary
+     * trees.
+     *
+     * This structure represents nodes of a rooted alignment tree.
+     *
+     * It stores the following meta information for the tree structure:
+     * - height of the subtree rooted in this node
+     * - size of the subtree rooted in this node
+     * - two pointers to its child nodes
+     *
+     * It stores the following alignment node properties:
+     * - pointers to the two matched nodes
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::BinaryTree
+     */
     struct AlignmentTree {
       std::shared_ptr<ttk::cta::AlignmentTree> child1;
       std::shared_ptr<ttk::cta::AlignmentTree> child2;
@@ -79,26 +80,27 @@ namespace ttk{
     struct AlignmentEdge;
 
     /**
-       * \ingroup base
-       * @brief Basic data structure for a node of an unrooted alignment tree.
-       *
-       * This structure represents nodes of an unrooted alignment tree.
-       * 
-       * It stores the following edge properties:
-       * - critical type
-       * - scalar value
-       * - branchID
-       * 
-       * It stores the following information for the tree structure:
-       * - a vector with reference ids to its incident edges.
-       * 
-       * It stores the following alignment information:
-       * - frequency
-       * - references to the ids of the represented nodes of the origial contour trees
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::AlignmentEdge
-       */
+     * \ingroup base
+     * @brief Basic data structure for a node of an unrooted alignment tree.
+     *
+     * This structure represents nodes of an unrooted alignment tree.
+     *
+     * It stores the following edge properties:
+     * - critical type
+     * - scalar value
+     * - branchID
+     *
+     * It stores the following information for the tree structure:
+     * - a vector with reference ids to its incident edges.
+     *
+     * It stores the following alignment information:
+     * - frequency
+     * - references to the ids of the represented nodes of the origial contour
+     * trees
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::AlignmentEdge
+     */
     struct AlignmentNode {
 
       ttk::cta::Type_Node type;
@@ -112,27 +114,28 @@ namespace ttk{
     };
 
     /**
-       * \ingroup base
-       * @brief Basic data structure for an edge of an unrooted alignment tree.
-       *
-       * This structure represents edges of an unrooted alignment tree.
-       * 
-       * It stores the following edge properties:
-       * - persistence
-       * - area
-       * - volume
-       * - the corresponding segment/region.
-       * 
-       * It stores the following information for the tree structure:
-       * - two reference ids to its incident nodes.
-       * 
-       * It stores the following alignment information:
-       * - frequency
-       * - references to the ids of the represented arcs of the origial contour trees
-       *
-       * \sa ttk::ContourTreeAlignment
-       * \sa ttk::cta::AlignmentNode
-       */
+     * \ingroup base
+     * @brief Basic data structure for an edge of an unrooted alignment tree.
+     *
+     * This structure represents edges of an unrooted alignment tree.
+     *
+     * It stores the following edge properties:
+     * - persistence
+     * - area
+     * - volume
+     * - the corresponding segment/region.
+     *
+     * It stores the following information for the tree structure:
+     * - two reference ids to its incident nodes.
+     *
+     * It stores the following alignment information:
+     * - frequency
+     * - references to the ids of the represented arcs of the origial contour
+     * trees
+     *
+     * \sa ttk::ContourTreeAlignment
+     * \sa ttk::cta::AlignmentNode
+     */
     struct AlignmentEdge {
 
       std::weak_ptr<ttk::cta::AlignmentNode> node1;
@@ -146,9 +149,9 @@ namespace ttk{
       std::vector<std::pair<int, int>> arcRefs;
     };
 
-  }
+  } // namespace cta
 
-}
+} // namespace ttk
 
 namespace ttk {
 
@@ -168,54 +171,82 @@ namespace ttk {
     }
 
     /// Setter for the matching mode based on arc properties.
-    /// 
+    ///
     /// \param mode Determines what arc properties should be compared.
     void setArcMatchMode(int mode) {
       arcMatchMode = static_cast<ttk::cta::Mode_ArcMatch>(mode);
     }
     /// Setter for the weight of combinatorial matching.
-    /// 
-    /// \param mode Determines the factor with which the combinatorial distance is weighted.
+    ///
+    /// \param mode Determines the factor with which the combinatorial distance
+    /// is weighted.
     void setWeightCombinatorialMatch(float weight) {
       weightCombinatorialMatch = weight;
     }
     /// Setter for the weight of arc property matching.
-    /// 
-    /// \param mode Determines the factor with which the arc property based distance is weighted.
+    ///
+    /// \param mode Determines the factor with which the arc property based
+    /// distance is weighted.
     void setWeightArcMatch(float weight) {
       weightArcMatch = weight;
     }
     /// Setter for the weight of node matching.
-    /// 
-    /// \param mode Determines the factor with which the scalar value distance is weighted.
+    ///
+    /// \param mode Determines the factor with which the scalar value distance
+    /// is weighted.
     void setWeightScalarValueMatch(float weight) {
       weightScalarValueMatch = weight;
     }
     /// Setter for the type of alignment tree.
-    /// 
-    /// \param mode Determines how the labels of the alignment tree are computed from the matched labels.
+    ///
+    /// \param mode Determines how the labels of the alignment tree are computed
+    /// from the matched labels.
     void setAlignmenttreeType(int type) {
       alignmenttreeType = static_cast<ttk::cta::Type_Alignmenttree>(type);
     }
 
-    /// The actual iterated n-tree-alignment algorithm. Computes the alignment of n input contour trees.
+    /// The actual iterated n-tree-alignment algorithm. Computes the alignment
+    /// of n input contour trees.
     ///
-    /// \param scalarsVP Vector holding n arrays that represent the node scalars of the n input trees. scalarsVP[i][j] should be the scalar value of the jth node in the ith tree.
-    /// \param regionSizes Vector holding n arrays that represent the region sizes of edges of the n input trees. regionSizes[i][j] should be the size of the segment associated with the jth edge in the ith tree.
-    /// \param segmentationIds Vector holding n arrays that represent the segmentation ids of the edges the n input trees. segmentationIds[i][j] should be the segment identifier of the jth node in the ith tree.
-    /// \param topologies Vector holding n arrays that represent the connectivity of the the n input trees.
-    /// \param nVertices Vector holding n integers representing the number of nodes of the n input trees.
-    /// \param nEdges Vector holding n integers representing the number of edges of the n input trees.
-    /// \param segmentations Vector holding n arrays representing the segmentation arrays of the n input trees.
-    /// \param segSizes Vector holding the sizes of the corresponding segmentations array. segSizes[i] should be the size of the number of points in the ith scalar field. This should also be the size of segmentations[i].
-    /// \param outputVertices Vector for the alignment node scalars that will be filled by this algorithm. outputVertices[i] should be the scalar value of the ith node in the alignment tree.
-    /// \param outputFrequencies Vector for the alignment node frequencies that will be filled by this algorithm. outputFrequencies[i] should be the number of original nodes matched the ith node in the alignment tree.
-    /// \param outputVertexIds Vector for the alignment node matching that will be filled by this algorithm. outputVertexIds[i*n+j] should be the id of the vertex from the jth input tree matched in the ith node of the alignment tree.
-    /// \param outputBranchIds Vector for the alignment node branch ids that will be filled by this algorithm. outputBranchIds[i] should be the branch id of the ith node in the alignment tree.
-    /// \param outputSegmentationIds Vector for the alignment edge segmentations that will be filled by this algorithm. outputSegmentationIds[i*n+j] should be the id of the segment from the jth input field associated the ith node of the alignment tree.
-    /// \param outputArcIds Vector for the alignment edge maching that will be filled by this algorithm. outputArcIds[i*n+j] should be the id of the arc from the jth input tree associated the ith node of the alignment tree.
-    /// \param outputEdges Vector for the alignment graph connectivity. The ith edge of the alignment connects the nodes of index outputEdges[2*i] and outputEdges[2*i+1].
-    /// \param seed seed for randomization.
+    /// \param scalarsVP Vector holding n arrays that represent the node scalars
+    /// of the n input trees. scalarsVP[i][j] should be the scalar value of the
+    /// jth node in the ith tree. \param regionSizes Vector holding n arrays
+    /// that represent the region sizes of edges of the n input trees.
+    /// regionSizes[i][j] should be the size of the segment associated with the
+    /// jth edge in the ith tree. \param segmentationIds Vector holding n arrays
+    /// that represent the segmentation ids of the edges the n input trees.
+    /// segmentationIds[i][j] should be the segment identifier of the jth node
+    /// in the ith tree. \param topologies Vector holding n arrays that
+    /// represent the connectivity of the the n input trees. \param nVertices
+    /// Vector holding n integers representing the number of nodes of the n
+    /// input trees. \param nEdges Vector holding n integers representing the
+    /// number of edges of the n input trees. \param segmentations Vector
+    /// holding n arrays representing the segmentation arrays of the n input
+    /// trees. \param segSizes Vector holding the sizes of the corresponding
+    /// segmentations array. segSizes[i] should be the size of the number of
+    /// points in the ith scalar field. This should also be the size of
+    /// segmentations[i]. \param outputVertices Vector for the alignment node
+    /// scalars that will be filled by this algorithm. outputVertices[i] should
+    /// be the scalar value of the ith node in the alignment tree. \param
+    /// outputFrequencies Vector for the alignment node frequencies that will be
+    /// filled by this algorithm. outputFrequencies[i] should be the number of
+    /// original nodes matched the ith node in the alignment tree. \param
+    /// outputVertexIds Vector for the alignment node matching that will be
+    /// filled by this algorithm. outputVertexIds[i*n+j] should be the id of the
+    /// vertex from the jth input tree matched in the ith node of the alignment
+    /// tree. \param outputBranchIds Vector for the alignment node branch ids
+    /// that will be filled by this algorithm. outputBranchIds[i] should be the
+    /// branch id of the ith node in the alignment tree. \param
+    /// outputSegmentationIds Vector for the alignment edge segmentations that
+    /// will be filled by this algorithm. outputSegmentationIds[i*n+j] should be
+    /// the id of the segment from the jth input field associated the ith node
+    /// of the alignment tree. \param outputArcIds Vector for the alignment edge
+    /// maching that will be filled by this algorithm. outputArcIds[i*n+j]
+    /// should be the id of the arc from the jth input tree associated the ith
+    /// node of the alignment tree. \param outputEdges Vector for the alignment
+    /// graph connectivity. The ith edge of the alignment connects the nodes of
+    /// index outputEdges[2*i] and outputEdges[2*i+1]. \param seed seed for
+    /// randomization.
     template <class scalarType>
     int execute(const std::vector<void *> &scalarsVP,
                 const std::vector<int *> &regionSizes,
@@ -242,20 +273,21 @@ namespace ttk {
     /// \param t The input contour tree.
     /// \return Return true if alignment was successful, false otherwise.
     bool alignTree(const std::shared_ptr<ContourTree> &t);
-    /// This function initializes a new alignment graph from a given contour tree.
-    /// \pre The given contour tree needs to be binary.
-    /// \param t The input contour tree.
-    /// \return Return true if initialization was successful, false otherwise.
+    /// This function initializes a new alignment graph from a given contour
+    /// tree. \pre The given contour tree needs to be binary. \param t The input
+    /// contour tree. \return Return true if initialization was successful,
+    /// false otherwise.
     bool initialize(const std::shared_ptr<ContourTree> &t);
-    /// This function aligns a new tree to the current alignment but keeps the old alignment's root.
-    /// \pre The given contour tree needs to be binary.
+    /// This function aligns a new tree to the current alignment but keeps the
+    /// old alignment's root. \pre The given contour tree needs to be binary.
     /// \param t The input contour tree.
     /// \return Return true if alignment was successful, false otherwise.
     bool alignTree_consistentRoot(const std::shared_ptr<ContourTree> &t);
-    /// This function initializes a new alignment graph from a given contour tree and sets the fixed root of the alignment to the given input.
-    /// \pre The given contour tree needs to be binary.
-    /// \param t The input contour tree.
-    /// \return Return true if initialization was successful, false otherwise.
+    /// This function initializes a new alignment graph from a given contour
+    /// tree and sets the fixed root of the alignment to the given input. \pre
+    /// The given contour tree needs to be binary. \param t The input contour
+    /// tree. \return Return true if initialization was successful, false
+    /// otherwise.
     bool initialize_consistentRoot(const std::shared_ptr<ContourTree> &t,
                                    int rootIdx);
 
@@ -265,7 +297,8 @@ namespace ttk {
                           std::vector<std::shared_ptr<ttk::cta::CTEdge>>>>
       getGraphs();
     /// Getter for aligned contour trees
-    /// \return Vector of aligned contour trees as ttk::cta::ContourTree data structures.
+    /// \return Vector of aligned contour trees as ttk::cta::ContourTree data
+    /// structures.
     std::vector<std::shared_ptr<ContourTree>> getContourTrees();
 
     /// Getter for the alignment tree in a graph representation
@@ -274,7 +307,8 @@ namespace ttk {
               std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>
       getAlignmentGraph();
     /// Getter for the alignment tree in a rooted tree representation
-    /// \return The alignment tree rooted in the fixed node determined on initialization.
+    /// \return The alignment tree rooted in the fixed node determined on
+    /// initialization.
     std::shared_ptr<ttk::cta::BinaryTree> getAlignmentGraphRooted();
     /// Getter for the fixed root index.
     /// \return The root index.
@@ -283,12 +317,14 @@ namespace ttk {
     /// Function for aligning two arbitrary binary trees.
     /// \param t1 The first binary rooted tree to align.
     /// \param t2 The second binary rooted tree to align.
-    /// \return A pair consisting of the alignment distance and the alignment tree representing the matching between the two trees.
+    /// \return A pair consisting of the alignment distance and the alignment
+    /// tree representing the matching between the two trees.
     std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>>
       getAlignmentBinary(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
                          const std::shared_ptr<ttk::cta::BinaryTree> &t2);
 
-    /// Function that adds branch decomposition information to the alignment nodes.
+    /// Function that adds branch decomposition information to the alignment
+    /// nodes.
     void computeBranches();
 
   protected:
@@ -334,7 +370,8 @@ namespace ttk {
                            std::vector<std::vector<float>> &memT,
                            std::vector<std::vector<float>> &memF);
     std::shared_ptr<ttk::cta::AlignmentTree>
-      traceNullAlignment(const std::shared_ptr<ttk::cta::BinaryTree> &t, bool first);
+      traceNullAlignment(const std::shared_ptr<ttk::cta::BinaryTree> &t,
+                         bool first);
 
     // function that defines the local editing costs of two nodes
     float editCost(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
@@ -348,9 +385,12 @@ namespace ttk {
       computeRootedTree(const std::shared_ptr<ttk::cta::AlignmentNode> &node,
                         const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
                         int &id);
-    std::shared_ptr<ttk::cta::BinaryTree> computeRootedDualTree(
-      const std::shared_ptr<ttk::cta::AlignmentEdge> &arc, bool parent1, int &id);
-    void computeNewAlignmenttree(const std::shared_ptr<ttk::cta::AlignmentTree> &res);
+    std::shared_ptr<ttk::cta::BinaryTree>
+      computeRootedDualTree(const std::shared_ptr<ttk::cta::AlignmentEdge> &arc,
+                            bool parent1,
+                            int &id);
+    void computeNewAlignmenttree(
+      const std::shared_ptr<ttk::cta::AlignmentTree> &res);
 
     // helper functions for branch decomposition
     std::pair<float, std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>>
@@ -363,22 +403,23 @@ namespace ttk {
 } // namespace ttk
 
 template <class scalarType>
-int ttk::ContourTreeAlignment::execute(const std::vector<void *> &scalarsVP,
-                                       const std::vector<int *> &regionSizes,
-                                       const std::vector<int *> &segmentationIds,
-                                       const std::vector<long long *> &topologies,
-                                       const std::vector<size_t> &nVertices,
-                                       const std::vector<size_t> &nEdges,
-                                       const std::vector<int *> &segmentations,
-                                       const std::vector<size_t> &segsizes,
-                                       std::vector<float> &outputVertices,
-                                       std::vector<long long> &outputFrequencies,
-                                       std::vector<long long> &outputVertexIds,
-                                       std::vector<long long> &outputBranchIds,
-                                       std::vector<long long> &outputSegmentationIds,
-                                       std::vector<long long> &outputArcIds,
-                                       std::vector<int> &outputEdges,
-                                       int seed) {
+int ttk::ContourTreeAlignment::execute(
+  const std::vector<void *> &scalarsVP,
+  const std::vector<int *> &regionSizes,
+  const std::vector<int *> &segmentationIds,
+  const std::vector<long long *> &topologies,
+  const std::vector<size_t> &nVertices,
+  const std::vector<size_t> &nEdges,
+  const std::vector<int *> &segmentations,
+  const std::vector<size_t> &segsizes,
+  std::vector<float> &outputVertices,
+  std::vector<long long> &outputFrequencies,
+  std::vector<long long> &outputVertexIds,
+  std::vector<long long> &outputBranchIds,
+  std::vector<long long> &outputSegmentationIds,
+  std::vector<long long> &outputArcIds,
+  std::vector<int> &outputEdges,
+  int seed) {
 
   Timer timer;
 

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -20,6 +20,16 @@
 /// Anna Pia Lohfink, Florian Wetzels, Jonas Lukasczyk, Gunther H. Weber, and
 /// Christoph Garth. Comput. Graph. Forum, 39(3):343-355, 2020.
 ///
+/// \sa ttk::cta::ContourTree
+/// \sa ttk::cta::CTNode
+/// \sa ttk::cta::CTEdge
+/// \sa ttk::cta::BinaryTree
+/// \sa ttk::cta::Tree
+/// \sa ttk::cta::AlignmentTree
+/// \sa ttk::cta::AlignmentNode
+/// \sa ttk::cta::AlignmentEdge
+/// \sa ttkContourTreeAlignment
+///
 
 #pragma once
 
@@ -31,224 +41,350 @@
 #include <memory>
 #include <random>
 
-enum Type_Alignmenttree { averageValues, medianValues, lastMatchedValue };
-// enum Type_Match { matchNodes, matchArcs };
-enum Mode_ArcMatch { persistence, area, volume, overlap };
+namespace ttk{
 
-struct AlignmentTree {
-  std::shared_ptr<AlignmentTree> child1;
-  std::shared_ptr<AlignmentTree> child2;
-  std::shared_ptr<BinaryTree> node1;
-  std::shared_ptr<BinaryTree> node2;
-  int size;
-  int height;
-  // int freq;
-};
+  namespace cta{
 
-struct AlignmentEdge;
+    enum Type_Alignmenttree { averageValues, medianValues, lastMatchedValue };
+    // enum Type_Match { matchNodes, matchArcs };
+    enum Mode_ArcMatch { persistence, area, volume, overlap };
 
-struct AlignmentNode {
+    /**
+       * \ingroup base
+       * @brief Basic tree data structure for an alignment of two rooted binary trees.
+       *
+       * This structure represents nodes of a rooted alignment tree.
+       * 
+       * It stores the following meta information for the tree structure:
+       * - height of the subtree rooted in this node
+       * - size of the subtree rooted in this node
+       * - two pointers to its child nodes
+       * 
+       * It stores the following alignment node properties:
+       * - pointers to the two matched nodes
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::BinaryTree
+       */
+    struct AlignmentTree {
+      std::shared_ptr<ttk::cta::AlignmentTree> child1;
+      std::shared_ptr<ttk::cta::AlignmentTree> child2;
+      std::shared_ptr<ttk::cta::BinaryTree> node1;
+      std::shared_ptr<ttk::cta::BinaryTree> node2;
+      int size;
+      int height;
+      // int freq;
+    };
 
-  Type_Node type;
-  int freq;
-  float scalarValue;
-  int branchID;
+    struct AlignmentEdge;
 
-  std::vector<std::shared_ptr<AlignmentEdge>> edgeList;
+    /**
+       * \ingroup base
+       * @brief Basic data structure for a node of an unrooted alignment tree.
+       *
+       * This structure represents nodes of an unrooted alignment tree.
+       * 
+       * It stores the following edge properties:
+       * - critical type
+       * - scalar value
+       * - branchID
+       * 
+       * It stores the following information for the tree structure:
+       * - a vector with reference ids to its incident edges.
+       * 
+       * It stores the following alignment information:
+       * - frequency
+       * - references to the ids of the represented nodes of the origial contour trees
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::AlignmentEdge
+       */
+    struct AlignmentNode {
 
-  std::vector<std::pair<int, int>> nodeRefs;
-};
+      ttk::cta::Type_Node type;
+      int freq;
+      float scalarValue;
+      int branchID;
 
-struct AlignmentEdge {
+      std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>> edgeList;
 
-  std::weak_ptr<AlignmentNode> node1;
-  std::weak_ptr<AlignmentNode> node2;
-  float scalardistance;
-  float area;
-  float volume;
-  std::vector<int> region;
-  int freq;
+      std::vector<std::pair<int, int>> nodeRefs;
+    };
 
-  std::vector<std::pair<int, int>> arcRefs;
-};
+    /**
+       * \ingroup base
+       * @brief Basic data structure for an edge of an unrooted alignment tree.
+       *
+       * This structure represents edges of an unrooted alignment tree.
+       * 
+       * It stores the following edge properties:
+       * - persistence
+       * - area
+       * - volume
+       * - the corresponding segment/region.
+       * 
+       * It stores the following information for the tree structure:
+       * - two reference ids to its incident nodes.
+       * 
+       * It stores the following alignment information:
+       * - frequency
+       * - references to the ids of the represented arcs of the origial contour trees
+       *
+       * \sa ttk::ContourTreeAlignment
+       * \sa ttk::cta::AlignmentNode
+       */
+    struct AlignmentEdge {
 
-using namespace std;
+      std::weak_ptr<ttk::cta::AlignmentNode> node1;
+      std::weak_ptr<ttk::cta::AlignmentNode> node2;
+      float scalardistance;
+      float area;
+      float volume;
+      std::vector<int> region;
+      int freq;
+
+      std::vector<std::pair<int, int>> arcRefs;
+    };
+
+  }
+
+}
 
 namespace ttk {
 
   class ContourTreeAlignment : virtual public Debug {
 
   public:
-    /// constructor and destructor
+    /// Constructor of the Alignment Object
     ContourTreeAlignment() {
       this->setDebugMsgPrefix("ContourTreeAlignment");
     }
+
+    /// Destructor of the Alignment Object
     ~ContourTreeAlignment() {
       contourtrees.clear();
       nodes.clear();
       arcs.clear();
     }
 
-    /// setter for parameters
+    /// Setter for the matching mode based on arc properties.
+    /// 
+    /// \param mode Determines what arc properties should be compared.
     void setArcMatchMode(int mode) {
-      arcMatchMode = static_cast<Mode_ArcMatch>(mode);
+      arcMatchMode = static_cast<ttk::cta::Mode_ArcMatch>(mode);
     }
+    /// Setter for the weight of combinatorial matching.
+    /// 
+    /// \param mode Determines the factor with which the combinatorial distance is weighted.
     void setWeightCombinatorialMatch(float weight) {
       weightCombinatorialMatch = weight;
     }
+    /// Setter for the weight of arc property matching.
+    /// 
+    /// \param mode Determines the factor with which the arc property based distance is weighted.
     void setWeightArcMatch(float weight) {
       weightArcMatch = weight;
     }
+    /// Setter for the weight of node matching.
+    /// 
+    /// \param mode Determines the factor with which the scalar value distance is weighted.
     void setWeightScalarValueMatch(float weight) {
       weightScalarValueMatch = weight;
     }
+    /// Setter for the type of alignment tree.
+    /// 
+    /// \param mode Determines how the labels of the alignment tree are computed from the matched labels.
     void setAlignmenttreeType(int type) {
-      alignmenttreeType = static_cast<Type_Alignmenttree>(type);
+      alignmenttreeType = static_cast<ttk::cta::Type_Alignmenttree>(type);
     }
 
-    /// The actual iterated n-tree-alignment algorithm
+    /// The actual iterated n-tree-alignment algorithm. Computes the alignment of n input contour trees.
+    ///
+    /// \param scalarsVP Vector holding n arrays that represent the node scalars of the n input trees. scalarsVP[i][j] should be the scalar value of the jth node in the ith tree.
+    /// \param regionSizes Vector holding n arrays that represent the region sizes of edges of the n input trees. regionSizes[i][j] should be the size of the segment associated with the jth edge in the ith tree.
+    /// \param segmentationIds Vector holding n arrays that represent the segmentation ids of the edges the n input trees. segmentationIds[i][j] should be the segment identifier of the jth node in the ith tree.
+    /// \param topologies Vector holding n arrays that represent the connectivity of the the n input trees.
+    /// \param nVertices Vector holding n integers representing the number of nodes of the n input trees.
+    /// \param nEdges Vector holding n integers representing the number of edges of the n input trees.
+    /// \param segmentations Vector holding n arrays representing the segmentation arrays of the n input trees.
+    /// \param segSizes ToDo: This should be reduntant with regionSizes.
+    /// \param outputVertices Vector for the alignment node scalars that will be filled by this algorithm. outputVertices[i] should be the scalar value of the ith node in the alignment tree.
+    /// \param outputFrequencies Vector for the alignment node frequencies that will be filled by this algorithm. outputFrequencies[i] should be the number of original nodes matched the ith node in the alignment tree.
+    /// \param outputVertexIds Vector for the alignment node matching that will be filled by this algorithm. outputVertexIds[i*n+j] should be the id of the vertex from the jth input tree matched in the ith node of the alignment tree.
+    /// \param outputBranchIds Vector for the alignment node branch ids that will be filled by this algorithm. outputBranchIds[i] should be the branch id of the ith node in the alignment tree.
+    /// \param outputSegmentationIds Vector for the alignment edge segmentations that will be filled by this algorithm. outputSegmentationIds[i*n+j] should be the id of the segment from the jth input field associated the ith node of the alignment tree.
+    /// \param outputArcIds Vector for the alignment edge maching that will be filled by this algorithm. outputArcIds[i*n+j] should be the id of the arc from the jth input tree associated the ith node of the alignment tree.
+    /// \param outputEdges Vector for the alignment graph connectivity. The ith edge of the alignment connects the nodes of index outputEdges[2*i] and outputEdges[2*i+1].
+    /// \param seed seed for randomization.
     template <class scalarType>
-    int execute(const vector<void *> &scalarsVP,
-                const vector<int *> &regionSizes,
-                const vector<int *> &segmentationIds,
-                const vector<long long *> &topologies,
-                const vector<size_t> &nVertices,
-                const vector<size_t> &nEdges,
-                const vector<int *> &segmentations,
-                const vector<size_t> &segsizes,
+    int execute(const std::vector<void *> &scalarsVP,
+                const std::vector<int *> &regionSizes,
+                const std::vector<int *> &segmentationIds,
+                const std::vector<long long *> &topologies,
+                const std::vector<size_t> &nVertices,
+                const std::vector<size_t> &nEdges,
+                const std::vector<int *> &segmentations,
+                const std::vector<size_t> &segsizes,
 
-                vector<float> &outputVertices,
-                vector<long long> &outputFrequencies,
-                vector<long long> &outputVertexIds,
-                vector<long long> &outputBranchIds,
-                vector<long long> &outputSegmentationIds,
-                vector<long long> &outputArcIds,
-                vector<int> &outputEdges,
+                std::vector<float> &outputVertices,
+                std::vector<long long> &outputFrequencies,
+                std::vector<long long> &outputVertexIds,
+                std::vector<long long> &outputBranchIds,
+                std::vector<long long> &outputSegmentationIds,
+                std::vector<long long> &outputArcIds,
+                std::vector<int> &outputEdges,
                 int seed);
 
     using ContourTree = cta::ContourTree;
 
-    /// functions for aligning single trees in iteration
+    /// This function aligns a new tree to the current alignment.
+    /// \pre The given contour tree needs to be binary.
+    /// \param t The input contour tree.
+    /// \return Return true if alignment was successful, false otherwise.
     bool alignTree(const std::shared_ptr<ContourTree> &t);
+    /// This function initializes a new alignment graph from a given contour tree.
+    /// \pre The given contour tree needs to be binary.
+    /// \param t The input contour tree.
+    /// \return Return true if initialization was successful, false otherwise.
     bool initialize(const std::shared_ptr<ContourTree> &t);
+    /// This function aligns a new tree to the current alignment but keeps the old alignment's root.
+    /// \pre The given contour tree needs to be binary.
+    /// \param t The input contour tree.
+    /// \return Return true if alignment was successful, false otherwise.
     bool alignTree_consistentRoot(const std::shared_ptr<ContourTree> &t);
+    /// This function initializes a new alignment graph from a given contour tree and sets the fixed root of the alignment to the given input.
+    /// \pre The given contour tree needs to be binary.
+    /// \param t The input contour tree.
+    /// \return Return true if initialization was successful, false otherwise.
     bool initialize_consistentRoot(const std::shared_ptr<ContourTree> &t,
                                    int rootIdx);
 
-    /// getters for graph data structures
-    std::vector<std::pair<std::vector<std::shared_ptr<CTNode>>,
-                          std::vector<std::shared_ptr<CTEdge>>>>
+    /// Getter for aligned contour trees
+    /// \return Vector of aligned contour trees in a graph representation.
+    std::vector<std::pair<std::vector<std::shared_ptr<ttk::cta::CTNode>>,
+                          std::vector<std::shared_ptr<ttk::cta::CTEdge>>>>
       getGraphs();
+    /// Getter for aligned contour trees
+    /// \return Vector of aligned contour trees as ttk::cta::ContourTree data structures.
     std::vector<std::shared_ptr<ContourTree>> getContourTrees();
 
-    std::pair<std::vector<std::shared_ptr<AlignmentNode>>,
-              std::vector<std::shared_ptr<AlignmentEdge>>>
+    /// Getter for the alignment tree in a graph representation
+    /// \return The alignment graph.
+    std::pair<std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>,
+              std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>>
       getAlignmentGraph();
-    std::shared_ptr<BinaryTree> getAlignmentGraphRooted();
+    /// Getter for the alignment tree in a rooted tree representation
+    /// \return The alignment tree rooted in the fixed node determined on initialization.
+    std::shared_ptr<ttk::cta::BinaryTree> getAlignmentGraphRooted();
+    /// Getter for the fixed root index.
+    /// \return The root index.
     int getAlignmentRootIdx();
 
-    /// function for aligning two sarbitrary binary trees
-    std::pair<float, std::shared_ptr<AlignmentTree>>
-      getAlignmentBinary(const std::shared_ptr<BinaryTree> &t1,
-                         const std::shared_ptr<BinaryTree> &t2);
+    /// Function for aligning two arbitrary binary trees.
+    /// \param t1 The first binary rooted tree to align.
+    /// \param t2 The second binary rooted tree to align.
+    /// \return A pair consisting of the alignment distance and the alignment tree representing the matching between the two trees.
+    std::pair<float, std::shared_ptr<ttk::cta::AlignmentTree>>
+      getAlignmentBinary(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                         const std::shared_ptr<ttk::cta::BinaryTree> &t2);
 
-    /// function that adds branch decomposition information
+    /// Function that adds branch decomposition information to the alignment nodes.
     void computeBranches();
 
   protected:
-    /// filter parameters
-    Type_Alignmenttree alignmenttreeType = averageValues;
-    Mode_ArcMatch arcMatchMode = persistence;
+    // filter parameters
+    ttk::cta::Type_Alignmenttree alignmenttreeType = ttk::cta::averageValues;
+    ttk::cta::Mode_ArcMatch arcMatchMode = ttk::cta::persistence;
     float weightArcMatch = 1;
     float weightCombinatorialMatch = 0;
     float weightScalarValueMatch = 0;
 
-    /// alignment graph data
-    std::vector<std::shared_ptr<AlignmentNode>> nodes;
-    std::vector<std::shared_ptr<AlignmentEdge>> arcs;
+    // alignment graph data
+    std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> nodes;
+    std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>> arcs;
 
-    /// iteration variables
+    // iteration variables
     std::vector<std::shared_ptr<ContourTree>> contourtrees;
     std::vector<size_t> permutation;
-    std::shared_ptr<AlignmentNode> alignmentRoot;
+    std::shared_ptr<ttk::cta::AlignmentNode> alignmentRoot;
     int alignmentRootIdx;
     float alignmentVal;
 
-    /// functions for aligning two trees (computing the alignment value and
-    /// memoization matrix)
-    float alignTreeBinary(const std::shared_ptr<BinaryTree> &t1,
-                          const std::shared_ptr<BinaryTree> &t2,
+    // functions for aligning two trees (computing the alignment value and
+    // memoization matrix)
+    float alignTreeBinary(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                          const std::shared_ptr<ttk::cta::BinaryTree> &t2,
                           std::vector<std::vector<float>> &memT,
                           std::vector<std::vector<float>> &memF);
-    float alignForestBinary(const std::shared_ptr<BinaryTree> &t1,
-                            const std::shared_ptr<BinaryTree> &t2,
+    float alignForestBinary(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                            const std::shared_ptr<ttk::cta::BinaryTree> &t2,
                             std::vector<std::vector<float>> &memT,
                             std::vector<std::vector<float>> &memF);
 
-    /// functions for the traceback of the alignment computation (computing the
-    /// actual alignment tree)
-    std::shared_ptr<AlignmentTree>
-      traceAlignmentTree(const std::shared_ptr<BinaryTree> &t1,
-                         const std::shared_ptr<BinaryTree> &t2,
+    // functions for the traceback of the alignment computation (computing the
+    // actual alignment tree)
+    std::shared_ptr<ttk::cta::AlignmentTree>
+      traceAlignmentTree(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                         const std::shared_ptr<ttk::cta::BinaryTree> &t2,
                          std::vector<std::vector<float>> &memT,
                          std::vector<std::vector<float>> &memF);
-    std::vector<std::shared_ptr<AlignmentTree>>
-      traceAlignmentForest(const std::shared_ptr<BinaryTree> &t1,
-                           const std::shared_ptr<BinaryTree> &t2,
+    std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
+      traceAlignmentForest(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                           const std::shared_ptr<ttk::cta::BinaryTree> &t2,
                            std::vector<std::vector<float>> &memT,
                            std::vector<std::vector<float>> &memF);
-    std::shared_ptr<AlignmentTree>
-      traceNullAlignment(const std::shared_ptr<BinaryTree> &t, bool first);
+    std::shared_ptr<ttk::cta::AlignmentTree>
+      traceNullAlignment(const std::shared_ptr<ttk::cta::BinaryTree> &t, bool first);
 
-    /// function that defines the local editing costs of two nodes
-    float editCost(const std::shared_ptr<BinaryTree> &t1,
-                   const std::shared_ptr<BinaryTree> &t2);
+    // function that defines the local editing costs of two nodes
+    float editCost(const std::shared_ptr<ttk::cta::BinaryTree> &t1,
+                   const std::shared_ptr<ttk::cta::BinaryTree> &t2);
 
-    /// helper functions for tree data structures
-    bool isBinary(const std::shared_ptr<Tree> &t);
-    std::shared_ptr<BinaryTree>
-      rootAtNode(const std::shared_ptr<AlignmentNode> &root);
-    std::shared_ptr<BinaryTree>
-      computeRootedTree(const std::shared_ptr<AlignmentNode> &node,
-                        const std::shared_ptr<AlignmentEdge> &parent,
+    // helper functions for tree data structures
+    bool isBinary(const std::shared_ptr<ttk::cta::Tree> &t);
+    std::shared_ptr<ttk::cta::BinaryTree>
+      rootAtNode(const std::shared_ptr<ttk::cta::AlignmentNode> &root);
+    std::shared_ptr<ttk::cta::BinaryTree>
+      computeRootedTree(const std::shared_ptr<ttk::cta::AlignmentNode> &node,
+                        const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
                         int &id);
-    std::shared_ptr<BinaryTree> computeRootedDualTree(
-      const std::shared_ptr<AlignmentEdge> &arc, bool parent1, int &id);
-    void computeNewAlignmenttree(const std::shared_ptr<AlignmentTree> &res);
+    std::shared_ptr<ttk::cta::BinaryTree> computeRootedDualTree(
+      const std::shared_ptr<ttk::cta::AlignmentEdge> &arc, bool parent1, int &id);
+    void computeNewAlignmenttree(const std::shared_ptr<ttk::cta::AlignmentTree> &res);
 
-    /// helper functions for branch decomposition
-    std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-      pathToMax(const std::shared_ptr<AlignmentNode> &root,
-                const std::shared_ptr<AlignmentNode> &parent);
-    std::pair<float, std::vector<std::shared_ptr<AlignmentNode>>>
-      pathToMin(const std::shared_ptr<AlignmentNode> &root,
-                const std::shared_ptr<AlignmentNode> &parent);
+    // helper functions for branch decomposition
+    std::pair<float, std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>>
+      pathToMax(const std::shared_ptr<ttk::cta::AlignmentNode> &root,
+                const std::shared_ptr<ttk::cta::AlignmentNode> &parent);
+    std::pair<float, std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>>
+      pathToMin(const std::shared_ptr<ttk::cta::AlignmentNode> &root,
+                const std::shared_ptr<ttk::cta::AlignmentNode> &parent);
   };
 } // namespace ttk
 
 template <class scalarType>
-int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
-                                       const vector<int *> &regionSizes,
-                                       const vector<int *> &segmentationIds,
-                                       const vector<long long *> &topologies,
-                                       const vector<size_t> &nVertices,
-                                       const vector<size_t> &nEdges,
-                                       const vector<int *> &segmentations,
-                                       const vector<size_t> &segsizes,
-                                       vector<float> &outputVertices,
-                                       vector<long long> &outputFrequencies,
-                                       vector<long long> &outputVertexIds,
-                                       vector<long long> &outputBranchIds,
-                                       vector<long long> &outputSegmentationIds,
-                                       vector<long long> &outputArcIds,
-                                       vector<int> &outputEdges,
+int ttk::ContourTreeAlignment::execute(const std::vector<void *> &scalarsVP,
+                                       const std::vector<int *> &regionSizes,
+                                       const std::vector<int *> &segmentationIds,
+                                       const std::vector<long long *> &topologies,
+                                       const std::vector<size_t> &nVertices,
+                                       const std::vector<size_t> &nEdges,
+                                       const std::vector<int *> &segmentations,
+                                       const std::vector<size_t> &segsizes,
+                                       std::vector<float> &outputVertices,
+                                       std::vector<long long> &outputFrequencies,
+                                       std::vector<long long> &outputVertexIds,
+                                       std::vector<long long> &outputBranchIds,
+                                       std::vector<long long> &outputSegmentationIds,
+                                       std::vector<long long> &outputArcIds,
+                                       std::vector<int> &outputEdges,
                                        int seed) {
 
   Timer timer;
 
   size_t nTrees = nVertices.size();
 
-  vector<float *> scalars(nTrees);
+  std::vector<float *> scalars(nTrees);
   for(size_t t = 0; t < nTrees; t++) {
     scalars[t] = (float *)((scalarType *)scalarsVP[t]);
   }
@@ -324,8 +460,8 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
 
   // prepare data structures
   contourtrees = std::vector<std::shared_ptr<ContourTree>>();
-  nodes = std::vector<std::shared_ptr<AlignmentNode>>();
-  arcs = std::vector<std::shared_ptr<AlignmentEdge>>();
+  nodes = std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>();
+  arcs = std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>();
   int bestRootIdx{};
 
   this->printMsg(ttk::debug::Separator::L1);
@@ -338,7 +474,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
     permutation.push_back(i);
   }
   std::srand(seed);
-  if(alignmenttreeType != lastMatchedValue)
+  if(alignmenttreeType != ttk::cta::lastMatchedValue)
     std::random_shuffle(permutation.begin(), permutation.end());
 
   this->printMsg(
@@ -357,8 +493,8 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
 
   this->printMsg("Starting alignment heuristic.");
 
-  std::tuple<std::vector<std::shared_ptr<AlignmentNode>>,
-             std::vector<std::shared_ptr<AlignmentEdge>>,
+  std::tuple<std::vector<std::shared_ptr<ttk::cta::AlignmentNode>>,
+             std::vector<std::shared_ptr<ttk::cta::AlignmentEdge>>,
              std::vector<std::shared_ptr<ContourTree>>>
     bestAlignment;
   float bestAlignmentValue = FLT_MAX;
@@ -415,7 +551,7 @@ int ttk::ContourTreeAlignment::execute(const vector<void *> &scalarsVP,
       "Initializing alignment with tree " + std::to_string(permutation[i]), 1,
       debug::Priority::DETAIL);
 
-    if(alignmentRoot->type == saddleNode) {
+    if(alignmentRoot->type == ttk::cta::saddleNode) {
 
       this->printMsg("Initialized root is saddle, alignment aborted.");
 

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.cpp
@@ -231,7 +231,7 @@ int ttkContourTreeAlignment::RequestData(vtkInformation *ttkNotUsed(request),
 
   this->setArcMatchMode(ArcMatchMode);
   if(MatchTime)
-    this->setAlignmenttreeType(lastMatchedValue);
+    this->setAlignmenttreeType(ttk::cta::lastMatchedValue);
   else
     this->setAlignmenttreeType(AlignmenttreeType);
   this->setWeightArcMatch(WeightArcMatch);

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.h
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.h
@@ -48,6 +48,11 @@
 /// Christoph Garth. Comput. Graph. Forum, 39(3):343-355, 2020.
 ///
 /// \sa ttk::ContourTreeAlignment
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/contourTreeAlignment/">
+///   Contour Tree Alignment example</a> \n
 
 #pragma once
 

--- a/paraview/xmls/ContourTreeAlignment.xml
+++ b/paraview/xmls/ContourTreeAlignment.xml
@@ -2,9 +2,7 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
         <SourceProxy name="ContourTreeAlignment" class="ttkContourTreeAlignment" label="TTK ContourTreeAlignment">
-            <Documentation long_help="TTK contourTreeAlignment" short_help="TTK contourTreeAlignment">
-
-                long_help="TTK plugin for computing an alignment of a multiblock of contour trees, given as unstructured grids."
+            <Documentation long_help="TTK plugin for computing an alignment of a multiblock of contour trees, given as unstructured grids."
                 short_help="TTK plugin for computing an alignment of contour trees.">
 
                 Given a multiblock of unstructured grids representing contour trees, this plugin comutes an alignment of the trees.
@@ -17,6 +15,10 @@
                 'Fuzzy contour trees: Alignment and joint layout of multiple contour trees'
                 Anna Pia Lohfink, Florian Wetzels, Jonas Lukasczyk, Gunther H. Weber, and Christoph Garth.
                 Comput. Graph. Forum, 39(3):343-355, 2020.
+
+                Online examples:
+
+                - https://topology-tool-kit.github.io/examples/contourTreeAlignment/
 
             </Documentation>
 


### PR DESCRIPTION
Added doxygen documentation for the ContourTreeAlignment base module. The vtk layer documentatoin was already there. I also cleaned up namespaces for all internal classes and structures that are involved in the alignment computation, since this cluttered the doxygen Class List a lot. They are now all bundled in the ttk::cta:: namespace.