### PR TITLE
PlanarGraphLayout Template Improvements

### DIFF
--- a/core/base/planarGraphLayout/PlanarGraphLayout.h
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.h
@@ -38,59 +38,59 @@ namespace ttk {
     PlanarGraphLayout();
     ~PlanarGraphLayout();
 
-    template <class idType, class dataType>
-    int execute(
+    template <typename ST, typename IT, typename CT>
+    int computeLayout(
       // Output
       float *layout,
 
       // Input
-      const LongSimplexId *connectivityList,
+      const CT *connectivityList,
       const size_t &nPoints,
       const size_t &nEdges,
-      const dataType *pointSequences,
+      const ST *pointSequences,
       const float *sizes,
-      const idType *branches,
-      const idType *levels) const;
+      const IT *branches,
+      const IT *levels) const;
 
-    template <class idType>
+    template <typename IT, typename CT>
     int extractLevel(
       // Output
       std::vector<size_t> &nodeIndicies,
       std::vector<size_t> &edgeIndicies,
 
       // Input
-      const LongSimplexId *connectivityList,
+      const CT *connectivityList,
       const size_t &nPoints,
       const size_t &nEdges,
-      const idType &level,
-      const idType *levels) const;
+      const IT &level,
+      const IT *levels) const;
 
-    template <class idType, class dataType>
+    template <typename ST, typename IT, typename CT>
     int computeDotString(
       // Output
       std::string &dotString,
 
       // Input
-      const LongSimplexId *connectivityList,
-      const dataType *pointSequences,
+      const CT *connectivityList,
+      const ST *pointSequences,
       const float *sizes,
-      const idType *branches,
+      const IT *branches,
       const std::vector<size_t> &nodeIndicies,
       const std::vector<size_t> &edgeIndicies,
-      const std::map<dataType, size_t> &sequenceValueToIndexMap) const;
+      const std::map<ST, size_t> &sequenceValueToIndexMap) const;
 
-    template <class idType>
+    template <typename IT, typename CT>
     int computeSlots(
       // Output
       float *layout,
 
       // Input
-      const LongSimplexId *connectivityList,
+      const CT *connectivityList,
       const size_t &nPoints,
       const size_t &nEdges,
       const float *sizes,
-      const idType *levels,
-      const idType &nLevels) const;
+      const IT *levels,
+      const IT &nLevels) const;
 
     // Compute Dot Layout
     int computeDotLayout(
@@ -106,18 +106,18 @@ namespace ttk {
 // =============================================================================
 // Extract Level
 // =============================================================================
-template <class idType>
+template <typename IT, typename CT>
 int ttk::PlanarGraphLayout::extractLevel(
   // Output
   std::vector<size_t> &nodeIndicies,
   std::vector<size_t> &edgeIndicies,
 
   // Input
-  const LongSimplexId *connectivityList,
+  const CT *connectivityList,
   const size_t &nPoints,
   const size_t &nEdges,
-  const idType &level,
-  const idType *levels) const {
+  const IT &level,
+  const IT *levels) const {
 
   // If levels==nullptr then return all points and edges
   if(levels == nullptr) {
@@ -138,12 +138,12 @@ int ttk::PlanarGraphLayout::extractLevel(
       nodeIndicies.push_back(i);
 
   // Get edges at level
-  size_t nEdges3 = nEdges * 3;
-  for(size_t i = 0; i < nEdges3; i += 3) {
-    auto n0l = levels[connectivityList[i + 1]];
-    auto n1l = levels[connectivityList[i + 2]];
+  size_t nEdges2 = nEdges * 2;
+  for(size_t i = 0; i < nEdges2; i += 2) {
+    auto n0l = levels[connectivityList[i + 0]];
+    auto n1l = levels[connectivityList[i + 1]];
     if(n0l == level && n0l == n1l)
-      edgeIndicies.push_back(i / 3);
+      edgeIndicies.push_back(i / 2);
   }
 
   return 1;
@@ -152,19 +152,19 @@ int ttk::PlanarGraphLayout::extractLevel(
 // =============================================================================
 // Compute Dot String
 // =============================================================================
-template <class idType, class dataType>
+template <typename ST, typename IT, typename CT>
 int ttk::PlanarGraphLayout::computeDotString(
   // Output
   std::string &dotString,
 
   // Input
-  const LongSimplexId *connectivityList,
-  const dataType *pointSequences,
+  const CT *connectivityList,
+  const ST *pointSequences,
   const float *sizes,
-  const idType *branches,
+  const IT *branches,
   const std::vector<size_t> &nodeIndicies,
   const std::vector<size_t> &edgeIndicies,
-  const std::map<dataType, size_t> &sequenceValueToIndexMap) const {
+  const std::map<ST, size_t> &sequenceValueToIndexMap) const {
 
   Timer t;
 
@@ -235,9 +235,9 @@ int ttk::PlanarGraphLayout::computeDotString(
   // ---------------------------------------------------------------------------
   {
     for(auto &edgeIndex : edgeIndicies) {
-      size_t temp = edgeIndex * 3;
-      auto &i0 = connectivityList[temp + 1];
-      auto &i1 = connectivityList[temp + 2];
+      size_t temp = edgeIndex * 2;
+      auto &i0 = connectivityList[temp + 0];
+      auto &i1 = connectivityList[temp + 1];
       edgeString += nl(i0) + "->" + nl(i1);
 
       if(useBranches) {
@@ -267,24 +267,22 @@ int ttk::PlanarGraphLayout::computeDotString(
 // =============================================================================
 // Compute Slots
 // =============================================================================
-template <class idType>
+template <typename IT, typename CT>
 int ttk::PlanarGraphLayout::computeSlots(
   // Output
   float *layout,
 
   // Input
-  const LongSimplexId *connectivityList,
+  const CT *connectivityList,
   const size_t &nPoints,
   const size_t &nEdges,
   const float *sizes,
-  const idType *levels,
-  const idType &nLevels) const {
+  const IT *levels,
+  const IT &nLevels) const {
 
-#ifndef TTK_ENABLE_KAMIKAZE
   if(sizes == nullptr || levels == nullptr) {
     return -1;
   }
-#endif // TTK_ENABLE_KAMIKAZE
 
   Timer t;
   this->printMsg("Computing slots", 0, debug::LineMode::REPLACE);
@@ -308,10 +306,10 @@ int ttk::PlanarGraphLayout::computeSlots(
   // ---------------------------------------------------------------------------
   std::vector<std::vector<size_t>> nodeIndexChildrenIndexMap(nPoints);
 
-  size_t nEdges3 = nEdges * 3;
-  for(size_t i = 0; i < nEdges3; i += 3) {
-    auto n0 = connectivityList[i + 1];
-    auto n1 = connectivityList[i + 2];
+  size_t nEdges2 = nEdges * 2;
+  for(size_t i = 0; i < nEdges2; i += 2) {
+    auto n0 = connectivityList[i + 0];
+    auto n1 = connectivityList[i + 1];
     if((levels[n0] + 1) == levels[n1])
       nodeIndexChildrenIndexMap[n0].push_back(n1);
   }
@@ -319,12 +317,12 @@ int ttk::PlanarGraphLayout::computeSlots(
   // ---------------------------------------------------------------------------
   // Adjust positions from bottom to top (skip last level)
   // ---------------------------------------------------------------------------
-  for(idType l = 0; l < nLevels - 1; l++) {
+  for(IT l = 0; l < nLevels - 1; l++) {
     std::vector<size_t> nodeIndicies;
     std::vector<size_t> edgeIndicies;
 
     // get nodes at current level (parents)
-    this->extractLevel<idType>(
+    this->extractLevel<IT, CT>(
       // Output
       nodeIndicies, edgeIndicies,
 
@@ -370,19 +368,19 @@ int ttk::PlanarGraphLayout::computeSlots(
 // =============================================================================
 // Execute
 // =============================================================================
-template <class idType, class dataType>
-int ttk::PlanarGraphLayout::execute(
+template <typename ST, typename IT, typename CT>
+int ttk::PlanarGraphLayout::computeLayout(
   // Output
   float *layout,
 
   // Input
-  const LongSimplexId *connectivityList,
+  const CT *connectivityList,
   const size_t &nPoints,
   const size_t &nEdges,
-  const dataType *pointSequences,
+  const ST *pointSequences,
   const float *sizes,
-  const idType *branches,
-  const idType *levels) const {
+  const IT *branches,
+  const IT *levels) const {
 
   Timer t;
 
@@ -417,7 +415,7 @@ int ttk::PlanarGraphLayout::execute(
   }
 
   // Global SequenceValue to SequenceIndex map
-  std::map<dataType, size_t> sequenceValueToIndexMap;
+  std::map<ST, size_t> sequenceValueToIndexMap;
   if(useSequences) {
     for(size_t i = 0; i < nPoints; i++)
       sequenceValueToIndexMap[pointSequences[i]] = 0;
@@ -427,7 +425,7 @@ int ttk::PlanarGraphLayout::execute(
   }
 
   // Get number of levels
-  idType nLevels = 1;
+  IT nLevels = 1;
   if(useLevels) {
     for(size_t i = 0; i < nPoints; i++)
       if(nLevels < levels[i])
@@ -438,13 +436,13 @@ int ttk::PlanarGraphLayout::execute(
   // ---------------------------------------------------------------------------
   // Compute initial layout for each level
   // ---------------------------------------------------------------------------
-  for(idType l = 0; l < nLevels; l++) {
+  for(IT l = 0; l < nLevels; l++) {
     std::vector<size_t> nodeIndicies;
     std::vector<size_t> edgeIndicies;
 
     // Extract nodes and edges at certain level
     {
-      int status = this->extractLevel<idType>(
+      int status = this->extractLevel<IT, CT>(
         // Output
         nodeIndicies, edgeIndicies,
 
@@ -457,7 +455,7 @@ int ttk::PlanarGraphLayout::execute(
     // Compute Dot String
     std::string dotString;
     {
-      int status = this->computeDotString<idType, dataType>(
+      int status = this->computeDotString<ST, IT, CT>(
         // Output
         dotString,
 
@@ -480,7 +478,7 @@ int ttk::PlanarGraphLayout::execute(
   // If nLevels>1 then compute slots
   // ---------------------------------------------------------------------------
   if(nLevels > 1) {
-    this->computeSlots<idType>(
+    this->computeSlots<IT, CT>(
       // Output
       layout,
 

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -101,3 +101,203 @@ using ttkSimplexIdTypeArray = vtkIntArray;
     call;                                                          \
   }; break
 #endif
+
+// -----------------------------------------------------------------------------
+
+#define ttkTypeMacroErrorCase(idx, type)                          \
+  default: {                                                      \
+    this->printErr("Unsupported " #idx "-th Template Data Type: " \
+                   + std::to_string(static_cast<int>(type)));     \
+  } break;
+
+#define ttkTypeMacroCase(enum, type, number, call) \
+  case enum: {                                     \
+    typedef type T##number;                        \
+    call;                                          \
+  } break;
+
+#define ttkTypeMacroT(group, call)                                 \
+  switch(group) {                                                  \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,           \
+                     ttk::ExplicitTriangulation, 0, call);         \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,           \
+                     ttk::ImplicitTriangulation, 0, call);         \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,           \
+                     ttk::PeriodicImplicitTriangulation, 0, call); \
+    ttkTypeMacroErrorCase(0, group);                               \
+  }
+
+#define ttkTypeMacroR(group, call)                 \
+  switch(group) {                                  \
+    ttkTypeMacroCase(VTK_FLOAT, float, 0, call);   \
+    ttkTypeMacroCase(VTK_DOUBLE, double, 0, call); \
+    ttkTypeMacroErrorCase(0, group);               \
+  }
+
+#define ttkTypeMacroI(group, call)                                         \
+  switch(group) {                                                          \
+    ttkTypeMacroCase(VTK_INT, int, 0, call);                               \
+    ttkTypeMacroCase(VTK_UNSIGNED_INT, unsigned int, 0, call);             \
+    ttkTypeMacroCase(VTK_CHAR, char, 0, call);                             \
+    ttkTypeMacroCase(VTK_SIGNED_CHAR, signed char, 0, call);               \
+    ttkTypeMacroCase(VTK_UNSIGNED_CHAR, unsigned char, 0, call);           \
+    ttkTypeMacroCase(VTK_LONG, long, 0, call);                             \
+    ttkTypeMacroCase(VTK_LONG_LONG, long long, 0, call);                   \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG, unsigned long, 0, call);           \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG_LONG, unsigned long long, 0, call); \
+    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 0, call);                     \
+    ttkTypeMacroErrorCase(0, group);                                       \
+  }
+
+#define ttkTypeMacroA(group, call)                                         \
+  switch(group) {                                                          \
+    ttkTypeMacroCase(VTK_FLOAT, float, 0, call);                           \
+    ttkTypeMacroCase(VTK_DOUBLE, double, 0, call);                         \
+    ttkTypeMacroCase(VTK_INT, int, 0, call);                               \
+    ttkTypeMacroCase(VTK_UNSIGNED_INT, unsigned int, 0, call);             \
+    ttkTypeMacroCase(VTK_CHAR, char, 0, call);                             \
+    ttkTypeMacroCase(VTK_SIGNED_CHAR, signed char, 0, call);               \
+    ttkTypeMacroCase(VTK_UNSIGNED_CHAR, unsigned char, 0, call);           \
+    ttkTypeMacroCase(VTK_LONG, long, 0, call);                             \
+    ttkTypeMacroCase(VTK_LONG_LONG, long long, 0, call);                   \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG, unsigned long, 0, call);           \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG_LONG, unsigned long long, 0, call); \
+    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 0, call);                     \
+    ttkTypeMacroErrorCase(0, group);                                       \
+  }
+
+#define ttkTypeMacroAT(group0, group1, call)                \
+  switch(group1) {                                          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
+                     ttk::ExplicitTriangulation, 1,         \
+                     ttkTypeMacroA(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
+                     ttk::ImplicitTriangulation, 1,         \
+                     ttkTypeMacroA(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
+                     ttk::PeriodicImplicitTriangulation, 1, \
+                     ttkTypeMacroA(group0, call));          \
+    ttkTypeMacroErrorCase(1, group1);                       \
+  }
+
+#define ttkTypeMacroRT(group0, group1, call)                \
+  switch(group1) {                                          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
+                     ttk::ExplicitTriangulation, 1,         \
+                     ttkTypeMacroR(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
+                     ttk::ImplicitTriangulation, 1,         \
+                     ttkTypeMacroR(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
+                     ttk::PeriodicImplicitTriangulation, 1, \
+                     ttkTypeMacroR(group0, call));          \
+    ttkTypeMacroErrorCase(1, group1);                       \
+  }
+
+#define ttkTypeMacroIT(group0, group1, call)                \
+  switch(group1) {                                          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
+                     ttk::ExplicitTriangulation, 1,         \
+                     ttkTypeMacroI(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
+                     ttk::ImplicitTriangulation, 1,         \
+                     ttkTypeMacroI(group0, call));          \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
+                     ttk::PeriodicImplicitTriangulation, 1, \
+                     ttkTypeMacroI(group0, call));          \
+    ttkTypeMacroErrorCase(1, group1);                       \
+  }
+
+#define ttkTypeMacroAI(group0, group1, call)                                  \
+  switch(group1) {                                                            \
+    ttkTypeMacroCase(VTK_INT, int, 1, ttkTypeMacroA(group0, call));           \
+    ttkTypeMacroCase(                                                         \
+      VTK_LONG_LONG, long long, 1, ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 1, ttkTypeMacroA(group0, call)); \
+    ttkTypeMacroErrorCase(1, group1);                                         \
+  }
+
+#define ttkTypeMacroRR(group0, group1, call)                              \
+  switch(group1) {                                                        \
+    ttkTypeMacroCase(VTK_FLOAT, float, 1, ttkTypeMacroR(group0, call));   \
+    ttkTypeMacroCase(VTK_DOUBLE, double, 1, ttkTypeMacroR(group0, call)); \
+    ttkTypeMacroErrorCase(1, group1);                                     \
+  }
+
+#define ttkTypeMacroAA(group0, group1, call)                                  \
+  switch(group1) {                                                            \
+    ttkTypeMacroCase(VTK_FLOAT, float, 1, ttkTypeMacroA(group0, call));       \
+    ttkTypeMacroCase(VTK_DOUBLE, double, 1, ttkTypeMacroA(group0, call));     \
+    ttkTypeMacroCase(VTK_INT, int, 1, ttkTypeMacroA(group0, call));           \
+    ttkTypeMacroCase(                                                         \
+      VTK_UNSIGNED_INT, unsigned int, 1, ttkTypeMacroA(group0, call));        \
+    ttkTypeMacroCase(VTK_CHAR, char, 1, ttkTypeMacroA(group0, call));         \
+    ttkTypeMacroCase(                                                         \
+      VTK_SIGNED_CHAR, signed char, 1, ttkTypeMacroA(group0, call));          \
+    ttkTypeMacroCase(                                                         \
+      VTK_UNSIGNED_CHAR, unsigned char, 1, ttkTypeMacroA(group0, call));      \
+    ttkTypeMacroCase(VTK_LONG, long, 1, ttkTypeMacroA(group0, call));         \
+    ttkTypeMacroCase(                                                         \
+      VTK_LONG_LONG, long long, 1, ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(                                                         \
+      VTK_UNSIGNED_LONG, unsigned long, 1, ttkTypeMacroA(group0, call));      \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG_LONG, unsigned long long, 1,           \
+                     ttkTypeMacroA(group0, call));                            \
+    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 1, ttkTypeMacroA(group0, call)); \
+    ttkTypeMacroErrorCase(1, group1);                                         \
+  }
+
+#define ttkTypeMacroAAA(group0, group1, group2, call)                          \
+  switch(group2) {                                                             \
+    ttkTypeMacroCase(                                                          \
+      VTK_FLOAT, float, 2, ttkTypeMacroAA(group0, group1, call));              \
+    ttkTypeMacroCase(                                                          \
+      VTK_DOUBLE, double, 2, ttkTypeMacroAA(group0, group1, call));            \
+    ttkTypeMacroCase(VTK_INT, int, 2, ttkTypeMacroAA(group0, group1, call));   \
+    ttkTypeMacroCase(VTK_UNSIGNED_INT, unsigned int, 2,                        \
+                     ttkTypeMacroAA(group0, group1, call));                    \
+    ttkTypeMacroCase(VTK_CHAR, char, 2, ttkTypeMacroAA(group0, group1, call)); \
+    ttkTypeMacroCase(                                                          \
+      VTK_SIGNED_CHAR, signed char, 2, ttkTypeMacroAA(group0, group1, call));  \
+    ttkTypeMacroCase(VTK_UNSIGNED_CHAR, unsigned char, 2,                      \
+                     ttkTypeMacroAA(group0, group1, call));                    \
+    ttkTypeMacroCase(VTK_LONG, long, 2, ttkTypeMacroAA(group0, group1, call)); \
+    ttkTypeMacroCase(                                                          \
+      VTK_LONG_LONG, long long, 2, ttkTypeMacroAA(group0, group1, call));      \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG, unsigned long, 2,                      \
+                     ttkTypeMacroAA(group0, group1, call));                    \
+    ttkTypeMacroCase(VTK_UNSIGNED_LONG_LONG, unsigned long long, 2,            \
+                     ttkTypeMacroAA(group0, group1, call));                    \
+    ttkTypeMacroCase(                                                          \
+      VTK_ID_TYPE, vtkIdType, 2, ttkTypeMacroAA(group0, group1, call));        \
+    ttkTypeMacroErrorCase(2, group2);                                          \
+  }
+
+#define ttkTypeMacroAII(group0, group1, group2, call)                        \
+  switch(group2) {                                                           \
+    ttkTypeMacroCase(VTK_INT, int, 2, ttkTypeMacroAI(group0, group1, call)); \
+    ttkTypeMacroCase(                                                        \
+      VTK_LONG_LONG, long long, 2, ttkTypeMacroAI(group0, group1, call));    \
+    ttkTypeMacroCase(                                                        \
+      VTK_ID_TYPE, vtkIdType, 2, ttkTypeMacroAI(group0, group1, call));      \
+    ttkTypeMacroErrorCase(2, group2);                                        \
+  }
+
+#define ttkTypeMacroRRR(group0, group1, group2, call)               \
+  switch(group2) {                                                  \
+    ttkTypeMacroCase(                                               \
+      VTK_FLOAT, float, 2, ttkTypeMacroRR(group0, group1, call));   \
+    ttkTypeMacroCase(                                               \
+      VTK_DOUBLE, double, 2, ttkTypeMacroRR(group0, group1, call)); \
+    ttkTypeMacroErrorCase(2, group2);                               \
+  }
+
+#define ttkTypeMacroRRI(group0, group1, group2, call)                        \
+  switch(group2) {                                                           \
+    ttkTypeMacroCase(VTK_INT, int, 2, ttkTypeMacroRR(group0, group1, call)); \
+    ttkTypeMacroCase(                                                        \
+      VTK_LONG_LONG, long long, 2, ttkTypeMacroRR(group0, group1, call));    \
+    ttkTypeMacroCase(                                                        \
+      VTK_ID_TYPE, vtkIdType, 2, ttkTypeMacroRR(group0, group1, call));      \
+    ttkTypeMacroErrorCase(2, group2);                                        \
+  }

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
@@ -19,76 +19,6 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
-#define ttkTypeMacroErrorCase(idx, type)                          \
-  default: {                                                      \
-    this->printErr("Unsupported " #idx "-th Template Data Type: " \
-                   + std::to_string(type));                       \
-  } break;
-
-#define ttkTypeMacroCase(enum, type, number, call) \
-  case enum: {                                     \
-    typedef type T##number;                        \
-    call;                                          \
-  } break;
-
-#define ttkTypeMacroR(target, call)                                 \
-  switch(target) {                                                  \
-    ttkTypeMacroCase(VTK_FLOAT, float, 0, call) ttkTypeMacroCase(   \
-      VTK_DOUBLE, double, 0, call) ttkTypeMacroErrorCase(0, target) \
-  }
-
-#define ttkTypeMacroA(target, call)                                        \
-  switch(target) {                                                         \
-    ttkTypeMacroCase(VTK_FLOAT, float, 0, call);                           \
-    ttkTypeMacroCase(VTK_DOUBLE, double, 0, call);                         \
-    ttkTypeMacroCase(VTK_INT, int, 0, call);                               \
-    ttkTypeMacroCase(VTK_UNSIGNED_INT, unsigned int, 0, call);             \
-    ttkTypeMacroCase(VTK_CHAR, char, 0, call);                             \
-    ttkTypeMacroCase(VTK_SIGNED_CHAR, signed char, 0, call);               \
-    ttkTypeMacroCase(VTK_UNSIGNED_CHAR, unsigned char, 0, call);           \
-    ttkTypeMacroCase(VTK_LONG, long, 0, call);                             \
-    ttkTypeMacroCase(VTK_LONG_LONG, long long, 0, call);                   \
-    ttkTypeMacroCase(VTK_UNSIGNED_LONG, unsigned long, 0, call);           \
-    ttkTypeMacroCase(VTK_UNSIGNED_LONG_LONG, unsigned long long, 0, call); \
-    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 0, call);                     \
-    ttkTypeMacroErrorCase(0, target);                                      \
-  }
-
-#define ttkTypeMacroRR(target0, target1, call)                             \
-  switch(target1) {                                                        \
-    ttkTypeMacroCase(VTK_FLOAT, float, 1, ttkTypeMacroR(target0, call));   \
-    ttkTypeMacroCase(VTK_DOUBLE, double, 1, ttkTypeMacroR(target0, call)); \
-    ttkTypeMacroErrorCase(1, target1);                                     \
-  }
-
-#define ttkTypeMacroRRR(target0, target1, target2, call)              \
-  switch(target2) {                                                   \
-    ttkTypeMacroCase(                                                 \
-      VTK_FLOAT, float, 2, ttkTypeMacroRR(target0, target1, call));   \
-    ttkTypeMacroCase(                                                 \
-      VTK_DOUBLE, double, 2, ttkTypeMacroRR(target0, target1, call)); \
-    ttkTypeMacroErrorCase(2, target2);                                \
-  }
-
-#define ttkTypeMacroRRI(target0, target1, target2, call)                       \
-  switch(target2) {                                                            \
-    ttkTypeMacroCase(VTK_INT, int, 2, ttkTypeMacroRR(target0, target1, call)); \
-    ttkTypeMacroCase(                                                          \
-      VTK_LONG_LONG, long long, 2, ttkTypeMacroRR(target0, target1, call));    \
-    ttkTypeMacroCase(                                                          \
-      VTK_ID_TYPE, vtkIdType, 2, ttkTypeMacroRR(target0, target1, call));      \
-    ttkTypeMacroErrorCase(2, target2);                                         \
-  }
-
-#define ttkTypeMacroAI(target0, target1, call)                                 \
-  switch(target1) {                                                            \
-    ttkTypeMacroCase(VTK_INT, int, 1, ttkTypeMacroA(target0, call));           \
-    ttkTypeMacroCase(                                                          \
-      VTK_LONG_LONG, long long, 1, ttkTypeMacroA(target0, call));              \
-    ttkTypeMacroCase(VTK_ID_TYPE, vtkIdType, 1, ttkTypeMacroA(target0, call)); \
-    ttkTypeMacroErrorCase(1, target1);                                         \
-  }
-
 vtkStandardNewMacro(ttkMeshGraph);
 
 ttkMeshGraph::ttkMeshGraph() {
@@ -178,16 +108,14 @@ int ttkMeshGraph::RequestData(vtkInformation *ttkNotUsed(request),
       outputConnectivityArray->GetDataType(),
       (status = this->execute<T2, T0, T1>(
          // Output
-         static_cast<T0 *>(ttkUtils::GetVoidPointer(outputPoints)),
-         static_cast<T2 *>(ttkUtils::GetVoidPointer(outputConnectivityArray)),
-         static_cast<T2 *>(ttkUtils::GetVoidPointer(outputOffsetArray)),
+         ttkUtils::GetPointer<T0>(outputPoints->GetData()),
+         ttkUtils::GetPointer<T2>(outputConnectivityArray),
+         ttkUtils::GetPointer<T2>(outputOffsetArray),
 
          // Input
-         static_cast<T0 *>(ttkUtils::GetVoidPointer(inputPoints)),
-         static_cast<T2 *>(
-           ttkUtils::GetVoidPointer(input->GetCells()->GetConnectivityArray())),
-         nInputPoints, nInputCells,
-         static_cast<T1 *>(ttkUtils::GetVoidPointer(inputPointSizes)),
+         ttkUtils::GetPointer<T0>(inputPoints->GetData()),
+         ttkUtils::GetPointer<T2>(input->GetCells()->GetConnectivityArray()),
+         nInputPoints, nInputCells, ttkUtils::GetPointer<T1>(inputPointSizes),
          this->GetSizeScale(), this->GetSizeAxis())));
   } else {
     ttkTypeMacroRRI(
@@ -195,17 +123,16 @@ int ttkMeshGraph::RequestData(vtkInformation *ttkNotUsed(request),
       outputConnectivityArray->GetDataType(),
       (status = this->execute2<T2, T0, T1>(
          // Output
-         static_cast<T0 *>(ttkUtils::GetVoidPointer(outputPoints)),
-         static_cast<T2 *>(ttkUtils::GetVoidPointer(outputConnectivityArray)),
-         static_cast<T2 *>(ttkUtils::GetVoidPointer(outputOffsetArray)),
+         ttkUtils::GetPointer<T0>(outputPoints->GetData()),
+         ttkUtils::GetPointer<T2>(outputConnectivityArray),
+         ttkUtils::GetPointer<T2>(outputOffsetArray),
 
          // Input
-         static_cast<T0 *>(ttkUtils::GetVoidPointer(inputPoints)),
-         static_cast<T2 *>(
-           ttkUtils::GetVoidPointer(input->GetCells()->GetConnectivityArray())),
+         ttkUtils::GetPointer<T0>(inputPoints->GetData()),
+         ttkUtils::GetPointer<T2>(input->GetCells()->GetConnectivityArray()),
          nInputPoints, nInputCells, this->GetSubdivisions(),
-         static_cast<T1 *>(ttkUtils::GetVoidPointer(inputPointSizes)),
-         this->GetSizeScale(), this->GetSizeAxis())));
+         ttkUtils::GetPointer<T1>(inputPointSizes), this->GetSizeScale(),
+         this->GetSizeAxis())));
   }
   if(!status)
     return 0;
@@ -245,12 +172,12 @@ int ttkMeshGraph::RequestData(vtkInformation *ttkNotUsed(request),
       ttkTypeMacroAI(
         iArray->GetDataType(), inputConnectivityArray->GetDataType(),
         (status = this->mapInputPointDataToOutputPointData<T0, T1>(
-           static_cast<T0 *>(ttkUtils::GetVoidPointer(oArray)),
+           ttkUtils::GetPointer<T0>(oArray),
 
            nInputPoints, nInputCells,
-           static_cast<T1 *>(ttkUtils::GetVoidPointer(inputConnectivityArray)),
-           static_cast<T0 *>(ttkUtils::GetVoidPointer(iArray)),
-           this->GetUseQuadraticCells(), this->GetSubdivisions())));
+           ttkUtils::GetPointer<T1>(inputConnectivityArray),
+           ttkUtils::GetPointer<T0>(iArray), this->GetUseQuadraticCells(),
+           this->GetSubdivisions())));
 
       if(!status)
         return 0;
@@ -277,9 +204,8 @@ int ttkMeshGraph::RequestData(vtkInformation *ttkNotUsed(request),
       ttkTypeMacroA(
         iArray->GetDataType(),
         (status = this->mapInputCellDataToOutputCellData<T0>(
-           static_cast<T0 *>(ttkUtils::GetVoidPointer(oArray)), nInputCells,
-           static_cast<T0 *>(ttkUtils::GetVoidPointer(iArray)),
-           this->GetUseQuadraticCells())));
+           ttkUtils::GetPointer<T0>(oArray), nInputCells,
+           ttkUtils::GetPointer<T0>(iArray), this->GetUseQuadraticCells())));
       if(!status)
         return 0;
     }

--- a/paraview/xmls/PlanarGraphLayout.xml
+++ b/paraview/xmls/PlanarGraphLayout.xml
@@ -38,6 +38,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                 </ProxyGroupDomain>
                 <DataTypeDomain name="input_type">
                     <DataType value="vtkUnstructuredGrid" />
+                    <DataType value="vtkPolyData" />
                 </DataTypeDomain>
                 <InputArrayDomain name="input_array" attribute_type="point" />
                 <Documentation>Graph.</Documentation>
@@ -68,7 +69,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                 <BooleanDomain name="bool" />
                 <Documentation>Points are positioned along the x-axis based on a sequence (e.g., time indicies or scalar values).</Documentation>
             </IntVectorProperty>
-            
+
             <StringVectorProperty name="SequenceArray" label="Sequence Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5">
                 <ArrayListDomain attribute_type="Scalars" name="array_list">
                     <RequiredProperties>
@@ -95,7 +96,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                 <BooleanDomain name="bool" />
                 <Documentation>Points cover space on the y-axis based on their size.</Documentation>
             </IntVectorProperty>
-            
+
             <StringVectorProperty name="SizeArray" label="Size Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5" default_values="1">
                 <ArrayListDomain attribute_type="Scalars" name="array_list">
                     <RequiredProperties>
@@ -122,7 +123,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                 <BooleanDomain name="bool" />
                 <Documentation>Points with the same branch label are positioned on straight lines.</Documentation>
             </IntVectorProperty>
-            
+
             <StringVectorProperty name="BranchArray" label="Branch Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5" default_values="2">
                 <ArrayListDomain attribute_type="Scalars" name="array_list">
                     <RequiredProperties>
@@ -149,7 +150,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                 <BooleanDomain name="bool" />
                 <Documentation>The layout of points with the same level label are computed individually and afterwards nested based on the level hierarchy.</Documentation>
             </IntVectorProperty>
-            
+
             <StringVectorProperty name="LevelArray" label="Level Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5" default_values="3">
                 <ArrayListDomain attribute_type="Scalars" name="array_list">
                     <RequiredProperties>
@@ -157,7 +158,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                     </RequiredProperties>
                 </ArrayListDomain>
                 <Hints>
-                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseLevels" value="1" 
+                    <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="UseLevels" value="1"
                     />
                     <PropertyWidgetDecorator type="GenericDecorator"
                                              mode="visibility"


### PR DESCRIPTION
Hi Julien,
this PR adds some template macros to `ttkMacros.h` which make it easier to templatize over function arguments. They can be called like this:
```
int status = 0;
ttkTypeMacroARIT(
  arrayThatDeterminesT0->GetDataType(), // A: array can be of any data type
  arrayThatDeterminesT1->GetDataType(), // R: array type can only be float or double 
  arrayThatDeterminesT2->GetDataType(), // I: array type can only be an integer type
  triangulationThatDeterminesT3->GetType(), // T: Triangulation type
  (
   status = someFunction<T0,T1,T2,T3>(
    ttkUtils::GetPointer<T0>(arrayThatDeterminesT0),
    ttkUtils::GetPointer<T1>(arrayThatDeterminesT1),
    ttkUtils::GetPointer<T2>(arrayThatDeterminesT2),
    ttkUtils::GetPointer<T3>(triangulation->getData()),
   )
  )
);
if(!status)
  return 0; // some error occurred
```
I provided several common use cases such as `ttkTypeMacroT` (only templatize over triangulation type), `ttkTypeMacroRT` (real and triangulation), and so on. If an array is not of a supported type the macro prints an error msg and the call arguments is not executed. In the example above `status` would therefore not be modified and an error would be detected.

I also updated the PlanarGraphLayout module to use the new macro. This macro refit also fixes a bug that resulted from the fact that the module until now not templatized over the connectivity list type.

NOTE: I tested this with the state files and everything is working as expected. However, immediately feeding the arcs of FTMTree to PlanarGraphLayout and enabling `isMergeTree` causes a segfault, but this already happened before my updates! So this seg fault is a separate issue independent of this PR.