### PR TITLE
Doxygen links for Builtin example 2 and Interaction sites examples

### DIFF
--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.h
@@ -37,6 +37,10 @@
 /// IEEE Transactions on Visualization and Computer Graphics, 2008.
 ///
 /// \sa ttk::ContinuousScatterPlot
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/builtInExample2/">
+///   Builtin example 2</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -63,6 +63,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge
 ///   Tree Temporal Reduction</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -63,7 +63,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge
 ///   Tree Temporal Reduction</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 
 #pragma once

--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.h
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.h
@@ -37,6 +37,10 @@
 ///
 /// \sa ttk::FiberSurface
 /// \sa vtkRangePolygon
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/builtInExample2/">
+///   Builtin example 2</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -38,7 +38,8 @@
 ///   Harmonic Skeleton example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/morseMolecule/">
 /// Morse molecule example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -38,6 +38,8 @@
 ///   Harmonic Skeleton example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/morseMolecule/">
 /// Morse molecule example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
@@ -17,7 +17,8 @@
 ///   Harmonic Skeleton example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/morseMolecule/">
 /// Morse molecule example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
@@ -17,6 +17,8 @@
 ///   Harmonic Skeleton example</a> \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/morseMolecule/">
 /// Morse molecule example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkJacobiSet/ttkJacobiSet.h
+++ b/core/vtk/ttkJacobiSet/ttkJacobiSet.h
@@ -47,6 +47,10 @@
 ///
 /// \sa ttk::JacobiSet
 /// \sa vtkReebSpace
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/builtInExample2/">
+///   Builtin example 2</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -38,6 +38,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
 ///   Persistence example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 
 #ifndef _TTK_PERSISTENCECURVE_H

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -38,7 +38,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
 ///   Persistence example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -102,6 +102,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -102,7 +102,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 

--- a/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
+++ b/core/vtk/ttkProjectionFromField/ttkProjectionFromField.h
@@ -36,6 +36,10 @@
 ///
 /// \sa vtkTextureMapFromField
 ///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/builtInExample2/">
+///   Builtin example 2</a> \n
+
 #pragma once
 
 // VTK Module

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.h
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.h
@@ -47,6 +47,10 @@
 /// \sa ttk::FiberSurface
 /// \sa vtkReebSpace
 ///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/builtInExample2/">
+///   Builtin example 2</a> \n
+
 #pragma once
 
 // VTK includes -- to adapt

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -59,7 +59,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 #pragma once

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.h
@@ -59,6 +59,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 #pragma once
 

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -104,6 +104,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.h
@@ -104,7 +104,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
 ///   Uncertain Starting Vortex example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
 ///   Interaction sites</a> \n
 ///
 

--- a/paraview/xmls/ContinuousScatterPlot.xml
+++ b/paraview/xmls/ContinuousScatterPlot.xml
@@ -20,6 +20,11 @@ point data.
 Related publication: 'Continuous Scatterplots', Sven Bachthaler,
 Daniel Weiskopf, Proc. of IEEE VIS 2008, IEEE Transactions on Visualization and
 Computer Graphics, 2008.
+
+    Online examples:
+
+    - https://topology-tool-kit.github.io/examples/builtInExample2/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/FTMTree.xml
+++ b/paraview/xmls/FTMTree.xml
@@ -41,11 +41,13 @@
 
               - https://topology-tool-kit.github.io/examples/dragon/
 
-        - https://topology-tool-kit.github.io/examples/morsePersistence/
+              - https://topology-tool-kit.github.io/examples/morsePersistence/
         
-        - https://topology-tool-kit.github.io/examples/mergeTreeClustering/
+              - https://topology-tool-kit.github.io/examples/mergeTreeClustering/
         
-        - https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/
+              - https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/
+        
+              - https://topology-tool-kit.github.io/examples/interactionSites/
 
             </Documentation>
 

--- a/paraview/xmls/FiberSurface.xml
+++ b/paraview/xmls/FiberSurface.xml
@@ -30,6 +30,11 @@ Related publication:
 "Fast and Exact Fiber Surface Extraction for Tetrahedral Meshes",
 Pavol Klacansky, Julien Tierny, Hamish Carr, Zhao Geng
 IEEE Transactions on Visualization and Computer Graphics, 2016.
+
+    Online examples:
+
+    - https://topology-tool-kit.github.io/examples/builtInExample2/
+
      </Documentation>
      <InputProperty
         name="Input Domain"

--- a/paraview/xmls/GeometrySmoother.xml
+++ b/paraview/xmls/GeometrySmoother.xml
@@ -31,6 +31,8 @@
         - https://topology-tool-kit.github.io/examples/morsePersistence/
         
         - https://topology-tool-kit.github.io/examples/morseMolecule/
+        
+        - https://topology-tool-kit.github.io/examples/interactionSites/
 
 
       </Documentation>

--- a/paraview/xmls/IcospheresFromPoints.xml
+++ b/paraview/xmls/IcospheresFromPoints.xml
@@ -14,6 +14,8 @@
         - https://topology-tool-kit.github.io/examples/morsePersistence/
         
         - https://topology-tool-kit.github.io/examples/morseMolecule/
+        
+        - https://topology-tool-kit.github.io/examples/interactionSites/
 
             </Documentation>
 

--- a/paraview/xmls/JacobiSet.xml
+++ b/paraview/xmls/JacobiSet.xml
@@ -24,6 +24,11 @@ Related publication:
 "Jacobi sets of multiple Morse functions"
 Herbert Edelsbrunner, John Harer
 Foundations of Computational Mathematics. Cambridge University Press, 2002.
+
+    Online examples:
+
+    - https://topology-tool-kit.github.io/examples/builtInExample2/
+
      </Documentation>
      <InputProperty
         name="Input"

--- a/paraview/xmls/PersistenceCurve.xml
+++ b/paraview/xmls/PersistenceCurve.xml
@@ -32,6 +32,8 @@ See also ContourForests, PersistenceDiagram, ScalarFieldCriticalPoints, Topologi
         - https://topology-tool-kit.github.io/examples/dragon/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
+        
+        - https://topology-tool-kit.github.io/examples/interactionSites/
 
 
       </Documentation>

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -70,6 +70,7 @@
         - https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/
 
         - https://topology-tool-kit.github.io/examples/2manifoldLearning/        
+        
         - https://topology-tool-kit.github.io/examples/ctBones/
 
         - https://topology-tool-kit.github.io/examples/dragon/
@@ -81,7 +82,6 @@
         - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
-
         
         - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
 
@@ -98,6 +98,8 @@
         - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
 
         - https://topology-tool-kit.github.io/examples/uncertainStartingVortex/
+        
+        - https://topology-tool-kit.github.io/examples/interactionSites/
 
                 
       </Documentation>

--- a/paraview/xmls/ProjectionFromField.xml
+++ b/paraview/xmls/ProjectionFromField.xml
@@ -16,6 +16,11 @@ point-data scalar fields to be used as 2D coordinates."
 point-data scalar fields to be used as 2D coordinates.">
          TTK plugin which projects a data-set to 2D given two
 point-data scalar fields to be used as 2D coordinates.
+
+    Online examples:
+
+    - https://topology-tool-kit.github.io/examples/builtInExample2/
+
      </Documentation>
      <InputProperty
         name="Input"

--- a/paraview/xmls/RangePolygon.xml
+++ b/paraview/xmls/RangePolygon.xml
@@ -38,6 +38,11 @@ Pavol Klacansky, Julien Tierny, Hamish Carr, Zhao Geng
 IEEE Transactions on Visualization and Computer Graphics, 2016.
 
 See also ContinuousScatterplot, FiberSurface, Fiber, ProjectionFromField.
+
+    Online examples:
+
+    - https://topology-tool-kit.github.io/examples/builtInExample2/
+
      </Documentation>
      <InputProperty
         name="Input"

--- a/paraview/xmls/ScalarFieldCriticalPoints.xml
+++ b/paraview/xmls/ScalarFieldCriticalPoints.xml
@@ -58,6 +58,8 @@
         - https://topology-tool-kit.github.io/examples/morsePersistence/
 
         - https://topology-tool-kit.github.io/examples/uncertainStartingVortex/
+        
+        - https://topology-tool-kit.github.io/examples/interactionSites/
 
 
      </Documentation>

--- a/paraview/xmls/TopologicalSimplification.xml
+++ b/paraview/xmls/TopologicalSimplification.xml
@@ -77,7 +77,7 @@ Identifiers.
         
         - https://topology-tool-kit.github.io/examples/uncertainStartingVortex/
 
-                
+        - https://topology-tool-kit.github.io/examples/interactionSites/       
 
       </Documentation>
 


### PR DESCRIPTION
Added links to "Builtin example 2" and "Interaction sites" examples in the documentation.

The two related ttk-data PRs:
- https://github.com/topology-tool-kit/ttk-data/pull/101/
- https://github.com/topology-tool-kit/ttk-data/pull/103/

