### PR TITLE
example links

### DIFF
--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
@@ -17,6 +17,11 @@
 /// \param Input vtkPointSet that records the camera sampling locations
 /// (vtkPointSet) \param Output vtkMultiBlockDataSet that represents a list of
 /// images (vtkMultiBlockDataSet)
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/geometryApproximation/">Geometry
+///   Approximation example</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
@@ -25,6 +25,11 @@
 /// depth image (vtkMultiBlockDataSet)
 ///
 /// \sa ttk::DepthImageBasedGeometryApproximation
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/geometryApproximation/">Geometry
+///   Approximation example</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.h
+++ b/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.h
@@ -8,6 +8,11 @@
 ///
 /// \sa ttk::IcoSphere
 /// \sa ttk::ttkAlgorithm
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/geometryApproximation/">Geometry
+///   Approximation example</a> \n
 
 #pragma once
 

--- a/paraview/xmls/CinemaImaging.xml
+++ b/paraview/xmls/CinemaImaging.xml
@@ -2,7 +2,14 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
         <SourceProxy name="ttkCinemaImaging" class="ttkCinemaImaging" label="TTK CinemaImaging">
-            <Documentation long_help="TTK CinemaImaging" short_help="TTK CinemaImaging">This filter takes images of a vtkDataObject (first input) from angles specified on a vtkPointSet (second input). Each image will be a block of a vtkMultiBlockDataSet where block order corresponds to point order. Each sample point can optionally have vtkDoubleArrays to override the default rendering parameters, i.e, the resolution, camera direction, clipping planes, and viewport height.</Documentation>
+            <Documentation long_help="TTK CinemaImaging" short_help="TTK CinemaImaging">
+                This filter takes images of a vtkDataObject (first input) from angles specified on a vtkPointSet (second input). Each image will be a block of a vtkMultiBlockDataSet where block order corresponds to point order. Each sample point can optionally have vtkDoubleArrays to override the default rendering parameters, i.e, the resolution, camera direction, clipping planes, and viewport height.
+            
+                Online examples:
+
+                - https://topology-tool-kit.github.io/examples/geometryApproximation/
+
+            </Documentation>
 
             <!-- Inputs -->
             <InputProperty name="Dataset" port_index="0" command="SetInputConnection">

--- a/paraview/xmls/DepthImageBasedGeometryApproximation.xml
+++ b/paraview/xmls/DepthImageBasedGeometryApproximation.xml
@@ -2,11 +2,16 @@
 <ServerManagerConfiguration>
     <ProxyGroup name="filters">
         <SourceProxy name="ttkDepthImageBasedGeometryApproximation" class="ttkDepthImageBasedGeometryApproximation" label="TTK DepthImageBasedGeometryApproximation">
-            <Documentation long_help="TTK depthImageBasedGeometryApproximation" short_help="TTK depthImageBasedGeometryApproximation">This filter approximates the geometry that is depicted by a set of depth images.
+            <Documentation long_help="TTK depthImageBasedGeometryApproximation" short_help="TTK depthImageBasedGeometryApproximation">
+                This filter approximates the geometry that is depicted by a set of depth images.
 
                 Related publication:
 
                 'VOIDGA: A View-Approximation Oriented Image Database Generation Approach', Jonas Lukasczyk, Eric Kinner, James Ahrens, Heike Leitte, and Christoph Garth. IEEE 8th Symposium on Large Data Analysis and Visualization (LDAV), 2018.
+                
+                Online examples:
+
+                - https://topology-tool-kit.github.io/examples/geometryApproximation/
 
             </Documentation>
 

--- a/paraview/xmls/IcosphereFromObject.xml
+++ b/paraview/xmls/IcosphereFromObject.xml
@@ -4,6 +4,11 @@
         <SourceProxy name="ttkIcosphereFromObject" class="ttkIcosphereFromObject" label="TTK IcosphereFromObject">
             <Documentation long_help="TTK filter that creates an IcosphereFromObject" short_help="TTK filter that creates an IcosphereFromObject">
                 This filter creates an IcosphereFromObject with a specified radius, center, and number of subdivisions. Alternatively, by providing an optional input, the filter will automatically determine the radius and center such that the resulting IcosphereFromObject encapsulates the input object. In this case, the entered radius parameter is used as a scaling factor.
+
+                Online examples:
+
+                - https://topology-tool-kit.github.io/examples/geometryApproximation/
+                
             </Documentation>
 
             <InputProperty name="Object" port_index="0" command="SetInputConnection">


### PR DESCRIPTION
Added links to geometry approximation example for all included modules, (clang-formatted hopefully).

Pull request from ttk-data:

- https://github.com/topology-tool-kit/ttk-data/pull/111
