### PR TITLE
Fix CI Doxygen check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -151,7 +151,7 @@ jobs:
       if: matrix.config.dox
       run: |
         cd build
-        ! cmake --build . --target doc | grep warning
+        ! cmake --build . --target doc |& grep warning
 
 
   # ----------------------- #

--- a/core/base/contourTreeAlignment/CTA_contourtree.h
+++ b/core/base/contourTreeAlignment/CTA_contourtree.h
@@ -199,7 +199,7 @@ namespace ttk {
       /// Constructor for internal contour tree class. Constructs graph from vtk
       /// style array input.
       ///
-      /// \param scalar Scalar values of the contour tree nodes. scalars[i] is
+      /// \param scalars Scalar values of the contour tree nodes. scalars[i] is
       /// scalar values of the node of index i. \param regionSizes Region size
       /// values of the contour tree edges. regionSizes[i] is the number of
       /// vertices in the segment associated with the edge of index i. \param

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -178,28 +178,28 @@ namespace ttk {
     }
     /// Setter for the weight of combinatorial matching.
     ///
-    /// \param mode Determines the factor with which the combinatorial distance
-    /// is weighted.
+    /// \param weight Determines the factor with which the combinatorial
+    /// distance is weighted.
     void setWeightCombinatorialMatch(float weight) {
       weightCombinatorialMatch = weight;
     }
     /// Setter for the weight of arc property matching.
     ///
-    /// \param mode Determines the factor with which the arc property based
+    /// \param weight Determines the factor with which the arc property based
     /// distance is weighted.
     void setWeightArcMatch(float weight) {
       weightArcMatch = weight;
     }
     /// Setter for the weight of node matching.
     ///
-    /// \param mode Determines the factor with which the scalar value distance
+    /// \param weight Determines the factor with which the scalar value distance
     /// is weighted.
     void setWeightScalarValueMatch(float weight) {
       weightScalarValueMatch = weight;
     }
     /// Setter for the type of alignment tree.
     ///
-    /// \param mode Determines how the labels of the alignment tree are computed
+    /// \param type Determines how the labels of the alignment tree are computed
     /// from the matched labels.
     void setAlignmenttreeType(int type) {
       alignmenttreeType = static_cast<ttk::cta::Type_Alignmenttree>(type);
@@ -222,7 +222,7 @@ namespace ttk {
     /// input trees. \param nEdges Vector holding n integers representing the
     /// number of edges of the n input trees. \param segmentations Vector
     /// holding n arrays representing the segmentation arrays of the n input
-    /// trees. \param segSizes Vector holding the sizes of the corresponding
+    /// trees. \param segsizes Vector holding the sizes of the corresponding
     /// segmentations array. segSizes[i] should be the size of the number of
     /// points in the ith scalar field. This should also be the size of
     /// segmentations[i]. \param outputVertices Vector for the alignment node
@@ -286,8 +286,8 @@ namespace ttk {
     /// This function initializes a new alignment graph from a given contour
     /// tree and sets the fixed root of the alignment to the given input. \pre
     /// The given contour tree needs to be binary. \param t The input contour
-    /// tree. \return Return true if initialization was successful, false
-    /// otherwise.
+    /// tree. \param rootIdx \return Return true if initialization was
+    /// successful, false otherwise.
     bool initialize_consistentRoot(const std::shared_ptr<ContourTree> &t,
                                    int rootIdx);
 


### PR DESCRIPTION
The Doxygen check introduced in #702 was not properly enabled, since the Doxygen process in the virtual machine was outputting warnings on `stderr` instead of `stdout`.

This PR fixes behavior. Now any Doxygen warning will be correctly detected by the check.
Incidentally, some Doxygen typos introduced in #694 have been fixed.

Enjoy,
Pierre