### PR TITLE
Enforce Clang static analyzer CI check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -139,13 +139,13 @@ jobs:
         | grep -E "\.cpp$|\.cxx$" \
         | xargs -n1 $CLANG_TIDY -p build 2> /dev/null
 
-    - name: Use Clang static analyzer [NOT ENFORCED]
+    - name: Use Clang static analyzer
       if: matrix.config.sa
       run: |
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 -P2 $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" 2> /dev/null
+        | xargs -n1 -P2 $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" --warnings-as-errors="*" 2> /dev/null
 
     - name: Check Doxygen documentation warnings
       if: matrix.config.dox


### PR DESCRIPTION
This PR fixes the last warning of the Clang static analyzer CI check concerning the `ProjectionFromField` module. To do so, the branches that select the operating mode (`UseTextureCoordinates`, `Use3DCoordinatesArray` or neither)  were hoisted out of the main (parallel) loop to be closer to the corresponding nullptr checks.

As a consequence, the CI check is now enforced.

Enjoy,
Pierre