### PR TITLE
[DimensionReduction] t-SNE and Isomap distance matrix support

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -277,6 +277,7 @@ int DimensionReduction::execute() const {
   PyList_Append(pISOParams, PyUnicode_FromString(iso_PathMethod.data()));
   PyList_Append(
     pISOParams, PyUnicode_FromString(iso_NeighborsAlgorithm.data()));
+  PyList_Append(pISOParams, PyUnicode_FromString(iso_Metric.data()));
 
   pPCAParams = PyList_New(0);
   PyList_Append(pPCAParams, PyBool_FromLong(pca_Copy));

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -227,6 +227,7 @@ namespace ttk {
     int iso_MaxIteration{300};
     std::string iso_PathMethod{"auto"};
     std::string iso_NeighborsAlgorithm{"auto"};
+    std::string iso_Metric{"euclidean"};
 
     // pca
     bool pca_Copy{true};

--- a/core/base/dimensionReduction/dimensionReduction.py
+++ b/core/base/dimensionReduction/dimensionReduction.py
@@ -106,6 +106,7 @@ def doIt(X, method, ncomponents, nneighbors, njobs, rstate, params):
                 max_iter=isoParams[2],
                 path_method=isoParams[3],
                 neighbors_algorithm=isoParams[4],
+                metric=isoParams[5],
                 n_jobs=njobs,
             )
             Y = iso.fit_transform(X)

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -85,6 +85,7 @@ public:
     if(b) {
       this->mds_Dissimilarity = "precomputed";
       this->se_Affinity = "precomputed";
+      this->tsne_Metric = "precomputed";
     }
     Modified();
   }

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -86,6 +86,7 @@ public:
       this->mds_Dissimilarity = "precomputed";
       this->se_Affinity = "precomputed";
       this->tsne_Metric = "precomputed";
+      this->iso_Metric = "precomputed";
     }
     Modified();
   }
@@ -191,6 +192,9 @@ public:
 
   vtkSetMacro(iso_NeighborsAlgorithm, const std::string &);
   vtkGetMacro(iso_NeighborsAlgorithm, std::string);
+
+  vtkSetMacro(iso_Metric, const std::string &);
+  vtkGetMacro(iso_Metric, std::string);
 
   // PCA
   vtkSetMacro(pca_Copy, bool);

--- a/paraview/xmls/DimensionReduction.xml
+++ b/paraview/xmls/DimensionReduction.xml
@@ -169,6 +169,10 @@
                                        mode="visibility"
                                        property="Method"
                                        value="2" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="3" />
             </Expression>
           </PropertyWidgetDecorator>
         </Hints>

--- a/paraview/xmls/DimensionReduction.xml
+++ b/paraview/xmls/DimensionReduction.xml
@@ -173,6 +173,10 @@
                                        mode="visibility"
                                        property="Method"
                                        value="3" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="4" />
             </Expression>
           </PropertyWidgetDecorator>
         </Hints>
@@ -581,6 +585,16 @@
         <Documentation>
         </Documentation>
       </StringVectorProperty>
+      
+      <StringVectorProperty name="iso_Metric"
+        label="Metric"
+        command="Setiso_Metric"
+        number_of_elements="1"
+        default_values="euclidean"
+        panel_visibility="advanced">
+        <Documentation>
+        </Documentation>
+      </StringVectorProperty>
 
       <IntVectorProperty name="pca_Copy"
         label="Copy"
@@ -776,6 +790,7 @@
         <Property name="iso_MaxIteration" />
         <Property name="iso_PathMethod" />
         <Property name="iso_NeighborsAlgorithm" />
+        <Property name="iso_Metric" />
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
             mode="visibility"


### PR DESCRIPTION
Since the last update of the DimensionReduction filter, sklearn has updated t-SNE and Isomap to allow to consider the input as a distance matrix.
This PR modifies the DimensionReduction filter to take these changes into account by adding the distance matrix support for t-SNE and Isomap.