### PR TITLE
Remove unused round macro

### DIFF
--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -15,9 +15,6 @@
 
 #define drand48() (double(rand()) / RAND_MAX)
 //  #define               isnan(x)      _isnan(x)
-#ifndef _MSC_VER
-#define round(x) OsCall::roundToNearestInt(x)
-#endif
 #define srand48(seed) srand(seed)
 #endif // _WIN32
 


### PR DESCRIPTION
This PR removes an unused macro definition that exports the `ttk::OsCall::roundToNearestInt` function with the `round` name.
I believe this macro name is the root cause to issue #705. Since this macro is unused, removing it should solve this issue. The `ttk::OsCall::roundToNearestInt` function is still available for those who need it. 

As an alternative to this removal, we can scope properly the `round` function with 
```cpp
namespace ttk {
  constexpr auto round = OsCall::roundToNearestInt;
}
```

Enjoy,
Pierre