### PR TITLE
PersistenceDiagramDistanceMatrix: Fix distance computation

### DIFF
--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
+#include <limits>
 
+#include <PersistenceDiagramAuction.h>
 #include <PersistenceDiagramDistanceMatrix.h>
 
 using namespace ttk;
@@ -138,8 +140,9 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   return distMat;
 }
 
+template <typename T>
 double PersistenceDiagramDistanceMatrix::getMostPersistent(
-  const std::vector<BidderDiagram<double>> &bidder_diags) const {
+  const std::vector<T> &bidder_diags) const {
 
   double max_persistence = 0;
 
@@ -155,12 +158,14 @@ double PersistenceDiagramDistanceMatrix::getMostPersistent(
   return max_persistence;
 }
 
-double PersistenceDiagramDistanceMatrix::computePowerDistance(
-  const BidderDiagram<double> &D1, const BidderDiagram<double> &D2) const {
+template <typename T>
+double
+  PersistenceDiagramDistanceMatrix::computePowerDistance(const T &D1,
+                                                         const T &D2) const {
 
   GoodDiagram<double> D2_bis{};
   for(int i = 0; i < D2.size(); i++) {
-    const Bidder<double> &b = D2.get(i);
+    const auto &b = D2.get(i);
     Good<double> g(b.x_, b.y_, b.isDiagonal(), D2_bis.size());
     g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
     g.setPrice(0);
@@ -173,12 +178,13 @@ double PersistenceDiagramDistanceMatrix::computePowerDistance(
   return auction.run();
 }
 
+template <typename T>
 void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
   const std::array<size_t, 2> &nInputs,
   std::vector<std::vector<double>> &distanceMatrix,
-  const std::vector<BidderDiagram<double>> &diags_min,
-  const std::vector<BidderDiagram<double>> &diags_sad,
-  const std::vector<BidderDiagram<double>> &diags_max) const {
+  const std::vector<T> &diags_min,
+  const std::vector<T> &diags_sad,
+  const std::vector<T> &diags_max) const {
 
   distanceMatrix.resize(nInputs[0]);
 
@@ -238,10 +244,11 @@ void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
   }
 }
 
+template <typename T>
 void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   const size_t nInputs,
   std::vector<Diagram> &inputDiagrams,
-  std::vector<BidderDiagram<double>> &bidder_diags) const {
+  std::vector<T> &bidder_diags) const {
 
   bidder_diags.resize(nInputs);
 
@@ -262,9 +269,10 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   }
 }
 
+template <typename T>
 void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
-  const std::vector<BidderDiagram<double>> &bidder_diags,
-  std::vector<BidderDiagram<double>> &current_bidder_diags,
+  const std::vector<T> &bidder_diags,
+  std::vector<T> &current_bidder_diags,
   const std::vector<double> &maxDiagPersistence) const {
 
   current_bidder_diags.resize(bidder_diags.size());
@@ -319,7 +327,7 @@ void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
     double local_min_persistence = std::numeric_limits<double>::min();
     std::vector<double> persistences;
     for(int j = 0; j < bidder_diags[i].size(); j++) {
-      Bidder<double> b = bidder_diags[i].get(j);
+      const auto b = bidder_diags[i].get(j);
       double persistence = b.getPersistence();
       if(persistence >= 0.0 && persistence <= prev_min_persistence) {
         candidates_to_be_added[i].emplace_back(j);
@@ -350,8 +358,7 @@ void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
     // 3. Add the points to the current diagrams
     const auto s = candidates_to_be_added[i].size();
     for(size_t j = 0; j < std::min(max_points_to_add, s); j++) {
-      Bidder<double> b
-        = bidder_diags[i].get(candidates_to_be_added[i][idx[i][j]]);
+      auto b = bidder_diags[i].get(candidates_to_be_added[i][idx[i][j]]);
       const double persistence = b.getPersistence();
       if(persistence >= new_min_persistence) {
         b.id_ = current_bidder_diags[i].size();

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -155,7 +155,7 @@ double PersistenceDiagramDistanceMatrix::getMostPersistent(
   return max_persistence;
 }
 
-double PersistenceDiagramDistanceMatrix::computeDistance(
+double PersistenceDiagramDistanceMatrix::computePowerDistance(
   const BidderDiagram<double> &D1, const BidderDiagram<double> &D2) const {
 
   GoodDiagram<double> D2_bis{};
@@ -200,19 +200,19 @@ void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
       if(this->do_min_) {
         auto &dimin = diags_min[a];
         auto &djmin = diags_min[b];
-        distance += computeDistance(dimin, djmin);
+        distance += computePowerDistance(dimin, djmin);
       }
       if(this->do_sad_) {
         auto &disad = diags_sad[a];
         auto &djsad = diags_sad[b];
-        distance += computeDistance(disad, djsad);
+        distance += computePowerDistance(disad, djsad);
       }
       if(this->do_max_) {
         auto &dimax = diags_max[a];
         auto &djmax = diags_max[b];
-        distance += computeDistance(dimax, djmax);
+        distance += computePowerDistance(dimax, djmax);
       }
-      return distance;
+      return Geometry::pow(distance, 1.0 / this->Wasserstein);
     };
 
     if(nInputs[1] == 0) {

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -103,8 +103,8 @@ namespace ttk {
   protected:
     double getMostPersistent(
       const std::vector<BidderDiagram<double>> &bidder_diags) const;
-    double computeDistance(const BidderDiagram<double> &D1,
-                           const BidderDiagram<double> &D2) const;
+    double computePowerDistance(const BidderDiagram<double> &D1,
+                                const BidderDiagram<double> &D2) const;
     void getDiagramsDistMat(
       const std::array<size_t, 2> &nInputs,
       std::vector<std::vector<double>> &distanceMatrix,

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -15,10 +15,8 @@
 #pragma once
 
 #include <array>
-#include <limits>
 
-#include <PersistenceDiagramAuction.h>
-#include <Wrapper.h>
+#include <Debug.h>
 
 namespace ttk {
 
@@ -101,23 +99,24 @@ namespace ttk {
     }
 
   protected:
-    double getMostPersistent(
-      const std::vector<BidderDiagram<double>> &bidder_diags) const;
-    double computePowerDistance(const BidderDiagram<double> &D1,
-                                const BidderDiagram<double> &D2) const;
-    void getDiagramsDistMat(
-      const std::array<size_t, 2> &nInputs,
-      std::vector<std::vector<double>> &distanceMatrix,
-      const std::vector<BidderDiagram<double>> &diags_min,
-      const std::vector<BidderDiagram<double>> &diags_sad,
-      const std::vector<BidderDiagram<double>> &diags_max) const;
-    void
-      setBidderDiagrams(const size_t nInputs,
-                        std::vector<Diagram> &inputDiagrams,
-                        std::vector<BidderDiagram<double>> &bidder_diags) const;
+    template <typename T>
+    double getMostPersistent(const std::vector<T> &bidder_diags) const;
+    template <typename T>
+    double computePowerDistance(const T &D1, const T &D2) const;
+    template <typename T>
+    void getDiagramsDistMat(const std::array<size_t, 2> &nInputs,
+                            std::vector<std::vector<double>> &distanceMatrix,
+                            const std::vector<T> &diags_min,
+                            const std::vector<T> &diags_sad,
+                            const std::vector<T> &diags_max) const;
+    template <typename T>
+    void setBidderDiagrams(const size_t nInputs,
+                           std::vector<Diagram> &inputDiagrams,
+                           std::vector<T> &bidder_diags) const;
+    template <typename T>
     void enrichCurrentBidderDiagrams(
-      const std::vector<BidderDiagram<double>> &bidder_diags,
-      std::vector<BidderDiagram<double>> &current_bidder_diags,
+      const std::vector<T> &bidder_diags,
+      std::vector<T> &current_bidder_diags,
       const std::vector<double> &maxDiagPersistence) const;
 
     int Wasserstein{2};

--- a/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
+++ b/core/vtk/ttkPersistenceDiagramDistanceMatrix/ttkPersistenceDiagramDistanceMatrix.cpp
@@ -249,10 +249,10 @@ double ttkPersistenceDiagramDistanceMatrix::getPersistenceDiagram(
 
       } else {
         diagram[pairIdentifier] = std::make_tuple(
-          vertexId1, (BNodeType)nodeType1, vertexId2, (BNodeType)nodeType2,
-          persistence, pairType, birth, coordsBirth[0], coordsBirth[1],
-          coordsBirth[2], death, coordsDeath[0], coordsDeath[1],
-          coordsDeath[2]);
+          vertexId1, static_cast<ttk::CriticalType>(nodeType1), vertexId2,
+          static_cast<ttk::CriticalType>(nodeType2), persistence, pairType,
+          birth, coordsBirth[0], coordsBirth[1], coordsBirth[2], death,
+          coordsDeath[0], coordsDeath[1], coordsDeath[2]);
       }
     }
     if(pairIdentifier >= pairingsSize) {


### PR DESCRIPTION
The persistenceDiagramDistanceMatrix module was computing the square (L2-) distance between diagrams instead of the distance itself. This PR addresses this bug.

Additionally, the base layer has been refactored with templates to decrease the scope of the `PersistenceDiagramAuction.h` include. This include has been moved from the header file to the cpp file, in order not to expose the included header to the VTK layer.

Enjoy,
Pierre
