### PR TITLE
Fixing boundary saddles on volumes

### DIFF
--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -793,7 +793,9 @@ namespace ttk {
       if(params_->simplifyMethod == SimplifMethod::Persist) {
         pairs.emplace_back(
           orig, term,
-          fabs(getValue<scalarType>(orig) - getValue<scalarType>(term)), goUp);
+          std::abs(static_cast<double>(getValue<scalarType>(orig)
+                                       - getValue<scalarType>(term))),
+          goUp);
       } else if(params_->simplifyMethod == SimplifMethod::Span) {
         float coordOrig[3], coordTerm[3], span;
         mesh->getVertexPoint(orig, coordOrig[0], coordOrig[1], coordOrig[2]);

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -208,9 +208,9 @@ namespace ttk {
 
           // each task uses its local forests
           for(idVertex v = lowerBound; v < upperBound; ++v) {
-            std::tie(valences_.lower[v], valences_.upper[v])
-              = critPoints.getNumberOfLowerUpperComponents(
-                v, scalars_.getOffsets(), mesh_.getTriangulation());
+            critPoints.getNumberOfLowerUpperComponents(
+              v, scalars_.getOffsets(), mesh_.getTriangulation(),
+              valences_.lower[v], valences_.upper[v]);
 
             // leaf cases
             if(addMin && valences_.lower[v] == 0) {

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -208,9 +208,10 @@ namespace ttk {
 
           // each task uses its local forests
           for(idVertex v = lowerBound; v < upperBound; ++v) {
+            bool lBoundary = false, uBoundary = false;
             critPoints.getNumberOfLowerUpperComponents(
               v, scalars_.getOffsets(), mesh_.getTriangulation(),
-              valences_.lower[v], valences_.upper[v]);
+              valences_.lower[v], valences_.upper[v], lBoundary, uBoundary);
 
             // leaf cases
             if(addMin && valences_.lower[v] == 0) {

--- a/core/base/gaussianPointCloud/GaussianPointCloud.h
+++ b/core/base/gaussianPointCloud/GaussianPointCloud.h
@@ -50,7 +50,7 @@ int ttk::GaussianPointCloud::castSample(const int &dimension,
   v = (dimension >= 2 ? uniformDistribution(gen) : 0);
   w = (dimension == 3 ? uniformDistribution(gen) : 0);
 
-  dataType norm = sqrt(u * u + v * v + w * w);
+  dataType norm = std::sqrt(u * u + v * v + w * w);
 
   std::normal_distribution<dataType> normalDistribution{0, 1};
 

--- a/core/base/icosphere/Icosphere.h
+++ b/core/base/icosphere/Icosphere.h
@@ -103,7 +103,7 @@ namespace ttk {
                  IT &vertexIndex) const {
       IT cIndex = vertexIndex * 3;
 
-      DT length = sqrt(x * x + y * y + z * z);
+      DT length = std::sqrt(x * x + y * y + z * z);
       vertexCoords[cIndex] = x / length;
       vertexCoords[cIndex + 1] = y / length;
       vertexCoords[cIndex + 2] = z / length;

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -142,7 +142,7 @@ namespace ttk {
     bool forceNonManifoldCheck{false};
 
     // progressive
-    BACKEND BackEnd{BACKEND::PROGRESSIVE_TOPOLOGY};
+    BACKEND BackEnd{BACKEND::GENERIC};
     ProgressiveTopology progT_{};
     int StartingResolutionLevel{0};
     int StoppingResolutionLevel{-1};

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -72,10 +72,12 @@ namespace ttk {
     void checkProgressivityRequirement(const triangulationType *triangulation);
 
     template <class triangulationType = AbstractTriangulation>
-    std::pair<SimplexId, SimplexId> getNumberOfLowerUpperComponents(
+    int getNumberOfLowerUpperComponents(
       const SimplexId vertexId,
       const SimplexId *const offsets,
-      const triangulationType *triangulation) const;
+      const triangulationType *triangulation,
+      ttk::SimplexId &lowerComponentNumber,
+      ttk::SimplexId &upperComponentNumber) const;
 
     template <class triangulationType = AbstractTriangulation>
     char getCriticalType(const SimplexId &vertexId,
@@ -102,6 +104,7 @@ namespace ttk {
       if(triangulation) {
         triangulation->preconditionVertexNeighbors();
         triangulation->preconditionVertexStars();
+        triangulation->preconditionBoundaryVertices();
       }
 
       setDomainDimension(triangulation->getDimensionality());
@@ -323,11 +326,12 @@ int ttk::ScalarFieldCriticalPoints::executeLegacy(
 }
 
 template <class triangulationType>
-std::pair<ttk::SimplexId, ttk::SimplexId>
-  ttk::ScalarFieldCriticalPoints::getNumberOfLowerUpperComponents(
-    const SimplexId vertexId,
-    const SimplexId *const offsets,
-    const triangulationType *triangulation) const {
+int ttk::ScalarFieldCriticalPoints::getNumberOfLowerUpperComponents(
+  const SimplexId vertexId,
+  const SimplexId *const offsets,
+  const triangulationType *triangulation,
+  ttk::SimplexId &lowerComponentNumber,
+  ttk::SimplexId &upperComponentNumber) const {
 
   SimplexId neighborNumber = triangulation->getVertexNeighborNumber(vertexId);
   std::vector<SimplexId> lowerNeighbors, upperNeighbors;
@@ -349,12 +353,16 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
   // shortcut, if min or max do not construct the complete star
   if(!forceNonManifoldCheck && lowerNeighbors.empty()) {
     // minimum
-    return std::make_pair(0, 1);
+    lowerComponentNumber = 0;
+    upperComponentNumber = 1;
+    return 0;
   }
 
   if(!forceNonManifoldCheck && upperNeighbors.empty()) {
     // maximum
-    return std::make_pair(1, 0);
+    lowerComponentNumber = 1;
+    upperComponentNumber = 0;
+    return 0;
   }
 
   // now do the actual work
@@ -451,7 +459,10 @@ std::pair<ttk::SimplexId, ttk::SimplexId>
              debug::Priority::VERBOSE);
   }
 
-  return std::make_pair(lowerList.size(), upperList.size());
+  lowerComponentNumber = lowerList.size();
+  upperComponentNumber = upperList.size();
+
+  return 0;
 }
 
 template <class triangulationType>
@@ -460,23 +471,28 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
   const SimplexId *const offsets,
   const triangulationType *triangulation) const {
 
-  SimplexId downValence, upValence;
-  std::tie(downValence, upValence)
-    = getNumberOfLowerUpperComponents(vertexId, offsets, triangulation);
+  SimplexId lowerComponentNumber, upperComponentNumber;
+  getNumberOfLowerUpperComponents(vertexId, offsets, triangulation,
+                                  lowerComponentNumber, upperComponentNumber);
 
-  if(downValence == 0 && upValence == 1) {
+  if(lowerComponentNumber == 0 && upperComponentNumber == 1) {
     return (char)(CriticalType::Local_minimum);
-  } else if(downValence == 1 && upValence == 0) {
+  } else if(lowerComponentNumber == 1 && upperComponentNumber == 0) {
     return (char)(CriticalType::Local_maximum);
-  } else if(downValence == 1 && upValence == 1) {
+  } else if(lowerComponentNumber == 1 && upperComponentNumber == 1) {
+
+    if(dimension_ == 3) {
+      // special case of boundary saddles
+    }
+
     // regular point
     return (char)(CriticalType::Regular);
   } else {
     // saddles
     if(dimension_ == 2) {
-      if((downValence == 2 && upValence == 1)
-         || (downValence == 1 && upValence == 2)
-         || (downValence == 2 && upValence == 2)) {
+      if((lowerComponentNumber == 2 && upperComponentNumber == 1)
+         || (lowerComponentNumber == 1 && upperComponentNumber == 2)
+         || (lowerComponentNumber == 2 && upperComponentNumber == 2)) {
         // regular saddle
         return (char)(CriticalType::Saddle1);
       } else {
@@ -488,9 +504,9 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
         // disambiguate boundary from interior vertices
       }
     } else if(dimension_ == 3) {
-      if(downValence == 2 && upValence == 1) {
+      if(lowerComponentNumber == 2 && upperComponentNumber == 1) {
         return (char)(CriticalType::Saddle1);
-      } else if(downValence == 1 && upValence == 2) {
+      } else if(lowerComponentNumber == 1 && upperComponentNumber == 2) {
         return (char)(CriticalType::Saddle2);
       } else {
         // monkey saddle, saddle + extremum

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -494,12 +494,12 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     return (char)(CriticalType::Local_maximum);
   } else if(lowerComponentNumber == 1 && upperComponentNumber == 1) {
 
-    if(dimension_ == 3) {
+    if((dimension_ == 3) && (triangulation->isVertexOnBoundary(vertexId))) {
       // special case of boundary saddles
       if((isUpperOnBoundary) && (!isLowerOnBoundary))
+        return (char)(CriticalType::Saddle1);
+      if((!isUpperOnBoundary) && (isLowerOnBoundary))
         return (char)(CriticalType::Saddle2);
-      //       if((!isUpperOnBoundary)&&(isLowerOnBoundary))
-      //         return (char)(CriticalType::Saddle1);
     }
 
     // regular point

--- a/core/vtk/ttkGridLayout/ttkGridLayout.cpp
+++ b/core/vtk/ttkGridLayout/ttkGridLayout.cpp
@@ -148,7 +148,7 @@ int ttkGridLayout::RequestData(vtkInformation *ttkNotUsed(request),
   const size_t nRows
     = this->GetNumberOfRows() < 1 ? 0 : (size_t)this->GetNumberOfRows();
   const size_t nColumns
-    = nRows == 0 ? ceil(sqrt(nBlocks)) : ceil(nBlocks / nRows);
+    = nRows == 0 ? std::ceil(std::sqrt(nBlocks)) : std::ceil(nBlocks / nRows);
 
   for(size_t i = 0; i < nBlocks; i++) {
     // get block
@@ -157,7 +157,7 @@ int ttkGridLayout::RequestData(vtkInformation *ttkNotUsed(request),
     auto outBlock = vtkSmartPointer<vtkDataObject>::Take(block->NewInstance());
     this->CopyObject(outBlock, block);
 
-    const size_t row = floor(i / nColumns);
+    const size_t row = std::floor(i / nColumns);
     const size_t col = i % nColumns;
 
     if(!this->TranslateObject(

--- a/paraview/xmls/ScalarFieldCriticalPoints.xml
+++ b/paraview/xmls/ScalarFieldCriticalPoints.xml
@@ -15,18 +15,20 @@
        short_help="TTK plugin for the computation of critical points in PL
        scalar fields defined on PL manifolds.">
 
-       This plugin computes the list of critical points of the input scalar field and classify them according to their type.
-
-       Related publication:
-       "Critical points and curvature for embedded polyhedral surfaces"
-       Thomas Banchoff
-       American Mathematical Monthly, 1970.
+       This plugin computes the list of critical points of the input scalar 
+field and classify them according to their type.
 
        Two backends are available for the computation of critical points:
 
         1) Default generic backend
+        
+        Related publication:
+        "Critical points and curvature for embedded polyhedral surfaces"
+        Thomas Banchoff
+        American Mathematical Monthly, 1970.
 
-        This generic backend uses a Union Find data structure on the lower and upper link of each vertex to compute its critical type.
+        This generic backend uses a Union Find data structure on the lower and 
+upper link of each vertex to compute its critical type.
 
         2) A progressive approach
 
@@ -174,7 +176,7 @@
           label="Backend"
           command="SetBackEnd"
           number_of_elements="1"
-         default_values="1" 
+         default_values="0" 
          panel_visibility="advanced" >
 		 <EnumerationDomain name="enum">
           <Entry value="0" text="Default generic backend"/>


### PR DESCRIPTION
The generic backend for scalar field critical points classifies vertices based on the number of connected components of lower and upper links. For manifold domains, this is sufficient in practice up to dimension 3, where the components additionally need to be checked for simply-connectedness (specifically on the boundary). This is what this PR adds.
The previously default backend (progressive computation) hasn't included this fix yet so the generic backend came back as the default for now.