### PR TITLE
LDistanceMatrix: Improve performance

### DIFF
--- a/core/base/lDistance/LDistance.h
+++ b/core/base/lDistance/LDistance.h
@@ -51,6 +51,10 @@ namespace ttk {
       return result;
     }
 
+    inline void setPrintRes(const bool data) {
+      this->printRes = data;
+    }
+
     template <typename type>
     static type abs_diff(const type var1, const type var2) {
       return (var1 > var2) ? var1 - var2 : var2 - var1;
@@ -58,6 +62,7 @@ namespace ttk {
 
   protected:
     double result{};
+    bool printRes{true};
   };
 } // namespace ttk
 
@@ -89,8 +94,10 @@ int ttk::LDistance::execute(const dataType *const inputData1,
     status = computeLn(inputData1, inputData2, outputData, n, vertexNumber);
   }
 
-  this->printMsg(
-    "Data-set processed", 1.0, t.getElapsedTime(), this->threadNumber_);
+  if(this->printRes) {
+    this->printMsg(
+      "Data-set processed", 1.0, t.getElapsedTime(), this->threadNumber_);
+  }
 
   return status;
 }
@@ -124,8 +131,10 @@ int ttk::LDistance::computeLn(const dataType *const input1,
 
   // Affect result.
   result = (double)sum;
-  this->printMsg("L" + std::to_string(n)
-                 + "-distance: " + std::to_string(result));
+  if(this->printRes) {
+    this->printMsg("L" + std::to_string(n)
+                   + "-distance: " + std::to_string(result));
+  }
 
   return 0;
 }
@@ -156,7 +165,9 @@ int ttk::LDistance::computeLinf(const dataType *const input1,
 
   // Affect result.
   result = (double)maxValue;
-  this->printMsg("Linf-distance: " + std::to_string(result));
+  if(this->printRes) {
+    this->printMsg("Linf-distance: " + std::to_string(result));
+  }
 
   return 0;
 }

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -21,8 +21,9 @@ namespace ttk {
     }
 
     template <typename T>
-    std::vector<std::vector<double>> execute(const std::vector<void *> &inputs,
-                                             const size_t nPoints) const;
+    int execute(std::vector<std::vector<double>> &output,
+                const std::vector<const T *> &inputs,
+                const size_t nPoints) const;
 
   protected:
     std::string DistanceType{"2"};
@@ -30,12 +31,12 @@ namespace ttk {
 } // namespace ttk
 
 template <typename T>
-std::vector<std::vector<double>>
-  ttk::LDistanceMatrix::execute(const std::vector<void *> &inputs,
-                                const size_t nPoints) const {
+int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
+                                  const std::vector<const T *> &inputs,
+                                  const size_t nPoints) const {
 
   const auto nInputs = inputs.size();
-  std::vector<std::vector<double>> distMatrix(nInputs);
+  output.resize(nInputs);
 
   LDistance worker{};
   worker.setThreadNumber(this->threadNumber_);
@@ -43,20 +44,13 @@ std::vector<std::vector<double>>
   // compute matrix upper triangle
   // (some parallelism inside the LDistance computation)
   for(size_t i = 0; i < nInputs; ++i) {
-    auto &distCol = distMatrix[i];
+    auto &distCol = output[i];
     distCol.resize(nInputs);
-    // get pointer to scalar field of input i
-    const auto inputDataPtr1{static_cast<T *>(inputs[i])};
     for(size_t j = i + 1; j < nInputs; ++j) {
-      // get pointer to scalar field of input jc
-      const auto inputDataPtr2{static_cast<T *>(inputs[j])};
-      // empty output
-      T *outputPtr{};
-      // call execute
-      worker.execute(
-        inputDataPtr1, inputDataPtr2, outputPtr, this->DistanceType, nPoints);
+      // call execute with nullptr output
+      worker.execute(inputs[i], inputs[j], {}, this->DistanceType, nPoints);
       // store result
-      distMatrix[i][j] = worker.getResult();
+      output[i][j] = worker.getResult();
     }
   }
 
@@ -66,9 +60,9 @@ std::vector<std::vector<double>>
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; ++i) {
     for(size_t j = i + 1; j < nInputs; ++j) {
-      distMatrix[j][i] = distMatrix[i][j];
+      output[j][i] = output[i][j];
     }
   }
 
-  return distMatrix;
+  return 0;
 }

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -48,7 +48,7 @@ int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
 
   // compute matrix upper triangle
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_) collapse(2) \
+#pragma omp parallel for num_threads(this->threadNumber_) schedule(dynamic) \
   firstprivate(worker)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; ++i) {

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -39,13 +39,18 @@ int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
   output.resize(nInputs);
 
   LDistance worker{};
-  worker.setThreadNumber(this->threadNumber_);
+  worker.setThreadNumber(1);
+
+  for(size_t i = 0; i < nInputs; ++i) {
+    output[i].resize(nInputs);
+  }
 
   // compute matrix upper triangle
-  // (some parallelism inside the LDistance computation)
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_) collapse(2) \
+  firstprivate(worker)
+#endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; ++i) {
-    auto &distCol = output[i];
-    distCol.resize(nInputs);
     for(size_t j = i + 1; j < nInputs; ++j) {
       // call execute with nullptr output
       worker.execute(inputs[i], inputs[j], {}, this->DistanceType, nPoints);

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -56,16 +56,7 @@ int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
       worker.execute(inputs[i], inputs[j], {}, this->DistanceType, nPoints);
       // store result
       output[i][j] = worker.getResult();
-    }
-  }
-
-  // distance matrix is symmetric
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nInputs; ++i) {
-    for(size_t j = i + 1; j < nInputs; ++j) {
-      output[j][i] = output[i][j];
+      output[j][i] = worker.getResult();
     }
   }
 

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -40,6 +40,7 @@ int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
 
   LDistance worker{};
   worker.setThreadNumber(1);
+  worker.setPrintRes(false);
 
   for(size_t i = 0; i < nInputs; ++i) {
     output[i].resize(nInputs);

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -25,7 +25,7 @@ namespace ttk {
                                              const size_t nPoints) const;
 
   protected:
-    std::string DistanceType{};
+    std::string DistanceType{"2"};
   };
 } // namespace ttk
 

--- a/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.h
+++ b/core/vtk/ttkLDistanceMatrix/ttkLDistanceMatrix.h
@@ -36,6 +36,11 @@ protected:
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
+  template <typename T>
+  int dispatch(std::vector<std::vector<double>> &distanceMatrix,
+               const std::vector<vtkDataSet *> &inputData,
+               const size_t nPoints);
+
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;


### PR DESCRIPTION
This PR improves the performance of the `LDistanceMatrix` filter by modifying the parallel execution. Previously, parallelism was managed by the `LDistance` backend module, thus creating a lot of parallel sections (one per LDistance computation).

In this PR, the parallel section has been moved up in the `LDistanceMatrix` base module. Print statements inside the `LDistance` module have also been disabled: the `std::to_string` calls may reduce performance.

The module API has been tweaked to receive typed and const pointers instead of void pointers. A templated `ttkLDistanceMatrix::dispatch` method has been introduced in the VTK layer to access these typed pointers.

Enjoy,
Pierre