### PR TITLE
Add RipsComplex module

### DIFF
--- a/core/base/ripsComplex/CMakeLists.txt
+++ b/core/base/ripsComplex/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(ripsComplex
+  SOURCES
+    RipsComplex.cpp
+  HEADERS
+    RipsComplex.h
+  DEPENDS
+    common
+  )

--- a/core/base/ripsComplex/CMakeLists.txt
+++ b/core/base/ripsComplex/CMakeLists.txt
@@ -5,4 +5,5 @@ ttk_add_base_library(ripsComplex
     RipsComplex.h
   DEPENDS
     common
+    lDistanceMatrix
   )

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -78,6 +78,12 @@ void computeEdges(std::vector<ttk::SimplexId> &connectivity,
   }
 }
 
+static inline void maxAssign(double &a, const double b) {
+  if(a < b) {
+    a = b;
+  }
+}
+
 void computeTriangles(std::vector<ttk::SimplexId> &connectivity,
                       std::vector<double> &diameters,
                       const double epsilon,
@@ -99,12 +105,8 @@ void computeTriangles(std::vector<ttk::SimplexId> &connectivity,
           continue;
         }
         auto diam{distanceMatrix[i][j]};
-        if(diam < distanceMatrix[i][k]) {
-          diam = distanceMatrix[i][k];
-        }
-        if(diam < distanceMatrix[j][k]) {
-          diam = distanceMatrix[j][k];
-        }
+        maxAssign(diam, distanceMatrix[i][k]);
+        maxAssign(diam, distanceMatrix[j][k]);
         triangles[i].emplace_back(
           LocCell<2>{diam, std::array<ttk::SimplexId, 2>{
                              static_cast<ttk::SimplexId>(j),
@@ -162,21 +164,11 @@ void computeTetras(std::vector<ttk::SimplexId> &connectivity,
             continue;
           }
           auto diam{distanceMatrix[i][j]};
-          if(diam < distanceMatrix[i][k]) {
-            diam = distanceMatrix[i][k];
-          }
-          if(diam < distanceMatrix[i][l]) {
-            diam = distanceMatrix[i][l];
-          }
-          if(diam < distanceMatrix[j][k]) {
-            diam = distanceMatrix[j][k];
-          }
-          if(diam < distanceMatrix[j][l]) {
-            diam = distanceMatrix[j][l];
-          }
-          if(diam < distanceMatrix[k][l]) {
-            diam = distanceMatrix[k][l];
-          }
+          maxAssign(diam, distanceMatrix[i][k]);
+          maxAssign(diam, distanceMatrix[i][l]);
+          maxAssign(diam, distanceMatrix[j][k]);
+          maxAssign(diam, distanceMatrix[j][l]);
+          maxAssign(diam, distanceMatrix[k][l]);
           tetras[i].emplace_back(
             LocCell<3>{diam, std::array<ttk::SimplexId, 3>{
                                static_cast<ttk::SimplexId>(j),

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -42,6 +42,8 @@ void computeEdges(std::vector<ttk::SimplexId> &connectivity,
                   const std::vector<std::vector<double>> &distanceMatrix,
                   const int nThreads) {
 
+  TTK_FORCE_USE(nThreads);
+
   std::vector<std::vector<LocCell<1>>> edges(distanceMatrix.size());
 
 #ifdef TTK_ENABLE_OPENMP
@@ -89,6 +91,8 @@ void computeTriangles(std::vector<ttk::SimplexId> &connectivity,
                       const double epsilon,
                       const std::vector<std::vector<double>> &distanceMatrix,
                       const int nThreads) {
+
+  TTK_FORCE_USE(nThreads);
 
   std::vector<std::vector<LocCell<2>>> triangles(distanceMatrix.size());
 
@@ -143,6 +147,8 @@ void computeTetras(std::vector<ttk::SimplexId> &connectivity,
                    const double epsilon,
                    const std::vector<std::vector<double>> &distanceMatrix,
                    const int nThreads) {
+
+  TTK_FORCE_USE(nThreads);
 
   std::vector<std::vector<LocCell<3>>> tetras(distanceMatrix.size());
 

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -4,6 +4,53 @@ ttk::RipsComplex::RipsComplex() {
   this->setDebugMsgPrefix("RipsComplex");
 }
 
-int ttk::RipsComplex::execute() const {
+int ttk::RipsComplex::execute(
+  std::vector<LongSimplexId> &connectivity,
+  const std::vector<std::vector<double>> &inputMatrix) const {
+
+  Timer tm{};
+
+  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
+    std::vector<size_t> candidates{};
+    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
+      if(inputMatrix[i][j] < this->Epsilon) {
+        candidates.emplace_back(j);
+      }
+    }
+    if(static_cast<SimplexId>(candidates.size()) < this->OutputDimension) {
+      continue;
+    }
+
+    if(this->OutputDimension == 1) {
+      std::array<LongSimplexId, 2> verts{static_cast<LongSimplexId>(i), -1};
+      for(const auto c : candidates) {
+        verts[1] = c;
+        connectivity.insert(connectivity.end(), verts.begin(), verts.end());
+      }
+    } else if(this->OutputDimension == 2) {
+      std::array<LongSimplexId, 3> verts{static_cast<LongSimplexId>(i), -1};
+      for(size_t j = 0; j < candidates.size(); ++j) {
+        verts[1] = candidates[j];
+        for(size_t k = j + 1; k < candidates.size(); ++k) {
+          verts[2] = candidates[k];
+          connectivity.insert(connectivity.end(), verts.begin(), verts.end());
+        }
+      }
+    } else if(this->OutputDimension == 3) {
+      std::array<LongSimplexId, 4> verts{static_cast<LongSimplexId>(i), -1};
+      for(size_t j = 0; j < candidates.size(); ++j) {
+        verts[1] = candidates[j];
+        for(size_t k = j + 1; k < candidates.size(); ++k) {
+          verts[2] = candidates[k];
+          for(size_t l = k + 1; l < candidates.size(); ++l) {
+            verts[3] = candidates[l];
+            connectivity.insert(connectivity.end(), verts.begin(), verts.end());
+          }
+        }
+      }
+    }
+  }
+
+  this->printMsg("Complete", 1.0, tm.getElapsedTime(), 1);
   return 0;
 }

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -4,51 +4,109 @@ ttk::RipsComplex::RipsComplex() {
   this->setDebugMsgPrefix("RipsComplex");
 }
 
-int ttk::RipsComplex::execute(
-  std::vector<LongSimplexId> &connectivity,
-  const std::vector<std::vector<double>> &inputMatrix) const {
+void computeEdges(std::vector<ttk::LongSimplexId> &connectivity,
+                  std::vector<double> &diameters,
+                  const double epsilon,
+                  const std::vector<std::vector<double>> &inputMatrix) {
+  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
+    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
+      if(inputMatrix[i][j] < epsilon) {
+        connectivity.emplace_back(i);
+        connectivity.emplace_back(j);
+        diameters.emplace_back(inputMatrix[i][j]);
+      }
+    }
+  }
+}
 
-  Timer tm{};
+void computeTriangles(std::vector<ttk::LongSimplexId> &connectivity,
+                      std::vector<double> &diameters,
+                      const double epsilon,
+                      const std::vector<std::vector<double>> &inputMatrix) {
+  using ttk::LongSimplexId;
 
   for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
     std::vector<size_t> candidates{};
     for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
-      if(inputMatrix[i][j] < this->Epsilon) {
+      if(inputMatrix[i][j] < epsilon) {
         candidates.emplace_back(j);
       }
     }
-    if(static_cast<SimplexId>(candidates.size()) < this->OutputDimension) {
+    if(candidates.size() < 2) {
       continue;
     }
-
-    if(this->OutputDimension == 1) {
-      std::array<LongSimplexId, 2> verts{static_cast<LongSimplexId>(i), -1};
-      for(const auto c : candidates) {
-        verts[1] = c;
-        connectivity.insert(connectivity.end(), verts.begin(), verts.end());
-      }
-    } else if(this->OutputDimension == 2) {
-      std::array<LongSimplexId, 3> verts{static_cast<LongSimplexId>(i), -1};
-      for(size_t j = 0; j < candidates.size(); ++j) {
-        verts[1] = candidates[j];
-        for(size_t k = j + 1; k < candidates.size(); ++k) {
-          verts[2] = candidates[k];
+    std::array<LongSimplexId, 3> verts{static_cast<LongSimplexId>(i), -1, -1};
+    for(size_t j = 0; j < candidates.size(); ++j) {
+      verts[1] = candidates[j];
+      double diam = inputMatrix[verts[0]][verts[1]];
+      for(size_t k = j + 1; k < candidates.size(); ++k) {
+        verts[2] = candidates[k];
+        diam = std::max(diam, inputMatrix[verts[1]][verts[2]]);
+        if(diam < epsilon) {
           connectivity.insert(connectivity.end(), verts.begin(), verts.end());
-        }
-      }
-    } else if(this->OutputDimension == 3) {
-      std::array<LongSimplexId, 4> verts{static_cast<LongSimplexId>(i), -1};
-      for(size_t j = 0; j < candidates.size(); ++j) {
-        verts[1] = candidates[j];
-        for(size_t k = j + 1; k < candidates.size(); ++k) {
-          verts[2] = candidates[k];
-          for(size_t l = k + 1; l < candidates.size(); ++l) {
-            verts[3] = candidates[l];
-            connectivity.insert(connectivity.end(), verts.begin(), verts.end());
-          }
+          diameters.emplace_back(diam);
         }
       }
     }
+  }
+}
+
+void computeTetras(std::vector<ttk::LongSimplexId> &connectivity,
+                   std::vector<double> &diameters,
+                   const double epsilon,
+                   const std::vector<std::vector<double>> &inputMatrix) {
+  using ttk::LongSimplexId;
+
+  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
+    std::vector<size_t> candidates{};
+    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
+      if(inputMatrix[i][j] < epsilon) {
+        candidates.emplace_back(j);
+      }
+    }
+    if(candidates.size() < 3) {
+      continue;
+    }
+    std::array<LongSimplexId, 4> verts{
+      static_cast<LongSimplexId>(i), -1, -1, -1};
+    for(size_t j = 0; j < candidates.size(); ++j) {
+      verts[1] = candidates[j];
+      double diam = inputMatrix[verts[0]][verts[1]];
+      for(size_t k = j + 1; k < candidates.size(); ++k) {
+        verts[2] = candidates[k];
+        diam = std::max(diam, inputMatrix[verts[1]][verts[2]]);
+        if(diam > epsilon) {
+          continue;
+        }
+        for(size_t l = k + 1; l < candidates.size(); ++l) {
+          verts[3] = candidates[l];
+          diam = std::max(diam, inputMatrix[verts[0]][verts[3]]);
+          diam = std::max(diam, inputMatrix[verts[1]][verts[3]]);
+          diam = std::max(diam, inputMatrix[verts[2]][verts[3]]);
+          if(diam > epsilon) {
+            continue;
+          }
+          connectivity.insert(connectivity.end(), verts.begin(), verts.end());
+          diameters.emplace_back(diam);
+        }
+      }
+    }
+  }
+}
+
+int ttk::RipsComplex::execute(
+  std::vector<LongSimplexId> &connectivity,
+  std::vector<double> &diameters,
+  const std::vector<std::vector<double>> &inputMatrix) const {
+
+  Timer tm{};
+
+  if(this->OutputDimension == 1) {
+    computeEdges(connectivity, diameters, this->Epsilon, inputMatrix);
+  } else if(this->OutputDimension == 2) {
+    computeTriangles(connectivity, diameters, this->Epsilon, inputMatrix);
+  } else if(this->OutputDimension == 3) {
+    computeTetras(connectivity, diameters, this->Epsilon, inputMatrix);
   }
 
   this->printMsg("Complete", 1.0, tm.getElapsedTime(), 1);

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -217,6 +217,12 @@ int ttk::RipsComplex::execute(
   const auto &distanceMatrix
     = this->InputIsADistanceMatrix ? inputMatrix : distanceMatrix_;
 
+  if(distanceMatrix.empty()
+     || distanceMatrix.size() != distanceMatrix[0].size()) {
+    this->printErr("Invalid distance matrix");
+    return 1;
+  }
+
   if(this->OutputDimension == 1) {
     computeEdges(connectivity, diameters, this->Epsilon, distanceMatrix);
   } else if(this->OutputDimension == 2) {

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -1,0 +1,9 @@
+#include <RipsComplex.h>
+
+ttk::RipsComplex::RipsComplex() {
+  this->setDebugMsgPrefix("RipsComplex");
+}
+
+int ttk::RipsComplex::execute() const {
+  return 0;
+}

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -1,19 +1,42 @@
+#include <LDistanceMatrix.h>
 #include <RipsComplex.h>
 
 ttk::RipsComplex::RipsComplex() {
   this->setDebugMsgPrefix("RipsComplex");
 }
 
+int ttk::RipsComplex::computeDistanceMatrix(
+  std::vector<std::vector<double>> &distanceMatrix,
+  const std::vector<std::vector<double>> &inputMatrix) const {
+
+  Timer tm{};
+
+  std::vector<const double *> inputPtrs(inputMatrix.size());
+  for(size_t i = 0; i < inputMatrix.size(); ++i) {
+    const auto &vec{inputMatrix[i]};
+    inputPtrs[i] = vec.data();
+  }
+
+  ttk::LDistanceMatrix worker{};
+  worker.setThreadNumber(this->threadNumber_);
+  worker.setDebugLevel(this->debugLevel_);
+  worker.execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
+
+  this->printMsg(
+    "Computed distance matrix", 1.0, tm.getElapsedTime(), this->threadNumber_);
+  return 0;
+}
+
 void computeEdges(std::vector<ttk::LongSimplexId> &connectivity,
                   std::vector<double> &diameters,
                   const double epsilon,
-                  const std::vector<std::vector<double>> &inputMatrix) {
-  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
-    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
-      if(inputMatrix[i][j] < epsilon) {
+                  const std::vector<std::vector<double>> &distanceMatrix) {
+  for(size_t i = 0; i < distanceMatrix.size(); ++i) {
+    for(size_t j = i + 1; j < distanceMatrix.size(); ++j) {
+      if(distanceMatrix[i][j] < epsilon) {
         connectivity.emplace_back(i);
         connectivity.emplace_back(j);
-        diameters.emplace_back(inputMatrix[i][j]);
+        diameters.emplace_back(distanceMatrix[i][j]);
       }
     }
   }
@@ -22,13 +45,13 @@ void computeEdges(std::vector<ttk::LongSimplexId> &connectivity,
 void computeTriangles(std::vector<ttk::LongSimplexId> &connectivity,
                       std::vector<double> &diameters,
                       const double epsilon,
-                      const std::vector<std::vector<double>> &inputMatrix) {
+                      const std::vector<std::vector<double>> &distanceMatrix) {
   using ttk::LongSimplexId;
 
-  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
+  for(size_t i = 0; i < distanceMatrix.size(); ++i) {
     std::vector<size_t> candidates{};
-    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
-      if(inputMatrix[i][j] < epsilon) {
+    for(size_t j = i + 1; j < distanceMatrix.size(); ++j) {
+      if(distanceMatrix[i][j] < epsilon) {
         candidates.emplace_back(j);
       }
     }
@@ -38,10 +61,10 @@ void computeTriangles(std::vector<ttk::LongSimplexId> &connectivity,
     std::array<LongSimplexId, 3> verts{static_cast<LongSimplexId>(i), -1, -1};
     for(size_t j = 0; j < candidates.size(); ++j) {
       verts[1] = candidates[j];
-      double diam = inputMatrix[verts[0]][verts[1]];
+      double diam = distanceMatrix[verts[0]][verts[1]];
       for(size_t k = j + 1; k < candidates.size(); ++k) {
         verts[2] = candidates[k];
-        diam = std::max(diam, inputMatrix[verts[1]][verts[2]]);
+        diam = std::max(diam, distanceMatrix[verts[1]][verts[2]]);
         if(diam < epsilon) {
           connectivity.insert(connectivity.end(), verts.begin(), verts.end());
           diameters.emplace_back(diam);
@@ -54,13 +77,13 @@ void computeTriangles(std::vector<ttk::LongSimplexId> &connectivity,
 void computeTetras(std::vector<ttk::LongSimplexId> &connectivity,
                    std::vector<double> &diameters,
                    const double epsilon,
-                   const std::vector<std::vector<double>> &inputMatrix) {
+                   const std::vector<std::vector<double>> &distanceMatrix) {
   using ttk::LongSimplexId;
 
-  for(size_t i = 0; i < inputMatrix.size() - 1; ++i) {
+  for(size_t i = 0; i < distanceMatrix.size(); ++i) {
     std::vector<size_t> candidates{};
-    for(size_t j = i + 1; j < inputMatrix.size(); ++j) {
-      if(inputMatrix[i][j] < epsilon) {
+    for(size_t j = i + 1; j < distanceMatrix.size(); ++j) {
+      if(distanceMatrix[i][j] < epsilon) {
         candidates.emplace_back(j);
       }
     }
@@ -71,18 +94,18 @@ void computeTetras(std::vector<ttk::LongSimplexId> &connectivity,
       static_cast<LongSimplexId>(i), -1, -1, -1};
     for(size_t j = 0; j < candidates.size(); ++j) {
       verts[1] = candidates[j];
-      double diam = inputMatrix[verts[0]][verts[1]];
+      double diam = distanceMatrix[verts[0]][verts[1]];
       for(size_t k = j + 1; k < candidates.size(); ++k) {
         verts[2] = candidates[k];
-        diam = std::max(diam, inputMatrix[verts[1]][verts[2]]);
+        diam = std::max(diam, distanceMatrix[verts[1]][verts[2]]);
         if(diam > epsilon) {
           continue;
         }
         for(size_t l = k + 1; l < candidates.size(); ++l) {
           verts[3] = candidates[l];
-          diam = std::max(diam, inputMatrix[verts[0]][verts[3]]);
-          diam = std::max(diam, inputMatrix[verts[1]][verts[3]]);
-          diam = std::max(diam, inputMatrix[verts[2]][verts[3]]);
+          diam = std::max(diam, distanceMatrix[verts[0]][verts[3]]);
+          diam = std::max(diam, distanceMatrix[verts[1]][verts[3]]);
+          diam = std::max(diam, distanceMatrix[verts[2]][verts[3]]);
           if(diam > epsilon) {
             continue;
           }
@@ -101,12 +124,19 @@ int ttk::RipsComplex::execute(
 
   Timer tm{};
 
+  std::vector<std::vector<double>> distanceMatrix_{};
+  if(!this->InputIsADistanceMatrix) {
+    computeDistanceMatrix(distanceMatrix_, inputMatrix);
+  }
+  const auto &distanceMatrix
+    = this->InputIsADistanceMatrix ? inputMatrix : distanceMatrix_;
+
   if(this->OutputDimension == 1) {
-    computeEdges(connectivity, diameters, this->Epsilon, inputMatrix);
+    computeEdges(connectivity, diameters, this->Epsilon, distanceMatrix);
   } else if(this->OutputDimension == 2) {
-    computeTriangles(connectivity, diameters, this->Epsilon, inputMatrix);
+    computeTriangles(connectivity, diameters, this->Epsilon, distanceMatrix);
   } else if(this->OutputDimension == 3) {
-    computeTetras(connectivity, diameters, this->Epsilon, inputMatrix);
+    computeTetras(connectivity, diameters, this->Epsilon, distanceMatrix);
   }
 
   this->printMsg("Complete", 1.0, tm.getElapsedTime(), 1);

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -1,6 +1,7 @@
 #include <LDistanceMatrix.h>
 #include <RipsComplex.h>
 
+#include <array>
 #include <limits>
 
 ttk::RipsComplex::RipsComplex() {

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -24,8 +24,9 @@ int ttk::RipsComplex::computeDistanceMatrix(
   worker.setDebugLevel(this->debugLevel_);
   worker.execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
 
-  this->printMsg(
-    "Computed distance matrix", 1.0, tm.getElapsedTime(), this->threadNumber_);
+  this->printMsg("Computed distance matrix", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
   return 0;
 }
 
@@ -223,6 +224,8 @@ int ttk::RipsComplex::execute(
     return 1;
   }
 
+  Timer tm_rips{};
+
   if(this->OutputDimension == 1) {
     computeEdges(connectivity, diameters, this->Epsilon, distanceMatrix);
   } else if(this->OutputDimension == 2) {
@@ -231,6 +234,10 @@ int ttk::RipsComplex::execute(
     computeTetras(connectivity, diameters, this->Epsilon, distanceMatrix);
   }
 
+  this->printMsg("Generated Rips complex from distance matrix", 1.0,
+                 tm_rips.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
   this->computeDiameterStats(
     distanceMatrix.size(), diamStats, connectivity, diameters);
 
@@ -238,6 +245,6 @@ int ttk::RipsComplex::execute(
     this->computeGaussianDensity(density, distanceMatrix);
   }
 
-  this->printMsg("Complete", 1.0, tm.getElapsedTime(), 1);
+  this->printMsg("Complete", 1.0, tm.getElapsedTime(), this->threadNumber_);
   return 0;
 }

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -30,10 +30,16 @@ namespace ttk {
                 const std::vector<std::vector<double>> &inputMatrix) const;
 
   protected:
+    int computeDistanceMatrix(
+      std::vector<std::vector<double>> &distanceMatrix,
+      const std::vector<std::vector<double>> &inputMatrix) const;
+
     /** Dimension of the generated complex */
     int OutputDimension{2};
     /** Distance threshold */
     double Epsilon{1.0};
+    /** If input matrix is a distance matrix (compute it otherwise) */
+    bool InputIsADistanceMatrix{false};
   };
 
 } // namespace ttk

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -24,7 +24,15 @@ namespace ttk {
   class RipsComplex : virtual public Debug {
   public:
     RipsComplex();
-    int execute() const;
+
+    int execute(std::vector<LongSimplexId> &connectivity,
+                const std::vector<std::vector<double>> &inputMatrix) const;
+
+  protected:
+    /** Dimension of the generated complex */
+    int OutputDimension{2};
+    /** Distance threshold */
+    double Epsilon{1.0};
   };
 
 } // namespace ttk

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -27,17 +27,32 @@ namespace ttk {
 
     int execute(std::vector<SimplexId> &connectivity,
                 std::vector<double> &diameters,
-                const std::vector<std::vector<double>> &inputMatrix) const;
+                std::array<double *const, 3> diamStats,
+                const std::vector<std::vector<double>> &inputMatrix,
+                double *const density = nullptr) const;
 
   protected:
     int computeDistanceMatrix(
       std::vector<std::vector<double>> &distanceMatrix,
       const std::vector<std::vector<double>> &inputMatrix) const;
 
+    int computeDiameterStats(const SimplexId nPoints,
+                             std::array<double *const, 3> diamStats,
+                             const std::vector<SimplexId> &connectivity,
+                             const std::vector<double> &cellDiameters) const;
+
+    int computeGaussianDensity(
+      double *const density,
+      const std::vector<std::vector<double>> &distanceMatrix) const;
+
     /** Dimension of the generated complex */
     int OutputDimension{2};
     /** Distance threshold */
     double Epsilon{1.0};
+    /** Standard Deviation for Gaussian density */
+    double StdDev{1.0};
+    /** Compute the Gaussian density from the distance matrix */
+    bool ComputeGaussianDensity{false};
     /** If input matrix is a distance matrix (compute it otherwise) */
     bool InputIsADistanceMatrix{false};
   };

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -25,6 +25,15 @@ namespace ttk {
   public:
     RipsComplex();
 
+    /**
+     * @brief Main entry point
+     *
+     * @param[out] connectivity Cell connectivity array (VTK format)
+     * @param[out] diameters Cell diameters
+     * @param[out] diamStats Min, mean and max cell diameters around point
+     * @param[in] inputMatrix Either coordinates array or distance matrix
+     * @param[out] density Gaussian density array on points
+     */
     int execute(std::vector<SimplexId> &connectivity,
                 std::vector<double> &diameters,
                 std::array<double *const, 3> diamStats,
@@ -32,15 +41,35 @@ namespace ttk {
                 double *const density = nullptr) const;
 
   protected:
+    /**
+     * @brief Compute distance matrix from coordinates matrix
+     *
+     * @param[out] distanceMatrix Output distance matrix
+     * @param[in] inputMatrix Input coordinates matrix
+     */
     int computeDistanceMatrix(
       std::vector<std::vector<double>> &distanceMatrix,
       const std::vector<std::vector<double>> &inputMatrix) const;
 
+    /**
+     * @brief Compute diameter statistics on points
+     *
+     * @param[in] nPoints Number of input points
+     * @param[out] diamStats Min, mean and max cell diameters around point
+     * @param[in] connectivity Cell connectivity array (pre-filled)
+     * @param[in] cellDiameters Cell diameters
+     */
     int computeDiameterStats(const SimplexId nPoints,
                              std::array<double *const, 3> diamStats,
                              const std::vector<SimplexId> &connectivity,
                              const std::vector<double> &cellDiameters) const;
 
+    /**
+     * @brief Compute Gaussian density on points
+     *
+     * @param[out] density Gaussian density array on points
+     * @param[in] distanceMatrix Distance matrix between points
+     */
     int computeGaussianDensity(
       double *const density,
       const std::vector<std::vector<double>> &distanceMatrix) const;

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -1,0 +1,30 @@
+/// \ingroup base
+/// \class ttk::RipsComplex
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date January 2022
+///
+/// \brief TTK VTK-filter that computes a Rips complex.
+///
+/// \param Input Input table (vtkTable)
+/// \param Output Triangulation (vtkUnstructuredGrid)
+///
+/// \brief TTK VTK-filter that takes a matrix (vtkTable) as input and
+/// computes a Rips complex from it to generate an explicit
+/// triangulation.
+///
+/// \sa ttk::Triangulation
+/// \sa ttkRipsComplex.cpp %for a usage example.
+
+#pragma once
+
+#include <Debug.h>
+
+namespace ttk {
+
+  class RipsComplex : virtual public Debug {
+  public:
+    RipsComplex();
+    int execute() const;
+  };
+
+} // namespace ttk

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -26,6 +26,7 @@ namespace ttk {
     RipsComplex();
 
     int execute(std::vector<LongSimplexId> &connectivity,
+                std::vector<double> &diameters,
                 const std::vector<std::vector<double>> &inputMatrix) const;
 
   protected:

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -25,7 +25,7 @@ namespace ttk {
   public:
     RipsComplex();
 
-    int execute(std::vector<LongSimplexId> &connectivity,
+    int execute(std::vector<SimplexId> &connectivity,
                 std::vector<double> &diameters,
                 const std::vector<std::vector<double>> &inputMatrix) const;
 

--- a/core/vtk/ttkRipsComplex/CMakeLists.txt
+++ b/core/vtk/ttkRipsComplex/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkRipsComplex/ttk.module
+++ b/core/vtk/ttkRipsComplex/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkRipsComplex
+SOURCES
+  ttkRipsComplex.cpp
+HEADERS
+  ttkRipsComplex.h
+DEPENDS
+  ripsComplex
+  ttkAlgorithm

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -113,7 +113,7 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
     }
   }
 
-  std::vector<ttk::LongSimplexId> vec_connectivity{};
+  std::vector<ttk::SimplexId> vec_connectivity{};
   std::vector<double> diameters{};
 
   this->execute(vec_connectivity, diameters, inputMatrix);

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -1,11 +1,15 @@
 #include <ttkRipsComplex.h>
 #include <ttkUtils.h>
 
+#include <vtkAbstractArray.h>
+#include <vtkCellType.h>
 #include <vtkDoubleArray.h>
 #include <vtkInformation.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
+#include <vtkPointData.h>
 #include <vtkTable.h>
+#include <vtkType.h>
 #include <vtkUnstructuredGrid.h>
 
 #include <regex>
@@ -38,6 +42,7 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
                                 vtkInformationVector *outputVector) {
 
   using ttk::SimplexId;
+  ttk::Timer tm{};
 
   auto *input = vtkTable::GetData(inputVector[0]);
   auto *output = vtkUnstructuredGrid::GetData(outputVector);
@@ -53,6 +58,115 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
       }
     }
   }
+
+  const SimplexId numberOfRows = input->GetNumberOfRows();
+  const SimplexId numberOfColumns = ScalarFields.size();
+
+  if(numberOfRows <= 0 || numberOfColumns <= 0) {
+    this->printErr("Input matrix has invalid dimensions (rows: "
+                   + std::to_string(numberOfRows)
+                   + ", columns: " + std::to_string(numberOfColumns) + ")");
+    return 0;
+  }
+
+  std::array<vtkAbstractArray *, 3> components{
+    input->GetColumnByName(this->XColumn.data()),
+    input->GetColumnByName(this->YColumn.data()),
+    input->GetColumnByName(this->ZColumn.data()),
+  };
+
+  // points from components arrays
+  vtkNew<vtkPoints> points{};
+  const auto nPoints = components[0]->GetNumberOfTuples();
+  points->SetNumberOfPoints(nPoints);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(vtkIdType i = 0; i < nPoints; ++i) {
+    std::array<float, 3> coords{};
+    if(components[0] != nullptr) {
+      coords[0] = components[0]->GetVariantValue(i).ToFloat();
+    }
+    if(components[1] != nullptr && components[1] != components[0]) {
+      coords[1] = components[1]->GetVariantValue(i).ToFloat();
+    }
+    if(components[2] != nullptr && components[2] != components[0]
+       && components[2] != components[1]) {
+      coords[2] = components[2]->GetVariantValue(i).ToFloat();
+    }
+    points->SetPoint(i, coords.data());
+  }
+
+  std::vector<vtkAbstractArray *> arrays{};
+  for(const auto &s : ScalarFields) {
+    arrays.push_back(input->GetColumnByName(s.data()));
+  }
+
+  std::vector<std::vector<double>> inputMatrix(arrays.size());
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < numberOfRows; ++i) {
+    for(size_t j = 0; j < arrays.size(); ++j) {
+      inputMatrix[i].emplace_back(arrays[j]->GetVariantValue(i).ToDouble());
+    }
+  }
+
+  std::vector<ttk::LongSimplexId> vec_connectivity{};
+
+  this->execute(vec_connectivity, inputMatrix);
+
+  const auto nCells = vec_connectivity.size() / (this->OutputDimension + 1);
+  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+  offsets->SetNumberOfComponents(1);
+  offsets->SetNumberOfTuples(nCells + 1);
+  connectivity->SetNumberOfComponents(1);
+  connectivity->SetNumberOfTuples(vec_connectivity.size());
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nCells + 1; ++i) {
+    offsets->SetTuple1(i, i * (this->OutputDimension + 1));
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < vec_connectivity.size(); ++i) {
+    connectivity->SetTuple1(i, vec_connectivity[i]);
+  }
+
+  // gather arrays to make the PolyData
+  vtkNew<vtkCellArray> cells{};
+  cells->SetData(offsets, connectivity);
+
+  const auto getCellType = [](const SimplexId dim) -> int {
+    if(dim == 3) {
+      return VTK_TETRA;
+    } else if(dim == 2) {
+      return VTK_TRIANGLE;
+    } else if(dim == 1) {
+      return VTK_LINE;
+    }
+    return VTK_VERTEX;
+  };
+
+  output->SetPoints(points);
+  output->SetCells(getCellType(this->OutputDimension), cells);
+
+  if(this->KeepAllDataArrays) {
+    auto pd = output->GetPointData();
+    if(pd != nullptr) {
+      for(vtkIdType i = 0; i < input->GetNumberOfColumns(); ++i) {
+        pd->AddArray(input->GetColumn(i));
+      }
+    }
+  }
+
+  this->printMsg("Produced " + std::to_string(nCells) + " cells of dimension "
+                   + std::to_string(this->OutputDimension),
+                 1.0, tm.getElapsedTime(), this->threadNumber_);
 
   return 1;
 }

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -127,13 +127,18 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
   gaussianDensity->SetName("GaussianDensity");
   gaussianDensity->SetNumberOfTuples(numberOfRows);
 
-  this->execute(vec_connectivity, diameters,
-                std::array<double *const, 3>{
-                  ttkUtils::GetPointer<double>(diamMin),
-                  ttkUtils::GetPointer<double>(diamMean),
-                  ttkUtils::GetPointer<double>(diamMax),
-                },
-                inputMatrix, ttkUtils::GetPointer<double>(gaussianDensity));
+  const auto ret
+    = this->execute(vec_connectivity, diameters,
+                    std::array<double *const, 3>{
+                      ttkUtils::GetPointer<double>(diamMin),
+                      ttkUtils::GetPointer<double>(diamMean),
+                      ttkUtils::GetPointer<double>(diamMax),
+                    },
+                    inputMatrix, ttkUtils::GetPointer<double>(gaussianDensity));
+
+  if(ret != 0) {
+    return 0;
+  }
 
   const auto nCells = vec_connectivity.size() / (this->OutputDimension + 1);
   vtkNew<vtkIdTypeArray> offsets{}, connectivity{};

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -1,3 +1,4 @@
+#include <ttkMacros.h>
 #include <ttkRipsComplex.h>
 #include <ttkUtils.h>
 
@@ -141,7 +142,7 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
   }
 
   const auto nCells = vec_connectivity.size() / (this->OutputDimension + 1);
-  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
+  vtkNew<ttkSimplexIdTypeArray> offsets{}, connectivity{};
   offsets->SetNumberOfComponents(1);
   offsets->SetNumberOfTuples(nCells + 1);
   connectivity->SetNumberOfComponents(1);
@@ -161,8 +162,11 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
     connectivity->SetTuple1(i, vec_connectivity[i]);
   }
 
-  // gather arrays to make the PolyData
+  // gather arrays to make the UnstructuredGrid
   vtkNew<vtkCellArray> cells{};
+#ifndef TTK_ENABLE_64BIT_IDS
+  cells->Use32BitStorage();
+#endif // TTK_ENABLE_64BIT_IDS
   cells->SetData(offsets, connectivity);
 
   const auto getCellType = [](const SimplexId dim) -> int {

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -103,7 +103,7 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
     arrays.push_back(input->GetColumnByName(s.data()));
   }
 
-  std::vector<std::vector<double>> inputMatrix(arrays.size());
+  std::vector<std::vector<double>> inputMatrix(numberOfRows);
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -14,6 +14,7 @@
 #include <vtkType.h>
 #include <vtkUnstructuredGrid.h>
 
+#include <array>
 #include <regex>
 
 vtkStandardNewMacro(ttkRipsComplex);

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -1,0 +1,58 @@
+#include <ttkRipsComplex.h>
+#include <ttkUtils.h>
+
+#include <vtkDoubleArray.h>
+#include <vtkInformation.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkTable.h>
+#include <vtkUnstructuredGrid.h>
+
+#include <regex>
+
+vtkStandardNewMacro(ttkRipsComplex);
+
+ttkRipsComplex::ttkRipsComplex() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkRipsComplex::FillInputPortInformation(int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkRipsComplex::FillOutputPortInformation(int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
+                                vtkInformationVector **inputVector,
+                                vtkInformationVector *outputVector) {
+
+  using ttk::SimplexId;
+
+  auto *input = vtkTable::GetData(inputVector[0]);
+  auto *output = vtkUnstructuredGrid::GetData(outputVector);
+
+  if(SelectFieldsWithRegexp) {
+    // select all input columns whose name is matching the regexp
+    ScalarFields.clear();
+    const auto n = input->GetNumberOfColumns();
+    for(int i = 0; i < n; ++i) {
+      const auto &name = input->GetColumnName(i);
+      if(std::regex_match(name, std::regex(RegexpString))) {
+        ScalarFields.emplace_back(name);
+      }
+    }
+  }
+
+  return 1;
+}

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.h
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.h
@@ -1,0 +1,74 @@
+/// \class ttkRipsComplex
+/// \ingroup vtk
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date January 2022.
+///
+/// \brief TTK VTK-filter that wraps the ttk::RipsComplex processing
+/// package.
+///
+/// VTK wrapping code for the ttk::RipsComplex package.
+///
+/// \param Input Input table (vtkTable)
+/// \param Output Triangulation (vtkUnstructuredGrid)
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutput()).
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::RipsComplex
+
+#pragma once
+
+// VTK Module
+#include <ttkRipsComplexModule.h>
+
+// TTK includes
+#include <RipsComplex.h>
+#include <ttkAlgorithm.h>
+
+class TTKRIPSCOMPLEX_EXPORT ttkRipsComplex : public ttkAlgorithm,
+                                             protected ttk::RipsComplex {
+
+public:
+  static ttkRipsComplex *New();
+  vtkTypeMacro(ttkRipsComplex, ttkAlgorithm);
+
+  void SetScalarFields(const std::string &s) {
+    ScalarFields.push_back(s);
+    Modified();
+  }
+
+  void ClearScalarFields() {
+    ScalarFields.clear();
+    Modified();
+  }
+  vtkSetMacro(InputIsADistanceMatrix, bool);
+  vtkGetMacro(InputIsADistanceMatrix, bool);
+
+  vtkSetMacro(KeepAllDataArrays, bool);
+  vtkGetMacro(KeepAllDataArrays, bool);
+
+  vtkSetMacro(SelectFieldsWithRegexp, bool);
+  vtkGetMacro(SelectFieldsWithRegexp, bool);
+
+  vtkSetMacro(RegexpString, const std::string &);
+  vtkGetMacro(RegexpString, std::string);
+
+protected:
+  ttkRipsComplex();
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+private:
+  bool InputIsADistanceMatrix{true};
+  bool KeepAllDataArrays{true};
+  bool SelectFieldsWithRegexp{false};
+  std::string RegexpString{".*"};
+  std::vector<std::string> ScalarFields{};
+};

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.h
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.h
@@ -81,7 +81,6 @@ protected:
                   vtkInformationVector *outputVector) override;
 
 private:
-  bool InputIsADistanceMatrix{true};
   bool KeepAllDataArrays{true};
   bool SelectFieldsWithRegexp{false};
   std::string RegexpString{".*"};

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.h
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.h
@@ -59,6 +59,12 @@ public:
   vtkSetMacro(SelectFieldsWithRegexp, bool);
   vtkGetMacro(SelectFieldsWithRegexp, bool);
 
+  vtkSetMacro(StdDev, double);
+  vtkGetMacro(StdDev, double);
+
+  vtkSetMacro(ComputeGaussianDensity, bool);
+  vtkGetMacro(ComputeGaussianDensity, bool);
+
   vtkSetMacro(RegexpString, const std::string &);
   vtkGetMacro(RegexpString, std::string);
 

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.h
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.h
@@ -47,6 +47,12 @@ public:
   vtkSetMacro(InputIsADistanceMatrix, bool);
   vtkGetMacro(InputIsADistanceMatrix, bool);
 
+  vtkSetMacro(OutputDimension, int);
+  vtkGetMacro(OutputDimension, int);
+
+  vtkSetMacro(Epsilon, double);
+  vtkGetMacro(Epsilon, double);
+
   vtkSetMacro(KeepAllDataArrays, bool);
   vtkGetMacro(KeepAllDataArrays, bool);
 
@@ -55,6 +61,15 @@ public:
 
   vtkSetMacro(RegexpString, const std::string &);
   vtkGetMacro(RegexpString, std::string);
+
+  vtkSetMacro(XColumn, const std::string &);
+  vtkGetMacro(XColumn, std::string);
+
+  vtkSetMacro(YColumn, const std::string &);
+  vtkGetMacro(YColumn, std::string);
+
+  vtkSetMacro(ZColumn, const std::string &);
+  vtkGetMacro(ZColumn, std::string);
 
 protected:
   ttkRipsComplex();
@@ -71,4 +86,7 @@ private:
   bool SelectFieldsWithRegexp{false};
   std::string RegexpString{".*"};
   std::vector<std::string> ScalarFields{};
+  std::string XColumn{};
+  std::string YColumn{};
+  std::string ZColumn{};
 };

--- a/core/vtk/ttkRipsComplex/vtk.module
+++ b/core/vtk/ttkRipsComplex/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkRipsComplex
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/RipsComplex.xml
+++ b/paraview/xmls/RipsComplex.xml
@@ -178,6 +178,36 @@
         </Documentation>
       </IntVectorProperty>
 
+      <IntVectorProperty name="ComputeGaussianDensity"
+        label="Compute Gaussian Density"
+        command="SetComputeGaussianDensity"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Should Gaussian density be computed on every vertex?
+        </Documentation>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty
+          name="StdDev"
+          label="Standard Deviation"
+          command="SetStdDev"
+          number_of_elements="1"
+          default_values="1.0"
+          >
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ComputeGaussianDensity"
+                                   value="1" />
+        </Hints>
+        <Documentation>
+          Gaussian density standard deviation
+        </Documentation>
+      </DoubleVectorProperty>
+
+
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
@@ -191,6 +221,8 @@
         <Property name="ZColumn" />
         <Property name="KeepAllDataArrays" />
         <Property name="InputDistanceMatrix" />
+        <Property name="ComputeGaussianDensity" />
+        <Property name="StdDev" />
       </PropertyGroup>
 
       <Hints>

--- a/paraview/xmls/RipsComplex.xml
+++ b/paraview/xmls/RipsComplex.xml
@@ -85,6 +85,77 @@
       </StringVectorProperty>
 
       <IntVectorProperty
+        name="OutputDimension"
+        label="Output Dimension"
+        command="SetOutputDimension"
+        number_of_elements="1"
+        default_values="2">
+        <Documentation>
+          Cell dimension of the generated Rips complex.
+        </Documentation>
+      </IntVectorProperty>
+
+      <DoubleVectorProperty
+          name="Epsilon"
+          label="Diameter (epsilon)"
+          command="SetEpsilon"
+          number_of_elements="1"
+          default_values="1.0"
+          >
+        <Documentation>
+          Distance threshold above with no cell should be generated.
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <StringVectorProperty command="SetXColumn"
+                            name="XColumn"
+                            number_of_elements="1"
+                            default_values="Component_0"
+                            panel_visibility="default">
+        <ArrayListDomain name="array_list">
+          <RequiredProperties>
+            <Property function="Input"
+                      name="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>This property specifies which data array is going to be
+        used as the X coordinate in the generated polydata
+        dataset.</Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty command="SetYColumn"
+                            name="YColumn"
+                            number_of_elements="1"
+                            default_values="Component_1"
+                            panel_visibility="default">
+        <ArrayListDomain name="array_list">
+          <RequiredProperties>
+            <Property function="Input"
+                      name="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>This property specifies which data array is going to be
+        used as the Y coordinate in the generated polydata
+        dataset.</Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty command="SetZColumn"
+                            name="ZColumn"
+                            number_of_elements="1"
+                            default_values="Component_2"
+                            panel_visibility="default">
+        <ArrayListDomain name="array_list">
+          <RequiredProperties>
+            <Property function="Input"
+                      name="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>This property specifies which data array is going to be
+        used as the Z coordinate in the generated polydata
+        dataset.</Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
         name="KeepAllDataArrays"
         label="Keep All Data Arrays"
         command="SetKeepAllDataArrays"
@@ -102,24 +173,8 @@
         number_of_elements="1"
         default_values="0">
         <BooleanDomain name="bool"/>
-        <Hints>
-          <PropertyWidgetDecorator type="CompositeDecorator">
-            <Expression type="or">
-              <PropertyWidgetDecorator type="GenericDecorator"
-                                       mode="visibility"
-                                       property="Method"
-                                       value="0" />
-              <PropertyWidgetDecorator type="GenericDecorator"
-                                       mode="visibility"
-                                       property="Method"
-                                       value="2" />
-            </Expression>
-          </PropertyWidgetDecorator>
-        </Hints>
         <Documentation>
-          The Spectral Embedding and MDS methods can be fed directly
-          with dissimilarity (distance) matrices instead of raw point
-          clouds.
+          The RipsComplex filter can be fed directly with Distance Matrices.
         </Documentation>
       </IntVectorProperty>
 
@@ -129,9 +184,11 @@
         <Property name="SelectFieldsWithRegexp" />
         <Property name="ScalarFields" />
         <Property name="Regexp" />
-      </PropertyGroup>
-
-      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="OutputDimension" />
+        <Property name="Epsilon" />
+        <Property name="XColumn" />
+        <Property name="YColumn" />
+        <Property name="ZColumn" />
         <Property name="KeepAllDataArrays" />
         <Property name="InputDistanceMatrix" />
       </PropertyGroup>

--- a/paraview/xmls/RipsComplex.xml
+++ b/paraview/xmls/RipsComplex.xml
@@ -1,0 +1,144 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+      name="ttkRipsComplex"
+      class="ttkRipsComplex"
+      label="TTK RipsComplex">
+      <Documentation
+        long_help="TTK ripsComplex plugin."
+        short_help="TTK ripsComplex plugin.">
+        TTK ripsComplex plugin documentation.
+      </Documentation>
+      <InputProperty
+        name="Input"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkTable"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+        </Documentation>
+      </InputProperty>
+
+      <IntVectorProperty
+        name="SelectFieldsWithRegexp"
+        label="Select Fields with a Regexp"
+        command="SetSelectFieldsWithRegexp"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Select input scalar fields matching a regular expression.
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty command="SetScalarFields"
+        clean_command="ClearScalarFields"
+        label="Input Columns"
+        name="ScalarFields"
+        number_of_elements="0"
+        default_values="1"
+        number_of_elements_per_command="1"
+        repeat_command="1">
+        <ArrayListDomain name="array_list"
+          default_values="1">
+          <RequiredProperties>
+            <Property name="Input"
+              function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <NoDefault />
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="0" />
+        </Hints>
+        <Documentation>
+          Select the scalar fields to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty
+         name="Regexp"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*"
+         panel_visibility="advanced">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="1" />
+        </Hints>
+         <Documentation>
+            This regexp will be used to filter the chosen fields. Only
+            matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+        name="KeepAllDataArrays"
+        label="Keep All Data Arrays"
+        command="SetKeepAllDataArrays"
+        number_of_elements="1"
+        default_values="1">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Keep all data arrays.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty name="InputDistanceMatrix"
+        label="Input Is a Distance Matrix"
+        command="SetInputIsADistanceMatrix"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="or">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="0" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="Method"
+                                       value="2" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          The Spectral Embedding and MDS methods can be fed directly
+          with dissimilarity (distance) matrices instead of raw point
+          clouds.
+        </Documentation>
+      </IntVectorProperty>
+
+      ${DEBUG_WIDGETS}
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="SelectFieldsWithRegexp" />
+        <Property name="ScalarFields" />
+        <Property name="Regexp" />
+      </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="KeepAllDataArrays" />
+        <Property name="InputDistanceMatrix" />
+      </PropertyGroup>
+
+      <Hints>
+        <ShowInMenu category="TTK - High Dimension / Point Cloud Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
On top of #719, this PR adds a new module that compute Rips complexes from either coordinates in a high dimension space or a distance matrix plus some low dimension coordinates (typically a `DimensionReduction` filter output).

Enjoy,
Pierre