### PR TITLE
Metric distortion

### DIFF
--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -272,6 +272,17 @@ int Geometry::computeTriangleArea(const T *p0,
 }
 
 template <typename T>
+int Geometry::computeTriangleAreaFromSides(const T s0,
+                                           const T s1,
+                                           const T s2,
+                                           T &area) {
+  double s = (s0 + s1 + s2) / 2.0;
+  area = std::sqrt(s * (s - s0) * (s - s1) * (s - s2));
+
+  return 0;
+}
+
+template <typename T>
 int Geometry::computeTriangleAngles(const T *p0,
                                     const T *p1,
                                     const T *p2,
@@ -529,6 +540,8 @@ int Geometry::subtractVectors(const T *a, const T *b, T *out) {
     TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &);           \
   template int Geometry::computeTriangleArea<TYPE>(                           \
     TYPE const *, TYPE const *, TYPE const *, TYPE &);                        \
+  template int Geometry::computeTriangleAreaFromSides<TYPE>(                  \
+    TYPE const, TYPE const, TYPE const, TYPE &);                              \
   template int Geometry::crossProduct<TYPE>(TYPE const *, TYPE const *,       \
                                             TYPE const *, TYPE const *,       \
                                             std::vector<TYPE> &);             \

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -276,6 +276,7 @@ int Geometry::computeTriangleAreaFromSides(const T s0,
                                            const T s1,
                                            const T s2,
                                            T &area) {
+
   double s = (s0 + s1 + s2) / 2.0;
   area = std::sqrt(s * (s - s0) * (s - s1) * (s - s2));
 
@@ -293,6 +294,17 @@ int Geometry::computeTriangleAngles(const T *p0,
   angles[0] = angle(p0, p1, p1, p2);
   angles[1] = angle(p1, p2, p2, p0);
   angles[2] = angle(p2, p0, p0, p1);
+
+  return 0;
+}
+
+template <typename T>
+int Geometry::computeTriangleAngleFromSides(const T s0,
+                                            const T s1,
+                                            const T s2,
+                                            T &angle) {
+
+  angle = std::acos((s0 * s0 + s1 * s1 - s2 * s2) / (2.0 * s0 * s1));
 
   return 0;
 }
@@ -538,6 +550,8 @@ int Geometry::subtractVectors(const T *a, const T *b, T *out) {
     TYPE const &, TYPE const &, TYPE const &, TYPE &, TYPE &);                \
   template int Geometry::computeTriangleAngles<TYPE>(                         \
     TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &);           \
+  template int Geometry::computeTriangleAngleFromSides<TYPE>(                 \
+    TYPE const, TYPE const, TYPE const, TYPE &);                              \
   template int Geometry::computeTriangleArea<TYPE>(                           \
     TYPE const *, TYPE const *, TYPE const *, TYPE &);                        \
   template int Geometry::computeTriangleAreaFromSides<TYPE>(                  \

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -107,6 +107,18 @@ namespace ttk {
                               const T *p2,
                               std::vector<T> &angles);
 
+    // Get the angle opposite to edge s2 using cosine law
+    /// \param s0 length of the first side of the triangle
+    /// \param s1 length of the second side of the triangle
+    /// \param s2 length of the third side of the triangle
+    /// \param angle Angle opposite to edge s2
+    /// \return Returns 0 upon success, negative values otherwise.
+    template <typename T>
+    int computeTriangleAngleFromSides(const T s0,
+                                      const T s1,
+                                      const T s2,
+                                      T &angle);
+
     /// Compute the area of a 3D triangle.
     /// \param p0 xyz coordinates of the first vertex of the triangle
     /// \param p1 xyz coordinates of the second vertex of the triangle
@@ -116,10 +128,10 @@ namespace ttk {
     template <typename T>
     int computeTriangleArea(const T *p0, const T *p1, const T *p2, T &area);
 
-    /// Compute the area of a triangle given length of its sides.
+    /// Compute the area of a triangle given length of its sides
     /// \param s0 length of the first side of the triangle
-    /// \param s1 length of the first side of the triangle
-    /// \param s2 length of the first side of the triangle
+    /// \param s1 length of the second side of the triangle
+    /// \param s2 length of the third side of the triangle
     /// \param area Output area.
     /// \return Returns 0 upon success, negative values otherwise.
     template <typename T>

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -116,6 +116,16 @@ namespace ttk {
     template <typename T>
     int computeTriangleArea(const T *p0, const T *p1, const T *p2, T &area);
 
+    /// Compute the area of a triangle given length of its sides.
+    /// \param s0 length of the first side of the triangle
+    /// \param s1 length of the first side of the triangle
+    /// \param s2 length of the first side of the triangle
+    /// \param area Output area.
+    /// \return Returns 0 upon success, negative values otherwise.
+    template <typename T>
+    int
+      computeTriangleAreaFromSides(const T s0, const T s1, const T s2, T &area);
+
     /// Compute the cross product of two 3D std::vectors
     /// \param vA0 xyz coordinates of vA's origin
     /// \param vA1 xyz coordinates of vA's destination

--- a/core/base/metricDistortion/CMakeLists.txt
+++ b/core/base/metricDistortion/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(metricDistortion
+  SOURCES
+    MetricDistortion.cpp
+  HEADERS
+    MetricDistortion.h
+  DEPENDS
+    triangulation
+)

--- a/core/base/metricDistortion/CMakeLists.txt
+++ b/core/base/metricDistortion/CMakeLists.txt
@@ -5,4 +5,5 @@ ttk_add_base_library(metricDistortion
     MetricDistortion.h
   DEPENDS
     triangulation
+    geometry
 )

--- a/core/base/metricDistortion/MetricDistortion.cpp
+++ b/core/base/metricDistortion/MetricDistortion.cpp
@@ -1,0 +1,6 @@
+#include <MetricDistortion.h>
+
+ttk::MetricDistortion::MetricDistortion() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("MetricDistortion");
+}

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -1,0 +1,130 @@
+/// TODO 1: Provide your information
+///
+/// \ingroup base
+/// \class ttk::MetricDistortion
+/// \author Your Name Here <your.email@address.here>
+/// \date The Date Here.
+///
+/// This module defines the %MetricDistortion class that computes for each
+/// vertex of a triangulation the average scalar value of itself and its direct
+/// neighbors.
+///
+/// \b Related \b publication: \n
+/// 'MetricDistortion'
+/// Jonas Lukasczyk and Julien Tierny.
+/// TTK Publications.
+/// 2021.
+///
+
+#pragma once
+
+// ttk common includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+namespace ttk {
+
+  /**
+   * The MetricDistortion class provides methods to compute for each vertex of a
+   * triangulation the average scalar value of itself and its direct neighbors.
+   */
+  class MetricDistortion : virtual public Debug {
+
+  public:
+    MetricDistortion();
+
+    /**
+     * TODO 2: This method preconditions the triangulation for all operations
+     *         the algorithm of this module requires. For instance,
+     *         preconditionVertexNeighbors, preconditionBoundaryEdges, ...
+     *
+     *         Note: If the algorithm does not require a triangulation then
+     *               this method can be deleted.
+     */
+    int preconditionTriangulation(
+      ttk::AbstractTriangulation *triangulation) const {
+      return triangulation->preconditionVertexNeighbors();
+    }
+
+    /**
+     * TODO 3: Implmentation of the algorithm.
+     *
+     *         Note: If the algorithm requires a triangulation then this
+     *               method must be called after the triangulation has been
+     *               preconditioned for the upcoming operations.
+     */
+    template <class dataType,
+              class triangulationType = ttk::AbstractTriangulation>
+    int computeAverages(dataType *outputData,
+                        const dataType *inputData,
+                        const triangulationType *triangulation) const {
+      // start global timer
+      ttk::Timer globalTimer;
+
+      // print horizontal separator
+      this->printMsg(ttk::debug::Separator::L1); // L1 is the '=' separator
+
+      // print input parameters in table format
+      this->printMsg({
+        {"#Threads", std::to_string(this->threadNumber_)},
+        {"#Vertices", std::to_string(triangulation->getNumberOfVertices())},
+      });
+      this->printMsg(ttk::debug::Separator::L1);
+
+      // -----------------------------------------------------------------------
+      // Compute Vertex Averages
+      // -----------------------------------------------------------------------
+      {
+        // start a local timer for this subprocedure
+        ttk::Timer localTimer;
+
+        // print the progress of the current subprocedure (currently 0%)
+        this->printMsg("Computing Averages",
+                       0, // progress form 0-1
+                       0, // elapsed time so far
+                       this->threadNumber_, ttk::debug::LineMode::REPLACE);
+
+        // compute the average of each vertex in parallel
+        size_t nVertices = triangulation->getNumberOfVertices();
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif
+        for(size_t i = 0; i < nVertices; i++) {
+          // initialize average
+          outputData[i] = inputData[i];
+
+          // add neighbor values to average
+          size_t nNeighbors = triangulation->getVertexNeighborNumber(i);
+          ttk::SimplexId neighborId;
+          for(size_t j = 0; j < nNeighbors; j++) {
+            triangulation->getVertexNeighbor(i, j, neighborId);
+            outputData[i] += inputData[neighborId];
+          }
+
+          // devide by neighbor number
+          outputData[i] /= (nNeighbors + 1);
+        }
+
+        // print the progress of the current subprocedure with elapsed time
+        this->printMsg("Computing Averages",
+                       1, // progress
+                       localTimer.getElapsedTime(), this->threadNumber_);
+      }
+
+      // ---------------------------------------------------------------------
+      // print global performance
+      // ---------------------------------------------------------------------
+      {
+        this->printMsg(ttk::debug::Separator::L2); // horizontal '-' separator
+        this->printMsg(
+          "Complete", 1, globalTimer.getElapsedTime() // global progress, time
+        );
+        this->printMsg(ttk::debug::Separator::L1); // horizontal '=' separator
+      }
+
+      return 1; // return success
+    }
+
+  }; // MetricDistortion class
+
+} // namespace ttk

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -28,12 +28,20 @@ namespace ttk {
 
   public:
     MetricDistortion();
+    
+    int preconditionTriangulation(AbstractTriangulation *triangulation) {
+      // Pre-condition functions.
+      if(triangulation) {
+        triangulation->preconditionBoundaryVertices();
+      }
+
+      return 0;
+    }
 
     template <class triangulationType>
     void
       computeSurfaceCurvature(const triangulationType *triangulation,
                               std::vector<std::vector<double>> &distanceMatrix,
-                              std::vector<bool> &isPointBoundary,
                               std::vector<double> &surfaceCurvature,
                               std::vector<double> &metricCurvature,
                               std::vector<double> &diffCurvature) {
@@ -94,11 +102,11 @@ namespace ttk {
             sumAngleMetric += angleMetric;
           }
         }
-
+        
         unsigned int cornerNoCell = (noTriangle > noQuad ? 2 : 1);
         double coef = (point2CellPoints[i].size() <= cornerNoCell
                          ? 0.5
-                         : (isPointBoundary[i] ? 1 : 2));
+                         : (triangulation->isVertexOnBoundary(i) ? 1 : 2));
         surfaceCurvature[i] = coef * M_PI - sumAngleSurface;
         // surfaceCurvature[i] *= std::pow(coef, -1);
 

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -59,13 +59,13 @@ namespace ttk {
           auto first = (j + 1) % cellNoPoints;
           auto second = (j + (cellNoPoints - 1)) % cellNoPoints;
 
-          int i0, i1;
+          SimplexId i0, i1;
           triangulation->getCellVertex(i, first, i0);
           triangulation->getCellVertex(i, second, i1);
 
           std::tuple<int, int> tup = std::make_tuple(i0, i1);
 
-          int ij;
+          SimplexId ij;
           triangulation->getCellVertex(i, j, ij);
           point2CellPoints[ij].push_back(tup);
         }
@@ -133,7 +133,7 @@ namespace ttk {
         if(triangulation->getCellVertexNumber(i) != 2)
           continue;
 
-        int i0, i1;
+        SimplexId i0, i1;
         triangulation->getCellVertex(i, 0, i0);
         triangulation->getCellVertex(i, 1, i1);
 
@@ -165,7 +165,7 @@ namespace ttk {
         if(cellNoPoints < 3 or cellNoPoints > 4)
           continue;
 
-        int i0, i1, i2;
+        SimplexId i0, i1, i2;
         triangulation->getCellVertex(i, 0, i0);
         triangulation->getCellVertex(i, 1, i1);
         triangulation->getCellVertex(i, 2, i2);
@@ -190,7 +190,7 @@ namespace ttk {
         }
 
         if(cellNoPoints == 4) {
-          int i3;
+          SimplexId i3;
           triangulation->getCellVertex(i, 3, i3);
           float p3[3];
           triangulation->getVertexPoint(i3, p3[0], p3[1], p3[2]);

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -3,7 +3,10 @@
 /// \author Mathieu Pont <mathieu.pont@lip6.fr>
 /// \date 2022.
 ///
-/// This module defines the %MetricDistortion class that computes TODO
+/// This module defines the %MetricDistortion class that computes distance,
+/// area and curvature information about a surface and an optionnal distance
+/// matrix (giving the distance between the points of the surface in a metric
+/// space).
 ///
 
 #pragma once
@@ -15,7 +18,10 @@
 namespace ttk {
 
   /**
-   * The MetricDistortion class provides methods to compute TODO
+   * The MetricDistortion class provides methods to compute distance,
+   * area and curvature information about a surface and an optionnal distance
+   * matrix (giving the distance between the points of the surface in a metric
+   * space).
    */
   class MetricDistortion : virtual public Debug {
 

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -1,19 +1,9 @@
-/// TODO 1: Provide your information
-///
 /// \ingroup base
 /// \class ttk::MetricDistortion
-/// \author Your Name Here <your.email@address.here>
-/// \date The Date Here.
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2022.
 ///
-/// This module defines the %MetricDistortion class that computes for each
-/// vertex of a triangulation the average scalar value of itself and its direct
-/// neighbors.
-///
-/// \b Related \b publication: \n
-/// 'MetricDistortion'
-/// Jonas Lukasczyk and Julien Tierny.
-/// TTK Publications.
-/// 2021.
+/// This module defines the %MetricDistortion class that computes TODO
 ///
 
 #pragma once
@@ -25,106 +15,169 @@
 namespace ttk {
 
   /**
-   * The MetricDistortion class provides methods to compute for each vertex of a
-   * triangulation the average scalar value of itself and its direct neighbors.
+   * The MetricDistortion class provides methods to compute TODO
    */
   class MetricDistortion : virtual public Debug {
 
   public:
     MetricDistortion();
 
-    /**
-     * TODO 2: This method preconditions the triangulation for all operations
-     *         the algorithm of this module requires. For instance,
-     *         preconditionVertexNeighbors, preconditionBoundaryEdges, ...
-     *
-     *         Note: If the algorithm does not require a triangulation then
-     *               this method can be deleted.
-     */
-    int preconditionTriangulation(
-      ttk::AbstractTriangulation *triangulation) const {
-      return triangulation->preconditionVertexNeighbors();
-    }
+    void
+      computeSurfaceCurvature(std::vector<std::vector<double>> &surfacePoints,
+                              std::vector<std::vector<int>> &surfaceCells,
+                              std::vector<std::vector<double>> &distanceMatrix,
+                              std::vector<double> &surfaceCurvature,
+                              std::vector<double> &metricCurvature,
+                              std::vector<double> &ratioCurvature) {
+      unsigned int dim = surfacePoints.size();
+      surfaceCurvature = std::vector<double>(dim, std::nan(""));
+      metricCurvature = std::vector<double>(dim, std::nan(""));
+      ratioCurvature = std::vector<double>(dim, std::nan(""));
 
-    /**
-     * TODO 3: Implmentation of the algorithm.
-     *
-     *         Note: If the algorithm requires a triangulation then this
-     *               method must be called after the triangulation has been
-     *               preconditioned for the upcoming operations.
-     */
-    template <class dataType,
-              class triangulationType = ttk::AbstractTriangulation>
-    int computeAverages(dataType *outputData,
-                        const dataType *inputData,
-                        const triangulationType *triangulation) const {
-      // start global timer
-      ttk::Timer globalTimer;
+      std::vector<std::vector<std::tuple<int, int>>> point2CellPoints(dim);
+      for(unsigned int i = 0; i < surfaceCells.size(); ++i) {
+        if(surfaceCells[i].size() < 3 or surfaceCells[i].size() > 4)
+          continue;
+        auto cellNoPoints = surfaceCells[i].size();
+        for(unsigned int j = 0; j < cellNoPoints; ++j) {
+          std::tuple<int, int> tup
+            = std::make_tuple((j + 1) % cellNoPoints, (j + 2) % cellNoPoints);
+          if(cellNoPoints == 4)
+            tup = std::make_tuple(
+              (j != 3 ? j + 1 : j - 2), (j != 0 ? j - 1 : j + 2));
+          point2CellPoints[surfaceCells[i][j]].push_back(tup);
+        }
+      }
 
-      // print horizontal separator
-      this->printMsg(ttk::debug::Separator::L1); // L1 is the '=' separator
+      for(unsigned int i = 0; i < dim; ++i) {
+        double sumAngleSurface = 0.0, sumAngleMetric = 0.0;
 
-      // print input parameters in table format
-      this->printMsg({
-        {"#Threads", std::to_string(this->threadNumber_)},
-        {"#Vertices", std::to_string(triangulation->getNumberOfVertices())},
-      });
-      this->printMsg(ttk::debug::Separator::L1);
-
-      // -----------------------------------------------------------------------
-      // Compute Vertex Averages
-      // -----------------------------------------------------------------------
-      {
-        // start a local timer for this subprocedure
-        ttk::Timer localTimer;
-
-        // print the progress of the current subprocedure (currently 0%)
-        this->printMsg("Computing Averages",
-                       0, // progress form 0-1
-                       0, // elapsed time so far
-                       this->threadNumber_, ttk::debug::LineMode::REPLACE);
-
-        // compute the average of each vertex in parallel
-        size_t nVertices = triangulation->getNumberOfVertices();
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_)
-#endif
-        for(size_t i = 0; i < nVertices; i++) {
-          // initialize average
-          outputData[i] = inputData[i];
-
-          // add neighbor values to average
-          size_t nNeighbors = triangulation->getVertexNeighborNumber(i);
-          ttk::SimplexId neighborId;
-          for(size_t j = 0; j < nNeighbors; j++) {
-            triangulation->getVertexNeighbor(i, j, neighborId);
-            outputData[i] += inputData[neighborId];
-          }
-
-          // devide by neighbor number
-          outputData[i] /= (nNeighbors + 1);
+        for(unsigned int j = 0; j < point2CellPoints[i].size(); ++j) {
+          auto tup = point2CellPoints[i][j];
+          int i0 = std::get<0>(tup);
+          int i1 = std::get<1>(tup);
+          auto p_i0 = surfacePoints[i0];
+          auto p_i1 = surfacePoints[i1];
+          auto p_i = surfacePoints[i];
+          sumAngleSurface
+            += cosineLaw(l2Distance(p_i, p_i0), l2Distance(p_i, p_i1),
+                         l2Distance(p_i0, p_i1));
+          if(distanceMatrix.size() != 0)
+            sumAngleMetric
+              += cosineLaw(distanceMatrix[i][i0], distanceMatrix[i][i1],
+                           distanceMatrix[i0][i1]);
         }
 
-        // print the progress of the current subprocedure with elapsed time
-        this->printMsg("Computing Averages",
-                       1, // progress
-                       localTimer.getElapsedTime(), this->threadNumber_);
-      }
+        surfaceCurvature[i] = 2 * M_PI - sumAngleSurface;
 
-      // ---------------------------------------------------------------------
-      // print global performance
-      // ---------------------------------------------------------------------
-      {
-        this->printMsg(ttk::debug::Separator::L2); // horizontal '-' separator
-        this->printMsg(
-          "Complete", 1, globalTimer.getElapsedTime() // global progress, time
-        );
-        this->printMsg(ttk::debug::Separator::L1); // horizontal '=' separator
+        if(distanceMatrix.size() != 0) {
+          metricCurvature[i] = 2 * M_PI - sumAngleMetric;
+          ratioCurvature[i] = metricCurvature[i] / surfaceCurvature[i];
+        }
       }
-
-      return 1; // return success
     }
 
+    void
+      computeSurfaceDistance(std::vector<std::vector<double>> &surfacePoints,
+                             std::vector<std::vector<int>> &surfaceCells,
+                             std::vector<std::vector<double>> &distanceMatrix,
+                             std::vector<double> &surfaceDistance,
+                             std::vector<double> &metricDistance,
+                             std::vector<double> &ratioDistance) {
+      unsigned int dim = surfaceCells.size();
+      surfaceDistance = std::vector<double>(dim, std::nan(""));
+      metricDistance = std::vector<double>(dim, std::nan(""));
+      ratioDistance = std::vector<double>(dim, std::nan(""));
+      for(unsigned int i = 0; i < dim; ++i) {
+        if(surfaceCells[i].size() != 2)
+          continue;
+
+        int i0 = surfaceCells[i][0];
+        int i1 = surfaceCells[i][1];
+
+        surfaceDistance[i] = l2Distance(surfacePoints[i0], surfacePoints[i1]);
+
+        if(distanceMatrix.size() != 0) {
+          metricDistance[i] = distanceMatrix[i0][i1];
+          ratioDistance[i] = metricDistance[i] / surfaceDistance[i];
+        }
+      }
+    }
+
+    void computeSurfaceArea(std::vector<std::vector<double>> &surfacePoints,
+                            std::vector<std::vector<int>> &surfaceCells,
+                            std::vector<std::vector<double>> &distanceMatrix,
+                            std::vector<double> &surfaceArea,
+                            std::vector<double> &metricArea,
+                            std::vector<double> &ratioArea) {
+      unsigned int dim = surfaceCells.size();
+      surfaceArea = std::vector<double>(dim, std::nan(""));
+      metricArea = std::vector<double>(dim, std::nan(""));
+      ratioArea = std::vector<double>(dim, std::nan(""));
+      for(unsigned int i = 0; i < dim; ++i) {
+        if(surfaceCells[i].size() < 3 or surfaceCells[i].size() > 4)
+          continue;
+
+        int i0 = surfaceCells[i][0];
+        int i1 = surfaceCells[i][1];
+        int i2 = surfaceCells[i][2];
+
+        surfaceArea[i] = triangleArea3D(
+          surfacePoints[i0], surfacePoints[i1], surfacePoints[i2]);
+
+        if(distanceMatrix.size() != 0)
+          metricArea[i] = triangleAreaFromSides(distanceMatrix[i0][i1],
+                                                distanceMatrix[i1][i2],
+                                                distanceMatrix[i2][i1]);
+
+        if(surfaceCells[i].size() == 4) {
+          int i3 = surfaceCells[i][3];
+          surfaceArea[i] += triangleArea3D(
+            surfacePoints[i1], surfacePoints[i2], surfacePoints[i3]);
+          if(distanceMatrix.size() != 0)
+            metricArea[i] += triangleAreaFromSides(distanceMatrix[i1][i2],
+                                                   distanceMatrix[i2][i3],
+                                                   distanceMatrix[i3][i1]);
+        }
+
+        if(distanceMatrix.size() != 0)
+          ratioArea[i] = metricArea[i] / surfaceArea[i];
+      }
+    }
+
+    //-------------------------------------------------------------------------
+    // Utils
+    //-------------------------------------------------------------------------
+    double cosineLaw(double a, double b, double c) {
+      // Get the angle opposite to edge c
+      return std::acos((a * a + b * b - c * c) / (2.0 * a * b));
+    }
+
+    double l2Distance(std::vector<double> &p1, std::vector<double> &p2) {
+      double distance = 0.0;
+      for(unsigned int i = 0; i < p1.size(); ++i)
+        distance += std::pow(p1[i] - p2[i], 2);
+      return std::sqrt(distance);
+    }
+
+    double triangleArea3D(std::vector<double> &x1,
+                          std::vector<double> &x2,
+                          std::vector<double> &x3) {
+      std::vector<double> AB(3), AC(3);
+      for(unsigned int i = 0; i < 3; ++i) {
+        AB[i] = x2[i] - x1[i];
+        AC[i] = x3[i] - x1[i];
+      }
+      return std::sqrt(std::pow(AB[1] * AC[2] - AB[2] * AC[1], 2)
+                       + std::pow(AB[2] * AC[0] - AB[0] * AC[2], 2)
+                       + std::pow(AB[0] * AC[1] - AB[1] * AC[0], 2))
+             / 2.0;
+    }
+
+    double triangleAreaFromSides(double a, double b, double c) {
+      double s = (a + b + c) / 2.0;
+      return std::sqrt(s * (s - a) * (s - b) * (s - c));
+    }
   }; // MetricDistortion class
 
 } // namespace ttk

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -72,11 +72,17 @@ namespace ttk {
           auto dist_i_i0 = Geometry::distance(&p_i[0], &p_i0[0]);
           auto dist_i_i1 = Geometry::distance(&p_i[0], &p_i1[0]);
           auto dist_i0_i1 = Geometry::distance(&p_i0[0], &p_i1[0]);
-          sumAngleSurface += cosineLaw(dist_i_i0, dist_i_i1, dist_i0_i1);
-          if(distanceMatrix.size() != 0)
-            sumAngleMetric
-              += cosineLaw(distanceMatrix[i][i0], distanceMatrix[i][i1],
-                           distanceMatrix[i0][i1]);
+          double angleSurface;
+          Geometry::computeTriangleAngleFromSides(
+            dist_i_i0, dist_i_i1, dist_i0_i1, angleSurface);
+          sumAngleSurface += angleSurface;
+          if(distanceMatrix.size() != 0) {
+            double angleMetric;
+            Geometry::computeTriangleAngleFromSides(
+              distanceMatrix[i][i0], distanceMatrix[i][i1],
+              distanceMatrix[i0][i1], angleMetric);
+            sumAngleMetric += angleMetric;
+          }
         }
 
         unsigned int cornerNoCell = (noTriangle > noQuad ? 2 : 1);
@@ -152,18 +158,18 @@ namespace ttk {
 
         if(surfaceCells[i].size() == 4) {
           int i3 = surfaceCells[i][3];
-          double temp;
+          double areaSurface;
           Geometry::computeTriangleArea(&surfacePoints[i1][0],
                                         &surfacePoints[i2][0],
-                                        &surfacePoints[i3][0], temp);
-          surfaceArea[i] += temp;
+                                        &surfacePoints[i3][0], areaSurface);
+          surfaceArea[i] += areaSurface;
 
           if(distanceMatrix.size() != 0) {
-            double tempMetric;
+            double areaMetric;
             Geometry::computeTriangleAreaFromSides(
               distanceMatrix[i1][i2], distanceMatrix[i2][i3],
-              distanceMatrix[i3][i1], tempMetric);
-            metricArea[i] += tempMetric;
+              distanceMatrix[i3][i1], areaMetric);
+            metricArea[i] += areaMetric;
           }
         }
 
@@ -172,13 +178,6 @@ namespace ttk {
       }
     }
 
-    //-------------------------------------------------------------------------
-    // Utils
-    //-------------------------------------------------------------------------
-    double cosineLaw(double a, double b, double c) {
-      // Get the angle opposite to edge c
-      return std::acos((a * a + b * b - c * c) / (2.0 * a * b));
-    }
   }; // MetricDistortion class
 
 } // namespace ttk

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -28,7 +28,7 @@ namespace ttk {
 
   public:
     MetricDistortion();
-    
+
     int preconditionTriangulation(AbstractTriangulation *triangulation) {
       // Pre-condition functions.
       if(triangulation) {
@@ -38,13 +38,12 @@ namespace ttk {
       return 0;
     }
 
-    template <class triangulationType>
-    void
-      computeSurfaceCurvature(const triangulationType *triangulation,
-                              std::vector<std::vector<double>> &distanceMatrix,
-                              std::vector<double> &surfaceCurvature,
-                              std::vector<double> &metricCurvature,
-                              std::vector<double> &diffCurvature) {
+    template <class triangulationType, class tableDataType>
+    void computeSurfaceCurvature(const triangulationType *triangulation,
+                                 std::vector<tableDataType *> &distanceMatrix,
+                                 std::vector<double> &surfaceCurvature,
+                                 std::vector<double> &metricCurvature,
+                                 std::vector<double> &diffCurvature) {
       unsigned int dim = triangulation->getNumberOfVertices();
       surfaceCurvature = std::vector<double>(dim, std::nan(""));
       metricCurvature = std::vector<double>(dim, std::nan(""));
@@ -96,13 +95,15 @@ namespace ttk {
           sumAngleSurface += angleSurface;
           if(distanceMatrix.size() != 0) {
             double angleMetric;
+            double distMat_i_i0 = distanceMatrix[i][i0];
+            double distMat_i_i1 = distanceMatrix[i][i1];
+            double distMat_i0_i1 = distanceMatrix[i0][i1];
             Geometry::computeTriangleAngleFromSides(
-              distanceMatrix[i][i0], distanceMatrix[i][i1],
-              distanceMatrix[i0][i1], angleMetric);
+              distMat_i_i0, distMat_i_i1, distMat_i0_i1, angleMetric);
             sumAngleMetric += angleMetric;
           }
         }
-        
+
         unsigned int cornerNoCell = (noTriangle > noQuad ? 2 : 1);
         double coef = (point2CellPoints[i].size() <= cornerNoCell
                          ? 0.5
@@ -118,13 +119,12 @@ namespace ttk {
       }
     }
 
-    template <class triangulationType>
-    void
-      computeSurfaceDistance(const triangulationType *triangulation,
-                             std::vector<std::vector<double>> &distanceMatrix,
-                             std::vector<double> &surfaceDistance,
-                             std::vector<double> &metricDistance,
-                             std::vector<double> &ratioDistance) {
+    template <class triangulationType, class tableDataType>
+    void computeSurfaceDistance(const triangulationType *triangulation,
+                                std::vector<tableDataType *> &distanceMatrix,
+                                std::vector<double> &surfaceDistance,
+                                std::vector<double> &metricDistance,
+                                std::vector<double> &ratioDistance) {
       unsigned int dim = triangulation->getNumberOfCells();
       surfaceDistance = std::vector<double>(dim, std::nan(""));
       metricDistance = std::vector<double>(dim, std::nan(""));
@@ -150,9 +150,9 @@ namespace ttk {
       }
     }
 
-    template <class triangulationType>
+    template <class triangulationType, class tableDataType>
     void computeSurfaceArea(const triangulationType *triangulation,
-                            std::vector<std::vector<double>> &distanceMatrix,
+                            std::vector<tableDataType *> &distanceMatrix,
                             std::vector<double> &surfaceArea,
                             std::vector<double> &metricArea,
                             std::vector<double> &ratioArea) {
@@ -180,9 +180,13 @@ namespace ttk {
         surfaceArea[i] = area;
 
         if(distanceMatrix.size() != 0) {
+          double areaMetric;
+          double distMat_i0_i1 = distanceMatrix[i0][i1];
+          double distMat_i1_i2 = distanceMatrix[i1][i2];
+          double distMat_i2_i0 = distanceMatrix[i2][i0];
           Geometry::computeTriangleAreaFromSides(
-            distanceMatrix[i0][i1], distanceMatrix[i1][i2],
-            distanceMatrix[i2][i0], metricArea[i]);
+            distMat_i0_i1, distMat_i1_i2, distMat_i2_i0, areaMetric);
+          metricArea[i] = areaMetric;
         }
 
         if(cellNoPoints == 4) {
@@ -197,9 +201,11 @@ namespace ttk {
 
           if(distanceMatrix.size() != 0) {
             double areaMetric;
+            double distMat_i1_i2 = distanceMatrix[i1][i2];
+            double distMat_i2_i3 = distanceMatrix[i2][i3];
+            double distMat_i3_i1 = distanceMatrix[i3][i1];
             Geometry::computeTriangleAreaFromSides(
-              distanceMatrix[i1][i2], distanceMatrix[i2][i3],
-              distanceMatrix[i3][i1], areaMetric);
+              distMat_i1_i2, distMat_i2_i3, distMat_i3_i1, areaMetric);
             metricArea[i] += areaMetric;
           }
         }

--- a/core/vtk/ttkMetricDistortion/CMakeLists.txt
+++ b/core/vtk/ttkMetricDistortion/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkMetricDistortion/ttk.module
+++ b/core/vtk/ttkMetricDistortion/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkMetricDistortion
+SOURCES
+  ttkMetricDistortion.cpp
+HEADERS
+  ttkMetricDistortion.h
+DEPENDS
+  metricDistortion
+  ttkAlgorithm

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -49,7 +49,7 @@ ttkMetricDistortion::~ttkMetricDistortion() {
 int ttkMetricDistortion::FillInputPortInformation(int port,
                                                   vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
   } else if(port == 1) {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
     info->Set(vtkAlgorithm::INPUT_IS_OPTIONAL(), 1);

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -101,10 +101,30 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   vtkPolyData *inputSurface = vtkPolyData::GetData(inputVector[0]);
   if(!inputSurface)
     return 0;
-  vtkTable *distanceMatrix = vtkTable::GetData(inputVector[1]);
-
+  auto noPoints = inputSurface->GetNumberOfPoints();
+  std::vector<std::vector<double>> surfacePoints(noPoints, std::vector<double>(3));
+  for(unsigned int i = 0; i < noPoints; ++i) {
+    double point[3];
+    inputSurface->GetPoints()->GetPoint(i, point);
+    for(unsigned int j = 0; j < 3; ++j)
+      surfacePoints[i][j] = point[j];
+  }
+  
+  vtkTable *distanceMatrixVTK = vtkTable::GetData(inputVector[1]);
+  std::vector<std::vector<double>> distanceMatrix;
+  if(distanceMatrixVTK) {
+    auto noRows = distanceMatrixVTK->GetNumberOfRows();
+    auto noCols = distanceMatrixVTK->GetNumberOfColumns();
+    distanceMatrix = std::vector<std::vector<double>>(noRows, std::vector<double>(noCols, 0.0));
+    for(unsigned int i = 0; i < noRows; ++i) 
+      for(unsigned int j = 0; j < noCols; ++j) 
+        distanceMatrix[i][j] = distanceMatrixVTK->GetColumn(j)
+                        ->GetVariantValue(i)
+                        .ToDouble();
+  }
+  
   // Get output object
-  auto outputSurface = vtkPolyData::GetData(outputVector, 0);
+  //auto outputSurface = vtkPolyData::GetData(outputVector, 0);
 
   // return success
   return 1;

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -1,0 +1,111 @@
+#include <ttkMetricDistortion.h>
+
+#include <vtkInformation.h>
+
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+// A VTK macro that enables the instantiation of this class via ::New()
+// You do not have to modify this
+vtkStandardNewMacro(ttkMetricDistortion);
+
+/**
+ * Implement the filter constructor and destructor in the cpp file.
+ *
+ * The constructor has to specify the number of input and output ports
+ * with the functions SetNumberOfInputPorts and SetNumberOfOutputPorts,
+ * respectively. It should also set default values for all filter
+ * parameters.
+ *
+ * The destructor is usually empty unless you want to manage memory
+ * explicitly, by for example allocating memory on the heap that needs
+ * to be freed when the filter is destroyed.
+ */
+ttkMetricDistortion::ttkMetricDistortion() {
+  this->SetNumberOfInputPorts(2);
+  this->SetNumberOfOutputPorts(1);
+}
+
+ttkMetricDistortion::~ttkMetricDistortion() {
+}
+
+/**
+ * Specify the required input data type of each input port
+ *
+ * This method specifies the required input object data types of the
+ * filter by adding the vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE() key to
+ * the port information.
+ */
+int ttkMetricDistortion::FillInputPortInformation(int port,
+                                                  vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+  } else if(port == 1) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+    info->Set(vtkAlgorithm::INPUT_IS_OPTIONAL(), 1);
+  } else
+    return 0;
+  return 1;
+}
+
+/**
+ * Specify the data object type of each output port
+ *
+ * This method specifies in the port information object the data type of the
+ * corresponding output objects. It is possible to either explicitly
+ * specify a type by adding a vtkDataObject::DATA_TYPE_NAME() key:
+ *
+ *      info->Set( vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid" );
+ *
+ * or to pass a type of an input port to an output port by adding the
+ * ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT() key (see below).
+ *
+ * Note: prior to the execution of the RequestData method the pipeline will
+ * initialize empty output data objects based on this information.
+ */
+int ttkMetricDistortion::FillOutputPortInformation(int port,
+                                                   vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * Pass VTK data to the base code and convert base code output to VTK
+ *
+ * This method is called during the pipeline execution to update the
+ * already initialized output data objects based on the given input
+ * data objects and filter parameters.
+ *
+ * Note:
+ *     1) The passed input data objects are validated based on the information
+ *        provided by the FillInputPortInformation method.
+ *     2) The output objects are already initialized based on the information
+ *        provided by the FillOutputPortInformation method.
+ */
+int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
+                                     vtkInformationVector **inputVector,
+                                     vtkInformationVector *outputVector) {
+
+  // Get input object from input vector
+  vtkPolyData *inputSurface = vtkPolyData::GetData(inputVector[0]);
+  if(!inputSurface)
+    return 0;
+  vtkTable *distanceMatrix = vtkTable::GetData(inputVector[1]);
+
+  // Get output object
+  auto outputSurface = vtkPolyData::GetData(outputVector, 0);
+
+  // return success
+  return 1;
+}

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -106,6 +106,11 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   vtkPolyData *inputSurface = vtkPolyData::GetData(inputVector[0]);
   if(!inputSurface)
     return 0;
+
+  auto triangulation = ttkAlgorithm::GetTriangulation(inputSurface);
+  if(!triangulation)
+    return -1;
+
   auto noPoints = inputSurface->GetNumberOfPoints();
   std::vector<std::vector<double>> surfacePoints(
     noPoints, std::vector<double>(3));
@@ -167,15 +172,15 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   // Call base
   // --------------------------------------------------------------------------
   std::vector<double> surfaceArea, metricArea, ratioArea;
-  computeSurfaceArea(surfacePoints, surfaceCells, distanceMatrix, surfaceArea,
+  computeSurfaceArea(triangulation->getData(), distanceMatrix, surfaceArea,
                      metricArea, ratioArea);
 
   std::vector<double> surfaceDistance, metricDistance, ratioDistance;
-  computeSurfaceDistance(surfacePoints, surfaceCells, distanceMatrix,
+  computeSurfaceDistance(triangulation->getData(), distanceMatrix,
                          surfaceDistance, metricDistance, ratioDistance);
 
   std::vector<double> surfaceCurvature, metricCurvature, diffCurvature;
-  computeSurfaceCurvature(surfacePoints, surfaceCells, distanceMatrix,
+  computeSurfaceCurvature(triangulation->getData(), distanceMatrix,
                           isPointBoundary, surfaceCurvature, metricCurvature,
                           diffCurvature);
 

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -120,7 +120,7 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   for(unsigned int i = 0; i < noCells; ++i) {
     auto noCellPoints = inputSurface->GetCell(i)->GetNumberOfPoints();
     surfaceCells[i] = std::vector<int>(noCellPoints);
-    for(unsigned int j = 0; j < noCellPoints; ++i)
+    for(unsigned int j = 0; j < noCellPoints; ++j)
       surfaceCells[i][j] = inputSurface->GetCell(i)->GetPointId(j);
   }
 
@@ -149,9 +149,10 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   computeSurfaceDistance(surfacePoints, surfaceCells, distanceMatrix,
                          surfaceDistance, metricDistance, ratioDistance);
 
-  std::vector<double> surfaceCurvature, metricCurvature, ratioCurvature;
+  std::vector<double> surfaceCurvature, metricCurvature, diffCurvature;
   computeSurfaceCurvature(surfacePoints, surfaceCells, distanceMatrix,
-                          surfaceCurvature, metricCurvature, ratioCurvature);
+                          surfaceCurvature, metricCurvature, diffCurvature);
+
   // --------------------------------------------------------------------------
   // Get output object
   // --------------------------------------------------------------------------
@@ -159,19 +160,19 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   outputSurface->DeepCopy(inputSurface);
 
   vtkNew<vtkDoubleArray> surfaceCurvatureArray{};
-  surfaceCurvatureArray->SetName("SurfaceCurvature");
+  surfaceCurvatureArray->SetName("CurvatureSurface");
   surfaceCurvatureArray->SetNumberOfTuples(noPoints);
   vtkNew<vtkDoubleArray> metricCurvatureArray{};
-  metricCurvatureArray->SetName("MetricCurvature");
+  metricCurvatureArray->SetName("CurvatureMetric");
   metricCurvatureArray->SetNumberOfTuples(noPoints);
   vtkNew<vtkDoubleArray> ratioCurvatureArray{};
-  ratioCurvatureArray->SetName("RatioCurvature");
+  ratioCurvatureArray->SetName("CurvatureDiff");
   ratioCurvatureArray->SetNumberOfTuples(noPoints);
 
   for(unsigned int i = 0; i < noPoints; ++i) {
     surfaceCurvatureArray->SetTuple1(i, surfaceCurvature[i]);
     metricCurvatureArray->SetTuple1(i, metricCurvature[i]);
-    ratioCurvatureArray->SetTuple1(i, ratioCurvature[i]);
+    ratioCurvatureArray->SetTuple1(i, diffCurvature[i]);
   }
 
   outputSurface->GetPointData()->AddArray(surfaceCurvatureArray);
@@ -181,26 +182,26 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   }
 
   vtkNew<vtkDoubleArray> surfaceAreaArray{};
-  surfaceAreaArray->SetName("SurfaceArea");
+  surfaceAreaArray->SetName("AreaSurface");
   surfaceAreaArray->SetNumberOfTuples(noCells);
   vtkNew<vtkDoubleArray> metricAreaArray{};
-  metricAreaArray->SetName("MetricArea");
+  metricAreaArray->SetName("AreaMetric");
   metricAreaArray->SetNumberOfTuples(noCells);
   vtkNew<vtkDoubleArray> ratioAreaArray{};
-  ratioAreaArray->SetName("RatioArea");
+  ratioAreaArray->SetName("AreaRatio");
   ratioAreaArray->SetNumberOfTuples(noCells);
 
   vtkNew<vtkDoubleArray> surfaceDistanceArray{};
-  surfaceDistanceArray->SetName("SurfaceDistance");
+  surfaceDistanceArray->SetName("DistanceSurface");
   surfaceDistanceArray->SetNumberOfTuples(noCells);
   vtkNew<vtkDoubleArray> metricDistanceArray{};
-  metricDistanceArray->SetName("MetricDistance");
+  metricDistanceArray->SetName("DistanceMetric");
   metricDistanceArray->SetNumberOfTuples(noCells);
   vtkNew<vtkDoubleArray> ratioDistanceArray{};
-  ratioDistanceArray->SetName("RatioDistance");
+  ratioDistanceArray->SetName("DistanceRatio");
   ratioDistanceArray->SetNumberOfTuples(noCells);
 
-  for(unsigned int i = 0; i < noPoints; ++i) {
+  for(unsigned int i = 0; i < noCells; ++i) {
     surfaceAreaArray->SetTuple1(i, surfaceArea[i]);
     metricAreaArray->SetTuple1(i, metricArea[i]);
     ratioAreaArray->SetTuple1(i, ratioArea[i]);

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -165,7 +165,7 @@ int ttkMetricDistortion::RequestData(vtkInformation *ttkNotUsed(request),
   metricCurvatureArray->SetName("MetricCurvature");
   metricCurvatureArray->SetNumberOfTuples(noPoints);
   vtkNew<vtkDoubleArray> ratioCurvatureArray{};
-  ratioCurvatureArray->SetName("RatioCurvautre");
+  ratioCurvatureArray->SetName("RatioCurvature");
   ratioCurvatureArray->SetNumberOfTuples(noPoints);
 
   for(unsigned int i = 0; i < noPoints; ++i) {

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -67,13 +67,13 @@ class TTKMETRICDISTORTION_EXPORT ttkMetricDistortion
 private:
   // Filled by the algorithm
   // Area
-  std::vector<double> surfaceArea, metricArea, ratioArea;
+  std::vector<double> surfaceArea_, metricArea_, ratioArea_;
   // Distance
-  std::vector<double> surfaceDistance, metricDistance, ratioDistance;
-  std::vector<std::array<double, 3>> surfacePointDistance, metricPointDistance,
-    ratioPointDistance;
+  std::vector<double> surfaceDistance_, metricDistance_, ratioDistance_;
+  std::vector<std::array<double, 3>> surfacePointDistance_,
+    metricPointDistance_, ratioPointDistance_;
   // Curvature
-  std::vector<double> surfaceCurvature, metricCurvature, diffCurvature;
+  std::vector<double> surfaceCurvature_, metricCurvature_, diffCurvature_;
 
   /**
    * Add all filter parameters only as private member variables and

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -65,6 +65,11 @@ class TTKMETRICDISTORTION_EXPORT ttkMetricDistortion
     protected ttk::MetricDistortion // and we inherit from the base class
 {
 private:
+  // Filled by the algorithm
+  std::vector<double> surfaceArea, metricArea, ratioArea;
+  std::vector<double> surfaceDistance, metricDistance, ratioDistance;
+  std::vector<double> surfaceCurvature, metricCurvature, diffCurvature;
+
   /**
    * Add all filter parameters only as private member variables and
    * initialize them here.
@@ -110,4 +115,7 @@ protected:
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;
+
+  template <class tableDataType>
+  int run(vtkInformationVector **inputVector);
 };

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -5,9 +5,10 @@
 ///
 /// \brief TTK VTK-filter that wraps the ttk::MetricDistortion module.
 ///
-/// This VTK filter uses the ttk::MetricDistortion module to compute an
-/// averaging of the data values of an input point data array defined on the
-/// input vtkDataSet.
+/// This VTK filter uses the ttk::MetricDistortion module to compute distance,
+/// area and curvature information about a surface and an optionnal distance
+/// matrix (giving the distance between the points of the surface in a metric
+/// space).
 ///
 /// \param Input vtkPolyData.
 /// \param Input vtkTable (optionnal)

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -66,8 +66,13 @@ class TTKMETRICDISTORTION_EXPORT ttkMetricDistortion
 {
 private:
   // Filled by the algorithm
+  // Area
   std::vector<double> surfaceArea, metricArea, ratioArea;
+  // Distance
   std::vector<double> surfaceDistance, metricDistance, ratioDistance;
+  std::vector<std::array<double, 3>> surfacePointDistance, metricPointDistance,
+    ratioPointDistance;
+  // Curvature
   std::vector<double> surfaceCurvature, metricCurvature, diffCurvature;
 
   /**

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -1,0 +1,112 @@
+/// \ingroup vtk
+/// \class ttkMetricDistortion
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2022.
+///
+/// \brief TTK VTK-filter that wraps the ttk::MetricDistortion module.
+///
+/// This VTK filter uses the ttk::MetricDistortion module to compute an
+/// averaging of the data values of an input point data array defined on the
+/// input vtkDataSet.
+///
+/// \param Input vtkPolyData.
+/// \param Input vtkTable (optionnal)
+/// \param Output vtkDataSet.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
+/// See the corresponding standalone program for a usage example:
+///   - standalone/MetricDistortion/main.cpp
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::MetricDistortion
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkMetricDistortionModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+
+/* Note on including VTK modules
+ *
+ * Each VTK module that you include a header from needs to be specified in this
+ * module's vtk.module file, either in the DEPENDS or PRIVATE_DEPENDS (if the
+ * header is included in the cpp file only) sections.
+ *
+ * In order to find the corresponding module, check its location within the VTK
+ * source code. The VTK module name is composed of the path to the header. You
+ * can also find the module name within the vtk.module file located in the same
+ * directory as the header file.
+ *
+ * For example, vtkSphereSource.h is located in directory VTK/Filters/Sources/,
+ * so its corresponding VTK module is called VTK::FiltersSources. In this case,
+ * the vtk.module file would need to be extended to
+ *
+ * NAME
+ *   ttkMetricDistortion
+ * DEPENDS
+ *   ttkAlgorithm
+ *   VTK::FiltersSources
+ */
+
+// TTK Base Includes
+#include <MetricDistortion.h>
+
+class TTKMETRICDISTORTION_EXPORT ttkMetricDistortion
+  : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
+  ,
+    protected ttk::MetricDistortion // and we inherit from the base class
+{
+private:
+  /**
+   * Add all filter parameters only as private member variables and
+   * initialize them here.
+   */
+
+public:
+  /**
+   * Automatically generate getters and setters of filter
+   * parameters via vtkMacros.
+   */
+
+  /**
+   * This static method and the macro below are VTK conventions on how to
+   * instantiate VTK objects. You don't have to modify this.
+   */
+  static ttkMetricDistortion *New();
+  vtkTypeMacro(ttkMetricDistortion, ttkAlgorithm);
+
+protected:
+  /**
+   * Implement the filter constructor and destructor
+   * (see cpp file)
+   */
+  ttkMetricDistortion();
+  ~ttkMetricDistortion() override;
+
+  /**
+   * Specify the input data type of each input port
+   * (see cpp file)
+   */
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Specify the data object type of each output port
+   * (see cpp file)
+   */
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Pass VTK data to the base code and convert base code output to VTK
+   * (see cpp file)
+   */
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+};

--- a/core/vtk/ttkMetricDistortion/vtk.module
+++ b/core/vtk/ttkMetricDistortion/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkMetricDistortion
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- TODO 11: Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
+<!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
+<!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ttkMetricDistortion" class="ttkMetricDistortion" label="TTK MetricDistortion">
+      <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter is a well documented ttk example filter that computes for each vertex of a vtkDataSet the average scalar value of itself and its neighbors.</Documentation>
+
+      <!-- INPUT DATA OBJECTS -->
+      <InputProperty
+        name="Surface"
+        port_index="0"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkUnstructuredGrid"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          
+        </Documentation>
+      </InputProperty>
+      
+      <InputProperty
+        name="Distance Matrix"
+        port_index="1"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkTable"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          
+        </Documentation>
+      </InputProperty>
+
+      <!-- INPUT PARAMETER WIDGETS -->
+
+      <!-- Create a UI group that contains all input parameter widgets (here only one) -->
+      <PropertyGroup panel_widget="Line" label="Input Options">
+        <Property name="InputArray" />
+      </PropertyGroup>
+
+      <!-- OUTPUT PARAMETER WIDGETS -->
+
+      <!-- Create a UI group that contains all output parameter widgets (here only one) -->
+      <PropertyGroup panel_widget="Line" label="Output Options">
+        <Property name="OutputArrayName" />
+      </PropertyGroup>
+
+      <!-- DEBUG -->
+      ${DEBUG_WIDGETS}
+
+      <!-- MENU CATEGORY -->
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -8,7 +8,7 @@
     <SourceProxy name="ttkMetricDistortion" class="ttkMetricDistortion" label="TTK MetricDistortion">
       <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter computes distance, area and curvature information about a surface and an optionnal distance matrix (giving the distance between the points of the surface in a metric space).</Documentation>
 
-      <!-- INPUT DATA OBJECTS -->
+      <!-- INPUT DATA OBJECTS -->      
       <InputProperty
         name="Surface"
         port_index="0"
@@ -26,7 +26,7 @@
       </InputProperty>
       
       <InputProperty
-        name="Distance Matrix"
+        name="TableDistance"
         port_index="1"
         command="SetInputConnection">
         <ProxyGroupDomain name="groups">
@@ -48,9 +48,6 @@
       <!-- OUTPUT PARAMETER WIDGETS -->
 
       <!-- Create a UI group that contains all output parameter widgets (here only one) -->
-
-      <!-- Output -->
-      <OutputPort name="Output Surface" index="0" id="port0" />
       
       <!-- DEBUG -->
       ${DEBUG_WIDGETS}

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -18,11 +18,8 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkPolyData"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
-          <Property name="Input" function="FieldDataSelection" />
-        </InputArrayDomain>
         <Documentation>
           
         </Documentation>
@@ -39,9 +36,6 @@
         <DataTypeDomain name="input_type">
           <DataType value="vtkTable"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
-          <Property name="Input" function="FieldDataSelection" />
-        </InputArrayDomain>
         <Documentation>
           
         </Documentation>
@@ -55,6 +49,9 @@
 
       <!-- Create a UI group that contains all output parameter widgets (here only one) -->
 
+      <!-- Output -->
+      <OutputPort name="Output Surface" index="0" id="port0" />
+      
       <!-- DEBUG -->
       ${DEBUG_WIDGETS}
 

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -50,16 +50,10 @@
       <!-- INPUT PARAMETER WIDGETS -->
 
       <!-- Create a UI group that contains all input parameter widgets (here only one) -->
-      <PropertyGroup panel_widget="Line" label="Input Options">
-        <Property name="InputArray" />
-      </PropertyGroup>
 
       <!-- OUTPUT PARAMETER WIDGETS -->
 
       <!-- Create a UI group that contains all output parameter widgets (here only one) -->
-      <PropertyGroup panel_widget="Line" label="Output Options">
-        <Property name="OutputArrayName" />
-      </PropertyGroup>
 
       <!-- DEBUG -->
       ${DEBUG_WIDGETS}

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -18,7 +18,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkPolyData"/>
+          <DataType value="vtkPointSet"/>
         </DataTypeDomain>
         <Documentation>
           
@@ -54,7 +54,7 @@
 
       <!-- MENU CATEGORY -->
       <Hints>
-        <ShowInMenu category="TTK - Misc" />
+        <ShowInMenu category="TTK - Domain" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- TODO 11: Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- Add widgets to the ParaView UI that control the member variables of the vtk filter -->
 <!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
 <!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
 <!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy name="ttkMetricDistortion" class="ttkMetricDistortion" label="TTK MetricDistortion">
-      <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter is a well documented ttk example filter that computes for each vertex of a vtkDataSet the average scalar value of itself and its neighbors.</Documentation>
+      <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter computes distance, area and curvature information about a surface and an optionnal distance matrix (giving the distance between the points of the surface in a metric space).</Documentation>
 
       <!-- INPUT DATA OBJECTS -->
       <InputProperty

--- a/standalone/MetricDistortion/CMakeLists.txt
+++ b/standalone/MetricDistortion/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(ttkMetricDistortionCmd)
+
+if(TARGET ttkMetricDistortion)
+  add_executable(${PROJECT_NAME} main.cpp)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ttkMetricDistortion
+      VTK::IOXML
+    )
+  set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+      INSTALL_RPATH
+        "${CMAKE_INSTALL_RPATH}"
+    )
+  install(
+    TARGETS
+      ${PROJECT_NAME}
+    RUNTIME DESTINATION
+      ${TTK_INSTALL_BINARY_DIR}
+    )
+endif()

--- a/standalone/MetricDistortion/main.cpp
+++ b/standalone/MetricDistortion/main.cpp
@@ -1,0 +1,164 @@
+/// TODO 12: Add your information
+/// \author Your Name Here <Your Email Address Here>.
+/// \date The Date Here.
+///
+/// \brief dummy program example.
+
+// TTK Includes
+#include <CommandLineParser.h>
+#include <ttkMetricDistortion.h>
+
+// VTK Includes
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkXMLDataObjectWriter.h>
+#include <vtkXMLGenericDataObjectReader.h>
+
+int main(int argc, char **argv) {
+
+  // ---------------------------------------------------------------------------
+  // Program variables
+  // ---------------------------------------------------------------------------
+  std::vector<std::string> inputFilePaths;
+  std::vector<std::string> inputArrayNames;
+  std::string outputArrayName{"AveragedArray"};
+  std::string outputPathPrefix{"output"};
+  bool listArrays{false};
+
+  // ---------------------------------------------------------------------------
+  // Set program variables based on command line arguments
+  // ---------------------------------------------------------------------------
+  {
+    ttk::CommandLineParser parser;
+
+    // -------------------------------------------------------------------------
+    // Standard options and arguments
+    // -------------------------------------------------------------------------
+    parser.setArgument(
+      "i", &inputFilePaths, "Input data-sets (*.vti, *vtu, *vtp)", false);
+    parser.setArgument("a", &inputArrayNames, "Input array names", true);
+    parser.setArgument(
+      "o", &outputPathPrefix, "Output file prefix (no extension)", true);
+    parser.setOption("l", &listArrays, "List available arrays");
+
+    // -------------------------------------------------------------------------
+    // TODO 13: Declare custom arguments and options
+    // -------------------------------------------------------------------------
+    parser.setArgument("O", &outputArrayName, "Output array name", true);
+
+    parser.parse(argc, argv);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Command line output messages.
+  // ---------------------------------------------------------------------------
+  ttk::Debug msg;
+  msg.setDebugMsgPrefix("MetricDistortion");
+
+  // ---------------------------------------------------------------------------
+  // Initialize ttkMetricDistortion module (adjust parameters)
+  // ---------------------------------------------------------------------------
+  auto metricDistortion = vtkSmartPointer<ttkMetricDistortion>::New();
+
+  // ---------------------------------------------------------------------------
+  // TODO 14: Pass custom arguments and options to the module
+  // ---------------------------------------------------------------------------
+  // metricDistortion->SetOutputArrayName(outputArrayName);
+
+  // ---------------------------------------------------------------------------
+  // Read input vtkDataObjects (optionally: print available arrays)
+  // ---------------------------------------------------------------------------
+  vtkDataArray *defaultArray = nullptr;
+  for(size_t i = 0; i < inputFilePaths.size(); i++) {
+    // init a reader that can parse any vtkDataObject stored in xml format
+    auto reader = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();
+    reader->SetFileName(inputFilePaths[i].data());
+    reader->Update();
+
+    // check if input vtkDataObject was successfully read
+    auto inputDataObject = reader->GetOutput();
+    if(!inputDataObject) {
+      msg.printErr("Unable to read input file `" + inputFilePaths[i] + "' :(");
+      return 1;
+    }
+
+    auto inputAsVtkDataSet = vtkDataSet::SafeDownCast(inputDataObject);
+
+    // if requested print list of arrays, otherwise proceed with execution
+    if(listArrays) {
+      msg.printMsg(inputFilePaths[i] + ":");
+      if(inputAsVtkDataSet) {
+        // Point Data
+        msg.printMsg("  PointData:");
+        auto pointData = inputAsVtkDataSet->GetPointData();
+        for(int j = 0; j < pointData->GetNumberOfArrays(); j++)
+          msg.printMsg("    - " + std::string(pointData->GetArrayName(j)));
+
+        // Cell Data
+        msg.printMsg("  CellData:");
+        auto cellData = inputAsVtkDataSet->GetCellData();
+        for(int j = 0; j < cellData->GetNumberOfArrays(); j++)
+          msg.printMsg("    - " + std::string(cellData->GetArrayName(j)));
+      } else {
+        msg.printErr("Unable to list arrays on file `" + inputFilePaths[i]
+                     + "'");
+        return 1;
+      }
+    } else {
+      // feed input object to ttkMetricDistortion filter
+      metricDistortion->SetInputDataObject(i, reader->GetOutput());
+
+      // default arrays
+      if(!defaultArray) {
+        defaultArray = inputAsVtkDataSet->GetPointData()->GetArray(0);
+        if(!defaultArray)
+          defaultArray = inputAsVtkDataSet->GetCellData()->GetArray(0);
+      }
+    }
+  }
+
+  // terminate program if it was just asked to list arrays
+  if(listArrays) {
+    return 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Specify which arrays of the input vtkDataObjects will be processed
+  // ---------------------------------------------------------------------------
+  if(!inputArrayNames.size()) {
+    if(defaultArray)
+      inputArrayNames.push_back(defaultArray->GetName());
+  }
+  for(size_t i = 0; i < inputArrayNames.size(); i++)
+    metricDistortion->SetInputArrayToProcess(
+      i, 0, 0, 0, inputArrayNames[i].data());
+
+  // ---------------------------------------------------------------------------
+  // Execute ttkMetricDistortion filter
+  // ---------------------------------------------------------------------------
+  metricDistortion->Update();
+
+  // ---------------------------------------------------------------------------
+  // If output prefix is specified then write all output objects to disk
+  // ---------------------------------------------------------------------------
+  if(!outputPathPrefix.empty()) {
+    for(int i = 0; i < metricDistortion->GetNumberOfOutputPorts(); i++) {
+      auto output = metricDistortion->GetOutputDataObject(i);
+      auto writer
+        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+
+      std::string outputFileName = outputPathPrefix + "_port_"
+                                   + std::to_string(i) + "."
+                                   + writer->GetDefaultFileExtension();
+      msg.printMsg("Writing output file `" + outputFileName + "'...");
+      writer->SetInputDataObject(output);
+      writer->SetFileName(outputFileName.data());
+      writer->Update();
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds the MetricDistortion filter that compute information about curvature, distance and area over a surface.

It takes in input a vtkPolyData corresponding to the surface and an optional distance matrix corresponding to the distance between the points of the surface in a metric space. 

If the distance matrix is not provided only information about the surface is computed, otherwise they are also computed for the metric space and a ratio or a difference between information about the surface and the metric space is computed to allow to compare them easily.