### PR TITLE
Add TableDistanceMatrix filter

### DIFF
--- a/core/base/ripsComplex/CMakeLists.txt
+++ b/core/base/ripsComplex/CMakeLists.txt
@@ -5,5 +5,4 @@ ttk_add_base_library(ripsComplex
     RipsComplex.h
   DEPENDS
     common
-    lDistanceMatrix
   )

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -1,4 +1,3 @@
-#include <LDistanceMatrix.h>
 #include <RipsComplex.h>
 
 #include <array>
@@ -6,29 +5,6 @@
 
 ttk::RipsComplex::RipsComplex() {
   this->setDebugMsgPrefix("RipsComplex");
-}
-
-int ttk::RipsComplex::computeDistanceMatrix(
-  std::vector<std::vector<double>> &distanceMatrix,
-  const std::vector<std::vector<double>> &inputMatrix) const {
-
-  Timer tm{};
-
-  std::vector<const double *> inputPtrs(inputMatrix.size());
-  for(size_t i = 0; i < inputMatrix.size(); ++i) {
-    const auto &vec{inputMatrix[i]};
-    inputPtrs[i] = vec.data();
-  }
-
-  ttk::LDistanceMatrix worker{};
-  worker.setThreadNumber(this->threadNumber_);
-  worker.setDebugLevel(this->debugLevel_);
-  worker.execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
-
-  this->printMsg("Computed distance matrix", 1.0, tm.getElapsedTime(),
-                 this->threadNumber_, debug::LineMode::NEW,
-                 debug::Priority::DETAIL);
-  return 0;
 }
 
 template <size_t n>
@@ -286,17 +262,10 @@ int ttk::RipsComplex::execute(
   std::vector<SimplexId> &connectivity,
   std::vector<double> &diameters,
   std::array<double *const, 3> diamStats,
-  const std::vector<std::vector<double>> &inputMatrix,
+  const std::vector<std::vector<double>> &distanceMatrix,
   double *const density) const {
 
   Timer tm{};
-
-  std::vector<std::vector<double>> distanceMatrix_{};
-  if(!this->InputIsADistanceMatrix) {
-    computeDistanceMatrix(distanceMatrix_, inputMatrix);
-  }
-  const auto &distanceMatrix
-    = this->InputIsADistanceMatrix ? inputMatrix : distanceMatrix_;
 
   if(distanceMatrix.empty()
      || distanceMatrix.size() != distanceMatrix[0].size()) {

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -31,26 +31,16 @@ namespace ttk {
      * @param[out] connectivity Cell connectivity array (VTK format)
      * @param[out] diameters Cell diameters
      * @param[out] diamStats Min, mean and max cell diameters around point
-     * @param[in] inputMatrix Either coordinates array or distance matrix
+     * @param[in] distanceMatrix Input distance matrix
      * @param[out] density Gaussian density array on points
      */
     int execute(std::vector<SimplexId> &connectivity,
                 std::vector<double> &diameters,
                 std::array<double *const, 3> diamStats,
-                const std::vector<std::vector<double>> &inputMatrix,
+                const std::vector<std::vector<double>> &distanceMatrix,
                 double *const density = nullptr) const;
 
   protected:
-    /**
-     * @brief Compute distance matrix from coordinates matrix
-     *
-     * @param[out] distanceMatrix Output distance matrix
-     * @param[in] inputMatrix Input coordinates matrix
-     */
-    int computeDistanceMatrix(
-      std::vector<std::vector<double>> &distanceMatrix,
-      const std::vector<std::vector<double>> &inputMatrix) const;
-
     /**
      * @brief Compute diameter statistics on points
      *
@@ -82,8 +72,6 @@ namespace ttk {
     double StdDev{1.0};
     /** Compute the Gaussian density from the distance matrix */
     bool ComputeGaussianDensity{false};
-    /** If input matrix is a distance matrix (compute it otherwise) */
-    bool InputIsADistanceMatrix{false};
   };
 
 } // namespace ttk

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.cpp
@@ -72,6 +72,13 @@ int ttkRipsComplex::RequestData(vtkInformation *ttkNotUsed(request),
     return 0;
   }
 
+  if(numberOfColumns != numberOfRows) {
+    this->printErr("Input distance matrix is not square (rows: "
+                   + std::to_string(numberOfRows)
+                   + ", columns: " + std::to_string(numberOfColumns) + ")");
+    return 0;
+  }
+
   std::array<vtkAbstractArray *, 3> components{
     input->GetColumnByName(this->XColumn.data()),
     input->GetColumnByName(this->YColumn.data()),

--- a/core/vtk/ttkRipsComplex/ttkRipsComplex.h
+++ b/core/vtk/ttkRipsComplex/ttkRipsComplex.h
@@ -44,8 +44,6 @@ public:
     ScalarFields.clear();
     Modified();
   }
-  vtkSetMacro(InputIsADistanceMatrix, bool);
-  vtkGetMacro(InputIsADistanceMatrix, bool);
 
   vtkSetMacro(OutputDimension, int);
   vtkGetMacro(OutputDimension, int);

--- a/core/vtk/ttkTableDistanceMatrix/CMakeLists.txt
+++ b/core/vtk/ttkTableDistanceMatrix/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkTableDistanceMatrix/ttk.module
+++ b/core/vtk/ttkTableDistanceMatrix/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkTableDistanceMatrix
+SOURCES
+  ttkTableDistanceMatrix.cpp
+HEADERS
+  ttkTableDistanceMatrix.h
+DEPENDS
+  lDistanceMatrix
+  ttkAlgorithm

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.cpp
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.cpp
@@ -1,0 +1,122 @@
+#include <ttkTableDistanceMatrix.h>
+#include <ttkUtils.h>
+
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkTable.h>
+
+#include <regex>
+
+vtkStandardNewMacro(ttkTableDistanceMatrix);
+
+ttkTableDistanceMatrix::ttkTableDistanceMatrix() {
+  SetNumberOfInputPorts(1);
+  SetNumberOfOutputPorts(1);
+}
+
+int ttkTableDistanceMatrix::FillInputPortInformation(int port,
+                                                     vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkTableDistanceMatrix::FillOutputPortInformation(int port,
+                                                      vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkTable");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkTableDistanceMatrix::RequestData(vtkInformation * /*request*/,
+                                        vtkInformationVector **inputVector,
+                                        vtkInformationVector *outputVector) {
+  ttk::Timer tm{};
+
+  auto *input = vtkTable::GetData(inputVector[0]);
+  auto *output = vtkTable::GetData(outputVector);
+  output->ShallowCopy(input);
+
+  if(SelectFieldsWithRegexp) {
+    // select all input columns whose name is matching the regexp
+    ScalarFields.clear();
+    const auto n = input->GetNumberOfColumns();
+    for(int i = 0; i < n; ++i) {
+      const auto &name = input->GetColumnName(i);
+      if(std::regex_match(name, std::regex(RegexpString))) {
+        ScalarFields.emplace_back(name);
+      }
+    }
+  }
+
+  const auto numberOfRows = input->GetNumberOfRows();
+  const auto numberOfColumns = ScalarFields.size();
+
+  if(numberOfRows <= 0 || numberOfColumns <= 0) {
+    this->printErr("Input matrix has invalid dimensions (rows: "
+                   + std::to_string(numberOfRows)
+                   + ", columns: " + std::to_string(numberOfColumns) + ")");
+    return 0;
+  }
+
+  std::vector<vtkAbstractArray *> arrays{};
+  for(const auto &s : ScalarFields) {
+    arrays.push_back(input->GetColumnByName(s.data()));
+  }
+
+  std::vector<std::vector<double>> inputMatrix(numberOfRows);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(int i = 0; i < numberOfRows; ++i) {
+    for(size_t j = 0; j < numberOfColumns; ++j) {
+      inputMatrix[i].emplace_back(arrays[j]->GetVariantValue(i).ToDouble());
+    }
+  }
+
+  std::vector<const double *> inputPtrs(inputMatrix.size());
+  for(size_t i = 0; i < inputMatrix.size(); ++i) {
+    const auto &vec{inputMatrix[i]};
+    inputPtrs[i] = vec.data();
+  }
+
+  std::vector<std::vector<double>> distanceMatrix{};
+  this->execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
+
+  // zero-padd column name to keep Row Data columns ordered
+  const auto zeroPad
+    = [](std::string &colName, const size_t numberCols, const size_t colIdx) {
+        std::string max{std::to_string(numberCols - 1)};
+        std::string cur{std::to_string(colIdx)};
+        std::string zer(max.size() - cur.size(), '0');
+        colName.append(zer).append(cur);
+      };
+
+  // copy distance matrix to output
+  for(int i = 0; i < numberOfRows; ++i) {
+    std::string name{"Distance"};
+    zeroPad(name, distanceMatrix.size(), i);
+
+    vtkNew<vtkDoubleArray> col{};
+    col->SetNumberOfTuples(numberOfRows);
+    col->SetName(name.c_str());
+    for(int j = 0; j < numberOfRows; ++j) {
+      col->SetTuple1(j, distanceMatrix[i][j]);
+    }
+    output->AddColumn(col);
+  }
+
+  this->printMsg("Complete (#dimensions: " + std::to_string(numberOfColumns)
+                   + ", #points: " + std::to_string(numberOfRows) + ")",
+                 1.0, tm.getElapsedTime(), this->threadNumber_);
+
+  return 1;
+}

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
@@ -1,0 +1,67 @@
+/// \ingroup vtk
+/// \class ttkTableDistanceMatrix
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date January 2022
+///
+/// \brief Computes a distance matrix using LDistance from a vtkTable
+///
+/// \sa LDistanceMatrix
+
+#pragma once
+
+// VTK Module
+#include <ttkTableDistanceMatrixModule.h>
+
+// TTK code includes
+#include <LDistanceMatrix.h>
+#include <ttkAlgorithm.h>
+
+class TTKTABLEDISTANCEMATRIX_EXPORT ttkTableDistanceMatrix
+  : public ttkAlgorithm,
+    protected ttk::LDistanceMatrix {
+
+public:
+  static ttkTableDistanceMatrix *New();
+
+  vtkTypeMacro(ttkTableDistanceMatrix, ttkAlgorithm);
+
+  void SetScalarFields(const std::string &s) {
+    ScalarFields.emplace_back(s);
+    Modified();
+  }
+
+  vtkSetMacro(SelectFieldsWithRegexp, bool);
+  vtkGetMacro(SelectFieldsWithRegexp, bool);
+
+  vtkSetMacro(RegexpString, const std::string &);
+  vtkGetMacro(RegexpString, std::string);
+
+  void ClearScalarFields() {
+    ScalarFields.clear();
+    Modified();
+  }
+
+  vtkSetMacro(DistanceType, const std::string &);
+  vtkGetMacro(DistanceType, std::string);
+
+protected:
+  ttkTableDistanceMatrix();
+  ~ttkTableDistanceMatrix() override = default;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  template <typename T>
+  int dispatch(std::vector<std::vector<double>> &distanceMatrix,
+               const std::vector<vtkDataSet *> &inputData,
+               const size_t nPoints);
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+private:
+  std::vector<std::string> ScalarFields{};
+  std::string RegexpString{".*"};
+  bool SelectFieldsWithRegexp{false};
+};

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
@@ -51,11 +51,6 @@ protected:
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
-  template <typename T>
-  int dispatch(std::vector<std::vector<double>> &distanceMatrix,
-               const std::vector<vtkDataSet *> &inputData,
-               const size_t nPoints);
-
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
                   vtkInformationVector *outputVector) override;

--- a/core/vtk/ttkTableDistanceMatrix/vtk.module
+++ b/core/vtk/ttkTableDistanceMatrix/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkTableDistanceMatrix
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/RipsComplex.xml
+++ b/paraview/xmls/RipsComplex.xml
@@ -167,17 +167,6 @@
         </Documentation>
       </IntVectorProperty>
 
-      <IntVectorProperty name="InputDistanceMatrix"
-        label="Input Is a Distance Matrix"
-        command="SetInputIsADistanceMatrix"
-        number_of_elements="1"
-        default_values="0">
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          The RipsComplex filter can be fed directly with Distance Matrices.
-        </Documentation>
-      </IntVectorProperty>
-
       <IntVectorProperty name="ComputeGaussianDensity"
         label="Compute Gaussian Density"
         command="SetComputeGaussianDensity"
@@ -220,7 +209,6 @@
         <Property name="YColumn" />
         <Property name="ZColumn" />
         <Property name="KeepAllDataArrays" />
-        <Property name="InputDistanceMatrix" />
         <Property name="ComputeGaussianDensity" />
         <Property name="StdDev" />
       </PropertyGroup>

--- a/paraview/xmls/TableDistanceMatrix.xml
+++ b/paraview/xmls/TableDistanceMatrix.xml
@@ -1,0 +1,115 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+   <SourceProxy
+     name="ttkTableDistanceMatrix"
+     class="ttkTableDistanceMatrix"
+     label="TTK TableDistanceMatrix">
+     <Documentation
+       long_help="Computes distance matrix from a vtkTable."
+       shorthelp="Table Distance Matrix."
+       >
+       TTK Table Distance Matrix.
+    </Documentation>
+
+     <InputProperty
+        name="Input"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkTable"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+        </Documentation>
+      </InputProperty>
+
+      <IntVectorProperty
+        name="SelectFieldsWithRegexp"
+        label="Select Fields with a Regexp"
+        command="SetSelectFieldsWithRegexp"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Select input scalar fields matching a regular expression.
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty command="SetScalarFields"
+        clean_command="ClearScalarFields"
+        label="Input Columns"
+        name="ScalarFields"
+        number_of_elements="0"
+        default_values="1"
+        number_of_elements_per_command="1"
+        repeat_command="1">
+        <ArrayListDomain name="array_list"
+          default_values="1">
+          <RequiredProperties>
+            <Property name="Input"
+              function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <NoDefault />
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="0" />
+        </Hints>
+        <Documentation>
+          Select the scalar fields to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty
+         name="Regexp"
+         command="SetRegexpString"
+         number_of_elements="1"
+         default_values=".*"
+         panel_visibility="advanced">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="SelectFieldsWithRegexp"
+                                   value="1" />
+        </Hints>
+         <Documentation>
+            This regexp will be used to filter the chosen fields. Only
+            matching ones will be selected.
+         </Documentation>
+      </StringVectorProperty>
+
+      <StringVectorProperty
+         name="n"
+         label="p parameter"
+         command="SetDistanceType"
+         number_of_elements="1"
+         default_values="2" >
+         <Documentation>
+          Value of the parameter p for the Lp distance computation
+          (type "inf" for the L-infinity distance).
+         </Documentation>
+     </StringVectorProperty>
+
+       ${DEBUG_WIDGETS}
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="SelectFieldsWithRegexp" />
+        <Property name="ScalarFields" />
+        <Property name="Regexp" />
+        <Property name="n" />
+      </PropertyGroup>
+
+      <Hints>
+        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+      </Hints>
+   </SourceProxy>
+ </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/xmls/TableDistanceMatrix.xml
+++ b/paraview/xmls/TableDistanceMatrix.xml
@@ -108,7 +108,7 @@
       </PropertyGroup>
 
       <Hints>
-        <ShowInMenu category="TTK - Ensemble Scalar Data" />
+        <ShowInMenu category="TTK - High Dimension / Point Cloud Data" />
       </Hints>
    </SourceProxy>
  </ProxyGroup>


### PR DESCRIPTION
This PR adds a new VTK module, `ttkTableDistanceMatrix`, that calls the `lDistanceMatrix` base module on vtkTables.
The corresponding feature in the `RipsComplex` module (computing a distance matrix from coordinates in a high-dimension space) has been removed. Now, `RipsComplex` only acts on distance matrices (+ a lower dimension embedding).

Enjoy,
Pierre

