### PR TITLE
DiscreteGradient: Simplify setManifoldSize

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -595,9 +595,8 @@ in the gradient.
       /**
        * Compute manifold size for critical extrema
        */
-      int setManifoldSize(const std::vector<Cell> &criticalPoints,
+      int setManifoldSize(const size_t nCritPoints,
                           const std::vector<size_t> &nCriticalPointsByDim,
-                          const std::vector<SimplexId> &maxSeeds,
                           const SimplexId *const ascendingManifold,
                           const SimplexId *const descendingManifold,
                           std::vector<SimplexId> &manifoldSize) const;

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -547,7 +547,6 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   this->printMsg("2-separatrices computed", 1.0, tm2sep.getElapsedTime(),
                  this->threadNumber_);
 
-  std::vector<SimplexId> maxSeeds{};
   if(ComputeAscendingSegmentation || ComputeDescendingSegmentation) {
     Timer tmp;
 
@@ -555,6 +554,7 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
     SimplexId numberOfMinima{};
 
     if(ComputeAscendingSegmentation) {
+      std::vector<SimplexId> maxSeeds{};
       setAscendingSegmentation(criticalPoints, maxSeeds, outManifold.ascending_,
                                numberOfMaxima, triangulation);
     }
@@ -576,14 +576,13 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   if(ComputeCriticalPoints) {
     std::vector<size_t> nCriticalPointsByDim{};
     discreteGradient_.setCriticalPoints(
-
       criticalPoints, nCriticalPointsByDim, outCP.points_,
       outCP.cellDimensions_, outCP.cellIds_, outCP.isOnBoundary_,
       outCP.PLVertexIdentifiers_, triangulation);
 
     if(ComputeAscendingSegmentation && ComputeDescendingSegmentation) {
       discreteGradient_.setManifoldSize(
-        criticalPoints, nCriticalPointsByDim, maxSeeds, outManifold.ascending_,
+        criticalPoints.size(), nCriticalPointsByDim, outManifold.ascending_,
         outManifold.descending_, outCP.manifoldSize_);
     }
   }


### PR DESCRIPTION
This PR simplifies the `DiscreteGradient::setManifoldSize` method by computing directly the manifold sizes from the ascending and the descending manifolds without using maps. This is due to the fact that manifolds are identified following the critical points order.

As a consequence, some segfaults that could be happening when computing a Morse-Smale Complex on Rips complexes should not occur anymore.

Enjoy,
Pierre