### PR TITLE
GitHub Actions: Add CI for ttk-data Python scripts

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -46,16 +46,18 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       name: Fetch TTK-ParaView headless Debian package
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-headless-${{ matrix.os }}.deb"
+        target: "ttk-paraview-headless.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-headless-${{ matrix.os }}.deb
+        sudo apt install ./ttk-paraview-headless.deb
 
     - name: Create & configure TTK build directory
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,15 +114,17 @@ jobs:
           doxygen \
           $CLANG_TIDY
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-headless-ubuntu-20.04.deb"
+        target: "ttk-paraview-headless.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-headless-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview-headless.deb
 
     - name: Create & configure TTK build directory
       run: |
@@ -191,15 +193,17 @@ jobs:
           zlib1g-dev \
           clang-tools-11
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-headless-ubuntu-20.04.deb"
+        target: "ttk-paraview-headless.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-headless-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview-headless.deb
 
     - name: Create & configure TTK build directory
       run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -278,7 +278,8 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge qt boost eigen spectralib zfp scikit-learn openmp graphviz
+        conda install -c conda-forge qt boost eigen spectralib zfp \
+          scikit-learn openmp "graphviz>=2.50"
 
     - name: Remove hosted Python
       shell: bash
@@ -314,6 +315,11 @@ jobs:
           -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
           -DBUILD_SHARED_LIBS:BOOL=TRUE ^
           -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
+          -DGraphviz_INCLUDE_DIR="%CONDA_ROOT%\Library\include\graphviz" ^
+          -DGraphviz_CDT_LIBRARY="%CONDA_ROOT%\Library\lib\cdt.lib" ^
+          -DGraphviz_GVC_LIBRARY="%CONDA_ROOT%\Library\lib\gvc.lib" ^
+          -DGraphviz_CGRAPH_LIBRARY="%CONDA_ROOT%\Library\lib\cgraph.lib" ^
+          -DGraphviz_PATHPLAN_LIBRARY="%CONDA_ROOT%\Library\lib\pathplan.lib" ^
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
           -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
           -DTTK_BUILD_STANDALONE_APPS=TRUE ^
@@ -359,7 +365,8 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge qt boost eigen spectralib zfp scikit-learn openmp graphviz
+        conda install -c conda-forge qt boost eigen spectralib zfp \
+          scikit-learn openmp "graphviz>=2.50"
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,16 +49,18 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       name: Fetch TTK-ParaView package
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb"
+        target: "ttk-paraview.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview.deb
 
     - name: Create & configure TTK build directory
       run: |
@@ -111,12 +113,14 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout TTK source code
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       name: Fetch TTK-ParaView package
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb"
+        target: "ttk-paraview.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Fetch TTK .deb artifact
       uses: actions/download-artifact@v2
@@ -126,7 +130,7 @@ jobs:
     - name: Install generated .deb packages
       run: |
         sudo apt update
-        sudo apt install ./ttk-paraview-${{ env.PV_TAG }}-ubuntu-20.04.deb
+        sudo apt install ./ttk-paraview.deb
         sudo apt install ./ttk-ubuntu-20.04.deb
 
     - name: Run TTK tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,8 @@ jobs:
         name: screenshots-${{ matrix.os }}.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
 
-    - name: Run ttk-data Python scripts
+    - name: Run ttk-data Python scripts [NOT ENFORCED]
+      continue-on-error: true
       run: |
         cd ttk-data
         python3 -u python/run.py
@@ -240,7 +241,8 @@ jobs:
         name: screenshots-macOS.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
 
-    - name: Run ttk-data Python scripts
+    - name: Run ttk-data Python scripts [NOT ENFORCED]
+      continue-on-error: true
       run: |
         cd ttk-data
         python3 -u python/run.py
@@ -377,7 +379,8 @@ jobs:
         path: "ttk-data"
       name: Checkout ttk-data
 
-    - name: Run ttk-data Python scripts
+    - name: Run ttk-data Python scripts [NOT ENFORCED]
+      continue-on-error: true
       shell: cmd
       run: |
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,16 @@ jobs:
         name: screenshots-${{ matrix.os }}.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
 
+    - name: Run ttk-data Python scripts
+      run: |
+        cd ttk-data
+        python3 -u python/run.py
+        cat python/res.json
+        diff python/hashes/${{ matrix.os }}.json python/res.json
+      env:
+        OMP_NUM_THREADS: 1
+
+
   # -----------------#
   # Test macOS build #
   # -----------------#
@@ -229,6 +239,16 @@ jobs:
       with:
         name: screenshots-macOS.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
+
+    - name: Run ttk-data Python scripts
+      run: |
+        cd ttk-data
+        python3 -u python/run.py
+        cat python/res.json
+        diff python/hashes/macOS.json python/res.json
+      env:
+        PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
+        OMP_NUM_THREADS: 1
 
 
   # ------------------ #
@@ -349,3 +369,22 @@ jobs:
       run: |
         cd %GITHUB_WORKSPACE%\examples\vtk-c++
         ttkHelloWorldCmd.exe -i %GITHUB_WORKSPACE%\examples\data\inputData.vtu
+
+    - uses: actions/checkout@v2
+      with:
+        repository: "pierre-guillou/ttk-data"
+        ref: "dev"
+        path: "ttk-data"
+      name: Checkout ttk-data
+
+    - name: Run ttk-data Python scripts
+      shell: cmd
+      run: |
+        set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib
+        set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
+        cd ttk-data
+        python -u python\run.py
+        type python\res.json
+        FC python\hashes\windows.json python\res.json
+      env:
+        OMP_NUM_THREADS: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,8 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge boost glew eigen spectralib zfp scikit-learn openmp graphviz
+        conda install -c conda-forge boost glew eigen spectralib zfp \
+          scikit-learn openmp "graphviz>=2.50"
 
     - name: Remove hosted Python
       shell: bash
@@ -249,6 +250,11 @@ jobs:
           -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
           -DBUILD_SHARED_LIBS:BOOL=TRUE ^
           -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
+          -DGraphviz_INCLUDE_DIR="%CONDA_ROOT%\Library\include\graphviz" ^
+          -DGraphviz_CDT_LIBRARY="%CONDA_ROOT%\Library\lib\cdt.lib" ^
+          -DGraphviz_GVC_LIBRARY="%CONDA_ROOT%\Library\lib\gvc.lib" ^
+          -DGraphviz_CGRAPH_LIBRARY="%CONDA_ROOT%\Library\lib\cgraph.lib" ^
+          -DGraphviz_PATHPLAN_LIBRARY="%CONDA_ROOT%\Library\lib\pathplan.lib" ^
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
           -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
           -DTTK_BUILD_STANDALONE_APPS=TRUE ^

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,6 +205,32 @@ jobs:
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 
+    - uses: actions/checkout@v2
+      with:
+        repository: "topology-tool-kit/ttk-data"
+        ref: "dev"
+        path: "ttk-data"
+      name: Checkout ttk-data
+
+    - name: Run ttk-data states [NOT ENFORCED]
+      if: false
+      id: validate
+      continue-on-error: true
+      run: |
+        cd ttk-data/tests
+        mkdir output_screenshots
+        python3 -u validate.py || (tar zcf screenshots.tar.gz output_screenshots && false)
+      env:
+        PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
+
+    - name: Upload result screenshots
+      if: steps.validate.outcome == 'failure'
+      uses: actions/upload-artifact@v2
+      with:
+        name: screenshots-macOS.tar.gz
+        path: ttk-data/tests/screenshots.tar.gz
+
+
   # ------------------ #
   # Test Windows build #
   # ------------------ #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,28 +55,32 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       name: Fetch archived ccache
       with:
         repo: "topology-tool-kit/ttk"
         version: "tags/ccache"
         file: "ttk-ccache-${{ matrix.os }}.tar.gz"
+        target: "ttk-ccache.tar.gz"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Decompress ccache archive
       run: |
-        tar xzf ttk-ccache-${{ matrix.os }}.tar.gz
+        tar xzf ttk-ccache.tar.gz
         mv .ccache /home/runner/
 
-    - uses: dsaltares/fetch-gh-release-asset@0.0.5
+    - uses: dsaltares/fetch-gh-release-asset@master
       name: Fetch TTK-ParaView headless Debian package
       with:
         repo: "${{ env.PV_REPO }}"
         version: "tags/${{ env.PV_TAG }}"
         file: "ttk-paraview-headless-${{ matrix.os }}.deb"
+        target: "ttk-paraview-headless.deb"
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install ParaView .deb
       run: |
-        sudo apt install ./ttk-paraview-headless-${{ matrix.os }}.deb
+        sudo apt install ./ttk-paraview-headless.deb
 
     - name: Create & configure TTK build directory
       run: |

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1334,8 +1334,8 @@ int ttk::MorseSmaleComplex::setDescendingSeparatrices2(
   const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
-  auto separatrixFunctionMaxima = outSeps2.cl.sepFuncMaxId_;
-  auto separatrixFunctionMinima = outSeps2.cl.sepFuncMinId_;
+  auto &separatrixFunctionMaxima = outSeps2.cl.sepFuncMaxId_;
+  auto &separatrixFunctionMinima = outSeps2.cl.sepFuncMinId_;
 
   // max existing separatrix id + 1 or 0 if no previous separatrices
   const SimplexId separatrixId

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -161,10 +161,10 @@ int ttk::TopologicalCompression::ReadCompactSegmentation(
   int numberOfBytesRead = 0;
 
   numberOfBytesRead += sizeof(int);
-  numberOfVertices = Read<int>(fm);
+  numberOfVertices = Read<int32_t>(fm);
 
   numberOfBytesRead += sizeof(int);
-  numberOfSegments = Read<int>(fm);
+  numberOfSegments = Read<int32_t>(fm);
 
   unsigned int numberOfBitsPerSegment = log2(numberOfSegments) + 1;
 
@@ -189,7 +189,7 @@ int ttk::TopologicalCompression::ReadCompactSegmentation(
 
     int compressedInt;
     numberOfBytesRead += sizeof(int);
-    compressedInt = Read<int>(fm);
+    compressedInt = Read<int32_t>(fm);
 
     while(offset + numberOfBitsPerSegment <= 32) {
 
@@ -309,7 +309,7 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
     // Test for overflow filling last part of current container.
     if(currentCell >= numberOfVertices) {
       numberOfBytesWritten += sizeof(int);
-      Write(fm, compressedInt);
+      Write<int32_t>(fm, compressedInt);
       break;
     }
 
@@ -333,7 +333,7 @@ int ttk::TopologicalCompression::WriteCompactSegmentation(
 
     // Dump current container.
     numberOfBytesWritten += sizeof(int);
-    Write(fm, compressedInt);
+    Write<int32_t>(fm, compressedInt);
   }
 
   return numberOfBytesWritten;
@@ -353,12 +353,12 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
   // 1.a. Read mapping.
   int mappingSize;
   numberOfBytesRead += sizeof(int);
-  mappingSize = Read<int>(fm);
+  mappingSize = Read<int32_t>(fm);
 
   for(int i = 0; i < mappingSize; ++i) {
     int idv;
     numberOfBytesRead += sizeof(int);
-    idv = Read<int>(fm);
+    idv = Read<int32_t>(fm);
 
     double value;
     numberOfBytesRead += sizeof(double);
@@ -374,7 +374,7 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
 
   // 1.b. Read constraints.
   numberOfBytesRead += sizeof(int);
-  nbConstraints = Read<int>(fm);
+  nbConstraints = Read<int32_t>(fm);
 
   for(int i = 0; i < nbConstraints; ++i) {
     int idVertex;
@@ -382,13 +382,13 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
     int vertexType;
 
     numberOfBytesRead += sizeof(int);
-    idVertex = Read<int>(fm);
+    idVertex = Read<int32_t>(fm);
 
     numberOfBytesRead += sizeof(double);
     value = Read<double>(fm);
 
     numberOfBytesRead += sizeof(int);
-    vertexType = Read<int>(fm);
+    vertexType = Read<int32_t>(fm);
 
     if(i == 0) {
       min = value;
@@ -416,23 +416,23 @@ int ttk::TopologicalCompression::WritePersistenceIndex(
   // Size.
   auto mappingSize = (int)mapping.size();
   numberOfBytesWritten += sizeof(int);
-  Write(fm, mappingSize);
+  Write<int32_t>(fm, mappingSize);
 
   // Segmentation values for each particular index.
   for(int i = 0; i < mappingSize; ++i) {
     std::tuple<double, int> t = mapping[i];
     int idv = std::get<1>(t);
     numberOfBytesWritten += sizeof(int);
-    Write(fm, idv);
+    Write<int32_t>(fm, idv);
 
     auto value = std::get<0>(t);
     numberOfBytesWritten += sizeof(double);
-    Write(fm, value);
+    Write<double>(fm, value);
   }
 
   auto nbConstraints = (int)constraints.size();
   numberOfBytesWritten += sizeof(int);
-  Write(fm, nbConstraints);
+  Write<int32_t>(fm, nbConstraints);
 
   for(int i = 0; i < nbConstraints; ++i) {
     std::tuple<int, double, int> t = constraints[i];
@@ -441,13 +441,13 @@ int ttk::TopologicalCompression::WritePersistenceIndex(
     int vertexType = std::get<2>(t);
 
     numberOfBytesWritten += sizeof(int);
-    Write(fm, idVertex);
+    Write<int32_t>(fm, idVertex);
 
     numberOfBytesWritten += sizeof(double);
-    Write(fm, value);
+    Write<double>(fm, value);
 
     numberOfBytesWritten += sizeof(int);
-    Write(fm, vertexType);
+    Write<int32_t>(fm, vertexType);
   }
 
   return numberOfBytesWritten;
@@ -494,10 +494,10 @@ int ttk::TopologicalCompression::WritePersistenceTopology(FILE *fm) {
     return -1;
 
   numberOfBytesWritten += sizeof(int);
-  Write(fm, numberOfVertices);
+  Write<int32_t>(fm, numberOfVertices);
 
   numberOfBytesWritten += sizeof(int);
-  Write(fm, numberOfSegments);
+  Write<int32_t>(fm, numberOfSegments);
 
   numberOfBytesWritten += WriteCompactSegmentation(
     fm, getSegmentation(), numberOfVertices, numberOfSegments);
@@ -625,9 +625,9 @@ int ttk::TopologicalCompression::WriteToFile(FILE *fp,
                 dataArrayName);
 
 #ifdef TTK_ENABLE_ZLIB
-  Write(fp, true);
+  Write<uint8_t>(fp, true);
 #else
-  Write(fp, false);
+  Write<uint8_t>(fp, false);
 #endif
 
   bool usePersistence
@@ -708,8 +708,8 @@ int ttk::TopologicalCompression::WriteToFile(FILE *fp,
   this->printMsg("Data successfully compressed.");
 
   // [fm->fp] Copy fm to fp.
-  Write(fp, destLen); // Compressed size...
-  Write(fp, sourceLen);
+  Write<uint64_t>(fp, destLen); // Compressed size...
+  Write<uint64_t>(fp, sourceLen);
   WriteByteArray(fp, ddest.data(), destLen);
   this->printMsg("Data successfully written to filesystem.");
 
@@ -719,8 +719,8 @@ int ttk::TopologicalCompression::WriteToFile(FILE *fp,
   unsigned long sourceLen = (unsigned long)rawFileLength;
   unsigned long destLen = (unsigned long)rawFileLength;
 
-  Write(fp, destLen); // Compressed size...
-  Write(fp, sourceLen);
+  Write<uint64_t>(fp, destLen); // Compressed size...
+  Write<uint64_t>(fp, sourceLen);
   WriteByteArray(fp, source, destLen);
 #endif
 
@@ -747,13 +747,13 @@ int ttk::TopologicalCompression::WriteMetaData(
   WriteByteArray(fp, magicBytes_, std::strlen(magicBytes_));
 
   // -3. File format version
-  Write(fp, formatVersion_);
+  Write<uint64_t>(fp, formatVersion_);
 
   // -2. Persistence, or Other
-  Write(fp, compressionType);
+  Write<int32_t>(fp, compressionType);
 
   // -1. zfpOnly
-  Write(fp, zfpOnly);
+  Write<uint8_t>(fp, zfpOnly);
 
   // 0. SQ type
   const char *sq = sqMethod;
@@ -762,30 +762,30 @@ int ttk::TopologicalCompression::WriteMetaData(
                : (strcmp(sq, "d") == 0 || strcmp(sq, "D") == 0) ? 2
                                                                 : 3;
 
-  Write(fp, sqType);
+  Write<int32_t>(fp, sqType);
 
   // 1. DataType
-  Write(fp, dataType);
+  Write<int32_t>(fp, dataType);
 
   // 2. Data extent, spacing, origin
   for(int i = 0; i < 6; ++i)
-    Write(fp, dataExtent[i]);
+    Write<int32_t>(fp, dataExtent[i]);
 
   for(int i = 0; i < 3; ++i)
-    Write(fp, dataSpacing[i]);
+    Write<double>(fp, dataSpacing[i]);
 
   for(int i = 0; i < 3; ++i)
-    Write(fp, dataOrigin[i]);
+    Write<double>(fp, dataOrigin[i]);
 
   // 4. Tolerance
-  Write(fp, tolerance);
+  Write<double>(fp, tolerance);
 
   // 5. ZFP ratio
-  Write(fp, zfpTolerance);
+  Write<double>(fp, zfpTolerance);
 
   // 6. Length of array name
   // (explicit call to unsigned long variant for MSVC compatibility)
-  Write<unsigned long>(fp, dataArrayName.size());
+  Write<uint64_t>(fp, dataArrayName.size());
 
   // 7. Array name (as unsigned chars)
   WriteByteArray(fp, dataArrayName.c_str(), dataArrayName.size());
@@ -811,7 +811,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   }
 
   // -3. File format version
-  const auto fileVersion = Read<unsigned long>(fm);
+  const auto fileVersion = Read<uint64_t>(fm);
   if(fileVersion < this->formatVersion_) {
     this->printErr("Old format version detected (" + std::to_string(fileVersion)
                    + " vs. " + std::to_string(this->formatVersion_) + ").");
@@ -826,21 +826,21 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   }
 
   // -2. Compression type.
-  compressionType_ = Read<int>(fm);
+  compressionType_ = Read<int32_t>(fm);
 
   // -1. ZFP only type.
-  ZFPOnly = Read<bool>(fm);
+  ZFPOnly = Read<uint8_t>(fm);
 
   // 0. SQ type
-  SQMethodInt = Read<int>(fm);
+  SQMethodInt = Read<int32_t>(fm);
 
   // 1. DataType
-  dataScalarType_ = Read<int>(fm);
+  dataScalarType_ = Read<int32_t>(fm);
   // DataScalarType = VTK_DOUBLE;
 
   // 2. Data extent, spacing, origin
   for(int i = 0; i < 6; ++i)
-    dataExtent_[i] = Read<int>(fm);
+    dataExtent_[i] = Read<int32_t>(fm);
 
   for(int i = 0; i < 3; ++i)
     dataSpacing_[i] = Read<double>(fm);
@@ -855,7 +855,7 @@ int ttk::TopologicalCompression::ReadMetaData(FILE *fm) {
   ZFPTolerance = Read<double>(fm);
 
   // 6. Length of array name
-  size_t dataArrayNameLength = Read<unsigned long>(fm);
+  size_t dataArrayNameLength = Read<uint64_t>(fm);
 
   // 7. Array name (as unsigned chars)
   dataArrayName_.resize(dataArrayNameLength + 1);

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -187,8 +187,8 @@ namespace ttk {
 
     template <typename T>
     T Read(FILE *fm) const {
-      static_assert(std::is_same<T, bool>() || std::is_same<T, int>()
-                      || std::is_same<T, unsigned long>()
+      static_assert(std::is_same<T, uint8_t>() || std::is_same<T, int32_t>()
+                      || std::is_same<T, uint64_t>()
                       || std::is_same<T, double>(),
                     "Function should have only those types");
       T ret;
@@ -208,8 +208,8 @@ namespace ttk {
     }
     template <typename T>
     void Write(FILE *fm, T data) const {
-      static_assert(std::is_same<T, bool>() || std::is_same<T, int>()
-                      || std::is_same<T, unsigned long>()
+      static_assert(std::is_same<T, uint8_t>() || std::is_same<T, int32_t>()
+                      || std::is_same<T, uint64_t>()
                       || std::is_same<T, double>(),
                     "Function should have only those types");
       auto status = std::fwrite(&data, sizeof(T), 1, fm);
@@ -451,7 +451,7 @@ int ttk::TopologicalCompression::ReadFromFile(
     return -4;
   }
 
-  bool useZlib = Read<bool>(fp);
+  bool useZlib = Read<uint8_t>(fp);
   unsigned char *dest;
   std::vector<unsigned char> ddest;
   unsigned long destLen;
@@ -459,8 +459,8 @@ int ttk::TopologicalCompression::ReadFromFile(
 #ifdef TTK_ENABLE_ZLIB
   if(useZlib) {
     // [fp->ff] Read compressed data.
-    auto sl = Read<unsigned long>(fp); // Compressed size...
-    auto dl = Read<unsigned long>(fp); // Uncompressed size...
+    auto sl = Read<uint64_t>(fp); // Compressed size...
+    auto dl = Read<uint64_t>(fp); // Uncompressed size...
 
     destLen = dl;
     std::vector<unsigned char> ssource(sl);
@@ -476,8 +476,8 @@ int ttk::TopologicalCompression::ReadFromFile(
   } else {
     this->printMsg("File was not compressed with ZLIB.");
 
-    Read<unsigned long>(fp); // Compressed size...
-    unsigned long dl = Read<unsigned long>(fp); // Uncompressed size...
+    Read<uint64_t>(fp); // Compressed size...
+    const auto dl = Read<uint64_t>(fp); // Uncompressed size...
 
     destLen = dl;
     ddest.resize(destLen);
@@ -492,8 +492,8 @@ int ttk::TopologicalCompression::ReadFromFile(
   } else {
     this->printMsg(" ZLIB not installed, but file was not compressed anyways.");
 
-    Read<unsigned long>(fp); // Compressed size...
-    unsigned long dl = Read<unsigned long>(fp); // Uncompressed size...
+    Read<uint64_t>(fp); // Compressed size...
+    const auto dl = Read<uint64_t>(fp); // Uncompressed size...
 
     destLen = dl;
     ddest.resize(destLen);

--- a/examples/pvpython/example.py
+++ b/examples/pvpython/example.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 
-#/// \ingroup examples
-#/// \author Julien Tierny <julien.tierny@lip6.fr>
-#/// \date October 2017.
-#///
-#/// \brief Minimalist python TTK example pipeline, including:
-#///  -# The computation of a persistence curve
-#///  -# The computation of a persistence diagram
-#///  -# The selection of the most persistent pairs of the diagram
-#///  -# The pre-simplification of the data according to this selection
-#///  -# The computation of the Morse-Smale complex on this simplified data
-#///  -# The storage of the output of this pipeline to disk.
-#///
-#/// This example reproduces the Figure 1 of the TTK companion paper:
-#/// "The Topology ToolKit", J. Tierny, G. Favelier, J. Levine, C. Gueunet, M.
-#/// Michaux., IEEE Transactions on Visualization and Computer Graphics, Proc.
-#/// of IEEE VIS 2017.
+# /// \ingroup examples
+# /// \author Julien Tierny <julien.tierny@lip6.fr>
+# /// \date October 2017.
+# ///
+# /// \brief Minimalist python TTK example pipeline, including:
+# ///  -# The computation of a persistence curve
+# ///  -# The computation of a persistence diagram
+# ///  -# The selection of the most persistent pairs of the diagram
+# ///  -# The pre-simplification of the data according to this selection
+# ///  -# The computation of the Morse-Smale complex on this simplified data
+# ///  -# The storage of the output of this pipeline to disk.
+# ///
+# /// This example reproduces the Figure 1 of the TTK companion paper:
+# /// "The Topology ToolKit", J. Tierny, G. Favelier, J. Levine, C. Gueunet, M.
+# /// Michaux., IEEE Transactions on Visualization and Computer Graphics, Proc.
+# /// of IEEE VIS 2017.
 
 from paraview.simple import *
 
@@ -29,6 +29,8 @@ def ThresholdBetween(threshold, lower, upper):
         threshold.ThresholdMethod = "Between"
         threshold.LowerThreshold = lower
         threshold.UpperThreshold = upper
+
+
 # end of comphatibility ========================================================
 
 if len(sys.argv) == 2:
@@ -44,32 +46,33 @@ inputData = XMLUnstructuredGridReader(FileName=[inputFilePath])
 
 # 2. computing the persistence curve
 persistenceCurve = TTKPersistenceCurve(inputData)
-persistenceCurve.ScalarField = ['POINTS', 'data']
+persistenceCurve.ScalarField = ["POINTS", "data"]
 
 # 3. computing the persitence diagram
 persistenceDiagram = TTKPersistenceDiagram(inputData)
-persistenceDiagram.ScalarField = ['POINTS', 'data']
+persistenceDiagram.ScalarField = ["POINTS", "data"]
 
 # 4. selecting the critical point pairs
 criticalPointPairs = Threshold(persistenceDiagram)
-criticalPointPairs.Scalars = ['CELLS', 'PairIdentifier']
+criticalPointPairs.Scalars = ["CELLS", "PairIdentifier"]
 ThresholdBetween(criticalPointPairs, -0.1, 999999999)
 
 # 5. selecting the most persistent pairs
 persistentPairs = Threshold(criticalPointPairs)
-persistentPairs.Scalars = ['CELLS', 'Persistence']
+persistentPairs.Scalars = ["CELLS", "Persistence"]
 ThresholdBetween(persistentPairs, 0.05, 999999999)
 
 # 6. simplifying the input data to remove non-persistent pairs
 topologicalSimplification = TTKTopologicalSimplification(
-  Domain=inputData, Constraints=persistentPairs)
-topologicalSimplification.ScalarField = ['POINTS', 'data']
+    Domain=inputData, Constraints=persistentPairs
+)
+topologicalSimplification.ScalarField = ["POINTS", "data"]
 
 # 7. computing the Morse-Smale complex
 morseSmaleComplex = TTKMorseSmaleComplex(topologicalSimplification)
-morseSmaleComplex.ScalarField = ['POINTS', 'data']
+morseSmaleComplex.ScalarField = ["POINTS", "data"]
 
 # 8. saving the output data
-SaveData('curve.vtk', OutputPort(persistenceCurve, 3))
-SaveData('separatrices.vtp', OutputPort(morseSmaleComplex, 1))
-SaveData('segmentation.vtu', OutputPort(morseSmaleComplex, 3))
+SaveData("curve.vtk", OutputPort(persistenceCurve, 3))
+SaveData("separatrices.vtp", OutputPort(morseSmaleComplex, 1))
+SaveData("segmentation.vtu", OutputPort(morseSmaleComplex, 3))

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 
-#/// \ingroup examples
-#/// \author Lutz Hofmann <lutz.hofmann@iwr.uni-heidelberg.de>
-#/// \date August 2019.
-#///
-#/// \brief Minimalist python TTK example pipeline, including:
-#///  -# The computation of a persistence curve
-#///  -# The computation of a persistence diagram
-#///  -# The selection of the most persistent pairs of the diagram
-#///  -# The pre-simplification of the data according to this selection
-#///  -# The computation of the Morse-Smale complex on this simplified data
-#///  -# The storage of the output of this pipeline to disk.
-#///
-#/// This example reproduces the Figure 1 of the TTK companion paper:
-#/// "The Topology ToolKit", J. Tierny, G. Favelier, J. Levine, C. Gueunet, M.
-#/// Michaux., IEEE Transactions on Visualization and Computer Graphics, Proc.
-#/// of IEEE VIS 2017.
+# /// \ingroup examples
+# /// \author Lutz Hofmann <lutz.hofmann@iwr.uni-heidelberg.de>
+# /// \date August 2019.
+# ///
+# /// \brief Minimalist python TTK example pipeline, including:
+# ///  -# The computation of a persistence curve
+# ///  -# The computation of a persistence diagram
+# ///  -# The selection of the most persistent pairs of the diagram
+# ///  -# The pre-simplification of the data according to this selection
+# ///  -# The computation of the Morse-Smale complex on this simplified data
+# ///  -# The storage of the output of this pipeline to disk.
+# ///
+# /// This example reproduces the Figure 1 of the TTK companion paper:
+# /// "The Topology ToolKit", J. Tierny, G. Favelier, J. Levine, C. Gueunet, M.
+# /// Michaux., IEEE Transactions on Visualization and Computer Graphics, Proc.
+# /// of IEEE VIS 2017.
 
 import sys
 
@@ -61,14 +61,16 @@ diagram.SetDebugLevel(3)
 criticalPairs = vtkThreshold()
 criticalPairs.SetInputConnection(diagram.GetOutputPort())
 criticalPairs.SetInputArrayToProcess(
-    0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "PairIdentifier")
+    0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "PairIdentifier"
+)
 criticalPairs.ThresholdBetween(-0.1, 999999)
 
 # 5. selecting the most persistent pairs
 persistentPairs = vtkThreshold()
 persistentPairs.SetInputConnection(criticalPairs.GetOutputPort())
 persistentPairs.SetInputArrayToProcess(
-    0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "Persistence")
+    0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "Persistence"
+)
 persistentPairs.ThresholdBetween(0.05, 999999)
 
 # 6. simplifying the input data to remove non-persistent pairs


### PR DESCRIPTION
This PR adds the GitHub Actions CI bits to run the new ttk-data Python scripts for each CI platform (using the hashes introduced in https://github.com/topology-tool-kit/ttk-data/pull/112). Additionally, it fixes several compatibility bugs in TTK:

* in TopologicalCompression, `size_t` writes were replaced with `uint64_t` (on Windows, `sizeof(size_t) == 4` instead of 8 in the other platforms). Every integer read/write now uses fixed-size integers.
* in MorseSmaleQuadrangulation, when executed in parallel, the separatrices that form the basis of the coarse-grain quadrangulation are now sorted to ensure a deterministic output.
* Python scripts in the `example` directory have been formatted using Black.
* on the Windows GitHub Actions CI, GraphViz is now correctly found by CMake.
* a bug in the MorseSmaleComplex introduced in #713 has been fixed.
* the `fetch-gh-release-asset` action has been updated to `master` since it seems to work better now.

Enjoy,
Pierre