### PR TITLE
IdentifierRandomizer: Optionally wrap values in compact range

### DIFF
--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -12,6 +12,7 @@
 #include <ttkUtils.h>
 
 #include <map>
+#include <numeric>
 #include <random>
 
 vtkStandardNewMacro(ttkIdentifierRandomizer);
@@ -47,6 +48,7 @@ int shuffleScalarFieldValues(const T *const inputField,
                              T *const outputField,
                              const int nValues,
                              const int seed,
+                             const bool compactRange,
                              const int nThreads = 1) {
 
   // copy input field into vector
@@ -58,7 +60,12 @@ int shuffleScalarFieldValues(const T *const inputField,
   inputValues.erase(last, inputValues.end());
 
   // copy the range of values
-  std::vector<T> shuffledValues(inputValues);
+  std::vector<T> shuffledValues(inputValues.size());
+  if(compactRange) {
+    std::iota(shuffledValues.begin(), shuffledValues.end(), T{});
+  } else {
+    std::copy(inputValues.begin(), inputValues.end(), shuffledValues.begin());
+  }
 
   // shuffle them using the seed
   std::mt19937 random_engine{};
@@ -131,7 +138,8 @@ int ttkIdentifierRandomizer::RequestData(vtkInformation *ttkNotUsed(request),
     vtkTemplateMacro(shuffleScalarFieldValues(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalarField)),
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputArray)),
-      outputArray->GetNumberOfTuples(), this->RandomSeed, this->threadNumber_));
+      outputArray->GetNumberOfTuples(), this->RandomSeed, this->CompactRange,
+      this->threadNumber_));
   }
 
   if(isPointData)

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.h
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.h
@@ -47,6 +47,9 @@ public:
   vtkGetMacro(RandomSeed, int);
   vtkSetMacro(RandomSeed, int);
 
+  vtkGetMacro(CompactRange, bool);
+  vtkSetMacro(CompactRange, bool);
+
 protected:
   ttkIdentifierRandomizer();
 
@@ -60,4 +63,5 @@ protected:
 
 private:
   int RandomSeed{};
+  bool CompactRange{false};
 };

--- a/paraview/xmls/IdentifierRandomizer.xml
+++ b/paraview/xmls/IdentifierRandomizer.xml
@@ -19,7 +19,7 @@
 
        - https://topology-tool-kit.github.io/examples/imageProcessing/
 
-        - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
+       - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
 
      </Documentation>
      <InputProperty
@@ -63,9 +63,21 @@
                          default_values="0">
       </IntVectorProperty>
 
+      <IntVectorProperty name="CompactRange"
+        label="Compact Range"
+        command="SetCompactRange"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Force the output values to be in the [0, #values - 1] integer range.
+        </Documentation>
+      </IntVectorProperty>
+
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="ScalarFieldNew" />
         <Property name="Seed" />
+        <Property name="CompactRange" />
       </PropertyGroup>
 
       ${DEBUG_WIDGETS}


### PR DESCRIPTION
This PR adds an optional parameter (disabled by default) to the IdentifierRandomizer filter in order to wrap the shuffled values into the `[0, #values[` integer range.

If the input values are already in this range, the output should be the same with and without this option.

Enjoy,
Pierre