### PR TITLE
Integration: Persistence diagram approximation (LDAV 21)

### DIFF
--- a/core/base/approximateTopology/ApproximateTopology.cpp
+++ b/core/base/approximateTopology/ApproximateTopology.cpp
@@ -1,0 +1,1 @@
+#include <ApproximateTopology.h>

--- a/core/base/approximateTopology/ApproximateTopology.h
+++ b/core/base/approximateTopology/ApproximateTopology.h
@@ -1,0 +1,1351 @@
+/// \ingroup base
+/// \class ttk::ApproximateTopology
+/// \author Jules Vidal <jules.vidal@lip6.fr>
+/// \date 2021.
+///
+/// \brief TTK processing package for progressive Topological Data Analysis
+///
+/// This package introduces an approximation algorithm for the
+/// computation of the extremum-saddle persistence diagram of a scalar field.
+/// The approximation comes with a user-controlled error on the Bottleneck
+/// distance to the exact diagram.
+///
+/// \b Related \b publication \n
+/// "Fast Approximation of Persistence Diagrams with Guarantees" \n
+/// Jules Vidal, Julien Tierny\n
+/// IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021
+///
+/// \sa PersistenceDiagram
+
+#pragma once
+
+// base code includes
+#include <DynamicTree.h>
+#include <ImplicitTriangulation.h>
+#include <MultiresTopology.h>
+#include <MultiresTriangulation.h>
+#include <OpenMPLock.h>
+
+#include <limits>
+#include <tuple>
+
+namespace ttk {
+
+  using triplet = std::tuple<ttk::SimplexId, ttk::SimplexId, ttk::SimplexId>;
+  using polarity = unsigned char;
+
+  class ApproximateTopology : public MultiresTopology {
+
+  public:
+    ApproximateTopology() {
+      this->setDebugMsgPrefix("ApproximateTopology");
+    }
+    void setEpsilon(double data) {
+      epsilon_ = data;
+    }
+    void setDelta(double data) {
+      delta_ = data;
+    }
+    template <typename scalarType>
+    int computeApproximatePD(std::vector<PersistencePair> &CTDiagram,
+                             const scalarType *scalars,
+                             scalarType *const fakeScalars,
+                             SimplexId *const outputOffsets,
+                             int *const outputMonotonyOffsets);
+
+    template <typename scalarType>
+    int executeApproximateTopology(const scalarType *scalars,
+                                   scalarType *fakeScalars,
+                                   SimplexId *outputOffsets,
+                                   int *outputMonotonyOffsets);
+
+    template <typename scalarType, typename offsetType>
+    void
+      initGlobalPolarity(std::vector<polarity> &isNew,
+                         std::vector<std::vector<std::pair<polarity, polarity>>>
+                           &vertexLinkPolarity,
+                         std::vector<polarity> &toProcess,
+                         const scalarType *fakeScalars,
+                         const offsetType *const offsets,
+                         const int *const monotonyOffsets) const;
+
+    template <typename scalarType, typename offsetType>
+    void updatePropagation(
+      std::vector<polarity> &toPropageMin,
+      std::vector<polarity> &toPropageMax,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+      std::vector<std::vector<SimplexId>> &saddleCCMin,
+      std::vector<std::vector<SimplexId>> &saddleCCMax,
+      std::vector<Lock> &vertLockMin,
+      std::vector<Lock> &vertLockMax,
+      std::vector<polarity> &isUpdatedMin,
+      std::vector<polarity> &isUpdatedMax,
+      const scalarType *fakeScalars,
+      const offsetType *const offsetField,
+      const int *const monotonyOffsets);
+
+    template <typename scalarType, typename offsetType>
+    void buildVertexLinkPolarityApproximate(
+      const SimplexId vertexId,
+      std::vector<std::pair<polarity, polarity>> &vlp,
+      const scalarType *fakeScalars,
+      const offsetType *const offsetField,
+      const int *const monotonyOffsets) const;
+
+    template <typename ScalarType, typename OffsetType>
+    void sortTripletsApproximate(std::vector<triplet> &triplets,
+                                 const ScalarType *const scalars,
+                                 const ScalarType *const fakeScalars,
+                                 const OffsetType *const offsets,
+                                 const int *const monotonyOffsets,
+                                 const bool splitTree) const;
+
+    template <typename scalarType, typename offsetType>
+    void getCriticalTypeApproximate(
+      const SimplexId &vertexId,
+      std::vector<std::pair<polarity, polarity>> &vlp,
+      uint8_t &vertexLink,
+      DynamicTree &link,
+      VLBoundaryType &vlbt,
+      const scalarType *fakeScalars,
+      const offsetType *const offsets,
+      const int *const monotonyOffsets) const;
+
+    template <typename ScalarType, typename offsetType>
+    void computeCriticalPoints(
+      std::vector<std::vector<std::pair<polarity, polarity>>>
+        &vertexLinkPolarity,
+      std::vector<polarity> &toPropageMin,
+      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toProcess,
+      std::vector<DynamicTree> &link,
+      std::vector<uint8_t> &vertexLink,
+      VLBoundaryType &vertexLinkByBoundaryType,
+      std::vector<std::vector<SimplexId>> &saddleCCMin,
+      std::vector<std::vector<SimplexId>> &saddleCCMax,
+      ScalarType *fakeScalars,
+      const offsetType *const offsets,
+      int *monotonyOffsets);
+
+    template <typename scalarType, typename offsetType>
+    ttk::SimplexId propageFromSaddles(
+      const SimplexId vertexId,
+      std::vector<Lock> &vertLock,
+      std::vector<polarity> &toPropage,
+      std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+      std::vector<std::vector<SimplexId>> &saddleCC,
+      std::vector<polarity> &isUpdated,
+      std::vector<SimplexId> &globalExtremum,
+      const bool splitTree,
+      const scalarType *fakeScalars,
+      const offsetType *const offsetField,
+      const int *const monotonyOffsets) const;
+
+    template <typename ScalarType, typename offsetType>
+    void computePersistencePairsFromSaddles(
+      std::vector<PersistencePair> &CTDiagram,
+      const ScalarType *const fakeScalars,
+      const offsetType *const offsets,
+      const int *const monotonyOffsets,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+      const std::vector<polarity> &toPropageMin,
+      const std::vector<polarity> &toPropageMax) const;
+
+    template <typename scalarType, typename offsetType>
+    void sortVertices(const SimplexId vertexNumber,
+                      std::vector<SimplexId> &sortedVertices,
+                      SimplexId *vertsOrder,
+                      const scalarType *const fakeScalars,
+                      const offsetType *const offsetField,
+                      const int *const monotonyOffsets);
+
+    template <typename scalarType>
+    int sortPersistenceDiagramApproximate(std::vector<PersistencePair> &diagram,
+                                          const scalarType *const scalars,
+                                          scalarType *fakeScalars,
+                                          const SimplexId *const offsets,
+                                          int *monotonyOffsets) const;
+
+  protected:
+    void sortPersistenceDiagram2(std::vector<PersistencePair> &diagram,
+                                 const SimplexId *const offsets) const;
+
+    // maximum link size in 3D
+    static const size_t nLink_ = 27;
+    using VLBoundaryType
+      = std::array<std::vector<std::pair<SimplexId, SimplexId>>, nLink_>;
+
+    void
+      initCriticalPoints(std::vector<polarity> &isNew,
+                         std::vector<std::vector<std::pair<polarity, polarity>>>
+                           &vertexLinkPolarity,
+                         std::vector<polarity> &toProcess,
+                         std::vector<DynamicTree> &link,
+                         std::vector<uint8_t> &vertexLink,
+                         VLBoundaryType &vertexLinkByBoundaryType,
+                         std::vector<char> &vertexTypes,
+                         const SimplexId *const offsets) const;
+
+    void initSaddleSeeds(std::vector<polarity> &isNew,
+                         std::vector<std::vector<std::pair<polarity, polarity>>>
+                           &vertexLinkPolarity,
+                         std::vector<polarity> &toPropageMin,
+                         std::vector<polarity> &toPropageMax,
+                         std::vector<polarity> &toProcess,
+                         std::vector<DynamicTree> &link,
+                         std::vector<uint8_t> &vertexLink,
+                         VLBoundaryType &vertexLinkByBoundaryType,
+                         std::vector<std::vector<SimplexId>> &saddleCCMin,
+                         std::vector<std::vector<SimplexId>> &saddleCCMax,
+                         const SimplexId *const offsets) const;
+
+    template <typename scalarType, typename offsetType>
+    void updatePropagation(
+      std::vector<polarity> &toPropageMin,
+      std::vector<polarity> &toPropageMax,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+      std::vector<std::vector<SimplexId>> &saddleCCMin,
+      std::vector<std::vector<SimplexId>> &saddleCCMax,
+      std::vector<Lock> &vertLockMin,
+      std::vector<Lock> &vertLockMax,
+      std::vector<polarity> &isUpdatedMin,
+      std::vector<polarity> &isUpdatedMax,
+      const scalarType *fakeScalars,
+      const offsetType *const offsets,
+      const int *const monotonyOffsets) const;
+
+    template <typename scalarType, typename offsetType>
+    void
+      buildVertexLinkPolarity(const SimplexId vertexId,
+                              std::vector<std::pair<polarity, polarity>> &vlp,
+                              const scalarType *fakeScalars,
+                              const offsetType *const offsets,
+                              const int *const monotonyOffsets) const;
+
+    template <typename ScalarType, typename OffsetType>
+    void sortTriplets(std::vector<triplet> &triplets,
+                      const ScalarType *const fakeScalars,
+                      const OffsetType *const offsets,
+                      const int *const monotonyOffsets,
+                      const bool splitTree) const;
+
+    template <typename scalarType, typename offsetType>
+    void tripletsToPersistencePairs(
+      std::vector<PersistencePair> &pairs,
+      std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+      std::vector<triplet> &triplets,
+      const scalarType *const fakeScalars,
+      const offsetType *const offsets,
+      const int *const monotonyOffsets,
+      const bool splitTree) const;
+
+    template <typename scalarType, typename offsetType>
+    int getMonotonyChangeByOldPointCPApproximate(
+      const SimplexId vertexId,
+      double eps,
+      const std::vector<polarity> &isNew,
+      std::vector<polarity> &toProcess,
+      std::vector<polarity> &toReprocess,
+      std::vector<std::pair<polarity, polarity>> &vlp,
+      scalarType *fakeScalars,
+      const offsetType *const offsets,
+      int *monotonyOffsets) const;
+
+    template <typename ScalarType, typename offsetType>
+    int updateGlobalPolarity(
+      double eps,
+      std::vector<polarity> &isNew,
+      std::vector<std::vector<std::pair<polarity, polarity>>>
+        &vertexLinkPolarity,
+      std::vector<polarity> &toProcess,
+      std::vector<polarity> &toReprocess,
+      ScalarType *fakeScalars,
+      const offsetType *const offsets,
+      int *monotonyOffsets) const;
+
+    ttk::SimplexId propageFromSaddles(
+      const SimplexId vertexId,
+      std::vector<Lock> &vertLock,
+      std::vector<polarity> &toPropage,
+      std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+      std::vector<std::vector<SimplexId>> &saddleCC,
+      std::vector<polarity> &isUpdated,
+      std::vector<SimplexId> &globalExtremum,
+      const SimplexId *const offsets,
+      const bool splitTree) const;
+
+    void computePersistencePairsFromSaddles(
+      std::vector<PersistencePair> &CTDiagram,
+      const SimplexId *const offsets,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+      std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+      const std::vector<polarity> &toPropageMin,
+      const std::vector<polarity> &toPropageMax) const;
+
+    template <typename scalarType, typename offsetType>
+    bool printPolarity(std::vector<polarity> &isNew,
+                       const SimplexId vertexId,
+                       std::vector<std::vector<std::pair<polarity, polarity>>>
+                         &vertexLinkPolarity,
+                       const scalarType *scalars,
+                       const scalarType *fakeScalars,
+                       const offsetType *const offsets,
+                       const int *const monotonyOffsets,
+                       bool verbose = false);
+
+    double epsilon_{};
+    double delta_{};
+  };
+} // namespace ttk
+
+template <typename scalarType>
+int ttk::ApproximateTopology::executeApproximateTopology(
+  const scalarType *scalars,
+  scalarType *fakeScalars,
+  SimplexId *outputOffsets,
+  int *outputMonotonyOffsets) {
+
+  Timer timer;
+
+  SimplexId *const vertsOrder = static_cast<SimplexId *>(outputOffsets);
+
+  decimationLevel_ = startingDecimationLevel_;
+  multiresTriangulation_.setTriangulation(triangulation_);
+  const SimplexId vertexNumber = multiresTriangulation_.getVertexNumber();
+
+  int *monotonyOffsets = static_cast<SimplexId *>(outputMonotonyOffsets);
+
+#ifdef TTK_ENABLE_KAMIKAZE
+  if(vertexNumber == 0) {
+    this->printErr("No points in triangulation");
+    return 1;
+  }
+#endif // TTK_ENABLE_KAMIKAZE
+
+  double tm_allocation = timer.getElapsedTime();
+
+  const auto dim = multiresTriangulation_.getDimensionality();
+  const size_t maxNeigh = dim == 3 ? 14 : (dim == 2 ? 6 : 0);
+
+  std::vector<std::vector<SimplexId>> saddleCCMin(vertexNumber),
+    saddleCCMax(vertexNumber);
+  std::vector<std::vector<SimplexId>> vertexRepresentativesMin(vertexNumber),
+    vertexRepresentativesMax(vertexNumber);
+
+  std::vector<std::vector<std::pair<polarity, polarity>>> vertexLinkPolarity(
+    vertexNumber);
+
+  std::vector<polarity> isNew(vertexNumber, 255);
+  std::vector<polarity> toPropageMin(vertexNumber, 0),
+    toPropageMax(vertexNumber, 0);
+  std::vector<polarity> isUpToDateMin(vertexNumber, 0),
+    isUpToDateMax(vertexNumber, 0);
+
+  // index in vertexLinkByBoundaryType
+  std::vector<uint8_t> vertexLink(vertexNumber);
+  VLBoundaryType vertexLinkByBoundaryType{};
+  std::vector<DynamicTree> link(vertexNumber);
+  std::vector<polarity> toProcess(vertexNumber, 0), toReprocess{};
+
+  std::vector<SimplexId> offsetsVec(vertexNumber);
+  std::iota(offsetsVec.begin(), offsetsVec.end(), 0);
+  const SimplexId *const offsets = offsetsVec.data();
+
+  if(this->startingDecimationLevel_ > this->stoppingDecimationLevel_) {
+    // only needed for progressive computation
+    toReprocess.resize(vertexNumber, 0);
+  }
+
+  std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
+
+  if(preallocateMemory_) {
+    double tm_prealloc = timer.getElapsedTime();
+    printMsg("Pre-allocating data structures", 0, 0, threadNumber_,
+             ttk::debug::LineMode::REPLACE);
+    for(SimplexId i = 0; i < vertexNumber; ++i) {
+      // for(int d = 0; d < vertexLinkPolarity.size(); d++) {
+      //   vertexLinkPolarity[d][i].reserve(maxNeigh);
+      // }
+      vertexLinkPolarity[i].reserve(maxNeigh);
+      link[i].alloc(maxNeigh);
+    }
+    printMsg("Pre-allocating data structures", 1,
+             timer.getElapsedTime() - tm_prealloc, threadNumber_);
+  }
+
+  tm_allocation = timer.getElapsedTime() - tm_allocation;
+  printMsg("Total memory allocation", 1, tm_allocation, threadNumber_);
+
+  // computation of implicit link
+  std::vector<SimplexId> boundReps{};
+  multiresTriangulation_.findBoundaryRepresentatives(boundReps);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(size_t i = 0; i < boundReps.size(); i++) {
+    if(boundReps[i] != -1) {
+      buildVertexLinkByBoundary(boundReps[i], vertexLinkByBoundaryType);
+    }
+  }
+
+  // if(debugLevel_ > 4) {
+  //   std::cout << "boundary representatives : ";
+  //   for(auto bb : boundReps) {
+  //     std::cout << ", " << bb;
+  //   }
+  //   std::cout << std::endl;
+  // }
+
+  multiresTriangulation_.setDecimationLevel(decimationLevel_);
+
+  initGlobalPolarity(isNew, vertexLinkPolarity, toProcess, fakeScalars, offsets,
+                     monotonyOffsets);
+
+  double delta = epsilon_ * delta_;
+
+  while(decimationLevel_ > stoppingDecimationLevel_) {
+    Timer tmIter{};
+    decimationLevel_--;
+    multiresTriangulation_.setDecimationLevel(decimationLevel_);
+    // double progress = (double)(startingDecimationLevel_ - decimationLevel_)
+    //                   / (startingDecimationLevel_);
+    // this->printMsg("decimation level: " + std::to_string(decimationLevel_),
+    //                progress, timer.getElapsedTime() - tm_allocation,
+    //                threadNumber_);
+
+    int ret = updateGlobalPolarity(delta, isNew, vertexLinkPolarity, toProcess,
+                                   toReprocess, fakeScalars, offsets,
+                                   monotonyOffsets);
+    if(ret == -1) {
+      std::cout << "Found ERROR - aborting" << std::endl;
+      return -1;
+    }
+  } // end while
+
+  computeCriticalPoints(vertexLinkPolarity, toPropageMin, toPropageMax,
+                        toProcess, link, vertexLink, vertexLinkByBoundaryType,
+                        saddleCCMin, saddleCCMax, fakeScalars, offsets,
+                        monotonyOffsets);
+
+  updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
+                    vertexRepresentativesMax, saddleCCMin, saddleCCMax,
+                    vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
+                    fakeScalars, offsets, monotonyOffsets);
+
+  computePersistencePairsFromSaddles(
+    CTDiagram_, fakeScalars, offsets, monotonyOffsets, vertexRepresentativesMin,
+    vertexRepresentativesMax, toPropageMin, toPropageMax);
+  // ADD GLOBAL MIN-MAX PAIR
+  CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
+  // fakeScalars[this->globalMax_] - fakeScalars[this->globalMin_], -1);
+
+  // std::cout << "# epsilon " << epsilon_ << " in "
+  //           << timer.getElapsedTime() - tm_allocation << " s." << std::endl;
+
+  this->printMsg("Complete", 1.0, timer.getElapsedTime() - tm_allocation,
+                 this->threadNumber_);
+
+  // finally sort the diagram
+  // std::cout << "SORTING" << std::endl;
+  sortPersistenceDiagramApproximate(
+    CTDiagram_, scalars, fakeScalars, offsets, monotonyOffsets);
+  // std::cout << "Final epsilon " << epsilon_ << std::endl;
+
+  // sort vertices to generate correct output offset order
+  std::vector<SimplexId> sortedVertices{};
+  sortVertices(vertexNumber, sortedVertices, vertsOrder, fakeScalars, offsets,
+               monotonyOffsets);
+  return 0;
+}
+
+template <typename ScalarType, typename OffsetType>
+void ttk::ApproximateTopology::computePersistencePairsFromSaddles(
+  std::vector<PersistencePair> &CTDiagram,
+  const ScalarType *const fakeScalars,
+  const OffsetType *const offsets,
+  const int *const monotonyOffsets,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+  const std::vector<polarity> &toPropageMin,
+  const std::vector<polarity> &toPropageMax) const {
+
+  Timer timer{};
+  // CTDiagram.clear();
+  std::vector<triplet> tripletsMax{}, tripletsMin{};
+  const SimplexId nbDecVert = multiresTriangulation_.getDecimatedVertexNumber();
+
+  for(SimplexId localId = 0; localId < nbDecVert; localId++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
+    if(toPropageMin[globalId]) {
+      getTripletsFromSaddles(globalId, tripletsMin, vertexRepresentativesMin);
+    }
+    if(toPropageMax[globalId]) {
+      getTripletsFromSaddles(globalId, tripletsMax, vertexRepresentativesMax);
+    }
+  }
+
+  sortTriplets(tripletsMax, fakeScalars, offsets, monotonyOffsets, true);
+  sortTriplets(tripletsMin, fakeScalars, offsets, monotonyOffsets, false);
+
+  const auto tm_sort = timer.getElapsedTime();
+
+  typename std::remove_reference<decltype(CTDiagram)>::type CTDiagramMin{},
+    CTDiagramMax{};
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel sections num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp section
+#endif // TTK_ENABLE_OPENMP
+    tripletsToPersistencePairs(CTDiagramMin, vertexRepresentativesMax,
+                               tripletsMax, fakeScalars, offsets,
+                               monotonyOffsets, true);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp section
+#endif // TTK_ENABLE_OPENMP
+    tripletsToPersistencePairs(CTDiagramMax, vertexRepresentativesMin,
+                               tripletsMin, fakeScalars, offsets,
+                               monotonyOffsets, false);
+  }
+  CTDiagram = std::move(CTDiagramMin);
+  CTDiagram.insert(CTDiagram.end(), CTDiagramMax.begin(), CTDiagramMax.end());
+
+  if(debugLevel_ > 3) {
+    std::cout << "PAIRS " << timer.getElapsedTime() - tm_sort << std::endl;
+  }
+}
+
+template <typename ScalarType, typename OffsetType>
+void ttk::ApproximateTopology::sortTriplets(std::vector<triplet> &triplets,
+                                            const ScalarType *const fakeScalars,
+                                            const OffsetType *const offsets,
+                                            const int *const monotonyOffsets,
+                                            const bool splitTree) const {
+  if(triplets.empty())
+    return;
+
+  // const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+  //   return (scalars[a] < scalars[b])
+  //          || (scalars[a] == scalars[b] && offsets[a] < offsets[b]);
+  // };
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return ((fakeScalars[a] < fakeScalars[b])
+            || (fakeScalars[a] == fakeScalars[b]
+                && ((monotonyOffsets[a] < monotonyOffsets[b])
+                    || (monotonyOffsets[a] == monotonyOffsets[b]
+                        && offsets[a] < offsets[b]))));
+  };
+
+  // Sorting step
+  const auto cmp = [=](const triplet &t1, const triplet &t2) {
+    const SimplexId s1 = std::get<0>(t1);
+    const SimplexId s2 = std::get<0>(t2);
+    const SimplexId m1 = std::get<2>(t1);
+    const SimplexId m2 = std::get<2>(t2);
+    if(s1 != s2)
+      return lt(s1, s2) != splitTree;
+    else // s1 == s2
+      return lt(m1, m2) == splitTree;
+  };
+
+  PSORT(this->threadNumber_)(triplets.begin(), triplets.end(), cmp);
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::tripletsToPersistencePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+  std::vector<triplet> &triplets,
+  const scalarType *const fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets,
+
+  const bool splitTree) const {
+  Timer tm;
+  if(triplets.empty())
+    return;
+  size_t numberOfPairs = 0;
+
+  // // accelerate getRep lookup?
+  // std::vector<SimplexId> firstRep(vertexRepresentatives.size());
+
+  // #ifdef TTK_ENABLE_OPENMP
+  // #pragma omp parallel for num_threads(threadNumber_)
+  // #endif // TTK_ENABLE_OPENMP
+  //   for(size_t i = 0; i < firstRep.size(); ++i) {
+  //     if(!vertexRepresentatives[i].empty()) {
+  //       firstRep[i] = vertexRepresentatives[i][0];
+  //     }
+  //   }
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return ((fakeScalars[a] < fakeScalars[b])
+            || (fakeScalars[a] == fakeScalars[b]
+                && ((monotonyOffsets[a] < monotonyOffsets[b])
+                    || (monotonyOffsets[a] == monotonyOffsets[b]
+                        && offsets[a] < offsets[b]))));
+  };
+
+  const auto getRep = [&](SimplexId v) -> SimplexId {
+    auto r = vertexRepresentatives[v][0];
+    while(r != v) {
+      v = r;
+      r = vertexRepresentatives[v][0];
+    }
+    return r;
+  };
+
+  for(const auto &t : triplets) {
+    SimplexId r1 = getRep(std::get<1>(t));
+    SimplexId r2 = getRep(std::get<2>(t));
+    if(r1 != r2) {
+      SimplexId s = std::get<0>(t);
+      numberOfPairs++;
+
+      // Add pair
+      if(splitTree) {
+        // r1 = min(r1, r2), r2 = max(r1, r2)
+        if(lt(r2, r1)) {
+          std::swap(r1, r2);
+        }
+        // pair saddle-max: s -> min(r1, r2);
+        pairs.emplace_back(s, r1, 2);
+        // fakeScalars[r1] - fakeScalars[s], 2);
+
+      } else {
+        // r1 = max(r1, r2), r2 = min(r1, r2)
+        if(lt(r1, r2)) {
+          std::swap(r1, r2);
+        }
+        // pair min-saddle: max(r1, r2) -> s;
+        pairs.emplace_back(r1, s, 0);
+        // fakeScalars[s] - fakeScalars[r1], 0);
+      }
+
+      vertexRepresentatives[std::get<1>(t)][0] = r2;
+      vertexRepresentatives[r1][0] = r2;
+      // vertexRepresentatives[std::get<1>(t)][0] = r2;
+      // vertexRepresentatives[r1][0] = r2;
+    }
+  }
+
+  if(debugLevel_ > 3) {
+    std::string prefix = splitTree ? "[sad-max]" : "[min-sad]";
+    std::cout << prefix << "  found all pairs in " << tm.getElapsedTime()
+              << " s." << std::endl;
+  }
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::sortVertices(
+  const SimplexId vertexNumber,
+  std::vector<SimplexId> &sortedVertices,
+  SimplexId *vertsOrder,
+  const scalarType *const fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) {
+
+  Timer tm;
+
+  sortedVertices.resize(vertexNumber);
+
+  // fill with numbers from 0 to vertexNumber - 1
+  std::iota(sortedVertices.begin(), sortedVertices.end(), 0);
+
+  // sort vertices in ascending order following scalarfield / offsets
+  PSORT(this->threadNumber_)
+  (sortedVertices.begin(), sortedVertices.end(),
+   [&](const SimplexId a, const SimplexId b) {
+     return ((fakeScalars[a] < fakeScalars[b])
+             || (fakeScalars[a] == fakeScalars[b]
+                 && ((monotonyOffsets[a] < monotonyOffsets[b])
+                     || (monotonyOffsets[a] == monotonyOffsets[b]
+                         && offsets[a] < offsets[b]))));
+   });
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < sortedVertices.size(); ++i) {
+    vertsOrder[sortedVertices[i]] = i;
+  }
+
+  // if(debugLevel_ > 2) {
+  //   std::cout << "SORT " << tm.getElapsedTime() << std::endl;
+  // }
+}
+
+template <typename scalarType, typename offsetType>
+int ttk::ApproximateTopology::getMonotonyChangeByOldPointCPApproximate(
+  const SimplexId vertexId,
+  double eps,
+  const std::vector<polarity> &isNew,
+  std::vector<polarity> &toProcess,
+  std::vector<polarity> &toReprocess,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  scalarType *fakeScalars,
+  const offsetType *const offsets,
+  int *monotonyOffsets) const {
+
+  int hasMonotonyChanged = 0;
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  for(SimplexId i = 0; i < neighborNumber; i++) {
+    SimplexId neighborId = -1;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
+
+    // check for monotony changes
+    // const bool lowerStatic
+    //   = (scalarField[neighborId] < fakeScalars[vertexId])
+    //     || ((scalarField[neighborId] == fakeScalars[vertexId])
+    //         && (offsets[neighborId] < offsets[vertexId]));
+    const bool lowerDynamic
+      = ((fakeScalars[neighborId] < fakeScalars[vertexId])
+         || (fakeScalars[neighborId] == fakeScalars[vertexId]
+             && ((monotonyOffsets[neighborId] < monotonyOffsets[vertexId])
+                 || (monotonyOffsets[neighborId] == monotonyOffsets[vertexId]
+                     && offsets[neighborId] < offsets[vertexId]))));
+
+    const polarity isUpperDynamic = lowerDynamic ? 0 : 255;
+    // const polarity isUpperStatic = lowerStatic ? 0 : 255;
+    const polarity isUpperOld = vlp[i].first;
+
+    if(isUpperDynamic != isUpperOld) { // change of monotony
+      SimplexId oldNeighbor = -1;
+      int oldDecimation = pow(2, decimationLevel_ + 1);
+      multiresTriangulation_.getVertexNeighborAtDecimation(
+        vertexId, i, oldNeighbor, oldDecimation);
+
+      double replacementValueDynamic
+        = (0.5 * (double)fakeScalars[oldNeighbor]
+           + .5 * (double)fakeScalars[vertexId]); // depends on epsilon
+      double deltaDynamic
+        = abs((double)fakeScalars[neighborId] - replacementValueDynamic);
+
+      //=====================
+      SimplexId oldNeighNumber = 0;
+      SimplexId nnumber
+        = multiresTriangulation_.getVertexNeighborNumber(neighborId);
+      for(int iii = 0; iii < nnumber; iii++) {
+        SimplexId neighborId2 = -1;
+        multiresTriangulation_.getVertexNeighbor(neighborId, iii, neighborId2);
+        if(!isNew[neighborId2]) {
+          oldNeighNumber++;
+        }
+      }
+
+      if(deltaDynamic > eps or !isNew[neighborId] or oldNeighNumber > 2) {
+        hasMonotonyChanged = 1;
+
+        toReprocess[vertexId] = 255;
+        if(isNew[neighborId]) {
+          toProcess[neighborId] = 255;
+        } else {
+          toReprocess[neighborId] = 255;
+        }
+        const SimplexId neighborNumberNew
+          = multiresTriangulation_.getVertexNeighborNumber(neighborId);
+        for(SimplexId j = 0; j < neighborNumberNew; j++) {
+          SimplexId neighborIdNew = -1;
+          multiresTriangulation_.getVertexNeighbor(
+            neighborId, j, neighborIdNew);
+          if(isNew[neighborIdNew])
+            toProcess[neighborIdNew] = 255;
+        }
+        vlp[i].second = 255;
+      } else {
+        fakeScalars[neighborId] = replacementValueDynamic;
+
+        // corrects rounding error when we process an integer scalar field
+        if(fakeScalars[neighborId] == fakeScalars[oldNeighbor]) {
+          fakeScalars[neighborId] = fakeScalars[vertexId];
+        }
+
+        // change monotony offset
+        // The monotony must be preserved, meaning that
+        // if we had f(vertexId)>f(oldNeighbor)
+        // we should have f(vertexId)>f(neighborId)
+        // which is enforced when
+        // monotonyOffsets[vertexId]>monotonyOffsets[neighborId]
+        if(isUpperOld) { // we should enforce f(vertexId)<f(neighborId)
+          if(offsets[vertexId] > offsets[neighborId]) {
+            monotonyOffsets[neighborId]
+              = monotonyOffsets[vertexId] + pow(2, decimationLevel_);
+            if(monotonyOffsets[vertexId] == monotonyOffsets[oldNeighbor]
+               and fakeScalars[vertexId] == fakeScalars[oldNeighbor]) {
+              std::cout << "THIS IS AN ISSUE" << std::endl;
+            }
+          } else {
+            monotonyOffsets[neighborId] = monotonyOffsets[vertexId];
+          }
+        } else { // we should enforce f(vertexId)>f(neighborId)
+          if(offsets[vertexId] < offsets[neighborId]) {
+            monotonyOffsets[neighborId]
+              = monotonyOffsets[vertexId] - pow(2, decimationLevel_);
+            if(monotonyOffsets[vertexId] == monotonyOffsets[oldNeighbor]
+               and fakeScalars[vertexId] == fakeScalars[oldNeighbor]) {
+              std::cout << "THIS IS AN ISSUE" << std::endl;
+            }
+          } else {
+            monotonyOffsets[neighborId] = monotonyOffsets[vertexId];
+          }
+        }
+      }
+    } // end if change of monotony
+  } // end for neighbors
+  return hasMonotonyChanged;
+}
+
+template <typename scalarType, typename offsetType>
+ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
+  const SimplexId vertexId,
+  std::vector<Lock> &vertLock,
+  std::vector<polarity> &toPropage,
+  std::vector<std::vector<SimplexId>> &vertexRepresentatives,
+  std::vector<std::vector<SimplexId>> &saddleCC,
+  std::vector<polarity> &isUpdated,
+  std::vector<SimplexId> &globalExtremum,
+  const bool splitTree,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) const {
+
+  auto &toProp = toPropage[vertexId];
+  auto &reps = vertexRepresentatives[vertexId];
+  auto &updated = isUpdated[vertexId];
+
+  if(updated) {
+    return reps[0];
+  }
+
+  // const auto gt = [=](const SimplexId v1, const SimplexId v2) {
+  //   return ((fakeScalars[v1] > fakeScalars[v2])
+  //           || (fakeScalars[v1] == fakeScalars[v2]
+  //               && offsets[v1] > offsets[v2]))
+  //          == splitTree;
+  // };
+  const auto gt = [=](const SimplexId v1, const SimplexId v2) {
+    return ((fakeScalars[v1] > fakeScalars[v2])
+            || (fakeScalars[v1] == fakeScalars[v2]
+                && ((monotonyOffsets[v1] > monotonyOffsets[v2])
+                    || (monotonyOffsets[v1] == monotonyOffsets[v2]
+                        && offsets[v1] > offsets[v2]))))
+           == splitTree;
+  };
+
+  if(this->threadNumber_ > 1) {
+    vertLock[vertexId].lock();
+  }
+  if(saddleCC[vertexId].size()
+     and !toProp) { // tis a saddle point, should have to propage on it
+    printErr("ERRRROR");
+  }
+  if(toProp) { // SADDLE POINT
+    if(debugLevel_ > 5)
+      printMsg("to saddle " + std::to_string(vertexId) + " "
+               + std::to_string(saddleCC[vertexId].size()));
+    // for(auto ccid : saddleCC[vertexId]) {
+    //   SimplexId ccV = -1;
+    //   multiresTriangulation_.getVertexNeighbor(vertexId, ccid, ccV);
+    //   std::cout << " " << ccid << " (" << ccV << ") , ";
+    // }
+    // std::cout << std::endl;
+    const auto &CC = saddleCC[vertexId];
+    reps.clear();
+    reps.reserve(CC.size());
+    for(size_t r = 0; r < CC.size(); r++) {
+      SimplexId neighborId = -1;
+      SimplexId localId = CC[r];
+      multiresTriangulation_.getVertexNeighbor(vertexId, localId, neighborId);
+      // printMsg("       CC " + std::to_string(CC[r]) + " "
+      //          + std::to_string(neighborId) + " ("
+      //          + std::to_string(fakeScalars[neighborId]) + " , "
+      //          + std::to_string(offsets[neighborId]) + ")");
+      SimplexId ret = propageFromSaddles(neighborId, vertLock, toPropage,
+                                         vertexRepresentatives, saddleCC,
+                                         isUpdated, globalExtremum, splitTree,
+                                         fakeScalars, offsets, monotonyOffsets);
+      reps.emplace_back(ret);
+    }
+
+    if(reps.size() > 1) {
+      // sort & remove duplicate elements
+      std::sort(reps.begin(), reps.end(), gt);
+      const auto last = std::unique(reps.begin(), reps.end());
+      reps.erase(last, reps.end());
+    }
+
+    updated = 255;
+    if(this->threadNumber_ > 1) {
+      vertLock[vertexId].unlock();
+    }
+
+    return reps[0];
+
+  } else {
+    if(debugLevel_ > 5)
+      printMsg("to non saddle " + std::to_string(vertexId) + " "
+               + std::to_string(saddleCC[vertexId].size()));
+
+    SimplexId ret = vertexId;
+    SimplexId neighborNumber
+      = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+    SimplexId maxNeighbor = vertexId;
+    // std::cout << "neigh number" << neighborNumber << std::endl;
+    for(SimplexId i = 0; i < neighborNumber; i++) {
+      SimplexId neighborId = -1;
+      multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId);
+      if(gt(neighborId, maxNeighbor)) {
+        maxNeighbor = neighborId;
+      }
+    }
+    if(maxNeighbor != vertexId) { // not an extremum
+      ret = propageFromSaddles(maxNeighbor, vertLock, toPropage,
+                               vertexRepresentatives, saddleCC, isUpdated,
+                               globalExtremum, splitTree, fakeScalars, offsets,
+                               monotonyOffsets);
+
+    } else { // needed to find the globalExtremum per thread
+#ifdef TTK_ENABLE_OPENMP
+      const auto tid = omp_get_thread_num();
+#else
+      const auto tid = 0;
+#endif // TTK_ENABLE_OPENMP
+      if(gt(vertexId, globalExtremum[tid])) {
+        // if(splitTree)
+        //   std::cout << "new global max " << std::endl;
+        // else
+        //   std::cout << "new global min " << std::endl;
+        globalExtremum[tid] = vertexId;
+      }
+    }
+    reps.resize(1);
+    reps[0] = ret;
+    updated = 255;
+    if(this->threadNumber_ > 1) {
+      vertLock[vertexId].unlock();
+    }
+    return ret;
+  }
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::updatePropagation(
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
+  std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  std::vector<Lock> &vertLockMin,
+  std::vector<Lock> &vertLockMax,
+  std::vector<polarity> &isUpdatedMin,
+  std::vector<polarity> &isUpdatedMax,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) {
+
+  Timer tm{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  if(debugLevel_ > 5) {
+    const auto pred = [](const polarity a) { return a > 0; };
+    const auto numberOfCandidatesToPropageMax
+      = std::count_if(toPropageMax.begin(), toPropageMax.end(), pred);
+    std::cout << " sad-max we have " << numberOfCandidatesToPropageMax
+              << " vertices to propage from outta " << nDecVerts << std::endl;
+    const auto numberOfCandidatesToPropageMin
+      = std::count_if(toPropageMin.begin(), toPropageMin.end(), pred);
+    std::cout << " min-sad we have " << numberOfCandidatesToPropageMin
+              << " vertices to propage from outta " << nDecVerts << std::endl;
+  }
+
+  std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
+  std::vector<SimplexId> globalMinThr(threadNumber_, 0);
+
+  // reset updated flag
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
+    isUpdatedMin[v] = 0;
+    isUpdatedMax[v] = 0;
+  }
+
+  // propage along split tree
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
+    if(toPropageMin[v]) {
+      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
+                         saddleCCMin, isUpdatedMin, globalMinThr, false,
+                         fakeScalars, offsets, monotonyOffsets);
+    }
+    if(toPropageMax[v]) {
+      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
+                         saddleCCMax, isUpdatedMax, globalMaxThr, true,
+                         fakeScalars, offsets, monotonyOffsets);
+    }
+  }
+
+  const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
+    return ((fakeScalars[a] < fakeScalars[b])
+            || (fakeScalars[a] == fakeScalars[b]
+                && ((monotonyOffsets[a] < monotonyOffsets[b])
+                    || (monotonyOffsets[a] == monotonyOffsets[b]
+                        && offsets[a] < offsets[b]))));
+  };
+
+  globalMin_ = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
+  globalMax_ = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
+
+  if(globalMin_ == 0 or globalMax_ == 0) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < nDecVerts; i++) {
+      SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
+
+#ifdef TTK_ENABLE_OPENMP
+      const auto tid = omp_get_thread_num();
+#else
+      const auto tid = 0;
+#endif // TTK_ENABLE_OPENMP
+
+      if(lt(globalMaxThr[tid], v)) {
+        globalMaxThr[tid] = v;
+      }
+      if(lt(v, globalMinThr[tid])) {
+        globalMinThr[tid] = v;
+      }
+    }
+    globalMin_
+      = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
+    globalMax_
+      = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
+    // printMsg("Explicitely found global extremas");
+  }
+  if(debugLevel_ > 3) {
+    printMsg("Propagation Update", 1, tm.getElapsedTime(), threadNumber_);
+  }
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::buildVertexLinkPolarityApproximate(
+  const SimplexId vertexId,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) const {
+
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  vlp.resize(neighborNumber);
+
+  for(SimplexId i = 0; i < neighborNumber; i++) {
+    SimplexId neighborId0 = 0;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, neighborId0);
+
+    // const bool lower0 = vertsOrder_[neighborId0] < vertsOrder_[vertexId];
+    const bool lower0
+      = ((fakeScalars[neighborId0] < fakeScalars[vertexId])
+         || (fakeScalars[neighborId0] == fakeScalars[vertexId]
+             && ((monotonyOffsets[neighborId0] < monotonyOffsets[vertexId])
+                 || (monotonyOffsets[neighborId0] == monotonyOffsets[vertexId]
+                     && offsets[neighborId0] < offsets[vertexId]))));
+
+    const polarity isUpper0 = static_cast<polarity>(!lower0) * 255;
+    vlp[i] = std::make_pair(isUpper0, 0);
+  }
+}
+
+template <typename scalarType, typename offsetType>
+bool ttk::ApproximateTopology::printPolarity(
+  std::vector<polarity> &isNew,
+  const SimplexId vertexId,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  const scalarType *scalars,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets,
+  bool verbose) {
+
+  bool error = false;
+  std::stringstream mymsg;
+  std::vector<std::pair<polarity, polarity>> &vlp
+    = vertexLinkPolarity[vertexId];
+  mymsg << "POLARITY PRINT"
+        << "\n";
+  mymsg << "vertex " << vertexId << " has "
+        << multiresTriangulation_.getVertexNeighborNumber(vertexId)
+        << " neighbors"
+        << "\n";
+  mymsg << "\tself  f:" << fakeScalars[vertexId] << " s:" << scalars[vertexId]
+        << " o:" << offsets[vertexId] << " m:" << monotonyOffsets[vertexId]
+        << "  isnew: " << (int)isNew[vertexId] << "\n";
+  if(vlp.empty()) {
+    if(verbose) {
+      std::cout << "\tpolarity not initialized for " << vertexId << std::endl;
+      std::cout << mymsg.str() << std::endl;
+    }
+    return false;
+  }
+  for(size_t i = 0;
+      i < multiresTriangulation_.getVertexNeighborNumber(vertexId); i++) {
+    SimplexId nId = -1;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, nId);
+    // find reverse pol
+    std::vector<std::pair<polarity, polarity>> &vlp2 = vertexLinkPolarity[nId];
+    bool init = false;
+    polarity rpol;
+    if(!vlp2.empty()) {
+      for(size_t j = 0; j < multiresTriangulation_.getVertexNeighborNumber(nId);
+          j++) {
+        SimplexId nId2 = -1;
+        multiresTriangulation_.getVertexNeighbor(nId, j, nId2);
+        if(nId2 == vertexId) {
+          rpol = vlp2[j].first;
+          init = true;
+        }
+      }
+    }
+
+    const bool lower
+      = ((fakeScalars[nId] < fakeScalars[vertexId])
+         || (fakeScalars[nId] == fakeScalars[vertexId]
+             && ((monotonyOffsets[nId] < monotonyOffsets[vertexId])
+                 || (monotonyOffsets[nId] == monotonyOffsets[vertexId]
+                     && offsets[nId] < offsets[vertexId]))));
+
+    const polarity isUpper = lower ? 0 : 255;
+
+    mymsg << " " << i << "th: " << nId << " f:" << fakeScalars[nId]
+          << " s:" << scalars[nId] << " o:" << offsets[nId]
+          << " m:" << monotonyOffsets[nId] << "  , pol:" << (bool)vlp[i].first
+          << "(" << (bool)vlp[i].second << ")"
+          << " rpol:" << (bool)rpol << "  true pol:" << (bool)isUpper
+          << " init " << init << "  isnew: " << (int)isNew[nId] << "\n";
+    if((rpol == isUpper and !vlp2.empty())
+       or (isUpper != vlp[i].first and !vlp[i].second)) {
+      mymsg << "POLARITY ERROR "
+            << "\n";
+      error = true;
+    }
+  }
+  if(error or verbose) {
+    std::cout << mymsg.str() << std::endl;
+  }
+  return error;
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::getCriticalTypeApproximate(
+  const SimplexId &vertexId,
+  std::vector<std::pair<polarity, polarity>> &vlp,
+  uint8_t &vertexLink,
+  DynamicTree &link,
+  VLBoundaryType &vlbt,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) const {
+
+  if(vlp.empty()) {
+    buildVertexLinkPolarityApproximate(
+      vertexId, vlp, fakeScalars, offsets, monotonyOffsets);
+  }
+  const SimplexId neighborNumber
+    = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  link.alloc(neighborNumber);
+
+  // associate vertex link boundary
+  vertexLink = multiresTriangulation_.getVertexBoundaryIndex(vertexId);
+
+  // update the link polarity for old points that are processed for
+  // the first time
+  const auto &vl = vlbt[vertexLink];
+
+  for(size_t edgeId = 0; edgeId < vl.size(); edgeId++) {
+    const SimplexId n0 = vl[edgeId].first;
+    const SimplexId n1 = vl[edgeId].second;
+    if(vlp[n0].first == vlp[n1].first) {
+      // the smallest id (n0) becomes the parent of n1
+      link.insertEdge(n1, n0);
+    }
+  }
+}
+
+template <typename scalarType, typename offsetType>
+void ttk::ApproximateTopology::initGlobalPolarity(
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toProcess,
+  const scalarType *fakeScalars,
+  const offsetType *const offsets,
+  const int *const monotonyOffsets) const {
+
+  Timer timer{};
+  const size_t nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+  // computes the critical types of all points
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < nDecVerts; i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+    buildVertexLinkPolarityApproximate(globalId, vertexLinkPolarity[globalId],
+                                       fakeScalars, offsets, monotonyOffsets);
+    toProcess[globalId] = 255;
+    isNew[globalId] = 0;
+  }
+  printMsg("Polarity Init", 1, timer.getElapsedTime(), threadNumber_,
+           debug::LineMode::NEW, debug::Priority::DETAIL);
+}
+
+template <typename ScalarType, typename offsetType>
+int ttk::ApproximateTopology::updateGlobalPolarity(
+  double eps,
+  std::vector<polarity> &isNew,
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toProcess,
+  std::vector<polarity> &toReprocess,
+  ScalarType *fakeScalars,
+  const offsetType *const offsets,
+  int *monotonyOffsets) const {
+
+  Timer tm;
+  const auto nDecVerts = multiresTriangulation_.getDecimatedVertexNumber();
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId localId = 0; localId < nDecVerts; localId++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
+    if(!isNew[globalId]) {
+      getMonotonyChangeByOldPointCPApproximate(
+        globalId, eps, isNew, toProcess, toReprocess,
+        vertexLinkPolarity[globalId], fakeScalars, offsets, monotonyOffsets);
+    }
+  }
+
+  // second Loop  process or reprocess
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(int i = 0; i < multiresTriangulation_.getDecimatedVertexNumber(); i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+    if(isNew[globalId]) { // new point
+      if(decimationLevel_ > stoppingDecimationLevel_) {
+        buildVertexLinkPolarityApproximate(
+          globalId, vertexLinkPolarity[globalId], fakeScalars, offsets,
+          monotonyOffsets);
+      }
+      isNew[globalId] = 0;
+
+    } else { // old point
+      if(toReprocess[globalId]) {
+        updateLinkPolarityPonctual(vertexLinkPolarity[globalId]);
+
+        toProcess[globalId] = 255; // mark for processing
+        toReprocess[globalId] = 0;
+      }
+    }
+  } // end for openmp
+  return 0;
+}
+
+template <typename ScalarType, typename offsetType>
+void ttk::ApproximateTopology::computeCriticalPoints(
+  std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toProcess,
+  std::vector<DynamicTree> &link,
+  std::vector<uint8_t> &vertexLink,
+  VLBoundaryType &vertexLinkByBoundaryType,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax,
+  ScalarType *fakeScalars,
+  const offsetType *const offsets,
+  int *monotonyOffsets) {
+
+  Timer tm;
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(int i = 0; i < multiresTriangulation_.getDecimatedVertexNumber(); i++) {
+    SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(i);
+
+    if(toProcess[globalId]) {
+      // nbComputations++;
+      getCriticalTypeApproximate(globalId, vertexLinkPolarity[globalId],
+                                 vertexLink[globalId], link[globalId],
+                                 vertexLinkByBoundaryType, fakeScalars, offsets,
+                                 monotonyOffsets);
+      getValencesFromLink(globalId, vertexLinkPolarity[globalId],
+                          link[globalId], toPropageMin, toPropageMax,
+                          saddleCCMin, saddleCCMax);
+    }
+  } // end for openmp
+
+  if(debugLevel_ > 3) {
+    printMsg(
+      "Critical Points Computation", 1, tm.getElapsedTime(), threadNumber_);
+  }
+}
+
+template <typename scalarType>
+int ttk::ApproximateTopology::sortPersistenceDiagramApproximate(
+  std::vector<PersistencePair> &diagram,
+  const scalarType *const scalars,
+  scalarType *fakeScalars,
+  const SimplexId *const offsets,
+  int *monotonyOffsets) const {
+  auto cmp = [scalars, fakeScalars, offsets, monotonyOffsets](
+               const PersistencePair &pA, const PersistencePair &pB) {
+    const ttk::SimplexId a = pA.birth;
+    const ttk::SimplexId b = pB.birth;
+
+    return ((fakeScalars[a] < fakeScalars[b])
+            || (fakeScalars[a] == fakeScalars[b]
+                && ((monotonyOffsets[a] < monotonyOffsets[b])
+                    || (monotonyOffsets[a] == monotonyOffsets[b]
+                        && offsets[a] < offsets[b]))));
+  };
+
+  std::sort(diagram.begin(), diagram.end(), cmp);
+
+  return 0;
+}
+
+template <typename scalarType>
+int ttk::ApproximateTopology::computeApproximatePD(
+  std::vector<PersistencePair> &CTDiagram,
+  const scalarType *scalars,
+  scalarType *const fakeScalars,
+  SimplexId *const outputOffsets,
+  int *const outputMonotonyOffsets) {
+
+  int ret = -1;
+  std::stringstream ss;
+  ss << "Approximate Persistence Diagram computation with "
+     << debug::output::UNDERLINED << debug::output::YELLOW << epsilon_ * 100
+     << "%" << debug::output::ENDCOLOR << debug::output::ENDCOLOR << " error";
+  printMsg(ss.str());
+
+  ret = executeApproximateTopology(
+    scalars, fakeScalars, outputOffsets, outputMonotonyOffsets);
+  CTDiagram = std::move(CTDiagram_);
+  CTDiagram_.clear();
+
+  return ret;
+}

--- a/core/base/approximateTopology/ApproximateTopology.h
+++ b/core/base/approximateTopology/ApproximateTopology.h
@@ -27,6 +27,7 @@
 #include <OpenMPLock.h>
 
 #include <limits>
+#include <numeric>
 #include <tuple>
 
 namespace ttk {

--- a/core/base/approximateTopology/CMakeLists.txt
+++ b/core/base/approximateTopology/CMakeLists.txt
@@ -1,0 +1,11 @@
+ttk_add_base_library(approximateTopology
+  SOURCES
+    ApproximateTopology.cpp
+  HEADERS
+    ApproximateTopology.h
+  DEPENDS
+    multiresTriangulation
+    triangulation
+    dynamicTree
+    progressiveTopology
+    )

--- a/core/base/common/OpenMPLock.h
+++ b/core/base/common/OpenMPLock.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef TTK_ENABLE_OPENMP
 #include <omp.h>
 #endif // TTK_ENABLE_OPENMP

--- a/core/base/multiresTopology/CMakeLists.txt
+++ b/core/base/multiresTopology/CMakeLists.txt
@@ -1,0 +1,10 @@
+ttk_add_base_library(multiresTopology
+  SOURCES
+  MultiresTopology.cpp
+  HEADERS
+  MultiresTopology.h
+  DEPENDS
+    multiresTriangulation
+    triangulation
+    dynamicTree
+    )

--- a/core/base/multiresTopology/MultiresTopology.cpp
+++ b/core/base/multiresTopology/MultiresTopology.cpp
@@ -1,0 +1,181 @@
+#include <MultiresTopology.h>
+
+void ttk::MultiresTopology::getValencesFromLink(
+  const SimplexId vertexId,
+  const std::vector<std::pair<polarity, polarity>> &vlp,
+  DynamicTree &link,
+  std::vector<polarity> &toPropageMin,
+  std::vector<polarity> &toPropageMax,
+  std::vector<std::vector<SimplexId>> &saddleCCMin,
+  std::vector<std::vector<SimplexId>> &saddleCCMax) const {
+
+  const auto nbCC = link.getNbCC();
+
+  SimplexId downValence = 0, upValence = 0;
+  saddleCCMin[vertexId].clear();
+  saddleCCMax[vertexId].clear();
+
+  if(nbCC > 2) {
+    std::vector<size_t> CCIds;
+    CCIds.reserve(nbCC);
+    link.retrieveNbCC(CCIds);
+    for(size_t i = 0; i < CCIds.size(); i++) {
+      const SimplexId neighbor = CCIds[i];
+      const polarity isUpper = vlp[neighbor].first;
+      if(isUpper) {
+        saddleCCMax[vertexId].emplace_back(neighbor);
+        upValence++;
+      } else {
+        saddleCCMin[vertexId].emplace_back(neighbor);
+        downValence++;
+      }
+    }
+
+    if(downValence > 1) {
+      toPropageMin[vertexId] = 255;
+    } else {
+      saddleCCMin[vertexId].clear();
+      toPropageMin[vertexId] = 0;
+    }
+    if(upValence > 1) {
+      toPropageMax[vertexId] = 255;
+    } else {
+      saddleCCMax[vertexId].clear();
+      toPropageMax[vertexId] = 0;
+    }
+
+  } else { // not a saddle
+    toPropageMax[vertexId] = 0;
+    toPropageMin[vertexId] = 0;
+  }
+}
+
+void ttk::MultiresTopology::buildVertexLinkByBoundary(
+  const SimplexId vertexId, VLBoundaryType &vlbt) const {
+
+  const auto bid = multiresTriangulation_.getVertexBoundaryIndex(vertexId);
+  const auto nneigh = multiresTriangulation_.getVertexNeighborNumber(vertexId);
+  vlbt[bid].reserve(nneigh);
+
+  for(SimplexId i = 0; i < nneigh; i++) {
+    SimplexId n0 = 0;
+    multiresTriangulation_.getVertexNeighbor(vertexId, i, n0);
+    for(SimplexId j = i + 1; j < nneigh; j++) {
+      SimplexId n1 = 0;
+      multiresTriangulation_.getVertexNeighbor(vertexId, j, n1);
+      if(multiresTriangulation_.areVerticesNeighbors(n0, n1)) {
+        vlbt[bid].emplace_back(i, j);
+      }
+    }
+  }
+}
+
+void ttk::MultiresTopology::getTripletsFromSaddles(
+  const SimplexId vertexId,
+  std::vector<triplet> &triplets,
+  const std::vector<std::vector<SimplexId>> &vertexReps) const {
+
+  const auto &reps = vertexReps[vertexId];
+  const SimplexId m = reps[0];
+#ifndef TTK_ENABLE_KAMIKAZE
+  const auto &repsm = vertexReps[m];
+  if(m == -1 || repsm.empty() || repsm[0] != m) {
+    this->printErr("HERE PROBLEM");
+  }
+#endif // TTK_ENABLE_KAMIKAZE
+  for(size_t i = 1; i < reps.size(); i++) {
+    const SimplexId n = reps[i];
+#ifndef TTK_ENABLE_KAMIKAZE
+    const auto &repsn = vertexReps[n];
+    if(n == -1 || repsn.empty() || repsn[0] != n) {
+      this->printErr("HERE2 PROBLEM");
+    }
+#endif // TTK_ENABLE_KAMIKAZE
+    triplets.emplace_back(vertexId, m, n);
+  }
+}
+
+char ttk::MultiresTopology::getCriticalTypeFromLink(
+  const std::vector<std::pair<polarity, polarity>> &vlp,
+  DynamicTree &link) const {
+
+  const auto nbCC = link.getNbCC();
+
+  int dimensionality = multiresTriangulation_.getDimensionality();
+  SimplexId downValence = 0, upValence = 0;
+
+  std::vector<size_t> CCIds;
+  CCIds.reserve(nbCC);
+  link.retrieveNbCC(CCIds);
+  for(size_t i = 0; i < CCIds.size(); i++) {
+    const SimplexId neighbor = CCIds[i];
+    const polarity isUpper = vlp[neighbor].first;
+    if(isUpper) {
+      upValence++;
+    } else {
+      downValence++;
+    }
+  }
+
+  if(downValence == -1 && upValence == -1) {
+    return -1;
+  } else if(downValence == 0 && upValence == 1) {
+    return static_cast<char>(CriticalType::Local_minimum);
+  } else if(downValence == 1 && upValence == 0) {
+    return static_cast<char>(CriticalType::Local_maximum);
+  } else if(downValence == 1 && upValence == 1) {
+    // regular point
+    return static_cast<char>(CriticalType::Regular);
+  } else {
+    // saddles
+    if(dimensionality == 2) {
+      if((downValence == 2 && upValence == 1)
+         || (downValence == 1 && upValence == 2)
+         || (downValence == 2 && upValence == 2)) {
+        // regular saddle
+        return static_cast<char>(CriticalType::Saddle1);
+      } else {
+        // monkey saddle, saddle + extremum
+        return static_cast<char>(CriticalType::Degenerate);
+        // NOTE: you may have multi-saddles on the boundary in that
+        // configuration
+        // to make this computation 100% correct, one would need to
+        // disambiguate boundary from interior vertices
+      }
+    } else if(dimensionality == 3) {
+      if(downValence == 2 && upValence == 1) {
+        return static_cast<char>(CriticalType::Saddle1);
+      } else if(downValence == 1 && upValence == 2) {
+        return static_cast<char>(CriticalType::Saddle2);
+      } else {
+        // monkey saddle, saddle + extremum
+        return static_cast<char>(CriticalType::Degenerate);
+        // NOTE: we may have a similar effect in 3D (TODO)
+      }
+    }
+  }
+
+  // -2: regular points
+  return static_cast<char>(CriticalType::Regular);
+}
+
+std::string ttk::MultiresTopology::resolutionInfoString() {
+  std::stringstream res;
+  res << "Resolution level "
+      << multiresTriangulation_.DL_to_RL(decimationLevel_);
+  if(decimationLevel_ == 0) {
+    res << " (final)";
+  }
+  return res.str();
+}
+
+void ttk::MultiresTopology::updateLinkPolarityPonctual(
+  std::vector<std::pair<polarity, polarity>> &vlp) const {
+
+  for(size_t i = 0; i < vlp.size(); i++) {
+    if(vlp[i].second) {
+      vlp[i].first = ~vlp[i].first;
+      vlp[i].second = 0;
+    }
+  }
+}

--- a/core/base/multiresTopology/MultiresTopology.h
+++ b/core/base/multiresTopology/MultiresTopology.h
@@ -1,0 +1,146 @@
+/// \ingroup base
+/// \class ttk::MultiresTopology
+/// \author Jules Vidal <jules.vidal@lip6.fr>
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date 2022.
+///
+/// \brief TTK processing package for progressive Topological Data Analysis
+///
+/// This package introduces a multiresolution hierarchical representation of the
+/// data.
+///
+/// It allows the definition of efficient algorithms for approximate or
+/// progressive computation in TDA.
+//
+/// It is used in ttk::ProgressiveTopology for the definition of
+/// efficient progressive algorithms for the computation of critical points and
+/// extremum-saddle persistence diagrams.
+///
+/// It is also used in ttk::ApproximateTopology for the approximate computation
+/// of the extremum-saddle persistence diagrams with guarantees.
+///
+/// \b Related \b publications \n
+/// "A Progressive Approach to Scalar Field Topology" \n
+/// Jules Vidal, Pierre Guillou, Julien Tierny\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2021
+///
+/// "Fast Approximation of Persistence Diagrams with Guarantees" \n
+/// Jules Vidal, Julien Tierny\n
+/// IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021
+///
+///
+/// \sa ProgressiveTopology
+/// \sa ApproximateTopology
+
+#pragma once
+
+// base code includes
+#include <DynamicTree.h>
+#include <ImplicitTriangulation.h>
+#include <MultiresTriangulation.h>
+
+#include <limits>
+#include <tuple>
+
+namespace ttk {
+
+  using triplet = std::tuple<ttk::SimplexId, ttk::SimplexId, ttk::SimplexId>;
+  using polarity = unsigned char;
+
+  class MultiresTopology : public Debug {
+
+  public:
+    struct PersistencePair {
+      /** first (lower) vertex id */
+      ttk::SimplexId birth{};
+      /** second (higher) vertex id */
+      ttk::SimplexId death{};
+      /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
+      ttk::SimplexId pairType{};
+
+      PersistencePair() = default;
+      PersistencePair(const SimplexId b,
+                      const SimplexId d,
+                      const SimplexId pType)
+        : birth{b}, death{d}, pairType{pType} {
+      }
+    };
+
+    MultiresTopology() {
+      this->setDebugMsgPrefix("MultiresTopology");
+    }
+
+    inline void setupTriangulation(ImplicitTriangulation *const data) {
+      triangulation_ = data;
+      multiresTriangulation_.setTriangulation(triangulation_);
+    }
+
+    virtual void setStartingDecimationLevel(int data) {
+      startingDecimationLevel_ = std::max(data, 0);
+    }
+    virtual void setStoppingDecimationLevel(int data) {
+      stoppingDecimationLevel_ = std::max(data, 0);
+    }
+    virtual void setPreallocateMemory(const bool b) {
+      this->preallocateMemory_ = b;
+    }
+    inline int getStoppingDecimationLevel() {
+      return this->stoppingDecimationLevel_;
+    }
+
+    void setStartingResolutionLevel(int rl) {
+      this->setStartingDecimationLevel(multiresTriangulation_.RL_to_DL(rl));
+    }
+
+    void setStoppingResolutionLevel(int rl) {
+      this->setStoppingDecimationLevel(multiresTriangulation_.RL_to_DL(rl));
+    }
+
+  protected:
+    // maximum link size in 3D
+    static const size_t nLink_ = 27;
+
+    using VLBoundaryType
+      = std::array<std::vector<std::pair<SimplexId, SimplexId>>, nLink_>;
+
+    void buildVertexLinkByBoundary(const SimplexId vertexId,
+                                   VLBoundaryType &vlbt) const;
+
+    char getCriticalTypeFromLink(
+      const std::vector<std::pair<polarity, polarity>> &vlp,
+      DynamicTree &link) const;
+
+    void getValencesFromLink(
+      const SimplexId vertexId,
+      const std::vector<std::pair<polarity, polarity>> &vlp,
+      DynamicTree &link,
+      std::vector<polarity> &toPropageMin,
+      std::vector<polarity> &toPropageMax,
+      std::vector<std::vector<SimplexId>> &saddleCCMin,
+      std::vector<std::vector<SimplexId>> &saddleCCMax) const;
+
+    void getTripletsFromSaddles(
+      const SimplexId vertexId,
+      std::vector<triplet> &triplets,
+      const std::vector<std::vector<SimplexId>> &vertexReps) const;
+
+    void updateLinkPolarityPonctual(
+      std::vector<std::pair<polarity, polarity>> &vlp) const;
+
+    std::string resolutionInfoString();
+
+    ImplicitTriangulation *triangulation_{};
+
+    MultiresTriangulation multiresTriangulation_{};
+
+    // store the two global extrema extracted from the whole dataset vertices
+    // sorting operation
+    mutable SimplexId globalMax_{}, globalMin_{};
+
+    int decimationLevel_{};
+    int startingDecimationLevel_{};
+    int stoppingDecimationLevel_{};
+    bool preallocateMemory_{true};
+    std::vector<PersistencePair> CTDiagram_{};
+  };
+} // namespace ttk

--- a/core/base/persistenceDiagram/CMakeLists.txt
+++ b/core/base/persistenceDiagram/CMakeLists.txt
@@ -9,4 +9,5 @@ ttk_add_base_library(persistenceDiagram
     ftmTreePP
     persistentSimplexPairs
     progressiveTopology
+    approximateTopology
     )

--- a/core/base/progressiveTopology/CMakeLists.txt
+++ b/core/base/progressiveTopology/CMakeLists.txt
@@ -7,4 +7,5 @@ ttk_add_base_library(progressiveTopology
     multiresTriangulation
     triangulation
     dynamicTree
+    multiresTopology
     )

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -23,8 +23,7 @@
 
 // base code includes
 #include <DynamicTree.h>
-#include <ImplicitTriangulation.h>
-#include <MultiresTriangulation.h>
+#include <MultiresTopology.h>
 #include <OpenMPLock.h>
 
 #include <limits>
@@ -43,32 +42,27 @@ namespace ttk {
    * Compute the persistence diagram of a function on a triangulation.
    * TTK assumes that the input dataset is made of only one connected component.
    */
-  class ProgressiveTopology : public Debug {
+  class ProgressiveTopology : public MultiresTopology {
 
   public:
-    struct PersistencePair {
-      /** first (lower) vertex id */
-      ttk::SimplexId birth{};
-      /** second (higher) vertex id */
-      ttk::SimplexId death{};
-      /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
-      ttk::SimplexId pairType{};
+    // struct PersistencePair {
+    //   /** first (lower) vertex id */
+    //   ttk::SimplexId birth{};
+    //   /** second (higher) vertex id */
+    //   ttk::SimplexId death{};
+    //   /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
+    //   ttk::SimplexId pairType{};
 
-      PersistencePair() = default;
-      PersistencePair(const SimplexId b,
-                      const SimplexId d,
-                      const SimplexId pType)
-        : birth{b}, death{d}, pairType{pType} {
-      }
-    };
+    //   PersistencePair() = default;
+    //   PersistencePair(const SimplexId b,
+    //                   const SimplexId d,
+    //                   const SimplexId pType)
+    //     : birth{b}, death{d}, pairType{pType} {
+    //   }
+    // };
 
     ProgressiveTopology() {
       this->setDebugMsgPrefix("ProgressiveTopology");
-    }
-
-    inline void setupTriangulation(ImplicitTriangulation *const data) {
-      triangulation_ = data;
-      multiresTriangulation_.setTriangulation(triangulation_);
     }
 
     /* PROGRESSIVE MODE DECLARATIONS */
@@ -81,13 +75,14 @@ namespace ttk {
     inline void setAlgorithm(int data) {
       computePersistenceDiagram_ = data;
     }
-    inline void setStartingDecimationLevel(int data) {
+    void setStartingDecimationLevel(int data) {
       if(data != startingDecimationLevel_) {
         resumeProgressive_ = false;
       }
       startingDecimationLevel_ = std::max(data, 0);
     }
-    inline void setStoppingDecimationLevel(int data) {
+    void setStoppingDecimationLevel(int data) {
+      std::cout << "Stopping DL from progressive topo" << std::endl;
       if(data >= stoppingDecimationLevel_) {
         resumeProgressive_ = false;
       }
@@ -99,7 +94,7 @@ namespace ttk {
         resumeProgressive_ = false;
       }
     }
-    inline void setPreallocateMemory(const bool b) {
+    void setPreallocateMemory(const bool b) {
       if(b != preallocateMemory_) {
         resumeProgressive_ = false;
       }
@@ -112,9 +107,6 @@ namespace ttk {
         this->timeLimit_ = d;
       }
     }
-    inline int getStoppingDecimationLevel() {
-      return this->stoppingDecimationLevel_;
-    }
 
     int computeProgressivePD(std::vector<PersistencePair> &CTDiagram,
                              const SimplexId *offsets);
@@ -123,20 +115,10 @@ namespace ttk {
       std::vector<std::pair<SimplexId, char>> *criticalPoints,
       const SimplexId *offsets);
 
-    void setStartingResolutionLevel(int rl) {
-      this->setStartingDecimationLevel(multiresTriangulation_.RL_to_DL(rl));
-    }
-
-    void setStoppingResolutionLevel(int rl) {
-      this->setStoppingDecimationLevel(multiresTriangulation_.RL_to_DL(rl));
-    }
-
   protected:
     void sortPersistenceDiagram2(std::vector<PersistencePair> &diagram,
                                  const SimplexId *const offsets) const;
 
-    // maximum link size in 3D
-    static const size_t nLink_ = 27;
     using VLBoundaryType
       = std::array<std::vector<std::pair<SimplexId, SimplexId>>, nLink_>;
 
@@ -206,9 +188,6 @@ namespace ttk {
       const SimplexId *const offsets,
       const bool splitTree) const;
 
-    void buildVertexLinkByBoundary(const SimplexId vertexId,
-                                   VLBoundaryType &vlbt) const;
-
     void initDynamicLink(const SimplexId &vertexId,
                          std::vector<std::pair<polarity, polarity>> &vlp,
                          uint8_t &vertexLink,
@@ -219,15 +198,6 @@ namespace ttk {
     char getCriticalTypeFromLink(
       const std::vector<std::pair<polarity, polarity>> &vlp,
       DynamicTree &link) const;
-
-    void getValencesFromLink(
-      const SimplexId vertexId,
-      const std::vector<std::pair<polarity, polarity>> &vlp,
-      DynamicTree &link,
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
-      std::vector<std::vector<SimplexId>> &saddleCCMin,
-      std::vector<std::vector<SimplexId>> &saddleCCMax) const;
 
     void
       updateDynamicLink(DynamicTree &link,
@@ -286,11 +256,6 @@ namespace ttk {
       const SimplexId *const offsets,
       const bool splitTree) const;
 
-    void getTripletsFromSaddles(
-      const SimplexId vertexId,
-      std::vector<triplet> &triplets,
-      const std::vector<std::vector<SimplexId>> &vertexReps) const;
-
     void computePersistencePairsFromSaddles(
       std::vector<PersistencePair> &CTDiagram,
       const SimplexId *const offsets,
@@ -304,22 +269,10 @@ namespace ttk {
 
     void stopComputationIf(const bool b);
     void clearResumableState();
-    std::string resolutionInfoString();
-
-    ImplicitTriangulation *triangulation_{};
-
-    // new non-progressive approach
-    MultiresTriangulation multiresTriangulation_{};
-
-    // store the two global extrema extracted from the whole dataset vertices
-    // sorting operation
-    mutable SimplexId globalMax_{}, globalMin_{};
 
     // progressive approach
     int computePersistenceDiagram_{1};
-    int decimationLevel_{};
-    int startingDecimationLevel_{};
-    int stoppingDecimationLevel_{};
+
     // do some extra computations to allow to resume computation
     bool isResumable_{false};
     bool resumeProgressive_{false};
@@ -342,6 +295,5 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> saddleCCMin_{};
     std::vector<std::vector<SimplexId>> saddleCCMax_{};
     std::vector<char> vertexTypes_{};
-    std::vector<PersistencePair> CTDiagram_;
   };
 } // namespace ttk

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -33,12 +33,6 @@ int ttkPersistenceDiagram::FillOutputPortInformation(int port,
   if(port == 0) {
     info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
     return 1;
-  } else if(port == 1) {
-    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
-    return 1;
-  } else if(port == 2) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
-    return 1;
   }
   return 0;
 }
@@ -218,7 +212,6 @@ int ttkPersistenceDiagram::dispatch(
   vtkUnstructuredGrid *outputCTPersistenceDiagram,
   vtkDataArray *const inputScalarsArray,
   const scalarType *const inputScalars,
-  vtkDataArray *const outputScalarsArray,
   scalarType *outputScalars,
   SimplexId *outputOffsets,
   int *outputMonotonyOffsets,
@@ -249,9 +242,6 @@ int ttkPersistenceDiagram::dispatch(
   setPersistenceDiagram(outputCTPersistenceDiagram, CTDiagram,
                         inputScalarsArray, outputScalars, triangulation);
 
-  // drawBottleneckBounds(outputBounds, CTDiagram, inputScalarsArray,
-  //                      outputScalars, inputScalars, triangulation);
-
   return 1;
 }
 
@@ -262,9 +252,6 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *ttkNotUsed(request),
   vtkDataSet *input = vtkDataSet::GetData(inputVector[0]);
   vtkUnstructuredGrid *outputCTPersistenceDiagram
     = vtkUnstructuredGrid::GetData(outputVector, 0);
-  vtkDataSet *outputField = vtkDataSet::GetData(outputVector, 1);
-  vtkUnstructuredGrid *outputBounds
-    = vtkUnstructuredGrid::GetData(outputVector, 2);
 
   ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -323,10 +310,9 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *ttkNotUsed(request),
     status = this->dispatch(
       outputCTPersistenceDiagram, inputScalars,
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
-      outputScalars,
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
       static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-      static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputMonotonyOffsets)),
+      static_cast<int *>(ttkUtils::GetVoidPointer(outputMonotonyOffsets)),
       static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsetField)),
       static_cast<TTK_TT *>(triangulation->getData())));
 
@@ -334,144 +320,5 @@ int ttkPersistenceDiagram::RequestData(vtkInformation *ttkNotUsed(request),
   outputCTPersistenceDiagram->GetFieldData()->ShallowCopy(
     input->GetFieldData());
 
-  // outputField->ShallowCopy(input);
-  // outputField->GetPointData()->AddArray(outputScalars);
-  // outputField->GetPointData()->AddArray(outputOffsets);
-  // outputField->GetPointData()->AddArray(outputMonotonyOffsets);
-
   return status;
-}
-
-template <typename scalarType, typename triangulationType>
-int ttkPersistenceDiagram::drawBottleneckBounds(
-  vtkUnstructuredGrid *outputBounds,
-  const std::vector<ttk::PersistencePair> &diagram,
-  vtkDataArray *inputScalarsArray,
-  const scalarType *const outputScalars,
-  const scalarType *const inputScalars,
-  const triangulationType *triangulation) const {
-
-  if(diagram.empty()) {
-    return 1;
-  }
-
-  vtkNew<vtkUnstructuredGrid> bounds{};
-  double *range = inputScalarsArray->GetRange(0);
-  double delta = (range[1] - range[0]) * Epsilon;
-  // std::cout << "DELTA for BOUNDS " << delta << " " << getEpsilon() <<
-  // std::endl;
-
-  vtkNew<ttkSimplexIdTypeArray> BirthId{};
-  BirthId->SetNumberOfComponents(1);
-  BirthId->SetName("BirthId");
-  vtkNew<ttkSimplexIdTypeArray> DeathId{};
-  DeathId->SetNumberOfComponents(1);
-  DeathId->SetName("DeathId");
-
-  vtkNew<ttkSimplexIdTypeArray> pairIdentifierScalars{};
-  pairIdentifierScalars->SetNumberOfComponents(1);
-  pairIdentifierScalars->SetName("PairIdentifier");
-
-  vtkNew<vtkDoubleArray> persistenceScalars{};
-  persistenceScalars->SetNumberOfComponents(1);
-  persistenceScalars->SetName("Persistence");
-
-  vtkNew<vtkIntArray> unfolded{};
-  unfolded->SetNumberOfComponents(1);
-  unfolded->SetName("TrueValues");
-
-  vtkNew<vtkIntArray> extremumIndexScalars{};
-  extremumIndexScalars->SetNumberOfComponents(1);
-  extremumIndexScalars->SetName("PairType");
-
-  const ttk::SimplexId minIndex = 0;
-  const ttk::SimplexId saddleSaddleIndex = 1;
-  const ttk::SimplexId maxIndex = triangulation->getCellVertexNumber(0) - 2;
-
-  vtkNew<vtkPoints> points{};
-
-  for(size_t i = 0; i < diagram.size(); ++i) {
-    const auto a = diagram[i].birth;
-    const auto b = diagram[i].death;
-    const auto ta = diagram[i].birthType;
-    const auto tb = diagram[i].deathType;
-
-    const auto sa = outputScalars[a];
-    const auto sb = outputScalars[b];
-    if(sb - sa >= 2 * delta) {
-      vtkIdType p0 = points->InsertNextPoint(sa - delta, sb - delta, 0);
-      vtkIdType p1 = points->InsertNextPoint(sa + delta, sb - delta, 0);
-      vtkIdType p2 = points->InsertNextPoint(sa - delta, sb + delta, 0);
-      vtkIdType p3 = points->InsertNextPoint(sa + delta, sb + delta, 0);
-
-      vtkNew<vtkIdList> quad{};
-      quad->InsertNextId(p0);
-      quad->InsertNextId(p1);
-      quad->InsertNextId(p3);
-      quad->InsertNextId(p2);
-      bounds->InsertNextCell(VTK_QUAD, quad);
-
-      pairIdentifierScalars->InsertNextTuple1(i);
-      BirthId->InsertNextTuple1(a);
-      DeathId->InsertNextTuple1(b);
-      persistenceScalars->InsertNextTuple1(sb - sa);
-      if(i == 0) {
-        extremumIndexScalars->InsertNextTuple1(-1);
-      } else {
-        const auto type = diagram[i].pairType;
-        if(type == 0) {
-          extremumIndexScalars->InsertNextTuple1(minIndex);
-        } else if(type == 1) {
-          extremumIndexScalars->InsertNextTuple1(saddleSaddleIndex);
-        } else if(type == 2) {
-          extremumIndexScalars->InsertNextTuple1(maxIndex);
-        }
-      }
-      if((abs((double)(outputScalars[a] - inputScalars[a])) > 1e-6)
-         or (abs((double)(outputScalars[b] - inputScalars[b])) > 1e-6)) {
-        unfolded->InsertNextTuple1(0);
-      } else {
-        unfolded->InsertNextTuple1(1);
-      }
-    }
-  }
-
-  // ____________________________________________
-  // Case of the uncertain zone, near the diagonal
-  // ____________________________________________
-  const auto s0 = inputScalars[diagram[0].birth];
-  const auto s2 = inputScalars[diagram[0].death];
-  auto s1 = inputScalars[diagram.back().birth];
-  s1 = s1 > s2 / 2 ? s1 : s2 / 2;
-  vtkIdType p0 = points->InsertNextPoint(s0, s0, 0);
-  vtkIdType p1 = points->InsertNextPoint(s0, s0 + 2 * delta, 0);
-  vtkIdType p2 = points->InsertNextPoint(s1, s1, 0);
-  vtkIdType p3 = points->InsertNextPoint(s1, s1 + 2 * delta, 0);
-
-  vtkNew<vtkIdList> quad{};
-  quad->InsertNextId(p0);
-  quad->InsertNextId(p1);
-  quad->InsertNextId(p3);
-  quad->InsertNextId(p2);
-  bounds->InsertNextCell(VTK_QUAD, quad);
-  pairIdentifierScalars->InsertNextTuple1(-1);
-  BirthId->InsertNextTuple1(-1);
-  DeathId->InsertNextTuple1(-1);
-  persistenceScalars->InsertNextTuple1(Epsilon);
-  extremumIndexScalars->InsertNextTuple1(-1);
-  unfolded->InsertNextTuple1(-1);
-  // ____________________________________________
-
-  bounds->SetPoints(points);
-
-  bounds->GetCellData()->AddArray(BirthId);
-  bounds->GetCellData()->AddArray(DeathId);
-  bounds->GetCellData()->AddArray(persistenceScalars);
-  bounds->GetCellData()->AddArray(pairIdentifierScalars);
-  bounds->GetCellData()->AddArray(extremumIndexScalars);
-  bounds->GetCellData()->AddArray(unfolded);
-
-  outputBounds->ShallowCopy(bounds);
-
-  return 0;
 }

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -183,7 +183,6 @@ private:
   int dispatch(vtkUnstructuredGrid *outputCTPersistenceDiagram,
                vtkDataArray *const inputScalarsArray,
                const scalarType *const inputScalars,
-               vtkDataArray *const outputScalarsArray,
                scalarType *outputScalars,
                SimplexId *outputOffsets,
                int *outputMonotonyOffsets,
@@ -196,14 +195,6 @@ private:
                             vtkDataArray *inputScalarsArray,
                             const scalarType *const inputScalars,
                             const triangulationType *triangulation) const;
-
-  template <typename scalarType, typename triangulationType>
-  int drawBottleneckBounds(vtkUnstructuredGrid *outputBounds,
-                           const std::vector<ttk::PersistencePair> &diagram,
-                           vtkDataArray *inputScalarsArray,
-                           const scalarType *const outputScalars,
-                           const scalarType *const inputScalars,
-                           const triangulationType *triangulation) const;
 
   bool ForceInputOffsetScalarField{false};
   bool ShowInsideDomain{false};

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -37,7 +37,7 @@
 /// Herbert Edelsbrunner and John Harer \n
 /// American Mathematical Society, 2010
 ///
-/// Two backends are available for the computation:
+/// Four backends are available for the computation:
 ///
 ///  1) FTM \n
 /// \b Related \b publication \n
@@ -50,6 +50,17 @@
 /// "A Progressive Approach to Scalar Field Topology" \n
 /// Jules Vidal, Pierre Guillou, Julien Tierny\n
 /// IEEE Transactions on Visualization and Computer Graphics, 2021
+///
+/// 3) Persistent Simplex \n
+/// This is a textbook (and very slow) algorithm, described in
+/// "Algorithm and Theory of Computation Handbook (Second Edition)
+/// - Special Topics and Techniques" by Atallah and Blanton on page 97.
+///
+/// 4) Approximate Approach \n
+/// \b Related \b publication \n
+/// "Fast Approximation of Persistence Diagrams with Guarantees" \n
+/// Jules Vidal, Julien Tierny\n
+/// IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021\n
 ///
 /// \sa ttkFTMTreePP
 /// \sa ttkPersistenceCurve
@@ -154,6 +165,9 @@ public:
   vtkGetMacro(TimeLimit, double);
   vtkSetMacro(TimeLimit, double);
 
+  vtkGetMacro(Epsilon, double);
+  vtkSetMacro(Epsilon, double);
+
 protected:
   ttkPersistenceDiagram();
 
@@ -169,6 +183,10 @@ private:
   int dispatch(vtkUnstructuredGrid *outputCTPersistenceDiagram,
                vtkDataArray *const inputScalarsArray,
                const scalarType *const inputScalars,
+               vtkDataArray *const outputScalarsArray,
+               scalarType *outputScalars,
+               SimplexId *outputOffsets,
+               int *outputMonotonyOffsets,
                const SimplexId *const inputOrder,
                const triangulationType *triangulation);
 
@@ -178,6 +196,14 @@ private:
                             vtkDataArray *inputScalarsArray,
                             const scalarType *const inputScalars,
                             const triangulationType *triangulation) const;
+
+  template <typename scalarType, typename triangulationType>
+  int drawBottleneckBounds(vtkUnstructuredGrid *outputBounds,
+                           const std::vector<ttk::PersistencePair> &diagram,
+                           vtkDataArray *inputScalarsArray,
+                           const scalarType *const outputScalars,
+                           const scalarType *const inputScalars,
+                           const triangulationType *triangulation) const;
 
   bool ForceInputOffsetScalarField{false};
   bool ShowInsideDomain{false};

--- a/core/vtk/ttkPersistenceDiagramApproximation/CMakeLists.txt
+++ b/core/vtk/ttkPersistenceDiagramApproximation/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttk.module
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttk.module
@@ -1,0 +1,8 @@
+NAME
+  ttkPersistenceDiagramApproximation
+SOURCES
+  ttkPersistenceDiagramApproximation.cpp
+HEADERS
+  ttkPersistenceDiagramApproximation.h
+DEPENDS
+  persistenceDiagram

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
@@ -319,7 +319,7 @@ int ttkPersistenceDiagramApproximation::RequestData(
   outputScalars->DeepCopy(inputScalars);
 
   std::stringstream ss;
-  ss << inputScalars->GetName() << "_approximated";
+  ss << inputScalars->GetName() << "_Approximated";
   outputScalars->SetName(ss.str().c_str());
 
   int status{};

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
@@ -330,7 +330,7 @@ int ttkPersistenceDiagramApproximation::RequestData(
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(inputScalars)),
       static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(outputScalars)),
       static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputOffsets)),
-      static_cast<SimplexId *>(ttkUtils::GetVoidPointer(outputMonotonyOffsets)),
+      static_cast<int *>(ttkUtils::GetVoidPointer(outputMonotonyOffsets)),
       static_cast<SimplexId *>(ttkUtils::GetVoidPointer(offsetField)),
       static_cast<TTK_TT *>(triangulation->getData())));
 

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.h
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.h
@@ -1,0 +1,121 @@
+/// \ingroup vtk
+/// \class ttkPersistenceDiagramApproximation
+/// \author Jules Vidal <julien.tierny@lip6.fr>
+/// \date 2022.
+///
+/// \brief TTK VTK-filter for the computation of an approximation of a
+/// persistence diagram.
+///
+/// This filter computes an *approximation* of the persistence diagram of
+/// the extremum-saddle pairs of an input scalar field.
+/// The approximation comes with a user-controlled error on the relative
+/// Bottleneck distance to the exact diagram.
+///
+/// \param Input Input scalar field, either 2D or 3D. Must be a regular grid.
+//
+/// \param Output The output of this filter is composed of:\n
+/// 1. The approximation of the persistence diagram (VTU).
+/// 2. The corresponding approximation of the scalar field (VTI).
+/// 3. Uncertainty boumds on the correct localization of persistence pairs.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutput()).
+///
+/// \b Related \b publication \n
+/// "Fast Approximation of Persistence Diagrams with Guarantees" \n
+/// Jules Vidal, Julien Tierny\n
+/// IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021
+///
+/// \sa ttk::ApproximateTopology
+/// \sa ttk::PersistenceDiagram
+///
+/// \b Online \b examples: \n
+///
+
+#pragma once
+
+// VTK includes
+#include <vtkDataArray.h>
+#include <vtkUnstructuredGrid.h>
+
+// VTK Module
+#include <ttkPersistenceDiagramApproximationModule.h>
+
+// ttk code includes
+#include <PersistenceDiagram.h>
+#include <ttkAlgorithm.h>
+#include <ttkMacros.h>
+
+class TTKPERSISTENCEDIAGRAMAPPROXIMATION_EXPORT
+  ttkPersistenceDiagramApproximation : public ttkAlgorithm,
+                                       protected ttk::PersistenceDiagram {
+
+public:
+  static ttkPersistenceDiagramApproximation *New();
+
+  vtkTypeMacro(ttkPersistenceDiagramApproximation, ttkAlgorithm);
+
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
+
+  vtkSetMacro(ComputeSaddleConnectors, bool);
+  vtkGetMacro(ComputeSaddleConnectors, bool);
+
+  vtkSetMacro(ShowInsideDomain, bool);
+  vtkGetMacro(ShowInsideDomain, bool);
+
+  vtkGetMacro(StartingResolutionLevel, int);
+  vtkSetMacro(StartingResolutionLevel, int);
+
+  vtkGetMacro(StoppingResolutionLevel, int);
+  vtkSetMacro(StoppingResolutionLevel, int);
+
+  vtkGetMacro(IsResumable, bool);
+  vtkSetMacro(IsResumable, bool);
+
+  vtkGetMacro(TimeLimit, double);
+  vtkSetMacro(TimeLimit, double);
+
+  vtkGetMacro(Epsilon, double);
+  vtkSetMacro(Epsilon, double);
+
+protected:
+  ttkPersistenceDiagramApproximation();
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+private:
+  template <typename scalarType, typename triangulationType>
+  int dispatch(vtkUnstructuredGrid *outputCTPersistenceDiagram,
+               vtkUnstructuredGrid *outputBounds,
+               vtkDataArray *const inputScalarsArray,
+               const scalarType *const inputScalars,
+               scalarType *outputScalars,
+               SimplexId *outputOffsets,
+               int *outputMonotonyOffsets,
+               const SimplexId *const inputOrder,
+               const triangulationType *triangulation);
+
+  template <typename scalarType, typename triangulationType>
+  int setPersistenceDiagram(vtkUnstructuredGrid *outputCTPersistenceDiagram,
+                            const std::vector<ttk::PersistencePair> &diagram,
+                            vtkDataArray *inputScalarsArray,
+                            const scalarType *const inputScalars,
+                            const triangulationType *triangulation) const;
+
+  template <typename scalarType, typename triangulationType>
+  int drawBottleneckBounds(vtkUnstructuredGrid *outputBounds,
+                           const std::vector<ttk::PersistencePair> &diagram,
+                           vtkDataArray *inputScalarsArray,
+                           const scalarType *const outputScalars,
+                           const scalarType *const inputScalars,
+                           const triangulationType *triangulation) const;
+
+  bool ForceInputOffsetScalarField{false};
+  bool ShowInsideDomain{false};
+};

--- a/core/vtk/ttkPersistenceDiagramApproximation/vtk.module
+++ b/core/vtk/ttkPersistenceDiagramApproximation/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkPersistenceDiagramApproximation
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -31,7 +31,7 @@
         thresholds for topological simplification or for fast similarity
         estimations for instance.
 
-        Three backends are available for the computation of the persistence diagram:
+        Four backends are available for the computation of the persistence diagram:
 
         1) FTM
 
@@ -59,6 +59,24 @@
         "Algorithm and Theory of Computation Handbook (Second Edition)
         - Special Topics and Techniques" by Atallah and Blanton on
         page 97.
+
+        4) Approximate Approach
+
+        Related publication
+        "Fast Approximation of Persistence Diagrams with Guarantees"
+        Jules Vidal, Julien Tierny
+        IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021.
+
+        This approach computes an approximation of the persistence diagram of the extremum-saddle pairs
+        of an input scalar field. It necessitates the input data to be defined on an implicit regular grid.
+
+        The approximation comes with a user-controlled error on the Bottleneck distance to the exact diagram.
+        The tolerance on the relative Bottleneck error is set using the parameter epsilon.
+        Epsilon = 0.05 corresponds to a maximal relative Bottleneck error of 5%.
+
+        See ttkPersistenceDiagramApproximation for more outputs, such as the approximated scalar field and visual cues
+        about the diagram approximation.
+
 
         See also ContourForests, PersistenceCurve, ScalarFieldCriticalPoints,
         TopologicalSimplification.
@@ -197,10 +215,11 @@
           <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
           <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
           <Entry value="2" text="Persistent Simplex (Zomorodian 2010)"/>
+          <Entry value="3" text="Approximate Approach (IEEE LDAV 2021)"/>
         </EnumerationDomain>
         <Documentation>
             Backend for the computation of the persistence diagram.
-            The progressive approach only allows the computation of saddle-extremum pairs.
+            The progressive and approximate approaches only allow the computation of saddle-extremum pairs on regular grids.
         </Documentation>
       </IntVectorProperty>
 
@@ -213,10 +232,7 @@
          panel_visibility="advanced" >
         <IntRangeDomain name="range" min="-1" max="100" />
         <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="BackEnd"
-            value="1" />
+          <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="BackEnd" values="1" />
         </Hints>
         <Documentation>
              Set the starting level of resolution for the progressive approach.
@@ -233,10 +249,7 @@
          panel_visibility="advanced" >
         <IntRangeDomain name="range" min="-1" max="100" />
         <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="BackEnd"
-            value="1" />
+          <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="BackEnd" values="1" />
         </Hints>
         <Documentation>
              Set the ending level of resolution for the progressive approach.
@@ -262,6 +275,25 @@
           Allow resuming computation from a lower resolution
         </Documentation>
       </IntVectorProperty>
+
+      <DoubleVectorProperty
+          name="Epsilon"
+          label="Error (ε)"
+          command="SetEpsilon"
+          number_of_elements="1"
+          default_values="0.05"
+         panel_visibility="advanced" >
+          <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="BackEnd"
+                                   value="3" />
+        </Hints>
+        <Documentation>
+            Tolerance on the maximal relative Bottleneck error.
+            A value of 0.05 denotes a maximal error of 5%. 
+        </Documentation>
+      </DoubleVectorProperty>
 
       <DoubleVectorProperty
           name="TimeLimit"
@@ -321,6 +353,7 @@
         <Property name="StoppingResolutionLevel" />
         <Property name="IsResumable" />
         <Property name="TimeLimit" />
+        <Property name="Epsilon" />
         <Property name="ScalarFieldNew" />
         <Property name="ForceInputOffsetScalarField"/>
         <Property name="InputOffsetScalarFieldNameNew"/>

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -71,8 +71,8 @@
         of an input scalar field. It necessitates the input data to be defined on an implicit regular grid.
 
         The approximation comes with a user-controlled error on the Bottleneck distance to the exact diagram.
-        The tolerance on the relative Bottleneck error is set using the parameter epsilon.
-        Epsilon = 0.05 corresponds to a maximal relative Bottleneck error of 5%.
+        The tolerance on the relative Bottleneck error is set using the parameter "Error".
+        An error of 0.05 corresponds to a maximal relative Bottleneck error of 5%.
 
         See ttkPersistenceDiagramApproximation for more outputs, such as the approximated scalar field and visual cues
         about the diagram approximation.
@@ -215,7 +215,7 @@
           <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
           <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
           <Entry value="2" text="Persistent Simplex (Zomorodian 2010)"/>
-          <Entry value="3" text="Approximate Approach (IEEE LDAV 2021)"/>
+          <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
         </EnumerationDomain>
         <Documentation>
             Backend for the computation of the persistence diagram.
@@ -278,7 +278,7 @@
 
       <DoubleVectorProperty
           name="Epsilon"
-          label="Error (ε)"
+          label="Error"
           command="SetEpsilon"
           number_of_elements="1"
           default_values="0.05"
@@ -291,7 +291,8 @@
         </Hints>
         <Documentation>
             Tolerance on the maximal relative Bottleneck error.
-            A value of 0.05 denotes a maximal error of 5%. 
+            Corresponds to the parameter Epsilon in the publication.
+            An error of 0.05 denotes a maximal relative error of 5%. 
         </Documentation>
       </DoubleVectorProperty>
 

--- a/paraview/xmls/PersistenceDiagramApproximation.xml
+++ b/paraview/xmls/PersistenceDiagramApproximation.xml
@@ -1,0 +1,169 @@
+<ServerManagerConfiguration>
+  <!-- This is the server manager configuration XML. It defines the interface to
+       our new filter. As a rule of thumb, try to locate the configuration for
+       a filter already in ParaView (in Servers/ServerManager/Resources/*.xml)
+       that matches your filter and then model your xml on it -->
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkPersistenceDiagramApproximation"
+        class="ttkPersistenceDiagramApproximation"
+        label="TTK PersistenceDiagramApproximation">
+      <Documentation
+          long_help="TTK plugin for the computation of persistence diagrams."
+          short_help="TTK plugin for the computation of persistence diagrams.">
+        TTK plugin for the computation of apprroximations of persistence diagrams.
+
+        This plugin computes an approximation of the persistence diagram of the extremum-saddle pairs
+        of an input scalar field.
+        This approach necessitates the input data to be defined on an implicit regular grid.
+
+        The approximation comes with a user-controlled error on the Bottleneck distance to the exact diagram.
+        The tolerance on the relative Bottleneck error is set using the parameter epsilon.
+        Epsilon = 0.05 corresponds to a maximal relative Bottleneck error of 5%.
+
+        This plugins produces three outputs:
+        1 - The approximate persistence diagram
+        2 - The corresponding approximation of the field (labelled "_approximated"), defined on the input domain.
+        3 - Representations of the uncertainty on the approximation.
+
+        Related publication
+        "Fast Approximation of Persistence Diagrams with Guarantees"
+        Jules Vidal, Julien Tierny
+        IEEE Symposium on Large Data Visualization and Analysis (LDAV), 2021
+
+        Online examples:
+
+      </Documentation>
+
+      <InputProperty
+          name="Input"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+          Input should be a regular grid (.vti), otherwise FTM will be used
+          to compute the persistence diagram, and other fields will be empty.
+        </Documentation>
+      </InputProperty>
+
+      <StringVectorProperty
+          name="ScalarFieldNew"
+          label="Scalar Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
+          >
+        <ArrayListDomain
+            name="array_list"
+            default_values="0">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the scalar field to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+          name="ForceInputOffsetScalarField"
+          command="SetForceInputOffsetScalarField"
+          label="Force Input Offset Field"
+          number_of_elements="1"
+          panel_visibility="advanced"
+          default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box to force the usage of a specific input scalar field
+          as vertex offset (used to disambiguate flat plateaus).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+          name="InputOffsetScalarFieldNameNew"
+          label="Input Offset Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="1"
+          panel_visibility="advanced"
+          >
+        <ArrayListDomain
+            name="array_list"
+            default_values="1"
+            >
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ForceInputOffsetScalarField"
+                                   value="1" />
+        </Hints>
+        <Documentation>
+          Select the input offset field (used to disambiguate flat plateaus).
+        </Documentation>
+      </StringVectorProperty>
+
+      <DoubleVectorProperty
+          name="Epsilon"
+          label="Error (ε)"
+          command="SetEpsilon"
+          number_of_elements="1"
+        default_values="0.05">
+        <Documentation>
+            Tolerance on the maximal relative Bottleneck error.
+            A value of 0.05 denotes a maximal error of 5%. 
+        </Documentation>
+      </DoubleVectorProperty>
+
+      <IntVectorProperty name="ShowInsideDomain"
+                         label="Embed in Domain"
+                         command="SetShowInsideDomain"
+                         number_of_elements="1"
+                         default_values="0"
+                         panel_visibility="default">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Embed the persistence pairs in the domain.
+        </Documentation>
+      </IntVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+          <Property name="ScalarFieldNew" />
+          <Property name="ForceInputOffsetScalarField"/>
+          <Property name="InputOffsetScalarFieldNameNew"/>
+        <Property name="Epsilon" />
+        <Property name="ScalarFieldNew" />
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="InputOffsetScalarFieldNameNew"/>
+      </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="ShowInsideDomain" />
+      </PropertyGroup>
+
+      ${DEBUG_WIDGETS}
+
+      <OutputPort name="Persistence Diagram" index="0" id="port0" />
+      <OutputPort name="Approximate Field" index="1" id="port1" />
+      <OutputPort name="Uncertainty Bounds" index="2" id="port2"/>
+
+      <Hints>
+        <ShowInMenu category="TTK - Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/xmls/PersistenceDiagramApproximation.xml
+++ b/paraview/xmls/PersistenceDiagramApproximation.xml
@@ -18,8 +18,8 @@
         This approach necessitates the input data to be defined on an implicit regular grid.
 
         The approximation comes with a user-controlled error on the Bottleneck distance to the exact diagram.
-        The tolerance on the relative Bottleneck error is set using the parameter epsilon.
-        Epsilon = 0.05 corresponds to a maximal relative Bottleneck error of 5%.
+        The tolerance on the relative Bottleneck error is set using the parameter "Error".
+        An error of 0.05 corresponds to a maximal relative Bottleneck error of 5%.
 
         This plugins produces three outputs:
         1 - The approximate persistence diagram
@@ -119,13 +119,14 @@
 
       <DoubleVectorProperty
           name="Epsilon"
-          label="Error (ε)"
+          label="Error"
           command="SetEpsilon"
           number_of_elements="1"
         default_values="0.05">
         <Documentation>
             Tolerance on the maximal relative Bottleneck error.
-            A value of 0.05 denotes a maximal error of 5%. 
+            It corresponds to the parameter Epsilon in the publication.
+            A value of 0.05 denotes a maximal relative error of 5%. 
         </Documentation>
       </DoubleVectorProperty>
 

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char **argv) {
   int startingRL = 0;
   int stoppingRL = -1;
   double tl = 0.0;
+  double epsilon = 0.0;
   bool listArrays{false};
 
   // ---------------------------------------------------------------------------
@@ -45,7 +46,8 @@ int main(int argc, char **argv) {
     parser.setArgument(
       "o", &outputPathPrefix, "Output file prefix (no extension)", true);
     parser.setArgument("B", &backEnd,
-                       "Method (0: FTM, 1: progressive, 2: persistent simplex)",
+                       "Method (0: FTM, 1: progressive, 2: persistent simplex, "
+                       "3: approximation)",
                        true);
     parser.setArgument("S", &startingRL,
                        "Starting Resolution Level for progressive "
@@ -56,6 +58,8 @@ int main(int argc, char **argv) {
                        "multiresolution scheme (-1: finest level)",
                        true);
     parser.setArgument("T", &tl, "Time limit for progressive method", true);
+    parser.setArgument(
+      "e", &epsilon, "% error (for approximate approach)", true);
     parser.setOption("l", &listArrays, "List available arrays");
     parser.parse(argc, argv);
   }
@@ -146,6 +150,7 @@ int main(int argc, char **argv) {
   persistenceDiagram->SetTimeLimit(tl);
   persistenceDiagram->SetStartingResolutionLevel(startingRL);
   persistenceDiagram->SetStoppingResolutionLevel(stoppingRL);
+  persistenceDiagram->SetEpsilon(epsilon);
   persistenceDiagram->Update();
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Dear Julien, 

This PR integrates the work  pubished in LDAV 2021 on the computation of a persistence diagram approximation, with guarantees on the related Bottleneck error. 

Changes are the following:

- introduction of a new base class **approximateTopology**
- introduction of a new base class **multiresTopology**, which contains utilities shared by approximateTopology and progressiveTopology
- introduction of a new back-end approach (the fourth!) for the computation of the persistence diagram, both in PersistenceDiagram and the paraview filter TTKPersistenceDiagram.
- introduction of a new ParaView filter **TTKPersistenceDiagramApproximation** that only uses the approximation approach to compute the persistence diagram, but also produces the related scalar field approximation and visual indications about the related uncertainty in the diagram. (3 outputs in total in ParaView).
- some documentation about this new approach.

Cheers,