### PR TITLE
Connected Component Filter

### DIFF
--- a/core/base/connectedComponents/CMakeLists.txt
+++ b/core/base/connectedComponents/CMakeLists.txt
@@ -1,0 +1,4 @@
+ttk_add_base_template_library(connectedComponents
+  HEADERS ConnectedComponents.h
+  DEPENDS triangulation
+)

--- a/core/base/connectedComponents/ConnectedComponents.h
+++ b/core/base/connectedComponents/ConnectedComponents.h
@@ -1,0 +1,162 @@
+/// \ingroup base
+/// \class ttk::ConnectedComponents
+/// \author Jonas Lukasczyk <jl@jluk.de>
+/// \date 01.02.2019
+///
+/// \brief TTK %connectedComponents processing package.
+///
+/// This filter consumes a scalar field with a feature mask and computes for
+/// each edge connected group of vertices with a non-background mask value a
+/// so-called connected component via flood-filling, where the backgroud is
+/// masked with values smaller-equal zero. The computed components store the
+/// size, seed, and center of mass of each component. The flag
+/// UseSeedIdAsComponentId controls if the resulting segmentation is either
+/// labeled by the index of the component, or by its seed location (which can be
+/// used as a deterministic component label).
+
+#pragma once
+
+// base code includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+#include <stack>
+
+namespace ttk {
+  class ConnectedComponents : virtual public Debug {
+
+    using TID = ttk::SimplexId;
+
+  private:
+    static const int UNLABELED{-2};
+    static const int IGNORE{-1};
+
+  public:
+    struct Component {
+      int seed = -1;
+      float center[3]{0, 0, 0};
+      float size{0};
+    };
+
+    ConnectedComponents() {
+      this->setDebugMsgPrefix("ConnectedComponents");
+    };
+    virtual ~ConnectedComponents() = default;
+
+    int preconditionTriangulation(
+      ttk::AbstractTriangulation *triangulation) const {
+      return triangulation->preconditionVertexNeighbors();
+    };
+
+    template <typename TT = ttk::AbstractTriangulation>
+    int computeFloodFill(int *labels,
+                         std::vector<Component> &components,
+
+                         const TT *triangulation,
+                         const TID seed) const {
+      // get component id
+      const TID componentId = components.size();
+
+      std::stack<TID> stack;
+      stack.push(seed);
+      labels[seed] = componentId;
+
+      float size = 0;
+      float x, y, z;
+      float center[3] = {0, 0, 0};
+
+      while(!stack.empty()) {
+        const auto cIndex = stack.top();
+        stack.pop();
+
+        // update node data
+        triangulation->getVertexPoint(cIndex, x, y, z);
+        center[0] += x;
+        center[1] += y;
+        center[2] += z;
+        size++;
+
+        // add neihbors
+        size_t nNeighbors = triangulation->getVertexNeighborNumber(cIndex);
+        for(size_t i = 0; i < nNeighbors; i++) {
+          TID nIndex;
+          triangulation->getVertexNeighbor(cIndex, i, nIndex);
+          if(labels[nIndex] == this->UNLABELED) {
+            labels[nIndex] = componentId;
+            stack.push(nIndex);
+          }
+        }
+      }
+      center[0] /= size;
+      center[1] /= size;
+      center[2] /= size;
+
+      // create component
+      components.resize(componentId + 1);
+      auto &c = components[componentId];
+      std::copy(center, center + 3, c.center);
+      c.size = size;
+      c.seed = seed;
+
+      return 1;
+    }
+
+    template <typename DT>
+    int initializeOutputLabels(int *labels,
+                               const TID nVertices,
+                               const DT *featureMask = nullptr) const {
+      Timer timer;
+      std::string msg
+        = "Initializing IDs" + std::string(featureMask ? " via Mask" : "");
+      this->printMsg(msg, 0, 0, 1, ttk::debug::LineMode::REPLACE);
+      if(featureMask) {
+        for(TID i = 0; i < nVertices; i++)
+          labels[i] = featureMask[i] > 0 ? this->UNLABELED : this->IGNORE;
+      } else {
+        std::fill(labels, labels + nVertices, this->UNLABELED);
+      }
+      this->printMsg(msg, 1, timer.getElapsedTime(), 1);
+
+      return 1;
+    }
+
+    template <typename TT = ttk::AbstractTriangulation>
+    int computeConnectedComponents(std::vector<Component> &components,
+                                   int *outputLabels,
+                                   const TT *triangulation,
+                                   const bool useSeedAsComponentId
+                                   = false) const {
+
+      TID nVertices = triangulation->getNumberOfVertices();
+
+      {
+        Timer timer;
+        const std::string msg = "Computing Connected Components";
+        this->printMsg(msg, 0, 0, 1, ttk::debug::LineMode::REPLACE);
+
+        for(TID i = 0; i < nVertices; i++)
+          if(outputLabels[i] == this->UNLABELED)
+            this->computeFloodFill<TT>(
+              outputLabels, components, triangulation, i);
+
+        this->printMsg(msg, 1, timer.getElapsedTime(), 1);
+      }
+
+      if(useSeedAsComponentId) {
+        Timer timer;
+        const std::string msg = "Labeling Components by Seed Id";
+        this->printMsg(msg, 0, 0, 1, ttk::debug::LineMode::REPLACE);
+
+        for(TID i = 0; i < nVertices; i++) {
+          auto &cid = outputLabels[i];
+          if(cid >= 0)
+            cid = components[cid].seed;
+        }
+
+        this->printMsg(msg, 1, timer.getElapsedTime(), 1);
+      }
+
+      return 1;
+    }
+  };
+} // namespace ttk

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -109,7 +109,7 @@ using ttkSimplexIdTypeArray = vtkIntArray;
 #define ttkTypeMacroErrorCase(idx, type)                          \
   default: {                                                      \
     this->printErr("Unsupported " #idx "-th Template Data Type: " \
-                   + std::to_string(type));                       \
+                   + std::to_string(static_cast<int>(type)));     \
   } break;
 
 #define ttkTypeMacroCase(enum, type, number, call) \

--- a/core/vtk/ttkConnectedComponents/CMakeLists.txt
+++ b/core/vtk/ttkConnectedComponents/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkConnectedComponents/ttk.module
+++ b/core/vtk/ttkConnectedComponents/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkConnectedComponents
+SOURCES
+  ttkConnectedComponents.cpp
+HEADERS
+  ttkConnectedComponents.h
+DEPENDS
+  ttkAlgorithm
+  connectedComponents

--- a/core/vtk/ttkConnectedComponents/ttkConnectedComponents.cpp
+++ b/core/vtk/ttkConnectedComponents/ttkConnectedComponents.cpp
@@ -1,0 +1,167 @@
+#include <ttkConnectedComponents.h>
+
+#include <vtkDataArray.h>
+#include <vtkInformation.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+
+#include <vtkFloatArray.h>
+#include <vtkIntArray.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+vtkStandardNewMacro(ttkConnectedComponents);
+
+ttkConnectedComponents::ttkConnectedComponents() {
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(2);
+
+  // Suppress warning if one does not set the optional input array
+  this->SetInputArrayToProcess(0, 0, 0, 0, "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%");
+}
+
+int ttkConnectedComponents::FillInputPortInformation(int port,
+                                                     vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkConnectedComponents::FillOutputPortInformation(int port,
+                                                      vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  } else if(port == 1) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkConnectedComponents::RequestData(vtkInformation *,
+                                        vtkInformationVector **inputVector,
+                                        vtkInformationVector *outputVector) {
+
+  // Fetch Input Data
+  auto inputDataSet = vtkDataSet::GetData(inputVector[0]);
+  if(!inputDataSet)
+    return 0;
+
+  const auto nPoints = inputDataSet->GetNumberOfPoints();
+
+  auto featureMask = this->GetInputArrayToProcess(0, inputVector);
+
+  if(featureMask && this->GetInputArrayAssociation(0, inputVector) != 0)
+    return !this->printErr("Input array needs to be a point data array.");
+
+  if(featureMask && featureMask->GetNumberOfComponents() != 1)
+    return !this->printErr("Input array needs to be a scalar array.");
+
+  auto triangulation = ttkAlgorithm::GetTriangulation(inputDataSet);
+  if(!triangulation)
+    return 0;
+
+  // Allocate Output Label Data
+  auto outputArray = vtkSmartPointer<vtkIntArray>::New();
+  outputArray->SetName("ComponentId");
+  outputArray->SetNumberOfTuples(nPoints);
+
+  // Compute Connected Components
+  std::vector<ttk::ConnectedComponents::Component> components;
+  {
+    int status = 0;
+
+    ttkTypeMacroA(featureMask ? featureMask->GetDataType() : VTK_INT,
+                  (status = this->initializeOutputLabels<T0>(
+                     ttkUtils::GetPointer<int>(outputArray), nPoints,
+                     ttkUtils::GetPointer<const T0>(featureMask))));
+    if(status != 1)
+      return 0;
+
+    this->preconditionTriangulation(triangulation);
+    ttkTypeMacroT(triangulation->getType(),
+                  (status = this->computeConnectedComponents<T0>(
+                     components, ttkUtils::GetPointer<int>(outputArray),
+                     static_cast<const T0 *>(triangulation->getData()),
+                     this->UseSeedIdAsComponentId)));
+    if(status != 1)
+      return 0;
+  }
+
+  // Segmentation Output
+  {
+    auto outputDataSet = vtkDataSet::GetData(outputVector, 0);
+    outputDataSet->ShallowCopy(inputDataSet);
+    outputDataSet->GetPointData()->AddArray(outputArray);
+  }
+
+  // Components Output
+  {
+    const int nComponents = components.size();
+    auto outputComponents = vtkPolyData::GetData(outputVector, 1);
+
+    // points
+    {
+      auto sizeArray = vtkSmartPointer<vtkFloatArray>::New();
+      sizeArray->SetName("Size");
+      sizeArray->SetNumberOfTuples(nComponents);
+      auto sizeArrayData = ttkUtils::GetPointer<float>(sizeArray);
+
+      auto idArray = vtkSmartPointer<vtkIntArray>::New();
+      idArray->SetName("ComponentId");
+      idArray->SetNumberOfTuples(nComponents);
+      auto idArrayData = ttkUtils::GetPointer<int>(idArray);
+
+      auto points = vtkSmartPointer<vtkPoints>::New();
+      points->SetDataTypeToFloat();
+      points->SetNumberOfPoints(nComponents);
+      auto pointsData = ttkUtils::GetPointer<float>(points->GetData());
+      for(int i = 0, j = 0; i < nComponents; i++) {
+        const auto &c = components[i];
+        pointsData[j++] = c.center[0];
+        pointsData[j++] = c.center[1];
+        pointsData[j++] = c.center[2];
+
+        sizeArrayData[i] = c.size;
+        idArrayData[i] = this->UseSeedIdAsComponentId ? c.seed : i;
+      }
+
+      outputComponents->SetPoints(points);
+      auto pd = outputComponents->GetPointData();
+      pd->AddArray(sizeArray);
+      pd->AddArray(idArray);
+    }
+
+    // cells
+    {
+      auto connectivityArray = vtkSmartPointer<vtkIntArray>::New();
+      connectivityArray->SetNumberOfTuples(nComponents);
+      auto connectivityArrayData = ttkUtils::GetPointer<int>(connectivityArray);
+      for(int i = 0; i < nComponents; i++)
+        connectivityArrayData[i] = i;
+
+      auto offsetArray = vtkSmartPointer<vtkIntArray>::New();
+      offsetArray->SetNumberOfTuples(nComponents + 1);
+      auto offsetArrayData = ttkUtils::GetPointer<int>(offsetArray);
+      for(int i = 0; i <= nComponents; i++)
+        offsetArrayData[i] = i;
+
+      auto cellArray = vtkSmartPointer<vtkCellArray>::New();
+      cellArray->SetData(offsetArray, connectivityArray);
+
+      outputComponents->SetVerts(cellArray);
+    }
+
+    // Copy Field Data
+    outputComponents->GetFieldData()->ShallowCopy(inputDataSet->GetFieldData());
+  }
+
+  // return success
+  return 1;
+}

--- a/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
+++ b/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
@@ -1,0 +1,64 @@
+/// \ingroup vtk
+/// \class ttkConnectedComponents
+/// \author Jonas Lukasczyk (jl@jluk.de)
+/// \date 22.02.2022
+///
+/// \brief TTK VTK-filter that computes connected components based on a scalar
+/// field.
+///
+/// VTK wrapping code for the ttk::ConnectedComponents package.
+///
+/// This filter consumes a scalar field with a feature mask and computes for
+/// each edge connected group of vertices with a non-background mask value a
+/// so-called connected component via flood-filling, where the backgroud is
+/// masked with values smaller-equal zero. The computed components store the
+/// size, seed, and center of mass of each component. The flag
+/// UseSeedIdAsComponentId controls if the resulting segmentation is either
+/// labeled by the index of the component, or by its seed location (which can be
+/// used as a deterministic component label).
+///
+/// The input data array that contains the feature mask needs to be specified
+/// via the standard VTK call SetInputArrayToProcess() with the following
+/// parameters:
+/// \param idx 0 (FIXED: the first array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the VTK array)
+///
+/// \sa ttk::ConnectedComponents
+
+#pragma once
+
+// VTK Module
+#include <ttkConnectedComponentsModule.h>
+
+// TTK Include
+#include <ConnectedComponents.h>
+#include <ttkAlgorithm.h>
+
+class TTKCONNECTEDCOMPONENTS_EXPORT ttkConnectedComponents
+  : public ttkAlgorithm,
+    protected ttk::ConnectedComponents {
+
+private:
+  bool UseSeedIdAsComponentId{true};
+
+public:
+  vtkSetMacro(UseSeedIdAsComponentId, bool);
+  vtkGetMacro(UseSeedIdAsComponentId, bool);
+
+  static ttkConnectedComponents *New();
+  vtkTypeMacro(ttkConnectedComponents, ttkAlgorithm);
+
+protected:
+  ttkConnectedComponents();
+  virtual ~ttkConnectedComponents() override = default;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+};

--- a/core/vtk/ttkConnectedComponents/vtk.module
+++ b/core/vtk/ttkConnectedComponents/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkConnectedComponents
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/ConnectedComponents.xml
+++ b/paraview/xmls/ConnectedComponents.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ConnectedComponents" class="ttkConnectedComponents" label="TTK ConnectedComponents">
+      <Documentation long_help="TTK connectedComponents" short_help="TTK connectedComponents">
+        This filter consumes a scalar field with a feature mask and computes for each edge connected group of vertices with a non-background mask value a so-called connected component via flood-filling, where the backgroud is masked with values smaller-equal zero. The computed components store the size, seed, and center of mass of each component. The flag UseSeedIdAsComponentId controls if the resulting segmentation is either labeled by the index of the component, or by its seed location (which can be used as a deterministic component label).
+      </Documentation>
+
+      <InputProperty name="Segmentation" command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources" />
+          <Group name="filters" />
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet" />
+        </DataTypeDomain>
+        <InputArrayDomain attribute_type="point" name="segmantation_point_arrays" number_of_components="1" optional="1" />
+        <Documentation>A vtkDataSet.</Documentation>
+      </InputProperty>
+
+      <OutputPort index="0" id="port0" name="Segmentation" />
+      <OutputPort index="1" id="port1" name="Components" />
+
+      <StringVectorProperty name="FeatureMask" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5" default_values="None">
+        <ArrayListDomain name="array_list" input_domain_name="segmantation_point_arrays" none_string="None">
+          <RequiredProperties>
+            <Property function="Input" name="Segmentation" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>Feature Mask where values smaller equal than zero correspond to the background.</Documentation>
+      </StringVectorProperty>
+      <IntVectorProperty name="UseSeedIdAsComponentId" command="SetUseSeedIdAsComponentId" number_of_elements="1" default_values="1">
+          <BooleanDomain name="bool" />
+          <Documentation>This flag controls if the resulting segmentation is either labeled by the index of the component, or by its seed location (which can be used as a deterministic feature label).</Documentation>
+      </IntVectorProperty>
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
Hi Julien,
this PR adds a new connected components filter which has advantages over the version that already exists in PV:
1. Vertex neighbors are determined with the TTK::Triangulation data structure.
2. The filter can compute connected components of a feature mask on an implicit grid. Lets say we have some volume data with a scalar field where 0 represents the background and 1 the features (e.g., a mask that identifies superlevel set components can be generated with the calculator and the expression: Scalar>SomeIsoValue). The filter will then compute the connectivity inside the mask without having to explicitly derive the geometry of the components. 
3. The filter has two outputs: 1. the segmentation of the input data where each vertex is associated with its component id (or -1 if it belongs to the background), and 2. a point set where each point represents a single connected component (the location of the point is at the center of mass of the associated component and stores its size, id, and seed vertex).

Best
Jonas