### PR TITLE
[MergeTreeClustering] cap alpha

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -243,6 +243,8 @@ public:
 
   void SetAlpha(double alpha) {
     Alpha = 1 - alpha;
+    Alpha = std::min(1 - 1e-6, Alpha);
+    Alpha = std::max(1e-6, Alpha);
     Modified();
     resetDataVisualization();
   }


### PR DESCRIPTION
This PR caps the alpha parameter of the MergeTreeClustering filter to avoid 0 and 1 value.