### PR TITLE
ttkConnectedComponents Upgrades

### DIFF
--- a/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
+++ b/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
@@ -42,11 +42,14 @@ class TTKCONNECTEDCOMPONENTS_EXPORT ttkConnectedComponents
     protected ttk::ConnectedComponents {
 
 private:
-  bool UseSeedIdAsComponentId{true};
+  double BackgroundThreshold{0.0};
+  bool AugmentSegmentationWithComponentSize{false};
 
 public:
-  vtkSetMacro(UseSeedIdAsComponentId, bool);
-  vtkGetMacro(UseSeedIdAsComponentId, bool);
+  vtkSetMacro(BackgroundThreshold, double);
+  vtkGetMacro(BackgroundThreshold, double);
+  vtkSetMacro(AugmentSegmentationWithComponentSize, bool);
+  vtkGetMacro(AugmentSegmentationWithComponentSize, bool);
 
   static ttkConnectedComponents *New();
   vtkTypeMacro(ttkConnectedComponents, ttkAlgorithm);

--- a/paraview/xmls/ConnectedComponents.xml
+++ b/paraview/xmls/ConnectedComponents.xml
@@ -29,9 +29,12 @@
         </ArrayListDomain>
         <Documentation>Feature Mask where values smaller equal than zero correspond to the background.</Documentation>
       </StringVectorProperty>
-      <IntVectorProperty name="UseSeedIdAsComponentId" command="SetUseSeedIdAsComponentId" number_of_elements="1" default_values="1">
-          <BooleanDomain name="bool" />
-          <Documentation>This flag controls if the resulting segmentation is either labeled by the index of the component, or by its seed location (which can be used as a deterministic feature label).</Documentation>
+      <DoubleVectorProperty name="BackgroundThreshold" command="SetBackgroundThreshold" number_of_elements="1" default_values="0">
+        <Documentation>Values of the mask smaller or equal to this threshold are considered background.</Documentation>
+      </DoubleVectorProperty>
+      <IntVectorProperty name="SegmentationSize" command="SetAugmentSegmentationWithComponentSize" number_of_elements="1" default_values="0">
+        <BooleanDomain name="bool" />
+        <Documentation>If yes the segmentation will have an additional point data array that records for each vertex the size of its corresponding component.</Documentation>
       </IntVectorProperty>
 
       ${DEBUG_WIDGETS}


### PR DESCRIPTION
Hi,
as suggested by @julien-tierny this PR upgrades the ttkConnectedComponents filter which brings the following features:
- Connected components will always have a deterministic id
- The segmentation can optionally record the size of each component
- The background threshold can now be chosen dynamically and therefore simple threshold based feature masks (which are a very common use case) no longer require the prior execution of a calculator filter.