### PR TITLE
[PDCLustering] Fixes: global pair duplicate in centroids and matching…

### DIFF
--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -119,8 +119,15 @@ namespace ttk {
     void updateClusters();
     void invertClusters();
     void invertInverseClusters();
-    void computeBarycenterForTwo(
+    void computeBarycenterForTwoGlobal(
       std::vector<std::vector<std::vector<std::vector<matchingTuple>>>> &);
+
+    void computeBarycenterForTwo(
+      std::vector<std::vector<matchingTuple>> &matchings,
+      std::vector<std::vector<int>> &bidders_ids,
+      std::vector<BidderDiagram<dataType>> &current_bidder_diagrams,
+      std::vector<BidderDiagram<dataType>> &bidder_diagrams,
+      GoodDiagram<dataType> &barycenter);
 
     void acceleratedUpdateClusters();
     std::vector<dataType> updateCentroidsPosition(

--- a/core/base/persistenceDiagramClustering/PDClusteringImpl.h
+++ b/core/base/persistenceDiagramClustering/PDClusteringImpl.h
@@ -503,7 +503,7 @@ std::vector<int> ttk::PDClustering<dataType>::execute(
   // }
   // printMatchings(all_matchings_per_type_and_cluster[0]);
   if(matchings_only) {
-    computeBarycenterForTwo(all_matchings_per_type_and_cluster);
+    computeBarycenterForTwoGlobal(all_matchings_per_type_and_cluster);
   }
   correctMatchings(all_matchings_per_type_and_cluster);
   // Filling the final centroids for output
@@ -521,8 +521,27 @@ std::vector<int> ttk::PDClustering<dataType>::execute(
   }
 
   for(int c = 0; c < k_; ++c) {
+    // if NumberOfClusters > 1, the global pair was duplicated
+    // and needs to be removed from the min-saddle problem
+    // It is the first pair.
+    int removeFirstPair
+      = (k_ > 1 and original_dos[0] and original_dos[2]) ? 1 : 0;
+    if(do_max_ and removeFirstPair) {
+      // min-max Pair
+      Good<dataType> &g = centroids_max_[c].get(0);
+      std::tuple<float, float, float> critCoords = g.GetCriticalCoordinates();
+      float x = std::get<0>(critCoords);
+      float y = std::get<1>(critCoords);
+      float z = std::get<2>(critCoords);
+      diagramTuple t
+        = std::make_tuple(0, ttk::CriticalType::Local_minimum, 0,
+                          ttk::CriticalType::Local_maximum, g.getPersistence(),
+                          -1, g.x_, x, y, z, g.y_, x, y, z);
+      final_centroids[c].push_back(t);
+    }
+
     if(do_min_) {
-      for(int i = 0; i < centroids_min_[c].size(); ++i) {
+      for(int i = removeFirstPair; i < centroids_min_[c].size(); ++i) {
         Good<dataType> &g = centroids_min_[c].get(i);
         std::tuple<float, float, float> critCoords = g.GetCriticalCoordinates();
         float x = std::get<0>(critCoords);
@@ -558,7 +577,18 @@ std::vector<int> ttk::PDClustering<dataType>::execute(
     }
 
     if(do_max_) {
-      for(int i = 0; i < centroids_max_[c].size(); ++i) {
+      // min-max Pair
+      // Good<dataType> &g0 = centroids_max_[c].get(0);
+      // std::tuple<float, float, float> critCoords0 =
+      // g0.GetCriticalCoordinates(); float x0 = std::get<0>(critCoords0); float
+      // y0 = std::get<1>(critCoords0); float z0 = std::get<2>(critCoords0);
+      // diagramTuple t0 = std::make_tuple(
+      //   0, ttk::CriticalType::Local_minimum, 0,
+      //   ttk::CriticalType::Local_maximum, g0.getPersistence(), -1, g0.x_, x0,
+      //   y0, z0, g0.y_, x0, y0, z0);
+      // final_centroids[c].push_back(t0);
+
+      for(int i = removeFirstPair; i < centroids_max_[c].size(); ++i) {
         Good<dataType> &g = centroids_max_[c].get(i);
         std::tuple<float, float, float> critCoords = g.GetCriticalCoordinates();
         float y = std::get<1>(critCoords);
@@ -598,6 +628,7 @@ template <typename dataType>
 void ttk::PDClustering<dataType>::correctMatchings(
   std::vector<std::vector<std::vector<std::vector<matchingTuple>>>>
     &previous_matchings) {
+  printMsg("Correct matchings");
   for(int c = 0; c < k_; c++) {
     for(unsigned int i = 0; i < clustering_[c].size(); i++) {
       int diagram_id = clustering_[c][i];
@@ -623,6 +654,10 @@ void ttk::PDClustering<dataType>::correctMatchings(
           int new_id = std::get<0>(m);
           if(new_id >= 0 && std::get<1>(m) >= 0) {
             std::get<0>(m) = new_to_old_id[new_id];
+            matchings_diagram_i.push_back(m);
+          } else if(std::get<1>(m)
+                    >= 0) { // new_id < 0 corresponds to a diagonal matching
+            std::get<0>(m) = -1;
             matchings_diagram_i.push_back(m);
           }
         }
@@ -658,6 +693,10 @@ void ttk::PDClustering<dataType>::correctMatchings(
                 matchings_diagram_i.push_back(m);
               }
             }
+          } else if(std::get<1>(m)
+                    >= 0) { // new_id < 0 corresponds to a diagonal matching
+            std::get<0>(m) = -1;
+            matchings_diagram_i.push_back(m);
           }
         }
         previous_matchings[c][1][i].resize(matchings_diagram_i.size());
@@ -692,6 +731,10 @@ void ttk::PDClustering<dataType>::correctMatchings(
                 matchings_diagram_i.push_back(m);
               }
             }
+          } else if(std::get<1>(m)
+                    >= 0) { // new_id < 0 corresponds to a diagonal matching
+            std::get<0>(m) = -1;
+            matchings_diagram_i.push_back(m);
           }
         }
         previous_matchings[c][2][i].resize(matchings_diagram_i.size());
@@ -699,6 +742,7 @@ void ttk::PDClustering<dataType>::correctMatchings(
       }
     }
   }
+  printMsg("Correct matchings done");
 }
 
 template <typename dataType>
@@ -2971,175 +3015,137 @@ dataType ttk::PDClustering<dataType>::computeRealCost() {
 }
 
 template <typename dataType>
-void ttk::PDClustering<dataType>::computeBarycenterForTwo(
+void ttk::PDClustering<dataType>::computeBarycenterForTwoGlobal(
   std::vector<std::vector<std::vector<std::vector<matchingTuple>>>>
     &all_matchings_per_type_and_cluster) {
 
   if(do_min_) {
-    std::vector<int> new_to_old_id(current_bidder_diagrams_min_[1].size());
-    // 1. Invert the current_bidder_ids_ vector
-    for(unsigned int j = 0; j < current_bidder_ids_min_[1].size(); j++) {
-      int new_id = current_bidder_ids_min_[1][j];
-      if(new_id >= 0) {
-        new_to_old_id[new_id] = j;
-      }
-    }
-    std::vector<matchingTuple> matching_to_add(0);
-    for(unsigned int i = 0;
-        i < all_matchings_per_type_and_cluster[0][0][1].size(); i++) {
-      matchingTuple t = all_matchings_per_type_and_cluster[0][0][1][i];
-      int bidderId = std::get<0>(t);
-      int goodId = std::get<1>(t);
-      if(bidderId >= 0) {
-        Bidder<dataType> b
-          = bidder_diagrams_min_[1].get(new_to_old_id[bidderId]);
-        dataType bx = b.x_;
-        dataType by = b.y_;
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_min_[0].get(goodId);
-          dataType gx = g.x_;
-          dataType gy = g.y_;
-          centroids_min_[0].get(goodId).x_ = (bx + gx) / 2;
-          centroids_min_[0].get(goodId).y_ = (by + gy) / 2;
-        } else {
-          dataType gx = (bx + by) / 2;
-          dataType gy = (bx + by) / 2;
-          gx = (gx + bx) / 2;
-          gy = (gy + by) / 2;
-          dataType cost = Geometry::pow((gx - bx), wasserstein_)
-                          + Geometry::pow((gy - by), wasserstein_);
-          Good<dataType> g
-            = Good<dataType>(gx, gy, false, centroids_min_[0].size());
-          // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
-          matchingTuple t2
-            = std::make_tuple(bidderId, centroids_min_[0].size(), cost);
-          centroids_min_[0].addGood(g);
-          matching_to_add.push_back(t2);
-        }
-      } else {
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_min_[0].get(goodId);
-          dataType gx = (g.x_ + g.y_) / 2;
-          dataType gy = (g.x_ + g.y_) / 2;
-          centroids_min_[0].get(goodId).x_ = (gx + g.x_) / 2;
-          centroids_min_[0].get(goodId).y_ = (gy + g.y_) / 2;
-        }
-      }
-    }
-    for(unsigned int j = 0; j < matching_to_add.size(); j++) {
-      all_matchings_per_type_and_cluster[0][0][1].push_back(matching_to_add[j]);
-    }
+    computeBarycenterForTwo(
+      all_matchings_per_type_and_cluster[0][0], current_bidder_ids_min_,
+      current_bidder_diagrams_min_, bidder_diagrams_min_, centroids_min_[0]);
   }
-
   if(do_sad_) {
-    std::vector<int> new_to_old_id(current_bidder_diagrams_saddle_[1].size());
-    // 1. Invert the current_bidder_ids_ vector
-    for(unsigned int j = 0; j < current_bidder_ids_sad_[1].size(); j++) {
-      int new_id = current_bidder_ids_sad_[1][j];
-      if(new_id >= 0) {
-        new_to_old_id[new_id] = j;
-      }
-    }
-    std::vector<matchingTuple> matching_to_add(0);
-    for(unsigned int i = 0;
-        i < all_matchings_per_type_and_cluster[0][1][1].size(); i++) {
-      matchingTuple t = all_matchings_per_type_and_cluster[0][1][1][i];
-      int bidderId = std::get<0>(t);
-      int goodId = std::get<1>(t);
-      if(bidderId >= 0) {
-        Bidder<dataType> b
-          = bidder_diagrams_saddle_[1].get(new_to_old_id[bidderId]);
-        dataType bx = b.x_;
-        dataType by = b.y_;
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_saddle_[0].get(goodId);
-          dataType gx = g.x_;
-          dataType gy = g.y_;
-          centroids_saddle_[0].get(goodId).x_ = (bx + gx) / 2;
-          centroids_saddle_[0].get(goodId).y_ = (by + gy) / 2;
-        } else {
-          dataType gx = (bx + by) / 2;
-          dataType gy = (bx + by) / 2;
-          gx = (gx + bx) / 2;
-          gy = (gy + by) / 2;
-          dataType cost = Geometry::pow((gx - bx), wasserstein_)
-                          + Geometry::pow((gy - by), wasserstein_);
-          matchingTuple t2
-            = std::make_tuple(bidderId, centroids_saddle_[0].size(), cost);
-          Good<dataType> g
-            = Good<dataType>(gx, gy, false, centroids_saddle_[0].size());
-          // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
-          centroids_saddle_[0].addGood(g);
-          matching_to_add.push_back(t2);
-        }
-      } else {
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_saddle_[0].get(goodId);
-          dataType gx = (g.x_ + g.y_) / 2;
-          dataType gy = (g.x_ + g.y_) / 2;
-          centroids_saddle_[0].get(goodId).x_ = (gx + g.x_) / 2;
-          centroids_saddle_[0].get(goodId).y_ = (gy + g.y_) / 2;
-        }
-      }
-    }
-    for(unsigned int j = 0; j < matching_to_add.size(); j++) {
-      all_matchings_per_type_and_cluster[0][1][1].push_back(matching_to_add[j]);
+    computeBarycenterForTwo(all_matchings_per_type_and_cluster[0][1],
+                            current_bidder_ids_sad_,
+                            current_bidder_diagrams_saddle_,
+                            bidder_diagrams_saddle_, centroids_saddle_[0]);
+  }
+  if(do_max_) {
+    computeBarycenterForTwo(
+      all_matchings_per_type_and_cluster[0][2], current_bidder_ids_max_,
+      current_bidder_diagrams_max_, bidder_diagrams_max_, centroids_max_[0]);
+  }
+}
+
+template <typename dataType>
+void ttk::PDClustering<dataType>::computeBarycenterForTwo(
+  std::vector<std::vector<matchingTuple>> &matchings,
+  std::vector<std::vector<int>> &bidders_ids,
+  std::vector<BidderDiagram<dataType>> &current_bidder_diagrams,
+  std::vector<BidderDiagram<dataType>> &bidder_diagrams,
+  GoodDiagram<dataType> &barycenter) {
+
+  auto &matchings0 = matchings[0];
+  auto &diagram0 = bidder_diagrams[0];
+  auto &current_diagram0 = current_bidder_diagrams[0];
+  auto &ids0 = bidders_ids[0];
+
+  auto &matchings1 = matchings[1];
+  auto &diagram1 = bidder_diagrams[1];
+  auto &current_diagram1 = current_bidder_diagrams[1];
+  auto &ids1 = bidders_ids[1];
+
+  std::vector<int> new_to_old_id(current_diagram1.size());
+  // 1. Invert the current_bidder_ids_ vector
+  for(unsigned int j = 0; j < ids1.size(); j++) {
+    int new_id = ids1[j];
+    if(new_id >= 0) {
+      new_to_old_id[new_id] = j;
     }
   }
 
-  if(do_max_) {
-    std::vector<int> new_to_old_id(current_bidder_diagrams_max_[1].size());
-    // 1. Invert the current_bidder_ids_ vector
-    for(unsigned int j = 0; j < current_bidder_ids_max_[1].size(); j++) {
-      int new_id = current_bidder_ids_max_[1][j];
-      if(new_id >= 0) {
-        new_to_old_id[new_id] = j;
-      }
-    }
-    std::vector<matchingTuple> matching_to_add(0);
-    for(unsigned int i = 0;
-        i < all_matchings_per_type_and_cluster[0][2][1].size(); i++) {
-      matchingTuple t = all_matchings_per_type_and_cluster[0][2][1][i];
-      int bidderId = std::get<0>(t);
-      int goodId = std::get<1>(t);
-      if(bidderId >= 0) {
-        Bidder<dataType> b
-          = bidder_diagrams_max_[1].get(new_to_old_id[bidderId]);
-        dataType bx = b.x_;
-        dataType by = b.y_;
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_max_[0].get(goodId);
-          dataType gx = g.x_;
-          dataType gy = g.y_;
-          centroids_max_[0].get(goodId).x_ = (bx + gx) / 2;
-          centroids_max_[0].get(goodId).y_ = (by + gy) / 2;
-        } else {
-          dataType gx = (bx + by) / 2;
-          dataType gy = (bx + by) / 2;
-          gx = (gx + bx) / 2;
-          gy = (gy + by) / 2;
-          dataType cost = Geometry::pow((gx - bx), wasserstein_)
-                          + Geometry::pow((gy - by), wasserstein_);
-          matchingTuple t2
-            = std::make_tuple(bidderId, centroids_max_[0].size(), cost);
-          Good<dataType> g
-            = Good<dataType>(gx, gy, false, centroids_max_[0].size());
-          // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
-          centroids_max_[0].addGood(g);
-          matching_to_add.push_back(t2);
-        }
+  std::vector<matchingTuple> matching_to_add(0);
+  std::vector<matchingTuple> matching_to_add2(0);
+
+  for(unsigned int i = 0; i < matchings1.size(); i++) {
+    matchingTuple &t = matchings1[i];
+    int bidderId = std::get<0>(t);
+    int goodId = std::get<1>(t);
+
+    if(bidderId >= 0) {
+      Bidder<dataType> b = diagram1.get(new_to_old_id[bidderId]);
+      dataType bx = b.x_;
+      dataType by = b.y_;
+      if(goodId >= 0) {
+        Good<dataType> g = barycenter.get(goodId);
+        dataType gx = g.x_;
+        dataType gy = g.y_;
+        barycenter.get(goodId).x_ = (bx + gx) / 2;
+        barycenter.get(goodId).y_ = (by + gy) / 2;
+        // divide by 4 in order to display the cost of the half matching
+        // i.e. the cost of matching to the barycenter
+        std::get<2>(t) /= 4;
+
       } else {
-        if(goodId >= 0) {
-          Good<dataType> g = centroids_max_[0].get(goodId);
-          dataType gx = (g.x_ + g.y_) / 2;
-          dataType gy = (g.x_ + g.y_) / 2;
-          centroids_max_[0].get(goodId).x_ = (gx + g.x_) / 2;
-          centroids_max_[0].get(goodId).y_ = (gy + g.y_) / 2;
-        }
+        dataType gx = (bx + by) / 2;
+        dataType gy = (bx + by) / 2;
+        gx = (gx + bx) / 2;
+        gy = (gy + by) / 2;
+        dataType cost = Geometry::pow((gx - bx), wasserstein_)
+                        + Geometry::pow((gy - by), wasserstein_);
+        matchingTuple t2 = std::make_tuple(bidderId, barycenter.size(), cost);
+        matchingTuple t3 = std::make_tuple(-1, barycenter.size(), cost);
+        Good<dataType> g = Good<dataType>(gx, gy, false, barycenter.size());
+        // g.SetCriticalCoordinates(b.coords_x_, b.coords_y_, b.coords_z_);
+        barycenter.addGood(g);
+        matching_to_add.push_back(t2);
+        matching_to_add2.push_back(t3);
+      }
+    } else {
+      if(goodId >= 0) {
+        Good<dataType> g = barycenter.get(goodId);
+        dataType gx = (g.x_ + g.y_) / 2;
+        dataType gy = (g.x_ + g.y_) / 2;
+        barycenter.get(goodId).x_ = (gx + g.x_) / 2;
+        barycenter.get(goodId).y_ = (gy + g.y_) / 2;
+        std::get<2>(t) /= 4;
       }
     }
-    for(unsigned int j = 0; j < matching_to_add.size(); j++) {
-      all_matchings_per_type_and_cluster[0][2][1].push_back(matching_to_add[j]);
+  }
+  for(unsigned int j = 0; j < matching_to_add.size(); j++) {
+    matchings1.push_back(matching_to_add[j]);
+  }
+  for(unsigned int j = 0; j < matching_to_add2.size(); j++) {
+    matchings0.push_back(matching_to_add2[j]);
+  }
+
+  // correct the costs of matchings in diagram 0
+  // costs are initially allzeros because the barycenter is identical
+  // to diagram 0
+  std::vector<int> new_to_old_id2(current_diagram0.size());
+  // 1. Invert the current_bidder_ids_ vector
+  for(unsigned int j = 0; j < ids0.size(); j++) {
+    int new_id = ids0[j];
+    if(new_id >= 0) {
+      new_to_old_id2[new_id] = j;
+    }
+  }
+
+  for(unsigned int i = 0; i < matchings0.size(); i++) {
+    matchingTuple &t = matchings0[i];
+    int bidderId = std::get<0>(t);
+    int goodId = std::get<1>(t);
+
+    if(bidderId >= 0 and goodId >= 0) {
+      Bidder<dataType> b = diagram0.get(new_to_old_id2[bidderId]);
+      dataType bx = b.x_;
+      dataType by = b.y_;
+      Good<dataType> g = barycenter.get(goodId);
+      dataType gx = g.x_;
+      dataType gy = g.y_;
+      dataType cost = Geometry::pow((gx - bx), wasserstein_)
+                      + Geometry::pow((gy - by), wasserstein_);
+      std::get<2>(t) = cost;
     }
   }
 }

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -233,29 +233,21 @@ namespace ttk {
       }
     }
 
+    bool removeDuplicateGlobalPair = false;
+    if(NumberOfClusters > 1 and do_min and do_max) {
+      removeDuplicateGlobalPair = true;
+    }
+
     all_matchings.resize(NumberOfClusters);
     for(int c = 0; c < NumberOfClusters; c++) {
       all_matchings[c].resize(numberOfInputs_);
+      if(removeDuplicateGlobalPair) {
+        centroids_sizes[c][0] -= 1;
+      }
     }
     for(int i = 0; i < numberOfInputs_; i++) {
       unsigned int c = inv_clustering[i];
-      // cout<<"CLUSTER : "<<inv_clustering[i]<<endl;
-      // LARGEST PAIR MUST BE FIRST
-      if(do_max) {
-        matchingTuple t
-          = all_matchings_per_type_and_cluster[c][2][idxInCluster[i]][0];
-        int bidder_id = std::get<0>(t);
-        if(bidder_id >= 0 && bidder_id < (int)data_max[i].size()) {
-          std::get<0>(t) = data_max_idx[i][bidder_id];
-          if(std::get<1>(t) >= 0) {
-            std::get<1>(t)
-              = std::get<1>(t) + centroids_sizes[c][0] + centroids_sizes[c][1];
-          } else {
-            std::get<1>(t) = -1;
-          }
-          all_matchings[inv_clustering[i]][i].push_back(t);
-        }
-      }
+
       if(do_min) {
         for(unsigned int j = 0;
             j
@@ -264,8 +256,12 @@ namespace ttk {
           matchingTuple t
             = all_matchings_per_type_and_cluster[c][0][idxInCluster[i]][j];
           int bidder_id = std::get<0>(t);
-          if(bidder_id >= 0 && bidder_id < (int)data_min[i].size()) {
-            std::get<0>(t) = data_min_idx[i][bidder_id];
+          if(bidder_id < (int)data_min[i].size()) {
+            if(bidder_id < 0) { // matching with a diagonal point
+              std::get<0>(t) = -1;
+            } else {
+              std::get<0>(t) = data_min_idx[i][bidder_id];
+            }
             // cout<<" IDS :  "<<bidder_id<<" "<<std::get<0>(t)<<endl;
             if(std::get<1>(t) < 0) {
               std::get<1>(t) = -1;
@@ -276,15 +272,19 @@ namespace ttk {
       }
 
       if(do_sad) {
-        for(unsigned int j = 1;
+        for(unsigned int j = 0;
             j
             < all_matchings_per_type_and_cluster[c][1][idxInCluster[i]].size();
             j++) {
           matchingTuple t
             = all_matchings_per_type_and_cluster[c][1][idxInCluster[i]][j];
           int bidder_id = std::get<0>(t);
-          if(bidder_id >= 0 && bidder_id < (int)data_sad[i].size()) {
-            std::get<0>(t) = data_sad_idx[i][bidder_id];
+          if(bidder_id < (int)data_sad[i].size()) {
+            if(bidder_id < 0) { // matching with a diagonal point
+              std::get<0>(t) = -1;
+            } else {
+              std::get<0>(t) = data_sad_idx[i][bidder_id];
+            }
             if(std::get<1>(t) >= 0) {
               std::get<1>(t) = std::get<1>(t) + centroids_sizes[c][0];
             } else {
@@ -303,11 +303,21 @@ namespace ttk {
           matchingTuple t
             = all_matchings_per_type_and_cluster[c][2][idxInCluster[i]][j];
           int bidder_id = std::get<0>(t);
-          if(bidder_id >= 0 && bidder_id < (int)data_max[i].size()) {
-            std::get<0>(t) = data_max_idx[i][bidder_id];
-            if(std::get<1>(t) >= 0) {
+          if(bidder_id < (int)data_max[i].size()) {
+            if(bidder_id < 0) { // matching with a diagonal point
+              std::get<0>(t) = -1;
+            } else {
+              std::get<0>(t) = data_max_idx[i][bidder_id];
+            }
+            // std::get<0>(t) = data_max_idx[i][bidder_id];
+            if(std::get<1>(t) > 0) {
               std::get<1>(t) = std::get<1>(t) + centroids_sizes[c][0]
                                + centroids_sizes[c][1];
+            } else if(std::get<1>(t) == 0) {
+              if(!removeDuplicateGlobalPair) {
+                std::get<1>(t) = std::get<1>(t) + centroids_sizes[c][0]
+                                 + centroids_sizes[c][1];
+              }
             } else {
               std::get<1>(t) = -1;
             }

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -137,9 +137,15 @@ namespace ttk {
         // if (abs<dataType>(dt) < zeroThresh) continue;
         if(dt > 0) {
           if(nt1 == BLocalMin && nt2 == BLocalMax) {
-            data_max[i].push_back(t);
-            data_max_idx[i].push_back(j);
-            do_max = true;
+            if(PairTypeClustering == 2) {
+              data_max[i].push_back(t);
+              data_max_idx[i].push_back(j);
+              do_max = true;
+            } else {
+              data_min[i].push_back(t);
+              data_min_idx[i].push_back(j);
+              do_min = true;
+            }
           } else {
             if(nt1 == BLocalMax || nt2 == BLocalMax) {
               data_max[i].push_back(t);


### PR DESCRIPTION
This PR adds some fixes to PersistenceDiagramClustering:

1) The global minimum-maximum pair is no longer duplicated in the centroids when the number of clusters is larger than 1. It also has the correct pairType (-1) and criticalType for the extremities.
This issue resulted in a bad localization of the centroids when performing a dimension reduction on the wasserstein matrix between diagrams and centroids (see image below).
 
![old_mds_isabel](https://user-images.githubusercontent.com/42967827/155749527-93aeaa67-be7f-4d61-81a1-6070fd853d72.png)

This fix results in a better visualization on the isabel ensemble: 
![new_mds_isabel](https://user-images.githubusercontent.com/42967827/155749649-ca42cfae-c476-496a-b1dc-c4911e061157.png)


2) It's now possible to explore all the mathings involved in a Wasserstein distance computation between two diagrams. Previously, some diagonal matchings were absent from the result displayed in ParaView. Additionnally, the cost of the matchings was 0 for half of them, this has been also fixed.
This fix will change the images produced by persistenceDiagramDistance.pvsm in ttk-data, and I expect it to trigger an error in the automatic testings.
![new_matchings](https://user-images.githubusercontent.com/42967827/155750612-44b07adb-eafa-4158-a83e-fc29df753145.png)

Best,
