### PR TITLE
Removed unnecessary include in ttkMergeTreeClustering

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -15,7 +15,6 @@
 #include <vtkDataArray.h>
 #include <vtkDataSet.h>
 #include <vtkFloatArray.h>
-#include <vtkGeometryFilter.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
 #include <vtkMultiBlockDataSet.h>


### PR DESCRIPTION
This PR removes `vtkGeometryFilter.h` from `ttkMergeTreeClustering.cpp`. This header does not seem to be necessary and the include causes a build error when using a newer VTK version.