### PR TITLE
[MergeTreeVisu] fix vertexID

### DIFF
--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -918,7 +918,7 @@ public:
 
             // Add VertexId
             int nodeVertexId = -1;
-            if(i < int(treesNodes.size())) {
+            if(i < int(treesNodes.size()) and treesNodes[i]) {
               auto vertexIdArray
                 = treesNodes[i]->GetPointData()->GetArray("VertexId");
               if(vertexIdArray and nodeMesh != -1)


### PR DESCRIPTION
This PR fixes the PR #731 and solves the issue #738 .

The source of the problem was that the interpolated trees, made with the temporal reduction algorithm, don't have nodes and arcs (output of FTM) like the other trees.

Enjoy.