### PR TITLE
OpenMP: Fix stored number of threads

### DIFF
--- a/core/base/common/OpenMP.h
+++ b/core/base/common/OpenMP.h
@@ -18,7 +18,7 @@ namespace ttk {
 
   public:
     ParallelGuard(const int nThreads)
-      : oldThreadNumber_{omp_get_num_threads()} {
+      : oldThreadNumber_{omp_get_max_threads()} {
       omp_set_num_threads(nThreads);
     }
     ~ParallelGuard() {


### PR DESCRIPTION
This PR fixes an OpenMP shortcoming introduced in #728. As it happens, `omp_get_num_threads` is not the complementary to `omp_set_num_threads` but merely indicates the *current* number of threads in use (1 in a sequential context). This can lead to setting an incorrect number of thread and making the execution of following filters sequential. To reproduce, compute twice a DiscreteGradient over any dataset in ParaView, the first order field computation will trigger the bug.

According to the [OpenMP documentation](https://www.openmp.org/spec-html/5.0/openmpsu112.html), `omp_set_num_threads`'s complement is in fact `omp_get_max_threads` since both access the *nthreads-var* ICV which
> controls the number of threads requested for encountered parallel regions.

This PR modifies TTK's code accordingly.

Enjoy,
Pierre