### PR TITLE
Developer experience improvements

### DIFF
--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -52,6 +52,10 @@ macro(ttk_add_vtk_module)
       vtk_module_definitions(${TTK_NAME} PRIVATE TTK_ENABLE_DOUBLE_TEMPLATING)
     endif()
 
+    if(TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
+      vtk_module_definitions(${TTK_NAME} PRIVATE TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
+    endif()
+
     if(TTK_LINKER_FLAGS)
       vtk_module_link_options(${TTK_NAME} PRIVATE ${TTK_LINKER_FLAGS})
     endif()

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -107,6 +107,9 @@ mark_as_advanced(TTK_ENABLE_CPU_OPTIMIZATION)
 option(TTK_ENABLE_DOUBLE_TEMPLATING "Use double templating for bivariate data" OFF)
 mark_as_advanced(TTK_ENABLE_DOUBLE_TEMPLATING)
 
+option(TTK_REDUCE_TEMPLATE_INSTANTIATIONS "Use a reduced list of template instatiations to fasten build times" OFF)
+mark_as_advanced(TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
+
 option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" ON)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -110,6 +110,12 @@ mark_as_advanced(TTK_ENABLE_DOUBLE_TEMPLATING)
 option(TTK_REDUCE_TEMPLATE_INSTANTIATIONS "Use a reduced list of template instatiations to fasten build times" OFF)
 mark_as_advanced(TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
 
+option(TTK_TIME_TARGETS "Print targets build time" OFF)
+mark_as_advanced(TTK_TIME_TARGETS)
+if(TTK_TIME_TARGETS)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
+endif()
+
 option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" ON)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -116,6 +116,11 @@ if(TTK_TIME_TARGETS)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_COMMAND} -E time")
 endif()
 
+set(TTK_SCRIPTS_PATH ${CMAKE_INSTALL_PREFIX}/scripts/ttk
+  CACHE PATH "Install path for TTK scripts"
+  )
+mark_as_advanced(TTK_SCRIPTS_PATH)
+
 option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" ON)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -18,3 +18,8 @@ ttk_add_base_library(common
         VisitedMask.h
         Wrapper.h
         )
+
+if(TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
+  # in the base layer, only this module is affected
+  target_compile_definitions(common PRIVATE TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
+endif()

--- a/core/base/common/Debug.cpp
+++ b/core/base/common/Debug.cpp
@@ -93,6 +93,25 @@ int Debug::welcomeMsg(ostream &stream) {
              debug::Priority::WARNING, debug::LineMode::NEW, stream);
     printMsg("", debug::Priority::WARNING, debug::LineMode::NEW, stream);
 #endif
+#ifdef TTK_REDUCE_TEMPLATE_INSTANTIATIONS
+    printMsg("", debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg(
+      debug::output::YELLOW + "TTK has *NOT* been built with all VTK types!",
+      debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg(debug::output::YELLOW + "DEVELOPERS ONLY!",
+             debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg(debug::output::YELLOW + "Expect unsupported scalar field types!",
+             debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg("", debug::Priority::WARNING, debug::LineMode::NEW, stream);
+
+    printMsg(
+      debug::output::YELLOW + "To support all VTK types, rebuild TTK with:",
+      debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg(
+      debug::output::YELLOW + "  -DTTK_REDUCE_TEMPLATE_INSTANTIATIONS=OFF",
+      debug::Priority::WARNING, debug::LineMode::NEW, stream);
+    printMsg("", debug::Priority::WARNING, debug::LineMode::NEW, stream);
+#endif // TTK_REDUCE_TEMPLATE_INSTANTIATIONS
 
     debugMsgPrefix_ = currentPrefix;
   }

--- a/core/base/dimensionReduction/CMakeLists.txt
+++ b/core/base/dimensionReduction/CMakeLists.txt
@@ -11,10 +11,10 @@ install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/dimensionReduction.py
   DESTINATION
-    scripts/ttk
+    ${TTK_SCRIPTS_PATH}
   )
 
-target_compile_definitions(dimensionReduction PUBLIC -DTTK_SCRIPTS_PATH=${CMAKE_INSTALL_PREFIX}/scripts/ttk)
+target_compile_definitions(dimensionReduction PUBLIC TTK_SCRIPTS_PATH=${TTK_SCRIPTS_PATH})
 
 if(TTK_ENABLE_SCIKIT_LEARN)
   target_compile_definitions(dimensionReduction PRIVATE TTK_ENABLE_SCIKIT_LEARN)

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -46,6 +46,19 @@ using ttkSimplexIdTypeArray = vtkIntArray;
   }                                                       \
   vtkSetEnumMacro(name, enumType);
 
+#ifdef TTK_REDUCE_TEMPLATE_INSTANTIATIONS
+// reduced list of template instantiations by redefining vtkTemplateMacro
+#include <vtkSetGet.h>
+#ifdef vtkTemplateMacro
+#undef vtkTemplateMacro
+#define vtkTemplateMacro(call)                    \
+  vtkTemplateMacroCase(VTK_DOUBLE, double, call); \
+  vtkTemplateMacroCase(VTK_FLOAT, float, call);   \
+  vtkTemplateMacroCase(VTK_INT, int, call);       \
+  vtkTemplateMacroCase(VTK_LONG_LONG, long long, call);
+#endif // vtkTemplateMacro
+#endif // TTK_REDUCE_TEMPLATE_INSTANTIATIONS
+
 #define ttkVtkTemplateMacroCase(                         \
   dataType, triangulationType, triangulationClass, call) \
   case triangulationType: {                              \


### PR DESCRIPTION
This PR introduce 3 new CMake cache keys that might be useful for TTK developers:
1. `TTK_TIME_TARGETS` (OFF by default) prints the build time of every C++ compilation unit. It helps to diagnose where the compilation takes time;
2. `TTK_SCRIPTS_PATH` (defaulting to `$prefix/scripts/ttk`) allows to set the path of TTK scripts (`dimensionReduction.py`) at compile time. It can be useful for install-less uses of TTK where it is points directly to the `core/base/dimensionReduction` source folder;
3. `TTK_REDUCE_TEMPLATE_INSTANTIATIONS` (OFF by default) redefines the `vtkTemplateMacro` to reduce the number of types used in TTK (only `int`, `long long`, `float` & `double`). This greatly reduces the number of template instantiations and thus the edit-compile-run cycle (scalar fields of unsupported types can still be converted to `float` or `double` with a `Calculator`).

These three variables are marked as advanced and should only be used by TTK developers, especially the 3rd one, which has been only tested so far on my Linux computer(s).

What do you think?
Pierre