### PR TITLE
ttkConnectedComponent: removed static keyword from member variables.

### DIFF
--- a/core/base/connectedComponents/ConnectedComponents.h
+++ b/core/base/connectedComponents/ConnectedComponents.h
@@ -28,8 +28,8 @@ namespace ttk {
     using TID = ttk::SimplexId;
 
   private:
-    static const int UNLABELED{-2};
-    static const int IGNORE{-1};
+    const int UNLABELED{-2};
+    const int IGNORE{-1};
 
   public:
     struct Component {


### PR DESCRIPTION
I removed the static keyword from the member variables of ttkConnectedComponents as some compilers seem to have problems with static const member variables in header files. According to @JonasLukasczyk, this does not change the behaviour of the filter anyway, so it seems a reasonable fix.

