### PR TITLE
Cache DiscreteGradient internal structure

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -9,8 +9,7 @@
 ///
 /// \sa Triangulation
 
-#ifndef _ABSTRACTTRIANGULATION_H
-#define _ABSTRACTTRIANGULATION_H
+#pragma once
 
 // base code includes
 #include <Geometry.h>
@@ -3306,8 +3305,3 @@ namespace ttk {
     mutable gradientCacheType gradientCache_{};
   };
 } // namespace ttk
-
-// if the package is not a template, comment the following line
-// #include                  <AbstractTriangulation.cpp>
-
-#endif // _ABSTRACTTRIANGULATION_H

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -17,6 +17,7 @@
 #include <Wrapper.h>
 
 #include <array>
+#include <map>
 #include <ostream>
 
 #ifdef TTK_ENABLE_KAMIKAZE
@@ -56,6 +57,12 @@ namespace ttk {
     AbstractTriangulation(AbstractTriangulation &&) = default;
     AbstractTriangulation &operator=(const AbstractTriangulation &) = default;
     AbstractTriangulation &operator=(AbstractTriangulation &&) = default;
+
+    using gradientType = std::array<std::vector<SimplexId>, 6>;
+    using gradientCacheType = std::map<const void *const, gradientType *>;
+    inline gradientCacheType *getGradientCacheHandler() {
+      return &this->gradientCache_;
+    }
 
     /// Reset the triangulation data-structures.
     /// \return Returns 0 upon success, negative values otherwise.
@@ -3243,6 +3250,10 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> cellEdgeVector_{};
     std::vector<std::vector<SimplexId>> cellTriangleVector_{};
     std::vector<std::vector<SimplexId>> triangleEdgeVector_{};
+
+    // store, for each triangulation object and per offset field, a
+    // reference to the discrete gradient internal structure
+    gradientCacheType gradientCache_{};
   };
 } // namespace ttk
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -77,8 +77,8 @@ namespace ttk {
      */
     using gradientType = std::array<std::vector<gradIdType>, 6>;
     using gradientKeyType = std::pair<const void *, size_t>;
-    using gradientCacheType = std::map<gradientKeyType, gradientType *>;
-    inline gradientCacheType *getGradientCacheHandler() {
+    using gradientCacheType = std::map<gradientKeyType, gradientType>;
+    inline gradientCacheType *getGradientCacheHandler() const {
       return &this->gradientCache_;
     }
 
@@ -3271,7 +3271,7 @@ namespace ttk {
 
     // store, for each triangulation object and per offset field, a
     // reference to the discrete gradient internal structure
-    gradientCacheType gradientCache_{};
+    mutable gradientCacheType gradientCache_{};
   };
 } // namespace ttk
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -59,7 +59,8 @@ namespace ttk {
     AbstractTriangulation &operator=(AbstractTriangulation &&) = default;
 
     using gradientType = std::array<std::vector<SimplexId>, 6>;
-    using gradientCacheType = std::map<const void *const, gradientType *>;
+    using gradientKeyType = std::pair<const void *, size_t>;
+    using gradientCacheType = std::map<gradientKeyType, gradientType *>;
     inline gradientCacheType *getGradientCacheHandler() {
       return &this->gradientCache_;
     }

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -46,6 +46,13 @@
 
 namespace ttk {
 
+  // forward declaration of the ttk::dcg::DiscreteGradient class to
+  // give it access to the gradient cache (with a `friend`
+  // declaration)
+  namespace dcg {
+    class DiscreteGradient;
+  }
+
   class AbstractTriangulation : public Wrapper {
 
   public:
@@ -57,52 +64,6 @@ namespace ttk {
     AbstractTriangulation(AbstractTriangulation &&) = default;
     AbstractTriangulation &operator=(const AbstractTriangulation &) = default;
     AbstractTriangulation &operator=(AbstractTriangulation &&) = default;
-
-#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-    using gradIdType = char;
-#else
-    using gradIdType = SimplexId;
-#endif
-
-    /**
-     * @brief Discrete gradient internal struct
-     *
-     * 0: paired edge id per vertex
-     * 1: paired vertex id per edge
-     * 2: paired triangle id per edge
-     * 3: paired edge id per triangle
-     * 4: paired tetra id per triangle
-     * 5: paired triangle id per tetra
-     * Values: -1 if critical or paired to a cell of another dimension
-     *
-     * Is used as a value type for \ref gradientCacheType.
-     */
-    using gradientType = std::array<std::vector<gradIdType>, 6>;
-    /**
-     * @brief Key type for \ref gradientCacheType.
-     *
-     * The key type models a scalar field buffer. The first element is
-     * a const void pointer to the beginning of the buffer and the
-     * second stores the timestamp of the last modification of the
-     * scalar field.
-     */
-    using gradientKeyType = std::pair<const void *, size_t>;
-    /*
-     * @brief Type for caching Discrete Gradient internal data structure.
-     *
-     * Uses a std::map with \ref gradientKeytype as key and \ref
-     * gradientType as value types.
-     */
-    using gradientCacheType = std::map<gradientKeyType, gradientType>;
-    /*
-     * @brief Access to the gradientCache_ mutable member variable
-     *
-     * \warning This should only be used by the
-     * ttk::dcg::DiscreteGradient class.
-     */
-    inline gradientCacheType *getGradientCacheHandler() const {
-      return &this->gradientCache_;
-    }
 
     /// Reset the triangulation data-structures.
     /// \return Returns 0 upon success, negative values otherwise.
@@ -3290,6 +3251,55 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> cellEdgeVector_{};
     std::vector<std::vector<SimplexId>> cellTriangleVector_{};
     std::vector<std::vector<SimplexId>> triangleEdgeVector_{};
+
+    // only ttk::dcg::DiscreteGradient should use what's defined below.
+    friend class ttk::dcg::DiscreteGradient;
+
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
+    using gradIdType = char;
+#else
+    using gradIdType = SimplexId;
+#endif
+
+    /**
+     * @brief Discrete gradient internal struct
+     *
+     * 0: paired edge id per vertex
+     * 1: paired vertex id per edge
+     * 2: paired triangle id per edge
+     * 3: paired edge id per triangle
+     * 4: paired tetra id per triangle
+     * 5: paired triangle id per tetra
+     * Values: -1 if critical or paired to a cell of another dimension
+     *
+     * Is used as a value type for \ref gradientCacheType.
+     */
+    using gradientType = std::array<std::vector<gradIdType>, 6>;
+    /**
+     * @brief Key type for \ref gradientCacheType.
+     *
+     * The key type models a scalar field buffer. The first element is
+     * a const void pointer to the beginning of the buffer and the
+     * second stores the timestamp of the last modification of the
+     * scalar field.
+     */
+    using gradientKeyType = std::pair<const void *, size_t>;
+    /*
+     * @brief Type for caching Discrete Gradient internal data structure.
+     *
+     * Uses a std::map with \ref gradientKeytype as key and \ref
+     * gradientType as value types.
+     */
+    using gradientCacheType = std::map<gradientKeyType, gradientType>;
+    /*
+     * @brief Access to the gradientCache_ mutable member variable
+     *
+     * \warning This should only be used by the
+     * ttk::dcg::DiscreteGradient class.
+     */
+    inline gradientCacheType *getGradientCacheHandler() const {
+      return &this->gradientCache_;
+    }
 
     // store, for each triangulation object and per offset field, a
     // reference to the discrete gradient internal structure

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -58,7 +58,24 @@ namespace ttk {
     AbstractTriangulation &operator=(const AbstractTriangulation &) = default;
     AbstractTriangulation &operator=(AbstractTriangulation &&) = default;
 
-    using gradientType = std::array<std::vector<SimplexId>, 6>;
+#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
+    using gradIdType = char;
+#else
+    using gradIdType = SimplexId;
+#endif
+
+    /**
+     * @brief Discrete gradient internal struct
+     *
+     * 0: paired edge id per vertex
+     * 1: paired vertex id per edge
+     * 2: paired triangle id per edge
+     * 3: paired edge id per triangle
+     * 4: paired tetra id per triangle
+     * 5: paired triangle id per tetra
+     * -1 if critical or paired to a cell of another dimension
+     */
+    using gradientType = std::array<std::vector<gradIdType>, 6>;
     using gradientKeyType = std::pair<const void *, size_t>;
     using gradientCacheType = std::map<gradientKeyType, gradientType *>;
     inline gradientCacheType *getGradientCacheHandler() {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -73,11 +73,33 @@ namespace ttk {
      * 3: paired edge id per triangle
      * 4: paired tetra id per triangle
      * 5: paired triangle id per tetra
-     * -1 if critical or paired to a cell of another dimension
+     * Values: -1 if critical or paired to a cell of another dimension
+     *
+     * Is used as a value type for \ref gradientCacheType.
      */
     using gradientType = std::array<std::vector<gradIdType>, 6>;
+    /**
+     * @brief Key type for \ref gradientCacheType.
+     *
+     * The key type models a scalar field buffer. The first element is
+     * a const void pointer to the beginning of the buffer and the
+     * second stores the timestamp of the last modification of the
+     * scalar field.
+     */
     using gradientKeyType = std::pair<const void *, size_t>;
+    /*
+     * @brief Type for caching Discrete Gradient internal data structure.
+     *
+     * Uses a std::map with \ref gradientKeytype as key and \ref
+     * gradientType as value types.
+     */
     using gradientCacheType = std::map<gradientKeyType, gradientType>;
+    /*
+     * @brief Access to the gradientCache_ mutable member variable
+     *
+     * \warning This should only be used by the
+     * ttk::dcg::DiscreteGradient class.
+     */
     inline gradientCacheType *getGradientCacheHandler() const {
       return &this->gradientCache_;
     }

--- a/core/base/abstractTriangulation/CMakeLists.txt
+++ b/core/base/abstractTriangulation/CMakeLists.txt
@@ -7,3 +7,10 @@ ttk_add_base_library(abstractTriangulation
     common
     geometry
     )
+
+option(TTK_ENABLE_DCG_OPTIMIZE_MEMORY "Enable Discrete Gradient memory optimization" OFF)
+mark_as_advanced(TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
+
+if (TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
+  target_compile_definitions(abstractTriangulation PUBLIC TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
+endif()

--- a/core/base/discreteGradient/CMakeLists.txt
+++ b/core/base/discreteGradient/CMakeLists.txt
@@ -8,10 +8,3 @@ ttk_add_base_library(discreteGradient
     triangulation
     ftmTree
     )
-
-option(TTK_ENABLE_DCG_OPTIMIZE_MEMORY "Enable Discrete Gradient memory optimization" OFF)
-mark_as_advanced(TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
-
-if (TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
-  target_compile_definitions(discreteGradient PUBLIC TTK_ENABLE_DCG_OPTIMIZE_MEMORY)
-endif()

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -29,10 +29,10 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
 
   // clear & init gradient memory
   for(int i = 0; i < dimensionality_; ++i) {
-    gradient_[2 * i].clear();
-    gradient_[2 * i].resize(numberOfCells[i], -1);
-    gradient_[2 * i + 1].clear();
-    gradient_[2 * i + 1].resize(numberOfCells[i + 1], -1);
+    (*gradient_)[2 * i].clear();
+    (*gradient_)[2 * i].resize(numberOfCells[i], -1);
+    (*gradient_)[2 * i + 1].clear();
+    (*gradient_)[2 * i + 1].resize(numberOfCells[i + 1], -1);
   }
 
   std::vector<std::vector<std::string>> rows{
@@ -120,7 +120,7 @@ CriticalType
 
 bool DiscreteGradient::isMinimum(const Cell &cell) const {
   if(cell.dim_ == 0) {
-    return (gradient_[0][cell.id_] == -1);
+    return ((*gradient_)[0][cell.id_] == -1);
   }
 
   return false;
@@ -128,7 +128,8 @@ bool DiscreteGradient::isMinimum(const Cell &cell) const {
 
 bool DiscreteGradient::isSaddle1(const Cell &cell) const {
   if(cell.dim_ == 1) {
-    return (gradient_[1][cell.id_] == -1 and gradient_[2][cell.id_] == -1);
+    return ((*gradient_)[1][cell.id_] == -1
+            and (*gradient_)[2][cell.id_] == -1);
   }
 
   return false;
@@ -136,7 +137,8 @@ bool DiscreteGradient::isSaddle1(const Cell &cell) const {
 
 bool DiscreteGradient::isSaddle2(const Cell &cell) const {
   if(dimensionality_ == 3 and cell.dim_ == 2) {
-    return (gradient_[3][cell.id_] == -1 and gradient_[4][cell.id_] == -1);
+    return ((*gradient_)[3][cell.id_] == -1
+            and (*gradient_)[4][cell.id_] == -1);
   }
 
   return false;
@@ -144,15 +146,15 @@ bool DiscreteGradient::isSaddle2(const Cell &cell) const {
 
 bool DiscreteGradient::isMaximum(const Cell &cell) const {
   if(dimensionality_ == 1 and cell.dim_ == 1) {
-    return (gradient_[1][cell.id_] == -1);
+    return ((*gradient_)[1][cell.id_] == -1);
   }
 
   if(dimensionality_ == 2 and cell.dim_ == 2) {
-    return (gradient_[3][cell.id_] == -1);
+    return ((*gradient_)[3][cell.id_] == -1);
   }
 
   if(dimensionality_ == 3 and cell.dim_ == 3) {
-    return (gradient_[5][cell.id_] == -1);
+    return ((*gradient_)[5][cell.id_] == -1);
   }
 
   return false;
@@ -166,21 +168,21 @@ bool DiscreteGradient::isCellCritical(const int cellDim,
   }
 
   if(cellDim == 0) {
-    return (gradient_[0][cellId] == -1);
+    return ((*gradient_)[0][cellId] == -1);
   }
 
   if(cellDim == 1) {
-    return (gradient_[1][cellId] == -1
-            && (dimensionality_ == 1 || gradient_[2][cellId] == -1));
+    return ((*gradient_)[1][cellId] == -1
+            && (dimensionality_ == 1 || (*gradient_)[2][cellId] == -1));
   }
 
   if(cellDim == 2) {
-    return (gradient_[3][cellId] == -1
-            && (dimensionality_ == 2 || gradient_[4][cellId] == -1));
+    return ((*gradient_)[3][cellId] == -1
+            && (dimensionality_ == 2 || (*gradient_)[4][cellId] == -1));
   }
 
   if(cellDim == 3) {
-    return (gradient_[5][cellId] == -1);
+    return ((*gradient_)[5][cellId] == -1);
   }
 
   return false;

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -288,18 +288,6 @@ namespace ttk {
         this->setDebugMsgPrefix("DiscreteGradient");
       }
 
-      ~DiscreteGradient() override {
-        if(this->cacheHandler_ != nullptr
-           && this->inputScalarField_.first != nullptr) {
-          auto pos = this->cacheHandler_->find(this->inputScalarField_);
-          if(pos != this->cacheHandler_->end()
-             && pos->second == &this->gradient_) {
-            // avoid dangling pointers
-            this->cacheHandler_->erase(pos);
-          }
-        }
-      }
-
       /**
        * Impose a threshold on the number of simplification passes.
        */
@@ -412,7 +400,6 @@ according to them.
             // for filterSaddleConnectors
             contourTree_.preconditionTriangulation(data);
           }
-          this->cacheHandler_ = data->getGradientCacheHandler();
         }
       }
 
@@ -924,14 +911,13 @@ gradient, false otherwise.
 
       int dimensionality_{-1};
       SimplexId numberOfVertices_{};
-      AbstractTriangulation::gradientType gradient_{};
-      AbstractTriangulation::gradientCacheType *cacheHandler_{};
       std::vector<SimplexId> dmtMax2PL_{};
       std::vector<SimplexId> dmt1Saddle2PL_{};
       std::vector<SimplexId> dmt2Saddle2PL_{};
       std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
 
       AbstractTriangulation::gradientKeyType inputScalarField_{};
+      AbstractTriangulation::gradientType *gradient_{};
       const SimplexId *inputOffsets_{};
     };
 

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -309,7 +309,7 @@ namespace ttk {
 
       ~DiscreteGradient() override {
         if(this->cacheHandler_ != nullptr
-           && this->inputScalarField_ != nullptr) {
+           && this->inputScalarField_.first != nullptr) {
           auto pos = this->cacheHandler_->find(this->inputScalarField_);
           if(pos != this->cacheHandler_->end()
              && pos->second == &this->gradient_) {
@@ -390,9 +390,15 @@ according to them.
 
       /**
        * Set the input scalar function.
+       *
+       * The first parameter is a pointer to the scalar field buffer
+       * (often provided by ttkUtils::GetVoidPointer()), the second
+       * one is a timestamp representing the last modification time of
+       * the scalar field (often provided by vtkObject::GetMTime()).
        */
-      inline void setInputScalarField(const void *const data) {
-        inputScalarField_ = data;
+      inline void setInputScalarField(const void *const data,
+                                      const size_t mTime) {
+        inputScalarField_ = std::make_pair(data, mTime);
       }
 
       /**
@@ -944,7 +950,7 @@ gradient, false otherwise.
       std::vector<SimplexId> dmt2Saddle2PL_{};
       std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
 
-      const void *inputScalarField_{};
+      AbstractTriangulation::gradientKeyType inputScalarField_{};
       const SimplexId *inputOffsets_{};
     };
 

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -307,6 +307,18 @@ namespace ttk {
         this->setDebugMsgPrefix("DiscreteGradient");
       }
 
+      ~DiscreteGradient() override {
+        if(this->cacheHandler_ != nullptr
+           && this->inputScalarField_ != nullptr) {
+          auto pos = this->cacheHandler_->find(this->inputScalarField_);
+          if(pos != this->cacheHandler_->end()
+             && pos->second == &this->gradient_) {
+            // avoid dangling pointers
+            this->cacheHandler_->erase(pos);
+          }
+        }
+      }
+
       /**
        * Impose a threshold on the number of simplification passes.
        */
@@ -413,7 +425,7 @@ according to them.
             // for filterSaddleConnectors
             contourTree_.preconditionTriangulation(data);
           }
-          this->initMemory(*data);
+          this->cacheHandler_ = data->getGradientCacheHandler();
         }
       }
 
@@ -926,6 +938,7 @@ gradient, false otherwise.
       int dimensionality_{-1};
       SimplexId numberOfVertices_{};
       gradientType gradient_{};
+      AbstractTriangulation::gradientCacheType *cacheHandler_{};
       std::vector<SimplexId> dmtMax2PL_{};
       std::vector<SimplexId> dmt1Saddle2PL_{};
       std::vector<SimplexId> dmt2Saddle2PL_{};

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -276,25 +276,6 @@ namespace ttk {
       }
     };
 
-#ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-    using gradIdType = char;
-#else
-    using gradIdType = SimplexId;
-#endif
-
-    /**
-     * @brief Discrete gradient struct
-     *
-     * 0: paired edge id per vertex
-     * 1: paired vertex id per edge
-     * 2: paired triangle id per edge
-     * 3: paired edge id per triangle
-     * 4: paired tetra id per triangle
-     * 5: paired triangle id per tetra
-     * -1 if critical or paired to a cell of another dimension
-     */
-    using gradientType = std::array<std::vector<gradIdType>, 6>;
-
     /**
      * Compute and manage a discrete gradient of a function on a triangulation.
      * TTK assumes that the input dataset is made of only one connected
@@ -943,7 +924,7 @@ gradient, false otherwise.
 
       int dimensionality_{-1};
       SimplexId numberOfVertices_{};
-      gradientType gradient_{};
+      AbstractTriangulation::gradientType gradient_{};
       AbstractTriangulation::gradientCacheType *cacheHandler_{};
       std::vector<SimplexId> dmtMax2PL_{};
       std::vector<SimplexId> dmt1Saddle2PL_{};

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -38,59 +38,37 @@ dataType DiscreteGradient::getPersistence(
 
 template <typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
-  Timer t;
 
-  const auto findGradient = [this]() -> AbstractTriangulation::gradientType * {
-    if(this->cacheHandler_ == nullptr
-       || this->inputScalarField_.first == nullptr) {
+  auto &cacheHandler = *triangulation.getGradientCacheHandler();
+  const auto findGradient
+    = [this, &cacheHandler]() -> AbstractTriangulation::gradientType * {
+    if(this->inputScalarField_.first == nullptr) {
       return {};
     }
-    const auto pos = this->cacheHandler_->find(this->inputScalarField_);
-    if(pos != this->cacheHandler_->end()) {
-      return pos->second;
+    const auto pos = cacheHandler.find(this->inputScalarField_);
+    if(pos != cacheHandler.end()) {
+      return &pos->second;
     }
     return {};
   };
 
-  const auto cachedGradient = findGradient();
-  if(cachedGradient == nullptr) {
-    // compute gradient pairs
+  this->gradient_ = findGradient();
+  if(this->gradient_ == nullptr) {
+    // add new cache entry
+    cacheHandler[this->inputScalarField_] = {};
+    this->gradient_ = &cacheHandler[this->inputScalarField_];
+    // allocate gradient memory
     this->initMemory(triangulation);
+
+    Timer tm{};
+    // compute gradient pairs
     this->processLowerStars(this->inputOffsets_, triangulation);
 
     this->printMsg(
-      "Built discrete gradient", 1.0, t.getElapsedTime(), this->threadNumber_);
-
+      "Built discrete gradient", 1.0, tm.getElapsedTime(), this->threadNumber_);
   } else {
-    if(cachedGradient != &this->gradient_) {
-      // restore gradient from cache
-      this->gradient_ = std::move(*cachedGradient);
-    }
-
-    this->printMsg(
-      "Fetched cached discrete gradient", 1.0, t.getElapsedTime(), 1);
+    this->printMsg("Fetched cached discrete gradient");
   }
-
-  const auto storeGradient = [this]() -> bool {
-    if(this->cacheHandler_ == nullptr
-       || this->inputScalarField_.first == nullptr) {
-      return false;
-    }
-    // ensure only one cache entry points to the current instance
-    for(auto it = this->cacheHandler_->begin();
-        it != this->cacheHandler_->end();) {
-      if(it->second == &this->gradient_) {
-        this->cacheHandler_->erase(it++);
-      } else {
-        ++it;
-      }
-    }
-    (*this->cacheHandler_)[this->inputScalarField_] = &this->gradient_;
-    return true;
-  };
-
-  // cache the current discrete gradient instance
-  storeGradient();
 
   return 0;
 }
@@ -2005,12 +1983,12 @@ inline void DiscreteGradient::pairCells(
       }
     }
   }
-  gradient_[2 * alpha.dim_][alpha.id_] = localBId;
-  gradient_[2 * alpha.dim_ + 1][beta.id_] = localAId;
+  (*gradient_)[2 * alpha.dim_][alpha.id_] = localBId;
+  (*gradient_)[2 * alpha.dim_ + 1][beta.id_] = localAId;
 #else
   TTK_FORCE_USE(triangulation);
-  gradient_[2 * alpha.dim_][alpha.id_] = beta.id_;
-  gradient_[2 * alpha.dim_ + 1][beta.id_] = alpha.id_;
+  (*gradient_)[2 * alpha.dim_][alpha.id_] = beta.id_;
+  (*gradient_)[2 * alpha.dim_ + 1][beta.id_] = alpha.id_;
 #endif // TTK_ENABLE_DCG_OPTIMIZE_MEMORY
   alpha.paired_ = true;
   beta.paired_ = true;
@@ -2240,9 +2218,9 @@ SimplexId
   if(cell.dim_ == 0) {
     if(!isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getVertexEdge(cell.id_, gradient_[0][cell.id_], id);
+      triangulation.getVertexEdge(cell.id_, (*gradient_)[0][cell.id_], id);
 #else
-      id = gradient_[0][cell.id_];
+      id = (*gradient_)[0][cell.id_];
 #endif
     }
   }
@@ -2250,15 +2228,15 @@ SimplexId
   else if(cell.dim_ == 1) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getEdgeVertex(cell.id_, gradient_[1][cell.id_], id);
+      triangulation.getEdgeVertex(cell.id_, (*gradient_)[1][cell.id_], id);
 #else
-      id = gradient_[1][cell.id_];
+      id = (*gradient_)[1][cell.id_];
 #endif
     } else {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getEdgeTriangle(cell.id_, gradient_[2][cell.id_], id);
+      triangulation.getEdgeTriangle(cell.id_, (*gradient_)[2][cell.id_], id);
 #else
-      id = gradient_[2][cell.id_];
+      id = (*gradient_)[2][cell.id_];
 #endif
     }
   }
@@ -2266,15 +2244,15 @@ SimplexId
   else if(cell.dim_ == 2) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getTriangleEdge(cell.id_, gradient_[3][cell.id_], id);
+      triangulation.getTriangleEdge(cell.id_, (*gradient_)[3][cell.id_], id);
 #else
-      id = gradient_[3][cell.id_];
+      id = (*gradient_)[3][cell.id_];
 #endif
     } else {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getTriangleStar(cell.id_, gradient_[4][cell.id_], id);
+      triangulation.getTriangleStar(cell.id_, (*gradient_)[4][cell.id_], id);
 #else
-      id = gradient_[4][cell.id_];
+      id = (*gradient_)[4][cell.id_];
 #endif
     }
   }
@@ -2282,9 +2260,9 @@ SimplexId
   else if(cell.dim_ == 3) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getCellTriangle(cell.id_, gradient_[5][cell.id_], id);
+      triangulation.getCellTriangle(cell.id_, (*gradient_)[5][cell.id_], id);
 #else
-      id = gradient_[5][cell.id_];
+      id = (*gradient_)[5][cell.id_];
 #endif
     }
   }
@@ -2800,7 +2778,7 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getCellEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[3][triangleId] = k;
+          (*gradient_)[3][triangleId] = k;
           break;
         }
       }
@@ -2808,14 +2786,14 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getEdgeStar(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[2][edgeId] = k;
+          (*gradient_)[2][edgeId] = k;
           break;
         }
       }
 #else
       TTK_FORCE_USE(triangulation);
-      gradient_[3][triangleId] = edgeId;
-      gradient_[2][edgeId] = triangleId;
+      (*gradient_)[3][triangleId] = edgeId;
+      (*gradient_)[2][edgeId] = triangleId;
 #endif
     }
   } else if(dimensionality_ == 3) {
@@ -2830,7 +2808,7 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getCellTriangle(tetraId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[5][tetraId] = k;
+          (*gradient_)[5][tetraId] = k;
           break;
         }
       }
@@ -2838,13 +2816,13 @@ int DiscreteGradient::reverseAscendingPath(
         SimplexId tmp;
         triangulation.getTriangleStar(triangleId, k, tmp);
         if(tmp == tetraId) {
-          gradient_[4][triangleId] = k;
+          (*gradient_)[4][triangleId] = k;
           break;
         }
       }
 #else
-      gradient_[5][tetraId] = triangleId;
-      gradient_[4][triangleId] = tetraId;
+      (*gradient_)[5][tetraId] = triangleId;
+      (*gradient_)[4][triangleId] = tetraId;
 #endif
     }
   }
@@ -2867,7 +2845,7 @@ int DiscreteGradient::reverseDescendingPath(
       SimplexId tmp;
       triangulation.getVertexEdge(vertId, k, tmp);
       if(tmp == edgeId) {
-        gradient_[0][vertId] = k;
+        (*gradient_)[0][vertId] = k;
         break;
       }
     }
@@ -2876,14 +2854,14 @@ int DiscreteGradient::reverseDescendingPath(
       SimplexId tmp;
       triangulation.getEdgeVertex(edgeId, k, tmp);
       if(tmp == vertId) {
-        gradient_[1][edgeId] = k;
+        (*gradient_)[1][edgeId] = k;
         break;
       }
     }
 #else
     TTK_FORCE_USE(triangulation);
-    gradient_[0][vertId] = edgeId;
-    gradient_[1][edgeId] = vertId;
+    (*gradient_)[0][vertId] = edgeId;
+    (*gradient_)[1][edgeId] = vertId;
 #endif
   }
 
@@ -2906,7 +2884,7 @@ int DiscreteGradient::reverseAscendingPathOnWall(
         SimplexId tmp;
         triangulation.getTriangleEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[3][triangleId] = k;
+          (*gradient_)[3][triangleId] = k;
           break;
         }
       }
@@ -2914,14 +2892,14 @@ int DiscreteGradient::reverseAscendingPathOnWall(
         SimplexId tmp;
         triangulation.getEdgeTriangle(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[2][edgeId] = k;
+          (*gradient_)[2][edgeId] = k;
           break;
         }
       }
 #else
       TTK_FORCE_USE(triangulation);
-      gradient_[3][triangleId] = edgeId;
-      gradient_[2][edgeId] = triangleId;
+      (*gradient_)[3][triangleId] = edgeId;
+      (*gradient_)[2][edgeId] = triangleId;
 #endif
     }
   }
@@ -2945,7 +2923,7 @@ int DiscreteGradient::reverseDescendingPathOnWall(
         SimplexId tmp;
         triangulation.getTriangleEdge(triangleId, k, tmp);
         if(tmp == edgeId) {
-          gradient_[3][triangleId] = k;
+          (*gradient_)[3][triangleId] = k;
           break;
         }
       }
@@ -2953,14 +2931,14 @@ int DiscreteGradient::reverseDescendingPathOnWall(
         SimplexId tmp;
         triangulation.getEdgeTriangle(edgeId, k, tmp);
         if(tmp == triangleId) {
-          gradient_[2][edgeId] = k;
+          (*gradient_)[2][edgeId] = k;
           break;
         }
       }
 #else
       TTK_FORCE_USE(triangulation);
-      gradient_[2][edgeId] = triangleId;
-      gradient_[3][triangleId] = edgeId;
+      (*gradient_)[2][edgeId] = triangleId;
+      (*gradient_)[3][triangleId] = edgeId;
 #endif
     }
   }

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -40,7 +40,7 @@ template <typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 
-  const auto findGradient = [this]() -> gradientType * {
+  const auto findGradient = [this]() -> AbstractTriangulation::gradientType * {
     if(this->cacheHandler_ == nullptr
        || this->inputScalarField_.first == nullptr) {
       return {};

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -41,7 +41,8 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   Timer t;
 
   const auto findGradient = [this]() -> gradientType * {
-    if(this->cacheHandler_ == nullptr || this->inputScalarField_ == nullptr) {
+    if(this->cacheHandler_ == nullptr
+       || this->inputScalarField_.first == nullptr) {
       return {};
     }
     const auto pos = this->cacheHandler_->find(this->inputScalarField_);
@@ -71,7 +72,8 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
   }
 
   const auto storeGradient = [this]() -> bool {
-    if(this->cacheHandler_ == nullptr || this->inputScalarField_ == nullptr) {
+    if(this->cacheHandler_ == nullptr
+       || this->inputScalarField_.first == nullptr) {
       return false;
     }
     // ensure only one cache entry points to the current instance
@@ -394,7 +396,8 @@ int DiscreteGradient::initializeSaddleSaddleConnections1(
   const triangulationType &triangulation) const {
   Timer t;
 
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
 
   const int maximumDim = dimensionality_;
   const int saddle2Dim = maximumDim - 1;
@@ -557,7 +560,8 @@ int DiscreteGradient::processSaddleSaddleConnections1(
   const triangulationType &triangulation) {
   Timer t;
 
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
 
   const SimplexId numberOfEdges = triangulation.getNumberOfEdges();
   const SimplexId numberOfTriangles = triangulation.getNumberOfTriangles();
@@ -988,7 +992,8 @@ int DiscreteGradient::initializeSaddleSaddleConnections2(
   const triangulationType &triangulation) const {
   Timer t;
 
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
 
   const int maximumDim = dimensionality_;
   const int saddle2Dim = maximumDim - 1;
@@ -1153,7 +1158,8 @@ int DiscreteGradient::processSaddleSaddleConnections2(
   this->printMsg("Saddle connector persistence threshold: "
                  + std::to_string(this->SaddleConnectorsPersistenceThreshold));
 
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
 
   const SimplexId numberOfEdges = triangulation.getNumberOfEdges();
   const SimplexId numberOfTriangles = triangulation.getNumberOfTriangles();
@@ -1605,7 +1611,8 @@ int DiscreteGradient::filterSaddleConnectors(
 
   std::vector<std::pair<SimplexId, char>> cpset;
 
-  const auto *const scalars = static_cast<const dataType *>(inputScalarField_);
+  const auto *const scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
   const auto *const offsets = inputOffsets_;
 
   contourTree_.setDebugLevel(debugLevel_);
@@ -1723,7 +1730,8 @@ void DiscreteGradient::computeSaddleSaddlePersistencePairs(
   std::vector<std::tuple<SimplexId, SimplexId, dataType>> &pl_saddleSaddlePairs,
   const triangulationType &triangulation) {
 
-  const dataType *scalars = static_cast<const dataType *>(inputScalarField_);
+  const dataType *scalars
+    = static_cast<const dataType *>(inputScalarField_.first);
 
   std::vector<std::array<dcg::Cell, 2>> dmt_pairs;
   {

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -112,6 +112,7 @@ namespace ttk {
                        Output2Separatrices &outSeps2,
                        OutputManifold &outManifold,
                        const dataType *const scalars,
+                       const size_t scalarsMTime,
                        const SimplexId *const offsets,
                        const triangulationType &triangulation);
 
@@ -413,6 +414,7 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
                                     Output2Separatrices &outSeps2,
                                     OutputManifold &outManifold,
                                     const dataType *const scalars,
+                                    const size_t scalarsMTime,
                                     const SimplexId *const offsets,
                                     const triangulationType &triangulation) {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -435,7 +437,7 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
 
   this->discreteGradient_.setThreadNumber(threadNumber_);
   this->discreteGradient_.setDebugLevel(debugLevel_);
-  this->discreteGradient_.setInputScalarField(scalars);
+  this->discreteGradient_.setInputScalarField(scalars, scalarsMTime);
   this->discreteGradient_.setInputOffsets(offsets);
   this->discreteGradient_.buildGradient(triangulation);
 

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -53,6 +53,7 @@ namespace ttk {
     template <typename scalarType,
               class triangulationType = ttk::AbstractTriangulation>
     int execute(const scalarType *inputScalars,
+                const size_t scalarsMTime,
                 const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
 
@@ -115,6 +116,7 @@ int ttk::PersistenceCurve::computePersistencePlot(
 
 template <typename scalarType, class triangulationType>
 int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
+                                   const size_t scalarsMTime,
                                    const SimplexId *inputOffsets,
                                    const triangulationType *triangulation) {
 
@@ -160,7 +162,7 @@ int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
   if(dimensionality == 3 and ComputeSaddleConnectors and MSCPlot_ != nullptr) {
     std::vector<std::tuple<SimplexId, SimplexId, scalarType>>
       pl_saddleSaddlePairs;
-    dcg_.setInputScalarField(inputScalars);
+    dcg_.setInputScalarField(inputScalars, scalarsMTime);
     dcg_.setInputOffsets(inputOffsets);
     dcg_.computeSaddleSaddlePersistencePairs<scalarType>(
       pl_saddleSaddlePairs, *triangulation);

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -139,12 +139,14 @@ namespace ttk {
     template <typename scalarType, class triangulationType>
     int execute(std::vector<PersistencePair> &CTDiagram,
                 const scalarType *inputScalars,
+                const size_t scalarsMTime,
                 const SimplexId *inputOffsets,
                 const triangulationType *triangulation);
 
     template <typename scalarType, class triangulationType>
     int executeFTM(std::vector<PersistencePair> &CTDiagram,
                    const scalarType *inputScalars,
+                   const size_t scalarsMTime,
                    const SimplexId *inputOffsets,
                    const triangulationType *triangulation);
 
@@ -265,6 +267,7 @@ int ttk::PersistenceDiagram::computeCTPersistenceDiagram(
 template <typename scalarType, class triangulationType>
 int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
                                      const scalarType *inputScalars,
+                                     const size_t scalarsMTime,
                                      const SimplexId *inputOffsets,
                                      const triangulationType *triangulation) {
 
@@ -286,7 +289,8 @@ int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
       break;
 
     case BACKEND::FTM:
-      executeFTM(CTDiagram, inputScalars, inputOffsets, triangulation);
+      executeFTM(
+        CTDiagram, inputScalars, scalarsMTime, inputOffsets, triangulation);
       break;
     default:
       printErr("No method was selected");
@@ -457,6 +461,7 @@ template <typename scalarType, class triangulationType>
 int ttk::PersistenceDiagram::executeFTM(
   std::vector<PersistencePair> &CTDiagram,
   const scalarType *inputScalars,
+  const size_t scalarsMTime,
   const SimplexId *inputOffsets,
   const triangulationType *triangulation) {
 
@@ -508,7 +513,7 @@ int ttk::PersistenceDiagram::executeFTM(
   std::vector<std::tuple<SimplexId, SimplexId, scalarType>>
     pl_saddleSaddlePairs;
   if(triangulation->getDimensionality() == 3 and ComputeSaddleConnectors) {
-    dcg_.setInputScalarField(inputScalars);
+    dcg_.setInputScalarField(inputScalars, scalarsMTime);
     dcg_.setInputOffsets(inputOffsets);
     dcg_.computeSaddleSaddlePersistencePairs<scalarType>(
       pl_saddleSaddlePairs, *triangulation);

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -103,7 +103,8 @@ int ttk::TrackingFromFields::performDiagramComputation(
 
     // persistenceDiagram.setOutputCTDiagram(&CTDiagram);
     persistenceDiagram.execute<dataType, triangulationType>(
-      CTDiagram, (dataType *)(inputData_[i]), inputOffsets_[i], triangulation);
+      CTDiagram, (dataType *)(inputData_[i]), 0, inputOffsets_[i],
+      triangulation);
 
     // Copy diagram into augmented diagram.
     persistenceDiagrams[i] = std::vector<diagramTuple>(CTDiagram.size());

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -268,7 +268,8 @@ int ttkDiscreteGradient::RequestData(vtkInformation *ttkNotUsed(request),
 #endif
 
   // baseCode processing
-  this->setInputScalarField(ttkUtils::GetVoidPointer(inputScalars));
+  this->setInputScalarField(
+    ttkUtils::GetVoidPointer(inputScalars), inputScalars->GetMTime());
   this->setInputOffsets(
     static_cast<SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)));
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -61,9 +61,9 @@ int ttkMorseSmaleComplex::dispatch(vtkDataArray *const inputScalars,
   const int dimensionality = triangulation.getDimensionality();
   const auto scalars = ttkUtils::GetPointer<scalarType>(inputScalars);
 
-  const int ret
-    = this->execute(criticalPoints_, separatrices1_, separatrices2_,
-                    segmentations_, scalars, inputOffsets, triangulation);
+  const int ret = this->execute(
+    criticalPoints_, separatrices1_, separatrices2_, segmentations_, scalars,
+    inputScalars->GetMTime(), inputOffsets, triangulation);
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ret != 0) {

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -150,6 +150,7 @@ int ttkPersistenceCurve::dispatch(vtkTable *outputJTPersistenceCurve,
                                   vtkTable *outputSTPersistenceCurve,
                                   vtkTable *outputCTPersistenceCurve,
                                   const VTK_TT *inputScalars,
+                                  const size_t scalarsMTime,
                                   const void *inputOffsets,
                                   const TTK_TT *triangulation) {
 
@@ -165,7 +166,7 @@ int ttkPersistenceCurve::dispatch(vtkTable *outputJTPersistenceCurve,
   this->setOutputMSCPlot(&MSCPlot);
 
   ret = this->execute<VTK_TT, TTK_TT>(
-    inputScalars, (SimplexId *)inputOffsets, triangulation);
+    inputScalars, scalarsMTime, (SimplexId *)inputOffsets, triangulation);
 
   ret = getPersistenceCurve<vtkDoubleArray, VTK_TT>(
     outputJTPersistenceCurve, TreeType::Join, JTPlot);
@@ -252,13 +253,14 @@ int ttkPersistenceCurve::RequestData(vtkInformation *ttkNotUsed(request),
 #endif
 
   int status = 0;
-  ttkVtkTemplateMacro(inputScalars->GetDataType(), triangulation->getType(),
-                      (status = this->dispatch<VTK_TT, TTK_TT>(
-                         outputJTPersistenceCurve, outputMSCPersistenceCurve,
-                         outputSTPersistenceCurve, outputCTPersistenceCurve,
-                         (VTK_TT *)ttkUtils::GetVoidPointer(inputScalars),
-                         ttkUtils::GetVoidPointer(offsetField),
-                         (TTK_TT *)(triangulation->getData()))));
+  ttkVtkTemplateMacro(
+    inputScalars->GetDataType(), triangulation->getType(),
+    (status = this->dispatch<VTK_TT, TTK_TT>(
+       outputJTPersistenceCurve, outputMSCPersistenceCurve,
+       outputSTPersistenceCurve, outputCTPersistenceCurve,
+       (VTK_TT *)ttkUtils::GetVoidPointer(inputScalars),
+       inputScalars->GetMTime(), ttkUtils::GetVoidPointer(offsetField),
+       (TTK_TT *)(triangulation->getData()))));
 
   // something wrong in baseCode
   if(status) {

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -114,6 +114,7 @@ private:
                vtkTable *outputSTPersistenceCurve,
                vtkTable *outputCTPersistenceCurve,
                const VTK_TT *inputScalars,
+               const size_t scalarsMTime,
                const void *inputOffsets,
                const TTK_TT *triangulation);
 };

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -230,7 +230,8 @@ int ttkPersistenceDiagram::dispatch(
     this->setOutputMonotonyOffsets(outputMonotonyOffsets);
   }
 
-  status = this->execute(CTDiagram, inputScalars, inputOrder, triangulation);
+  status = this->execute(CTDiagram, inputScalars, inputScalarsArray->GetMTime(),
+                         inputOrder, triangulation);
 
   // something wrong in baseCode
   if(status != 0) {

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
@@ -236,7 +236,8 @@ int ttkPersistenceDiagramApproximation::dispatch(
   this->setOutputOffsets(outputOffsets);
   this->setOutputMonotonyOffsets(outputMonotonyOffsets);
 
-  status = this->execute(CTDiagram, inputScalars, inputOrder, triangulation);
+  status = this->execute(CTDiagram, inputScalars, inputScalarsArray->GetMTime(),
+                         inputOrder, triangulation);
 
   // something wrong in baseCode
   if(status != 0) {

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -191,13 +191,14 @@ int main(int argc, char **argv) {
   std::vector<std::pair<float, ttk::SimplexId>> outputCurve;
   curve.preconditionTriangulation(&triangulation);
   curve.setOutputCTPlot(&outputCurve);
-  curve.execute<float>(height.data(), order.data(), &triangulation);
+  curve.execute<float>(height.data(), 0, order.data(), &triangulation);
 
   // 3. computing the persitence diagram
   ttk::PersistenceDiagram diagram;
   std::vector<ttk::PersistencePair> diagramOutput;
   diagram.preconditionTriangulation(&triangulation);
-  diagram.execute(diagramOutput, height.data(), order.data(), &triangulation);
+  diagram.execute(
+    diagramOutput, height.data(), 0, order.data(), &triangulation);
 
   // 4. selecting the critical point pairs
   std::vector<float> simplifiedHeight = height;
@@ -243,7 +244,7 @@ int main(int argc, char **argv) {
   morseSmaleComplex.preconditionTriangulation(&triangulation);
   morseSmaleComplex.execute(
     outCriticalPoints, out1Separatrices, out2Separatrices, outSegmentation,
-    simplifiedHeight.data(), simplifiedOrder.data(), triangulation);
+    simplifiedHeight.data(), 0, simplifiedOrder.data(), triangulation);
 
   // save the output
   save(pointSet, triangleSetCo, triangleSetOff, "output.off");


### PR DESCRIPTION
This PR adds a caching system to the DiscreteGradient internal data structure.
The AbstractTriangulation is now used to store this data structure. The DiscreteGradient::gradient_ member variable is now a pointer to the cached data structure.
The cache key is a pair (scalar field buffer pointer, scalar field last modified time). The VTK layer modules have been adapted to pass the modified time (`vtkObject::GetMTime()`) to the DiscreteGradient class.

Enjoy,
Pierre
