### PR TITLE
Fix repeatable inputs

### DIFF
--- a/paraview/xmls/PlanarGraphLayout.xml
+++ b/paraview/xmls/PlanarGraphLayout.xml
@@ -31,7 +31,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
             </Documentation>
 
             <!-- Inputs -->
-            <InputProperty name="Input" command="AddInputConnection" multiple_input="1">
+            <InputProperty name="Input" command="AddInputConnection" clean_command="RemoveAllInputs" multiple_input="1">
                 <ProxyGroupDomain name="groups">
                     <Group name="sources" />
                     <Group name="filters" />

--- a/paraview/xmls/TrackingFromPersistenceDiagrams.xml
+++ b/paraview/xmls/TrackingFromPersistenceDiagrams.xml
@@ -27,6 +27,7 @@ by a list of scalar fields) and which computes a tracking mesh."
       <InputProperty
       name="Input"
       command="AddInputConnection"
+      clean_command="RemoveAllInputs"
       multiple_input="1">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>

--- a/paraview/xmls/UncertainDataEstimator.xml
+++ b/paraview/xmls/UncertainDataEstimator.xml
@@ -25,6 +25,7 @@ See also MandatoryCriticalPoints.
      <InputProperty
         name="Input"
         command="AddInputConnection"
+        clean_command="RemoveAllInputs"
         multiple_input="1">
         <ProxyGroupDomain name="groups">
           <Group name="sources"/>


### PR DESCRIPTION
This PR adds missing `clean_command="RemoveAllInputs"` XML directives in modules using repeatable inputs. The absence of this directive was causing segfaults in Python scripts using those modules through the ParaView simple API.

Example of such a Python script (dragon + elevation, FTM, PlanarGraphLayout):

```python
from paraview import simple


dragon = simple.XMLUnstructuredGridReader(FileName=["./dragon.vtu"])

elev = simple.Elevation(Input=dragon)
elev.LowPoint = [-98.33509826660156, -41.225101470947266, -57.2041015625]
elev.HighPoint = [102.87000274658203, 48.877601623535156, 76.4677963256836]

ftm = simple.TTKMergeandContourTreeFTM(Input=elev)
ftm.ScalarField = ["POINTS", "Elevation"]
ftm.InputOffsetField = ["POINTS", "Elevation"]
ftm.TreeType = "Split Tree"

pgl = simple.TTKPlanarGraphLayout(
    Input=[simple.OutputPort(ftm, 0), simple.OutputPort(ftm, 1)]
)
pgl.SequenceArray = ["POINTS", "CriticalType"]
pgl.SizeArray = ["POINTS", "CriticalType"]
pgl.BranchArray = ["POINTS", "CriticalType"]
pgl.LevelArray = ["POINTS", "CriticalType"]
pgl.InputisaMergeTree = 1

simple.UpdatePipeline()
```

Besides `PlanarGraphLayout`, only `TrackingFromPersistenceDiagrams` and `UncertainDataEstimator` were missing the `clean_command` directive. All other filters with a repeatable input feature it.

Enjoy,
Pierre