### PR TITLE
Display FTM, FTR skeleton nodes in ParaView

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -361,7 +361,7 @@ int ttkUtils::CellVertexFromPoints(vtkDataSet *const dataSet,
     const auto vtu{vtkUnstructuredGrid::SafeDownCast(dataSet)};
     if(vtu != nullptr) {
       vtu->SetPoints(points);
-      vtu->SetCells(VTK_VERTEX, cells);
+      vtu->SetCells(VTK_POLY_VERTEX, cells);
     }
   } else if(dataSet->IsA("vtkPolyData")) {
     const auto vtp{vtkPolyData::SafeDownCast(dataSet)};

--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -325,8 +325,7 @@ void ttkUtils::FillCellArrayFromDual(vtkIdType const *cells_co,
 }
 
 int ttkUtils::CellVertexFromPoints(vtkDataSet *const dataSet,
-                                   vtkPoints *const points,
-                                   const int nThreads = 1) {
+                                   vtkPoints *const points) {
 
   if(dataSet == nullptr || points == nullptr) {
     return 0;
@@ -361,6 +360,5 @@ int ttkUtils::CellVertexFromPoints(vtkDataSet *const dataSet,
     }
   }
 
-  TTK_FORCE_USE(nThreads);
   return 1;
 }

--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -341,21 +341,11 @@ int ttkUtils::CellVertexFromPoints(vtkDataSet *const dataSet,
     return 0;
   }
 
-  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
-  offsets->SetNumberOfComponents(1);
-  offsets->SetNumberOfTuples(nPoints + 1);
-  connectivity->SetNumberOfComponents(1);
-  connectivity->SetNumberOfTuples(nPoints);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(nThreads)
-#endif // TTK_ENABLE_OPENMP
-  for(size_t i = 0; i < nPoints; ++i) {
-    offsets->SetTuple1(i, i);
-    connectivity->SetTuple1(i, i);
-  }
-  offsets->SetTuple1(nPoints, nPoints);
   vtkNew<vtkCellArray> cells{};
-  cells->SetData(offsets, connectivity);
+  cells->InsertNextCell(nPoints);
+  for(size_t i = 0; i < nPoints; ++i) {
+    cells->InsertCellPoint(i);
+  }
 
   if(dataSet->IsA("vtkUnstructuredGrid")) {
     const auto vtu{vtkUnstructuredGrid::SafeDownCast(dataSet)};

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -91,11 +91,9 @@ public:
    * @param[out] dataSet Dataset to fill (either UnstructuredGrid or
    * PolyData)
    * @param[in] points Input points
-   * @param[in] nThreads Number of threads
    *
    * @return 1 if success, 0 otherwise
    */
   static int CellVertexFromPoints(vtkDataSet *const dataSet,
-                                  vtkPoints *const points,
-                                  const int nThreads);
+                                  vtkPoints *const points);
 };

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -21,6 +21,7 @@ class vtkDoubleArray;
 class vtkPoints;
 class vtkAbstractArray;
 class vtkCellArray;
+class vtkDataSet;
 
 template <typename T>
 class vtkSmartPointer;
@@ -82,4 +83,19 @@ public:
                                     vtkIdType const *cells_off,
                                     vtkIdType ncells,
                                     vtkCellArray *cellArray);
+
+  /*
+   * @brief Fills an UnstructuredGrid or a PolyData dataset with
+   * vertices
+   *
+   * @param[out] dataSet Dataset to fill (either UnstructuredGrid or
+   * PolyData)
+   * @param[in] points Input points
+   * @param[in] nThreads Number of threads
+   *
+   * @return 1 if success, 0 otherwise
+   */
+  static int CellVertexFromPoints(vtkDataSet *const dataSet,
+                                  vtkPoints *const points,
+                                  const int nThreads);
 };

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -92,12 +92,6 @@ int ttkDiscreteGradient::fillCriticalPoints(
   PLVertexIdentifiers->SetName(ttk::VertexScalarFieldName);
   PLVertexIdentifiers->SetNumberOfTuples(nPoints);
 
-  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
-  offsets->SetNumberOfComponents(1);
-  offsets->SetNumberOfTuples(nPoints + 1);
-  connectivity->SetNumberOfComponents(1);
-  connectivity->SetNumberOfTuples(nPoints);
-
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
@@ -108,15 +102,10 @@ int ttkDiscreteGradient::fillCriticalPoints(
     cellScalars->SetTuple1(i, scalars[critPoints_PLVertexIdentifiers[i]]);
     isOnBoundary->SetTuple1(i, critPoints_isOnBoundary[i]);
     PLVertexIdentifiers->SetTuple1(i, critPoints_PLVertexIdentifiers[i]);
-    offsets->SetTuple1(i, i);
-    connectivity->SetTuple1(i, i);
   }
-  offsets->SetTuple1(nPoints, nPoints);
 
-  vtkNew<vtkCellArray> cells{};
-  cells->SetData(offsets, connectivity);
-  outputCriticalPoints->SetPoints(points);
-  outputCriticalPoints->SetVerts(cells);
+  ttkUtils::CellVertexFromPoints(
+    outputCriticalPoints, points, this->threadNumber_);
 
   vtkPointData *pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -104,8 +104,7 @@ int ttkDiscreteGradient::fillCriticalPoints(
     PLVertexIdentifiers->SetTuple1(i, critPoints_PLVertexIdentifiers[i]);
   }
 
-  ttkUtils::CellVertexFromPoints(
-    outputCriticalPoints, points, this->threadNumber_);
+  ttkUtils::CellVertexFromPoints(outputCriticalPoints, points);
 
   vtkPointData *pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -583,9 +583,11 @@ int ttkFTMTree::getSkeletonNodes(vtkUnstructuredGrid *outputSkeletonNodes) {
     }
   }
 
-  skeletonNodes->SetPoints(points);
+  ttkUtils::CellVertexFromPoints(skeletonNodes, points, this->threadNumber_);
+
   vtkPointData *pointData = skeletonNodes->GetPointData();
   nodeData.addArray(pointData, params_);
+
   outputSkeletonNodes->ShallowCopy(skeletonNodes);
 
   return 1;

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -583,7 +583,7 @@ int ttkFTMTree::getSkeletonNodes(vtkUnstructuredGrid *outputSkeletonNodes) {
     }
   }
 
-  ttkUtils::CellVertexFromPoints(skeletonNodes, points, this->threadNumber_);
+  ttkUtils::CellVertexFromPoints(skeletonNodes, points);
 
   vtkPointData *pointData = skeletonNodes->GetPointData();
   nodeData.addArray(pointData, params_);

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -433,7 +433,7 @@ int ttkFTRGraph::getSkeletonNodes(const Graph &graph,
     nodeData.addNode(graph, nodeId, scalar);
   }
 
-  nodes->SetPoints(points);
+  ttkUtils::CellVertexFromPoints(nodes, points, this->threadNumber_);
   nodeData.addArrays(nodes->GetPointData(), params_);
 
   outputSkeletonNodes->ShallowCopy(nodes);

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -433,7 +433,7 @@ int ttkFTRGraph::getSkeletonNodes(const Graph &graph,
     nodeData.addNode(graph, nodeId, scalar);
   }
 
-  ttkUtils::CellVertexFromPoints(nodes, points, this->threadNumber_);
+  ttkUtils::CellVertexFromPoints(nodes, points);
   nodeData.addArrays(nodes->GetPointData(), params_);
 
   outputSkeletonNodes->ShallowCopy(nodes);

--- a/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
+++ b/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
@@ -42,23 +42,7 @@ int ttkGaussianPointCloud::RequestData(
       static_cast<double *>(ttkUtils::GetVoidPointer(points)));
   }
 
-  domain->SetPoints(points);
-
-  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
-  offsets->SetNumberOfComponents(1);
-  offsets->SetNumberOfTuples(NumberOfSamples + 1);
-  connectivity->SetNumberOfComponents(1);
-  connectivity->SetNumberOfTuples(NumberOfSamples);
-
-  for(int i = 0; i < NumberOfSamples; i++) {
-    offsets->SetTuple1(i, i);
-    connectivity->SetTuple1(i, i);
-  }
-  offsets->SetTuple1(NumberOfSamples, NumberOfSamples);
-
-  vtkNew<vtkCellArray> cells{};
-  cells->SetData(offsets, connectivity);
-  domain->SetVerts(cells);
+  ttkUtils::CellVertexFromPoints(domain, points, this->threadNumber_);
 
   return 1;
 }

--- a/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
+++ b/core/vtk/ttkGaussianPointCloud/ttkGaussianPointCloud.cpp
@@ -42,7 +42,7 @@ int ttkGaussianPointCloud::RequestData(
       static_cast<double *>(ttkUtils::GetVoidPointer(points)));
   }
 
-  ttkUtils::CellVertexFromPoints(domain, points, this->threadNumber_);
+  ttkUtils::CellVertexFromPoints(domain, points);
 
   return 1;
 }

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -130,8 +130,7 @@ int ttkMorseSmaleComplex::dispatch(vtkDataArray *const inputScalars,
     }
     setArray(manifoldSizeScalars, criticalPoints_.manifoldSize_);
 
-    ttkUtils::CellVertexFromPoints(
-      outputCriticalPoints, points, this->threadNumber_);
+    ttkUtils::CellVertexFromPoints(outputCriticalPoints, points);
 
     auto pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -130,24 +130,8 @@ int ttkMorseSmaleComplex::dispatch(vtkDataArray *const inputScalars,
     }
     setArray(manifoldSizeScalars, criticalPoints_.manifoldSize_);
 
-    outputCriticalPoints->SetPoints(points);
-
-    vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
-    offsets->SetNumberOfComponents(1);
-    offsets->SetNumberOfTuples(nPoints + 1);
-    connectivity->SetNumberOfComponents(1);
-    connectivity->SetNumberOfTuples(nPoints);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-    for(size_t i = 0; i < nPoints; ++i) {
-      offsets->SetTuple1(i, i);
-      connectivity->SetTuple1(i, i);
-    }
-    offsets->SetTuple1(nPoints, nPoints);
-    vtkNew<vtkCellArray> cells{};
-    cells->SetData(offsets, connectivity);
-    outputCriticalPoints->SetVerts(cells);
+    ttkUtils::CellVertexFromPoints(
+      outputCriticalPoints, points, this->threadNumber_);
 
     auto pointData = outputCriticalPoints->GetPointData();
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -112,7 +112,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
     vertexTypes->SetTuple1(i, (float)criticalPoints_[i].second);
   }
 
-  ttkUtils::CellVertexFromPoints(output, pointSet, this->threadNumber_);
+  ttkUtils::CellVertexFromPoints(output, pointSet);
   output->GetPointData()->AddArray(vertexTypes);
 
   if(VertexBoundary) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -101,11 +101,6 @@ int ttkScalarFieldCriticalPoints::RequestData(
 
   vtkNew<vtkPoints> pointSet{};
   pointSet->SetNumberOfPoints(criticalPoints_.size());
-  vtkNew<vtkIdTypeArray> offsets{}, connectivity{};
-  offsets->SetNumberOfComponents(1);
-  offsets->SetNumberOfTuples(criticalPoints_.size() + 1);
-  connectivity->SetNumberOfComponents(1);
-  connectivity->SetNumberOfTuples(criticalPoints_.size());
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
@@ -115,15 +110,9 @@ int ttkScalarFieldCriticalPoints::RequestData(
     input->GetPoint(criticalPoints_[i].first, p.data());
     pointSet->SetPoint(i, p.data());
     vertexTypes->SetTuple1(i, (float)criticalPoints_[i].second);
-    offsets->SetTuple1(i, i);
-    connectivity->SetTuple1(i, i);
   }
-  offsets->SetTuple1(criticalPoints_.size(), criticalPoints_.size());
 
-  vtkNew<vtkCellArray> cells{};
-  cells->SetData(offsets, connectivity);
-  output->SetVerts(cells);
-  output->SetPoints(pointSet);
+  ttkUtils::CellVertexFromPoints(output, pointSet, this->threadNumber_);
   output->GetPointData()->AddArray(vertexTypes);
 
   if(VertexBoundary) {


### PR DESCRIPTION
This PR refactors #588 (and to a lesser extent #592) by refactoring the code used for generating vtkCells for a point cloud. A new function has been created in `ttkUtils` and is used in the relevant modules: `DiscreteGradient`, `GaussianPointCloud`, `MorseSmaleComplex` and `ScalarFieldCriticalPoints`.

Two other modules have been added to this list: `FTMTree` and `FTRGraph` with their `Skeleton Nodes` outputs.

Enjoy,
Pierre