### PR TITLE
[ProgressiveTopology] Boundary saddles fix

### DIFF
--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -925,7 +925,7 @@ namespace ttk {
       return dimensions;
     }
 
-    ImplicitTriangulation *getTriangulation() {
+    ImplicitTriangulation *getTriangulation() const {
       return triangulation_;
     }
 

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -81,7 +81,6 @@ namespace ttk {
       startingDecimationLevel_ = std::max(data, 0);
     }
     void setStoppingDecimationLevel(int data) {
-      std::cout << "Stopping DL from progressive topo" << std::endl;
       if(data >= stoppingDecimationLevel_) {
         resumeProgressive_ = false;
       }
@@ -126,6 +125,7 @@ namespace ttk {
                          std::vector<std::vector<std::pair<polarity, polarity>>>
                            &vertexLinkPolarity,
                          std::vector<polarity> &toProcess,
+                         std::vector<polarity> &toReprocess,
                          std::vector<DynamicTree> &link,
                          std::vector<uint8_t> &vertexLink,
                          VLBoundaryType &vertexLinkByBoundaryType,
@@ -195,8 +195,10 @@ namespace ttk {
                          const SimplexId *const offsets) const;
 
     char getCriticalTypeFromLink(
+      const SimplexId globalId,
       const std::vector<std::pair<polarity, polarity>> &vlp,
-      DynamicTree &link) const;
+      DynamicTree &link,
+      polarity &reprocess) const;
 
     void
       updateDynamicLink(DynamicTree &link,

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -142,7 +142,7 @@ namespace ttk {
     bool forceNonManifoldCheck{false};
 
     // progressive
-    BACKEND BackEnd{BACKEND::GENERIC};
+    BACKEND BackEnd{BACKEND::PROGRESSIVE_TOPOLOGY};
     ProgressiveTopology progT_{};
     int StartingResolutionLevel{0};
     int StoppingResolutionLevel{-1};

--- a/paraview/xmls/ScalarFieldCriticalPoints.xml
+++ b/paraview/xmls/ScalarFieldCriticalPoints.xml
@@ -176,7 +176,7 @@ upper link of each vertex to compute its critical type.
           label="Backend"
           command="SetBackEnd"
           number_of_elements="1"
-         default_values="0" 
+         default_values="1" 
          panel_visibility="advanced" >
 		 <EnumerationDomain name="enum">
           <Entry value="0" text="Default generic backend"/>


### PR DESCRIPTION
Dear Julien,
This PR addresses the problem of boundary saddles not being correctly extracted by the **progressive** version of ScalarFieldCriticalPoints.

This is the result of ttkScalarFieldCriticalPoints **before the PR**, on isabel.vti, with the progressive backend :
```
[ScalarFieldCriticalPoints]   #Minima       : 642
[ScalarFieldCriticalPoints]   #1-saddles    : 1804
[ScalarFieldCriticalPoints]   #2-saddles    : 1738
[ScalarFieldCriticalPoints]   #Multi-saddles: 53
[ScalarFieldCriticalPoints]   #Maxima       : 454
```

And this is the result after the PR:
```
[ScalarFieldCriticalPoints]   #Minima       : 642
[ScalarFieldCriticalPoints]   #1-saddles    : 2001
[ScalarFieldCriticalPoints]   #2-saddles    : 1852
[ScalarFieldCriticalPoints]   #Multi-saddles: 53
[ScalarFieldCriticalPoints]   #Maxima       : 454
```
This result is the same as the one obtained with the generic backend.

I took the liberty of setting back the progressive backend as the default backend :innocent:.
Cheers,
Jules
