### PR TITLE
TriangulationManager: Fix printed messages

### DIFF
--- a/core/base/triangulation/Triangulation.cpp
+++ b/core/base/triangulation/Triangulation.cpp
@@ -158,11 +158,29 @@ bool Triangulation::processImplicitStrategy(const STRATEGY strategy) const {
     // disable preconditioning above TTK_IMPLICIT_PRECONDITIONS_THRESHOLD
     const auto doPreconditioning = nVerts <= threshold * threshold * threshold;
 
-    if(!this->hasImplicitPreconditions()) {
-      const auto thr{std::to_string(TTK_IMPLICIT_PRECONDITIONS_THRESHOLD)};
-      this->printWrn("Large grid detected (> " + thr + "x" + thr + "x" + thr
-                     + ")");
+    if(!doPreconditioning) {
+
+      // ensure that the warning message is printed at creation time
+      int prevDebugLevel{-1};
+      if(this->debugLevel_ < 2) {
+        prevDebugLevel = this->debugLevel_;
+        this->debugLevel_ = 2;
+      }
+      if(gridDimensions_[0] > 1 && gridDimensions_[1] > 1
+         && gridDimensions_[2] > 1) {
+        // 3D data-set: breakdown by grid edge dimension
+        const auto thr{std::to_string(threshold)};
+        this->printWrn("Large grid detected (> " + thr + "x" + thr + "x" + thr
+                       + ")");
+      } else {
+        // other dimensions: print number of vertices
+        const auto thr{std::to_string(threshold * threshold * threshold)};
+        this->printWrn("Large grid detected (>" + thr + " vertices)");
+      }
       this->printWrn("Defaulting to the fully implicit triangulation");
+      if(prevDebugLevel != -1) {
+        this->debugLevel_ = prevDebugLevel;
+      }
     }
     return doPreconditioning;
   } else if(strategy == STRATEGY::WITH_PRECONDITIONS) {

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -69,10 +69,13 @@ void ttkTriangulationManager::processImplicit(
   }
 
   triangulation.setImplicitPreconditions(this->PreconditioningStrategy);
-  printMsg("Switching regular grid preconditions from "
-           + (prevPreconditions ? std::string("ON") : std::string("OFF"))
-           + " to "
-           + (!prevPreconditions ? std::string("ON") : std::string("OFF")));
+  const auto newPreconditions = triangulation.hasImplicitPreconditions();
+  if(prevPreconditions != newPreconditions) {
+    printMsg("Switching regular grid preconditions from "
+             + (prevPreconditions ? std::string("ON") : std::string("OFF"))
+             + " to "
+             + (newPreconditions ? std::string("ON") : std::string("OFF")));
+  }
 }
 
 int ttkTriangulationManager::processExplicit(


### PR DESCRIPTION
Following #750, this PR fixes a few logic errors leading to incorrect messages displayed to the user:
* in TriangulationManager, the "Switched regular grid preconditions" message is now displayed iff the preconditions state has changed,
* in Triangulation, the default strategy warning on large grids should appear on triangulation creation (by manipulating the `debugLevel_` member variable)
* the condition surrounding this message has been fixed
* the message is slightly different in 2D and 1D: the number of vertices at the threshold is displayed, instead of the 3D grid dimensions.

Sorry for this,
Pierre
