### PR TITLE
New SurfaceGeometrySmoother filter

### DIFF
--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -143,7 +143,7 @@ int FiberSurface::computeTriangleFiber(
   }
 
   // compute the interpolations
-  vector<double> baryCentrics0, baryCentrics1;
+  std::array<double, 2> baryCentrics0{}, baryCentrics1{};
   vector<double> p(2), p0(2), p1(2), p2(2);
 
   p[0] = intersection.first;
@@ -372,7 +372,7 @@ int FiberSurface::computeTriangleIntersection(
   }
 
   // 1. compute the barycentric coordinates of pA and pB
-  vector<double> barypA, barypB;
+  std::array<double, 3> barypA{}, barypB{};
   Geometry::computeBarycentricCoordinates(
     tetIntersections[tetId][triangleId].p_[0].data(),
     tetIntersections[tetId][triangleId].p_[1].data(),
@@ -387,7 +387,7 @@ int FiberSurface::computeTriangleIntersection(
   // [pivotVertexId, (pivotVertexId+2)%3]
   // that's the vertex which minimizes its coordinate [(pivotVertexId+1)%3]
   vector<double> A = pA, B = pB;
-  vector<double> baryA = barypA, baryB = barypB;
+  std::array<double, 3> baryA = barypA, baryB = barypB;
   if(fabs(barypB[(pivotVertexId + 1) % 3])
      < fabs(barypA[(pivotVertexId + 1) % 3])) {
     // let's swith the two
@@ -674,7 +674,7 @@ int FiberSurface::flipEdges(
         = (*polygonEdgeTriangleLists_[triangles[i].first])[triangles[i].second]
             .vertexIds_[2];
 
-      vector<double> angles;
+      std::array<double, 3> angles{};
       Geometry::computeTriangleAngles(
         (*globalVertexList_)[vertexIds[0]].p_.data(),
         (*globalVertexList_)[vertexIds[1]].p_.data(),
@@ -716,7 +716,7 @@ int FiberSurface::flipEdges(
         = (*polygonEdgeTriangleLists_[triangles[i].first])[triangles[i].second]
             .vertexIds_[2];
 
-      vector<double> angles;
+      std::array<double, 3> angles{};
       Geometry::computeTriangleAngles(
         (*globalVertexList_)[vertexIds[0]].p_.data(),
         (*globalVertexList_)[vertexIds[1]].p_.data(),
@@ -788,7 +788,7 @@ int FiberSurface::flipEdges(
 
               if((nonCommonVertexId != -1) && (otherNonCommonVertexId != -1)) {
 
-                vector<double> beta0angles, beta1angles;
+                std::array<double, 3> beta0angles{}, beta1angles{};
 
                 Geometry::computeTriangleAngles(
                   (*globalVertexList_)[nonCommonVertexId].p_.data(),
@@ -882,7 +882,7 @@ int FiberSurface::getTriangleRangeExtremities(
   pair<double, double> &extremity1) const {
 
   vector<double> p0(2), p1(2), p(2);
-  vector<double> baryCentrics;
+  std::array<double, 2> baryCentrics{};
   bool isInBetween = true;
 
   // check for edges that project to points first
@@ -1628,7 +1628,7 @@ int FiberSurface::snapVertexBarycentrics(
 
       // check for each triangle of the tet
       double minimum = -DBL_MAX;
-      vector<double> minBarycentrics;
+      std::array<double, 3> minBarycentrics{};
       vector<SimplexId> minimizer(3);
 
       for(int k = 0; k < 2; k++) {
@@ -1647,7 +1647,7 @@ int FiberSurface::snapVertexBarycentrics(
               p2[n] = pointSet_[3 * vertexId2 + n];
             }
 
-            vector<double> barycentrics;
+            std::array<double, 3> barycentrics{};
             Geometry::computeBarycentricCoordinates(
               p0.data(), p1.data(), p2.data(),
               (*globalVertexList_)[vertexId].p_.data(), barycentrics);

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -613,7 +613,7 @@ inline int ttk::FiberSurface::computeBaseTriangle(
         break;
     }
 
-    std::vector<double> baryCentrics;
+    std::array<double, 2> baryCentrics{};
     std::vector<double> p0(2), p1(2), p(2);
     p0[0] = ((dataTypeU *)uField_)[vertexId0];
     p0[1] = ((dataTypeV *)vField_)[vertexId0];
@@ -757,7 +757,7 @@ inline int ttk::FiberSurface::computeCase0(
         break;
     }
 
-    std::vector<double> baryCentrics;
+    std::array<double, 2> baryCentrics{};
     std::vector<double> p0(2), p1(2), p(2);
     p0[0] = ((dataTypeU *)uField_)[vertexId0];
     p0[1] = ((dataTypeV *)vField_)[vertexId0];

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -21,11 +21,11 @@ bool Geometry::areVectorsColinear(const T *vA0,
                                   const T *vA1,
                                   const T *vB0,
                                   const T *vB1,
-                                  vector<T> *coefficients,
+                                  std::array<T, 3> *coefficients,
                                   const T *tolerance) {
 
   int aNullComponents = 0, bNullComponents = 0;
-  vector<T> a(3), b(3);
+  std::array<T, 3> a{}, b{};
   for(int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
     if(fabs(a[i]) < PREC_FLT) {
@@ -59,7 +59,7 @@ bool Geometry::areVectorsColinear(const T *vA0,
     useDenominatorA = true;
   }
 
-  vector<T> k(3, 0);
+  std::array<T, 3> k{};
 
   T maxDenominator = 0;
   int isNan = -1, maximizer = 0;
@@ -124,10 +124,8 @@ template <typename T>
 int Geometry::computeBarycentricCoordinates(const T *p0,
                                             const T *p1,
                                             const T *p,
-                                            vector<T> &baryCentrics,
+                                            std::array<T, 2> &baryCentrics,
                                             const int &dimension) {
-
-  baryCentrics.resize(2);
 
   int bestI = 0;
   T maxDenominator = 0;
@@ -167,10 +165,11 @@ int Geometry::computeBarycentricCoordinates(const T *p0,
   return 0;
 }
 template <typename T>
-int Geometry::computeBarycentricCoordinates(
-  const T *p0, const T *p1, const T *p2, const T *p, vector<T> &baryCentrics) {
-
-  baryCentrics.resize(3);
+int Geometry::computeBarycentricCoordinates(const T *p0,
+                                            const T *p1,
+                                            const T *p2,
+                                            const T *p,
+                                            std::array<T, 3> &baryCentrics) {
 
   // find the pair of coordinates that maximize the sum of the denominators
   // (more stable computations)
@@ -262,7 +261,7 @@ int Geometry::computeTriangleArea(const T *p0,
                                   const T *p2,
                                   T &area) {
 
-  vector<T> cross;
+  std::array<T, 3> cross{};
 
   crossProduct(p0, p1, p1, p2, cross);
 
@@ -287,9 +286,7 @@ template <typename T>
 int Geometry::computeTriangleAngles(const T *p0,
                                     const T *p1,
                                     const T *p2,
-                                    vector<T> &angles) {
-
-  angles.resize(3);
+                                    std::array<T, 3> &angles) {
 
   angles[0] = angle(p0, p1, p1, p2);
   angles[1] = angle(p1, p2, p2, p0);
@@ -314,11 +311,9 @@ int Geometry::crossProduct(const T *vA0,
                            const T *vA1,
                            const T *vB0,
                            const T *vB1,
-                           vector<T> &crossProduct) {
+                           std::array<T, 3> &crossProduct) {
 
-  crossProduct.resize(3);
-
-  vector<T> a(3), b(3);
+  std::array<T, 3> a{}, b{};
 
   for(int i = 0; i < 3; i++) {
     a[i] = vA1[i] - vA0[i];
@@ -409,7 +404,7 @@ bool Geometry::isPointInTriangle(const T *p0,
                                  const T *p2,
                                  const T *p) {
 
-  vector<T> barycentrics;
+  std::array<T, 3> barycentrics{};
 
   Geometry::computeBarycentricCoordinates(p0, p1, p2, p, barycentrics);
 
@@ -449,7 +444,7 @@ bool Geometry::isPointOnSegment(const T *p,
                                 const T *pB,
                                 const int &dimension) {
 
-  vector<T> baryCentrics;
+  std::array<T, 2> baryCentrics{};
 
   Geometry::computeBarycentricCoordinates(pA, pB, p, baryCentrics, dimension);
 
@@ -466,7 +461,7 @@ bool Geometry::isTriangleColinear(const T *p0,
 
   bool maxDecision = false;
   T maxCoefficient = 0;
-  vector<T> coefficients(3);
+  std::array<T, 3> coefficients{};
 
   bool decision = areVectorsColinear(p0, p1, p1, p2, &coefficients, tolerance);
   maxDecision = decision;
@@ -538,18 +533,18 @@ int Geometry::subtractVectors(const T *a, const T *b, T *out) {
     TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
   template bool Geometry::areVectorsColinear<TYPE>(                           \
     TYPE const *, TYPE const *, TYPE const *, TYPE const *,                   \
-    std::vector<TYPE> *, TYPE const *);                                       \
+    std::array<TYPE, 3> *, TYPE const *);                                     \
   template int Geometry::computeBarycentricCoordinates<TYPE>(                 \
-    TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &,            \
+    TYPE const *, TYPE const *, TYPE const *, std::array<TYPE, 2> &,          \
     int const &);                                                             \
   template int Geometry::computeBarycentricCoordinates<TYPE>(                 \
     TYPE const *, TYPE const *, TYPE const *, TYPE const *,                   \
-    std::vector<TYPE> &);                                                     \
+    std::array<TYPE, 3> &);                                                   \
   template bool Geometry::computeSegmentIntersection<TYPE>(                   \
     TYPE const &, TYPE const &, TYPE const &, TYPE const &, TYPE const &,     \
     TYPE const &, TYPE const &, TYPE const &, TYPE &, TYPE &);                \
   template int Geometry::computeTriangleAngles<TYPE>(                         \
-    TYPE const *, TYPE const *, TYPE const *, std::vector<TYPE> &);           \
+    TYPE const *, TYPE const *, TYPE const *, std::array<TYPE, 3> &);         \
   template int Geometry::computeTriangleAngleFromSides<TYPE>(                 \
     TYPE const, TYPE const, TYPE const, TYPE &);                              \
   template int Geometry::computeTriangleArea<TYPE>(                           \
@@ -558,7 +553,7 @@ int Geometry::subtractVectors(const T *a, const T *b, T *out) {
     TYPE const, TYPE const, TYPE const, TYPE &);                              \
   template int Geometry::crossProduct<TYPE>(TYPE const *, TYPE const *,       \
                                             TYPE const *, TYPE const *,       \
-                                            std::vector<TYPE> &);             \
+                                            std::array<TYPE, 3> &);           \
   template int Geometry::crossProduct<TYPE>(                                  \
     TYPE const *, TYPE const *, TYPE *);                                      \
   template TYPE Geometry::distance<TYPE>(                                     \

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Debug.h>
+#include <array>
 
 namespace ttk {
 
@@ -26,7 +27,7 @@ namespace ttk {
     /// \param vA1 xyz coordinates of vA's destination
     /// \param vB0 xyz coordinates of vB's origin
     /// \param vB1 xyz coordinates of vB's destination
-    /// \param coefficients Optional output std::vector of colinearity
+    /// \param coefficients Optional output std::array of colinearity
     /// coefficients.
     /// \param tolerance Optional tolerance value (default: PREC_FLT)
     /// \returns Returns true if the std::vectors are colinear, false
@@ -36,7 +37,7 @@ namespace ttk {
                             const T *vA1,
                             const T *vB0,
                             const T *vB1,
-                            std::vector<T> *coefficients = NULL,
+                            std::array<T, 3> *coefficients = nullptr,
                             const T *tolerance = NULL);
 
     /// Compute the barycentric coordinates of point \p p with regard to the
@@ -53,7 +54,7 @@ namespace ttk {
     int computeBarycentricCoordinates(const T *p0,
                                       const T *p1,
                                       const T *p,
-                                      std::vector<T> &baryCentrics,
+                                      std::array<T, 2> &baryCentrics,
                                       const int &dimension = 3);
 
     /// Compute the barycentric coordinates of point \p p with regard to the
@@ -70,7 +71,7 @@ namespace ttk {
                                       const T *p1,
                                       const T *p2,
                                       const T *p,
-                                      std::vector<T> &baryCentrics);
+                                      std::array<T, 3> &baryCentrics);
 
     /// Compute the intersection between two 2D segments AB and CD.
     /// \param xA x coordinate of the first vertex of the first segment (AB)
@@ -105,7 +106,7 @@ namespace ttk {
     int computeTriangleAngles(const T *p0,
                               const T *p1,
                               const T *p2,
-                              std::vector<T> &angles);
+                              std::array<T, 3> &angles);
 
     // Get the angle opposite to edge s2 using cosine law
     /// \param s0 length of the first side of the triangle
@@ -150,7 +151,7 @@ namespace ttk {
                      const T *vA1,
                      const T *vB0,
                      const T *vB1,
-                     std::vector<T> &crossProduct);
+                     std::array<T, 3> &crossProduct);
 
     /// Compute the cross product of two 3D std::vectors
     /// \param vA xyz coordinates of vA std::vector

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
@@ -526,7 +526,7 @@ std::tuple<ttk::QuadrangulationSubdivision::Point,
     }
 
     // compute barycentric coords of projection
-    std::vector<float> baryCoords;
+    std::array<float, 3> baryCoords{};
     Geometry::computeBarycentricCoordinates(
       &pm.x, &pn.x, &po.x, &res.x, baryCoords);
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -27,24 +27,20 @@ namespace ttk {
     ScalarFieldSmoother();
     ~ScalarFieldSmoother();
 
-    int setDimensionNumber(const int &dimensionNumber) {
+    inline void setDimensionNumber(const int &dimensionNumber) {
       dimensionNumber_ = dimensionNumber;
-      return 0;
     }
 
-    int setInputDataPointer(void *data) {
+    inline void setInputDataPointer(void *data) {
       inputData_ = data;
-      return 0;
     }
 
-    int setOutputDataPointer(void *data) {
+    inline void setOutputDataPointer(void *data) {
       outputData_ = data;
-      return 0;
     }
 
-    int setMaskDataPointer(void *mask) {
-      mask_ = (char *)mask;
-      return 0;
+    inline void setMaskDataPointer(const char *const mask) {
+      mask_ = mask;
     }
 
     int preconditionTriangulation(AbstractTriangulation *triangulation) {
@@ -63,7 +59,7 @@ namespace ttk {
   protected:
     int dimensionNumber_{1};
     void *inputData_{nullptr}, *outputData_{nullptr};
-    char *mask_{nullptr};
+    const char *mask_{nullptr};
   };
 
 } // namespace ttk

--- a/core/base/surfaceGeometrySmoother/CMakeLists.txt
+++ b/core/base/surfaceGeometrySmoother/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(surfaceGeometrySmoother
+  SOURCES
+    SurfaceGeometrySmoother.cpp
+  HEADERS
+    SurfaceGeometrySmoother.h
+  DEPENDS
+    triangulation
+  )

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.cpp
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.cpp
@@ -1,0 +1,5 @@
+#include <SurfaceGeometrySmoother.h>
+
+ttk::SurfaceGeometrySmoother::SurfaceGeometrySmoother() {
+  this->setDebugMsgPrefix("SurfaceGeometrySmoother");
+}

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
@@ -1,0 +1,507 @@
+/// \ingroup base
+/// \class ttk::SurfaceGeometrySmoother
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date March 2022.
+///
+/// \brief TTK VTK-filter for smoothing meshes on surfaces.
+///
+/// ttk::GeometrySmoother with a twist!
+/// This class smoothes and projects a 1D or a 2D mesh onto a 2D
+/// closed triangulated surface.
+///
+/// \sa ttkSurfaceGeometrySmoother.cpp %for a usage example.
+
+#pragma once
+
+// base code includes
+#include <Triangulation.h>
+#include <VisitedMask.h>
+
+#include <stack>
+#include <string>
+
+namespace ttk {
+
+  class SurfaceGeometrySmoother : virtual public Debug {
+
+  public:
+    SurfaceGeometrySmoother();
+    ~SurfaceGeometrySmoother() override = default;
+
+    inline void preconditionTriangulationToSmooth(
+      AbstractTriangulation *const triangulation) {
+      if(triangulation != nullptr) {
+        triangulation->preconditionVertexNeighbors();
+      }
+    }
+    inline void preconditionTriangulationSurface(
+      AbstractTriangulation *const triangulation) {
+      if(triangulation != nullptr) {
+        triangulation->preconditionEdges();
+        triangulation->preconditionVertexNeighbors();
+        triangulation->preconditionVertexEdges();
+        triangulation->preconditionTriangles();
+        triangulation->preconditionVertexTriangles();
+        triangulation->preconditionEdgeTriangles();
+      }
+    }
+
+    template <typename triangulationType0, typename triangulationType1>
+    int execute(float *const outputCoords,
+                const float *const inputCoords,
+                const char *const mask,
+                const SimplexId *const vertsId,
+                const int nIter,
+                const triangulationType0 &triangulationToSmooth,
+                const triangulationType1 &triangulationSurface) const;
+
+  protected:
+    struct Point : public std::array<float, 3> {
+      Point operator+(const Point other) const {
+        Point res{};
+        res[0] = (*this)[0] + other[0];
+        res[1] = (*this)[1] + other[1];
+        res[2] = (*this)[2] + other[2];
+        return res;
+      }
+      Point operator*(const float scalar) const {
+        Point res{};
+        res[0] = (*this)[0] * scalar;
+        res[1] = (*this)[1] * scalar;
+        res[2] = (*this)[2] * scalar;
+        return res;
+      }
+      Point operator-(Point other) const {
+        return *this + other * (-1);
+      }
+      Point operator/(const float scalar) const {
+        return (*this * (1.0F / scalar));
+      }
+      friend std::ostream &operator<<(std::ostream &os, const Point &pt) {
+        return os << '(' << pt[0] << " " << pt[1] << " " << pt[2] << ')';
+      }
+    };
+
+    template <typename triangulationType0, typename triangulationType1>
+    int relaxProject(std::vector<Point> &outputPoints,
+                     std::vector<Point> &tmpStorage,
+                     std::vector<SimplexId> &nearestVertexId,
+                     std::vector<bool> &trianglesTested,
+                     std::vector<SimplexId> &visitedTriangles,
+                     std::vector<float> &dists,
+                     const char *const mask,
+                     const triangulationType0 &triangulationToSmooth,
+                     const triangulationType1 &triangulationSurface) const;
+
+    /**
+     * @brief Stores the findProjection() result
+     */
+    struct ProjectionResult {
+      /** Projection coordinates */
+      Point pt;
+      /** Nearest vertex id in the surface */
+      SimplexId nearestVertex;
+      /** Number of triangles processed */
+      size_t trianglesChecked;
+      /** Projection status */
+      bool projSuccess;
+    };
+
+    /**
+     * @brief Stores the findProjection() input
+     */
+    struct ProjectionInput {
+      /** Input point coordinates */
+      Point pt;
+      /** Nearest vertex in the surface */
+      SimplexId nearestVertex;
+    };
+
+    template <typename triangulationType>
+    ProjectionResult
+      findProjection(const ProjectionInput &pi,
+                     VisitedMask &trianglesTested,
+                     std::vector<float> &dists,
+                     const triangulationType &triangulation) const;
+
+    /**
+     * @brief Computes the barycenter of a given point's neighbors
+     *
+     * @param[in] a Input point index
+     * @param [in] outputPoints Coordinates storage
+     * @param[in] triangulationToSmooth To get neighbors
+     * @return Neighbors barycenter coordinates
+     */
+    template <typename triangulationType>
+    inline Point
+      relax(const SimplexId a,
+            std::vector<ttk::SurfaceGeometrySmoother::Point> &outputPoints,
+            const triangulationType &triangulationToSmooth) const {
+      Point relaxed{};
+      const auto nneigh{triangulationToSmooth.getVertexNeighborNumber(a)};
+      for(SimplexId i = 0; i < nneigh; ++i) {
+        SimplexId neigh{};
+        triangulationToSmooth.getVertexNeighbor(a, i, neigh);
+        relaxed = relaxed + outputPoints[neigh];
+      }
+      return relaxed * (1.0F / static_cast<float>(nneigh));
+    }
+
+    /**
+     * @brief Compute euclidian projection in a triangle plane
+     *
+     * @param[in] p Point to be projected
+     * @param[in] a Triangle vertex coordinates
+     * @param[in] normTri Triangle normal vector
+     * @return Projection coordinates
+     */
+    inline Point projectOnTrianglePlane(const Point &p,
+                                        const Point &a,
+                                        const Point &normTri) const {
+      const auto ap{p - a};
+      return p - normTri * Geometry::dotProduct(normTri.data(), ap.data());
+    }
+
+    /**
+     * @brief Compute euclidian projection on a 3D segment
+     *
+     * @param[in] p Point to be projected
+     * @param[in] a First segment vertex coordinates
+     * @param[in] b Second segment vertex coordinates
+     * @return Projection coordinates
+     */
+    inline Point
+      projectOnEdge(const Point &p, const Point &a, const Point &b) const {
+      const auto ab{b - a};
+      const auto ap{p - a};
+      return a
+             + ab * Geometry::dotProduct(ap.data(), ab.data())
+                 / Geometry::dotProduct(ab.data(), ab.data());
+    }
+
+    /**
+     * @brief Find nearest vertex on the surface.
+     *
+     * @param[in] pa Input point
+     * @param[in] dists Pre-allocated distances vector
+     * @param[in] triangulation Surface triangulation
+     * @return Nearest vertex id on the surface
+     */
+    template <typename triangulationType>
+    inline SimplexId
+      getNearestSurfaceVertex(const Point &pa,
+                              std::vector<float> &dists,
+                              const triangulationType &triangulation) const {
+      for(SimplexId i = 0; i < triangulation.getNumberOfVertices(); ++i) {
+        Point pv{};
+        triangulation.getVertexPoint(i, pv[0], pv[1], pv[2]);
+        dists[i] = Geometry::distance(pa.data(), pv.data());
+      }
+      return std::min_element(dists.begin(), dists.end()) - dists.begin();
+    }
+  };
+
+} // namespace ttk
+
+template <typename triangulationType>
+ttk::SurfaceGeometrySmoother::ProjectionResult
+  ttk::SurfaceGeometrySmoother::findProjection(
+    const ProjectionInput &pi,
+    VisitedMask &trianglesTested,
+    std::vector<float> &dists,
+    const triangulationType &triangulation) const {
+
+  ProjectionResult res{pi.pt, pi.nearestVertex, 0, false};
+
+  // list of triangle IDs to test to find a potential projection
+  std::stack<SimplexId> trianglesToTest{};
+
+  // init pipeline by checking in the first triangle around selected vertex
+  if(triangulation.getVertexTriangleNumber(res.nearestVertex) > 0) {
+    SimplexId next{};
+    triangulation.getVertexTriangle(res.nearestVertex, 0, next);
+    trianglesToTest.push(next);
+  }
+
+  while(!trianglesToTest.empty()) {
+    const auto curr = trianglesToTest.top();
+    trianglesToTest.pop();
+
+    // skip if already tested
+    if(trianglesTested.isVisited_[curr]) {
+      continue;
+    }
+
+    // get triangle vertices
+    std::array<SimplexId, 3> tverts{};
+    triangulation.getTriangleVertex(curr, 0, tverts[0]);
+    triangulation.getTriangleVertex(curr, 1, tverts[1]);
+    triangulation.getTriangleVertex(curr, 2, tverts[2]);
+
+    // get coordinates of triangle vertices (lets name is MNO)
+    std::array<Point, 3> mno{}; // [0] is M, [1] is N and [2] is O
+    triangulation.getVertexPoint(tverts[0], mno[0][0], mno[0][1], mno[0][2]);
+    triangulation.getVertexPoint(tverts[1], mno[1][0], mno[1][1], mno[1][2]);
+    triangulation.getVertexPoint(tverts[2], mno[2][0], mno[2][1], mno[2][2]);
+
+    // triangle normal: cross product of two edges
+    Point crossP{};
+    // mn, mo vectors
+    const Point mn = mno[1] - mno[0];
+    const Point mo = mno[2] - mno[0];
+    // compute mn ^ mo
+    Geometry::crossProduct(mn.data(), mo.data(), crossP.data());
+    // unitary normal vector
+    const Point normTri = crossP / Geometry::magnitude(crossP.data());
+
+    res.pt = this->projectOnTrianglePlane(pi.pt, mno[0], normTri);
+
+    // compute barycentric coords of projection
+    Point baryCoords{};
+    Geometry::computeBarycentricCoordinates(
+      mno[0].data(), mno[1].data(), mno[2].data(), res.pt.data(), baryCoords);
+
+    // check if projection in triangle
+    bool inTriangle = true;
+    static const float PREC_FLT{powf(10, -FLT_DIG)};
+
+    for(auto &coord : baryCoords) {
+      if(coord < -PREC_FLT) {
+        inTriangle = false;
+      }
+      if(coord > 1 + PREC_FLT) {
+        inTriangle = false;
+      }
+    }
+
+    // mark triangle as tested
+    trianglesTested.insert(curr);
+    res.trianglesChecked++;
+
+    if(inTriangle) {
+      res.projSuccess = true;
+      // should we check if we have the nearest triangle?
+      break;
+    }
+
+    // extrema values in baryCoords
+    const auto extrema
+      = std::minmax_element(baryCoords.begin(), baryCoords.end());
+
+    // find the nearest triangle vertices local ids (with the
+    // highest/positive values in baryCoords) from proj
+    std::array<SimplexId, 2> vid{
+      static_cast<SimplexId>(extrema.second - baryCoords.begin()), 0};
+    for(size_t j = 0; j < baryCoords.size(); j++) {
+      if(j != static_cast<size_t>(extrema.first - baryCoords.begin())
+         && j != static_cast<size_t>(extrema.second - baryCoords.begin())) {
+        vid[1] = j;
+        break;
+      }
+    }
+
+    // store vertex with highest barycentric coordinate
+    res.nearestVertex = tverts[vid[0]];
+    const auto secondNearVert{tverts[vid[1]]};
+
+    // get the triangle edge with the two vertices
+    SimplexId edge{};
+    const auto nEdges{triangulation.getVertexEdgeNumber(res.nearestVertex)};
+    for(SimplexId i = 0; i < nEdges; ++i) {
+      triangulation.getVertexEdge(res.nearestVertex, i, edge);
+      SimplexId v{};
+      triangulation.getEdgeVertex(edge, 0, v);
+      if(v == res.nearestVertex) {
+        triangulation.getEdgeVertex(edge, 1, v);
+      }
+      if(v == secondNearVert) {
+        break;
+      }
+    }
+
+    // next triangle to visit
+    SimplexId next{};
+    const auto nTri{triangulation.getEdgeTriangleNumber(edge)};
+    for(SimplexId i = 0; i < nTri; ++i) {
+      triangulation.getEdgeTriangle(edge, i, next);
+      if(next != curr) {
+        break;
+      }
+    }
+
+    const auto nVisited{trianglesTested.visitedIds_.size()};
+    if(nVisited > 1 && next == trianglesTested.visitedIds_[nVisited - 2]) {
+      // the relaxed point is probably over the edge separating the
+      // current and the last visited triangles
+      res.pt = this->projectOnEdge(pi.pt, mno[vid[0]], mno[vid[1]]);
+      res.projSuccess = true;
+      break;
+    }
+
+    if(!trianglesTested.isVisited_[next]) {
+      trianglesToTest.push(next);
+    }
+  }
+
+  const size_t maxTrChecked = 100;
+
+  if(res.projSuccess && res.trianglesChecked > maxTrChecked) {
+    res.projSuccess = false;
+  }
+
+  if(!res.projSuccess) {
+    // replace proj by the nearest vertex?
+    res.nearestVertex
+      = this->getNearestSurfaceVertex(pi.pt, dists, triangulation);
+    triangulation.getVertexPoint(
+      res.nearestVertex, res.pt[0], res.pt[1], res.pt[2]);
+  }
+
+  return res;
+}
+
+template <typename triangulationType0, typename triangulationType1>
+int ttk::SurfaceGeometrySmoother::relaxProject(
+  std::vector<ttk::SurfaceGeometrySmoother::Point> &outputPoints,
+  std::vector<ttk::SurfaceGeometrySmoother::Point> &tmpStorage,
+  std::vector<SimplexId> &nearestVertexId,
+  std::vector<bool> &trianglesTested,
+  std::vector<SimplexId> &visitedTriangles,
+  std::vector<float> &dists,
+  const char *const mask,
+  const triangulationType0 &triangulationToSmooth,
+  const triangulationType1 &triangulationSurface) const {
+
+  Timer tm;
+
+  // main loop
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_) \
+  firstprivate(trianglesTested, visitedTriangles, dists)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < outputPoints.size(); i++) {
+
+    // skip computation if i in filtered
+    if(mask != nullptr && mask[i] == 0) {
+      tmpStorage[i] = outputPoints[i];
+      continue;
+    }
+    tmpStorage[i] = this->relax(i, outputPoints, triangulationToSmooth);
+
+    VisitedMask vm{trianglesTested, visitedTriangles};
+
+    // replace curr in outputPoints_ by its projection
+    const auto res
+      = this->findProjection(ProjectionInput{tmpStorage[i], nearestVertexId[i]},
+                             vm, dists, triangulationSurface);
+
+    tmpStorage[i] = res.pt;
+    nearestVertexId[i] = res.nearestVertex;
+  }
+
+  std::swap(outputPoints, tmpStorage);
+
+  this->printMsg("Projected " + std::to_string(outputPoints.size()) + " points",
+                 1.0, tm.getElapsedTime(), this->threadNumber_,
+                 debug::LineMode::NEW, debug::Priority::DETAIL);
+
+  return 0;
+}
+
+template <typename triangulationType0, typename triangulationType1>
+int ttk::SurfaceGeometrySmoother::execute(
+  float *const outputCoords,
+  const float *const inputCoords,
+  const char *const mask,
+  const SimplexId *const vertsId,
+  const int nIter,
+  const triangulationType0 &triangulationToSmooth,
+  const triangulationType1 &triangulationSurface) const {
+
+  const auto nPoints{triangulationToSmooth.getNumberOfVertices()};
+  if(triangulationSurface.getDimensionality() != 2) {
+    this->printErr("Can only project onto a surface");
+    return -1;
+  }
+
+  if(triangulationToSmooth.getDimensionality() < 1
+     || triangulationToSmooth.getDimensionality() > 2) {
+    this->printErr("Can only project a 1D or a 2D triangulated object");
+    return -1;
+  }
+
+  Timer tm{};
+  this->printMsg("Smoothing " + std::to_string(nPoints) + " in "
+                 + std::to_string(nIter) + " iterations...");
+
+  // list of triangle IDs already tested
+  // (takes more memory to reduce computation time)
+  std::vector<bool> trianglesTested(
+    triangulationSurface.getNumberOfTriangles(), false);
+  std::vector<SimplexId> visitedTriangles{};
+  // distance between every mesh point and current point
+  std::vector<float> dists(triangulationSurface.getNumberOfVertices());
+
+  // temporary storage
+  std::vector<ttk::SurfaceGeometrySmoother::Point> outputPoints(nPoints),
+    tmpStorage(nPoints);
+  std::vector<SimplexId> nearestVertexId(nPoints);
+
+  // copy input
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < nPoints; ++i) {
+    outputPoints[i][0] = inputCoords[3 * i + 0];
+    outputPoints[i][1] = inputCoords[3 * i + 1];
+    outputPoints[i][2] = inputCoords[3 * i + 2];
+  }
+
+  // ttkVertexScalarField is optional (helps for instance with
+  // MorseSmaleComplex 1-separatrices)
+  if(vertsId != nullptr) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < nPoints; ++i) {
+      nearestVertexId[i] = vertsId[i];
+    }
+  } else {
+    // generate a ttkVertexScalarField-like point data array using raw
+    // euclidian distance between the points to smooth and every
+    // vertex of the surface
+    Timer tm_nv{};
+    this->printMsg("Computing nearest vertices...", debug::Priority::INFO,
+                   debug::LineMode::REPLACE);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_) firstprivate(dists)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < nPoints; ++i) {
+      nearestVertexId[i] = this->getNearestSurfaceVertex(
+        outputPoints[i], dists, triangulationSurface);
+    }
+    this->printMsg("Computed nearest vertices", 1.0, tm_nv.getElapsedTime(),
+                   this->threadNumber_);
+  }
+
+  for(int i = 0; i < nIter; ++i) {
+    this->relaxProject(outputPoints, tmpStorage, nearestVertexId,
+                       trianglesTested, visitedTriangles, dists, mask,
+                       triangulationToSmooth, triangulationSurface);
+  }
+
+  // copy output
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(SimplexId i = 0; i < nPoints; ++i) {
+    outputCoords[3 * i + 0] = outputPoints[i][0];
+    outputCoords[3 * i + 1] = outputPoints[i][1];
+    outputCoords[3 * i + 2] = outputPoints[i][2];
+  }
+
+  this->printMsg("Smoothed " + std::to_string(nPoints) + " points", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_);
+
+  return 0;
+}

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -66,7 +66,7 @@ int ttkGeometrySmoother::RequestData(vtkInformation *ttkNotUsed(request),
   this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputPoints));
 
   if(inputMaskField) {
-    this->setMaskDataPointer(ttkUtils::GetVoidPointer(inputMaskField));
+    this->setMaskDataPointer(ttkUtils::GetPointer<char>(inputMaskField));
   }
 
   switch(outputPoints->GetDataType()) {

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -65,9 +65,9 @@ int ttkGeometrySmoother::RequestData(vtkInformation *ttkNotUsed(request),
   this->setInputDataPointer(ttkUtils::GetVoidPointer(inputPoints));
   this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputPoints));
 
-  if(inputMaskField) {
-    this->setMaskDataPointer(ttkUtils::GetPointer<char>(inputMaskField));
-  }
+  const auto hasMask{this->UseMaskScalarField && inputMaskField != nullptr};
+  this->setMaskDataPointer(hasMask ? ttkUtils::GetPointer<char>(inputMaskField)
+                                   : nullptr);
 
   switch(outputPoints->GetDataType()) {
     vtkTemplateMacro(

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -55,12 +55,16 @@ class TTKGEOMETRYSMOOTHER_EXPORT ttkGeometrySmoother
 
 private:
   int NumberOfIterations{1};
+  bool UseMaskScalarField{true};
   int MaskIdentifier{0};
   bool ForceInputMaskScalarField{false};
 
 public:
   vtkSetMacro(NumberOfIterations, int);
   vtkGetMacro(NumberOfIterations, int);
+
+  vtkSetMacro(UseMaskScalarField, bool);
+  vtkGetMacro(UseMaskScalarField, bool);
 
   vtkSetMacro(MaskIdentifier, int);
   vtkGetMacro(MaskIdentifier, int);

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -87,8 +87,8 @@ int ttkScalarFieldSmoother::RequestData(vtkInformation *ttkNotUsed(request),
      {"  Mask Array", inputMaskField ? inputMaskField->GetName() : "None"},
      {"  #iterations", std::to_string(NumberOfIterations)}});
 
-  void *inputMaskPtr
-    = (inputMaskField) ? ttkUtils::GetVoidPointer(inputMaskField) : nullptr;
+  const auto inputMaskPtr
+    = (inputMaskField) ? ttkUtils::GetPointer<char>(inputMaskField) : nullptr;
 
   this->setDimensionNumber(inputScalarField->GetNumberOfComponents());
   this->setInputDataPointer(ttkUtils::GetVoidPointer(inputScalarField));

--- a/core/vtk/ttkSurfaceGeometrySmoother/CMakeLists.txt
+++ b/core/vtk/ttkSurfaceGeometrySmoother/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttk.module
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkSurfaceGeometrySmoother
+SOURCES
+  ttkSurfaceGeometrySmoother.cpp
+HEADERS
+  ttkSurfaceGeometrySmoother.h
+DEPENDS
+  surfaceGeometrySmoother
+  ttkAlgorithm

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
@@ -1,0 +1,95 @@
+#include <ttkSurfaceGeometrySmoother.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+#include <vtkInformation.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkPointSet.h>
+
+vtkStandardNewMacro(ttkSurfaceGeometrySmoother);
+
+ttkSurfaceGeometrySmoother::ttkSurfaceGeometrySmoother() {
+  this->SetNumberOfInputPorts(2);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkSurfaceGeometrySmoother::FillInputPortInformation(int port,
+                                                         vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
+    return 1;
+  } else if(port == 1) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkUnstructuredGrid");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkSurfaceGeometrySmoother::FillOutputPortInformation(
+  int port, vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
+}
+
+int ttkSurfaceGeometrySmoother::RequestData(
+  vtkInformation *ttkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector) {
+
+  auto inputPointSet = vtkPointSet::GetData(inputVector[0]);
+  auto inputMesh = vtkPointSet::GetData(inputVector[1]);
+  auto outputPointSet = vtkPointSet::GetData(outputVector);
+
+  auto triangulationToSmooth = ttkAlgorithm::GetTriangulation(inputPointSet);
+  if(triangulationToSmooth == nullptr) {
+    return 0;
+  }
+  this->preconditionTriangulationToSmooth(triangulationToSmooth);
+
+  auto triangulationSurface = ttkAlgorithm::GetTriangulation(inputMesh);
+  if(triangulationSurface == nullptr) {
+    return 0;
+  }
+  this->preconditionTriangulationSurface(triangulationSurface);
+
+  std::vector<ttk::SimplexId> idSpareStorage{};
+  const auto *vertsId = this->GetIdentifierArrayPtr(
+    ForceIdentifiersField, 0, ttk::VertexScalarFieldName, inputPointSet,
+    idSpareStorage);
+
+  vtkDataArray *inputMaskField = ttkAlgorithm::GetOptionalArray(
+    ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, inputPointSet);
+
+  // Copy all input points/cells + scalar fields
+  outputPointSet->DeepCopy(inputPointSet);
+
+  // calling the smoothing package
+  auto inputPoints = inputPointSet->GetPoints();
+  auto outputPoints = outputPointSet->GetPoints();
+
+  const auto hasMask{this->UseMaskScalarField && inputMaskField != nullptr};
+
+  if(triangulationSurface->getType() != triangulationToSmooth->getType()) {
+    this->printErr("Triangulations should have the same type");
+    return 0;
+  }
+
+  // here we assume that the two triangulation objects have the same
+  // underlying type
+  ttkTemplateMacro(
+    triangulationToSmooth->getType(),
+    this->execute(
+      ttkUtils::GetPointer<float>(outputPoints->GetData()),
+      ttkUtils::GetPointer<float>(inputPoints->GetData()),
+      hasMask ? ttkUtils::GetPointer<char>(inputMaskField) : nullptr, vertsId,
+      this->NumberOfIterations,
+      *static_cast<TTK_TT *>(triangulationToSmooth->getData()),
+      *static_cast<TTK_TT *>(triangulationSurface->getData())));
+
+  return 1;
+}

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
@@ -1,0 +1,87 @@
+/// \ingroup vtk
+/// \class ttkSurfaceGeometrySmoother
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date March 2022.
+///
+/// \brief TTK VTK-filter for smoothing meshes on surfaces.
+///
+/// ttk::GeometrySmoother with a twist!
+/// This class smoothes and projects a 1D or a 2D mesh onto a 2D
+/// closed triangulated surface.
+///
+/// \param Input vtkDataSet
+/// \param Output vtkDataSet
+///
+/// The input data array needs to be specified via the standard VTK call
+/// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
+/// \param idx 0 (FIXED: the first array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the input array)
+///
+/// The optional mask array can be specified via the standard VTK call
+/// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
+/// \param idx 1 (FIXED: the second array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the mask array)
+/// \note: To use this optional array, `ForceInputMaskScalarField` needs to be
+/// enabled with the setter `setForceInputMaskScalarField()'.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutput()).
+///
+/// \sa vtkGeometrySmoother
+/// \sa ttk::SurfaceGeometrySmoother
+///
+
+#pragma once
+
+// VTK Module
+#include <ttkSurfaceGeometrySmootherModule.h>
+
+// ttk code includes
+#include <SurfaceGeometrySmoother.h>
+#include <ttkAlgorithm.h>
+
+class TTKSURFACEGEOMETRYSMOOTHER_EXPORT ttkSurfaceGeometrySmoother
+  : public ttkAlgorithm,
+    protected ttk::SurfaceGeometrySmoother {
+
+public:
+  static ttkSurfaceGeometrySmoother *New();
+
+  vtkTypeMacro(ttkSurfaceGeometrySmoother, ttkAlgorithm);
+
+  vtkSetMacro(NumberOfIterations, int);
+  vtkGetMacro(NumberOfIterations, int);
+
+  vtkSetMacro(UseMaskScalarField, bool);
+  vtkGetMacro(UseMaskScalarField, bool);
+
+  vtkSetMacro(ForceInputMaskScalarField, bool);
+  vtkGetMacro(ForceInputMaskScalarField, bool);
+
+  vtkSetMacro(ForceIdentifiersField, bool);
+  vtkGetMacro(ForceIdentifiersField, bool);
+
+protected:
+  ttkSurfaceGeometrySmoother();
+  ~ttkSurfaceGeometrySmoother() override = default;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+private:
+  int NumberOfIterations{1};
+  bool UseMaskScalarField{true};
+  bool ForceInputMaskScalarField{false};
+  bool ForceIdentifiersField{false};
+};

--- a/core/vtk/ttkSurfaceGeometrySmoother/vtk.module
+++ b/core/vtk/ttkSurfaceGeometrySmoother/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkSurfaceGeometrySmoother
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/GeometrySmoother.xml
+++ b/paraview/xmls/GeometrySmoother.xml
@@ -19,19 +19,19 @@
         Online examples:
 
         - https://topology-tool-kit.github.io/examples/1manifoldLearning/
-        
+
         - https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/
 
         - https://topology-tool-kit.github.io/examples/2manifoldLearning/
-        
+
         - https://topology-tool-kit.github.io/examples/dragon/
 
         - https://topology-tool-kit.github.io/examples/harmonicSkeleton/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
-        
+
         - https://topology-tool-kit.github.io/examples/morseMolecule/
-        
+
         - https://topology-tool-kit.github.io/examples/interactionSites/
 
 
@@ -65,12 +65,12 @@
       </IntVectorProperty>
 
       <IntVectorProperty
-        name="ForceInputMaskScalarField"
-        command="SetForceInputMaskScalarField"
-        label="Force Input Mask Scalar Field"
+        name="UseMaskScalarField"
+        command="SetUseMaskScalarField"
+        label="Use a Scalar Field as Mask"
         number_of_elements="1"
         panel_visibility="advanced"
-        default_values="0">
+        default_values="1">
         <BooleanDomain name="bool"/>
         <Documentation>
           Check this box if an input scalar field should be considered as
@@ -78,9 +78,29 @@
         </Documentation>
       </IntVectorProperty>
 
-      <StringVectorProperty name="InputMaskNew" 
-                            label="Input Mask Field" 
-command="SetInputArrayToProcess" element_types="0 0 0 0 2" 
+      <IntVectorProperty
+        name="ForceInputMaskScalarField"
+        command="SetForceInputMaskScalarField"
+        label="Force Input Mask Scalar Field"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+          <Hints>
+            <PropertyWidgetDecorator type="GenericDecorator"
+              mode="visibility"
+              property="UseMaskScalarField"
+              value="1" />
+          </Hints>
+        <Documentation>
+          Check this box to choose a non-default scalar field as mask
+          (default mask scalar field is named ttk::MaskScalarFieldName).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty name="InputMaskNew"
+                            label="Input Mask Field"
+command="SetInputArrayToProcess" element_types="0 0 0 0 2"
 number_of_elements="5" panel_visibility="advanced">
           <ArrayListDomain attribute_type="Scalars" name="array_list">
             <RequiredProperties>
@@ -99,6 +119,7 @@ number_of_elements="5" panel_visibility="advanced">
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="Input" />
         <Property name="NumberOfIterations" />
+        <Property name="UseMaskScalarField" />
         <Property name="ForceInputMaskScalarField" />
         <Property name="InputMaskNew" />
       </PropertyGroup>

--- a/paraview/xmls/SurfaceGeometrySmoother.xml
+++ b/paraview/xmls/SurfaceGeometrySmoother.xml
@@ -1,0 +1,195 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+      name="ttkSurfaceGeometrySmoother"
+      class="ttkSurfaceGeometrySmoother"
+      label="TTK SurfaceGeometrySmoother">
+      <Documentation
+        long_help="TTK plugin for smoothing meshes on surfaces."
+        short_help="TTK plugin for smoothing meshes.">
+        GeometrySmoother with a twist!
+
+        This class smoothes and projects a 1D or a 2D mesh onto a 2D
+        closed triangulated surface.
+      </Documentation>
+
+      <InputProperty
+          name="Input"
+          port_index="0"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkPointSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1" >
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Point-set to smooth.
+        </Documentation>
+      </InputProperty>
+
+      <InputProperty
+          name="Surface"
+          label="Triangulated surface"
+          port_index="1"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkUnstructuredGrid"/>
+        </DataTypeDomain>
+        <Documentation>
+          Input triangulated surface.
+        </Documentation>
+      </InputProperty>
+
+      <IntVectorProperty
+        name="NumberOfIterations"
+        label="Iteration Number"
+        command="SetNumberOfIterations"
+        number_of_elements="1"
+        default_values="1" >
+        <IntRangeDomain name="range" min="0" max="100" />
+        <Documentation>
+          Number of iterations for the smoothing filter.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+          name="ForceIdentifiersField"
+          label="Force Vertex Identifiers Field"
+          command="SetForceIdentifiersField"
+          number_of_elements="1"
+          default_values="0"
+          panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Use a non-default vertex identifiers field.
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+          name="VertexIdsField"
+          label="Identifiers Field"
+          command="SetInputArrayToProcess"
+          number_of_elements="5"
+          element_types="0 0 0 0 2"
+          default_values="0"
+          panel_visibility="advanced"
+          >
+        <ArrayListDomain
+            name="array_list"
+            input_domain_name="input_scalars"
+            default_values="0"
+            >
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator
+              type="GenericDecorator"
+              mode="visibility"
+              property="ForceIdentifiersField"
+              value="1" />
+        </Hints>
+        <Documentation>
+          Select the vertex identifiers field.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+        name="UseMaskScalarField"
+        command="SetUseMaskScalarField"
+        label="Use a Scalar Field as Mask"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="1">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box if an input scalar field should be considered as
+          vertex mask (used to mark vertices to smooth).
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+        name="ForceInputMaskScalarField"
+        command="SetForceInputMaskScalarField"
+        label="Force Input Mask Scalar Field"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+            mode="visibility"
+            property="UseMaskScalarField"
+            value="1" />
+        </Hints>
+        <Documentation>
+          Check this box to choose a non-default scalar field as mask
+          (default mask scalar field is named ttk::MaskScalarFieldName).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+          name="InputMaskNew"
+          label="Mask Field"
+          command="SetInputArrayToProcess"
+          number_of_elements="5"
+          element_types="0 0 0 0 2"
+          default_values="1"
+          >
+        <ArrayListDomain
+          name="array_list"
+          input_domain_name="input_scalars"
+          default_values="0"
+          >
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="ForceInputMaskScalarField"
+                                       value="1" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="UseMaskScalarField"
+                                       value="1" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          Input mask field (used to mark vertices to smooth).
+        </Documentation>
+      </StringVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="Input" />
+        <Property name="NumberOfIterations" />
+        <Property name="ForceIdentifiersField" />
+        <Property name="VertexIdsField" />
+        <Property name="UseMaskScalarField" />
+        <Property name="ForceInputMaskScalarField" />
+        <Property name="InputMaskNew" />
+      </PropertyGroup>
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Scalar Data" />
+      </Hints>
+
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
This PR adds a new filter, `SurfaceGeometrySmoother` that works a bit like `GeometrySmoother` but takes a triangulated surface as a second input and projects its first input onto it. This is a bit similar to what `QuadrangulationSubdivision` does internally after the subdivision step (in fact, `SurfaceGeometrySmoother` borrows a lot from it - and a potential future `QuadrangulationSubdivision` PR should take advantage of this new filter).

The first input is expected to be a triangulation of dimensions 1 or 2. Similarly to `GeometrySmoother`, a mask field is supported. The filter also supports an optional `ttkVertexScalarField` point data array on the first input. If absent, for each point to smooth, the nearest vertex on the surface is computed using the euclidean distance. This helps supporting a broader range of input datasets (Morse-Smale 1-separatrices for instance).

To improve performance, a majority of heap allocations inside `Geometry` have been replaced with stack allocations (`std::vector` to `std::array`). This should have an impact also on `FiberSurface` and `QuadrangulationSubdivision`.

Additionally, `GeometrySmoother` has been updated with a new GUI option that disable the use of the mask field. Previously, a dataset with a `ttkMaskScalarField` was always using it.

Enjoy,
Pierre