### PR TITLE
Point set to surface

### DIFF
--- a/core/vtk/ttkPointSetToSurface/CMakeLists.txt
+++ b/core/vtk/ttkPointSetToSurface/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkPointSetToSurface/ttk.module
+++ b/core/vtk/ttkPointSetToSurface/ttk.module
@@ -1,0 +1,8 @@
+NAME
+  ttkPointSetToSurface
+SOURCES
+  ttkPointSetToSurface.cpp
+HEADERS
+  ttkPointSetToSurface.h
+DEPENDS
+  ttkAlgorithm

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -1,19 +1,10 @@
 #include <ttkPointSetToSurface.h>
 
 #include <vtkCellData.h>
-#include <vtkPointData.h>
-#include <vtkPointSet.h>
 #include <vtkUnstructuredGrid.h>
-
 #include <vtkInformation.h>
-#include <vtkInformationVector.h>
 
-#include <ttkMacros.h>
 #include <ttkUtils.h>
-
-#include <array>
-#include <map>
-#include <set>
 
 vtkStandardNewMacro(ttkPointSetToSurface);
 

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -2,7 +2,7 @@
 
 #include <vtkCellData.h>
 #include <vtkInformation.h>
-#include <vtkUnstructuredGrid.h>
+#include <vtkPolyData.h>
 
 #include <ttkUtils.h>
 
@@ -29,7 +29,7 @@ int ttkPointSetToSurface::FillInputPortInformation(int port,
 int ttkPointSetToSurface::FillOutputPortInformation(int port,
                                                     vtkInformation *info) {
   if(port == 0) {
-    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
     return 1;
   }
   return 0;
@@ -52,7 +52,7 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
                                       vtkInformationVector **inputVector,
                                       vtkInformationVector *outputVector) {
   const auto input = vtkPointSet::GetData(inputVector[0]);
-  auto output = vtkUnstructuredGrid::GetData(outputVector);
+  auto output = vtkPolyData::GetData(outputVector);
 
   if(input == nullptr || output == nullptr) {
     this->printErr("Null input data, aborting");
@@ -130,7 +130,7 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
   }
 
   // Create new grid
-  vtkNew<vtkUnstructuredGrid> vtkOutput{};
+  vtkNew<vtkPolyData> vtkOutput{};
   vtkOutput->ShallowCopy(input);
 
   for(unsigned int i = 0; i < nUniqueValues; ++i) {

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -6,6 +6,8 @@
 
 #include <ttkUtils.h>
 
+#include <array>
+
 vtkStandardNewMacro(ttkPointSetToSurface);
 
 ttkPointSetToSurface::ttkPointSetToSurface() {

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -1,8 +1,8 @@
 #include <ttkPointSetToSurface.h>
 
 #include <vtkCellData.h>
-#include <vtkUnstructuredGrid.h>
 #include <vtkInformation.h>
+#include <vtkUnstructuredGrid.h>
 
 #include <ttkUtils.h>
 

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -1,0 +1,178 @@
+#include <ttkPointSetToSurface.h>
+
+#include <vtkCellData.h>
+#include <vtkPointData.h>
+#include <vtkPointSet.h>
+#include <vtkUnstructuredGrid.h>
+
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+#include <array>
+#include <map>
+#include <set>
+
+vtkStandardNewMacro(ttkPointSetToSurface);
+
+ttkPointSetToSurface::ttkPointSetToSurface() {
+  this->setDebugMsgPrefix("PointSetToSurface");
+
+  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfOutputPorts(1);
+}
+
+int ttkPointSetToSurface::FillInputPortInformation(int port,
+                                                   vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPointSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkPointSetToSurface::FillOutputPortInformation(int port,
+                                                    vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkUnstructuredGrid");
+    return 1;
+  }
+  return 0;
+}
+
+template <typename VTK_T1, typename VTK_T2>
+void ttkPointSetToSurface::dispatch(
+  std::vector<std::tuple<vtkIdType, double, double>> &storage,
+  const VTK_T1 *const values,
+  const VTK_T2 *const values2,
+  const size_t nvalues) {
+
+  for(size_t i = 0; i < nvalues; ++i) {
+    storage.emplace_back(
+      i, static_cast<double>(values[i]), static_cast<double>(values2[i]));
+  }
+}
+
+int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
+                                      vtkInformationVector **inputVector,
+                                      vtkInformationVector *outputVector) {
+  const auto input = vtkPointSet::GetData(inputVector[0]);
+  auto output = vtkUnstructuredGrid::GetData(outputVector);
+
+  if(input == nullptr || output == nullptr) {
+    this->printErr("Null input data, aborting");
+    return 0;
+  }
+  const auto oa = this->GetInputArrayToProcess(0, inputVector);
+  const auto oa2 = this->GetInputArrayToProcess(1, inputVector);
+  if(oa == nullptr) {
+    this->printErr("Cannot find the required data X array");
+    return 0;
+  }
+  if(oa2 == nullptr) {
+    this->printErr("Cannot find the required data Y array");
+    return 0;
+  }
+
+  const auto nvalues = oa->GetNumberOfTuples();
+
+  // store point index <-> ordering value in vector
+  std::vector<std::tuple<vtkIdType, double, double>> orderedValues;
+
+#ifndef TTK_ENABLE_DOUBLE_TEMPLATING
+  switch(oa->GetDataType()) {
+    vtkTemplateMacro(dispatch(
+      orderedValues, static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(oa)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(oa2)), nvalues));
+  }
+#else
+  switch(vtkTemplate2PackMacro(oa->GetDataType(), oa2->GetDataType())) {
+    vtkTemplate2Macro(dispatch(
+      orderedValues, static_cast<VTK_T1 *>(ttkUtils::GetVoidPointer(oa)),
+      static_cast<VTK_T2 *>(ttkUtils::GetVoidPointer(oa2)), nvalues));
+  }
+#endif // TTK_ENABLE_DOUBLE_TEMPLATING
+
+  // Get number of unique values of each array
+  std::vector<double> xValues(orderedValues.size()),
+    yValues(orderedValues.size());
+  for(unsigned int i = 0; i < orderedValues.size(); ++i) {
+    auto tup = orderedValues[i];
+    xValues[i] = std::get<1>(tup);
+    yValues[i] = std::get<2>(tup);
+  }
+  std::sort(xValues.begin(), xValues.end());
+  const auto nUniqueValues
+    = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
+  std::sort(yValues.begin(), yValues.end());
+  const auto nUniqueValues2
+    = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
+
+  if(nUniqueValues * nUniqueValues2 != input->GetNumberOfPoints()) {
+    printErr("Number of values in first array times the number of values in "
+             "the second one does not equal the number of points");
+    return 0;
+  }
+
+  // compare two pairs of index/value according to their values
+  const auto cmp = [&](const std::tuple<vtkIdType, double, double> &a,
+                       const std::tuple<vtkIdType, double, double> &b) {
+    return std::get<1>(a) * nUniqueValues2 + std::get<2>(a)
+           < std::get<1>(b) * nUniqueValues2 + std::get<2>(b);
+  };
+
+  // sort the vector of indices/values in ascending order
+  std::sort(orderedValues.begin(), orderedValues.end(), cmp);
+
+  // Create point ids matrix
+  std::vector<std::vector<vtkIdType>> orderedIds(
+    nUniqueValues, std::vector<vtkIdType>(nUniqueValues2));
+  for(unsigned int i = 0; i < nUniqueValues; ++i) {
+    for(unsigned int j = 0; j < nUniqueValues2; ++j) {
+      auto index = i * nUniqueValues2 + j;
+      orderedIds[i][j] = std::get<0>(orderedValues[index]);
+    }
+  }
+
+  // Create new grid
+  vtkNew<vtkUnstructuredGrid> vtkOutput{};
+  vtkOutput->ShallowCopy(input);
+
+  for(unsigned int i = 0; i < nUniqueValues; ++i) {
+    for(unsigned int j = 0; j < nUniqueValues2; ++j) {
+      if(j != 0) {
+        std::array<vtkIdType, 2> linePoints{
+          orderedIds[i][j - 1], orderedIds[i][j]};
+        vtkOutput->InsertNextCell(VTK_LINE, 2, linePoints.data());
+      }
+
+      if(i != 0) {
+        std::array<vtkIdType, 2> linePoints{
+          orderedIds[i - 1][j], orderedIds[i][j]};
+        vtkOutput->InsertNextCell(VTK_LINE, 2, linePoints.data());
+      }
+
+      if(i != 0 and j != 0) {
+        std::array<vtkIdType, 4> cellPoints{
+          orderedIds[i - 1][j - 1], orderedIds[i - 1][j], orderedIds[i][j],
+          orderedIds[i][j - 1]};
+        vtkOutput->InsertNextCell(VTK_QUAD, 4, cellPoints.data());
+      }
+    }
+  }
+
+  auto noCells = vtkOutput->GetNumberOfCells();
+  vtkNew<vtkIntArray> cellTypeArray{};
+  cellTypeArray->SetName("CellType");
+  cellTypeArray->SetNumberOfTuples(noCells);
+  for(int i = 0; i < noCells; ++i) {
+    cellTypeArray->SetTuple1(i, vtkOutput->GetCellType(i));
+  }
+  vtkOutput->GetCellData()->AddArray(cellTypeArray);
+
+  output->ShallowCopy(vtkOutput);
+
+  return 1;
+}

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.h
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.h
@@ -1,0 +1,45 @@
+/// \class ttkPointSetToSurface
+/// \ingroup vtk
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date April 2022
+///
+/// \brief TTK VTK-filter that reads a Cinema Spec D Database.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutput()).
+///
+/// \param Output content of the data.csv file of the database in form of a
+/// vtkTable
+
+#pragma once
+
+// Module include
+#include <ttkPointSetToSurfaceModule.h>
+
+// VTK includes
+#include <ttkAlgorithm.h>
+
+class TTKPOINTSETTOSURFACE_EXPORT ttkPointSetToSurface : public ttkAlgorithm {
+
+public:
+  static ttkPointSetToSurface *New();
+  vtkTypeMacro(ttkPointSetToSurface, ttkAlgorithm);
+
+protected:
+  ttkPointSetToSurface();
+  ~ttkPointSetToSurface() = default;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+  template <typename VTK_T1, typename VTK_T2>
+  void dispatch(std::vector<std::tuple<vtkIdType, double, double>> &storage,
+                const VTK_T1 *const values,
+                const VTK_T2 *const values2,
+                const size_t nvalues);
+
+private:
+};

--- a/core/vtk/ttkPointSetToSurface/vtk.module
+++ b/core/vtk/ttkPointSetToSurface/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkPointSetToSurface
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/PointSetToCurve.xml
+++ b/paraview/xmls/PointSetToCurve.xml
@@ -72,7 +72,7 @@
       </PropertyGroup>
 
       <Hints>
-        <ShowInMenu category="TTK - Misc" />
+        <ShowInMenu category="TTK - Domain" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>

--- a/paraview/xmls/PointSetToSurface.xml
+++ b/paraview/xmls/PointSetToSurface.xml
@@ -1,0 +1,86 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkPointSetToSurface"
+        class="ttkPointSetToSurface"
+        label="TTK PointSetToSurface">
+      <Documentation
+          long_help="TTK filter converting point set to surface"
+          short_help="Converts point set to surface.">
+        This filter generates a surface between points in a Point Set
+        according to the ordering of two given Point Data arrays.
+      </Documentation>
+
+      <InputProperty
+          name="Domain"
+          label="Input Data Set"
+          port_index="0"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkPointSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input Domain" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+        </Documentation>
+      </InputProperty>
+
+      <StringVectorProperty
+        name="InputOrderingXArray"
+        command="SetInputArrayToProcess"
+        label="Input Ordering X Array"
+        element_types="0 0 0 0 2"
+        number_of_elements="5"
+        default_values="0"
+        animateable="0"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0">
+          <RequiredProperties>
+            <Property name="Domain" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the input ordering X array.
+        </Documentation>
+      </StringVectorProperty>
+      
+      <StringVectorProperty
+        name="InputOrderingYArray"
+        command="SetInputArrayToProcess"
+        label="Input Ordering Y Array"
+        element_types="0 0 0 0 2"
+        number_of_elements="5"
+        default_values="1"
+        animateable="0"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0">
+          <RequiredProperties>
+            <Property name="Domain" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the input ordering Y array.
+        </Documentation>
+      </StringVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="InputOrderingXArray" />
+        <Property name="InputOrderingYArray" />
+      </PropertyGroup>
+
+      <Hints>
+        <ShowInMenu category="TTK - Misc" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/paraview/xmls/PointSetToSurface.xml
+++ b/paraview/xmls/PointSetToSurface.xml
@@ -79,7 +79,7 @@
       </PropertyGroup>
 
       <Hints>
-        <ShowInMenu category="TTK - Misc" />
+        <ShowInMenu category="TTK - Domain" />
       </Hints>
     </SourceProxy>
   </ProxyGroup>


### PR DESCRIPTION
This PR adds the PointSetToSurface filter to TTK.
It takes a point set as its only input and produces a vtkUnstructuredGrid as output corresponding to a surface made by "linking" points together given two arrays (corresponding to the X and Y values of a point in the grid of the resulting surface).
It can be seen as an extension of the PointSetToCurve filter to two dimensions (PointSetToSurface is very inspired by PointSetToCurve).

