### PR TITLE
Changed compile flags for Apple Silicon

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -84,7 +84,11 @@ function(ttk_add_base_template_library library)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
   if(uppercase_CMAKE_BUILD_TYPE MATCHES RELEASE)
     if(TTK_ENABLE_CPU_OPTIMIZATION AND NOT MSVC)
-      target_compile_options(${library} INTERFACE -march=native -O3)
+      if (CMAKE_OSX_ARCHITECTURES MATCHES arm64) # Apple Silicon
+        target_compile_options(${library} INTERFACE -mcpu=apple-m1 -O3)
+      else()
+        target_compile_options(${library} INTERFACE -march=native -O3)
+      endif()
     endif()
   endif()
 

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -12,8 +12,12 @@ if (NOT MSVC) # GCC and Clang
 
   # performance and debug flags
   if(TTK_ENABLE_CPU_OPTIMIZATION AND CMAKE_BUILD_TYPE MATCHES Release)
+    if (CMAKE_OSX_ARCHITECTURES MATCHES arm64) # Apple Silicon
+      list(APPEND TTK_COMPILER_FLAGS -mcpu=apple-m1 -Wfatal-errors)
+    else()
     # -O3 already enabled by CMake's Release configuration
-    list(APPEND TTK_COMPILER_FLAGS -march=native -Wfatal-errors)
+      list(APPEND TTK_COMPILER_FLAGS -march=native -Wfatal-errors)
+    endif()
   endif()
 
   if(CMAKE_BUILD_TYPE MATCHES Debug)


### PR DESCRIPTION
This PR adds a check if we are on Apple Silicon on which the '-march=native' flag is currently not available. Alternatively, '-mcpu=apple-m1' is available, which allows for some optimization.