### PR TITLE
MergeTreeDistanceMatrix better memory usage

### DIFF
--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -334,9 +334,6 @@ namespace ttk {
       Memory m;
       Timer t_total;
 
-      ftm::FTMTree_MT *tree1 = &(mTree1.tree);
-      ftm::FTMTree_MT *tree2 = &(mTree2.tree);
-
       // ---------------------
       // ----- Testing
       // --------------------
@@ -345,14 +342,16 @@ namespace ttk {
       // ---------------------
       // ----- Preprocessing
       // --------------------
-      ftm::MergeTree<dataType> tree1Ori = mTree1;
-      ftm::MergeTree<dataType> tree2Ori = mTree2;
+      ftm::MergeTree<dataType> mTree1Copy;
+      ftm::MergeTree<dataType> mTree2Copy;
       if(saveTree_) {
-        mTree1 = ftm::copyMergeTree<dataType>(mTree1);
-        mTree2 = ftm::copyMergeTree<dataType>(mTree2);
-        tree1 = &(mTree1.tree);
-        tree2 = &(mTree2.tree);
+        mTree1Copy = ftm::copyMergeTree<dataType>(mTree1);
+        mTree2Copy = ftm::copyMergeTree<dataType>(mTree2);
       }
+      ftm::MergeTree<dataType> &mTree1Int = (saveTree_ ? mTree1Copy : mTree1);
+      ftm::MergeTree<dataType> &mTree2Int = (saveTree_ ? mTree2Copy : mTree2);
+      ftm::FTMTree_MT *tree1 = &(mTree1Int.tree);
+      ftm::FTMTree_MT *tree2 = &(mTree2Int.tree);
       if(not isCalled_) {
         verifyMergeTreeStructure<dataType>(tree1);
         verifyMergeTreeStructure<dataType>(tree2);
@@ -360,14 +359,14 @@ namespace ttk {
       if(preprocess_) {
         treesNodeCorr_ = std::vector<std::vector<int>>(2);
         preprocessingPipeline<dataType>(
-          mTree1, epsilonTree1_, epsilon2Tree1_, epsilon3Tree1_,
+          mTree1Int, epsilonTree1_, epsilon2Tree1_, epsilon3Tree1_,
           branchDecomposition_, useMinMaxPair_, cleanTree_, treesNodeCorr_[0]);
         preprocessingPipeline<dataType>(
-          mTree2, epsilonTree2_, epsilon2Tree2_, epsilon3Tree2_,
+          mTree2Int, epsilonTree2_, epsilon2Tree2_, epsilon3Tree2_,
           branchDecomposition_, useMinMaxPair_, cleanTree_, treesNodeCorr_[1]);
       }
-      tree1 = &(mTree1.tree);
-      tree2 = &(mTree2.tree);
+      tree1 = &(mTree1Int.tree);
+      tree2 = &(mTree2Int.tree);
 
       // ---------------------
       // ----- Compute Distance
@@ -401,11 +400,6 @@ namespace ttk {
       ss4 << "MEMORY          = " << m.getElapsedUsage();
       printMsg(ss4.str());
       printMsg(debug::Separator::L2);
-
-      if(saveTree_) {
-        mTree1 = tree1Ori;
-        mTree2 = tree2Ori;
-      }
 
       return distance;
     }

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -65,9 +65,11 @@ namespace ttk {
 #pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix, trees)
         {
 #endif
-          std::stringstream stream;
-          stream << i << " / " << distanceMatrix.size();
-          printMsg(stream.str());
+          if(i % (distanceMatrix.size() / 10) == 0) {
+            std::stringstream stream;
+            stream << i << " / " << distanceMatrix.size();
+            printMsg(stream.str());
+          }
 
           distanceMatrix[i][i] = 0.0;
           for(unsigned int j = i + 1; j < distanceMatrix[0].size(); ++j) {
@@ -97,6 +99,7 @@ namespace ttk {
             mergeTreeDistance.setSaveTree(true);
             mergeTreeDistance.setCleanTree(true);
             mergeTreeDistance.setIsCalled(true);
+            mergeTreeDistance.setPostprocess(false);
             std::vector<std::tuple<ftm::idNode, ftm::idNode>> outputMatching;
             distanceMatrix[i][j] = mergeTreeDistance.execute<dataType>(
               trees[i], trees[j], outputMatching);

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -62,7 +62,7 @@ namespace ttk {
                          std::vector<std::vector<double>> &distanceMatrix) {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix)
+#pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix, trees)
         {
 #endif
           std::stringstream stream;

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -119,6 +119,9 @@ int ttkMergeTreeDistanceMatrix::run(
   epsilonTree2_ = epsilonTree1_;
   epsilon2Tree2_ = epsilon2Tree1_;
   epsilon3Tree2_ = epsilon3Tree1_;
+  printMsg("BranchDecomposition: " + std::to_string(branchDecomposition_));
+  printMsg("NormalizedWasserstein: " + std::to_string(normalizedWasserstein_));
+  printMsg("KeepSubtree: " + std::to_string(keepSubtree_));
 
   // --- Call base
   std::vector<std::vector<double>> treesDistMat(


### PR DESCRIPTION
This PR modifies the MergeTreeDistanceMatrix filter in order to have a better memory usage. 

Here after, a table showing the maximum memory usage (RES column of htop) for different datasets before and after the PR:
```
                   |  N |  BEFORE |  AFTER |
Dark Sky           | 40 | 12.5 Gb | 2.3 Gb |
Sea Surface Height | 48 | 12.1 Gb | 2.5 Gb |
Isabel             | 12 |  2.2 Gb | 1.3 Gb |
```

The problem was that before this PR the trees were copied among all threads instead of being shared! Moreover there are slight changes in MergeTreeDistance to better manage the option "SaveTree" (i.e. not modifying the original trees, important for the MergeTreeDistanceMatrix filter, especially if the trees are shared).

Some messages have also been added, such as the value of the parameters BranchDecomposition, NormalizedWasserstein and KeepSubtree at the beginning of the execution to avoid any ambiguities about what is executed and MergeTreeDistanceMatrix shows less messages.