### PR TITLE
FTMTree new utils functions

### DIFF
--- a/core/base/ftmTree/FTMTreeUtils.cpp
+++ b/core/base/ftmTree/FTMTreeUtils.cpp
@@ -462,13 +462,15 @@ namespace ttk {
       return ss;
     }
 
-    void FTMTree_MT::printTreeStats() {
+    std::stringstream FTMTree_MT::printTreeStats(bool doPrint) {
       auto noNodesT = this->getNumberOfNodes();
       auto noNodes = this->getRealNumberOfNodes();
       std::stringstream ss;
       ss << "tree [node: " << noNodes << " / " << noNodesT;
       ss << ", depth: " << this->getTreeDepth() << "]";
-      printMsg(ss.str());
+      if(doPrint)
+        printMsg(ss.str());
+      return ss;
     }
 
     std::stringstream

--- a/core/base/ftmTree/FTMTreeUtils.h
+++ b/core/base/ftmTree/FTMTreeUtils.h
@@ -71,10 +71,11 @@ namespace ttk {
       std::vector<std::vector<MergeTree<dataType>>> &mts,
       std::vector<std::vector<MergeTree<double>>> &newMts) {
       newMts.clear();
+      newMts.reserve(mts.size());
       for(auto &mt : mts) {
         std::vector<MergeTree<double>> newMt;
         mergeTreesTemplateToDouble<dataType>(mt, newMt);
-        newMts.push_back(newMt);
+        newMts.emplace_back(newMt);
       }
     }
 
@@ -104,10 +105,11 @@ namespace ttk {
       std::vector<std::vector<MergeTree<double>>> &mts,
       std::vector<std::vector<MergeTree<dataType>>> &newMts) {
       newMts.clear();
+      newMts.reserve(mts.size());
       for(auto &mt : mts) {
         std::vector<MergeTree<dataType>> newMt;
         mergeTreesDoubleToTemplate<dataType>(mt, newMt);
-        newMts.push_back(newMt);
+        newMts.emplace_back(newMt);
       }
     }
 

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -36,8 +36,7 @@ namespace ttk {
     }
 
     template <class dataType>
-    bool FTMTree_MT::isImportantPair(idNode nodeId,
-                                     double threshold) {
+    bool FTMTree_MT::isImportantPair(idNode nodeId, double threshold) {
       dataType rootPers = this->getNodePersistence<dataType>(this->getRoot());
       if(threshold > 1)
         threshold /= 100.0;

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -84,7 +84,7 @@ namespace ttk {
     // Get
     // --------------------
     template <class dataType>
-    int FTMTree_MT::getMergedRootOrigin() {
+    idNode FTMTree_MT::getMergedRootOrigin() {
       dataType maxPers = std::numeric_limits<dataType>::lowest();
       int maxIndex = -1;
       auto root = this->getRoot();

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -36,12 +36,14 @@ namespace ttk {
     }
 
     template <class dataType>
-    bool FTMTree_MT::isImportantPair(idNode nodeId, double threshold) {
+    bool FTMTree_MT::isImportantPair(idNode nodeId,
+                                     double threshold) {
       dataType rootPers = this->getNodePersistence<dataType>(this->getRoot());
       if(threshold > 1)
         threshold /= 100.0;
       threshold = rootPers * threshold;
-      return this->getNodePersistence<dataType>(nodeId) > threshold;
+      auto pers = this->getNodePersistence<dataType>(nodeId);
+      return pers > threshold;
     }
 
     template <class dataType>
@@ -83,6 +85,24 @@ namespace ttk {
     // Get
     // --------------------
     template <class dataType>
+    int FTMTree_MT::getMergedRootOrigin() {
+      dataType maxPers = std::numeric_limits<dataType>::lowest();
+      int maxIndex = -1;
+      auto root = this->getRoot();
+      for(unsigned int j = 0; j < this->getNumberOfNodes(); ++j) {
+        if(j != root and this->isNodeOriginDefined(j)
+           and this->getNode(j)->getOrigin() == (int)root) {
+          dataType nodePers = this->getNodePersistence<dataType>(j);
+          if(nodePers > maxPers) {
+            maxPers = nodePers;
+            maxIndex = j;
+          }
+        }
+      }
+      return maxIndex;
+    }
+
+    template <class dataType>
     idNode FTMTree_MT::getLowestNode(idNode nodeStart) {
       idNode lowestNode = nodeStart;
       bool isJT = this->isJoinTree<dataType>();
@@ -110,17 +130,60 @@ namespace ttk {
     // Persistence
     // --------------------
     template <class dataType>
+    std::tuple<dataType, dataType>
+      FTMTree_MT::getBirthDeathFromIds(idNode nodeId1, idNode nodeId2) {
+      dataType scalar1 = this->getValue<dataType>(nodeId1);
+      dataType scalar2 = this->getValue<dataType>(nodeId2);
+      dataType birth = std::min(scalar1, scalar2);
+      dataType death = std::max(scalar1, scalar2);
+      return std::make_tuple(birth, death);
+    }
+
+    template <class dataType>
+    std::tuple<dataType, dataType>
+      FTMTree_MT::getBirthDeathNodeFromIds(idNode nodeId1, idNode nodeId2) {
+      auto nodeValue = this->getValue<dataType>(nodeId1);
+      auto node2Value = this->getValue<dataType>(nodeId2);
+      auto nodeBirth = (nodeValue < node2Value ? nodeId1 : nodeId2);
+      auto nodeDeath = (nodeValue < node2Value ? nodeId2 : nodeId1);
+      return std::make_tuple(nodeBirth, nodeDeath);
+    }
+
+    template <class dataType>
     std::tuple<dataType, dataType> FTMTree_MT::getBirthDeath(idNode nodeId) {
-      idNode originId = this->getNode(nodeId)->getOrigin();
-      if(this->isNodeOriginDefined(
-           nodeId)) { // Avoid error if origin is not defined
-        dataType pers1 = this->getValue<dataType>(nodeId);
-        dataType pers2 = this->getValue<dataType>(originId);
-        dataType birth = std::min(pers1, pers2);
-        dataType death = std::max(pers1, pers2);
-        return std::make_tuple(birth, death);
+      // Avoid error if origin is not defined
+      if(this->isNodeOriginDefined(nodeId)) {
+        return this->getBirthDeathFromIds<dataType>(
+          nodeId, this->getNode(nodeId)->getOrigin());
       }
       return std::make_tuple(0.0, 0.0);
+    }
+
+    template <class dataType>
+    std::tuple<ftm::idNode, ftm::idNode>
+      FTMTree_MT::getBirthDeathNode(idNode nodeId) {
+      if(this->isNodeOriginDefined(nodeId)) {
+        return this->getBirthDeathNodeFromIds<dataType>(
+          nodeId, this->getNode(nodeId)->getOrigin());
+      }
+      return std::make_tuple(0.0, 0.0);
+    }
+
+    template <class dataType>
+    std::tuple<dataType, dataType> FTMTree_MT::getMergedRootBirthDeath() {
+      if(!this->isFullMerge())
+        return this->getBirthDeath<dataType>(this->getRoot());
+      return this->getBirthDeathFromIds<dataType>(
+        this->getRoot(), this->getMergedRootOrigin<dataType>());
+    }
+
+    template <class dataType>
+    std::tuple<ftm::idNode, ftm::idNode>
+      FTMTree_MT::getMergedRootBirthDeathNode() {
+      if(!this->isFullMerge())
+        return this->getBirthDeathNode<dataType>(this->getRoot());
+      return this->getBirthDeathNodeFromIds<dataType>(
+        this->getRoot(), this->getMergedRootOrigin<dataType>());
     }
 
     template <class dataType>
@@ -147,7 +210,7 @@ namespace ttk {
       // Full merge case
       dataType maxPers = std::numeric_limits<dataType>::lowest();
       for(unsigned int i = 0; i < this->getNumberOfNodes(); ++i)
-        if(not this->isNodeAlone(i) and this->isNodeOriginDefined(i)
+        if(/*not this->isNodeAlone(i) and*/ this->isNodeOriginDefined(i)
            and this->getNode(i)->getOrigin() == (int)root)
           maxPers = std::max(maxPers, this->getNodePersistence<dataType>(i));
 
@@ -155,20 +218,31 @@ namespace ttk {
     }
 
     template <class dataType>
-    dataType FTMTree_MT::getSecondMaximumPersistence() {
+    ftm::idNode FTMTree_MT::getSecondMaximumPersistenceNode() {
       idNode root = this->getRoot();
       dataType pers = std::numeric_limits<dataType>::lowest();
+      ftm::idNode nodeSecMax = -1;
       for(unsigned int i = 0; i < this->getNumberOfNodes(); ++i) {
-        if(this->isLeaf(i) and not this->isNodeAlone(i)
+        if(not this->isRoot(i) and not this->isNodeAlone(i)
            and this->isNodeOriginDefined(i)) {
           idNode nodeOrigin = this->getNode(i)->getOrigin();
           if(not(nodeOrigin == root
-                 and this->getNode(nodeOrigin)->getOrigin() == (int)i))
-            pers = std::max(pers, this->getNodePersistence<dataType>(i));
+                 and this->getNode(nodeOrigin)->getOrigin() == (int)i)) {
+            auto nodePers = this->getNodePersistence<dataType>(i);
+            if(pers < nodePers) {
+              pers = nodePers;
+              nodeSecMax = i;
+            }
+          }
         }
       }
+      return nodeSecMax;
+    }
 
-      return pers;
+    template <class dataType>
+    dataType FTMTree_MT::getSecondMaximumPersistence() {
+      return this->getNodePersistence<dataType>(
+        this->getSecondMaximumPersistenceNode<dataType>());
     }
 
     template <class dataType>
@@ -222,17 +296,40 @@ namespace ttk {
     // Utils
     // --------------------
     template <class dataType>
-    void FTMTree_MT::printNode2(idNode nodeId) {
-      auto birthDeath = this->getBirthDeath<dataType>(nodeId);
+    std::stringstream FTMTree_MT::printNode2(idNode nodeId, bool doPrint) {
+      auto origin = this->getNode(nodeId)->getOrigin();
       std::stringstream ss;
-      ss << "nodeId = " << nodeId << " (" << std::get<0>(birthDeath)
-         << ") _ originId = " << this->getNode(nodeId)->getOrigin() << " ("
-         << std::get<1>(birthDeath) << ")";
-      printMsg(ss.str());
+      ss << "nodeId = " << nodeId << " (" << this->getValue<dataType>(nodeId)
+         << ") _ originId = " << this->getNode(nodeId)->getOrigin();
+      if(not this->isNodeIdInconsistent(origin))
+        ss << " (" << this->getValue<dataType>(origin) << ")";
+      if(doPrint)
+        printMsg(ss.str());
+      return ss;
     }
 
     template <class dataType>
-    void FTMTree_MT::printTreeScalars(bool printNodeAlone) {
+    std::stringstream FTMTree_MT::printMergedRoot(bool doPrint) {
+      std::stringstream ss;
+      ss << this->getRoot() << " (" << this->getValue<dataType>(this->getRoot())
+         << ") _ ";
+      auto mergedRootOrigin = this->getMergedRootOrigin<dataType>();
+      ss << mergedRootOrigin;
+      if(not this->isNodeIdInconsistent(mergedRootOrigin))
+        ss << " (" << this->getValue<dataType>(mergedRootOrigin) << ")";
+      ss << " _ " << this->getNodePersistence<dataType>(this->getRoot());
+      if(not this->isNodeIdInconsistent(mergedRootOrigin))
+        ss << " _ " << this->getNodePersistence<dataType>(mergedRootOrigin);
+      ss << std::endl;
+      if(doPrint)
+        printMsg(ss.str());
+      return ss;
+    }
+
+    template <class dataType>
+    std::stringstream FTMTree_MT::printTreeScalars(bool printNodeAlone,
+                                                   bool doPrint) {
+      std::stringstream wholeSS;
       std::streamsize sSize = std::cout.precision();
       for(unsigned int i = 0; i < this->getNumberOfNodes(); ++i) {
         idNode iOrigin
@@ -244,11 +341,15 @@ namespace ttk {
           std::stringstream ss;
           ss << i << " _ " << std::setprecision(12)
              << this->getValue<dataType>(i);
-          printMsg(ss.str());
+          if(doPrint)
+            printMsg(ss.str());
+          wholeSS << ss.str() << std::endl;
         }
       }
-      printMsg(debug::Separator::L2);
+      if(doPrint)
+        printMsg(debug::Separator::L2);
       std::cout.precision(sSize);
+      return wholeSS;
     }
 
     template <class dataType>
@@ -276,7 +377,9 @@ namespace ttk {
     }
 
     template <class dataType>
-    void FTMTree_MT::printMultiPersPairsFromTree(bool useBD, bool printPairs) {
+    std::stringstream FTMTree_MT::printMultiPersPairsFromTree(bool useBD,
+                                                              bool printPairs,
+                                                              bool doPrint) {
       std::vector<std::tuple<idNode, idNode, dataType>> pairs;
       this->getPersistencePairsFromTree(pairs, useBD);
       std::vector<int> noOrigin(this->getNumberOfNodes(), 0);
@@ -294,8 +397,11 @@ namespace ttk {
         for(auto node : multiPers)
           ss << node << std::endl;
       }
-      printMsg(ss.str());
-      printMsg(debug::Separator::L2);
+      if(doPrint) {
+        printMsg(ss.str());
+        printMsg(debug::Separator::L2);
+      }
+      return ss;
     }
 
   } // namespace ftm

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -628,6 +628,9 @@ namespace ttk {
 
       int getRealNumberOfNodes();
 
+      template <class dataType>
+      int getMergedRootOrigin();
+
       void getBranchOriginsFromThisBranch(
         idNode node, std::tuple<std::vector<idNode>, std::vector<idNode>> &res);
 
@@ -663,7 +666,24 @@ namespace ttk {
       // Persistence
       // --------------------
       template <class dataType>
+      std::tuple<dataType, dataType> getBirthDeathFromIds(idNode nodeId1,
+                                                          idNode nodeId2);
+
+      template <class dataType>
+      std::tuple<dataType, dataType> getBirthDeathNodeFromIds(idNode nodeId1,
+                                                              idNode nodeId2);
+
+      template <class dataType>
       std::tuple<dataType, dataType> getBirthDeath(idNode nodeId);
+
+      template <class dataType>
+      std::tuple<ftm::idNode, ftm::idNode> getBirthDeathNode(idNode nodeId);
+
+      template <class dataType>
+      std::tuple<dataType, dataType> getMergedRootBirthDeath();
+
+      template <class dataType>
+      std::tuple<ftm::idNode, ftm::idNode> getMergedRootBirthDeathNode();
 
       template <class dataType>
       dataType getBirth(idNode nodeId);
@@ -673,6 +693,9 @@ namespace ttk {
 
       template <class dataType>
       dataType getMaximumPersistence();
+
+      template <class dataType>
+      ftm::idNode getSecondMaximumPersistenceNode();
 
       template <class dataType>
       dataType getSecondMaximumPersistence();
@@ -718,14 +741,18 @@ namespace ttk {
       void printNodeSS(idNode node, std::stringstream &ss);
 
       template <class dataType>
-      void printNode2(idNode nodeId);
+      std::stringstream printNode2(idNode nodeId, bool doPrint = true);
+
+      template <class dataType>
+      std::stringstream printMergedRoot(bool doPrint = true);
 
       std::stringstream printTree(bool doPrint = true);
 
-      void printTreeStats();
+      std::stringstream printTreeStats(bool doPrint = true);
 
       template <class dataType>
-      void printTreeScalars(bool printNodeAlone = true);
+      std::stringstream printTreeScalars(bool printNodeAlone = true,
+                                         bool doPrint = true);
 
       template <class dataType>
       std::stringstream printPairsFromTree(bool useBD = false,
@@ -736,8 +763,9 @@ namespace ttk {
                                                             = true);
 
       template <class dataType>
-      void printMultiPersPairsFromTree(bool useBD = false,
-                                       bool printPairs = true);
+      std::stringstream printMultiPersPairsFromTree(bool useBD = false,
+                                                    bool printPairs = true,
+                                                    bool doPrint = true);
 
       // ----------------------------------------
       // End of utils functions

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -629,7 +629,7 @@ namespace ttk {
       int getRealNumberOfNodes();
 
       template <class dataType>
-      int getMergedRootOrigin();
+      idNode getMergedRootOrigin();
 
       void getBranchOriginsFromThisBranch(
         idNode node, std::tuple<std::vector<idNode>, std::vector<idNode>> &res);


### PR DESCRIPTION
This PR adds some utils functions to FTMTree that can/will be useful.

First, the debug functions consisting in printing some information that returned nothing now return a stringstream corresponding to the (potentially) displayed message (like some other functions that already did that in this module).
Among the added functions we have for example some of them that allow to directly get the nodes of a persistence pair and order them according their birth and death and other things that make life easier when manipulating merge trees.