### PR TITLE
Fix/Enforce some clang-tidy modernize checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  modernize-redundant-void-arg,
   modernize-use-bool-literals,
   modernize-use-emplace,
   modernize-use-equals-default,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  modernize-use-bool-literals,
   modernize-use-emplace,
   modernize-use-equals-default,
   modernize-use-nullptr,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >-
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
   modernize-use-emplace,
+  modernize-use-equals-default,
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >-
   modernize-use-emplace,
   modernize-use-nullptr,
   modernize-use-override,
+  modernize-use-using,
   openmp-*,
   -openmp-use-default-none,
   performance-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
-  -modernize-*,
+  modernize-use-override,
   openmp-*,
   -openmp-use-default-none,
   performance-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  modernize-use-emplace,
   modernize-use-nullptr,
   modernize-use-override,
   openmp-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  modernize-use-nullptr,
   modernize-use-override,
   openmp-*,
   -openmp-use-default-none,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  modernize-deprecated-headers,
   modernize-redundant-void-arg,
   modernize-use-bool-literals,
   modernize-use-emplace,

--- a/core/base/abstractTriangulation/AbstractTriangulation.cpp
+++ b/core/base/abstractTriangulation/AbstractTriangulation.cpp
@@ -10,8 +10,7 @@ AbstractTriangulation::AbstractTriangulation() {
   clear();
 }
 
-AbstractTriangulation::~AbstractTriangulation() {
-}
+AbstractTriangulation::~AbstractTriangulation() = default;
 
 int AbstractTriangulation::clear() {
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2824,17 +2824,17 @@ namespace ttk {
 
     virtual inline bool
       isEdgeOnBoundaryInternal(const SimplexId &ttkNotUsed(edgeId)) const {
-      return 0;
+      return false;
     }
 
     virtual inline bool isTriangleOnBoundaryInternal(
       const SimplexId &ttkNotUsed(triangleId)) const {
-      return 0;
+      return false;
     }
 
     virtual inline bool
       isVertexOnBoundaryInternal(const SimplexId &ttkNotUsed(vertexId)) const {
-      return 0;
+      return false;
     }
 
     inline bool hasPreconditionedBoundaryEdges() const {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -61,7 +61,7 @@ namespace ttk {
   public:
     AbstractTriangulation();
 
-    virtual ~AbstractTriangulation();
+    ~AbstractTriangulation() override;
 
     AbstractTriangulation(const AbstractTriangulation &) = default;
     AbstractTriangulation(AbstractTriangulation &&) = default;
@@ -3114,7 +3114,7 @@ namespace ttk {
     }
 
     // empty wrapping to VTK for now
-    bool needsToAbort() {
+    bool needsToAbort() override {
       return false;
     }
 
@@ -3214,7 +3214,7 @@ namespace ttk {
                                const std::string &tableName = "",
                                std::ostream &stream = std::cout) const;
 
-    int updateProgress(const float &ttkNotUsed(progress)) {
+    int updateProgress(const float &ttkNotUsed(progress)) override {
       return 0;
     }
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -179,7 +179,7 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getCellEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedCellEdges())
-        return NULL;
+        return nullptr;
 #endif
       if(getDimensionality() == 1)
         return getCellNeighbors();
@@ -276,7 +276,7 @@ namespace ttk {
       getCellNeighbors() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedCellNeighbors())
-        return NULL;
+        return nullptr;
 #endif
       return getCellNeighborsInternal();
     }
@@ -389,10 +389,10 @@ namespace ttk {
       getCellTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedCellTriangles())
-        return NULL;
+        return nullptr;
 #endif
       if(getDimensionality() == 2)
         return getCellNeighbors();
@@ -463,10 +463,10 @@ namespace ttk {
     virtual inline const std::vector<std::array<SimplexId, 2>> *getEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedEdges())
-        return NULL;
+        return nullptr;
 #endif
       return getEdgesInternal();
     }
@@ -557,10 +557,10 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedEdgeLinks())
-        return NULL;
+        return nullptr;
 #endif
       return getEdgeLinksInternal();
     }
@@ -663,10 +663,10 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getEdgeStars() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedEdgeStars())
-        return NULL;
+        return nullptr;
 #endif
       return getEdgeStarsInternal();
     }
@@ -768,10 +768,10 @@ namespace ttk {
       getEdgeTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedEdgeTriangles())
-        return NULL;
+        return nullptr;
 #endif
 
       if(getDimensionality() == 2)
@@ -934,7 +934,7 @@ namespace ttk {
     virtual inline const std::vector<std::array<SimplexId, 3>> *getTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedTriangles())
-        return NULL;
+        return nullptr;
 #endif
       return getTrianglesInternal();
     }
@@ -1030,10 +1030,10 @@ namespace ttk {
       getTriangleEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedTriangleEdges())
-        return NULL;
+        return nullptr;
 #endif
 
       return getTriangleEdgesInternal();
@@ -1129,10 +1129,10 @@ namespace ttk {
       getTriangleLinks() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() != 3)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedTriangleLinks())
-        return NULL;
+        return nullptr;
 #endif
       return getTriangleLinksInternal();
     }
@@ -1228,10 +1228,10 @@ namespace ttk {
       getTriangleStars() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() != 3)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedTriangleStars())
-        return NULL;
+        return nullptr;
 #endif
       return getTriangleStarsInternal();
     }
@@ -1371,7 +1371,7 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getVertexEdges() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedVertexEdges())
-        return NULL;
+        return nullptr;
 #endif
       if(getDimensionality() == 1)
         return getVertexStars();
@@ -1461,7 +1461,7 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getVertexLinks() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedVertexLinks())
-        return NULL;
+        return nullptr;
 #endif
       return getVertexLinksInternal();
     }
@@ -1542,7 +1542,7 @@ namespace ttk {
       getVertexNeighbors() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedVertexNeighbors())
-        return NULL;
+        return nullptr;
 #endif
       return getVertexNeighborsInternal();
     }
@@ -1644,7 +1644,7 @@ namespace ttk {
     virtual inline const std::vector<std::vector<SimplexId>> *getVertexStars() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!hasPreconditionedVertexStars())
-        return NULL;
+        return nullptr;
 #endif
       return getVertexStarsInternal();
     }
@@ -1747,10 +1747,10 @@ namespace ttk {
       getVertexTriangles() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(getDimensionality() == 1)
-        return NULL;
+        return nullptr;
 
       if(!hasPreconditionedVertexTriangles())
-        return NULL;
+        return nullptr;
 #endif
       if(getDimensionality() == 2)
         return getVertexStars();
@@ -2534,7 +2534,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getCellEdgesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2551,7 +2551,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getCellNeighborsInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2568,7 +2568,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getCellTrianglesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2589,7 +2589,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::array<SimplexId, 2>> *
       getEdgesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2606,7 +2606,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getEdgeLinksInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2623,7 +2623,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getEdgeStarsInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2640,7 +2640,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getEdgeTrianglesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2668,7 +2668,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::array<SimplexId, 3>> *
       getTrianglesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2685,7 +2685,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getTriangleEdgesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2702,7 +2702,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getTriangleLinksInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2719,7 +2719,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getTriangleStarsInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2743,7 +2743,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2760,7 +2760,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getVertexLinksInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2777,7 +2777,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getVertexNeighborsInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2802,7 +2802,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getVertexStarsInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline int
@@ -2819,7 +2819,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getVertexTrianglesInternal() {
-      return NULL;
+      return nullptr;
     }
 
     virtual inline bool

--- a/core/base/assignmentSolver/AssignmentAuction.h
+++ b/core/base/assignmentSolver/AssignmentAuction.h
@@ -28,9 +28,9 @@ namespace ttk {
   public:
     AssignmentAuction() = default;
 
-    ~AssignmentAuction() = default;
+    ~AssignmentAuction() override = default;
 
-    int run(std::vector<asgnMatchingTuple> &matchings);
+    int run(std::vector<asgnMatchingTuple> &matchings) override;
     void runAuctionRound(std::vector<std::vector<dataType>> &cMatrix);
 
     void initFirstRound();
@@ -43,7 +43,7 @@ namespace ttk {
     dataType getRelativePrecision(std::vector<std::vector<dataType>> &cMatrix);
     dataType getMatchingDistance(std::vector<std::vector<dataType>> &cMatrix);
 
-    inline void setBalanced(bool balanced) {
+    inline void setBalanced(bool balanced) override {
       AssignmentSolver<dataType>::setBalanced(balanced);
       if(this->balancedAssignment)
         goodPrices.resize(this->colSize, 0);

--- a/core/base/assignmentSolver/AssignmentAuction.h
+++ b/core/base/assignmentSolver/AssignmentAuction.h
@@ -11,10 +11,9 @@
 ///   - the mth column is the same but with jobs
 ///   - the last cell (costMatrix[n][m]) is not used
 
-#ifndef _ASSIGNMENTAUCTION_H
-#define _ASSIGNMENTAUCTION_H
+#pragma once
 
-#include "AssignmentSolver.h"
+#include <AssignmentSolver.h>
 
 #include <limits>
 #include <queue>
@@ -353,5 +352,3 @@ namespace ttk {
   }
 
 } // namespace ttk
-
-#endif

--- a/core/base/assignmentSolver/AssignmentExhaustive.h
+++ b/core/base/assignmentSolver/AssignmentExhaustive.h
@@ -14,12 +14,10 @@
 /// An exhaustive search for the assignment problem has an exponential
 /// complexity Use this algorithm only for small assigment problem
 
-#ifndef _ASSIGNMENTEXHAUSTIVE_H
-#define _ASSIGNMENTEXHAUSTIVE_H
+#pragma once
 
+#include <AssignmentSolver.h>
 #include <Debug.h>
-
-#include "AssignmentSolver.h"
 
 #include <iterator>
 #include <limits>
@@ -364,5 +362,3 @@ namespace ttk {
   }
 
 } // namespace ttk
-
-#endif

--- a/core/base/assignmentSolver/AssignmentExhaustive.h
+++ b/core/base/assignmentSolver/AssignmentExhaustive.h
@@ -36,9 +36,9 @@ namespace ttk {
   public:
     AssignmentExhaustive() = default;
 
-    ~AssignmentExhaustive() = default;
+    ~AssignmentExhaustive() override = default;
 
-    int run(std::vector<asgnMatchingTuple> &matchings);
+    int run(std::vector<asgnMatchingTuple> &matchings) override;
 
     dataType tryAssignment(std::vector<int> &asgn,
                            std::vector<asgnMatchingTuple> &matchings);

--- a/core/base/assignmentSolver/AssignmentMunkres.h
+++ b/core/base/assignmentSolver/AssignmentMunkres.h
@@ -21,17 +21,17 @@ namespace ttk {
       this->setDebugMsgPrefix("AssignmentMunkres");
     }
 
-    ~AssignmentMunkres() = default;
+    ~AssignmentMunkres() override = default;
 
-    int run(std::vector<asgnMatchingTuple> &matchings);
+    int run(std::vector<asgnMatchingTuple> &matchings) override;
 
-    inline void clear() {
+    inline void clear() override {
       AssignmentSolver<dataType>::clear();
       pathCount = 0;
       createdZeros.clear();
     }
 
-    inline int setInput(std::vector<std::vector<dataType>> &C_) {
+    inline int setInput(std::vector<std::vector<dataType>> &C_) override {
       AssignmentSolver<dataType>::setInput(C_);
 
       createdZeros.clear();

--- a/core/base/assignmentSolver/AssignmentSolver.h
+++ b/core/base/assignmentSolver/AssignmentSolver.h
@@ -11,8 +11,7 @@
 ///   - the mth column is the same but with jobs
 ///   - the last cell (costMatrix[n][m]) is not used
 
-#ifndef _ASSIGNMENTSOLVER_H
-#define _ASSIGNMENTSOLVER_H
+#pragma once
 
 #define asgnMatchingTuple std::tuple<int, int, double>
 
@@ -85,5 +84,3 @@ namespace ttk {
     bool balancedAssignment;
   };
 } // namespace ttk
-
-#endif

--- a/core/base/assignmentSolver/AssignmentSolver.h
+++ b/core/base/assignmentSolver/AssignmentSolver.h
@@ -26,7 +26,7 @@ namespace ttk {
   public:
     AssignmentSolver() = default;
 
-    virtual ~AssignmentSolver() = default;
+    ~AssignmentSolver() override = default;
 
     virtual int run(std::vector<asgnMatchingTuple> &matchings) = 0;
 

--- a/core/base/bottleneckDistance/BottleneckDistance.h
+++ b/core/base/bottleneckDistance/BottleneckDistance.h
@@ -44,7 +44,7 @@ namespace ttk {
       this->setDebugMsgPrefix("BottleneckDistance");
     }
 
-    ~BottleneckDistance() = default;
+    ~BottleneckDistance() override = default;
 
     template <typename dataType>
     int execute(bool usePersistenceMetric);

--- a/core/base/bottleneckDistance/GabowTarjan.h
+++ b/core/base/bottleneckDistance/GabowTarjan.h
@@ -22,7 +22,7 @@ namespace ttk {
       this->setDebugMsgPrefix("Gabow-Tarjan");
     }
 
-    ~GabowTarjan() {
+    ~GabowTarjan() override {
     }
 
     template <typename dataType>

--- a/core/base/bottleneckDistance/GabowTarjan.h
+++ b/core/base/bottleneckDistance/GabowTarjan.h
@@ -22,8 +22,7 @@ namespace ttk {
       this->setDebugMsgPrefix("Gabow-Tarjan");
     }
 
-    ~GabowTarjan() override {
-    }
+    ~GabowTarjan() override = default;
 
     template <typename dataType>
     dataType Distance(dataType maxLevel);

--- a/core/base/boundingVolumeHierarchy/BoundingVolumeHierarchy.h
+++ b/core/base/boundingVolumeHierarchy/BoundingVolumeHierarchy.h
@@ -22,8 +22,7 @@ namespace ttk {
   class BoundingVolumeHierarchy {
   protected:
     struct Node {
-      Node() {
-      }
+      Node() = default;
       // leaf constructor
       Node(const std::vector<int> &triangleIndices,
            const size_t nTriangles,
@@ -74,8 +73,7 @@ namespace ttk {
       float m_centroid_x, m_centroid_y, m_centroid_z;
       float m_minX, m_minY, m_minZ;
       float m_maxX, m_maxY, m_maxZ;
-      Triangle() {
-      }
+      Triangle() = default;
 
       void init(const int &index,
                 const float &centroid_x,

--- a/core/base/cinemaImaging/CinemaImagingEmbree.cpp
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.cpp
@@ -29,7 +29,7 @@ int ttk::CinemaImagingEmbree::initializeDevice(RTCDevice &device) const {
 
   if(!device) {
     this->printErr("Unable to create device");
-    this->printErr(std::to_string(rtcGetDeviceError(NULL)));
+    this->printErr(std::to_string(rtcGetDeviceError(nullptr)));
     return 0;
   }
 
@@ -38,7 +38,7 @@ int ttk::CinemaImagingEmbree::initializeDevice(RTCDevice &device) const {
         printf("error %d: %s\n", error, str);
       };
 
-  rtcSetDeviceErrorFunction(device, errorFunction, NULL);
+  rtcSetDeviceErrorFunction(device, errorFunction, nullptr);
 
   this->printMsg("Initializing Device", 1, timer.getElapsedTime());
 

--- a/core/base/cinemaImaging/CinemaImagingEmbree.cpp
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.cpp
@@ -3,8 +3,7 @@
 ttk::CinemaImagingEmbree::CinemaImagingEmbree() {
   this->setDebugMsgPrefix("CinemaImaging(Embree)");
 }
-ttk::CinemaImagingEmbree::~CinemaImagingEmbree() {
-}
+ttk::CinemaImagingEmbree::~CinemaImagingEmbree() = default;
 
 #if TTK_ENABLE_EMBREE
 

--- a/core/base/cinemaImaging/CinemaImagingEmbree.h
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.h
@@ -22,7 +22,7 @@ namespace ttk {
   class CinemaImagingEmbree : public CinemaImaging {
   public:
     CinemaImagingEmbree();
-    ~CinemaImagingEmbree();
+    ~CinemaImagingEmbree() override;
 
 #if TTK_ENABLE_EMBREE
 

--- a/core/base/cinemaImaging/CinemaImagingNative.h
+++ b/core/base/cinemaImaging/CinemaImagingNative.h
@@ -19,7 +19,7 @@ namespace ttk {
     CinemaImagingNative() {
       this->setDebugMsgPrefix("CinemaImaging(Native)");
     }
-    ~CinemaImagingNative() = default;
+    ~CinemaImagingNative() override = default;
 
     template <typename IT>
     int renderImage(float *depthBuffer,

--- a/core/base/cinemaQuery/CinemaQuery.cpp
+++ b/core/base/cinemaQuery/CinemaQuery.cpp
@@ -8,8 +8,7 @@
 ttk::CinemaQuery::CinemaQuery() {
   this->setDebugMsgPrefix("CinemaQuery");
 }
-ttk::CinemaQuery::~CinemaQuery() {
-}
+ttk::CinemaQuery::~CinemaQuery() = default;
 
 int ttk::CinemaQuery::execute(
   const std::vector<std::string> &sqlTableDefinitions,

--- a/core/base/cinemaQuery/CinemaQuery.cpp
+++ b/core/base/cinemaQuery/CinemaQuery.cpp
@@ -36,7 +36,7 @@ int ttk::CinemaQuery::execute(
 
   // SQLite Variables
   sqlite3 *db;
-  char *zErrMsg = 0;
+  char *zErrMsg = nullptr;
   int rc;
 
   // Create Temporary Database
@@ -54,7 +54,8 @@ int ttk::CinemaQuery::execute(
 
     // Create table
     for(auto &sqlTableDefinition : sqlTableDefinitions) {
-      rc = sqlite3_exec(db, sqlTableDefinition.data(), nullptr, 0, &zErrMsg);
+      rc = sqlite3_exec(
+        db, sqlTableDefinition.data(), nullptr, nullptr, &zErrMsg);
       if(rc != SQLITE_OK) {
         this->printErr("Create table: " + std::string{zErrMsg});
 
@@ -67,7 +68,8 @@ int ttk::CinemaQuery::execute(
 
     // Fill table
     for(auto &sqlInsertStatement : sqlInsertStatements) {
-      rc = sqlite3_exec(db, sqlInsertStatement.data(), nullptr, 0, &zErrMsg);
+      rc = sqlite3_exec(
+        db, sqlInsertStatement.data(), nullptr, nullptr, &zErrMsg);
       if(rc != SQLITE_OK) {
         this->printErr("Insert values: " + std::string{zErrMsg});
 
@@ -87,7 +89,7 @@ int ttk::CinemaQuery::execute(
 
     sqlite3_stmt *sqlStatement;
 
-    if(sqlite3_prepare_v2(db, sqlQuery.data(), -1, &sqlStatement, NULL)
+    if(sqlite3_prepare_v2(db, sqlQuery.data(), -1, &sqlStatement, nullptr)
        != SQLITE_OK) {
       this->printErr("Query: " + std::string{sqlite3_errmsg(db)});
 

--- a/core/base/cinemaQuery/CinemaQuery.h
+++ b/core/base/cinemaQuery/CinemaQuery.h
@@ -19,7 +19,7 @@ namespace ttk {
   class CinemaQuery : virtual public Debug {
   public:
     CinemaQuery();
-    ~CinemaQuery();
+    ~CinemaQuery() override;
 
     /** Creates a temporary database based on a SQL table definition and
      *  and table content to subsequentually return a query result.

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -5,8 +5,7 @@
 ///
 ///\brief TTK base package.
 
-#ifndef _BASECLASS_H
-#define _BASECLASS_H
+#pragma once
 
 #ifdef _WIN32
 // enable the `and` and `or` keywords on MSVC
@@ -89,5 +88,3 @@ namespace ttk {
     Wrapper *wrapper_;
   };
 } // namespace ttk
-
-#endif // _BASECLASS_H

--- a/core/base/common/CommandLineParser.h
+++ b/core/base/common/CommandLineParser.h
@@ -118,7 +118,7 @@ namespace ttk {
       setDebugMsgPrefix("CMD");
     }
 
-    ~CommandLineParser() = default;
+    ~CommandLineParser() override = default;
 
     // 2) functions
     int parse(int argc, char **argv) {

--- a/core/base/common/CommandLineParser.h
+++ b/core/base/common/CommandLineParser.h
@@ -20,13 +20,13 @@ namespace ttk {
 
     public:
       CommandLineArgument() {
-        boolValue_ = NULL;
-        intValue_ = NULL;
-        intValueList_ = NULL;
-        doubleValue_ = NULL;
-        doubleValueList_ = NULL;
-        stringValue_ = NULL;
-        stringValueList_ = NULL;
+        boolValue_ = nullptr;
+        intValue_ = nullptr;
+        intValueList_ = nullptr;
+        doubleValue_ = nullptr;
+        doubleValueList_ = nullptr;
+        stringValue_ = nullptr;
+        stringValueList_ = nullptr;
         isSet_ = false;
 
         setDebugMsgPrefix("CMD");

--- a/core/base/common/CommandLineParser.h
+++ b/core/base/common/CommandLineParser.h
@@ -5,8 +5,7 @@
 ///
 /// \brief Basic command line parsing.
 
-#ifndef _COMMAND_LINE_PARSER_H
-#define _COMMAND_LINE_PARSER_H
+#pragma once
 
 #include <Debug.h>
 
@@ -423,5 +422,3 @@ namespace ttk {
     std::vector<CommandLineArgument> arguments_;
   };
 } // namespace ttk
-
-#endif

--- a/core/base/common/DataTypes.h
+++ b/core/base/common/DataTypes.h
@@ -5,8 +5,7 @@
 ///
 ///\brief TTK base package defining the standard types.
 
-#ifndef _DATATYPES_H
-#define _DATATYPES_H
+#pragma once
 
 namespace ttk {
   /// \brief Identifier type for simplices of any dimension.
@@ -83,5 +82,3 @@ namespace ttk {
   const int CriticalTypeNumber = 6;
 
 } // namespace ttk
-
-#endif // _DATATYPES_H

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -90,7 +90,7 @@ namespace ttk {
     // 1) constructors, destructors, operators, etc.
     Debug();
 
-    virtual ~Debug();
+    ~Debug() override;
 
     // 2) functions
     /// Set the debug level of a particular object. The global variable
@@ -105,7 +105,7 @@ namespace ttk {
     /// number of threads, etc.) from a wrapper to a base object.
     /// \param wrapper Pointer to the wrapping object.
     /// \return Returns 0 upon success, negative values otherwise.
-    virtual int setWrapper(const Wrapper *wrapper);
+    int setWrapper(const Wrapper *wrapper) override;
 
     // =========================================================================
     // New Debug Methods

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -157,7 +157,7 @@ namespace ttk {
       dbg.printErr(msg);
     } else {
       struct dirent *dirEntry;
-      while((dirEntry = readdir(d)) != NULL) {
+      while((dirEntry = readdir(d)) != nullptr) {
         if(extension.size()) {
           std::string entryExtension(dirEntry->d_name);
           entryExtension

--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -5,8 +5,7 @@
 ///
 /// \brief Os-specifics.
 
-#ifndef _OS_H
-#define _OS_H
+#pragma once
 
 #ifdef _WIN32
 #ifndef _USE_MATH_DEFINES
@@ -117,5 +116,3 @@ namespace ttk {
   };
 
 } // namespace ttk
-
-#endif

--- a/core/base/common/ProgramBase.h
+++ b/core/base/common/ProgramBase.h
@@ -23,7 +23,7 @@ namespace ttk {
       ttk::globalDebugLevel_ = 3;
 
       outputPath_ = "output";
-      ttkModule_ = NULL;
+      ttkModule_ = nullptr;
     }
 
     ~ProgramBase() override = default;

--- a/core/base/common/ProgramBase.h
+++ b/core/base/common/ProgramBase.h
@@ -6,8 +6,7 @@
 /// \brief Base editor class for standalone programs. This class parses the
 /// the comamnd line, execute the TTK module and takes care of the IO.
 
-#ifndef EDITOR_BASE_H
-#define EDITOR_BASE_H
+#pragma once
 
 // base code includes
 #include <CommandLineParser.h>
@@ -91,5 +90,3 @@ namespace ttk {
     }
   };
 } // namespace ttk
-
-#endif // EDITOR_BASE_H

--- a/core/base/common/ProgramBase.h
+++ b/core/base/common/ProgramBase.h
@@ -26,7 +26,7 @@ namespace ttk {
       ttkModule_ = NULL;
     }
 
-    virtual ~ProgramBase() = default;
+    ~ProgramBase() override = default;
 
     virtual int init(int &argc, char **argv) {
 

--- a/core/base/common/Wrapper.h
+++ b/core/base/common/Wrapper.h
@@ -5,8 +5,7 @@
 ///
 /// \brief Wrapper class to wrap ttk code.
 
-#ifndef _WRAPPER_H
-#define _WRAPPER_H
+#pragma once
 
 #include <Debug.h>
 
@@ -29,5 +28,3 @@ namespace ttk {
     float processingProgress_;
   };
 } // namespace ttk
-
-#endif

--- a/core/base/common/Wrapper.h
+++ b/core/base/common/Wrapper.h
@@ -19,7 +19,7 @@ namespace ttk {
       processingProgress_ = 0;
     }
 
-    virtual ~Wrapper() = default;
+    ~Wrapper() override = default;
 
     virtual bool needsToAbort() = 0;
 

--- a/core/base/compactTriangulation/CompactTriangulation.cpp
+++ b/core/base/compactTriangulation/CompactTriangulation.cpp
@@ -41,8 +41,7 @@ CompactTriangulation &
   return *this;
 }
 
-CompactTriangulation::~CompactTriangulation() {
-}
+CompactTriangulation::~CompactTriangulation() = default;
 
 int CompactTriangulation::reorderVertices(std::vector<SimplexId> &vertexMap) {
   // get the number of nodes (the max value in the array)

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -73,12 +73,10 @@ namespace ttk {
     std::vector<std::array<SimplexId, 4>> tetraTriangles_;
 
   public:
-    ImplicitCluster() {
-    }
+    ImplicitCluster() = default;
     ImplicitCluster(SimplexId id) : nid(id) {
     }
-    ~ImplicitCluster() {
-    }
+    ~ImplicitCluster() = default;
 
     friend class CompactTriangulation;
   };

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -92,7 +92,7 @@ namespace ttk {
     CompactTriangulation();
     CompactTriangulation(const CompactTriangulation &rhs);
     CompactTriangulation &operator=(const CompactTriangulation &rhs);
-    ~CompactTriangulation();
+    ~CompactTriangulation() override;
     CompactTriangulation(CompactTriangulation &&rhs) = default;
     CompactTriangulation &operator=(CompactTriangulation &&rhs) = default;
 

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -275,8 +275,8 @@ namespace ttk {
             getClusterTetraEdges(exnode);
           }
           for(size_t i = 0; i < exnode->tetraEdges_.size(); i++) {
-            cellEdgeVector_.push_back({exnode->tetraEdges_.at(i).begin(),
-                                       exnode->tetraEdges_.at(i).end()});
+            cellEdgeVector_.emplace_back(exnode->tetraEdges_.at(i).begin(),
+                                         exnode->tetraEdges_.at(i).end());
           }
         }
       }
@@ -396,9 +396,9 @@ namespace ttk {
             getClusterCellTriangles(exnode);
           }
           for(size_t i = 0; i < exnode->tetraTriangles_.size(); i++) {
-            cellTriangleVector_.push_back(
-              {exnode->tetraTriangles_.at(i).begin(),
-               exnode->tetraTriangles_.at(i).end()});
+            cellTriangleVector_.emplace_back(
+              exnode->tetraTriangles_.at(i).begin(),
+              exnode->tetraTriangles_.at(i).end());
           }
         }
       }
@@ -776,8 +776,9 @@ namespace ttk {
             getClusterTriangleEdges(exnode);
           }
           for(size_t i = 0; i < exnode->triangleEdges_.size(); i++) {
-            triangleEdgeVector_.push_back({exnode->triangleEdges_.at(i).begin(),
-                                           exnode->triangleEdges_.at(i).end()});
+            triangleEdgeVector_.emplace_back(
+              exnode->triangleEdges_.at(i).begin(),
+              exnode->triangleEdges_.at(i).end());
           }
         }
       }

--- a/core/base/compactTriangulationPreconditioning/CompactTriangulationPreconditioning.h
+++ b/core/base/compactTriangulationPreconditioning/CompactTriangulationPreconditioning.h
@@ -45,7 +45,8 @@ namespace ttk {
                                                 // will be printed at the
       // beginning of every msg
     };
-    ~CompactTriangulationPreconditioning() override{};
+    ~CompactTriangulationPreconditioning() override = default;
+    ;
 
     template <class triangulationType = ttk::AbstractTriangulation>
     int execute(const triangulationType *triangulation,

--- a/core/base/compactTriangulationPreconditioning/CompactTriangulationPreconditioning.h
+++ b/core/base/compactTriangulationPreconditioning/CompactTriangulationPreconditioning.h
@@ -45,7 +45,7 @@ namespace ttk {
                                                 // will be printed at the
       // beginning of every msg
     };
-    ~CompactTriangulationPreconditioning(){};
+    ~CompactTriangulationPreconditioning() override{};
 
     template <class triangulationType = ttk::AbstractTriangulation>
     int execute(const triangulationType *triangulation,

--- a/core/base/connectedComponents/ConnectedComponents.h
+++ b/core/base/connectedComponents/ConnectedComponents.h
@@ -41,7 +41,7 @@ namespace ttk {
     ConnectedComponents() {
       this->setDebugMsgPrefix("ConnectedComponents");
     };
-    virtual ~ConnectedComponents() = default;
+    ~ConnectedComponents() override = default;
 
     int preconditionTriangulation(
       ttk::AbstractTriangulation *triangulation) const {

--- a/core/base/continuousScatterPlot/ContinuousScatterPlot.h
+++ b/core/base/continuousScatterPlot/ContinuousScatterPlot.h
@@ -28,7 +28,7 @@ namespace ttk {
 
   public:
     ContinuousScatterPlot();
-    ~ContinuousScatterPlot();
+    ~ContinuousScatterPlot() override;
 
     template <typename dataType1,
               typename dataType2,

--- a/core/base/contourAroundPoint/ContourAroundPoint.hpp
+++ b/core/base/contourAroundPoint/ContourAroundPoint.hpp
@@ -30,7 +30,7 @@ namespace ttk {
       this->setDebugMsgPrefix("ContourAroundPoint");
     }
 
-    ~ContourAroundPoint() {
+    ~ContourAroundPoint() override {
     }
 
     /**

--- a/core/base/contourAroundPoint/ContourAroundPoint.hpp
+++ b/core/base/contourAroundPoint/ContourAroundPoint.hpp
@@ -30,8 +30,7 @@ namespace ttk {
       this->setDebugMsgPrefix("ContourAroundPoint");
     }
 
-    ~ContourAroundPoint() override {
-    }
+    ~ContourAroundPoint() override = default;
 
     /**
      * Setup a (valid) triangulation object for this TTK base object.

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -609,7 +609,7 @@ void ContourForests::printVectCT() {
       }
     }
 
-    if(1) {
+    if(true) {
       cout << "Leaves" << endl;
 
       for(const auto &l : parallelData_.trees[nb].getLeaves())

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -125,12 +125,12 @@ namespace ttk {
     public:
       ContourForests();
 
-      virtual ~ContourForests();
+      ~ContourForests() override;
 
       // Getters & Setters
       // {
 
-      inline int setThreadNumber(const int nbThread) {
+      inline int setThreadNumber(const int nbThread) override {
         if(nbThread) {
           parallelParams_.nbThreads = nbThread;
         } else {

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -41,22 +41,22 @@ namespace ttk {
       // Getter & Setter
       // {
 
-      inline const SimplexId &getSeed(void) const {
+      inline const SimplexId &getSeed() const {
         return seed_;
       }
 
-      inline std::vector<SimplexId> &getUpper(void) {
+      inline std::vector<SimplexId> &getUpper() {
         return upperOverlap_;
       }
 
-      inline std::vector<SimplexId> &getLower(void) {
+      inline std::vector<SimplexId> &getLower() {
         return lowerOverlap_;
       }
-      inline SimplexId getNbUpper(void) const {
+      inline SimplexId getNbUpper() const {
         return upperOverlap_.size();
       }
 
-      inline SimplexId getNbLower(void) const {
+      inline SimplexId getNbLower() const {
         return lowerOverlap_.size();
       }
 
@@ -215,12 +215,12 @@ namespace ttk {
 
       // Init
       // {
-      void initInterfaces(void);
+      void initInterfaces();
 
       template <typename triangulationType>
       void initOverlap(const triangulationType &mesh);
 
-      void initNbPartitions(void);
+      void initNbPartitions();
 
       //}
       // Process
@@ -235,7 +235,7 @@ namespace ttk {
                       std::vector<std::vector<ExtendedUnionFind *>> &baseUF_ST,
                       const triangulationType &mesh);
 
-      void stitch(void);
+      void stitch();
       void stitchTree(const char tree);
 
       // replace distributed tree by a global one, will be removed

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -17,8 +17,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef _CONTOURTREE_H
-#define _CONTOURTREE_H
+#pragma once
 
 #include <queue>
 #include <set>
@@ -116,5 +115,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif // CONTOURTREE_H

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -49,7 +49,7 @@ namespace ttk {
       ContourForestsTree(Params *const params,
                          Scalars *const scalars,
                          idPartition part = nullPartition);
-      virtual ~ContourForestsTree();
+      ~ContourForestsTree() override;
 
       // }
       // -----------------

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -56,7 +56,7 @@ namespace ttk {
       // -----------------
       // {
 
-      void flush(void) {
+      void flush() {
         MergeTree::flush();
         jt_->flush();
         st_->flush();
@@ -68,11 +68,11 @@ namespace ttk {
       // -----------------
       // {
 
-      inline MergeTree *getJoinTree(void) const {
+      inline MergeTree *getJoinTree() const {
         return jt_;
       }
 
-      inline MergeTree *getSplitTree(void) const {
+      inline MergeTree *getSplitTree() const {
         return st_;
       }
 
@@ -109,7 +109,7 @@ namespace ttk {
 
       /// \brief initialize data of the Merge Trees jt & st
       template <typename scalarType>
-      void initDataMT(void);
+      void initDataMT();
 
       // }
     };

--- a/core/base/contourForestsTree/DeprecatedDataTypes.h
+++ b/core/base/contourForestsTree/DeprecatedDataTypes.h
@@ -17,8 +17,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef DATATYPES_H
-#define DATATYPES_H
+#pragma once
 
 #include <DataTypes.h>
 #include <limits>
@@ -97,5 +96,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif /* end of include guard: DATATYPES_H */

--- a/core/base/contourForestsTree/DeprecatedNode.h
+++ b/core/base/contourForestsTree/DeprecatedNode.h
@@ -73,11 +73,11 @@ namespace ttk {
       // Linked node
       // ........................{
 
-      inline const SimplexId &getOrigin(void) const {
+      inline const SimplexId &getOrigin() const {
         return linkedNode_;
       }
 
-      inline const SimplexId &getTerminaison(void) const {
+      inline const SimplexId &getTerminaison() const {
         return linkedNode_;
       }
 
@@ -138,13 +138,13 @@ namespace ttk {
         vect_upSuperArcList_.emplace_back(upSuperArcId);
       }
 
-      inline idSuperArc clearDownSuperArcs(void) {
+      inline idSuperArc clearDownSuperArcs() {
         idSuperArc s = vect_downSuperArcList_.size();
         vect_downSuperArcList_.clear();
         return s;
       }
 
-      inline idSuperArc clearUpSuperArcs(void) {
+      inline idSuperArc clearUpSuperArcs() {
         idSuperArc s = vect_upSuperArcList_.size();
         vect_upSuperArcList_.clear();
         return s;
@@ -240,15 +240,15 @@ namespace ttk {
       // Valence
       // .......................................... {
 
-      inline idSuperArc getUpValence(void) const {
+      inline idSuperArc getUpValence() const {
         return std::get<1>(valence_);
       }
 
-      inline idSuperArc getDownValence(void) const {
+      inline idSuperArc getDownValence() const {
         return std::get<0>(valence_);
       }
 
-      inline idSuperArc getValence(void) const {
+      inline idSuperArc getValence() const {
         return std::get<0>(valence_) + std::get<1>(valence_);
       }
 
@@ -260,19 +260,19 @@ namespace ttk {
         std::get<0>(valence_) = v;
       }
 
-      inline void incUpValence(void) {
+      inline void incUpValence() {
         ++std::get<1>(valence_);
       }
 
-      inline void incDownValence(void) {
+      inline void incDownValence() {
         ++std::get<0>(valence_);
       }
 
-      inline void decUpValence(void) {
+      inline void decUpValence() {
         --std::get<1>(valence_);
       }
 
-      inline void decDownValence(void) {
+      inline void decDownValence() {
         --std::get<0>(valence_);
       }
 

--- a/core/base/contourForestsTree/DeprecatedNode.h
+++ b/core/base/contourForestsTree/DeprecatedNode.h
@@ -13,8 +13,7 @@
 /// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
 /// Proc. of IEEE LDAV 2016.
 
-#ifndef NODE_H
-#define NODE_H
+#pragma once
 
 #include <vector>
 
@@ -284,4 +283,3 @@ namespace ttk {
 
   } // namespace cf
 } // namespace ttk
-#endif /* end of include guard: NODE_H */

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -20,7 +20,7 @@ using namespace cf;
 Segment::Segment(const bool order) : ascendingOrder_(order) {
 }
 
-bool Segment::isAscending(void) const {
+bool Segment::isAscending() const {
   return ascendingOrder_;
 }
 
@@ -44,7 +44,7 @@ void Segment::emplace_back(const SimplexId &v) {
   vertices_.emplace_back(vertex{v, nullSuperArc});
 }
 
-void Segment::clear(void) {
+void Segment::clear() {
   vertices_.clear();
   vertices_.shrink_to_fit();
 }
@@ -77,11 +77,11 @@ sorted_iterator Segment::send() {
 // Segments
 // --------
 
-idSegment Segments::size(void) const {
+idSegment Segments::size() const {
   return segments_.size();
 }
 
-void Segments::clear(void) {
+void Segments::clear() {
   segments_.clear();
   segments_.shrink_to_fit();
 }

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -132,7 +132,7 @@ void ArcRegion::createSegmentation(const idSuperArc &thisArc) {
       while(head != end && head->ctArc != thisArc)
         ++head;
 
-      if(!added || 1) {
+      if(!added || true) {
       } // isLower than actual
       throw "Not finished yet";
     }

--- a/core/base/contourForestsTree/DeprecatedSegmentation.h
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.h
@@ -14,8 +14,7 @@
 /// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
 /// Proc. of IEEE LDAV 2016.
 
-#ifndef SEGMENTATION_H_
-#define SEGMENTATION_H_
+#pragma once
 
 #include <forward_list>
 #include <vector>
@@ -85,5 +84,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif /* end of include guard: SEGMENTATION_H_ */

--- a/core/base/contourForestsTree/DeprecatedSegmentation.h
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.h
@@ -30,21 +30,21 @@ namespace ttk {
     public:
       Segment(const bool order = true);
 
-      bool isAscending(void) const;
+      bool isAscending() const;
 
       void sort(const Scalars *s);
 
       // std::vector like
       void emplace_back(const SimplexId &v);
-      void clear(void);
+      void clear();
       void norm_next(segmentIterator &it);
 
       SimplexId &operator[](size_t idx);
       const SimplexId &operator[](size_t idx) const;
 
       // custom iterator to cross the segment in sorted order
-      sorted_iterator sbegin(void);
-      sorted_iterator send(void);
+      sorted_iterator sbegin();
+      sorted_iterator send();
 
     private:
       std::vector<vertex> vertices_;
@@ -54,8 +54,8 @@ namespace ttk {
     // All the segments of the mesh, like a std::vector<Segment>
     class Segments {
     public:
-      idSegment size(void) const;
-      void clear(void);
+      idSegment size() const;
+      void clear();
       Segment &operator[](size_t idx);
       const Segment &operator[](size_t idx) const;
 

--- a/core/base/contourForestsTree/DeprecatedStructures.h
+++ b/core/base/contourForestsTree/DeprecatedStructures.h
@@ -11,8 +11,7 @@
 /// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
 /// Proc. of IEEE LDAV 2016.
 
-#ifndef STRUCTURES_H
-#define STRUCTURES_H
+#pragma once
 
 #include <iterator>
 
@@ -118,5 +117,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif /* end of include guard: STRUCTURES_H */

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -105,11 +105,11 @@ namespace ttk {
       // node
       // .................................{
 
-      inline const idNode &getUpNodeId(void) const {
+      inline const idNode &getUpNodeId() const {
         return upNodeId_;
       }
 
-      inline const idNode &getDownNodeId(void) const {
+      inline const idNode &getDownNodeId() const {
         return downNodeId_;
       }
 
@@ -126,11 +126,11 @@ namespace ttk {
       // .................................{
       //
       // idPartition u_char so lighter than a ref
-      inline idPartition getDownCT(void) const {
+      inline idPartition getDownCT() const {
         return downCT_;
       }
 
-      inline idPartition getUpCT(void) const {
+      inline idPartition getUpCT() const {
         return upCT_;
       }
 
@@ -142,15 +142,15 @@ namespace ttk {
       // overlap
       // .................................{
 
-      inline bool getOverlapAbove(void) const {
+      inline bool getOverlapAbove() const {
         return overlapAbove_;
       }
 
-      inline bool getOverlapBelow(void) const {
+      inline bool getOverlapBelow() const {
         return overlapBelow_;
       }
 
-      inline bool isCrossing(void) const {
+      inline bool isCrossing() const {
         return overlapBelow_ || overlapAbove_;
       }
 
@@ -166,7 +166,7 @@ namespace ttk {
       // last vertex seen
       // .................................{
 
-      inline const SimplexId &getLastVisited(void) const {
+      inline const SimplexId &getLastVisited() const {
         return lastVisited_;
       }
 
@@ -179,27 +179,27 @@ namespace ttk {
       // state
       // .................................{
 
-      inline bool isHidden(void) const {
+      inline bool isHidden() const {
         return state_ == ComponentState::Hidden;
       }
 
-      inline bool isPruned(void) const {
+      inline bool isPruned() const {
         return state_ == ComponentState::Merged;
       }
 
-      inline bool isMerged(void) const {
+      inline bool isMerged() const {
         return state_ == ComponentState::Merged;
       }
 
-      inline bool isExternal(void) const {
+      inline bool isExternal() const {
         return downCT_ != upCT_;
       }
 
-      inline bool isVisible(void) const {
+      inline bool isVisible() const {
         return state_ == ComponentState::Visible;
       }
 
-      inline void hide(void) {
+      inline void hide() {
         state_ = ComponentState::Hidden;
       }
 
@@ -213,11 +213,11 @@ namespace ttk {
       // replacant arc/tree (merge)
       // .................................{
 
-      inline const idSuperArc &getReplacantArcId(void) const {
+      inline const idSuperArc &getReplacantArcId() const {
         return replacantId_;
       }
 
-      inline idPartition getReplacantCT(void) const {
+      inline idPartition getReplacantCT() const {
         return replacantCT_;
       }
 
@@ -225,7 +225,7 @@ namespace ttk {
       // regular nodes (segmentation)
       // .................................{
 
-      inline SimplexId getNumberOfRegularNodes(void) {
+      inline SimplexId getNumberOfRegularNodes() {
         return getVertSize();
       }
 
@@ -239,12 +239,12 @@ namespace ttk {
 
       // The std::vector
 
-      inline SimplexId getSegmentationSize(void) const {
+      inline SimplexId getSegmentationSize() const {
         return vertices_.size();
       }
 
       // not const for sort in simplify
-      inline std::vector<std::pair<SimplexId, bool>> &getSegmentation(void) {
+      inline std::vector<std::pair<SimplexId, bool>> &getSegmentation() {
         return vertices_;
       }
 
@@ -392,7 +392,7 @@ namespace ttk {
       }
 
       // Real reserve
-      inline void makeReserve(void) {
+      inline void makeReserve() {
         if(sizeVertList_ != -1) {
           // We have an offset of -1 due to the initial value of sizeVertList_
           vertices_.reserve(sizeVertList_ + 1);

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -15,8 +15,7 @@
 /// Charles Gueunet, Pierre Fortin, Julien Jomier, Julien Tierny \n
 /// Proc. of IEEE LDAV 2016.
 
-#ifndef SUPERARC_H
-#define SUPERARC_H
+#pragma once
 
 #include <list>
 #include <vector>
@@ -405,5 +404,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif /* end of include guard: SUPERARC_H */

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -92,7 +92,7 @@ namespace ttk {
                const ComponentState &state = ComponentState::Visible)
         : downNodeId_(d), upNodeId_(u), downCT_(ctd), upCT_(ctu),
           overlapBelow_(overB), overlapAbove_(overA), lastVisited_(nullVertex),
-          state_(state), replacantId_(nullSuperArc), vertList_(NULL),
+          state_(state), replacantId_(nullSuperArc), vertList_(nullptr),
           sizeVertList_(-1) {
         vertices_.reserve(resv);
       }

--- a/core/base/contourForestsTree/ExtendedUF.h
+++ b/core/base/contourForestsTree/ExtendedUF.h
@@ -108,10 +108,10 @@ namespace ttk {
 
       static inline ExtendedUnionFind *
         makeUnion(std::vector<ExtendedUnionFind *> &sets) {
-        ExtendedUnionFind *n = NULL;
+        ExtendedUnionFind *n = nullptr;
 
         if(!sets.size())
-          return NULL;
+          return nullptr;
 
         if(sets.size() == 1)
           return sets[0];

--- a/core/base/contourForestsTree/ExtendedUF.h
+++ b/core/base/contourForestsTree/ExtendedUF.h
@@ -17,8 +17,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef EXTENDEDUF_H
-#define EXTENDEDUF_H
+#pragma once
 
 #include <vector>
 
@@ -132,5 +131,3 @@ namespace ttk {
     };
   } // namespace cf
 } // namespace ttk
-
-#endif /* end of include guard: EXTENDEDUF_H */

--- a/core/base/contourForestsTree/ExtendedUF.h
+++ b/core/base/contourForestsTree/ExtendedUF.h
@@ -55,11 +55,11 @@ namespace ttk {
         origin_ = origin;
       }
 
-      inline const ufDataType &getData(void) const {
+      inline const ufDataType &getData() const {
         return data_;
       }
 
-      inline const SimplexId &getOrigin(void) const {
+      inline const SimplexId &getOrigin() const {
         return origin_;
       }
 

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -31,10 +31,9 @@ MergeTree::MergeTree(Params *const params,
   treeData_.partition = part;
 }
 
-MergeTree::~MergeTree() {
-  // all is automatically destroyed in treedata
-  // do not touch pointers
-}
+MergeTree::~MergeTree() = default;
+// all is automatically destroyed in treedata
+// do not touch pointers
 
 // }
 // Process

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -71,17 +71,17 @@ namespace ttk {
       }
 
       /// \brief init the type of the current tree froms params
-      void initTreeType(void) {
+      void initTreeType() {
         treeData_.treeType = params_->treeType;
       }
 
       /// \brief if sortedVertices_ is null, define and fill it
       /// Also fill the mirror std::vector
       template <typename scalarType>
-      void sortInput(void);
+      void sortInput();
 
       /// \brief clear local data for new computation
-      void flush(void) {
+      void flush() {
         treeData_.superArcs.clear();
         treeData_.nodes.clear();
         treeData_.leaves.clear();
@@ -139,7 +139,7 @@ namespace ttk {
       // partition
       // .....................{
 
-      inline idPartition getPartition(void) const {
+      inline idPartition getPartition() const {
         return treeData_.partition;
       }
 
@@ -177,11 +177,11 @@ namespace ttk {
       // arcs
       // .....................{
 
-      inline idSuperArc getNumberOfSuperArcs(void) const {
+      inline idSuperArc getNumberOfSuperArcs() const {
         return treeData_.superArcs.size();
       }
 
-      inline idSuperArc getNumberOfVisibleArcs(void) const {
+      inline idSuperArc getNumberOfVisibleArcs() const {
         // Costly ! for dedbug only
         idSuperArc visibleArc = 0;
         for(const SuperArc &arc : treeData_.superArcs) {
@@ -191,7 +191,7 @@ namespace ttk {
         return visibleArc;
       }
 
-      inline const std::vector<SuperArc> &getSuperArc(void) const {
+      inline const std::vector<SuperArc> &getSuperArc() const {
         // break encapsulation...
         return treeData_.superArcs;
       }
@@ -229,11 +229,11 @@ namespace ttk {
       // nodes
       // .....................{
 
-      inline idNode getNumberOfNodes(void) const {
+      inline idNode getNumberOfNodes() const {
         return treeData_.nodes.size();
       }
 
-      inline const std::vector<Node> &getNodes(void) const {
+      inline const std::vector<Node> &getNodes() const {
         // break encapsulation...
         return treeData_.nodes;
       }
@@ -246,11 +246,11 @@ namespace ttk {
       // leaves / root
       // .....................{
 
-      inline SimplexId getNumberOfLeaves(void) const {
+      inline SimplexId getNumberOfLeaves() const {
         return treeData_.leaves.size();
       }
 
-      inline const std::vector<idNode> &getLeaves(void) const {
+      inline const std::vector<idNode> &getLeaves() const {
         // break encapsulation...
         return treeData_.leaves;
       }
@@ -265,7 +265,7 @@ namespace ttk {
         return treeData_.leaves[id];
       }
 
-      inline const std::vector<idNode> &getRoots(void) const {
+      inline const std::vector<idNode> &getRoots() const {
         // break encapsulation...
         return treeData_.roots;
       }
@@ -566,7 +566,7 @@ namespace ttk {
       // {
 
       // Print
-      void printTree2(void);
+      void printTree2();
 
       std::string printArc(const idSuperArc &a) {
         const SuperArc *sa = getSuperArc(a);

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -57,7 +57,7 @@ namespace ttk {
                 TreeType type,
                 idPartition part = nullPartition);
 
-      virtual ~MergeTree();
+      ~MergeTree() override;
 
       //}
       // --------------------
@@ -103,7 +103,7 @@ namespace ttk {
       // On this implementation, the warpper communicate with ContourForest
       // A child class of this one.
 
-      inline int setDebugLevel(const int &local_debugLevel) {
+      inline int setDebugLevel(const int &local_debugLevel) override {
         Debug::setDebugLevel(local_debugLevel);
         params_->debugLevel = local_debugLevel;
         return 0;

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -28,7 +28,7 @@ namespace ttk {
     // {
 
     template <typename scalarType>
-    void MergeTree::sortInput(void) {
+    void MergeTree::sortInput() {
       const auto &nbVertices = scalars_->size;
 
       if(scalars_->sortedVertices.size() != static_cast<size_t>(nbVertices)) {

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -211,14 +211,14 @@ int SubLevelSetTree::build() {
 
   vector<UnionFind> seeds;
   vector<vector<int>> seedSuperArcs;
-  vector<UnionFind *> vertexSeeds(vertexNumber_, (UnionFind *)NULL);
+  vector<UnionFind *> vertexSeeds(vertexNumber_, (UnionFind *)nullptr);
   vector<UnionFind *> starSets;
   vector<bool> visitedVertices(vertexNumber_, false);
 
   SimplexId vertexId = -1, nId = -1;
-  UnionFind *seed = NULL, *firstUf = NULL;
+  UnionFind *seed = nullptr, *firstUf = nullptr;
 
-  const vector<int> *extremumList = NULL;
+  const vector<int> *extremumList = nullptr;
 
   bool isMergeTree = true;
 
@@ -272,7 +272,7 @@ int SubLevelSetTree::build() {
     starSets.clear();
 
     merge = false;
-    firstUf = NULL;
+    firstUf = nullptr;
 
     SimplexId neighborNumber
       = triangulation_->getVertexNeighborNumber(vertexId);
@@ -2437,7 +2437,7 @@ int ContourTree::combineTrees() {
     return -1;
 
   queue<const Node *> nodeQueue;
-  const Node *mergeNode = NULL, *splitNode = NULL;
+  const Node *mergeNode = nullptr, *splitNode = nullptr;
   int initNumber = 0;
 
   do {
@@ -2461,7 +2461,7 @@ int ContourTree::combineTrees() {
     if((int)nodeQueue.size() == initQueueSize)
       break;
 
-    const Node *n0 = NULL, *n1 = NULL, *other = NULL;
+    const Node *n0 = nullptr, *n1 = nullptr, *other = nullptr;
 
     do {
 
@@ -2483,7 +2483,7 @@ int ContourTree::combineTrees() {
         if(!((other->getNumberOfUpArcs())
              && (other->getNumberOfDownArcs() > 1))) {
 
-          n1 = NULL;
+          n1 = nullptr;
 
           if(n0->getNumberOfUpArcs()) {
 
@@ -2533,7 +2533,7 @@ int ContourTree::combineTrees() {
         if(!((other->getNumberOfUpArcs())
              && (other->getNumberOfDownArcs() > 1))) {
 
-          n1 = NULL;
+          n1 = nullptr;
 
           if(n0->getNumberOfUpArcs()) {
 
@@ -2682,7 +2682,7 @@ bool ContourTree::isNodeEligible(const Node *n) const {
   }
 #endif // TTK_ENABLE_KAMIKAZE
 
-  const Node *merge = NULL, *split = NULL;
+  const Node *merge = nullptr, *split = nullptr;
 
   if(mergeTree_.getNode(n - mergeTree_.getNode(0)) == n) {
     merge = n;

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -595,7 +595,7 @@ namespace ttk {
       std::vector<std::pair<std::pair<int, int>, double>> &pairs,
       std::vector<std::pair<std::pair<int, int>, double>> *mergePairs = nullptr,
       std::vector<std::pair<std::pair<int, int>, double>> *splitPairs
-      = nullptr) const;
+      = nullptr) const override;
 
     int getPersistencePlot(
       std::vector<std::pair<double, int>> &plot,
@@ -615,7 +615,7 @@ namespace ttk {
       return &splitTree_;
     }
 
-    inline int maintainRegularVertices(const bool &onOff) {
+    inline int maintainRegularVertices(const bool &onOff) override {
       mergeTree_.maintainRegularVertices(onOff);
       splitTree_.maintainRegularVertices(onOff);
       return 0;
@@ -627,12 +627,12 @@ namespace ttk {
     int setVertexNeighbors(const int &vertexId,
                            const std::vector<int> &neighborList);
 
-    int computeSkeleton(unsigned int arcResolution = 3);
-    int smoothSkeleton(unsigned int skeletonSmoothing);
-    int clearSkeleton();
+    int computeSkeleton(unsigned int arcResolution = 3) override;
+    int smoothSkeleton(unsigned int skeletonSmoothing) override;
+    int clearSkeleton() override;
 
     int simplify(const double &simplificationThreshold,
-                 ContourTreeSimplificationMetric *metric = NULL);
+                 ContourTreeSimplificationMetric *metric = NULL) override;
 
   protected:
     int combineTrees();

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -280,8 +280,8 @@ namespace ttk {
     int exportToVtk(const std::string &fileName,
                     // fixes a bug in paraview, the voxel size of the cube file
                     // format is not taken into account...
-                    const std::vector<float> *origin = NULL,
-                    const std::vector<float> *voxelSize = NULL);
+                    const std::vector<float> *origin = nullptr,
+                    const std::vector<float> *voxelSize = nullptr);
 
     int flush();
 
@@ -445,10 +445,10 @@ namespace ttk {
 
     inline const Node *getVertexNode(const int &vertexId) const {
       if((vertexId < 0) || (vertexId >= vertexNumber_))
-        return NULL;
+        return nullptr;
       if(vertex2node_[vertexId] != -1)
         return &(nodeList_[vertex2node_[vertexId]]);
-      return NULL;
+      return nullptr;
     }
 
     inline int getVertexNodeId(const int &vertexId) const {
@@ -458,12 +458,12 @@ namespace ttk {
     }
 
     bool isJoinTree() const {
-      return ((maximumList_ == NULL)
+      return ((maximumList_ == nullptr)
               || ((maximumList_) && (maximumList_->empty())));
     }
 
     bool isSplitTree() const {
-      return ((minimumList_ == NULL)
+      return ((minimumList_ == nullptr)
               || ((minimumList_) && (minimumList_->empty())));
     }
 
@@ -527,7 +527,7 @@ namespace ttk {
     }
 
     virtual int simplify(const double &simplificationThreshold,
-                         ContourTreeSimplificationMetric *metric = NULL);
+                         ContourTreeSimplificationMetric *metric = nullptr);
 
     int sample(unsigned int samplingLevel = 3);
     int computeBarycenters();
@@ -632,7 +632,7 @@ namespace ttk {
     int clearSkeleton() override;
 
     int simplify(const double &simplificationThreshold,
-                 ContourTreeSimplificationMetric *metric = NULL) override;
+                 ContourTreeSimplificationMetric *metric = nullptr) override;
 
   protected:
     int combineTrees();

--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -1,7 +1,7 @@
 #include <CTA_contourtree.h>
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
-#include <float.h>
 
 using ttk::cta::ContourTree;
 

--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -75,8 +75,7 @@ ContourTree::ContourTree(float *scalars,
   }
 }
 
-ContourTree::~ContourTree() {
-}
+ContourTree::~ContourTree() = default;
 
 std::shared_ptr<ttk::cta::Tree> ContourTree::computeRootedTree(
   const std::shared_ptr<ttk::cta::CTNode> &node,

--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -159,7 +159,7 @@ std::shared_ptr<ttk::cta::BinaryTree> ContourTree::computeRootedTree_binary(
   std::shared_ptr<ttk::cta::CTEdge> edge = arcs[node->edgeList[0]];
   int nodeIdx = nodes[edge->node1Idx] == node ? edge->node1Idx : edge->node2Idx;
   t->nodeRefs = std::vector<std::pair<int, int>>();
-  t->nodeRefs.push_back(std::make_pair(-1, nodeIdx));
+  t->nodeRefs.emplace_back(-1, nodeIdx);
   t->arcRefs = std::vector<std::pair<int, int>>();
   // if(parent != nullptr)
   // t->arcRefs.push_back(std::make_pair(-1,parent->segId));
@@ -167,7 +167,7 @@ std::shared_ptr<ttk::cta::BinaryTree> ContourTree::computeRootedTree_binary(
     int arcRef = arcs[node->edgeList[0]] == parent   ? node->edgeList[0]
                  : arcs[node->edgeList[1]] == parent ? node->edgeList[1]
                                                      : node->edgeList[2];
-    t->arcRefs.push_back(std::make_pair(-1, arcRef));
+    t->arcRefs.emplace_back(-1, arcRef);
   }
 
   // set height and size to 0/1. For inner nodes this will be updated while

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -206,7 +206,7 @@ bool ttk::ContourTreeAlignment::initialize(
   currNode->scalarValue = t->scalarValue;
 
   currNode->nodeRefs = std::vector<std::pair<int, int>>();
-  currNode->nodeRefs.push_back(std::make_pair(0, t->nodeRefs[0].second));
+  currNode->nodeRefs.emplace_back(0, t->nodeRefs[0].second);
 
   nodes.push_back(currNode);
 
@@ -228,8 +228,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->scalarValue = currTree->child1->scalarValue;
 
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
-      childNode->nodeRefs.push_back(
-        std::make_pair(0, currTree->child1->nodeRefs[0].second));
+      childNode->nodeRefs.emplace_back(0, currTree->child1->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -258,8 +257,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->scalarValue = currTree->child2->scalarValue;
 
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
-      childNode->nodeRefs.push_back(
-        std::make_pair(0, currTree->child2->nodeRefs[0].second));
+      childNode->nodeRefs.emplace_back(0, currTree->child2->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -309,7 +307,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
   currNode->scalarValue = t->scalarValue;
 
   currNode->nodeRefs = std::vector<std::pair<int, int>>();
-  currNode->nodeRefs.push_back(std::make_pair(0, t->nodeRefs[0].second));
+  currNode->nodeRefs.emplace_back(0, t->nodeRefs[0].second);
 
   nodes.push_back(currNode);
 
@@ -331,8 +329,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->scalarValue = currTree->child1->scalarValue;
 
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
-      childNode->nodeRefs.push_back(
-        std::make_pair(0, currTree->child1->nodeRefs[0].second));
+      childNode->nodeRefs.emplace_back(0, currTree->child1->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -344,8 +341,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childEdge->node2 = childNode;
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
-      childEdge->arcRefs.push_back(
-        std::make_pair(0, currTree->child1->arcRefs[0].second));
+      childEdge->arcRefs.emplace_back(0, currTree->child1->arcRefs[0].second);
 
       childNode->edgeList.push_back(childEdge);
       currNode->edgeList.push_back(childEdge);
@@ -366,8 +362,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->scalarValue = currTree->child2->scalarValue;
 
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
-      childNode->nodeRefs.push_back(
-        std::make_pair(0, currTree->child2->nodeRefs[0].second));
+      childNode->nodeRefs.emplace_back(0, currTree->child2->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -379,8 +374,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childEdge->node2 = childNode;
 
       childEdge->arcRefs = std::vector<std::pair<int, int>>();
-      childEdge->arcRefs.push_back(
-        std::make_pair(0, currTree->child2->arcRefs[0].second));
+      childEdge->arcRefs.emplace_back(0, currTree->child2->arcRefs[0].second);
 
       childNode->edgeList.push_back(childEdge);
       currNode->edgeList.push_back(childEdge);
@@ -562,8 +556,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
                                 res->node1->nodeRefs.begin(),
                                 res->node1->nodeRefs.end());
     if(res->node2 != nullptr)
-      currNode->nodeRefs.push_back(std::make_pair(
-        (int)contourtrees.size() - 1, res->node2->nodeRefs[0].second));
+      currNode->nodeRefs.emplace_back(
+        (int)contourtrees.size() - 1, res->node2->nodeRefs[0].second);
 
   } else if(alignmenttreeType == ttk::cta::averageValues) {
 
@@ -599,8 +593,8 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
                               res->node1->nodeRefs.begin(),
                               res->node1->nodeRefs.end());
   if(res->node2 != nullptr)
-    currNode->nodeRefs.push_back(std::make_pair(
-      (int)contourtrees.size() - 1, res->node2->nodeRefs[0].second));
+    currNode->nodeRefs.emplace_back(
+      (int)contourtrees.size() - 1, res->node2->nodeRefs[0].second);
 
   nodes.push_back(currNode);
 
@@ -684,9 +678,9 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
                                    currTree->child1->node1->nodeRefs.begin(),
                                    currTree->child1->node1->nodeRefs.end());
       if(currTree->child1->node2 != nullptr)
-        childNode->nodeRefs.push_back(
-          std::make_pair((int)contourtrees.size() - 1,
-                         currTree->child1->node2->nodeRefs[0].second));
+        childNode->nodeRefs.emplace_back(
+          (int)contourtrees.size() - 1,
+          currTree->child1->node2->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -775,14 +769,13 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         openEdgesOld1.push_back(childEdge);
       if(currTree->child1->node2 != nullptr) {
         for(const auto &e : openEdgesNew1) {
-          e->arcRefs.push_back(
-            std::make_pair((int)contourtrees.size() - 1,
-                           currTree->child1->node2->arcRefs[0].second));
+          e->arcRefs.emplace_back((int)contourtrees.size() - 1,
+                                  currTree->child1->node2->arcRefs[0].second);
         }
         openEdgesNew1.clear();
-        childEdge->arcRefs.push_back(
-          std::make_pair((int)contourtrees.size() - 1,
-                         currTree->child1->node2->arcRefs[0].second));
+        childEdge->arcRefs.emplace_back(
+          (int)contourtrees.size() - 1,
+          currTree->child1->node2->arcRefs[0].second);
       } else
         openEdgesNew1.push_back(childEdge);
 
@@ -865,9 +858,9 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
                                    currTree->child2->node1->nodeRefs.begin(),
                                    currTree->child2->node1->nodeRefs.end());
       if(currTree->child2->node2 != nullptr)
-        childNode->nodeRefs.push_back(
-          std::make_pair((int)contourtrees.size() - 1,
-                         currTree->child2->node2->nodeRefs[0].second));
+        childNode->nodeRefs.emplace_back(
+          (int)contourtrees.size() - 1,
+          currTree->child2->node2->nodeRefs[0].second);
 
       std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
         new ttk::cta::AlignmentEdge());
@@ -956,14 +949,13 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         openEdgesOld2.push_back(childEdge);
       if(currTree->child2->node2 != nullptr) {
         for(const auto &e : openEdgesNew1) {
-          e->arcRefs.push_back(
-            std::make_pair((int)contourtrees.size() - 1,
-                           currTree->child2->node2->arcRefs[0].second));
+          e->arcRefs.emplace_back((int)contourtrees.size() - 1,
+                                  currTree->child2->node2->arcRefs[0].second);
         }
         openEdgesNew2.clear();
-        childEdge->arcRefs.push_back(
-          std::make_pair((int)contourtrees.size() - 1,
-                         currTree->child2->node2->arcRefs[0].second));
+        childEdge->arcRefs.emplace_back(
+          (int)contourtrees.size() - 1,
+          currTree->child2->node2->arcRefs[0].second);
       } else
         openEdgesNew2.push_back(childEdge);
 

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -164,7 +164,7 @@ namespace ttk {
     }
 
     /// Destructor of the Alignment Object
-    ~ContourTreeAlignment() {
+    ~ContourTreeAlignment() override {
       contourtrees.clear();
       nodes.clear();
       arcs.clear();

--- a/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
+++ b/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
@@ -31,7 +31,7 @@ namespace ttk {
     DepthImageBasedGeometryApproximation() {
       this->setDebugMsgPrefix("DIBGA");
     }
-    ~DepthImageBasedGeometryApproximation() = default;
+    ~DepthImageBasedGeometryApproximation() override = default;
 
     /**
      * This function computes for an input depth image and its corresponding

--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -98,7 +98,7 @@ int DimensionReduction::execute() const {
 
   string modulePath;
 
-  if(PyArray_API == NULL) {
+  if(PyArray_API == nullptr) {
 #ifndef __clang_analyzer__
     import_array1(-1);
 #endif // __clang_analyzer__

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -2353,7 +2353,7 @@ bool DiscreteGradient::getDescendingPathThroughWall(
             if(vpath != nullptr) {
               vpath->push_back(Cell(1, edgeId));
             }
-            return 0;
+            return false;
           }
 
           currentId = edgeId;

--- a/core/base/dynamicTree/DynamicTree.cpp
+++ b/core/base/dynamicTree/DynamicTree.cpp
@@ -4,7 +4,7 @@
 
 // DynamicTree ----------------------------------
 
-std::string ttk::DynamicTree::print(void) const {
+std::string ttk::DynamicTree::print() const {
   std::stringstream res;
 
   for(const auto &node : nodes_) {
@@ -21,7 +21,7 @@ std::string ttk::DynamicTree::print(void) const {
   return res.str();
 }
 
-std::string ttk::DynamicTree::printNbCC(void) const {
+std::string ttk::DynamicTree::printNbCC() const {
   std::stringstream res;
   std::vector<DynTreeNode *> roots;
   roots.reserve(nodes_.size());
@@ -38,7 +38,7 @@ std::string ttk::DynamicTree::printNbCC(void) const {
 
 // DynTreeNode ----------------------------------
 
-void ttk::DynTreeNode::evert(void) {
+void ttk::DynTreeNode::evert() {
   if(!parent_)
     return;
 
@@ -63,7 +63,7 @@ void ttk::DynTreeNode::evert(void) {
   }
 }
 
-ttk::DynTreeNode *ttk::DynTreeNode::findRoot(void) const {
+ttk::DynTreeNode *ttk::DynTreeNode::findRoot() const {
   DynTreeNode *curNode = const_cast<DynTreeNode *>(this);
   while(curNode->parent_) {
     curNode = curNode->parent_;

--- a/core/base/dynamicTree/DynamicTree.h
+++ b/core/base/dynamicTree/DynamicTree.h
@@ -28,7 +28,7 @@ namespace ttk {
     // Accessor functions
     // ------------------
 
-    inline bool hasParent(void) const {
+    inline bool hasParent() const {
       return parent_ != nullptr;
     }
 
@@ -37,10 +37,10 @@ namespace ttk {
 
     /// Make this node the root of its tree
     // Various way to do that, test perfs ?
-    void evert(void);
+    void evert();
 
     /// Get representative node
-    DynTreeNode *findRoot(void) const;
+    DynTreeNode *findRoot() const;
 
     /// Create a new edge between this node and the node n
     /// @return true if we have merged two tree, false if it was just an intern
@@ -49,7 +49,7 @@ namespace ttk {
 
     /// Remove the link between this node and its parent, thus makeing a new
     /// root
-    inline void removeEdge(void) {
+    inline void removeEdge() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!parent_) {
         std::cerr << "[DynamicTree]: DynTree remove edge in root node"
@@ -146,8 +146,8 @@ namespace ttk {
 
     // Debug
 
-    std::string print(void) const;
-    std::string printNbCC(void) const;
+    std::string print() const;
+    std::string printNbCC() const;
   };
 
 } // namespace ttk

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -14,8 +14,7 @@ ExplicitTriangulation::ExplicitTriangulation() {
   clear();
 }
 
-ExplicitTriangulation::~ExplicitTriangulation() {
-}
+ExplicitTriangulation::~ExplicitTriangulation() = default;
 
 int ExplicitTriangulation::clear() {
   vertexNumber_ = 0;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -23,7 +23,7 @@ namespace ttk {
   public:
     ExplicitTriangulation();
 
-    virtual ~ExplicitTriangulation();
+    ~ExplicitTriangulation() override;
 
     ExplicitTriangulation(const ExplicitTriangulation &) = default;
     ExplicitTriangulation(ExplicitTriangulation &&) = default;

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -686,8 +686,7 @@ int FiberSurface::flipEdges(
           alpha = fabs(angles[j]);
       }
 
-      localTriangles.push_back(
-        pair<double, pair<SimplexId, SimplexId>>(alpha, triangles[i]));
+      localTriangles.emplace_back(alpha, triangles[i]);
     }
 
     const auto FiberSurfaceTriangleCmp

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -80,7 +80,7 @@ namespace ttk {
       const std::vector<std::pair<std::pair<double, double>,
                                   std::pair<double, double>>> &edgeList,
       const std::vector<SimplexId> &seedTetList,
-      const std::vector<SimplexId> *edgeIdList = NULL) const;
+      const std::vector<SimplexId> *edgeIdList = nullptr) const;
 
     template <class dataTypeU, class dataTypeV, typename triangulationType>
     inline int computeSurface(const std::pair<double, double> &rangePoint0,
@@ -161,8 +161,8 @@ namespace ttk {
 
     inline int setPolygonEdgeNumber(const SimplexId &polygonEdgeNumber) {
       polygonEdgeNumber_ = polygonEdgeNumber;
-      polygonEdgeVertexLists_.resize(polygonEdgeNumber, NULL);
-      polygonEdgeTriangleLists_.resize(polygonEdgeNumber, NULL);
+      polygonEdgeVertexLists_.resize(polygonEdgeNumber, nullptr);
+      polygonEdgeTriangleLists_.resize(polygonEdgeNumber, nullptr);
       return 0;
     }
 
@@ -378,7 +378,7 @@ namespace ttk {
       const std::vector<std::vector<Vertex>> &tetNewVertices,
       SimplexId &newTriangleNumber,
       std::vector<std::vector<IntersectionTriangle>> &tetIntersections,
-      const std::pair<double, double> *intersection = NULL) const;
+      const std::pair<double, double> *intersection = nullptr) const;
 
     int flipEdges() const;
 

--- a/core/base/ftmTree/FTMAtomicUF.h
+++ b/core/base/ftmTree/FTMAtomicUF.h
@@ -162,10 +162,10 @@ namespace ttk {
       }
 
       static inline AtomicUF *makeUnion(std::vector<AtomicUF *> &sets) {
-        AtomicUF *n = NULL;
+        AtomicUF *n = nullptr;
 
         if(!sets.size())
-          return NULL;
+          return nullptr;
 
         if(sets.size() == 1)
           return sets[0];

--- a/core/base/ftmTree/FTMAtomicUF.h
+++ b/core/base/ftmTree/FTMAtomicUF.h
@@ -51,11 +51,11 @@ namespace ttk {
 
       // Shared data get/set
 
-      inline SimplexId getExtrema(void) const {
+      inline SimplexId getExtrema() const {
         return data_.extrema;
       }
 
-      inline CurrentState *getFirstState(void) {
+      inline CurrentState *getFirstState() {
 #ifndef TTK_ENABLE_KAMIKAZE
         if(data_.states.size() != 1) {
           std::cout << "AtomicUF :: getFirstState : nb state 1 !=  "
@@ -75,19 +75,19 @@ namespace ttk {
         return data_.states[id];
       }
 
-      inline FTMAtomicVector<CurrentState *> &getStates(void) {
+      inline FTMAtomicVector<CurrentState *> &getStates() {
         return data_.states;
       }
 
-      inline size_t getNbStates(void) const {
+      inline size_t getNbStates() const {
         return data_.states.size();
       }
 
-      inline FTMAtomicVector<idSuperArc> &getOpenedArcs(void) {
+      inline FTMAtomicVector<idSuperArc> &getOpenedArcs() {
         return data_.openedArcs;
       }
 
-      inline void clearOpenedArcs(void) {
+      inline void clearOpenedArcs() {
         data_.openedArcs.reset();
       }
 
@@ -107,7 +107,7 @@ namespace ttk {
         data_.addArc(a);
       }
 
-      inline CurrentState *mergeStates(void) {
+      inline CurrentState *mergeStates() {
         CurrentState *s = data_.states[0];
         const auto &nbState = data_.states.size();
 

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -87,7 +87,7 @@ namespace ttk {
       nextId = nId;
     }
 
-    void clear(void) {
+    void clear() {
       reset();
 
       // Remove old content
@@ -96,7 +96,7 @@ namespace ttk {
       reserve(oldSize);
     }
 
-    std::size_t getNext(void) {
+    std::size_t getNext() {
       std::size_t resId;
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic capture
@@ -110,11 +110,11 @@ namespace ttk {
       return resId;
     }
 
-    std::size_t size(void) const {
+    std::size_t size() const {
       return nextId;
     }
 
-    bool empty(void) const {
+    bool empty() const {
       return nextId == 0;
     }
 

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -5,8 +5,7 @@
 ///
 ///\brief TTK processing package that manage a paralle vecrion of vector
 
-#ifndef FTMATOMICVECTOR_H
-#define FTMATOMICVECTOR_H
+#pragma once
 
 #ifdef TTK_ENABLE_OPENMP
 #include <omp.h>
@@ -164,5 +163,3 @@ namespace ttk {
     }
   };
 } // namespace ttk
-
-#endif /* end of include guard: FTMATOMICVECTOR_H */

--- a/core/base/ftmTree/FTMDataTypes.h
+++ b/core/base/ftmTree/FTMDataTypes.h
@@ -12,8 +12,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef DATATYPES_FTM_H
-#define DATATYPES_FTM_H
+#pragma once
 
 #include <DataTypes.h>
 #include <functional>
@@ -119,5 +118,3 @@ namespace ttk {
 // #define withStatsTime 1
 
 // #define withProcessSpeed 1
-
-#endif /* end of include guard: DATATYPES_H */

--- a/core/base/ftmTree/FTMNode.h
+++ b/core/base/ftmTree/FTMNode.h
@@ -61,11 +61,11 @@ namespace ttk {
 
       // Linked node
 
-      inline SimplexId getOrigin(void) const {
+      inline SimplexId getOrigin() const {
         return linkedNode_;
       }
 
-      inline SimplexId getTerminaison(void) const {
+      inline SimplexId getTerminaison() const {
         return linkedNode_;
       }
 
@@ -124,13 +124,13 @@ namespace ttk {
         vect_upSuperArcList_.emplace_back(upSuperArcId);
       }
 
-      inline idSuperArc clearDownSuperArcs(void) {
+      inline idSuperArc clearDownSuperArcs() {
         idSuperArc s = vect_downSuperArcList_.size();
         vect_downSuperArcList_.clear();
         return s;
       }
 
-      inline idSuperArc clearUpSuperArcs(void) {
+      inline idSuperArc clearUpSuperArcs() {
         idSuperArc s = vect_upSuperArcList_.size();
         vect_upSuperArcList_.clear();
         return s;

--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -100,8 +100,7 @@ void Segment::sort(const Scalars *s) {
 // Segments
 // --------
 
-Segments::Segments() {
-}
+Segments::Segments() = default;
 
 void Segments::clear(void) {
   segments_.clear();

--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -29,11 +29,11 @@ using namespace ftm;
 Segment::Segment(SimplexId size) : vertices_(size, nullVertex) {
 }
 
-segm_const_it Segment::begin(void) const {
+segm_const_it Segment::begin() const {
   return vertices_.begin();
 }
 
-segm_it Segment::begin(void) {
+segm_it Segment::begin() {
   return vertices_.begin();
 }
 
@@ -69,11 +69,11 @@ void Segment::createFromList(const Scalars *s,
   regularList.clear();
 }
 
-segm_const_it Segment::end(void) const {
+segm_const_it Segment::end() const {
   return vertices_.end();
 }
 
-segm_it Segment::end(void) {
+segm_it Segment::end() {
   return vertices_.end();
 }
 
@@ -85,7 +85,7 @@ SimplexId &Segment::operator[](const size_t &idx) {
   return vertices_[idx];
 }
 
-SimplexId Segment::size(void) const {
+SimplexId Segment::size() const {
   return vertices_.size();
 }
 
@@ -102,7 +102,7 @@ void Segment::sort(const Scalars *s) {
 
 Segments::Segments() = default;
 
-void Segments::clear(void) {
+void Segments::clear() {
   segments_.clear();
 }
 
@@ -127,7 +127,7 @@ void Segments::resize(const vector<SimplexId> &sizes) {
   }
 }
 
-idSegment Segments::size(void) const {
+idSegment Segments::size() const {
   return segments_.size();
 }
 

--- a/core/base/ftmTree/FTMSegmentation.h
+++ b/core/base/ftmTree/FTMSegmentation.h
@@ -39,11 +39,11 @@ namespace ttk {
                           std::list<std::vector<SimplexId>> &regularsList,
                           const bool reverse);
 
-      segm_const_it begin(void) const;
-      segm_const_it end(void) const;
-      segm_it begin(void);
-      segm_it end(void);
-      SimplexId size(void) const;
+      segm_const_it begin() const;
+      segm_const_it end() const;
+      segm_it begin();
+      segm_it end();
+      SimplexId size() const;
 
       SimplexId operator[](const size_t &idx) const;
       SimplexId &operator[](const size_t &idx);
@@ -69,13 +69,13 @@ namespace ttk {
       void resize(const std::vector<SimplexId> &sizes);
 
       // vector like
-      idSegment size(void) const;
-      void clear(void);
+      idSegment size() const;
+      void clear();
       Segment &operator[](const size_t &idx);
       const Segment &operator[](const size_t &idx) const;
 
       // print
-      inline std::string print(void) const {
+      inline std::string print() const {
         std::stringstream res;
         res << "{" << std::endl;
         for(const auto &s : segments_) {
@@ -131,7 +131,7 @@ namespace ttk {
       // else return false
       bool merge(const ArcRegion &r);
 
-      void clear(void) {
+      void clear() {
         segmentsIn_.clear();
         segmentation_.clear();
       }
@@ -143,7 +143,7 @@ namespace ttk {
       // a segment can contain vertices for several arcs
       void createSegmentation(const Scalars *s);
 
-      inline SimplexId count(void) const {
+      inline SimplexId count() const {
         SimplexId res = 0;
         for(const auto &reg : segmentsIn_) {
           res += std::abs(distance(reg.segmentBegin, reg.segmentEnd));
@@ -151,7 +151,7 @@ namespace ttk {
         return res;
       }
 
-      inline std::string print(void) const {
+      inline std::string print() const {
         std::stringstream res;
         res << "{";
         for(const auto &reg : segmentsIn_) {
@@ -168,17 +168,17 @@ namespace ttk {
       }
 
       // Direct access to the list of region
-      const decltype(segmentsIn_) &getRegions(void) const {
+      const decltype(segmentsIn_) &getRegions() const {
         return segmentsIn_;
       }
 
-      decltype(segmentsIn_) &getRegions(void) {
+      decltype(segmentsIn_) &getRegions() {
         return segmentsIn_;
       }
 
       // vector like manip
 
-      inline SimplexId size(void) const {
+      inline SimplexId size() const {
 #ifndef TTK_ENABLE_KAMIKAZE
         if(!segmented_)
           std::cerr << "Needs to create segmentation before size" << std::endl;
@@ -206,11 +206,11 @@ namespace ttk {
         return segmentation_[v];
       }
 
-      decltype(segmentation_)::iterator begin(void) {
+      decltype(segmentation_)::iterator begin() {
         return segmentation_.begin();
       }
 
-      decltype(segmentation_)::iterator end(void) {
+      decltype(segmentation_)::iterator end() {
         return segmentation_.end();
       }
     };

--- a/core/base/ftmTree/FTMStructures.h
+++ b/core/base/ftmTree/FTMStructures.h
@@ -82,7 +82,7 @@ namespace ttk {
         vertex = v;
       }
 
-      SimplexId getNextMinVertex(void) {
+      SimplexId getNextMinVertex() {
         vertex = propagation.top();
         propagation.pop();
         return vertex;

--- a/core/base/ftmTree/FTMSuperArc.h
+++ b/core/base/ftmTree/FTMSuperArc.h
@@ -65,11 +65,11 @@ namespace ttk {
 
       // node
 
-      inline idNode getUpNodeId(void) const {
+      inline idNode getUpNodeId() const {
         return upNodeId_;
       }
 
-      inline idNode getDownNodeId(void) const {
+      inline idNode getDownNodeId() const {
         return downNodeId_;
       }
 
@@ -83,7 +83,7 @@ namespace ttk {
 
       // last vertex seen, nb vertex seen & ids
 
-      inline SimplexId getLastVisited(void) const {
+      inline SimplexId getLastVisited() const {
         return lastVisited_;
       }
 
@@ -99,15 +99,15 @@ namespace ttk {
         verticesSeen_ += nb;
       }
 
-      inline void decrNbSeen(void) {
+      inline void decrNbSeen() {
         --verticesSeen_;
       }
 
-      inline SimplexId getNbVertSeen(void) const {
+      inline SimplexId getNbVertSeen() const {
         return verticesSeen_;
       }
 
-      inline idSuperArc getNormalizedId(void) const {
+      inline idSuperArc getNormalizedId() const {
         return normalizedId_;
       }
 
@@ -117,15 +117,15 @@ namespace ttk {
 
       // state
 
-      inline bool isHidden(void) const {
+      inline bool isHidden() const {
         return state_ == ComponentState::Hidden;
       }
 
-      inline bool isMerged(void) const {
+      inline bool isMerged() const {
         return state_ == ComponentState::Merged;
       }
 
-      inline bool isVisible(void) const {
+      inline bool isVisible() const {
         return state_ == ComponentState::Visible;
       }
 
@@ -157,38 +157,38 @@ namespace ttk {
       }
 
       // Direct read access to the list of region
-      const std::list<Region> &getRegions(void) const {
+      const std::list<Region> &getRegions() const {
         return region_.getRegions();
       }
 
-      std::list<Region> &getRegions(void) {
+      std::list<Region> &getRegions() {
         return region_.getRegions();
       }
 
-      const ArcRegion &getRegion(void) const {
+      const ArcRegion &getRegion() const {
         return region_;
       }
 
-      size_t regionSize(void) const {
+      size_t regionSize() const {
         return region_.count();
       }
 
-      void clearSegmentation(void) {
+      void clearSegmentation() {
         region_.clear();
       }
 
       // access segmentation (after createSegmentation)
       // vector-like
 
-      inline size_t size(void) const {
+      inline size_t size() const {
         return region_.size();
       }
 
-      std::vector<SimplexId>::iterator begin(void) {
+      std::vector<SimplexId>::iterator begin() {
         return region_.begin();
       }
 
-      std::vector<SimplexId>::iterator end(void) {
+      std::vector<SimplexId>::iterator end() {
         return region_.end();
       }
 
@@ -235,7 +235,7 @@ namespace ttk {
         return region_.merge(s.region_);
       }
 
-      std::string printReg(void) const {
+      std::string printReg() const {
         return region_.print();
       }
     };

--- a/core/base/ftmTree/FTMTree.h
+++ b/core/base/ftmTree/FTMTree.h
@@ -12,8 +12,7 @@
 ///
 /// \sa ttkFTMTree.cpp %for a usage example.
 
-#ifndef FTMTREE_H
-#define FTMTREE_H
+#pragma once
 
 // base code includes
 #include <Geometry.h>
@@ -53,5 +52,3 @@ namespace ttk {
 
   } // namespace ftm
 } // namespace ttk
-
-#endif // TASKEDTREE_H

--- a/core/base/ftmTree/FTMTree.h
+++ b/core/base/ftmTree/FTMTree.h
@@ -37,7 +37,7 @@ namespace ttk {
       // -----------------
 
       FTMTree();
-      virtual ~FTMTree();
+      ~FTMTree() override;
 
       // -------
       // PROCESS

--- a/core/base/ftmTree/FTMTreeUtils.h
+++ b/core/base/ftmTree/FTMTreeUtils.h
@@ -5,9 +5,6 @@
 ///
 /// Utils function for manipulating FTMTree class
 
-#ifndef _FTMTREEUTILS_H
-#define _FTMTREEUTILS_H
-
 #pragma once
 
 #include <FTMTree_MT.h>
@@ -324,5 +321,3 @@ namespace ttk {
 
   } // namespace ftm
 } // namespace ttk
-
-#endif

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -5,9 +5,6 @@
 ///
 /// Utils function for manipulating FTMTree class
 
-#ifndef _FTMTREEUTILS_TEMPLATE_H
-#define _FTMTREEUTILS_TEMPLATE_H
-
 #pragma once
 
 namespace ttk {
@@ -405,5 +402,3 @@ namespace ttk {
 
   } // namespace ftm
 } // namespace ttk
-
-#endif

--- a/core/base/ftmTree/FTMTree_CT.cpp
+++ b/core/base/ftmTree/FTMTree_CT.cpp
@@ -310,7 +310,7 @@ void FTMTree_CT::createCTArcSegmentation(idSuperArc ctArc,
   }
 }
 
-void FTMTree_CT::finalizeSegmentation(void) {
+void FTMTree_CT::finalizeSegmentation() {
   Timer finSegmTime;
   const auto &nbArc = getNumberOfSuperArcs();
 
@@ -324,7 +324,7 @@ void FTMTree_CT::finalizeSegmentation(void) {
   printTime(finSegmTime, "post-process segm", 4);
 }
 
-void FTMTree_CT::insertNodes(void) {
+void FTMTree_CT::insertNodes() {
   vector<idNode> sortedJTNodes = jt_->sortedNodes(true);
   vector<idNode> sortedSTNodes = st_->sortedNodes(true);
 

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -12,8 +12,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef FTMTREE_CT_H
-#define FTMTREE_CT_H
+#pragma once
 
 #include <queue>
 #include <set>
@@ -117,5 +116,3 @@ namespace ttk {
 } // namespace ttk
 
 #include <FTMTree_CT_Template.h>
-
-#endif // CONTOURTREE_H

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -38,7 +38,7 @@ namespace ttk {
       // -----------------
 
       FTMTree_CT(Params *const params, Scalars *const scalars);
-      virtual ~FTMTree_CT();
+      ~FTMTree_CT() override;
 
       // -----------------
       // ACCESSOR
@@ -76,14 +76,14 @@ namespace ttk {
         st_->preconditionTriangulation(tri, false);
       }
 
-      inline int setDebugLevel(const int &d) {
+      inline int setDebugLevel(const int &d) override {
         Debug::setDebugLevel(d);
         jt_->setDebugLevel(d);
         st_->setDebugLevel(d);
         return 0;
       }
 
-      inline int setThreadNumber(const int n) {
+      inline int setThreadNumber(const int n) override {
         Debug::setThreadNumber(n);
         jt_->setThreadNumber(n);
         st_->setThreadNumber(n);

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -43,11 +43,11 @@ namespace ttk {
       // ACCESSOR
       // -----------------
 
-      inline FTMTree_MT *getJoinTree(void) const {
+      inline FTMTree_MT *getJoinTree() const {
         return jt_;
       }
 
-      inline FTMTree_MT *getSplitTree(void) const {
+      inline FTMTree_MT *getSplitTree() const {
         return st_;
       }
 
@@ -109,7 +109,7 @@ namespace ttk {
                                    const bool isJT,
                                    idSuperArc xtArc);
 
-      void finalizeSegmentation(void);
+      void finalizeSegmentation();
     };
 
   } // namespace ftm

--- a/core/base/ftmTree/FTMTree_CT_Template.h
+++ b/core/base/ftmTree/FTMTree_CT_Template.h
@@ -1,5 +1,4 @@
-#ifndef FTMTree_CT_Template_h_INCLUDED
-#define FTMTree_CT_Template_h_INCLUDED
+#pragma once
 
 #include <FTMTree_CT.h>
 
@@ -159,4 +158,3 @@ int FTMTree_CT::leafSearch(const triangulationType *mesh) {
 
 } // namespace ftm
 } // namespace ttk
-#endif // FTMTree_CT_Template_h_INCLUDED

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -368,7 +368,7 @@ void FTMTree_MT::delNode(idNode node) {
 #endif
 }
 
-void FTMTree_MT::finalizeSegmentation(void) {
+void FTMTree_MT::finalizeSegmentation() {
   for(auto &arc : *mt_data_.superArcs) {
     arc.createSegmentation(scalars_);
   }
@@ -548,7 +548,7 @@ void FTMTree_MT::move(FTMTree_MT *mt) {
   mt->mt_data_.vert2tree = nullptr;
 }
 
-void FTMTree_MT::normalizeIds(void) {
+void FTMTree_MT::normalizeIds() {
   Timer normTime;
   sortLeaves(true);
 
@@ -723,7 +723,7 @@ string FTMTree_MT::printNode(idNode n) {
   return res.str();
 }
 
-void FTMTree_MT::printParams(void) const {
+void FTMTree_MT::printParams() const {
   if(debugLevel_ > 1) {
     if(debugLevel_ > 2) {
       this->printMsg(ttk::debug::Separator::L1);

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -12,8 +12,7 @@
 /// etc.).
 ///
 
-#ifndef FTMTREE_MT_H
-#define FTMTREE_MT_H
+#pragma once
 
 #include <functional>
 #include <map>
@@ -942,5 +941,3 @@ namespace ttk {
 
 #include <FTMTreeUtils_Template.h>
 #include <FTMTree_MT_Template.h>
-
-#endif /* end of include guard: MERGETREE_H */

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -113,7 +113,7 @@ namespace ttk {
         scalars_->size = triangulation->getNumberOfVertices();
       }
 
-      void initComp(void) {
+      void initComp() {
         if(isST()) {
           comp_.vertLower
             = [this](const SimplexId a, const SimplexId b) -> bool {
@@ -141,10 +141,10 @@ namespace ttk {
 
       /// \brief if sortedVertices_ is null, define and fill it
       template <typename scalarType>
-      void sortInput(void);
+      void sortInput();
 
       /// \brief clear local data for new computation
-      void makeAlloc(void) {
+      void makeAlloc() {
         createAtomicVector<SuperArc>(mt_data_.superArcs);
 
         // Stats alloc
@@ -183,7 +183,7 @@ namespace ttk {
         mt_data_.segments_.clear();
       }
 
-      void makeInit(void) {
+      void makeInit() {
         initVector<idCorresp>(mt_data_.vert2tree, nullCorresp);
         initVector<SimplexId>(mt_data_.visitOrder, nullVertex);
         initVector<UF>(mt_data_.ufs, nullptr);
@@ -259,7 +259,7 @@ namespace ttk {
       void buildSegmentation();
 
       // Create the segmentation of all arcs by operating the pending operations
-      void finalizeSegmentation(void);
+      void finalizeSegmentation();
 
       void normalizeIds();
 
@@ -279,11 +279,11 @@ namespace ttk {
         return getSuperArc(arcId)->size();
       }
 
-      inline bool isJT(void) const {
+      inline bool isJT() const {
         return mt_data_.treeType == TreeType::Join;
       }
 
-      inline bool isST(void) const {
+      inline bool isST() const {
         return mt_data_.treeType == TreeType::Split;
       }
 
@@ -353,7 +353,7 @@ namespace ttk {
 
       // arcs
 
-      inline idSuperArc getNumberOfSuperArcs(void) const {
+      inline idSuperArc getNumberOfSuperArcs() const {
         return mt_data_.superArcs->size();
       }
 
@@ -379,7 +379,7 @@ namespace ttk {
 
       // nodes
 
-      inline idNode getNumberOfNodes(void) const {
+      inline idNode getNumberOfNodes() const {
         return mt_data_.nodes->size();
       }
 
@@ -393,11 +393,11 @@ namespace ttk {
 
       // leaves / root
 
-      inline idNode getNumberOfLeaves(void) const {
+      inline idNode getNumberOfLeaves() const {
         return mt_data_.leaves->size();
       }
 
-      inline const std::vector<idNode> &getLeaves(void) const {
+      inline const std::vector<idNode> &getLeaves() const {
         // break encapsulation...
         return (*mt_data_.leaves);
       }
@@ -412,14 +412,14 @@ namespace ttk {
         return (*mt_data_.leaves)[id];
       }
 
-      inline const std::vector<idNode> &getRoots(void) const {
+      inline const std::vector<idNode> &getRoots() const {
         // break encapsulation...
         return (*mt_data_.roots);
       }
 
       // vertices
 
-      inline SimplexId getNumberOfVertices(void) const {
+      inline SimplexId getNumberOfVertices() const {
         return scalars_->size;
       }
 
@@ -558,9 +558,9 @@ namespace ttk {
 
       std::string printNode(idNode n);
 
-      void printTree2(void);
+      void printTree2();
 
-      void printParams(void) const;
+      void printParams() const;
 
       int printTime(Timer &t,
                     const std::string &s,

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -103,7 +103,7 @@ namespace ttk {
       // Tree with global data and partition number
       FTMTree_MT(Params *const params, Scalars *const scalars, TreeType type);
 
-      virtual ~FTMTree_MT();
+      ~FTMTree_MT() override;
 
       // --------------------
       // Init

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -13,8 +13,7 @@
 ///
 /// \sa ttkContourForests.cpp %for a usage example.
 
-#ifndef FTMTREE_MT_TPL_H
-#define FTMTREE_MT_TPL_H
+#pragma once
 
 #include <functional>
 
@@ -526,5 +525,3 @@ namespace ttk {
   } // namespace ftm
 } // namespace ttk
 // Process
-
-#endif /* end of include guard: FTMTREE_MT_TPL_H */

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -509,7 +509,7 @@ namespace ttk {
     // ------------------------------------------------------------------------
 
     template <typename scalarType>
-    void ftm::FTMTree_MT::sortInput(void) {
+    void ftm::FTMTree_MT::sortInput() {
 
       const auto nbVertices = scalars_->size;
       scalars_->sortedVertices.resize(nbVertices);

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -13,8 +13,7 @@
 ///
 /// \sa ttkFTMTree.cpp %for a usage example.
 
-#ifndef FTMTREE_TPL_H
-#define FTMTREE_TPL_H
+#pragma once
 
 #include "FTMTree.h"
 
@@ -199,5 +198,3 @@ void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
     }
   }
 }
-
-#endif /* end of include guard: FTMTREE_TPL_H */

--- a/core/base/ftmTreePP/FTMTreePP.cpp
+++ b/core/base/ftmTreePP/FTMTreePP.cpp
@@ -21,5 +21,4 @@ using namespace ftm;
 FTMTreePP::FTMTreePP() : FTMTree() {
 }
 
-FTMTreePP::~FTMTreePP() {
-}
+FTMTreePP::~FTMTreePP() = default;

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -11,8 +11,7 @@
 ///
 /// \sa ttkPersistenceDiagram.cpp %for a usage example.
 
-#ifndef FTMTREE_PP_H
-#define FTMTREE_PP_H
+#pragma once
 
 #include "FTMTree.h"
 
@@ -210,5 +209,3 @@ void ttk::ftm::FTMTreePP::sortPairs(
 
   sort(pairs.begin(), pairs.end(), comp);
 }
-
-#endif // FTMTREE_PP_H

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -35,7 +35,7 @@ namespace ttk {
 
     public:
       FTMTreePP();
-      virtual ~FTMTreePP();
+      ~FTMTreePP() override;
 
       template <typename scalarType>
       void computePersistencePairs(

--- a/core/base/ftmTreePP/FTMTreePPUtils.h
+++ b/core/base/ftmTreePP/FTMTreePPUtils.h
@@ -5,9 +5,6 @@
 ///
 /// Utils function for manipulating FTMTree class
 
-#ifndef _FTMTREEPPUTILS_H
-#define _FTMTREEPPUTILS_H
-
 #pragma once
 
 #include <FTMTree.h>
@@ -45,5 +42,3 @@ namespace ttk {
 
   } // namespace ftm
 } // namespace ttk
-
-#endif

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -183,13 +183,13 @@ namespace ttk {
 
       // Debug
 
-      std::string print(void);
+      std::string print();
 
       std::string print(const std::function<std::string(std::size_t)> &);
 
-      std::string printNbCC(void);
+      std::string printNbCC();
 
-      void test(void);
+      void test();
     };
 
     // Same as dynamic graph but keep the number of subtrees at any time
@@ -312,11 +312,11 @@ namespace ttk {
       // Accessor functions
       // ------------------
 
-      Type getWeight(void) const {
+      Type getWeight() const {
         return weight_;
       }
 
-      bool hasParent(void) const {
+      bool hasParent() const {
         return parent_;
       }
 
@@ -325,14 +325,14 @@ namespace ttk {
 
       /// Make this node the root of its tree
       // Various way to do that, test perfs ?
-      void evert(void);
+      void evert();
 
       /// Get representative node
-      DynGraphNode *findRoot(void) const;
+      DynGraphNode *findRoot() const;
 
       /// Get the arcs corresponding to this subtree:
       /// find the root before
-      idSuperArc findRootArc(void) const;
+      idSuperArc findRootArc() const;
 
       /// Get the arcs corresponding to this subtree
       idSuperArc getCorArc() const {
@@ -361,7 +361,7 @@ namespace ttk {
 
       /// Remove the link between this node and its parent, thus makeing a new
       /// root
-      void removeEdge(void);
+      void removeEdge();
     };
   } // namespace ftr
 } // namespace ttk

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -34,7 +34,7 @@ namespace ttk {
 
     public:
       DynamicGraph();
-      virtual ~DynamicGraph();
+      ~DynamicGraph() override;
 
       // Initialize functions
       // --------------------

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -11,8 +11,7 @@
 ///
 /// \sa ttk::FTRGraph
 
-#ifndef DYNAMICGRAPH_H
-#define DYNAMICGRAPH_H
+#pragma once
 
 #include "FTRCommon.h"
 
@@ -368,5 +367,3 @@ namespace ttk {
 } // namespace ttk
 
 #include "DynamicGraph_Template.h"
-
-#endif /* end of include guard: DYNAMICGRAPH_H */

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -215,7 +215,7 @@ namespace ttk {
         // corArc_ = corArc;
 
         // remove old
-        std::get<1>(nNodes)->parent_ = 0;
+        std::get<1>(nNodes)->parent_ = nullptr;
         std::get<1>(nNodes)->corArc_ = corArc;
       } else {
         corArc_ = corArc;

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -10,12 +10,10 @@ namespace ttk {
     // DynamicGraph ----------------------------------
 
     template <typename Type>
-    DynamicGraph<Type>::DynamicGraph() {
-    }
+    DynamicGraph<Type>::DynamicGraph() = default;
 
     template <typename Type>
-    DynamicGraph<Type>::~DynamicGraph() {
-    }
+    DynamicGraph<Type>::~DynamicGraph() = default;
 
     template <typename Type>
     void DynamicGraph<Type>::alloc() {

--- a/core/base/ftrGraph/DynamicGraph_Template.h
+++ b/core/base/ftrGraph/DynamicGraph_Template.h
@@ -41,7 +41,7 @@ namespace ttk {
     }
 
     template <typename Type>
-    std::string DynamicGraph<Type>::print(void) {
+    std::string DynamicGraph<Type>::print() {
 
       std::stringstream res;
 
@@ -84,7 +84,7 @@ namespace ttk {
     }
 
     template <typename Type>
-    std::string DynamicGraph<Type>::printNbCC(void) {
+    std::string DynamicGraph<Type>::printNbCC() {
 
       std::stringstream res;
       std::vector<DynGraphNode<Type> *> roots;
@@ -103,7 +103,7 @@ namespace ttk {
     // DynGraphNode ----------------------------------
 
     template <typename Type>
-    void DynGraphNode<Type>::evert(void) {
+    void DynGraphNode<Type>::evert() {
       if(!parent_)
         return;
 
@@ -139,7 +139,7 @@ namespace ttk {
     }
 
     template <typename Type>
-    DynGraphNode<Type> *DynGraphNode<Type>::findRoot(void) const {
+    DynGraphNode<Type> *DynGraphNode<Type>::findRoot() const {
       // the lastNode trick is used so we are sure to have a non null
       // return even if another thread is touching these nodes.
       DynGraphNode *curNode = const_cast<DynGraphNode<Type> *>(this);
@@ -155,7 +155,7 @@ namespace ttk {
     }
 
     template <typename Type>
-    idSuperArc DynGraphNode<Type>::findRootArc(void) const {
+    idSuperArc DynGraphNode<Type>::findRootArc() const {
       const auto root = findRoot();
       return root != nullptr ? root->corArc_ : -1;
     }
@@ -223,7 +223,7 @@ namespace ttk {
     }
 
     template <typename Type>
-    void DynGraphNode<Type>::removeEdge(void) {
+    void DynGraphNode<Type>::removeEdge() {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(!parent_) {
         Debug dbg{};

--- a/core/base/ftrGraph/FTRAtomicUF.h
+++ b/core/base/ftrGraph/FTRAtomicUF.h
@@ -48,7 +48,7 @@ namespace ttk {
 
       // Shared data get/set
 
-      inline Propagation *getPropagation(void) {
+      inline Propagation *getPropagation() {
         return prop_;
       }
 

--- a/core/base/ftrGraph/FTRAtomicUF.h
+++ b/core/base/ftrGraph/FTRAtomicUF.h
@@ -9,8 +9,7 @@
 ///
 /// \sa ftrGraph
 
-#ifndef ATOMICUFFTR_H
-#define ATOMICUFFTR_H
+#pragma once
 
 // c++ includes
 #include <memory>
@@ -126,5 +125,3 @@ namespace ttk {
 
   } // namespace ftr
 } // namespace ttk
-
-#endif /* end of include guard: ATOMICUFFTR_H */

--- a/core/base/ftrGraph/FTRAtomicUF.h
+++ b/core/base/ftrGraph/FTRAtomicUF.h
@@ -100,10 +100,10 @@ namespace ttk {
       }
 
       static inline AtomicUF *makeUnion(std::vector<AtomicUF *> &sets) {
-        AtomicUF *n = NULL;
+        AtomicUF *n = nullptr;
 
         if(!sets.size())
-          return NULL;
+          return nullptr;
 
         if(sets.size() == 1)
           return sets[0];

--- a/core/base/ftrGraph/FTRAtomicVector.h
+++ b/core/base/ftrGraph/FTRAtomicVector.h
@@ -6,8 +6,7 @@
 ///\brief TTK processing package that manage a paralle version of vector *Same
 /// as in FTM: Common ?*
 
-#ifndef FTRATOMICVECTOR_H
-#define FTRATOMICVECTOR_H
+#pragma once
 
 #include "BaseClass.h"
 
@@ -201,5 +200,3 @@ namespace ttk {
     }
   };
 } // namespace ttk
-
-#endif /* end of include guard: FTRATOMICVECTOR_H */

--- a/core/base/ftrGraph/FTRAtomicVector.h
+++ b/core/base/ftrGraph/FTRAtomicVector.h
@@ -96,7 +96,7 @@ namespace ttk {
       nextId = nId;
     }
 
-    void clear(void) {
+    void clear() {
       reset();
 
       // Remove old content
@@ -105,7 +105,7 @@ namespace ttk {
       reserve(oldSize, true);
     }
 
-    std::size_t getNext(void) {
+    std::size_t getNext() {
       std::size_t resId;
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic capture
@@ -119,11 +119,11 @@ namespace ttk {
       return resId;
     }
 
-    std::size_t size(void) const {
+    std::size_t size() const {
       return nextId;
     }
 
-    bool empty(void) const {
+    bool empty() const {
       return nextId == 0;
     }
 
@@ -139,7 +139,7 @@ namespace ttk {
       (*this)[curPos] = elmt;
     }
 
-    void pop_back(void) {
+    void pop_back() {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic update
 #endif

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -147,7 +147,7 @@ namespace ttk {
       // Accessor on the graph
       // ---------------------
 
-      Graph &&extractOutputGraph(void) {
+      Graph &&extractOutputGraph() {
         return std::move(graph_);
       }
 
@@ -229,7 +229,7 @@ namespace ttk {
 
       // Print function (FTRGraphPrint)
 
-      std::string printMesh(void) const;
+      std::string printMesh() const;
 
       std::string printEdge(const idEdge edgeId,
                             const Propagation *const localProp) const;

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -164,7 +164,7 @@ namespace ttk {
       }
 
       /// Control the verbosity of the base code
-      virtual int setDebugLevel(const int &lvl) override {
+      int setDebugLevel(const int &lvl) override {
         params_.debugLevel = lvl;
         return Debug::setDebugLevel(lvl);
       }

--- a/core/base/ftrGraph/FTRGraphPrint_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrint_Template.h
@@ -6,7 +6,7 @@ namespace ttk {
   namespace ftr {
 
     template <typename ScalarType, typename triangulationType>
-    std::string FTRGraph<ScalarType, triangulationType>::printMesh(void) const {
+    std::string FTRGraph<ScalarType, triangulationType>::printMesh() const {
       std::stringstream res;
 
       res << "cells     : " << mesh_.getNumberOfCells() << std::endl;

--- a/core/base/ftrGraph/FTRLazy.h
+++ b/core/base/ftrGraph/FTRLazy.h
@@ -28,8 +28,7 @@ namespace ttk {
       std::vector<std::set<linkEdge>> lazyAdd_;
 
     public:
-      Lazy() {
-      }
+      Lazy() = default;
 
       void alloc() override {
         lazyAdd_.resize(nbElmt_);

--- a/core/base/ftrGraph/FTRNode.h
+++ b/core/base/ftrGraph/FTRNode.h
@@ -31,7 +31,7 @@ namespace ttk {
         : vertexIdentifier_(vertIdentifier) {
       }
 
-      idVertex getVertexIdentifier(void) const {
+      idVertex getVertexIdentifier() const {
         return vertexIdentifier_;
       }
 
@@ -82,7 +82,7 @@ namespace ttk {
         upArcsIds_.reserve(nbUpArc);
       }
 
-      idSuperArc getNbUpArcs(void) const {
+      idSuperArc getNbUpArcs() const {
         return upArcsIds_.size();
       }
 
@@ -98,7 +98,7 @@ namespace ttk {
         downArcsIds_.reserve(nbDownArcs);
       }
 
-      idSuperArc getNbDownArcs(void) const {
+      idSuperArc getNbDownArcs() const {
         return downArcsIds_.size();
       }
 

--- a/core/base/ftrGraph/FTRPropagation.h
+++ b/core/base/ftrGraph/FTRPropagation.h
@@ -55,7 +55,7 @@ namespace ttk {
 
       Propagation(const Propagation &other) = delete;
 
-      idVertex getCurVertex(void) const {
+      idVertex getCurVertex() const {
         return curVert_;
       }
 
@@ -67,7 +67,7 @@ namespace ttk {
         curVert_ = v;
       }
 
-      idSuperArc getNbArcs(void) const {
+      idSuperArc getNbArcs() const {
         return nbArcs_;
       }
 
@@ -83,17 +83,17 @@ namespace ttk {
         // std::endl;
       }
 
-      AtomicUF *getId(void) {
+      AtomicUF *getId() {
         return id_.find();
       }
 
-      idVertex nextVertex(void) {
+      idVertex nextVertex() {
         curVert_ = propagation_.top();
         removeDuplicates(curVert_);
         return curVert_;
       }
 
-      idVertex getNextVertex(void) const {
+      idVertex getNextVertex() const {
 #ifndef TTK_ENABLE_KAMIKAZE
         if(propagation_.empty()) {
           std::cerr << "[FTR]: Propagation get next on empty structure"
@@ -136,7 +136,7 @@ namespace ttk {
         return propagation_.empty();
       }
 
-      void clear(void) {
+      void clear() {
         propagation_.clear();
       }
 
@@ -149,11 +149,11 @@ namespace ttk {
       }
 
       // true if propagation initiated form a min leaf
-      bool goUp(void) const {
+      bool goUp() const {
         return goUp_;
       }
 
-      bool goDown(void) const {
+      bool goDown() const {
         return !goUp_;
       }
 

--- a/core/base/ftrGraph/FTRPropagation.h
+++ b/core/base/ftrGraph/FTRPropagation.h
@@ -10,8 +10,7 @@
 ///
 /// \sa ttk::FTRGraph
 
-#ifndef PROPAGATION_H
-#define PROPAGATION_H
+#pragma once
 
 // local include
 #include "FTRAtomicUF.h"
@@ -188,5 +187,3 @@ namespace ttk {
     };
   } // namespace ftr
 } // namespace ttk
-
-#endif /* end of include guard: PROPAGATION_H */

--- a/core/base/ftrGraph/FTRPropagations.h
+++ b/core/base/ftrGraph/FTRPropagations.h
@@ -8,8 +8,7 @@
 /// \sa ttk::Triangulation
 /// \sa FTRGraph.h %for a usage example.
 
-#ifndef PROPAGATIONS_H
-#define PROPAGATIONS_H
+#pragma once
 
 // local includes
 #include "FTRAtomicVector.h"
@@ -143,5 +142,3 @@ namespace ttk {
     };
   } // namespace ftr
 } // namespace ttk
-
-#endif /* end of include guard: PROPAGATIONS_H */

--- a/core/base/ftrGraph/FTRPropagations.h
+++ b/core/base/ftrGraph/FTRPropagations.h
@@ -36,7 +36,7 @@ namespace ttk {
       Visits visits_;
 
     public:
-      virtual ~Propagations() {
+      ~Propagations() override {
         for(Propagation *p : propagations_) {
           delete p;
         }

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -41,7 +41,7 @@ namespace ttk {
         return offsets_;
       }
 
-      idVertex getSize(void) const {
+      idVertex getSize() const {
         return size_;
       }
 
@@ -95,7 +95,7 @@ namespace ttk {
         }
       }
 
-      void removeNaN(void) {
+      void removeNaN() {
         // This section is aimed to prevent un-deterministic results if the
         // data-set have NaN values in it. In this loop, we replace every NaN by
         // a 0 value. Recall: Equals values are distinguished using Simulation

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -28,8 +28,7 @@ namespace ttk {
       std::vector<Vert<ScalarType>> vertices_{};
 
     public:
-      Scalars() {
-      }
+      Scalars() = default;
 
       // Heavy, prevent using it
       Scalars(const Scalars &o) = delete;

--- a/core/base/ftrGraph/FTRSegmentation.cpp
+++ b/core/base/ftrGraph/FTRSegmentation.cpp
@@ -28,23 +28,23 @@ Segment::Segment(idVertex size) : vertices_(size, nullVertex) {
 
 Segment::Segment() = default;
 
-segm_const_it Segment::begin(void) const {
+segm_const_it Segment::begin() const {
   return vertices_.begin();
 }
 
-segm_it Segment::begin(void) {
+segm_it Segment::begin() {
   return vertices_.begin();
 }
 
-segm_const_it Segment::end(void) const {
+segm_const_it Segment::end() const {
   return vertices_.end();
 }
 
-segm_it Segment::end(void) {
+segm_it Segment::end() {
   return vertices_.end();
 }
 
-idVertex Segment::size(void) const {
+idVertex Segment::size() const {
   return vertices_.size();
 }
 

--- a/core/base/ftrGraph/FTRSegmentation.cpp
+++ b/core/base/ftrGraph/FTRSegmentation.cpp
@@ -26,8 +26,7 @@ using namespace ftr;
 Segment::Segment(idVertex size) : vertices_(size, nullVertex) {
 }
 
-Segment::Segment() {
-}
+Segment::Segment() = default;
 
 segm_const_it Segment::begin(void) const {
   return vertices_.begin();

--- a/core/base/ftrGraph/FTRSegmentation.h
+++ b/core/base/ftrGraph/FTRSegmentation.h
@@ -37,11 +37,11 @@ namespace ttk {
       explicit Segment(idVertex size);
       Segment();
 
-      segm_const_it begin(void) const;
-      segm_const_it end(void) const;
-      segm_it begin(void);
-      segm_it end(void);
-      idVertex size(void) const;
+      segm_const_it begin() const;
+      segm_const_it end() const;
+      segm_it begin();
+      segm_it end();
+      idVertex size() const;
       void reserve(const idVertex size);
       void emplace_back(const idVertex v);
 

--- a/core/base/ftrGraph/FTRSegmentation.h
+++ b/core/base/ftrGraph/FTRSegmentation.h
@@ -8,8 +8,7 @@
 ///\param dataType Data type of the input scalar field (char, float,
 /// etc.).
 
-#ifndef FTR_SEGMENTATION_H_
-#define FTR_SEGMENTATION_H_
+#pragma once
 
 #include "FTRDataTypes.h"
 #include "FTRScalars.h"
@@ -52,5 +51,3 @@ namespace ttk {
 
   } // namespace ftr
 } // namespace ttk
-
-#endif /* end of include guard: FTR_SEGMENTATION_H_ */

--- a/core/base/ftrGraph/FTRSuperArc.h
+++ b/core/base/ftrGraph/FTRSuperArc.h
@@ -45,7 +45,7 @@ namespace ttk {
         this->setDebugMsgPrefix("SuperNode");
       }
 
-      idNode getUpNodeId(void) const {
+      idNode getUpNodeId() const {
         // Caution. can be nullNode
         return upNodeId_;
       }
@@ -54,7 +54,7 @@ namespace ttk {
         upNodeId_ = id;
       }
 
-      idNode getDownNodeId(void) const {
+      idNode getDownNodeId() const {
 #ifndef TTK_ENABLE_KAMIKAZE
         if(downNodeId_ == nullNode) {
           this->printErr("Arc have null down node");
@@ -67,7 +67,7 @@ namespace ttk {
         downNodeId_ = id;
       }
 
-      Propagation *getPropagation(void) const {
+      Propagation *getPropagation() const {
 #ifndef TTK_ENABLE_KAMIKAZE
         if(!ufProp_) {
           this->printErr("Arc have null UF propagation");
@@ -80,13 +80,13 @@ namespace ttk {
         ufProp_ = UFprop;
       }
 
-      bool hide(void) {
+      bool hide() {
         bool old = visible_;
         visible_ = false;
         return old;
       }
 
-      bool isVisible(void) const {
+      bool isVisible() const {
         return visible_;
       }
 
@@ -108,7 +108,7 @@ namespace ttk {
         }
       }
 
-      idVertex getEnd(void) const {
+      idVertex getEnd() const {
         return endV_;
       }
 
@@ -131,15 +131,15 @@ namespace ttk {
         }
       }
 
-      bool merged(void) const {
+      bool merged() const {
         return merged_ != nullSuperArc;
       }
 
-      idSuperArc mergedIn(void) const {
+      idSuperArc mergedIn() const {
         return merged_;
       }
 
-      void restore(void) {
+      void restore() {
         visible_ = true;
         merged_ = nullSuperArc;
       }

--- a/core/base/ftrGraph/Graph.cpp
+++ b/core/base/ftrGraph/Graph.cpp
@@ -7,11 +7,9 @@ using namespace std;
 using namespace ttk;
 using namespace ftr;
 
-Graph::Graph() {
-}
+Graph::Graph() = default;
 
-Graph::~Graph() {
-}
+Graph::~Graph() = default;
 
 std::string Graph::print(const int verbosity) const {
   stringstream res;

--- a/core/base/ftrGraph/Graph.h
+++ b/core/base/ftrGraph/Graph.h
@@ -81,15 +81,15 @@ namespace ttk {
       // Accessor on structure
       // ---------------------
 
-      idNode getNumberOfNodes(void) const {
+      idNode getNumberOfNodes() const {
         return nodes_.size();
       }
 
-      idSuperArc getNumberOfArcs(void) const {
+      idSuperArc getNumberOfArcs() const {
         return arcs_.size();
       }
 
-      idSuperArc getNumberOfVisibleArcs(void) const {
+      idSuperArc getNumberOfVisibleArcs() const {
         idSuperArc res = 0;
         for(const auto &arc : arcs_) {
           if(arc.isVisible())
@@ -98,7 +98,7 @@ namespace ttk {
         return res;
       }
 
-      idNode getNumberOfLeaves(void) const {
+      idNode getNumberOfLeaves() const {
         return leaves_.size();
       }
 

--- a/core/base/ftrGraph/Graph.h
+++ b/core/base/ftrGraph/Graph.h
@@ -10,8 +10,7 @@
 ///
 /// \sa ttk::FTRGraph
 
-#ifndef GRAPH_H
-#define GRAPH_H
+#pragma once
 
 #include "FTRAtomicVector.h"
 #include "FTRCommon.h"
@@ -370,5 +369,3 @@ namespace ttk {
 } // namespace ttk
 
 #include "Graph_Template.h"
-
-#endif /* end of include guard: GRAPH_H */

--- a/core/base/ftrGraph/Graph.h
+++ b/core/base/ftrGraph/Graph.h
@@ -58,7 +58,7 @@ namespace ttk {
       Graph();
       Graph(Graph &&other) noexcept = default;
       Graph(const Graph &other) = delete;
-      virtual ~Graph();
+      ~Graph() override;
 
       Graph &operator=(Graph &&other) noexcept {
         if(this != &other) {

--- a/core/base/ftrGraph/Graph_Template.h
+++ b/core/base/ftrGraph/Graph_Template.h
@@ -1,5 +1,4 @@
-#ifndef GRAPH_TEMPLATE_H
-#define GRAPH_TEMPLATE_H
+#pragma once
 
 #ifndef NDEBUG
 // #include<sstream>
@@ -242,5 +241,3 @@ namespace ttk {
   } // namespace ftr
 
 } // namespace ttk
-
-#endif /* end of include guard: GRAPH_TEMPLATE_H */

--- a/core/base/ftrGraph/Mesh.h
+++ b/core/base/ftrGraph/Mesh.h
@@ -82,15 +82,15 @@ namespace ttk {
         return tri_;
       }
 
-      void alloc(void) override {
+      void alloc() override {
         edgesSortId_.resize(nbEdges_);
         trianglesSortId_.resize(nbTriangles_);
       }
 
-      void init(void) override {
+      void init() override {
       }
 
-      void preprocess(void) {
+      void preprocess() {
         tri_->preconditionVertexNeighbors();
         tri_->preconditionVertexEdges();
         tri_->preconditionVertexTriangles();
@@ -104,23 +104,23 @@ namespace ttk {
 
       // Facade Triangulation
 
-      inline SimplexId getDimensionality(void) const {
+      inline SimplexId getDimensionality() const {
         return tri_->getDimensionality();
       }
 
-      inline idVertex getNumberOfVertices(void) const {
+      inline idVertex getNumberOfVertices() const {
         return nbVerts_;
       }
 
-      inline idEdge getNumberOfEdges(void) const {
+      inline idEdge getNumberOfEdges() const {
         return nbEdges_;
       }
 
-      inline idCell getNumberOfTriangles(void) const {
+      inline idCell getNumberOfTriangles() const {
         return nbTriangles_;
       }
 
-      inline idCell getNumberOfCells(void) const {
+      inline idCell getNumberOfCells() const {
         return tri_->getNumberOfCells();
       }
 
@@ -216,7 +216,7 @@ namespace ttk {
 
       // tools
 
-      std::string printEdges(void) const;
+      std::string printEdges() const;
 
       std::string printEdge(const idEdge e) const;
     };
@@ -499,7 +499,7 @@ namespace ttk {
     }
 
     template <typename triangulationType>
-    std::string Mesh<triangulationType>::printEdges(void) const {
+    std::string Mesh<triangulationType>::printEdges() const {
       std::stringstream res;
       res << " edges: " << std::endl;
       for(idEdge i = 0; i < nbEdges_; ++i) {

--- a/core/base/ftrGraph/Mesh.h
+++ b/core/base/ftrGraph/Mesh.h
@@ -46,8 +46,7 @@ namespace ttk {
     struct triScheme {
       unsigned int scheme : 3;
 
-      triScheme() {
-      }
+      triScheme() = default;
 
       triScheme(const char u) : scheme(u) {
       }
@@ -73,8 +72,7 @@ namespace ttk {
       explicit Mesh(triangulationType *tri) : tri_{tri} {
       }
 
-      Mesh() {
-      }
+      Mesh() = default;
 
       void setTriangulation(triangulationType *tri) {
         tri_ = tri;

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -247,7 +247,7 @@ namespace ttk {
     bool isTriangleColinear(const T *p0,
                             const T *p1,
                             const T *p2,
-                            const T *tolerance = NULL);
+                            const T *tolerance = nullptr);
 
     /// Compute the magnitude of a 3D std::vector \p v.
     /// \param v xyz coordinates of the input std::vector.

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -60,8 +60,7 @@ ImplicitTriangulation::ImplicitTriangulation()
   setDebugMsgPrefix("ImplicitTriangulation");
 }
 
-ImplicitTriangulation::~ImplicitTriangulation() {
-}
+ImplicitTriangulation::~ImplicitTriangulation() = default;
 
 int ImplicitTriangulation::setInputGrid(const float &xOrigin,
                                         const float &yOrigin,

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -21,7 +21,7 @@ namespace ttk {
 
   public:
     ImplicitTriangulation();
-    ~ImplicitTriangulation();
+    ~ImplicitTriangulation() override;
 
     ImplicitTriangulation(const ImplicitTriangulation &) = default;
     ImplicitTriangulation(ImplicitTriangulation &&) = default;

--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -41,7 +41,7 @@ namespace ttk {
                 const dataTypeU *const uField,
                 const dataTypeV *const vField,
                 const triangulationType &triangulation,
-                std::vector<char> *isPareto = NULL);
+                std::vector<char> *isPareto = nullptr);
 
     template <class dataTypeU, class dataTypeV, typename triangulationType>
     char getCriticalType(const SimplexId &edgeId,

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -8,9 +8,6 @@
 
 #pragma once
 
-#ifndef _KDTREE_H
-#define _KDTREE_H
-
 // base code includes
 #include <Debug.h>
 #include <Geometry.h> // for pow
@@ -421,5 +418,3 @@ namespace ttk {
   }
 } // namespace ttk
 #include <buildWeights.h>
-
-#endif

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -54,7 +54,7 @@ namespace ttk {
       LocalizedTopologicalSimplification() {
         this->setDebugMsgPrefix("LTS");
       }
-      ~LocalizedTopologicalSimplification() = default;
+      ~LocalizedTopologicalSimplification() override = default;
 
       int preconditionTriangulation(
         ttk::AbstractTriangulation *triangulation) const {

--- a/core/base/lowestCommonAncestor/LowestCommonAncestor.h
+++ b/core/base/lowestCommonAncestor/LowestCommonAncestor.h
@@ -51,7 +51,7 @@ namespace ttk {
     /// Add a node in the tree
     /// \return Returns the id of the new node
     inline int addNode() {
-      node_.push_back(Node());
+      node_.emplace_back();
       int id = static_cast<int>(node_.size());
       node_[id].setAncestor(id);
       return id;

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
@@ -11,12 +11,12 @@ MandatoryCriticalPoints::MandatoryCriticalPoints() {
 }
 
 void MandatoryCriticalPoints::flush() {
-  inputUpperBoundField_ = NULL;
-  inputLowerBoundField_ = NULL;
-  outputMandatoryMinimum_ = NULL;
-  outputMandatoryJoinSaddle_ = NULL;
-  outputMandatorySplitSaddle_ = NULL;
-  outputMandatoryMaximum_ = NULL;
+  inputUpperBoundField_ = nullptr;
+  inputLowerBoundField_ = nullptr;
+  outputMandatoryMinimum_ = nullptr;
+  outputMandatoryJoinSaddle_ = nullptr;
+  outputMandatorySplitSaddle_ = nullptr;
+  outputMandatoryMaximum_ = nullptr;
   vertexNumber_ = 0;
   upperJoinTree_.flush();
   lowerJoinTree_.flush();

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
@@ -626,8 +626,7 @@ int MandatoryCriticalPoints::enumerateMandatoryExtrema(
       mandatoryExtremum.push_back(vertexId[i]);
       // Mark all the super arcs in the sub tree as visited and compute the
       // critical interval
-      criticalInterval.push_back(
-        std::pair<double, double>(vertexValue[i], vertexValue[i]));
+      criticalInterval.emplace_back(vertexValue[i], vertexValue[i]);
       for(int j = 0; j < (int)subTreeSuperArcId.size(); j++) {
         isSuperArcAlreadyVisited[subTreeSuperArcId[j]] = true;
         int downNodeId
@@ -1125,8 +1124,8 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
   for(unsigned int i = 0; i < lowerSaddleList.size(); i++) {
     if(!isLowerVisited[i]) {
       // New component
-      lowComponent.push_back(std::vector<int>());
-      uppComponent.push_back(std::vector<int>());
+      lowComponent.emplace_back();
+      uppComponent.emplace_back();
       int componentId = static_cast<int>(lowComponent.size()) - 1;
       lowComponent[componentId].push_back(i);
       isLowerVisited[i] = true;
@@ -1223,8 +1222,7 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
     mandatoryMergedExtrema_tmp[i].resize(
       distance(mandatoryMergedExtrema_tmp[i].begin(), newEnd));
     mandatoryMergedExtrema_tmp[i].shrink_to_fit();
-    order.push_back(
-      std::pair<int, int>(i, mandatoryMergedExtrema_tmp[i].size()));
+    order.emplace_back(i, mandatoryMergedExtrema_tmp[i].size());
   }
   // Sort by number of merged extrema
   mandatorySaddleComparaison cmp;

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
@@ -500,7 +500,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int setSoSoffsets(int *offsets = NULL) {
+    inline int setSoSoffsets(int *offsets = nullptr) {
       if((int)vertexSoSoffsets_.size() != vertexNumber_)
         vertexSoSoffsets_.resize(vertexNumber_);
       if(offsets) {

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
@@ -444,7 +444,7 @@ namespace ttk {
       return 0;
     }
 
-    inline int setDebugLevel(const int &debugLevel) {
+    inline int setDebugLevel(const int &debugLevel) override {
       Debug::setDebugLevel(debugLevel);
       upperJoinTree_.setDebugLevel(debugLevel);
       lowerJoinTree_.setDebugLevel(debugLevel);

--- a/core/base/manifoldCheck/ManifoldCheck.cpp
+++ b/core/base/manifoldCheck/ManifoldCheck.cpp
@@ -11,5 +11,4 @@ ManifoldCheck::ManifoldCheck() {
   this->setDebugMsgPrefix("ManifoldCheck");
 }
 
-ManifoldCheck::~ManifoldCheck() {
-}
+ManifoldCheck::~ManifoldCheck() = default;

--- a/core/base/manifoldCheck/ManifoldCheck.cpp
+++ b/core/base/manifoldCheck/ManifoldCheck.cpp
@@ -5,9 +5,9 @@ using namespace ttk;
 
 ManifoldCheck::ManifoldCheck() {
 
-  vertexLinkComponentNumber_ = NULL;
-  edgeLinkComponentNumber_ = NULL;
-  triangleLinkComponentNumber_ = NULL;
+  vertexLinkComponentNumber_ = nullptr;
+  edgeLinkComponentNumber_ = nullptr;
+  triangleLinkComponentNumber_ = nullptr;
   this->setDebugMsgPrefix("ManifoldCheck");
 }
 

--- a/core/base/manifoldCheck/ManifoldCheck.h
+++ b/core/base/manifoldCheck/ManifoldCheck.h
@@ -30,7 +30,7 @@ namespace ttk {
   public:
     ManifoldCheck();
 
-    ~ManifoldCheck();
+    ~ManifoldCheck() override;
 
     /// Execute the package.
     template <class triangulationType = AbstractTriangulation>

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -59,7 +59,7 @@ namespace ttk {
       omp_set_nested(1);
 #endif
     }
-    ~MergeTreeBarycenter() = default;
+    ~MergeTreeBarycenter() override = default;
 
     void setTol(double tolT) {
       tol_ = tolT;

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -211,7 +211,7 @@ namespace ttk {
       // Get nodes and scalars to add
       std::queue<std::tuple<ftm::idNode, ftm::idNode>> queue;
       queue.emplace(std::make_tuple(nodeId2, nodeId1));
-      nodesToProcess.push_back(std::make_tuple(nodeId2, nodeId1, i));
+      nodesToProcess.emplace_back(nodeId2, nodeId1, i);
       while(!queue.empty()) {
         auto queueTuple = queue.front();
         queue.pop();
@@ -225,7 +225,7 @@ namespace ttk {
         tree2->getChildren(node, children);
         for(auto child : children) {
           queue.emplace(std::make_tuple(child, nodeCpt + 1));
-          nodesToProcess.push_back(std::make_tuple(child, nodeCpt + 1, i));
+          nodesToProcess.emplace_back(child, nodeCpt + 1, i);
         }
         nodeCpt += 2; // we will add two nodes (birth and death)
       }
@@ -396,8 +396,8 @@ namespace ttk {
             std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
               nodesProcessedT;
             for(auto tup : nodesProcessed[i])
-              nodesProcessedT.push_back(
-                std::make_tuple(std::get<0>(tup), std::get<1>(tup), -1));
+              nodesProcessedT.emplace_back(
+                std::get<0>(tup), std::get<1>(tup), -1);
             matchings[i].insert(matchings[i].end(), nodesProcessedT.begin(),
                                 nodesProcessedT.end());
           }

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -439,15 +439,15 @@ namespace ttk {
         // Init vector with all origins
         std::vector<std::tuple<ftm::idNode, int>> vecOrigins;
         for(auto nodeMergedOrigin : treeNodeMerged[node]) {
-          vecOrigins.push_back(std::make_tuple(nodeMergedOrigin, 0));
+          vecOrigins.emplace_back(nodeMergedOrigin, 0);
           for(auto multiPersOrigin :
               treeMultiPers[tree->getNode(nodeMergedOrigin)->getOrigin()])
-            vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
+            vecOrigins.emplace_back(multiPersOrigin, 1);
         }
         if(not tree->isNodeMerged(node))
           for(auto multiPersOrigin : treeMultiPers[node])
-            vecOrigins.push_back(std::make_tuple(multiPersOrigin, 1));
-        vecOrigins.push_back(std::make_tuple(nodeOrigin, 2));
+            vecOrigins.emplace_back(multiPersOrigin, 1);
+        vecOrigins.emplace_back(nodeOrigin, 2);
 
         bool splitRoot = (vecOrigins.size() != 1 and treeNew->isRoot(node));
         splitRoot = false; // disabled
@@ -711,11 +711,11 @@ namespace ttk {
         if(tree->isLeaf(node)) {
           if(tree->isNodeAlone(nodeOrigin)) {
             if(not isFM)
-              nodeParent.push_back(std::make_tuple(nodeOrigin, node));
+              nodeParent.emplace_back(nodeOrigin, node);
             else
-              nodeParent.push_back(std::make_tuple(node, nodeOrigin));
+              nodeParent.emplace_back(node, nodeOrigin);
           } else if(tree->isMultiPersPair(node)) {
-            nodeParent.push_back(std::make_tuple(node, nodeOrigin));
+            nodeParent.emplace_back(node, nodeOrigin);
           }
           continue;
         }
@@ -741,7 +741,7 @@ namespace ttk {
           if(tree->isMultiPersPair(children[i]))
             continue;
           int index = getIndexNotMultiPers(i - 1, tree, children);
-          nodeParent.push_back(std::make_tuple(children[i], children[index]));
+          nodeParent.emplace_back(children[i], children[index]);
         }
 
         bool multiPersPair
@@ -750,15 +750,15 @@ namespace ttk {
           if(not isFM) {
             int index
               = getIndexNotMultiPers(children.size() - 1, tree, children);
-            nodeParent.push_back(std::make_tuple(nodeOrigin, children[index]));
+            nodeParent.emplace_back(nodeOrigin, children[index]);
           } else
-            nodeParent.push_back(std::make_tuple(children[0], node));
+            nodeParent.emplace_back(children[0], node);
         } else {
           // std::cout << "branchDecompositionToTree multiPersPair" <<
           // std::endl;
-          nodeParent.push_back(std::make_tuple(children[0], nodeOrigin));
+          nodeParent.emplace_back(children[0], nodeOrigin);
           int index = getIndexNotMultiPers(children.size() - 1, tree, children);
-          nodeParent.push_back(std::make_tuple(node, children[index]));
+          nodeParent.emplace_back(node, children[index]);
         }
 
         // Push children to the queue
@@ -882,8 +882,7 @@ namespace ttk {
               dataType costT
                 = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
               cost = static_cast<double>(costT);
-              outputMatching.push_back(
-                std::make_tuple(tree1Node, tree2Node, cost));
+              outputMatching.emplace_back(tree1Node, tree2Node, cost);
             }
           }
         } else {
@@ -933,9 +932,9 @@ namespace ttk {
 
         if(!tree1->isNodeAlone(node1Higher)
            and !tree2->isNodeAlone(node2Higher))
-          toAdd.push_back(std::make_tuple(node1Higher, node2Higher, cost));
+          toAdd.emplace_back(node1Higher, node2Higher, cost);
         if(!tree1->isNodeAlone(node1Lower) and !tree2->isNodeAlone(node2Lower))
-          toAdd.push_back(std::make_tuple(node1Lower, node2Lower, cost));
+          toAdd.emplace_back(node1Lower, node2Lower, cost);
       }
       outputMatching.clear();
       outputMatching.insert(outputMatching.end(), toAdd.begin(), toAdd.end());
@@ -958,8 +957,7 @@ namespace ttk {
 
       outputMatching.clear();
       for(auto tup : realOutputMatching)
-        outputMatching.push_back(
-          std::make_tuple(std::get<0>(tup), std::get<1>(tup)));
+        outputMatching.emplace_back(std::get<0>(tup), std::get<1>(tup));
     }
 
     template <class dataType>
@@ -976,8 +974,7 @@ namespace ttk {
         dataType deleteInsertCostVal = deleteCost<dataType>(tree1, tree1Node)
                                        + insertCost<dataType>(tree2, tree2Node);
         bool isRealMatching = (relabelCostVal <= deleteInsertCostVal);
-        realMatching.push_back(
-          std::make_tuple(tree1Node, tree2Node, isRealMatching));
+        realMatching.emplace_back(tree1Node, tree2Node, isRealMatching);
       }
     }
 
@@ -1247,7 +1244,7 @@ namespace ttk {
           continue;
         int tableId1 = children1[std::get<0>(mTuple)] + 1;
         int tableId2 = children2[std::get<1>(mTuple)] + 1;
-        forestAssignment.push_back(std::make_tuple(tableId1, tableId2));
+        forestAssignment.emplace_back(tableId1, tableId2);
       }
       return cost;
     }

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -217,7 +217,7 @@ namespace ttk {
       }
 
       for(unsigned int i = 0; i < bestCentroidT.size(); ++i)
-        assignmentC.push_back(std::make_tuple(bestCentroidT[i], i));
+        assignmentC.emplace_back(bestCentroidT[i], i);
     }
 
     template <class dataType>
@@ -414,7 +414,7 @@ namespace ttk {
       for(unsigned int i = 0; i < bestDistance_.size(); ++i)
         bestDistanceT[i] = bestDistance_[i];
       for(unsigned int i = 0; i < bestCentroid_.size(); ++i)
-        assignmentC.push_back(std::make_tuple(bestCentroid_[i], i));
+        assignmentC.emplace_back(bestCentroid_[i], i);
     }
 
     template <class dataType>
@@ -488,8 +488,8 @@ namespace ttk {
       for(int i : assignedTreesIndex) {
         std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> newMatching;
         for(auto tup : matchingT[i])
-          newMatching.push_back(std::make_tuple(
-            nodeCorr[std::get<0>(tup)], std::get<1>(tup), std::get<2>(tup)));
+          newMatching.emplace_back(
+            nodeCorr[std::get<0>(tup)], std::get<1>(tup), std::get<2>(tup));
         matchingT[i] = newMatching;
       }
     }
@@ -876,7 +876,7 @@ namespace ttk {
         newScalarsVector[root2] = newMax;
         newScalarsVector.push_back(newMin);
         std::vector<std::tuple<ftm::idNode, bool>> origins;
-        origins.push_back(std::make_tuple(root2, true));
+        origins.emplace_back(root2, true);
         updateNodesAndScalars<dataType>(
           centroids2[i], newScalarsVector, origins);
       }

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -66,7 +66,7 @@ namespace ttk {
         "MergeTreeClustering"); // inherited from Debug: prefix will be printed
                                 // at the beginning of every msg
     }
-    ~MergeTreeClustering() = default;
+    ~MergeTreeClustering() override = default;
 
     void setNoCentroids(unsigned int noCentroidsT) {
       noCentroids_ = noCentroidsT;

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -321,8 +321,7 @@ namespace ttk {
       dataType res
         = computeDistance<dataType>(tree1, tree2, realOutputMatching);
       for(auto tup : realOutputMatching)
-        outputMatching.push_back(
-          std::make_tuple(std::get<0>(tup), std::get<1>(tup)));
+        outputMatching.emplace_back(std::get<0>(tup), std::get<1>(tup));
       return res;
     }
 
@@ -413,8 +412,7 @@ namespace ttk {
         realOutputMatching;
       dataType res = execute<dataType>(tree1, tree2, realOutputMatching);
       for(auto tup : realOutputMatching)
-        outputMatching.push_back(
-          std::make_tuple(std::get<0>(tup), std::get<1>(tup)));
+        outputMatching.emplace_back(std::get<0>(tup), std::get<1>(tup));
       return res;
     }
 
@@ -1139,8 +1137,7 @@ namespace ttk {
                           < tree->getValue<dataType>(tree->getParentSafe(node));
 
           if(thisProblem)
-            problemNodes.push_back(
-              std::make_tuple(node, tree->getParentSafe(node)));
+            problemNodes.emplace_back(node, tree->getParentSafe(node));
 
           problem |= thisProblem;
         }

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -66,7 +66,7 @@ namespace ttk {
       omp_set_nested(1);
 #endif
     }
-    ~MergeTreeDistance() = default;
+    ~MergeTreeDistance() override = default;
 
     void setIsCalled(bool ic) {
       isCalled_ = ic;

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -31,7 +31,7 @@ namespace ttk {
                                     // printed at the
       // beginning of every msg
     }
-    ~MergeTreeDistanceMatrix() = default;
+    ~MergeTreeDistanceMatrix() override = default;
 
     /**
      * Implementation of the algorithm.

--- a/core/base/meshGraph/MeshGraph.h
+++ b/core/base/meshGraph/MeshGraph.h
@@ -44,7 +44,7 @@ namespace ttk {
     MeshGraph() {
       this->setDebugMsgPrefix("MeshGraph");
     }
-    ~MeshGraph() = default;
+    ~MeshGraph() override = default;
 
     inline size_t computeNumberOfOutputPoints(const size_t &nInputPoints,
                                               const size_t &nInputCells,

--- a/core/base/morphologicalOperators/MorphologicalOperators.h
+++ b/core/base/morphologicalOperators/MorphologicalOperators.h
@@ -27,8 +27,7 @@ namespace ttk {
       this->setDebugMsgPrefix("MorphologicalOperators");
     }
 
-    ~MorphologicalOperators() override {
-    }
+    ~MorphologicalOperators() override = default;
 
     int preconditionTriangulation(
       ttk::AbstractTriangulation *triangulation) const {

--- a/core/base/morphologicalOperators/MorphologicalOperators.h
+++ b/core/base/morphologicalOperators/MorphologicalOperators.h
@@ -27,7 +27,7 @@ namespace ttk {
       this->setDebugMsgPrefix("MorphologicalOperators");
     }
 
-    ~MorphologicalOperators() {
+    ~MorphologicalOperators() override {
     }
 
     int preconditionTriangulation(

--- a/core/base/multiresTriangulation/MultiresTriangulation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation.cpp
@@ -12,8 +12,7 @@ MultiresTriangulation::MultiresTriangulation() {
   this->setDebugMsgPrefix("MultiresTriangulation");
 }
 
-MultiresTriangulation::~MultiresTriangulation() {
-}
+MultiresTriangulation::~MultiresTriangulation() = default;
 
 int ttk::MultiresTriangulation::preconditionVerticesInternal() {
   vertexPositions_.resize(vertexNumber_);

--- a/core/base/multiresTriangulation/MultiresTriangulation.cpp
+++ b/core/base/multiresTriangulation/MultiresTriangulation.cpp
@@ -8,7 +8,7 @@ MultiresTriangulation::MultiresTriangulation() {
   decimationLevel_ = 0;
   debugLevel_ = 0;
   gridDimensions_[0] = gridDimensions_[1] = gridDimensions_[2] = -1;
-  triangulation_ = NULL;
+  triangulation_ = nullptr;
   this->setDebugMsgPrefix("MultiresTriangulation");
 }
 

--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -27,7 +27,7 @@ namespace ttk {
 
   public:
     MultiresTriangulation();
-    ~MultiresTriangulation();
+    ~MultiresTriangulation() override;
 
     SimplexId getVertexNeighborAtDecimation(const SimplexId &vertexId,
                                             const int &localNeighborId,

--- a/core/base/octree/Octree.cpp
+++ b/core/base/octree/Octree.cpp
@@ -11,8 +11,7 @@ Octree::Octree(const AbstractTriangulation *t, const int k) {
   initialize(t, k);
 }
 
-Octree::~Octree() {
-}
+Octree::~Octree() = default;
 
 // Initialize the octree with the given triangulation and bucket threshold.
 void Octree::initialize(const AbstractTriangulation *t, const int k) {

--- a/core/base/octree/Octree.h
+++ b/core/base/octree/Octree.h
@@ -49,7 +49,7 @@ class Octree : public virtual ttk::Debug {
 public:
   Octree(const ttk::AbstractTriangulation *t);
   Octree(const ttk::AbstractTriangulation *t, const int k);
-  ~Octree();
+  ~Octree() override;
   void initialize(const ttk::AbstractTriangulation *t, const int k);
 
   bool empty();

--- a/core/base/octree/Octree.h
+++ b/core/base/octree/Octree.h
@@ -33,8 +33,7 @@ public:
     childExists_ = 0;
   }
 
-  ~OctreeNode() {
-  }
+  ~OctreeNode() = default;
 
 protected:
   uint32_t locCode_;

--- a/core/base/octree/Octree.h
+++ b/core/base/octree/Octree.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <Triangulation.h>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <stack>
 #include <unordered_map>

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -10,8 +10,7 @@ PeriodicImplicitTriangulation::PeriodicImplicitTriangulation()
   hasPeriodicBoundaries_ = true;
 }
 
-PeriodicImplicitTriangulation::~PeriodicImplicitTriangulation() {
-}
+PeriodicImplicitTriangulation::~PeriodicImplicitTriangulation() = default;
 
 int PeriodicImplicitTriangulation::setInputGrid(const float &xOrigin,
                                                 const float &yOrigin,

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -10,8 +10,7 @@
 /// \sa ttk::Triangulation::setPeriodicBoundaryConditions
 ///
 
-#ifndef _PERIODICIMPLICITTRIANGULATION_H
-#define _PERIODICIMPLICITTRIANGULATION_H
+#pragma once
 
 // base code includes
 #include <AbstractTriangulation.h>
@@ -3388,5 +3387,3 @@ inline ttk::SimplexId
 #include <PeriodicPreconditions.h>
 
 /// @endcond
-
-#endif // _PERIODICIMPLICITTRIANGULATION_H

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -24,7 +24,7 @@ namespace ttk {
 
   public:
     PeriodicImplicitTriangulation();
-    ~PeriodicImplicitTriangulation();
+    ~PeriodicImplicitTriangulation() override;
 
     PeriodicImplicitTriangulation(const PeriodicImplicitTriangulation &)
       = default;

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
@@ -415,8 +415,7 @@ namespace ttk {
       diagonal_price_ = 0;
     }
 
-    ~Bidder() override {
-    }
+    ~Bidder() override = default;
 
     // Off-diagonal Bidding (with or without the use of a KD-Tree
     int runBidding(GoodDiagram<dataType> *goods,

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
@@ -1,5 +1,4 @@
-#ifndef _PERSISTENCEDIAGRAMAUCTIONACTOR_H
-#define _PERSISTENCEDIAGRAMAUCTIONACTOR_H
+#pragma once
 
 #include <Debug.h>
 #include <KDTree.h>
@@ -935,5 +934,3 @@ namespace ttk {
   };
 
 } // namespace ttk
-
-#endif

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
@@ -61,7 +61,7 @@ namespace ttk {
       // geom_pair_length_[1] = 0;
       // geom_pair_length_[2] = 0;
     }
-    ~PersistenceDiagramAuctionActor() = default;
+    ~PersistenceDiagramAuctionActor() override = default;
 
     void SetCoordinates(dataType &x, dataType &y);
     void SetCriticalCoordinates(float coords_x, float coords_y, float coords_z);
@@ -416,7 +416,7 @@ namespace ttk {
       diagonal_price_ = 0;
     }
 
-    ~Bidder() {
+    ~Bidder() override {
     }
 
     // Off-diagonal Bidding (with or without the use of a KD-Tree

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionImpl.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionImpl.h
@@ -1,5 +1,4 @@
-#ifndef _PERSISTENCEDIAGRAMAUCTIONIMPL_H
-#define _PERSISTENCEDIAGRAMAUCTIONIMPL_H
+#pragma once
 
 #ifndef matchingTuple
 #define matchingTuple std::tuple<SimplexId, SimplexId, dataType>
@@ -146,4 +145,3 @@ dataType ttk::PersistenceDiagramAuction<dataType>::run(
   dataType wassersteinDistance = this->getMatchingsAndDistance(matchings, true);
   return wassersteinDistance;
 }
-#endif

--- a/core/base/persistenceDiagramClustering/PDBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.h
@@ -39,7 +39,7 @@ namespace ttk {
       this->setDebugMsgPrefix("PersistenceDiagramBarycenter");
     }
 
-    ~PDBarycenter() = default;
+    ~PDBarycenter() override = default;
 
     std::vector<std::vector<matchingTuple>>
       execute(std::vector<diagramTuple> &barycenter);

--- a/core/base/persistenceDiagramClustering/PDClustering.h
+++ b/core/base/persistenceDiagramClustering/PDClustering.h
@@ -48,7 +48,7 @@ namespace ttk {
       this->setDebugMsgPrefix("PersistenceDiagramClustering");
     }
 
-    ~PDClustering() = default;
+    ~PDClustering() override = default;
 
     std::vector<int>
       execute(std::vector<std::vector<diagramTuple>> &final_centroids,

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
@@ -55,7 +55,7 @@ namespace ttk {
       this->setDebugMsgPrefix("PersistenceDiagramBarycenter");
     }
 
-    ~PersistenceDiagramBarycenter() = default;
+    ~PersistenceDiagramBarycenter() override = default;
 
     void execute(
       std::vector<std::vector<diagramTuple>> &intermediateDiagrams,

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.h
@@ -48,10 +48,10 @@ namespace ttk {
       numberOfInputs_ = 0;
       threadNumber_ = 1;
       time_limit_ = 1;
-      deterministic_ = 1;
-      reinit_prices_ = 1;
-      epsilon_decreases_ = 1;
-      use_progressive_ = 1;
+      deterministic_ = true;
+      reinit_prices_ = true;
+      epsilon_decreases_ = true;
+      use_progressive_ = true;
       this->setDebugMsgPrefix("PersistenceDiagramBarycenter");
     }
 

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -46,7 +46,7 @@ namespace ttk {
       this->setDebugMsgPrefix("PersistenceDiagramClustering");
     }
 
-    ~PersistenceDiagramClustering() = default;
+    ~PersistenceDiagramClustering() override = default;
 
     template <class dataType>
     std::vector<int> execute(

--- a/core/base/planarGraphLayout/MergeTreeVisualization.h
+++ b/core/base/planarGraphLayout/MergeTreeVisualization.h
@@ -26,7 +26,7 @@ namespace ttk {
 
   public:
     MergeTreeVisualization() = default;
-    virtual ~MergeTreeVisualization() = default;
+    ~MergeTreeVisualization() override = default;
 
     // ==========================================================================
     // Getter / Setter

--- a/core/base/planarGraphLayout/PlanarGraphLayout.cpp
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.cpp
@@ -8,8 +8,7 @@
 ttk::PlanarGraphLayout::PlanarGraphLayout() {
   this->setDebugMsgPrefix("PlanarGraphLayout");
 }
-ttk::PlanarGraphLayout::~PlanarGraphLayout() {
-}
+ttk::PlanarGraphLayout::~PlanarGraphLayout() = default;
 
 // Compute Dot Layout
 int ttk::PlanarGraphLayout::computeDotLayout(

--- a/core/base/planarGraphLayout/PlanarGraphLayout.h
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.h
@@ -36,7 +36,7 @@ namespace ttk {
 
   public:
     PlanarGraphLayout();
-    ~PlanarGraphLayout();
+    ~PlanarGraphLayout() override;
 
     template <typename ST, typename IT, typename CT>
     int computeLayout(

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -74,13 +74,13 @@ namespace ttk {
     inline void setAlgorithm(int data) {
       computePersistenceDiagram_ = data;
     }
-    void setStartingDecimationLevel(int data) {
+    void setStartingDecimationLevel(int data) override {
       if(data != startingDecimationLevel_) {
         resumeProgressive_ = false;
       }
       startingDecimationLevel_ = std::max(data, 0);
     }
-    void setStoppingDecimationLevel(int data) {
+    void setStoppingDecimationLevel(int data) override {
       if(data >= stoppingDecimationLevel_) {
         resumeProgressive_ = false;
       }
@@ -92,7 +92,7 @@ namespace ttk {
         resumeProgressive_ = false;
       }
     }
-    void setPreallocateMemory(const bool b) {
+    void setPreallocateMemory(const bool b) override {
       if(b != preallocateMemory_) {
         resumeProgressive_ = false;
       }

--- a/core/base/rangeDrivenOctree/RangeDrivenOctree.h
+++ b/core/base/rangeDrivenOctree/RangeDrivenOctree.h
@@ -158,7 +158,7 @@ int ttk::RangeDrivenOctree::build(
       cellDomainBox_[i][j].second = -FLT_MAX;
     }
 
-    const SimplexId *cell = NULL;
+    const SimplexId *cell = nullptr;
     if(!triangulation) {
       cell = &(cellList_[5 * i + 1]);
     }

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -905,8 +905,7 @@ int ttk::ReebSpace::compute1sheetsOnly(
 
         if(!visitedEdges[edgeId]) {
 
-          jacobiClassification.push_back(
-            std::pair<SimplexId, SimplexId>(edgeId, sheet1Id));
+          jacobiClassification.emplace_back(edgeId, sheet1Id);
 
           originalData_.sheet1List_.back().edgeList_.push_back(edgeId);
           originalData_.edge2sheet1_[edgeId] = sheet1Id;
@@ -1047,8 +1046,7 @@ int ttk::ReebSpace::compute1sheets(
 
         if(!visitedEdges[edgeId]) {
 
-          jacobiClassification.push_back(
-            std::pair<SimplexId, SimplexId>(edgeId, sheet1Id));
+          jacobiClassification.emplace_back(edgeId, sheet1Id);
 
           if(originalData_.edgeTypes_[edgeId] == 1) {
             // saddle edge

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -107,7 +107,7 @@ namespace ttk {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((sheetId < 0)
          || (sheetId >= (SimplexId)currentData_.sheet0List_.size()))
-        return NULL;
+        return nullptr;
 #endif
 
       return &(currentData_.sheet0List_[sheetId]);
@@ -117,7 +117,7 @@ namespace ttk {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((sheetId < 0)
          || (sheetId >= (SimplexId)currentData_.sheet1List_.size()))
-        return NULL;
+        return nullptr;
 #endif
 
       return &(currentData_.sheet1List_[sheetId]);
@@ -128,7 +128,7 @@ namespace ttk {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((sheetId < 0)
          || (sheetId >= (SimplexId)originalData_.sheet2List_.size()))
-        return NULL;
+        return nullptr;
 #endif
 
       return &(originalData_.sheet2List_[sheetId]);
@@ -138,7 +138,7 @@ namespace ttk {
 #ifndef TTK_ENABLE_KAMIKAZE
       if((sheetId < 0)
          || (sheetId >= (SimplexId)currentData_.sheet3List_.size()))
-        return NULL;
+        return nullptr;
 #endif
 
       return &(currentData_.sheet3List_[sheetId]);

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.cpp
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.cpp
@@ -4,5 +4,4 @@ ttk::ScalarFieldSmoother::ScalarFieldSmoother() {
   this->setDebugMsgPrefix("ScalarFieldSmoother");
 }
 
-ttk::ScalarFieldSmoother::~ScalarFieldSmoother() {
-}
+ttk::ScalarFieldSmoother::~ScalarFieldSmoother() = default;

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -25,7 +25,7 @@ namespace ttk {
 
   public:
     ScalarFieldSmoother();
-    ~ScalarFieldSmoother();
+    ~ScalarFieldSmoother() override;
 
     inline void setDimensionNumber(const int &dimensionNumber) {
       dimensionNumber_ = dimensionNumber;

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -663,7 +663,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     if(!already[vert]) {
       already[vert] = true;
       dataType dttt = outputData[i];
-      mapping_.push_back(std::make_tuple((double)dttt, vert));
+      mapping_.emplace_back((double)dttt, vert);
     }
   }
 
@@ -734,7 +734,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
       if(newSegment) {
         dataType result = (maxNewSegment + minNewSegment) / 2;
         segments.push_back(std::make_tuple(result, newIndex));
-        mapping_.push_back(std::make_tuple((double)result, newIndex));
+        mapping_.emplace_back((double)result, newIndex);
         newIndex++; // Set index for next potential segment.
       }
     }
@@ -754,7 +754,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
       if(type == -1 // Local_minimum
          || type == 1 // Local_maximum
          || type == 0) {
-        criticalConstraints_.push_back(std::make_tuple(id, (double)val, type));
+        criticalConstraints_.emplace_back(id, (double)val, type);
       } else { // 0 -> Saddle
       }
     }

--- a/core/base/topologicalCompression/TopologicalCompression.cpp
+++ b/core/base/topologicalCompression/TopologicalCompression.cpp
@@ -364,8 +364,8 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
     numberOfBytesRead += sizeof(double);
     value = Read<double>(fm);
 
-    mappings.push_back(std::make_tuple(value, idv));
-    mappingsSortedPerValue.push_back(std::make_tuple(value, idv));
+    mappings.emplace_back(value, idv);
+    mappingsSortedPerValue.emplace_back(value, idv);
   }
 
   // Sort mapping.
@@ -400,7 +400,7 @@ int ttk::TopologicalCompression::ReadPersistenceIndex(
     if(value > max)
       max = value;
 
-    constraints.push_back(std::make_tuple(idVertex, value, vertexType));
+    constraints.emplace_back(idVertex, value, vertexType);
   }
 
   return numberOfBytesRead;

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -43,8 +43,7 @@ namespace ttk {
     bool isIncreasingOrder_{};
 
   public:
-    SweepCmp() {
-    }
+    SweepCmp() = default;
 
     SweepCmp(bool isIncreasingOrder) : isIncreasingOrder_{isIncreasingOrder} {
     }

--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -50,7 +50,7 @@ namespace ttk {
     TrackingFromOverlap() {
       this->setDebugMsgPrefix("TrackingFromOverlap");
     }
-    ~TrackingFromOverlap() = default;
+    ~TrackingFromOverlap() override = default;
 
     struct Node {
       labelTypeVariant label{};

--- a/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
+++ b/core/base/trackingFromPersistenceDiagrams/TrackingFromPersistenceDiagrams.h
@@ -15,7 +15,7 @@ namespace ttk {
   public:
     TrackingFromPersistenceDiagrams();
 
-    ~TrackingFromPersistenceDiagrams();
+    ~TrackingFromPersistenceDiagrams() override;
 
     /// Execute the package.
     /// \return Returns 0 upon success, negative values otherwise.

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -54,7 +54,7 @@ namespace ttk {
     Triangulation(Triangulation &&) noexcept;
     Triangulation &operator=(const Triangulation &);
     Triangulation &operator=(Triangulation &&) noexcept;
-    ~Triangulation();
+    ~Triangulation() override;
 
     enum class Type {
       EXPLICIT,

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -32,8 +32,7 @@
 /// down.
 /// \sa ttkTriangulation
 
-#ifndef _TRIANGULATION_H
-#define _TRIANGULATION_H
+#pragma once
 
 // base code includes
 #include <AbstractTriangulation.h>
@@ -2628,8 +2627,3 @@ namespace ttk {
     CompactTriangulation compactTriangulation_;
   };
 } // namespace ttk
-
-// if the package is not a template, comment the following line
-// #include                  <Triangulation.cpp>
-
-#endif // _TRIANGULATION_H

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -191,7 +191,7 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *getCellEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getCellEdges();
     }
@@ -291,7 +291,7 @@ namespace ttk {
       getCellNeighbors() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getCellNeighbors();
     }
@@ -394,7 +394,7 @@ namespace ttk {
       getCellTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getCellTriangles();
     }
@@ -480,7 +480,7 @@ namespace ttk {
     inline const std::vector<std::array<SimplexId, 2>> *getEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getEdges();
     }
@@ -604,7 +604,7 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *getEdgeLinks() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getEdgeLinks();
     }
@@ -700,7 +700,7 @@ namespace ttk {
     inline const std::vector<std::vector<SimplexId>> *getEdgeStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getEdgeStars();
     }
@@ -791,7 +791,7 @@ namespace ttk {
       getEdgeTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getEdgeTriangles();
     }
@@ -944,7 +944,7 @@ namespace ttk {
       getTriangles() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getTriangles();
     }
@@ -1033,7 +1033,7 @@ namespace ttk {
       getTriangleEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getTriangleEdges();
     }
@@ -1123,7 +1123,7 @@ namespace ttk {
       getTriangleLinks() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getTriangleLinks();
     }
@@ -1214,7 +1214,7 @@ namespace ttk {
       getTriangleStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getTriangleStars();
     }
@@ -1359,7 +1359,7 @@ namespace ttk {
       getVertexEdges() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       if(getDimensionality() == 1)
         return abstractTriangulation_->getVertexStars();
@@ -1454,7 +1454,7 @@ namespace ttk {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getVertexLinks();
     }
@@ -1538,7 +1538,7 @@ namespace ttk {
       getVertexNeighbors() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getVertexNeighbors();
     }
@@ -1653,7 +1653,7 @@ namespace ttk {
       getVertexStars() override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getVertexStars();
     }
@@ -1747,7 +1747,7 @@ namespace ttk {
 
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return NULL;
+        return nullptr;
 #endif
       return abstractTriangulation_->getVertexTriangles();
     }

--- a/core/base/unionFind/UnionFind.h
+++ b/core/base/unionFind/UnionFind.h
@@ -57,10 +57,10 @@ namespace ttk {
     }
 
     static inline UnionFind *makeUnion(std::vector<UnionFind *> &sets) {
-      UnionFind *n = NULL;
+      UnionFind *n = nullptr;
 
       if(!sets.size())
-        return NULL;
+        return nullptr;
 
       if(sets.size() == 1)
         return sets[0];

--- a/core/base/webSocketIO/WebSocketIO.h
+++ b/core/base/webSocketIO/WebSocketIO.h
@@ -68,7 +68,7 @@ namespace ttk {
     };
 
     WebSocketIO();
-    ~WebSocketIO();
+    ~WebSocketIO() override;
 
     int isListening();
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -27,10 +27,8 @@ vtkInformationKeyMacro(ttkAlgorithm, SAME_DATA_TYPE_AS_INPUT_PORT, Integer);
 
 // Constructor / Destructor
 vtkStandardNewMacro(ttkAlgorithm);
-ttkAlgorithm::ttkAlgorithm() {
-}
-ttkAlgorithm::~ttkAlgorithm() {
-}
+ttkAlgorithm::ttkAlgorithm() = default;
+ttkAlgorithm::~ttkAlgorithm() = default;
 
 ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -206,7 +206,7 @@ public:
 
 protected:
   ttkAlgorithm();
-  virtual ~ttkAlgorithm();
+  ~ttkAlgorithm() override;
 
   /**
    * This method is called during the first pipeline pass in
@@ -313,9 +313,8 @@ protected:
    * This method has to be overridden to specify the required input data
    * types.
    */
-  virtual int
-    FillInputPortInformation(int ttkNotUsed(port),
-                             vtkInformation *ttkNotUsed(info)) override {
+  int FillInputPortInformation(int ttkNotUsed(port),
+                               vtkInformation *ttkNotUsed(info)) override {
     return 0;
   }
 
@@ -329,9 +328,8 @@ protected:
    * This method has to be overridden to specify the data types of the
    * outputs.
    */
-  virtual int
-    FillOutputPortInformation(int ttkNotUsed(port),
-                              vtkInformation *ttkNotUsed(info)) override {
+  int FillOutputPortInformation(int ttkNotUsed(port),
+                                vtkInformation *ttkNotUsed(info)) override {
     return 0;
   }
 };

--- a/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
+++ b/core/vtk/ttkArrayEditor/ttkArrayEditor.cpp
@@ -34,8 +34,7 @@ ttkArrayEditor::ttkArrayEditor() {
   }
 }
 
-ttkArrayEditor::~ttkArrayEditor() {
-}
+ttkArrayEditor::~ttkArrayEditor() = default;
 
 vtkDataArraySelection *ttkArrayEditor::GetArraySelection(int association) {
   if(association >= 0 && association < vtkDataObject::NUMBER_OF_ASSOCIATIONS) {

--- a/core/vtk/ttkArrayEditor/ttkArrayEditor.h
+++ b/core/vtk/ttkArrayEditor/ttkArrayEditor.h
@@ -91,7 +91,7 @@ public:
 
 protected:
   ttkArrayEditor();
-  ~ttkArrayEditor();
+  ~ttkArrayEditor() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
+++ b/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
@@ -19,8 +19,7 @@ ttkBlockAggregator::ttkBlockAggregator() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkBlockAggregator::~ttkBlockAggregator() {
-}
+ttkBlockAggregator::~ttkBlockAggregator() = default;
 
 int ttkBlockAggregator::FillInputPortInformation(int port,
                                                  vtkInformation *info) {

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomCamera.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomCamera.cpp
@@ -24,8 +24,7 @@ ttkCinemaDarkroomCamera::ttkCinemaDarkroomCamera() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaDarkroomCamera::~ttkCinemaDarkroomCamera() {
-}
+ttkCinemaDarkroomCamera::~ttkCinemaDarkroomCamera() = default;
 
 int ttkCinemaDarkroomCamera::FillInputPortInformation(int, vtkInformation *) {
   return 0;

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomColorMapping.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomColorMapping.cpp
@@ -21,8 +21,7 @@ ttkCinemaDarkroomColorMapping::ttkCinemaDarkroomColorMapping() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaDarkroomColorMapping::~ttkCinemaDarkroomColorMapping() {
-}
+ttkCinemaDarkroomColorMapping::~ttkCinemaDarkroomColorMapping() = default;
 
 template <typename DT>
 int mapScalarsToColor(unsigned char *color,

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomColorMapping.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomColorMapping.cpp
@@ -10,7 +10,7 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
-#include <math.h>
+#include <cmath>
 
 vtkStandardNewMacro(ttkCinemaDarkroomColorMapping);
 
@@ -40,7 +40,7 @@ int mapScalarsToColor(unsigned char *color,
   for(size_t i = 0; i < nPixels; i++) {
 
     const double value = (double)array[i];
-    if(isnan(value)) {
+    if(std::isnan(value)) {
       size_t idx = i * 3;
       color[idx + 0] = 255.0 * nanColor[0];
       color[idx + 1] = 255.0 * nanColor[1];

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomCompositing.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomCompositing.cpp
@@ -20,8 +20,7 @@ ttkCinemaDarkroomCompositing::ttkCinemaDarkroomCompositing() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaDarkroomCompositing::~ttkCinemaDarkroomCompositing() {
-}
+ttkCinemaDarkroomCompositing::~ttkCinemaDarkroomCompositing() = default;
 
 int ttkCinemaDarkroomCompositing::FillInputPortInformation(
   int port, vtkInformation *info) {

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomFXAA.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomFXAA.cpp
@@ -10,8 +10,7 @@ ttkCinemaDarkroomFXAA::ttkCinemaDarkroomFXAA() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomFXAA");
 }
 
-ttkCinemaDarkroomFXAA::~ttkCinemaDarkroomFXAA() {
-}
+ttkCinemaDarkroomFXAA::~ttkCinemaDarkroomFXAA() = default;
 
 std::string ttkCinemaDarkroomFXAA::GetVertexShaderCode() {
   return std::string(R"(

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomIBS.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomIBS.cpp
@@ -10,8 +10,7 @@ ttkCinemaDarkroomIBS::ttkCinemaDarkroomIBS() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomIBS");
 }
 
-ttkCinemaDarkroomIBS::~ttkCinemaDarkroomIBS() {
-}
+ttkCinemaDarkroomIBS::~ttkCinemaDarkroomIBS() = default;
 
 std::string ttkCinemaDarkroomIBS::GetFragmentShaderCode() {
   return std::string(R"(

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomNoise.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomNoise.cpp
@@ -12,8 +12,7 @@ vtkStandardNewMacro(ttkCinemaDarkroomNoise);
 ttkCinemaDarkroomNoise::ttkCinemaDarkroomNoise() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomNoise");
 }
-ttkCinemaDarkroomNoise::~ttkCinemaDarkroomNoise() {
-}
+ttkCinemaDarkroomNoise::~ttkCinemaDarkroomNoise() = default;
 
 int ttkCinemaDarkroomNoise::RequestData(vtkInformation *ttkNotUsed(request),
                                         vtkInformationVector **inputVector,

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSAO.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSAO.cpp
@@ -10,8 +10,7 @@ ttkCinemaDarkroomSSAO::ttkCinemaDarkroomSSAO() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomSSAO");
 }
 
-ttkCinemaDarkroomSSAO::~ttkCinemaDarkroomSSAO() {
-}
+ttkCinemaDarkroomSSAO::~ttkCinemaDarkroomSSAO() = default;
 
 std::string ttkCinemaDarkroomSSAO::GetFragmentShaderCode() {
   return std::string(R"(

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSDoF.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSDoF.cpp
@@ -10,8 +10,7 @@ ttkCinemaDarkroomSSDoF::ttkCinemaDarkroomSSDoF() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomSSDoF");
 }
 
-ttkCinemaDarkroomSSDoF::~ttkCinemaDarkroomSSDoF() {
-}
+ttkCinemaDarkroomSSDoF::~ttkCinemaDarkroomSSDoF() = default;
 
 std::string ttkCinemaDarkroomSSDoF::GetFragmentShaderCode() {
   return std::string(R"(

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSSAO.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomSSSAO.cpp
@@ -10,8 +10,7 @@ ttkCinemaDarkroomSSSAO::ttkCinemaDarkroomSSSAO() : ttkCinemaDarkroomShader() {
   this->setDebugMsgPrefix("CinemaDarkroomSSSAO");
 }
 
-ttkCinemaDarkroomSSSAO::~ttkCinemaDarkroomSSSAO() {
-}
+ttkCinemaDarkroomSSSAO::~ttkCinemaDarkroomSSSAO() = default;
 
 std::string ttkCinemaDarkroomSSSAO::GetFragmentShaderCode() {
   return std::string(R"(

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.cpp
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.cpp
@@ -40,8 +40,7 @@ ttkCinemaDarkroomShader::ttkCinemaDarkroomShader() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaDarkroomShader::~ttkCinemaDarkroomShader() {
-}
+ttkCinemaDarkroomShader::~ttkCinemaDarkroomShader() = default;
 
 int ttkCinemaDarkroomShader::FillInputPortInformation(int port,
                                                       vtkInformation *info) {

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -27,7 +27,8 @@ ttkCinemaImaging::ttkCinemaImaging() {
   this->SetNumberOfOutputPorts(1);
 };
 
-ttkCinemaImaging::~ttkCinemaImaging(){};
+ttkCinemaImaging::~ttkCinemaImaging() = default;
+;
 
 int ttkCinemaImaging::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
@@ -125,7 +125,7 @@ public:
 
 protected:
   ttkCinemaImaging();
-  ~ttkCinemaImaging();
+  ~ttkCinemaImaging() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.cpp
@@ -16,8 +16,7 @@
 ttk::ttkCinemaImagingEmbree::ttkCinemaImagingEmbree() {
   this->setDebugMsgPrefix("CinemaImaging(Embree)");
 };
-ttk::ttkCinemaImagingEmbree::~ttkCinemaImagingEmbree() {
-}
+ttk::ttkCinemaImagingEmbree::~ttkCinemaImagingEmbree() = default;
 
 int ttk::ttkCinemaImagingEmbree::RenderVTKObject(
   vtkMultiBlockDataSet *outputImages,

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.h
@@ -9,7 +9,7 @@ namespace ttk {
   class ttkCinemaImagingEmbree : public CinemaImagingEmbree {
   public:
     ttkCinemaImagingEmbree();
-    ~ttkCinemaImagingEmbree();
+    ~ttkCinemaImagingEmbree() override;
 
     int RenderVTKObject(vtkMultiBlockDataSet *outputImages,
 

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingNative.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingNative.cpp
@@ -19,8 +19,7 @@ ttk::ttkCinemaImagingNative::ttkCinemaImagingNative() {
   this->setDebugMsgPrefix("CinemaImaging(Native)");
 };
 
-ttk::ttkCinemaImagingNative::~ttkCinemaImagingNative() {
-}
+ttk::ttkCinemaImagingNative::~ttkCinemaImagingNative() = default;
 
 int ttk::ttkCinemaImagingNative::RenderVTKObject(
   vtkMultiBlockDataSet *outputImages,

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingNative.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingNative.h
@@ -9,7 +9,7 @@ namespace ttk {
   class ttkCinemaImagingNative : public CinemaImagingNative {
   public:
     ttkCinemaImagingNative();
-    ~ttkCinemaImagingNative();
+    ~ttkCinemaImagingNative() override;
 
     int RenderVTKObject(vtkMultiBlockDataSet *outputImages,
 

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
@@ -31,8 +31,7 @@
 ttk::ttkCinemaImagingVTK::ttkCinemaImagingVTK() {
   this->setDebugMsgPrefix("CinemaImaging(VTK)");
 };
-ttk::ttkCinemaImagingVTK::~ttkCinemaImagingVTK() {
-}
+ttk::ttkCinemaImagingVTK::~ttkCinemaImagingVTK() = default;
 
 int ttk::ttkCinemaImagingVTK::setupRenderer(vtkRenderer *renderer,
                                             vtkPointSet *object,

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.h
@@ -13,7 +13,7 @@ namespace ttk {
   class ttkCinemaImagingVTK : virtual public Debug {
   public:
     ttkCinemaImagingVTK();
-    ~ttkCinemaImagingVTK();
+    ~ttkCinemaImagingVTK() override;
 
     int RenderVTKObject(vtkMultiBlockDataSet *outputImages,
 

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.cpp
@@ -17,8 +17,7 @@ ttkCinemaProductReader::ttkCinemaProductReader() {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }
-ttkCinemaProductReader::~ttkCinemaProductReader() {
-}
+ttkCinemaProductReader::~ttkCinemaProductReader() = default;
 
 int ttkCinemaProductReader::FillInputPortInformation(int port,
                                                      vtkInformation *info) {

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -47,7 +47,7 @@ public:
 
 protected:
   ttkCinemaProductReader();
-  ~ttkCinemaProductReader();
+  ~ttkCinemaProductReader() override;
 
   vtkSmartPointer<vtkDataObject> readFileLocal(const std::string &pathToFile);
   int addFieldDataRecursively(vtkDataObject *object, vtkFieldData *fd);

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -23,8 +23,7 @@ ttkCinemaQuery::ttkCinemaQuery() {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }
-ttkCinemaQuery::~ttkCinemaQuery() {
-}
+ttkCinemaQuery::~ttkCinemaQuery() = default;
 
 int ttkCinemaQuery::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkCinemaReader/ttkCinemaReader.cpp
+++ b/core/vtk/ttkCinemaReader/ttkCinemaReader.cpp
@@ -20,8 +20,7 @@ ttkCinemaReader::ttkCinemaReader() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaReader::~ttkCinemaReader() {
-}
+ttkCinemaReader::~ttkCinemaReader() = default;
 
 int ttkCinemaReader::FillOutputPortInformation(int port, vtkInformation *info) {
   if(port == 0)

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -38,8 +38,7 @@ ttkCinemaWriter::ttkCinemaWriter() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkCinemaWriter::~ttkCinemaWriter() {
-}
+ttkCinemaWriter::~ttkCinemaWriter() = default;
 
 int ttkCinemaWriter::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.h
@@ -89,7 +89,7 @@ public:
 
 protected:
   ttkCinemaWriter();
-  ~ttkCinemaWriter();
+  ~ttkCinemaWriter() override;
 
   int ValidateDatabasePath();
   int ProcessDataProduct(vtkDataObject *input);

--- a/core/vtk/ttkComponentSize/ttkComponentSize.cpp
+++ b/core/vtk/ttkComponentSize/ttkComponentSize.cpp
@@ -20,8 +20,7 @@ ttkComponentSize::ttkComponentSize() {
                   "`Connectivity' instead.");
 }
 
-ttkComponentSize::~ttkComponentSize() {
-}
+ttkComponentSize::~ttkComponentSize() = default;
 
 int ttkComponentSize::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkComponentSize/ttkComponentSize.h
+++ b/core/vtk/ttkComponentSize/ttkComponentSize.h
@@ -41,7 +41,7 @@ public:
 
 protected:
   ttkComponentSize();
-  ~ttkComponentSize();
+  ~ttkComponentSize() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
+++ b/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
@@ -56,7 +56,7 @@ public:
 
 protected:
   ttkConnectedComponents();
-  virtual ~ttkConnectedComponents() override = default;
+  ~ttkConnectedComponents() override = default;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
+++ b/core/vtk/ttkContinuousScatterPlot/ttkContinuousScatterPlot.cpp
@@ -20,8 +20,7 @@ ttkContinuousScatterPlot::ttkContinuousScatterPlot() {
   SetNumberOfOutputPorts(1);
 }
 
-ttkContinuousScatterPlot::~ttkContinuousScatterPlot() {
-}
+ttkContinuousScatterPlot::~ttkContinuousScatterPlot() = default;
 
 int ttkContinuousScatterPlot::FillInputPortInformation(int port,
                                                        vtkInformation *info) {

--- a/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
+++ b/core/vtk/ttkContourAroundPoint/ttkContourAroundPoint.h
@@ -62,8 +62,7 @@ protected:
     SetNumberOfOutputPorts(2);
   }
 
-  ~ttkContourAroundPoint() override {
-  }
+  ~ttkContourAroundPoint() override = default;
 
   // Make sure this is consistent with the XML file and the
   // `SetNumberOfInputPorts` and `SetNumberOfOutputPorts` argument

--- a/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.h
+++ b/core/vtk/ttkContourTreeAlignment/ttkContourTreeAlignment.h
@@ -109,7 +109,8 @@ protected:
 
   // filter constructor and destructor
   ttkContourTreeAlignment();
-  ~ttkContourTreeAlignment() override{};
+  ~ttkContourTreeAlignment() override = default;
+  ;
 
 private:
   // filter parameters

--- a/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.cpp
+++ b/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.cpp
@@ -17,8 +17,7 @@ ttkDataSetInterpolator::ttkDataSetInterpolator() {
   vtkWarningMacro("`TTK DataSetInterpolator' is now deprecated. Please use "
                   "`ResampleWithDataset' instead.");
 }
-ttkDataSetInterpolator::~ttkDataSetInterpolator() {
-}
+ttkDataSetInterpolator::~ttkDataSetInterpolator() = default;
 
 int ttkDataSetInterpolator::FillInputPortInformation(int port,
                                                      vtkInformation *info) {

--- a/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
+++ b/core/vtk/ttkDataSetInterpolator/ttkDataSetInterpolator.h
@@ -34,7 +34,7 @@ public:
 
 protected:
   ttkDataSetInterpolator();
-  ~ttkDataSetInterpolator();
+  ~ttkDataSetInterpolator() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.cpp
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.cpp
@@ -16,8 +16,7 @@ ttkDataSetToTable::ttkDataSetToTable() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkDataSetToTable::~ttkDataSetToTable() {
-}
+ttkDataSetToTable::~ttkDataSetToTable() = default;
 
 int ttkDataSetToTable::FillInputPortInformation(int port,
                                                 vtkInformation *info) {

--- a/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
+++ b/core/vtk/ttkDataSetToTable/ttkDataSetToTable.h
@@ -34,7 +34,7 @@ public:
 
 protected:
   ttkDataSetToTable();
-  ~ttkDataSetToTable();
+  ~ttkDataSetToTable() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -23,8 +23,8 @@ ttkDepthImageBasedGeometryApproximation::
   this->SetNumberOfOutputPorts(1);
 }
 ttkDepthImageBasedGeometryApproximation::
-  ~ttkDepthImageBasedGeometryApproximation() {
-}
+  ~ttkDepthImageBasedGeometryApproximation()
+  = default;
 
 int ttkDepthImageBasedGeometryApproximation::FillInputPortInformation(
   int port, vtkInformation *info) {

--- a/core/vtk/ttkEndFor/ttkEndFor.cpp
+++ b/core/vtk/ttkEndFor/ttkEndFor.cpp
@@ -18,7 +18,8 @@ ttkEndFor::ttkEndFor() {
   SetNumberOfOutputPorts(1);
 }
 
-ttkEndFor::~ttkEndFor(){};
+ttkEndFor::~ttkEndFor() = default;
+;
 
 int ttkEndFor::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0 || port == 1) {

--- a/core/vtk/ttkEndFor/ttkEndFor.h
+++ b/core/vtk/ttkEndFor/ttkEndFor.h
@@ -34,7 +34,7 @@ public:
 
 protected:
   ttkEndFor();
-  ~ttkEndFor();
+  ~ttkEndFor() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -32,7 +32,8 @@ ttkExtract::ttkExtract() {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }
-ttkExtract::~ttkExtract(){};
+ttkExtract::~ttkExtract() = default;
+;
 
 std::string ttkExtract::GetVtkDataTypeName(const int outputType) const {
   switch(outputType) {

--- a/core/vtk/ttkExtract/ttkExtract.h
+++ b/core/vtk/ttkExtract/ttkExtract.h
@@ -148,7 +148,7 @@ public:
 
 protected:
   ttkExtract();
-  ~ttkExtract();
+  ~ttkExtract() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -1,5 +1,4 @@
-#ifndef TTKFTMSTRUCTURES_H
-#define TTKFTMSTRUCTURES_H
+#pragma once
 
 #include <FTMTree.h>
 #include <ttkAlgorithm.h>
@@ -489,5 +488,3 @@ namespace ttk {
     };
   }; // namespace ftm
 }; // namespace ttk
-
-#endif /* end of include guard: TTKFTMSTRUCTURES_H */

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -103,7 +103,7 @@ public:
     params_.treeType = (ttk::ftm::TreeType)type;
     Modified();
   }
-  ttk::ftm::TreeType GetTreeType(void) const {
+  ttk::ftm::TreeType GetTreeType() const {
     return params_.treeType;
   }
   /// @}
@@ -114,7 +114,7 @@ public:
     params_.segm = segm;
     Modified();
   }
-  bool GetWithSegmentation(void) const {
+  bool GetWithSegmentation() const {
     return params_.segm;
   }
   /// @}
@@ -126,7 +126,7 @@ public:
     params_.normalize = norm;
     Modified();
   }
-  bool GetWithNormalize(void) const {
+  bool GetWithNormalize() const {
     return params_.normalize;
   }
   /// @}
@@ -138,7 +138,7 @@ public:
     params_.advStats = adv;
     Modified();
   }
-  bool GetWithAdvStats(void) const {
+  bool GetWithAdvStats() const {
     return params_.advStats;
   }
   /// @}
@@ -149,7 +149,7 @@ public:
     params_.samplingLvl = lvl;
     Modified();
   }
-  int GetSuperArcSamplingLevel(void) const {
+  int GetSuperArcSamplingLevel() const {
     return params_.samplingLvl;
   }
   /// @}

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -77,7 +77,7 @@ public:
     params_.singleSweep = ss;
     Modified();
   }
-  bool GetSingleSweep(void) const {
+  bool GetSingleSweep() const {
     return params_.singleSweep;
   }
   /// @}
@@ -88,7 +88,7 @@ public:
     params_.segm = segm;
     Modified();
   }
-  bool GetWithSegmentation(void) const {
+  bool GetWithSegmentation() const {
     return params_.segm;
   }
   /// @}
@@ -100,7 +100,7 @@ public:
     params_.normalize = norm;
     Modified();
   }
-  bool GetWithNormalize(void) const {
+  bool GetWithNormalize() const {
     return params_.normalize;
   }
   /// @}
@@ -111,7 +111,7 @@ public:
     params_.samplingLvl = lvl;
     Modified();
   }
-  int GetSuperArcSamplingLevel(void) const {
+  int GetSuperArcSamplingLevel() const {
     return params_.samplingLvl;
   }
   /// @}

--- a/core/vtk/ttkFiber/ttkFiber.cpp
+++ b/core/vtk/ttkFiber/ttkFiber.cpp
@@ -12,8 +12,7 @@ ttkFiber::ttkFiber() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkFiber::~ttkFiber() {
-}
+ttkFiber::~ttkFiber() = default;
 
 int ttkFiber::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkFiber/ttkFiber.h
+++ b/core/vtk/ttkFiber/ttkFiber.h
@@ -49,7 +49,7 @@ public:
 
 protected:
   ttkFiber();
-  ~ttkFiber();
+  ~ttkFiber() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkForEach/ttkForEach.cpp
+++ b/core/vtk/ttkForEach/ttkForEach.cpp
@@ -21,7 +21,8 @@ ttkForEach::ttkForEach() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkForEach::~ttkForEach(){};
+ttkForEach::~ttkForEach() = default;
+;
 
 int addRecursivelyToFieldData(vtkDataObject *object,
                               const vtkSmartPointer<vtkDataArray> &array) {

--- a/core/vtk/ttkForEach/ttkForEach.h
+++ b/core/vtk/ttkForEach/ttkForEach.h
@@ -42,7 +42,7 @@ public:
 
 protected:
   ttkForEach();
-  ~ttkForEach();
+  ~ttkForEach() override;
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.cpp
@@ -16,8 +16,7 @@ ttkGeometrySmoother::ttkGeometrySmoother() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkGeometrySmoother::~ttkGeometrySmoother() {
-}
+ttkGeometrySmoother::~ttkGeometrySmoother() = default;
 
 int ttkGeometrySmoother::FillInputPortInformation(int port,
                                                   vtkInformation *info) {

--- a/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
+++ b/core/vtk/ttkGeometrySmoother/ttkGeometrySmoother.h
@@ -77,7 +77,7 @@ public:
 
 protected:
   ttkGeometrySmoother();
-  ~ttkGeometrySmoother();
+  ~ttkGeometrySmoother() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkGridLayout/ttkGridLayout.cpp
+++ b/core/vtk/ttkGridLayout/ttkGridLayout.cpp
@@ -21,8 +21,7 @@ ttkGridLayout::ttkGridLayout() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkGridLayout::~ttkGridLayout() {
-}
+ttkGridLayout::~ttkGridLayout() = default;
 
 int ttkGridLayout::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0)

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.h
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.h
@@ -102,7 +102,7 @@ protected:
    *         (see cpp file)
    */
   ttkHelloWorld();
-  virtual ~ttkHelloWorld() override = default;
+  ~ttkHelloWorld() override = default;
 
   /**
    * TODO 8: Specify the input data type of each input port

--- a/core/vtk/ttkIcosphere/ttkIcosphere.cpp
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.cpp
@@ -83,7 +83,7 @@ int ttkIcosphere::RequestData(vtkInformation *ttkNotUsed(request),
 
   int status = 0;
   if(useDoublePrecision) {
-    typedef double DT;
+    using DT = double;
     status = this->computeIcospheres<DT, vtkIdType>(
       ttkUtils::GetPointer<DT>(points->GetData()),
       ttkUtils::GetPointer<vtkIdType>(connectivity),
@@ -92,7 +92,7 @@ int ttkIcosphere::RequestData(vtkInformation *ttkNotUsed(request),
       this->Centers ? ttkUtils::GetPointer<DT>(this->Centers) : this->Center,
       this->ComputeNormals ? ttkUtils::GetPointer<DT>(normals) : nullptr);
   } else {
-    typedef float DT;
+    using DT = float;
     DT centerFloat[3]{
       (DT)this->Center[0], (DT)this->Center[1], (DT)this->Center[2]};
     status = this->computeIcospheres<DT, vtkIdType>(

--- a/core/vtk/ttkIcosphere/ttkIcosphere.cpp
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.cpp
@@ -19,8 +19,7 @@ ttkIcosphere::ttkIcosphere() {
   this->SetNumberOfInputPorts(0);
   this->SetNumberOfOutputPorts(1);
 }
-ttkIcosphere::~ttkIcosphere() {
-}
+ttkIcosphere::~ttkIcosphere() = default;
 
 int ttkIcosphere::FillInputPortInformation(int ttkNotUsed(port),
                                            vtkInformation *ttkNotUsed(info)) {

--- a/core/vtk/ttkIcosphere/ttkIcosphere.h
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.h
@@ -56,7 +56,7 @@ public:
 
 protected:
   ttkIcosphere();
-  ~ttkIcosphere();
+  ~ttkIcosphere() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.cpp
+++ b/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.cpp
@@ -12,8 +12,7 @@ ttkIcosphereFromObject::ttkIcosphereFromObject() : ttkIcosphere() {
   this->setDebugMsgPrefix("IcosphereFromObject");
   this->SetNumberOfInputPorts(1);
 }
-ttkIcosphereFromObject::~ttkIcosphereFromObject() {
-}
+ttkIcosphereFromObject::~ttkIcosphereFromObject() = default;
 
 int ttkIcosphereFromObject::FillInputPortInformation(int port,
                                                      vtkInformation *info) {

--- a/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.h
+++ b/core/vtk/ttkIcosphereFromObject/ttkIcosphereFromObject.h
@@ -37,7 +37,7 @@ public:
 
 protected:
   ttkIcosphereFromObject();
-  ~ttkIcosphereFromObject();
+  ~ttkIcosphereFromObject() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
 

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.cpp
@@ -14,8 +14,7 @@ ttkIcospheresFromPoints::ttkIcospheresFromPoints() : ttkIcosphere() {
   this->setDebugMsgPrefix("IcospheresFromPoints");
   this->SetNumberOfInputPorts(1);
 }
-ttkIcospheresFromPoints::~ttkIcospheresFromPoints() {
-}
+ttkIcospheresFromPoints::~ttkIcospheresFromPoints() = default;
 
 int ttkIcospheresFromPoints::FillInputPortInformation(int port,
                                                       vtkInformation *info) {

--- a/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
+++ b/core/vtk/ttkIcospheresFromPoints/ttkIcospheresFromPoints.h
@@ -45,7 +45,7 @@ public:
 
 protected:
   ttkIcospheresFromPoints();
-  ~ttkIcospheresFromPoints();
+  ~ttkIcospheresFromPoints() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
 

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
@@ -24,8 +24,7 @@ ttkIdentifiers::ttkIdentifiers() {
                   "`Generate Ids' instead.");
 }
 
-ttkIdentifiers::~ttkIdentifiers() {
-}
+ttkIdentifiers::~ttkIdentifiers() = default;
 
 int ttkIdentifiers::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
+++ b/core/vtk/ttkIdentifyByScalarField/ttkIdentifyByScalarField.h
@@ -54,7 +54,8 @@ public:
 protected:
   ttkIdentifyByScalarField();
 
-  ~ttkIdentifyByScalarField() override{};
+  ~ttkIdentifyByScalarField() override = default;
+  ;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.cpp
@@ -1,4 +1,3 @@
-#include <iso646.h>
 #include <regex>
 #include <ttkImportEmbeddingFromTable.h>
 

--- a/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
+++ b/core/vtk/ttkImportEmbeddingFromTable/ttkImportEmbeddingFromTable.h
@@ -48,7 +48,8 @@ protected:
     SetNumberOfOutputPorts(1);
   }
 
-  ~ttkImportEmbeddingFromTable() override{};
+  ~ttkImportEmbeddingFromTable() override = default;
+  ;
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,

--- a/core/vtk/ttkManifoldCheck/ttkManifoldCheck.h
+++ b/core/vtk/ttkManifoldCheck/ttkManifoldCheck.h
@@ -56,7 +56,8 @@ public:
 protected:
   ttkManifoldCheck();
 
-  ~ttkManifoldCheck() override{};
+  ~ttkManifoldCheck() override = default;
+  ;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
 

--- a/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.h
+++ b/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.h
@@ -44,7 +44,7 @@ public:
 
 protected:
   ttkMatrixToHeatMap();
-  ~ttkMatrixToHeatMap() = default;
+  ~ttkMatrixToHeatMap() override = default;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -49,8 +49,7 @@ ttkMergeTreeClustering::ttkMergeTreeClustering() {
   this->SetNumberOfOutputPorts(3);
 }
 
-ttkMergeTreeClustering::~ttkMergeTreeClustering() {
-}
+ttkMergeTreeClustering::~ttkMergeTreeClustering() = default;
 
 /**
  * Specify the required input data type of each input port

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -34,8 +34,7 @@ ttkMergeTreeDistanceMatrix::ttkMergeTreeDistanceMatrix() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkMergeTreeDistanceMatrix::~ttkMergeTreeDistanceMatrix() {
-}
+ttkMergeTreeDistanceMatrix::~ttkMergeTreeDistanceMatrix() = default;
 
 /**
  * Specify the required input data type of each input port

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -25,9 +25,6 @@
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge
 ///   Tree Clustering example</a> \n
 
-#ifndef _TTKMERGETREEDISTANCEMATRIX_
-#define _TTKMERGETREEDISTANCEMATRIX_
-
 #pragma once
 
 // VTK Module
@@ -198,5 +195,3 @@ protected:
   int run(vtkInformationVector *outputVector,
           std::vector<vtkMultiBlockDataSet *> inputTrees);
 };
-
-#endif

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -145,7 +145,7 @@ int ttkMergeTreeTemporalReductionDecoding::RequestData(
     int index2 = vtkDataArray::SafeDownCast(table->GetColumnByName("Index2"))
                    ->GetTuple1(i);
 
-    coefs.push_back(std::make_tuple(alpha, index1R, index2R, index1, index2));
+    coefs.emplace_back(alpha, index1R, index2R, index1, index2);
     for(int j = index1 + 1; j < index2; ++j)
       interpolatedTrees[j] = true;
   }
@@ -233,7 +233,7 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
       treesNodesT.push_back(nullptr);
       treesArcsT.push_back(nullptr);
       treesSegmentationT.push_back(nullptr);
-      treesNodeCorrMeshT.push_back(std::vector<int>());
+      treesNodeCorrMeshT.emplace_back();
       inputTreesT.push_back(nullptr);
       ++cpt;
     }

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -39,9 +39,8 @@ ttkMergeTreeTemporalReductionDecoding::ttkMergeTreeTemporalReductionDecoding() {
   this->SetNumberOfOutputPorts(2);
 }
 
-ttkMergeTreeTemporalReductionDecoding::
-  ~ttkMergeTreeTemporalReductionDecoding() {
-}
+ttkMergeTreeTemporalReductionDecoding::~ttkMergeTreeTemporalReductionDecoding()
+  = default;
 
 /**
  * Specify the required input data type of each input port

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -39,9 +39,8 @@ ttkMergeTreeTemporalReductionEncoding::ttkMergeTreeTemporalReductionEncoding() {
   this->SetNumberOfOutputPorts(2);
 }
 
-ttkMergeTreeTemporalReductionEncoding::
-  ~ttkMergeTreeTemporalReductionEncoding() {
-}
+ttkMergeTreeTemporalReductionEncoding::~ttkMergeTreeTemporalReductionEncoding()
+  = default;
 
 /**
  * This method specifies the required input object data types of the

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.cpp
@@ -26,8 +26,7 @@ ttkMeshGraph::ttkMeshGraph() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkMeshGraph::~ttkMeshGraph() {
-}
+ttkMeshGraph::~ttkMeshGraph() = default;
 
 int ttkMeshGraph::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkMeshGraph/ttkMeshGraph.h
+++ b/core/vtk/ttkMeshGraph/ttkMeshGraph.h
@@ -55,7 +55,7 @@ public:
 
 protected:
   ttkMeshGraph();
-  ~ttkMeshGraph();
+  ~ttkMeshGraph() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.cpp
@@ -36,8 +36,7 @@ ttkMetricDistortion::ttkMetricDistortion() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkMetricDistortion::~ttkMetricDistortion() {
-}
+ttkMetricDistortion::~ttkMetricDistortion() = default;
 
 /**
  * Specify the required input data type of each input port

--- a/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.cpp
+++ b/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.cpp
@@ -17,8 +17,7 @@ ttkMorphologicalOperators::ttkMorphologicalOperators() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkMorphologicalOperators::~ttkMorphologicalOperators() {
-}
+ttkMorphologicalOperators::~ttkMorphologicalOperators() = default;
 
 int ttkMorphologicalOperators::FillInputPortInformation(int port,
                                                         vtkInformation *info) {

--- a/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.h
+++ b/core/vtk/ttkMorphologicalOperators/ttkMorphologicalOperators.h
@@ -58,7 +58,7 @@ public:
 
 protected:
   ttkMorphologicalOperators();
-  ~ttkMorphologicalOperators();
+  ~ttkMorphologicalOperators() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.cpp
@@ -24,8 +24,7 @@ ttkOBJWriter::ttkOBJWriter() {
   this->setDebugMsgPrefix("OBJWriter");
 }
 
-ttkOBJWriter::~ttkOBJWriter() {
-}
+ttkOBJWriter::~ttkOBJWriter() = default;
 
 int ttkOBJWriter::OpenFile() {
 

--- a/core/vtk/ttkOBJWriter/ttkOBJWriter.h
+++ b/core/vtk/ttkOBJWriter/ttkOBJWriter.h
@@ -36,7 +36,7 @@ protected:
   ~ttkOBJWriter() override;
 
   int OpenFile();
-  virtual void WriteData() override;
+  void WriteData() override;
 
   char *Filename{};
   std::ofstream Stream{};

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.cpp
@@ -27,8 +27,7 @@ ttkOFFWriter::ttkOFFWriter() {
   this->setDebugMsgPrefix("OFFWriter");
 }
 
-ttkOFFWriter::~ttkOFFWriter() {
-}
+ttkOFFWriter::~ttkOFFWriter() = default;
 
 int ttkOFFWriter::OpenFile() {
 

--- a/core/vtk/ttkOFFWriter/ttkOFFWriter.h
+++ b/core/vtk/ttkOFFWriter/ttkOFFWriter.h
@@ -32,10 +32,10 @@ public:
 
 protected:
   ttkOFFWriter();
-  ~ttkOFFWriter();
+  ~ttkOFFWriter() override;
 
   int OpenFile();
-  virtual void WriteData() override;
+  void WriteData() override;
 
   char *Filename{};
   std::ofstream Stream{};

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.cpp
@@ -17,8 +17,7 @@ ttkPersistenceCurve::ttkPersistenceCurve() {
   this->SetNumberOfOutputPorts(4);
 }
 
-ttkPersistenceCurve::~ttkPersistenceCurve() {
-}
+ttkPersistenceCurve::~ttkPersistenceCurve() = default;
 
 vtkTable *ttkPersistenceCurve::GetOutput() {
   return this->GetOutput(0);

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -43,8 +43,6 @@
 ///   Interaction sites</a> \n
 ///
 
-#ifndef _TTK_PERSISTENCECURVE_H
-#define _TTK_PERSISTENCECURVE_H
 #pragma once
 
 // VTK includes
@@ -118,5 +116,3 @@ private:
                const void *inputOffsets,
                const TTK_TT *triangulation);
 };
-
-#endif // _TTK_PERSISTENCECURVE_H

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -86,8 +86,10 @@ private:
   double prevXMax = 0;
 
 public:
-  ttkMergeTreeVisualization(){};
-  ~ttkMergeTreeVisualization() override{};
+  ttkMergeTreeVisualization() = default;
+  ;
+  ~ttkMergeTreeVisualization() override = default;
+  ;
 
   // ==========================================================================
   // Getter / Setter

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -87,7 +87,7 @@ private:
 
 public:
   ttkMergeTreeVisualization(){};
-  ~ttkMergeTreeVisualization(){};
+  ~ttkMergeTreeVisualization() override{};
 
   // ==========================================================================
   // Getter / Setter

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -22,8 +22,7 @@ ttkPlanarGraphLayout::ttkPlanarGraphLayout() {
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
 }
-ttkPlanarGraphLayout::~ttkPlanarGraphLayout() {
-}
+ttkPlanarGraphLayout::~ttkPlanarGraphLayout() = default;
 
 int ttkPlanarGraphLayout::FillInputPortInformation(int port,
                                                    vtkInformation *info) {

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -130,7 +130,7 @@ public:
 
 protected:
   ttkPlanarGraphLayout();
-  ~ttkPlanarGraphLayout();
+  ~ttkPlanarGraphLayout() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.h
+++ b/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.h
@@ -30,7 +30,7 @@ public:
 
 protected:
   ttkPointSetToCurve();
-  ~ttkPointSetToCurve() = default;
+  ~ttkPointSetToCurve() override = default;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -6,8 +6,7 @@
 /// \brief Base VTK editor class for standalone programs. This class parses the
 /// the comamnd line, execute the TTK module and takes care of the IO.
 
-#ifndef _TTK_PROGRAM_BASE_H
-#define _TTK_PROGRAM_BASE_H
+#pragma once
 
 // VTK IO
 #include <vtkDataSet.h>
@@ -202,5 +201,3 @@ int ttkProgramBase::load(
 
   return 0;
 }
-
-#endif // VTK_PROGRAM_BASE_H

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -52,7 +52,7 @@ public:
     return inputs_.size();
   };
 
-  virtual int run() override {
+  int run() override {
 
     if(!vtkWrapper_) {
       return -1;
@@ -68,7 +68,7 @@ public:
   }
 
   /// Save the output(s) of the TTK module.
-  virtual int save() const override;
+  int save() const override;
 
   virtual int setTTKmodule(vtkDataSetAlgorithm *ttkModule) {
 
@@ -91,7 +91,7 @@ protected:
            std::vector<vtkSmartPointer<vtkReaderClass>> &readerList);
 
   /// Load a sequence of input data-sets.
-  virtual int load(const std::vector<std::string> &inputPaths) override;
+  int load(const std::vector<std::string> &inputPaths) override;
 
   template <class vtkWriterClass>
   int save(const int &outputPortId) const;
@@ -107,7 +107,7 @@ public:
     ttkModule_ = (Debug *)ttkObject_.GetPointer();
   }
 
-  virtual int run() {
+  int run() override {
     return ttkProgramBase::run();
   }
 

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -36,7 +36,8 @@ public:
     vtkWrapper_ = nullptr;
   };
 
-  ~ttkProgramBase() override{};
+  ~ttkProgramBase() override = default;
+  ;
 
   /// Set the arguments of your ttk module and execute it here.
   int execute() override;

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -34,7 +34,7 @@ class TTKPROGRAMBASE_EXPORT ttkProgramBase : public ttk::ProgramBase {
 public:
   ttkProgramBase() {
 
-    vtkWrapper_ = NULL;
+    vtkWrapper_ = nullptr;
   };
 
   ~ttkProgramBase() override{};
@@ -44,7 +44,7 @@ public:
 
   vtkDataSet *getInput(const int &inputId) {
     if((inputId < 0) || (inputId >= (int)inputs_.size()))
-      return NULL;
+      return nullptr;
     return inputs_[inputId];
   }
 

--- a/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
+++ b/core/vtk/ttkRangePolygon/ttkRangePolygon.cpp
@@ -27,8 +27,7 @@ ttkRangePolygon::ttkRangePolygon() {
                   "`Poly Line Source' followed by `Resample With Dataset'.");
 }
 
-ttkRangePolygon::~ttkRangePolygon() {
-}
+ttkRangePolygon::~ttkRangePolygon() = default;
 
 int ttkRangePolygon::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0)

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -25,8 +25,7 @@ ttkScalarFieldCriticalPoints::ttkScalarFieldCriticalPoints() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkScalarFieldCriticalPoints::~ttkScalarFieldCriticalPoints() {
-}
+ttkScalarFieldCriticalPoints::~ttkScalarFieldCriticalPoints() = default;
 
 int ttkScalarFieldCriticalPoints::FillInputPortInformation(
   int port, vtkInformation *info) {

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -23,8 +23,7 @@ ttkScalarFieldNormalizer::ttkScalarFieldNormalizer() {
   setDebugMsgPrefix("ScalarFieldNormalizer");
 }
 
-ttkScalarFieldNormalizer::~ttkScalarFieldNormalizer() {
-}
+ttkScalarFieldNormalizer::~ttkScalarFieldNormalizer() = default;
 
 int ttkScalarFieldNormalizer::FillInputPortInformation(int port,
                                                        vtkInformation *info) {

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -19,8 +19,7 @@ ttkScalarFieldSmoother::ttkScalarFieldSmoother() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkScalarFieldSmoother::~ttkScalarFieldSmoother() {
-}
+ttkScalarFieldSmoother::~ttkScalarFieldSmoother() = default;
 
 int ttkScalarFieldSmoother::FillInputPortInformation(int port,
                                                      vtkInformation *info) {

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.h
@@ -47,8 +47,7 @@
 ///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
 ///   Persistence example</a> \n
 
-#ifndef _TTK_SCALAR_FIELD_SMOOTHER_H
-#define _TTK_SCALAR_FIELD_SMOOTHER_H
+#pragma once
 
 // VTK includes
 
@@ -91,5 +90,3 @@ private:
   int NumberOfIterations{1};
   bool ForceInputMaskScalarField{false};
 };
-
-#endif // _TTK_SCALAR_FIELD_SMOOTHER_H

--- a/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.cpp
+++ b/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.cpp
@@ -16,7 +16,7 @@ vtkStandardNewMacro(ttkSphereFromPoint);
 
 ttkSphereFromPoint::ttkSphereFromPoint() {
 
-  masterAppender_ = NULL;
+  masterAppender_ = nullptr;
 
   this->SetNumberOfInputPorts(1);
   this->SetNumberOfOutputPorts(1);
@@ -75,7 +75,7 @@ int ttkSphereFromPoint::RequestData(vtkInformation *ttkNotUsed(request),
 
   if(masterAppender_) {
     masterAppender_->Delete();
-    masterAppender_ = NULL;
+    masterAppender_ = nullptr;
   }
 
   for(SimplexId i = 0; i < (SimplexId)appenderList_.size(); i++) {

--- a/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
+++ b/core/vtk/ttkSphereFromPoint/ttkSphereFromPoint.h
@@ -14,8 +14,8 @@
 /// See the related ParaView example state files for usage examples within a
 /// VTK pipeline.
 ///
-#ifndef _TTK_SPHERE_FROM_POINT_H
-#define _TTK_SPHERE_FROM_POINT_H
+
+#pragma once
 
 // VTK includes
 
@@ -79,5 +79,3 @@ private:
   std::vector<vtkSphereSource *> sphereList_;
   std::vector<std::vector<vtkDataArray *>> dataArrayList_;
 };
-
-#endif // _TTK_SPHERE_FROM_POINT_H

--- a/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.h
+++ b/core/vtk/ttkStringArrayConverter/ttkStringArrayConverter.h
@@ -28,7 +28,7 @@ public:
 
 protected:
   ttkStringArrayConverter();
-  ~ttkStringArrayConverter() = default;
+  ~ttkStringArrayConverter() override = default;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
+++ b/core/vtk/ttkTableDataSelector/ttkTableDataSelector.h
@@ -77,7 +77,8 @@ protected:
     RangeId[1] = std::numeric_limits<int>::max();
   }
 
-  ~ttkTableDataSelector() override{};
+  ~ttkTableDataSelector() override = default;
+  ;
 
   int RequestInformation(vtkInformation *request,
                          vtkInformationVector **inputVector,

--- a/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
+++ b/core/vtk/ttkTopologicalCompressionReader/ttkTopologicalCompressionReader.h
@@ -48,9 +48,9 @@ protected:
   int RequestData(vtkInformation *,
                   vtkInformationVector **,
                   vtkInformationVector *) override;
-  virtual int RequestInformation(vtkInformation *request,
-                                 vtkInformationVector **inputVector,
-                                 vtkInformationVector *outputVector) override;
+  int RequestInformation(vtkInformation *request,
+                         vtkInformationVector **inputVector,
+                         vtkInformationVector *outputVector) override;
 
   // TTK management.
   void BuildMesh(vtkImageData *mesh) const;

--- a/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
+++ b/core/vtk/ttkTopologicalCompressionWriter/ttkTopologicalCompressionWriter.h
@@ -83,7 +83,7 @@ public:
 protected:
   // Regular writer management.
   ttkTopologicalCompressionWriter();
-  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillInputPortInformation(int port, vtkInformation *info) override;
 
 private:
   // Writer parameters.

--- a/core/vtk/ttkTopologicalSimplificationByPersistence/ttkTopologicalSimplificationByPersistence.cpp
+++ b/core/vtk/ttkTopologicalSimplificationByPersistence/ttkTopologicalSimplificationByPersistence.cpp
@@ -22,8 +22,8 @@ ttkTopologicalSimplificationByPersistence::
 }
 
 ttkTopologicalSimplificationByPersistence::
-  ~ttkTopologicalSimplificationByPersistence() {
-}
+  ~ttkTopologicalSimplificationByPersistence()
+  = default;
 
 int ttkTopologicalSimplificationByPersistence::FillInputPortInformation(
   int port, vtkInformation *info) {

--- a/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
+++ b/core/vtk/ttkTrackingFromPersistenceDiagrams/ttkTrackingFromPersistenceDiagrams.h
@@ -247,7 +247,7 @@ int ttkTrackingFromPersistenceDiagrams::buildMesh(
       int cid = k;
       bool hasMergedFirst = false;
       // if(DoPostProc) {
-      if(0) {
+      if(false) {
         std::set<int> &connected = trackingTupleToMerged[k];
         if(!connected.empty()) {
           int min = *(connected.begin());

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -86,8 +86,7 @@ ttkUserInterfaceBase::ttkUserInterfaceBase() {
                   && (pngReader_->GetOutput()->GetNumberOfCells() == 1));
 }
 
-ttkUserInterfaceBase::~ttkUserInterfaceBase() {
-}
+ttkUserInterfaceBase::~ttkUserInterfaceBase() = default;
 
 int ttkUserInterfaceBase::exportScene(const string &fileName) const {
 

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -64,8 +64,8 @@ void ttkCustomInteractor::OnKeyPress() {
 
 ttkUserInterfaceBase::ttkUserInterfaceBase() {
 
-  keyHandler_ = NULL;
-  vtkWrapper_ = NULL;
+  keyHandler_ = nullptr;
+  vtkWrapper_ = nullptr;
   isUp_ = false;
   repeat_ = false;
   transparency_ = false;
@@ -128,7 +128,7 @@ int ttkUserInterfaceBase::refresh() {
   }
 
   if((int)surfaces_.size() != outputPortNumber) {
-    surfaces_.resize(outputPortNumber, NULL);
+    surfaces_.resize(outputPortNumber, nullptr);
     mainActors_.resize(outputPortNumber);
     boundaryFilters_.resize(outputPortNumber);
     boundaryMappers_.resize(outputPortNumber);
@@ -147,7 +147,7 @@ int ttkUserInterfaceBase::refresh() {
     if(visibleOutputs_[i]) {
 
       if(hasTexture_) {
-        vtkWrapper_->GetOutput(i)->GetPointData()->SetActiveScalars(NULL);
+        vtkWrapper_->GetOutput(i)->GetPointData()->SetActiveScalars(nullptr);
       }
 
       if((repeat_) && (i < vtkWrapper_->GetNumberOfInputPorts())) {
@@ -168,7 +168,7 @@ int ttkUserInterfaceBase::refresh() {
     if(visibleOutputs_[i]) {
       mainActors_[i]->SetMapper(boundaryMappers_[i]);
     } else {
-      mainActors_[i]->SetMapper(NULL);
+      mainActors_[i]->SetMapper(nullptr);
     }
     if(transparency_) {
       mainActors_[i]->GetProperty()->SetOpacity(0.3);

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.h
@@ -36,7 +36,7 @@ public:
 
   vtkTypeMacro(ttkCustomInteractor, vtkInteractorStyleTrackballCamera);
 
-  virtual void OnKeyPress() override;
+  void OnKeyPress() override;
 
   inline int setUserInterface(ttkUserInterfaceBase *userInterface) {
 
@@ -131,7 +131,7 @@ public:
     ttkModule_ = (Debug *)ttkObject_.GetPointer();
   };
 
-  virtual int run() {
+  int run() override {
     return ttkUserInterfaceBase::run();
   }
 

--- a/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
+++ b/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
@@ -35,8 +35,7 @@ ttkWebSocketIO::ttkWebSocketIO() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkWebSocketIO::~ttkWebSocketIO() {
-}
+ttkWebSocketIO::~ttkWebSocketIO() = default;
 
 int ttkWebSocketIO::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0) {

--- a/core/vtk/ttkWebSocketIO/ttkWebSocketIO.h
+++ b/core/vtk/ttkWebSocketIO/ttkWebSocketIO.h
@@ -59,7 +59,7 @@ public:
 
 protected:
   ttkWebSocketIO();
-  ~ttkWebSocketIO();
+  ~ttkWebSocketIO() override;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;

--- a/standalone/ContinuousScatterPlot/main.cpp
+++ b/standalone/ContinuousScatterPlot/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     csp->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/ContourAroundPoint/main.cpp
+++ b/standalone/ContourAroundPoint/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     contourAroundPoint->SetInputArrayToProcess(

--- a/standalone/ContourForests/main.cpp
+++ b/standalone/ContourForests/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     cf->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/FTMTree/main.cpp
+++ b/standalone/FTMTree/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     ftmTree->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/FTRGraph/main.cpp
+++ b/standalone/FTRGraph/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     ftrG->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/GeometrySmoother/cmd/main.cpp
+++ b/standalone/GeometrySmoother/cmd/main.cpp
@@ -17,7 +17,7 @@ template <class ttkModule>
 class ExampleProgram : public Program<ttkModule> {
 
 public:
-  int execute() {
+  int execute() override {
 
     ScalarFieldSmoother *smoother
       = dynamic_cast<ScalarFieldSmoother *>(Program<ttkModule>::ttkModule_);
@@ -38,7 +38,7 @@ public:
     return 0;
   }
 
-  int load(const vector<string> &inputPaths) {
+  int load(const vector<string> &inputPaths) override {
 
     if(inputPaths.empty())
       return -1;
@@ -122,7 +122,7 @@ public:
     return 0;
   }
 
-  int save() const {
+  int save() const override {
 
     string fileName(Program<ttkModule>::outputPath_ + ".off");
 

--- a/standalone/HelloWorld/main.cpp
+++ b/standalone/HelloWorld/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     helloWorld->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/JacobiSet/main.cpp
+++ b/standalone/JacobiSet/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     js->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/LDistance/main.cpp
+++ b/standalone/LDistance/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     ldist->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/MandatoryCriticalPoints/main.cpp
+++ b/standalone/MandatoryCriticalPoints/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     mcp->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/MeshSubdivision/main.cpp
+++ b/standalone/MeshSubdivision/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     msub->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/MetricDistortion/main.cpp
+++ b/standalone/MetricDistortion/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     metricDistortion->SetInputArrayToProcess(

--- a/standalone/MorseSmaleComplex/main.cpp
+++ b/standalone/MorseSmaleComplex/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     msc->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -137,7 +137,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     persistenceDiagram->SetInputArrayToProcess(

--- a/standalone/PointMerger/main.cpp
+++ b/standalone/PointMerger/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     pmerg->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/ReebSpace/main.cpp
+++ b/standalone/ReebSpace/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     rs->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());

--- a/standalone/ScalarFieldCriticalPoints/main.cpp
+++ b/standalone/ScalarFieldCriticalPoints/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     scalarFieldCriticalPoints->SetInputArrayToProcess(

--- a/standalone/ScalarFieldSmoother/main.cpp
+++ b/standalone/ScalarFieldSmoother/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
   // ---------------------------------------------------------------------------
   if(!inputArrayNames.size()) {
     if(defaultArray)
-      inputArrayNames.push_back(defaultArray->GetName());
+      inputArrayNames.emplace_back(defaultArray->GetName());
   }
   for(size_t i = 0; i < inputArrayNames.size(); i++)
     scalarFieldSmoother->SetInputArrayToProcess(

--- a/standalone/UncertainDataEstimator/Editor.cpp
+++ b/standalone/UncertainDataEstimator/Editor.cpp
@@ -302,7 +302,7 @@ int Editor::loadData(const std::string &fileName) {
       this->printErr("Function loadData: reader not initialized");
       return -1;
     }
-    input_ = NULL;
+    input_ = nullptr;
     rawReader_->SetFileName(fileName.c_str());
     rawReader_->UpdateWholeExtent();
     input_ = vtkDataSet::SafeDownCast(rawReader_->GetOutput());
@@ -312,31 +312,31 @@ int Editor::loadData(const std::string &fileName) {
     if(inputFormat_ == "vtu") {
       if(input_) {
         input_->Delete();
-        input_ = NULL;
+        input_ = nullptr;
       }
       input_ = readXMLFile<vtkXMLUnstructuredGridReader>(fileName);
     } else if(inputFormat_ == "vtp") {
       if(input_) {
         input_->Delete();
-        input_ = NULL;
+        input_ = nullptr;
       }
       input_ = readXMLFile<vtkXMLPolyDataReader>(fileName);
     } else if(inputFormat_ == "vts") {
       if(input_) {
         input_->Delete();
-        input_ = NULL;
+        input_ = nullptr;
       }
       input_ = readXMLFile<vtkXMLStructuredGridReader>(fileName);
     } else if(inputFormat_ == "vtr") {
       if(input_) {
         input_->Delete();
-        input_ = NULL;
+        input_ = nullptr;
       }
       input_ = readXMLFile<vtkXMLRectilinearGridReader>(fileName);
     } else if(inputFormat_ == "vti") {
       if(input_) {
         input_->Delete();
-        input_ = NULL;
+        input_ = nullptr;
       }
       input_ = readXMLFile<vtkXMLImageDataReader>(fileName);
     } else {


### PR DESCRIPTION
This PR enables, enforces & fixes several `modernize` clang-tidy checks. Among them:
* replace `NULL` with `nullptr`,
* replace `typedef` with `using`,
* replace `push_back` with `emplace_back` (when a copy can be avoided),
* replace C standard library includes with their C++ counterparts (they reside in the `std::` namespace),
* remove void arguments in functions (this is useless in C++),
* use bool literals instead of integers,
* use `= default` for relevant constructors & destructors
* use `override` on methods instead of `virtual` when there is a virtual parent class method with the same signature. Also adds `override` when missing. I believe this fixes #732.

All of this has been automatically fixed using `clang-tidy -fix` and should also be enforced by the GitHub Actions CI.

Additionally, header guards were replaced with `#pragma once` directives. This is shorter, might have dedicated code paths inside compilers and don't shadow other `#define`s. I did not find a way to enforce that (yet).

Enjoy,
Pierre
