### PR TITLE
SurfaceGeometrySmoother: Support PolyData surfaces, hide error message

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -216,17 +216,22 @@ ttk::SimplexId *
                                       const std::string &arrayName,
                                       vtkDataSet *const inputData,
                                       std::vector<ttk::SimplexId> &spareStorage,
-                                      const int inputPort) {
+                                      const int inputPort,
+                                      const bool printErr) {
 
   // fetch data array
   const auto array = this->GetOptionalArray(
     enforceArrayIndex, arrayIndex, arrayName, inputData, inputPort);
   if(array == nullptr) {
-    this->printErr("Could not find the requested identifiers array");
+    if(printErr) {
+      this->printErr("Could not find the requested identifiers array");
+    }
     return {};
   }
   if(array->GetNumberOfComponents() != 1) {
-    this->printErr("Identifiers field must have only one component!");
+    if(printErr) {
+      this->printErr("Identifiers field must have only one component!");
+    }
     return {};
   }
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -138,7 +138,8 @@ public:
                           const std::string &arrayName,
                           vtkDataSet *const inputData,
                           std::vector<ttk::SimplexId> &spareStorage,
-                          const int inputPort = 0);
+                          const int inputPort = 0,
+                          const bool printErr = true);
 
   /**
    * This method retrieves the ttk::Triangulation of a vtkDataSet.

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -164,7 +164,7 @@ public:
   ttk::Triangulation *GetTriangulation(vtkDataSet *object);
 
   /**
-   * This key can be used during the FillOutputPortInfomration() call to
+   * This key can be used during the FillOutputPortInformation() call to
    * specify that an output port should produce the same data type as a
    * certain input port.
    */

--- a/core/vtk/ttkAlgorithm/ttkUtils.cpp
+++ b/core/vtk/ttkAlgorithm/ttkUtils.cpp
@@ -1,7 +1,4 @@
-#include <BaseClass.h>
 #include <ttkUtils.h>
-
-#include <limits>
 
 #include <vtkAbstractArray.h>
 #include <vtkCellArray.h>

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.h
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.h
@@ -27,7 +27,7 @@ public:
 
 protected:
   ttkPointSetToSurface();
-  ~ttkPointSetToSurface() = default;
+  ~ttkPointSetToSurface() override = default;
 
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
@@ -40,6 +40,4 @@ protected:
                 const VTK_T1 *const values,
                 const VTK_T2 *const values2,
                 const size_t nvalues);
-
-private:
 };

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
@@ -60,7 +60,10 @@ int ttkSurfaceGeometrySmoother::RequestData(
   std::vector<ttk::SimplexId> idSpareStorage{};
   const auto *vertsId = this->GetIdentifierArrayPtr(
     ForceIdentifiersField, 0, ttk::VertexScalarFieldName, inputPointSet,
-    idSpareStorage);
+    idSpareStorage, 0, false);
+  if(vertsId == nullptr) {
+    this->printWrn("No vertex scalar field detected on input");
+  }
 
   vtkDataArray *inputMaskField = ttkAlgorithm::GetOptionalArray(
     ForceInputMaskScalarField, 1, ttk::MaskScalarFieldName, inputPointSet);

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.cpp
@@ -21,7 +21,7 @@ int ttkSurfaceGeometrySmoother::FillInputPortInformation(int port,
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
     return 1;
   } else if(port == 1) {
-    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkUnstructuredGrid");
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPointSet");
     return 1;
   }
   return 0;

--- a/paraview/xmls/SurfaceGeometrySmoother.xml
+++ b/paraview/xmls/SurfaceGeometrySmoother.xml
@@ -42,7 +42,7 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkUnstructuredGrid"/>
+          <DataType value="vtkPointSet"/>
         </DataTypeDomain>
         <Documentation>
           Input triangulated surface.


### PR DESCRIPTION
This PR updates the SurfaceGeometrySmoother filter by allowing the Surface input to be a `vtkPointSet` and not only a `vtkUnstructuredGrid`.

A new boolean parameter in the `ttkAlgorithm::GetIdentifierArrayPtr` now controls the display of the error log message. Since SurfaceGeometrySmoother can work even when `ttkVertexScalarField` is absent, a warning message is displayed in the filter instead.

Enjoy,
Pierre