### PR TITLE
[MergeTreeVisu] exlude pairs, custom arrays, copy point data and more

### DIFF
--- a/CMake/merge_tree_planar_layout.xml
+++ b/CMake/merge_tree_planar_layout.xml
@@ -92,6 +92,44 @@ panel_visibility="advanced">
   </Documentation>
 </IntVectorProperty>
 
+<StringVectorProperty
+name="ExcludeImportantPairsLower"
+command="SetExcludeImportantPairsLower"
+label="Exclude Important Pairs Lower"
+number_of_elements="1"
+default_values=""
+panel_visibility="advanced">
+  <Hints>
+  <PropertyWidgetDecorator type="GenericDecorator"
+                          mode="visibility"
+                          property="MergeTreePlanarLayout"
+                          value="1" />
+  </Hints>
+  <Documentation>
+    Allows to forbid some pairs to be treated as important using intervals of relative persistence. This parameter is a string containing all lower bounds separated with a comma (",").
+    For example, when setting this parameter to "0, 20" and the ExcludeImportantPairsHigher parameter to "10, 30", then persistence pairs having a persistence in the range 0%-10% and in the range 20%-30% of the maximum persistence will not be treated as important no matter the value of ImportantPairsThreshold.
+  </Documentation>
+</StringVectorProperty>
+
+<StringVectorProperty
+name="ExcludeImportantPairsHigher"
+command="SetExcludeImportantPairsHigher"
+label="Exclude Important Pairs Higher"
+number_of_elements="1"
+default_values=""
+panel_visibility="advanced">
+  <Hints>
+  <PropertyWidgetDecorator type="GenericDecorator"
+                          mode="visibility"
+                          property="MergeTreePlanarLayout"
+                          value="1" />
+  </Hints>
+  <Documentation>
+    Allows to forbid some pairs to be treated as important using intervals of relative persistence. This parameter is a string containing all higher bounds separated with a comma (",").
+    For example, when setting the ExcludeImportantPairsLower parameter to "0, 20" and this parameter to "10, 30", then persistence pairs having a persistence in the range 0%-10% and in the range 20%-30% of the maximum persistence will not be treated as important no matter the value of ImportantPairsThreshold.
+  </Documentation>
+</StringVectorProperty>
+
 <DoubleVectorProperty
 name="ImportantPairsSpacing"
 command="SetImportantPairsSpacing"
@@ -150,6 +188,8 @@ default_values="0.05">
   <Property name="ImportantPairs"/>
   <Property name="MaximumImportantPairs"/>
   <Property name="MinimumImportantPairs"/>
+  <Property name="ExcludeImportantPairsHigher"/>
+  <Property name="ExcludeImportantPairsLower"/>
   <Property name="ImportantPairsSpacing"/>
   <Property name="NonImportantPairsSpacing"/>
   <Property name="NonImportantPairsProximity"/>

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -33,13 +33,32 @@ namespace ttk {
     }
 
     template <class dataType>
-    bool FTMTree_MT::isImportantPair(idNode nodeId, double threshold) {
+    bool FTMTree_MT::isImportantPair(idNode nodeId,
+                                     double threshold,
+                                     std::vector<double> &excludeLower,
+                                     std::vector<double> &excludeHigher) {
       dataType rootPers = this->getNodePersistence<dataType>(this->getRoot());
       if(threshold > 1)
         threshold /= 100.0;
       threshold = rootPers * threshold;
       auto pers = this->getNodePersistence<dataType>(nodeId);
-      return pers > threshold;
+
+      // Excluded pairs
+      bool isExcluded = false;
+      if(excludeLower.size() == excludeHigher.size())
+        for(unsigned i = 0; i < excludeLower.size(); ++i) {
+          isExcluded |= (pers > rootPers * excludeLower[i] / 100.0
+                         and pers < rootPers * excludeHigher[i] / 100.0);
+        }
+
+      return pers > threshold and not isExcluded;
+    }
+
+    template <class dataType>
+    bool FTMTree_MT::isImportantPair(idNode nodeId, double threshold) {
+      std::vector<double> excludeLower, excludeHigher;
+      return this->isImportantPair<dataType>(
+        nodeId, threshold, excludeLower, excludeHigher);
     }
 
     template <class dataType>

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -591,6 +591,12 @@ namespace ttk {
       bool isJoinTree();
 
       template <class dataType>
+      bool isImportantPair(idNode nodeId,
+                           double threshold,
+                           std::vector<double> &excludeLower,
+                           std::vector<double> &excludeHigher);
+
+      template <class dataType>
       bool isImportantPair(idNode nodeId, double threshold);
 
       bool isNodeMerged(idNode nodeId);

--- a/core/base/planarGraphLayout/MergeTreeVisualization.h
+++ b/core/base/planarGraphLayout/MergeTreeVisualization.h
@@ -23,6 +23,10 @@ namespace ttk {
     double importantPairsSpacing_ = 1.;
     double nonImportantPairsSpacing_ = 1.;
     double nonImportantPairsProximity_ = 0.05;
+    std::string excludeImportantPairsLower_ = "";
+    std::string excludeImportantPairsHigher_ = "";
+    std::vector<double> excludeImportantPairsLowerValues_,
+      excludeImportantPairsHigherValues_;
 
   public:
     MergeTreeVisualization() = default;
@@ -52,6 +56,14 @@ namespace ttk {
     }
     void setNonImportantPairsProximity(double d) {
       nonImportantPairsProximity_ = d;
+    }
+    void setExcludeImportantPairsHigher(std::string &d) {
+      excludeImportantPairsHigher_ = d;
+      parseExcludeImportantPairsString(d, excludeImportantPairsHigherValues_);
+    }
+    void setExcludeImportantPairsLower(std::string &d) {
+      excludeImportantPairsLower_ = d;
+      parseExcludeImportantPairsString(d, excludeImportantPairsLowerValues_);
     }
 
     // ==========================================================================
@@ -131,19 +143,27 @@ namespace ttk {
             float nodeSpacing = 0;
             if(i > 0) {
               if(tree->isImportantPair<dataType>(
-                   nodeBranchingVector[i], importantPairs_)) {
+                   nodeBranchingVector[i], importantPairs_,
+                   excludeImportantPairsLowerValues_,
+                   excludeImportantPairsHigherValues_)) {
                 nodeSpacing = importantPairsGap;
               } else if(tree->isImportantPair<dataType>(
-                          nodeBranchingVector[i - 1], importantPairs_)) {
+                          nodeBranchingVector[i - 1], importantPairs_,
+                          excludeImportantPairsLowerValues_,
+                          excludeImportantPairsHigherValues_)) {
                 nodeSpacing = nonImportantPairsProximity_;
                 // prevX =
               } else {
                 nodeSpacing = nonImportantPairsGap;
               }
             } else if(not tree->isImportantPair<dataType>(
-                        nodeBranchingVector[i], importantPairs_)
+                        nodeBranchingVector[i], importantPairs_,
+                        excludeImportantPairsLowerValues_,
+                        excludeImportantPairsHigherValues_)
                       and tree->isImportantPair<dataType>(
-                        nodeOrigin, importantPairs_))
+                        nodeOrigin, importantPairs_,
+                        excludeImportantPairsLowerValues_,
+                        excludeImportantPairsHigherValues_))
               nodeSpacing = nonImportantPairsProximity_;
             float newMin = prevX + nodeSpacing;
             float shiftX = newMin - oldMin;
@@ -184,12 +204,16 @@ namespace ttk {
             // Update x base for next iteration
             prevX = std::get<1>(allNodeSpanX[nodeBranchingI]);
             if(tree->isImportantPair<dataType>(
-                 nodeBranchingVector[i], importantPairs_)) {
+                 nodeBranchingVector[i], importantPairs_,
+                 excludeImportantPairsLowerValues_,
+                 excludeImportantPairsHigherValues_)) {
               lastIndexImportant = i;
               prevX = std::get<1>(allNodeImportantSpanX[nodeBranchingI]);
               if(i < nodeBranchingVector.size() - 1
                  and not tree->isImportantPair<dataType>(
-                   nodeBranchingVector[i + 1], importantPairs_)) {
+                   nodeBranchingVector[i + 1], importantPairs_,
+                   excludeImportantPairsLowerValues_,
+                   excludeImportantPairsHigherValues_)) {
                 float spanMin
                   = std::get<0>(allNodeSpanX[nodeBranchingVector[0]]);
                 float spanMax
@@ -523,13 +547,17 @@ namespace ttk {
         for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
           ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
           bool isSubBranchImportant = tree->isImportantPair<dataType>(
-            branchNodeOrigin, importantPairs_);
+            branchNodeOrigin, importantPairs_,
+            excludeImportantPairsLowerValues_,
+            excludeImportantPairsHigherValues_);
           if(not isSubBranchImportant)
             allBranchOriginsSize[nodeOrigin]
               += allBranchOriginsSize[branchNodeOrigin];
         }
 
-        if(tree->isImportantPair<dataType>(nodeOrigin, importantPairs_))
+        if(tree->isImportantPair<dataType>(nodeOrigin, importantPairs_,
+                                           excludeImportantPairsLowerValues_,
+                                           excludeImportantPairsHigherValues_))
           maxSize = std::max(maxSize, allBranchOriginsSize[nodeOrigin]);
       }
       double nonImportantPairsGap
@@ -559,7 +587,9 @@ namespace ttk {
           ftm::idNode branchNode = tree->getNode(branchNodeOrigin)->getOrigin();
 
           bool isSubBranchImportant = tree->isImportantPair<dataType>(
-            branchNodeOrigin, importantPairs_);
+            branchNodeOrigin, importantPairs_,
+            excludeImportantPairsLowerValues_,
+            excludeImportantPairsHigherValues_);
           bool toLeft = not isSubBranchImportant;
 
           // float branchNodeOriginXmin =
@@ -615,7 +645,9 @@ namespace ttk {
                     previousbranchNodeOriginXmax
                       - retVec[treeSimplexId[branchNode] * 2];
               bool isSubBranchImportant = tree->isImportantPair<dataType>(
-                branchNodeOrigin, importantPairs_);
+                branchNodeOrigin, importantPairs_,
+                excludeImportantPairsLowerValues_,
+                excludeImportantPairsHigherValues_);
               shift += (isLeft ? -1 : 1)
                        * (isSubBranchImportant ? importantPairsGap
                                                : nonImportantPairsGap);
@@ -676,15 +708,18 @@ namespace ttk {
         queueCrossing.pop();
         ftm::idNode nodeOrigin = tree->getNode(node)->getOrigin();
 
-        bool isBranchImportant
-          = tree->isImportantPair<dataType>(nodeOrigin, importantPairs_);
+        bool isBranchImportant = tree->isImportantPair<dataType>(
+          nodeOrigin, importantPairs_, excludeImportantPairsLowerValues_,
+          excludeImportantPairsHigherValues_);
         if(not isBranchImportant)
           continue;
 
         for(size_t i = 0; i < allBranchOrigins[nodeOrigin].size(); ++i) {
           ftm::idNode branchNodeOrigin = allBranchOrigins[nodeOrigin][i];
           bool isSubBranchImportant = tree->isImportantPair<dataType>(
-            branchNodeOrigin, importantPairs_);
+            branchNodeOrigin, importantPairs_,
+            excludeImportantPairsLowerValues_,
+            excludeImportantPairsHigherValues_);
           double shift = 0;
           if(not isSubBranchImportant) {
             double gap = retVec[treeSimplexId[node] * 2]
@@ -776,10 +811,10 @@ namespace ttk {
     bool isConflictingBoundsXOneWay(
       std::tuple<float, float, float, float> first,
       std::tuple<float, float, float, float> second) {
-      return (std::get<0>(first) <= std::get<0>(second)
-              and std::get<0>(second) <= std::get<1>(first))
-             or (std::get<0>(first) <= std::get<1>(second)
-                 and std::get<1>(second) <= std::get<1>(first));
+      return (std::get<0>(first) <= std::get<0>(second) + 1e-6
+              and std::get<0>(second) <= std::get<1>(first) + 1e-6)
+             or (std::get<0>(first) <= std::get<1>(second) + 1e-6
+                 and std::get<1>(second) <= std::get<1>(first) + 1e-6);
     }
 
     bool isConflictingBoundsX(std::tuple<float, float, float, float> first,
@@ -791,10 +826,10 @@ namespace ttk {
     bool isConflictingBoundsYOneWay(
       std::tuple<float, float, float, float> first,
       std::tuple<float, float, float, float> second) {
-      return (std::get<2>(first) <= std::get<2>(second)
-              and std::get<2>(second) <= std::get<3>(first))
-             or (std::get<2>(first) <= std::get<3>(second)
-                 and std::get<3>(second) <= std::get<3>(first));
+      return (std::get<2>(first) <= std::get<2>(second) + 1e-6
+              and std::get<2>(second) <= std::get<3>(first) + 1e-6)
+             or (std::get<2>(first) <= std::get<3>(second) + 1e-6
+                 and std::get<3>(second) <= std::get<3>(first) + 1e-6);
     }
 
     bool isConflictingBoundsY(std::tuple<float, float, float, float> first,
@@ -904,6 +939,31 @@ namespace ttk {
           z_max = std::max(z_max, std::get<5>(allBounds[i]));
         }
       return std::make_tuple(x_min, x_max, y_min, y_max, z_min, z_max);
+    }
+
+    // ==========================================================================
+    // Utils
+    // ==========================================================================
+    void parseExcludeImportantPairsString(std::string &exludeString,
+                                          std::vector<double> &excludeVector) {
+      excludeVector.clear();
+      if(exludeString == "")
+        return;
+      std::string s{exludeString};
+      std::string delimiter = ",";
+
+      size_t pos = 0;
+      std::string token;
+      while((pos = s.find(delimiter)) != std::string::npos) {
+        token = s.substr(0, pos);
+        excludeVector.emplace_back(std::stod(token));
+        s.erase(0, pos + delimiter.length());
+      }
+      excludeVector.emplace_back(std::stod(s));
+
+      for(auto v : excludeVector)
+        std::cout << v << " ";
+      std::cout << std::endl;
     }
   };
 

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -404,11 +404,14 @@ int ttkMergeTreeClustering::runOutput(
       visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
       visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
       visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+      visuMaker.setExcludeImportantPairsHigher(ExcludeImportantPairsHigher);
+      visuMaker.setExcludeImportantPairsLower(ExcludeImportantPairsLower);
 
       nodeCorr.clear();
       // First tree
       visuMaker.setNoSampleOffset(1);
       visuMaker.setTreesNodes(treesNodes[0]);
+      visuMaker.copyPointData(treesNodes[0], trees1NodeCorrMesh[0]);
       visuMaker.setTreesNodeCorrMesh(trees1NodeCorrMesh[0]);
       visuMaker.setTreesSegmentation(treesSegmentation[0]);
       visuMaker.setVtkOutputNode(vtkOutputNode1);
@@ -422,6 +425,8 @@ int ttkMergeTreeClustering::runOutput(
       // Second tree
       visuMaker.setISampleOffset(1);
       visuMaker.setTreesNodes(treesNodes[1]);
+      visuMaker.clearAllCustomArrays();
+      visuMaker.copyPointData(treesNodes[1], trees1NodeCorrMesh[1]);
       visuMaker.setTreesNodeCorrMesh(trees1NodeCorrMesh[1]);
       visuMaker.setTreesSegmentation(treesSegmentation[1]);
       visuMaker.setVtkOutputNode(vtkOutputNode2);
@@ -528,7 +533,10 @@ int ttkMergeTreeClustering::runOutput(
           visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
           visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
           visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+          visuMaker.setExcludeImportantPairsHigher(ExcludeImportantPairsHigher);
+          visuMaker.setExcludeImportantPairsLower(ExcludeImportantPairsLower);
           visuMaker.setTreesNodes(treesNodes);
+          visuMaker.copyPointData(treesNodes[i], trees1NodeCorrMesh[i]);
           visuMaker.setTreesNodeCorrMesh(trees1NodeCorrMesh);
           visuMaker.setTreesSegmentation(treesSegmentation);
           visuMaker.setVtkOutputNode(vtkOutputNode1);
@@ -595,6 +603,9 @@ int ttkMergeTreeClustering::runOutput(
         visuMakerBary.setImportantPairsSpacing(ImportantPairsSpacing);
         visuMakerBary.setNonImportantPairsSpacing(NonImportantPairsSpacing);
         visuMakerBary.setNonImportantPairsProximity(NonImportantPairsProximity);
+        visuMakerBary.setExcludeImportantPairsHigher(
+          ExcludeImportantPairsHigher);
+        visuMakerBary.setExcludeImportantPairsLower(ExcludeImportantPairsLower);
         visuMakerBary.setShiftMode(1); // Star Barycenter
         visuMakerBary.setTreesNodes(treesNodes);
         visuMakerBary.setTreesNodeCorrMesh(trees1NodeCorrMesh);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -98,6 +98,8 @@ private:
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
   bool BarycenterPositionAlpha = false;
+  std::string ExcludeImportantPairsLower = "";
+  std::string ExcludeImportantPairsHigher = "";
 
   // Old options
   bool ProgressiveComputation = false;
@@ -351,6 +353,12 @@ public:
 
   vtkSetMacro(NonImportantPairsProximity, double);
   vtkGetMacro(NonImportantPairsProximity, double);
+  
+  vtkSetMacro(ExcludeImportantPairsLower, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsLower, std::string);
+
+  vtkSetMacro(ExcludeImportantPairsHigher, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsHigher, std::string);
 
   // Old options
   vtkSetMacro(ProgressiveComputation, bool);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -353,7 +353,7 @@ public:
 
   vtkSetMacro(NonImportantPairsProximity, double);
   vtkGetMacro(NonImportantPairsProximity, double);
-  
+
   vtkSetMacro(ExcludeImportantPairsLower, const std::string &);
   vtkGetMacro(ExcludeImportantPairsLower, std::string);
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -282,12 +282,15 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
     visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
     visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
     visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+    visuMaker.setExcludeImportantPairsHigher(ExcludeImportantPairsHigher);
+    visuMaker.setExcludeImportantPairsLower(ExcludeImportantPairsLower);
     // visuMaker.setShiftMode(3); // Double Line
     visuMaker.setShiftMode(2); // Line
     visuMaker.setVtkOutputNode(vtkOutputNode1);
     visuMaker.setVtkOutputArc(vtkOutputArc1);
     visuMaker.setVtkOutputSegmentation(vtkOutputSegmentation1);
     visuMaker.setTreesNodes(treesNodes);
+    visuMaker.copyPointData(treesNodes[i], treesNodeCorrMesh[i]);
     visuMaker.setTreesNodeCorrMesh(treesNodeCorrMesh);
     visuMaker.setTreesSegmentation(treesSegmentation);
     visuMaker.setInterpolatedTrees(interpolatedTrees);

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -183,7 +183,7 @@ public:
 
   vtkSetMacro(NonImportantPairsProximity, double);
   vtkGetMacro(NonImportantPairsProximity, double);
-  
+
   vtkSetMacro(ExcludeImportantPairsLower, const std::string &);
   vtkGetMacro(ExcludeImportantPairsLower, std::string);
 

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -94,6 +94,8 @@ private:
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 1.;
   double NonImportantPairsProximity = 0.05;
+  std::string ExcludeImportantPairsLower = "";
+  std::string ExcludeImportantPairsHigher = "";
 
   // ----------------------
   // Data for visualization
@@ -181,6 +183,12 @@ public:
 
   vtkSetMacro(NonImportantPairsProximity, double);
   vtkGetMacro(NonImportantPairsProximity, double);
+  
+  vtkSetMacro(ExcludeImportantPairsLower, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsLower, std::string);
+
+  vtkSetMacro(ExcludeImportantPairsHigher, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsHigher, std::string);
 
   /**
    * This static method and the macro below are VTK conventions on how to

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -292,6 +292,7 @@ int ttkMergeTreeTemporalReductionEncoding::runOutput(
     visuMaker.setVtkOutputArc(vtkOutputArc1);
     visuMaker.setVtkOutputSegmentation(vtkOutputSegmentation1);
     visuMaker.setTreesNodes(treesNodes);
+    visuMaker.copyPointData(treesNodes[i], treesNodeCorrMesh[i]);
     visuMaker.setTreesNodeCorrMesh(treesNodeCorrMesh);
     visuMaker.setTreesSegmentation(treesSegmentation);
     visuMaker.setPrintTreeId(i);

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -17,9 +17,13 @@
 #include <vtkCellData.h>
 #include <vtkDoubleArray.h>
 #include <vtkFloatArray.h>
+#include <vtkImageData.h>
 #include <vtkIntArray.h>
 #include <vtkPointData.h>
 #include <vtkPoints.h>
+#include <vtkStringArray.h>
+#include <vtkTransform.h>
+#include <vtkTransformFilter.h>
 #include <vtkUnstructuredGrid.h>
 
 class ttkMergeTreeVisualization : public ttk::MergeTreeVisualization {
@@ -34,9 +38,13 @@ private:
   double DimensionSpacing = 1.;
   int DimensionToShift = 0;
   bool OutputSegmentation = false;
-  int ShiftMode = 0; // 0: Star ; 1: Star Barycenter ; 2: Line ; 3: Double Line
   int MaximumImportantPairs = 0;
   int MinimumImportantPairs = 0;
+  bool outputTreeNodeIndex = false;
+
+  // Shift mode
+  // -1: None ; 0: Star ; 1: Star Barycenter ; 2: Line ; 3: Double Line
+  int ShiftMode = 0;
 
   // Offset
   int iSampleOffset = 0;
@@ -73,12 +81,18 @@ private:
   // Output
   vtkUnstructuredGrid *vtkOutputNode{};
   vtkUnstructuredGrid *vtkOutputArc{};
-  vtkUnstructuredGrid *vtkOutputSegmentation{};
+  vtkDataSet *vtkOutputSegmentation{};
 
   // Matching output
   vtkUnstructuredGrid *vtkOutputNode1{}, *vtkOutputNode2{}; // input data
   std::vector<std::vector<SimplexId>> nodeCorr1, nodeCorr2;
   vtkUnstructuredGrid *vtkOutputMatching{}; // output
+
+  // Custom array
+  std::vector<std::tuple<std::string, std::vector<double>>> customArrays;
+  std::vector<std::tuple<std::string, std::vector<int>>> customIntArrays;
+  std::vector<std::tuple<std::string, std::vector<std::string>>>
+    customStringArrays;
 
   // Filled by the algorithm
   std::vector<std::vector<SimplexId>> nodeCorr;
@@ -115,6 +129,10 @@ public:
   }
   void setMinimumImportantPairs(int minPairs) {
     MinimumImportantPairs = minPairs;
+  }
+
+  void setOutputTreeNodeId(int doOutput) {
+    outputTreeNodeIndex = doOutput;
   }
 
   // Offset
@@ -200,7 +218,7 @@ public:
   void setVtkOutputArc(vtkUnstructuredGrid *vtkArc) {
     vtkOutputArc = vtkArc;
   }
-  void setVtkOutputSegmentation(vtkUnstructuredGrid *vtkSegmentation) {
+  void setVtkOutputSegmentation(vtkDataSet *vtkSegmentation) {
     vtkOutputSegmentation = vtkSegmentation;
   }
 
@@ -227,6 +245,131 @@ public:
     outputMatchingBarycenter[0]
       = std::vector<std::vector<std::tuple<idNode, idNode, double>>>(1);
     outputMatchingBarycenter[0][0] = matching;
+  }
+
+  // Custom array
+  void addCustomArray(std::string &name, std::vector<double> &vec) {
+    customArrays.push_back(std::make_tuple(name, vec));
+  }
+  void addCustomIntArray(std::string &name, std::vector<int> &vec) {
+    customIntArrays.push_back(std::make_tuple(name, vec));
+  }
+  void addCustomStringArray(std::string &name, std::vector<std::string> &vec) {
+    customStringArrays.push_back(std::make_tuple(name, vec));
+  }
+  void clearCustomArrays() {
+    customArrays.clear();
+  }
+  void clearCustomIntArrays() {
+    customIntArrays.clear();
+  }
+  void clearCustomStringArrays() {
+    customStringArrays.clear();
+  }
+  void clearAllCustomArrays() {
+    clearCustomArrays();
+    clearCustomIntArrays();
+    clearCustomStringArrays();
+  }
+
+  template <class dataType>
+  void addVtkCustomArrays(
+    std::vector<std::tuple<std::string, std::vector<dataType>>> &cArrays,
+    std::vector<std::vector<dataType>> &cArraysValues,
+    vtkUnstructuredGrid *vtkOutput,
+    int type,
+    int output) {
+    for(unsigned int i = 0; i < cArrays.size(); ++i) {
+      vtkNew<vtkDoubleArray> customDoubleArrayVtk;
+      vtkNew<vtkIntArray> customIntArrayVtk;
+      vtkNew<vtkStringArray> customStringArrayVtk;
+      vtkAbstractArray *customArrayVtk;
+      if(type == 0)
+        customArrayVtk = customDoubleArrayVtk;
+      else if(type == 1)
+        customArrayVtk = customIntArrayVtk;
+      else
+        customArrayVtk = customStringArrayVtk;
+      customArrayVtk->SetName(std::get<0>(cArrays[i]).c_str());
+      customArrayVtk->SetNumberOfTuples(cArraysValues[i].size());
+      for(unsigned int j = 0; j < cArraysValues[i].size(); ++j) {
+        // Add value depending on type (vtkAbstractArray can not be used here)
+        if(type == 0) {
+          double doubleValue = (*(std::vector<double> *)&(cArraysValues[i]))[j];
+          customDoubleArrayVtk->SetValue(j, doubleValue);
+        } else if(type == 1) {
+          int intValue = (*(std::vector<int> *)&(cArraysValues[i]))[j];
+          customIntArrayVtk->SetValue(j, intValue);
+        } else {
+          std::string stringValue
+            = (*(std::vector<std::string> *)&(cArraysValues[i]))[j];
+          customStringArrayVtk->SetValue(j, stringValue);
+        }
+      }
+      if(output == 0)
+        vtkOutput->GetPointData()->AddArray(customArrayVtk);
+      else
+        vtkOutput->GetCellData()->AddArray(customArrayVtk);
+    }
+  }
+
+  void getTreeNodeIdRev(vtkDataArray *treeNodeIdArray,
+                        std::vector<int> &treeNodeIdRev) {
+    double valueRange[2];
+    treeNodeIdArray->GetRange(valueRange);
+    int maxValue = valueRange[1];
+    treeNodeIdRev = std::vector<int>(maxValue + 1);
+    for(int i = 0; i < treeNodeIdArray->GetNumberOfValues(); ++i)
+      treeNodeIdRev[treeNodeIdArray->GetTuple1(i)] = i;
+  }
+
+  void copyPointData(vtkUnstructuredGrid *treeNodes,
+                     std::vector<int> &nodeCorrT) {
+    if(!treeNodes)
+      return;
+    
+    auto treeNodeIdArray = treeNodes->GetPointData()->GetArray("TreeNodeId");
+    std::vector<int> treeNodeIdRev;
+    if(treeNodeIdArray)
+      getTreeNodeIdRev(treeNodeIdArray, treeNodeIdRev);
+
+    for(int i = 0; i < treeNodes->GetPointData()->GetNumberOfArrays(); ++i) {
+      auto dataArray
+        = vtkDataArray::SafeDownCast(treeNodes->GetPointData()->GetArray(i));
+      auto stringArray
+        = vtkStringArray::SafeDownCast(treeNodes->GetPointData()->GetArray(i));
+      vtkAbstractArray *array;
+      if(dataArray)
+        array = dataArray;
+      else if(stringArray)
+        array = stringArray;
+      else
+        continue;
+      auto vecSize = (nodeCorrT.size() == 0 ? array->GetNumberOfValues()
+                                            : nodeCorrT.size());
+      std::vector<double> vec(vecSize);
+      std::vector<std::string> vecString(vecSize);
+      for(unsigned int j = 0; j < vec.size(); ++j) {
+        int toGet = (nodeCorrT.size() == 0 ? j : nodeCorrT[j]);
+        if(treeNodeIdArray)
+          toGet = (nodeCorrT.size() == 0 ? treeNodeIdRev[j]
+                                         : treeNodeIdRev[nodeCorrT[j]]);
+        auto value = array->GetVariantValue(toGet);
+        if(dataArray)
+          vec[j] = value.ToDouble();
+        else
+          vecString[j] = value.ToString();
+      }
+      std::string name{array->GetName()};
+      if(dataArray)
+        addCustomArray(name, vec);
+      else
+        addCustomStringArray(name, vecString);
+    }
+  }
+  void copyPointData(vtkUnstructuredGrid *treeNodes) {
+    std::vector<int> nodeCorrT;
+    copyPointData(treeNodes, nodeCorrT);
   }
 
   // Filled by the algorithm
@@ -427,20 +570,35 @@ public:
     NumberOfBarycenters
       = std::max(NumberOfBarycenters, 1); // to always enter the outer loop
 
+    // TreeNodeIdRev
+    for(int i = 0; i < numInputs; ++i) {
+      if(treesNodes[i]) {
+        auto treeNodeIdArray
+          = treesNodes[i]->GetPointData()->GetArray("TreeNodeId");
+        if(treeNodeIdArray) {
+          std::vector<int> treeNodeIdRev;
+          getTreeNodeIdRev(treeNodeIdArray, treeNodeIdRev);
+          for(unsigned int j = 0; j < treesNodeCorrMesh[i].size(); ++j)
+            treesNodeCorrMesh[i][j] = treeNodeIdRev[treesNodeCorrMesh[i][j]];
+        }
+      }
+    }
+
     // Bounds
     printMsg("Bounds and branching", ttk::debug::Priority::VERBOSE);
     std::vector<std::tuple<double, double, double, double, double, double>>
       allBounds(numInputs);
     for(int i = 0; i < numInputs; ++i) {
-      if(OutputSegmentation) {
+      if(OutputSegmentation and treesSegmentation[i]) {
         double *tBounds = treesSegmentation[i]->GetBounds();
         allBounds[i] = std::make_tuple(tBounds[0], tBounds[1], tBounds[2],
                                        tBounds[3], tBounds[4], tBounds[5]);
-      } else if(treesNodes[i] != nullptr)
+      } else if(treesNodes.size() != 0 and treesNodes[i] != nullptr) {
         allBounds[i]
           = getRealBounds(treesNodes[i], trees[i], treesNodeCorrMesh[i]);
-      else
+      } else {
         allBounds[i] = allBounds[0];
+      }
       /*if(PlanarLayout){
         // TODO correctly manage bounds when planar layout
         std::vector<double> tBound = tupleToVector(allBounds[i]);
@@ -497,7 +655,9 @@ public:
     vtkNew<vtkIntArray> isImportantPairsNode{};
     isImportantPairsNode->SetName("isImportantPair");
     vtkNew<vtkIntArray> nodeID{};
-    nodeID->SetName("NodeId");
+    nodeID->SetName("NodeId"); // Simplex Id
+    vtkNew<vtkIntArray> trueNodeID{};
+    trueNodeID->SetName("TrueNodeId");
     vtkNew<vtkIntArray> vertexID{};
     vertexID->SetName("VertexId");
 
@@ -512,6 +672,19 @@ public:
     percentMatch->SetName("PercentMatchNode");
     vtkNew<vtkFloatArray> persistenceBaryNode{};
     persistenceBaryNode->SetName("PersistenceBarycenter");
+    vtkNew<vtkIntArray> persistenceBaryOrderNode{};
+    persistenceBaryOrderNode->SetName("PersistenceBarycenterOrder");
+
+    vtkNew<vtkFloatArray> treeNodeId{};
+    treeNodeId->SetName("TreeNodeId");
+
+    vtkNew<vtkIntArray> isMultiPersPairNode{};
+    isMultiPersPairNode->SetName("isMultiPersPairNode");
+
+    std::vector<std::vector<double>> customArraysValues(customArrays.size());
+    std::vector<std::vector<int>> customIntArraysValues(customIntArrays.size());
+    std::vector<std::vector<std::string>> customStringArraysValues(
+      customStringArrays.size());
 
     // Arc fields
     vtkNew<vtkFloatArray> persistenceArc{};
@@ -532,7 +705,7 @@ public:
     vtkNew<vtkIntArray> treeIDArc{};
     treeIDArc->SetName("TreeID");
     vtkNew<vtkIntArray> branchBaryID{};
-    branchBaryID->SetName("BranchBaryID");
+    branchBaryID->SetName("BranchBaryNodeID");
     vtkNew<vtkIntArray> isInterpolatedTreeArc{};
     isInterpolatedTreeArc->SetName("isInterpolatedTree");
 
@@ -540,6 +713,18 @@ public:
     percentMatchArc->SetName("PercentMatchArc");
     vtkNew<vtkFloatArray> persistenceBaryArc{};
     persistenceBaryArc->SetName("PersistenceBarycenter");
+    vtkNew<vtkIntArray> persistenceBaryOrderArc{};
+    persistenceBaryOrderArc->SetName("PersistenceBarycenterOrder");
+
+    vtkNew<vtkIntArray> isMultiPersPairArc{};
+    isMultiPersPairArc->SetName("isMultiPersPairArc");
+
+    std::vector<std::vector<double>> customCellArraysValues(
+      customArrays.size());
+    std::vector<std::vector<int>> customCellIntArraysValues(
+      customIntArrays.size());
+    std::vector<std::vector<std::string>> customCellStringArraysValues(
+      customStringArrays.size());
 
     // Segmentation
     vtkNew<vtkAppendFilter> appendFilter{};
@@ -559,9 +744,24 @@ public:
     double importantPairsOriginal = importantPairs_;
     for(int c = 0; c < NumberOfBarycenters; ++c) {
 
+      // Get persistence order
+      std::vector<int> baryPersistenceOrder;
+      if(clusteringOutput and ShiftMode != 1) {
+        baryPersistenceOrder
+          = std::vector<int>(barycenters[c]->getNumberOfNodes(), -1);
+        std::vector<std::tuple<ttk::ftm::idNode, ttk::ftm::idNode, dataType>>
+          pairsBary;
+        barycenters[c]->getPersistencePairsFromTree<dataType>(pairsBary, false);
+        for(unsigned int j = 0; j < pairsBary.size(); ++j) {
+          int index = pairsBary.size() - 1 - j;
+          baryPersistenceOrder[std::get<0>(pairsBary[j])] = index;
+          baryPersistenceOrder[std::get<1>(pairsBary[j])] = index;
+        }
+      }
+
       // Get radius
       printMsg("// Get radius", ttk::debug::Priority::VERBOSE);
-      double delta_max = std::numeric_limits<double>::lowest();
+      double delta_max = 1.0;
       int noSample = 0 + noSampleOffset;
       for(int i = 0; i < numInputsOri; ++i) {
         delta_max = std::max(
@@ -606,16 +806,20 @@ public:
           std::vector<std::tuple<idNode, idNode, dataType>> pairs;
           trees[i]->getPersistencePairsFromTree(pairs, false);
           if(MaximumImportantPairs > 0) {
-            double tempThreshold
-              = 0.999 * std::get<2>(pairs[pairs.size() - MaximumImportantPairs])
-                / std::get<2>(pairs[pairs.size() - 1]);
+            int firstIndex = pairs.size() - MaximumImportantPairs;
+            firstIndex
+              = std::max(std::min(firstIndex, int(pairs.size()) - 1), 0);
+            double tempThreshold = 0.999 * std::get<2>(pairs[firstIndex])
+                                   / std::get<2>(pairs[pairs.size() - 1]);
             tempThreshold *= 100;
             importantPairs_ = std::max(importantPairs_, tempThreshold);
           }
           if(MinimumImportantPairs > 0) {
-            double tempThreshold
-              = 0.999 * std::get<2>(pairs[pairs.size() - MinimumImportantPairs])
-                / std::get<2>(pairs[pairs.size() - 1]);
+            int firstIndex = pairs.size() - MinimumImportantPairs;
+            firstIndex
+              = std::max(std::min(firstIndex, int(pairs.size()) - 1), 0);
+            double tempThreshold = 0.999 * std::get<2>(pairs[firstIndex])
+                                   / std::get<2>(pairs[pairs.size() - 1]);
             tempThreshold *= 100;
             importantPairs_ = std::min(importantPairs_, tempThreshold);
           }
@@ -641,6 +845,10 @@ public:
         double alphaShift
           = BarycenterPositionAlpha ? (-radius + 2 * radius * Alpha) * -1 : 0;
         switch(ShiftMode) {
+          case -1:
+            diff_x = 0.0;
+            diff_y = 0.0;
+            break;
           case 0: // Star
             diff_x
               = -1 * radius * std::cos(-1 * angle * pi / 180) + clusterShift[c];
@@ -701,7 +909,7 @@ public:
         std::vector<SimplexId> treeDummySimplexId(trees[i]->getNumberOfNodes());
         std::vector<SimplexId> layoutCorr(trees[i]->getNumberOfNodes());
         std::vector<idNode> treeMatching(trees[i]->getNumberOfNodes(), -1);
-        if(clusteringOutput)
+        if(clusteringOutput and ShiftMode != 1)
           for(auto match : outputMatchingBarycenter[c][i])
             treeMatching[std::get<1>(match)] = std::get<0>(match);
         // _ m[i][j] contains the node in treesOri[j] matched to the node i in
@@ -713,7 +921,7 @@ public:
             for(auto match : outputMatchingBarycenter[c][j])
               baryMatching[std::get<0>(match)][j] = std::get<1>(match);
           allBaryPercentMatch[c]
-            = std::vector<float>(trees[i]->getNumberOfNodes(), 100);
+            = std::vector<float>(trees[i]->getNumberOfNodes(), 100.0);
         }
 
         // ----------------------------
@@ -757,7 +965,8 @@ public:
             }
             for(int k = 0; k < 3; ++k)
               point[k] /= noMatched;
-          } else if(not isInterpolatedTree) {
+          } else if(not isInterpolatedTree and treesNodes.size() != 0
+                    and treesNodes[i] != nullptr) {
             nodeMesh = treesNodeCorrMesh[i][node];
             double *pointP = treesNodes[i]->GetPoints()->GetPoint(nodeMesh);
             for(int p = 0; p < 3; ++p)
@@ -811,7 +1020,8 @@ public:
             // TODO too many dummy cells are created
             bool dummyCell = PlanarLayout
                              and not branchDecompositionPlanarLayout_
-                             and treeBranching[node] == nodeParent
+                             and (node < treeBranching.size()
+                                  and treeBranching[node] == nodeParent)
                              and !trees[i]->isRoot(nodeParent);
             if(PlanarLayout and branchDecompositionPlanarLayout_) {
               pointIds[1] = treeSimplexId[treeBranching[node]];
@@ -846,12 +1056,9 @@ public:
                 "// Push arc bary branch id", ttk::debug::Priority::VERBOSE);
               if(clusteringOutput and ShiftMode != 1) {
                 int tBranchID = -1;
-                if(treeMatching[node] < allBaryBranchingID[c].size()) {
-                  tBranchID = allBaryBranchingID[c][treeMatching[node]];
-                  if(!trees[i]->isLeaf(node)
-                     && treeMatching[nodeOrigin] < allBaryBranchingID[c].size())
-                    tBranchID = allBaryBranchingID[c][treeMatching[nodeOrigin]];
-                }
+                auto nodeToGet = node;
+                if(treeMatching[nodeToGet] < allBaryBranchingID[c].size())
+                  tBranchID = allBaryBranchingID[c][treeMatching[nodeToGet]];
                 branchBaryID->InsertNextTuple1(tBranchID);
               }
 
@@ -873,15 +1080,18 @@ public:
                 = trees[i]->getNodePersistence<dataType>(nodeToGetPers);
               persistenceArc->InsertNextTuple1(persToAdd);
 
-              // Add arc persistence barycenter
+              // Add arc persistence barycenter and order
               if(clusteringOutput and ShiftMode != 1) {
                 idNode nodeToGet = treeBranching[node];
                 if(PlanarLayout and branchDecompositionPlanarLayout_)
                   nodeToGet = node;
-                if(treeMatching[nodeToGet] < allBaryBranchingID[c].size())
+                if(treeMatching[nodeToGet] < allBaryBranchingID[c].size()) {
                   persistenceBaryArc->InsertTuple1(
                     cellCount, barycenters[c]->getNodePersistence<dataType>(
                                  treeMatching[nodeToGet]));
+                  persistenceBaryOrderArc->InsertTuple1(
+                    cellCount, baryPersistenceOrder[treeMatching[nodeToGet]]);
+                }
               }
 
               // Add arc cluster ID
@@ -896,7 +1106,9 @@ public:
               if(PlanarLayout and branchDecompositionPlanarLayout_)
                 nodeToGetImportance = node;
               isImportant = trees[i]->isImportantPair<dataType>(
-                nodeToGetImportance, importantPairs_);
+                nodeToGetImportance, importantPairs_,
+                excludeImportantPairsLowerValues_,
+                excludeImportantPairsHigherValues_);
               isImportantPairsArc->InsertNextTuple1(isImportant);
 
               // Add isDummyArc
@@ -905,6 +1117,30 @@ public:
 
               // Add isInterpolatedTree
               isInterpolatedTreeArc->InsertNextTuple1(isInterpolatedTree);
+
+              // Add isMultiPersPairArc
+              bool isMultiPersPair
+                = (trees[i]->isMultiPersPair(treeBranching[node])
+                   or trees[i]->isMultiPersPair(
+                     trees[i]->getNode(treeBranching[node])->getOrigin()));
+              isMultiPersPairArc->InsertNextTuple1(isMultiPersPair);
+
+              // Add custom point arrays to cells
+              for(unsigned int ca = 0; ca < customArrays.size(); ++ca) {
+                auto nodeToGet = treeBranching[node];
+                customCellArraysValues[ca].push_back(
+                  std::get<1>(customArrays[ca])[nodeToGet]);
+              }
+              for(unsigned int ca = 0; ca < customIntArrays.size(); ++ca) {
+                auto nodeToGet = treeBranching[node];
+                customCellIntArraysValues[ca].push_back(
+                  std::get<1>(customIntArrays[ca])[nodeToGet]);
+              }
+              for(unsigned int ca = 0; ca < customStringArrays.size(); ++ca) {
+                auto nodeToGet = treeBranching[node];
+                customCellStringArraysValues[ca].push_back(
+                  std::get<1>(customStringArrays[ca])[nodeToGet]);
+              }
 
               cellCount++;
             }
@@ -917,6 +1153,9 @@ public:
           for(int toAddT = 0; toAddT < toAdd; ++toAddT) {
             // Add node id
             nodeID->InsertNextTuple1(treeSimplexId[node]);
+            
+            // Add trueNodeId
+            trueNodeID->InsertNextTuple1(node);
 
             // Add VertexId
             int nodeVertexId = -1;
@@ -942,13 +1181,13 @@ public:
                       "CriticalType");
                   criticalTypeT = array->GetTuple1(nodeMesh);
                 }
-              } else {
+              } else if(treesNodes.size() != 0 and treesNodes[i] != nullptr) {
                 auto array
                   = treesNodes[i]->GetPointData()->GetArray("CriticalType");
                 criticalTypeT = array->GetTuple1(nodeMesh);
               }
             } else {
-              // TODO
+              // TODO critical type for interpolated trees
             }
             criticalType->InsertNextTuple1(criticalTypeT);
 
@@ -973,7 +1212,7 @@ public:
               branchBaryNodeID->InsertNextTuple1(tBranchID);
             }
 
-            // Add node branch bary id
+            // Add node branch id
             int tBranchID = treeBranchingID[node];
             if(not trees[i]->isLeaf(node))
               tBranchID = treeBranchingID[nodeOrigin];
@@ -985,16 +1224,20 @@ public:
               trees[i]->getNodePersistence<dataType>(node));
 
             // Add node persistence barycenter
-            if(clusteringOutput and ShiftMode != 1)
-              if(treeMatching[node] < allBaryBranchingID[c].size())
+            if(clusteringOutput and ShiftMode != 1) {
+              if(treeMatching[node] < allBaryBranchingID[c].size()) {
                 persistenceBaryNode->InsertTuple1(
                   pointCount, barycenters[c]->getNodePersistence<dataType>(
                                 treeMatching[node]));
+                persistenceBaryOrderNode->InsertTuple1(
+                  pointCount, baryPersistenceOrder[treeMatching[node]]);
+              }
+            }
 
             // Add node clusterID
             clusterIDNode->InsertNextTuple1(clusteringAssignment[i]);
 
-            // Add arc tree ID
+            // Add node tree ID
             treeIDNode->InsertNextTuple1(i);
 
             // Add isDummyNode
@@ -1007,9 +1250,30 @@ public:
 
             // Add isImportantPair
             bool isImportant = false;
-            isImportant
-              = trees[i]->isImportantPair<dataType>(node, importantPairs_);
+            isImportant = trees[i]->isImportantPair<dataType>(
+              node, importantPairs_, excludeImportantPairsLowerValues_,
+              excludeImportantPairsHigherValues_);
             isImportantPairsNode->InsertNextTuple1(isImportant);
+
+            // Add treeNodeId
+            treeNodeId->InsertNextTuple1(node);
+
+            // Add isMultiPersPairArc
+            bool isMultiPersPair = (trees[i]->isMultiPersPair(node)
+                                    or trees[i]->isMultiPersPair(
+                                      trees[i]->getNode(node)->getOrigin()));
+            isMultiPersPairNode->InsertNextTuple1(isMultiPersPair);
+
+            // Add custom arrays
+            for(unsigned int ca = 0; ca < customArrays.size(); ++ca)
+              customArraysValues[ca].push_back(
+                std::get<1>(customArrays[ca])[node]);
+            for(unsigned int ca = 0; ca < customIntArrays.size(); ++ca)
+              customIntArraysValues[ca].push_back(
+                std::get<1>(customIntArrays[ca])[node]);
+            for(unsigned int ca = 0; ca < customStringArrays.size(); ++ca)
+              customStringArraysValues[ca].push_back(
+                std::get<1>(customStringArrays[ca])[node]);
 
             pointCount++;
           }
@@ -1021,54 +1285,75 @@ public:
         // Manage segmentation
         // --------------
         printMsg("// Shift segmentation", ttk::debug::Priority::VERBOSE);
-        if(OutputSegmentation and not PlanarLayout) {
-          vtkNew<vtkUnstructuredGrid> iTreesSegmentationCopy{};
-          iTreesSegmentationCopy->DeepCopy(treesSegmentation[i]);
-          auto iVkOutputSegmentationTemp
-            = vtkUnstructuredGrid::SafeDownCast(iTreesSegmentationCopy);
-          for(int p = 0;
-              p < iVkOutputSegmentationTemp->GetPoints()->GetNumberOfPoints();
-              ++p) {
-            double *point = iVkOutputSegmentationTemp->GetPoints()->GetPoint(p);
-            point[0] += diff_x;
-            point[1] += diff_y;
-            point[2] += diff_z;
-            iVkOutputSegmentationTemp->GetPoints()->SetPoint(p, point);
-          }
-          appendFilter->AddInputData(iVkOutputSegmentationTemp);
+        if(OutputSegmentation and not PlanarLayout and treesSegmentation[i]) {
+          vtkNew<vtkTransform> transform{};
+          transform->Translate(diff_x, diff_y, diff_z);
+          vtkNew<vtkTransformFilter> transformFilter{};
+          transformFilter->SetTransform(transform);
+          transformFilter->SetInputData(treesSegmentation[i]);
+          transformFilter->Update();
+          appendFilter->AddInputData(transformFilter->GetOutputDataObject(0));
         }
+        printMsg("// Shift segmentation DONE", ttk::debug::Priority::VERBOSE);
       }
     }
     for(int i = persistenceBaryNode->GetNumberOfTuples(); i < pointCount; ++i)
       persistenceBaryNode->InsertNextTuple1(0);
     for(int i = persistenceBaryArc->GetNumberOfTuples(); i < cellCount; ++i)
       persistenceBaryArc->InsertNextTuple1(0);
+    for(int i = persistenceBaryOrderNode->GetNumberOfTuples(); i < pointCount;
+        ++i)
+      persistenceBaryOrderNode->InsertNextTuple1(0);
+    for(int i = persistenceBaryOrderArc->GetNumberOfTuples(); i < cellCount;
+        ++i)
+      persistenceBaryOrderArc->InsertNextTuple1(0);
 
     // --- Add VTK arrays to output
     printMsg("// Add VTK arrays to output", ttk::debug::Priority::VERBOSE);
-    // Manage node output
+    // - Manage node output
+    // Custom arrays
+    addVtkCustomArrays(customArrays, customArraysValues, vtkOutputNode, 0, 0);
+    addVtkCustomArrays(
+      customIntArrays, customIntArraysValues, vtkOutputNode, 1, 0);
+    addVtkCustomArrays(
+      customStringArrays, customStringArraysValues, vtkOutputNode, 2, 0);
+
+    // Classical arrays
     vtkOutputNode->SetPoints(points);
     vtkOutputNode->GetPointData()->AddArray(criticalType);
     vtkOutputNode->GetPointData()->AddArray(persistenceNode);
     vtkOutputNode->GetPointData()->AddArray(clusterIDNode);
     vtkOutputNode->GetPointData()->AddArray(treeIDNode);
     vtkOutputNode->GetPointData()->AddArray(isDummyNode);
-    vtkOutputNode->GetPointData()->AddArray(branchNodeID);
     vtkOutputNode->GetPointData()->AddArray(nodeID);
+    vtkOutputNode->GetPointData()->AddArray(trueNodeID);
     vtkOutputNode->GetPointData()->AddArray(vertexID);
     vtkOutputNode->GetPointData()->AddArray(isImportantPairsNode);
+    vtkOutputNode->GetPointData()->AddArray(isMultiPersPairNode);
+    vtkOutputNode->GetPointData()->AddArray(branchNodeID);
     if(not branchDecompositionPlanarLayout_)
       vtkOutputNode->GetPointData()->AddArray(scalar);
     if(clusteringOutput and ShiftMode != 1) {
       vtkOutputNode->GetPointData()->AddArray(branchBaryNodeID);
       vtkOutputNode->GetPointData()->AddArray(persistenceBaryNode);
+      vtkOutputNode->GetPointData()->AddArray(persistenceBaryOrderNode);
     }
     if(foundOneInterpolatedTree)
       vtkOutputNode->GetPointData()->AddArray(isInterpolatedTreeNode);
     if(ShiftMode == 1) // Star Barycenter
       vtkOutputNode->GetPointData()->AddArray(percentMatch);
+    if(outputTreeNodeIndex)
+      vtkOutputNode->GetPointData()->AddArray(treeNodeId);
 
-    // Manage arc output
+    // - Manage arc output
+    // Custom arrays
+    addVtkCustomArrays(customArrays, customCellArraysValues, vtkArcs, 0, 1);
+    addVtkCustomArrays(
+      customIntArrays, customCellIntArraysValues, vtkArcs, 1, 1);
+    addVtkCustomArrays(
+      customStringArrays, customCellStringArraysValues, vtkArcs, 2, 1);
+
+    // Classical arrays
     vtkArcs->SetPoints(points);
     vtkArcs->GetCellData()->AddArray(persistenceArc);
     vtkArcs->GetCellData()->AddArray(clusterIDArc);
@@ -1078,9 +1363,11 @@ public:
     vtkArcs->GetCellData()->AddArray(branchID);
     vtkArcs->GetCellData()->AddArray(upNodeId);
     vtkArcs->GetCellData()->AddArray(downNodeId);
+    vtkArcs->GetCellData()->AddArray(isMultiPersPairArc);
     if(clusteringOutput and ShiftMode != 1) {
       vtkArcs->GetCellData()->AddArray(branchBaryID);
       vtkArcs->GetCellData()->AddArray(persistenceBaryArc);
+      vtkArcs->GetCellData()->AddArray(persistenceBaryOrderArc);
     }
     if(foundOneInterpolatedTree)
       vtkArcs->GetCellData()->AddArray(isInterpolatedTreeArc);
@@ -1088,12 +1375,18 @@ public:
       vtkArcs->GetCellData()->AddArray(percentMatchArc);
     if(vtkOutputArc == vtkOutputNode)
       vtkArcs->GetPointData()->ShallowCopy(vtkOutputNode->GetPointData());
+    if(not branchDecompositionPlanarLayout_)
+      vtkArcs->GetPointData()->AddArray(scalar);
     vtkOutputArc->ShallowCopy(vtkArcs);
 
-    // Manage segmentation output
-    if(OutputSegmentation and not PlanarLayout) {
+    // - Manage segmentation output
+    if(OutputSegmentation and not PlanarLayout
+       and appendFilter->GetNumberOfInputConnections(0) != 0) {
+      appendFilter->SetMergePoints(false);
       appendFilter->Update();
       vtkOutputSegmentation->ShallowCopy(appendFilter->GetOutput());
+      // vtkOutputSegmentation =
+      // vtkDataSet::SafeDownCast(appendFilter->GetOutput());
     }
 
     //

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -1291,7 +1291,6 @@ public:
             iTreesSegmentationCopy->DeepCopy(treesSegmentation[i]);
           else
             iTreesSegmentationCopy->ShallowCopy(treesSegmentation[i]);
-          iTreesSegmentationCopy->DeepCopy(treesSegmentation[i]);
           auto iVkOutputSegmentationTemp
             = vtkUnstructuredGrid::SafeDownCast(iTreesSegmentationCopy);
           if(!iVkOutputSegmentationTemp

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -247,13 +247,13 @@ public:
 
   // Custom array
   void addCustomArray(std::string &name, std::vector<double> &vec) {
-    customArrays.push_back(std::make_tuple(name, vec));
+    customArrays.emplace_back(std::make_tuple(name, vec));
   }
   void addCustomIntArray(std::string &name, std::vector<int> &vec) {
-    customIntArrays.push_back(std::make_tuple(name, vec));
+    customIntArrays.emplace_back(std::make_tuple(name, vec));
   }
   void addCustomStringArray(std::string &name, std::vector<std::string> &vec) {
-    customStringArrays.push_back(std::make_tuple(name, vec));
+    customStringArrays.emplace_back(std::make_tuple(name, vec));
   }
   void clearCustomArrays() {
     customArrays.clear();
@@ -1126,17 +1126,17 @@ public:
               // Add custom point arrays to cells
               for(unsigned int ca = 0; ca < customArrays.size(); ++ca) {
                 auto nodeToGet = treeBranching[node];
-                customCellArraysValues[ca].push_back(
+                customCellArraysValues[ca].emplace_back(
                   std::get<1>(customArrays[ca])[nodeToGet]);
               }
               for(unsigned int ca = 0; ca < customIntArrays.size(); ++ca) {
                 auto nodeToGet = treeBranching[node];
-                customCellIntArraysValues[ca].push_back(
+                customCellIntArraysValues[ca].emplace_back(
                   std::get<1>(customIntArrays[ca])[nodeToGet]);
               }
               for(unsigned int ca = 0; ca < customStringArrays.size(); ++ca) {
                 auto nodeToGet = treeBranching[node];
-                customCellStringArraysValues[ca].push_back(
+                customCellStringArraysValues[ca].emplace_back(
                   std::get<1>(customStringArrays[ca])[nodeToGet]);
               }
 
@@ -1264,13 +1264,13 @@ public:
 
             // Add custom arrays
             for(unsigned int ca = 0; ca < customArrays.size(); ++ca)
-              customArraysValues[ca].push_back(
+              customArraysValues[ca].emplace_back(
                 std::get<1>(customArrays[ca])[node]);
             for(unsigned int ca = 0; ca < customIntArrays.size(); ++ca)
-              customIntArraysValues[ca].push_back(
+              customIntArraysValues[ca].emplace_back(
                 std::get<1>(customIntArrays[ca])[node]);
             for(unsigned int ca = 0; ca < customStringArrays.size(); ++ca)
-              customStringArraysValues[ca].push_back(
+              customStringArraysValues[ca].emplace_back(
                 std::get<1>(customStringArrays[ca])[node]);
 
             pointCount++;

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -247,13 +247,13 @@ public:
 
   // Custom array
   void addCustomArray(std::string &name, std::vector<double> &vec) {
-    customArrays.emplace_back(std::make_tuple(name, vec));
+    customArrays.emplace_back(name, vec);
   }
   void addCustomIntArray(std::string &name, std::vector<int> &vec) {
-    customIntArrays.emplace_back(std::make_tuple(name, vec));
+    customIntArrays.emplace_back(name, vec);
   }
   void addCustomStringArray(std::string &name, std::vector<std::string> &vec) {
-    customStringArrays.emplace_back(std::make_tuple(name, vec));
+    customStringArrays.emplace_back(name, vec);
   }
   void clearCustomArrays() {
     customArrays.clear();

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -127,7 +127,6 @@ int ttkPlanarGraphLayout::mergeTreePlanarLayoutCallTemplate(
   vtkUnstructuredGrid *output) {
   auto mergeTree = ttk::ftm::makeTree<dataType>(treeNodes, treeArcs);
   ttk::ftm::FTMTree_MT *tree = &(mergeTree.tree);
-  // tree->printTree2();
 
   ttk::ftm::computePersistencePairs<dataType>(tree);
 
@@ -147,11 +146,14 @@ int ttkPlanarGraphLayout::mergeTreePlanarLayoutCallTemplate(
   visuMaker.setImportantPairsSpacing(ImportantPairsSpacing);
   visuMaker.setNonImportantPairsSpacing(NonImportantPairsSpacing);
   visuMaker.setNonImportantPairsProximity(NonImportantPairsProximity);
+  visuMaker.setExcludeImportantPairsHigher(ExcludeImportantPairsHigher);
+  visuMaker.setExcludeImportantPairsLower(ExcludeImportantPairsLower);
   visuMaker.setVtkOutputNode(output);
   visuMaker.setVtkOutputArc(output);
   visuMaker.setTreesNodes(treeNodes);
   visuMaker.setTreesNodeCorrMesh(treeNodeCorrMesh);
   visuMaker.setDebugLevel(this->debugLevel_);
+  visuMaker.copyPointData(treeNodes);
   visuMaker.makeTreesOutput<dataType>(tree);
 
   return 1;

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -76,6 +76,8 @@ private:
   double ImportantPairsSpacing = 1.;
   double NonImportantPairsSpacing = 0.1;
   double NonImportantPairsProximity = 0.05;
+  std::string ExcludeImportantPairsLower = "";
+  std::string ExcludeImportantPairsHigher = "";
 
 public:
   // --- Graph Planar Layout
@@ -123,6 +125,12 @@ public:
 
   vtkSetMacro(NonImportantPairsProximity, double);
   vtkGetMacro(NonImportantPairsProximity, double);
+
+  vtkSetMacro(ExcludeImportantPairsLower, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsLower, std::string);
+
+  vtkSetMacro(ExcludeImportantPairsHigher, const std::string &);
+  vtkGetMacro(ExcludeImportantPairsHigher, std::string);
 
   // ---
   static ttkPlanarGraphLayout *New();

--- a/core/vtk/ttkPlanarGraphLayout/vtk.module
+++ b/core/vtk/ttkPlanarGraphLayout/vtk.module
@@ -2,4 +2,3 @@ NAME
   ttkPlanarGraphLayout
 DEPENDS
   ttkAlgorithm
-  VTK::FiltersGeneral

--- a/core/vtk/ttkPlanarGraphLayout/vtk.module
+++ b/core/vtk/ttkPlanarGraphLayout/vtk.module
@@ -2,3 +2,4 @@ NAME
   ttkPlanarGraphLayout
 DEPENDS
   ttkAlgorithm
+  VTK::FiltersGeneral


### PR DESCRIPTION
This PR adds some features to the MergeTreeVisualization class (used for the planar layout for instance).

Among the new features we found:
- Add the exclude important pairs intervals, that allow to forbid some pairs to be considered as important, useful to have a better layout and focus on some pairs in particular
- Add the custom arrays, useful when one want to add custom arrays to the point/cell data of the merge tree planar layout
- Allows to automatically copy point data of the input trees
- Add TrueNodeId array to ensure the same node ids when passing from FTMTree to vtkUnstructuredGrid to FTMTree again
- Fix some bugs (most are out of bounds access)