### PR TITLE
Projection from table

### DIFF
--- a/core/base/projectionFromTable/CMakeLists.txt
+++ b/core/base/projectionFromTable/CMakeLists.txt
@@ -1,0 +1,9 @@
+ttk_add_base_library(projectionFromTable
+  SOURCES
+    ProjectionFromTable.cpp
+  HEADERS
+    ProjectionFromTable.h
+  DEPENDS
+    triangulation
+    geometry
+)

--- a/core/base/projectionFromTable/ProjectionFromTable.cpp
+++ b/core/base/projectionFromTable/ProjectionFromTable.cpp
@@ -1,0 +1,6 @@
+#include <ProjectionFromTable.h>
+
+ttk::ProjectionFromTable::ProjectionFromTable() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("ProjectionFromTable");
+}

--- a/core/base/projectionFromTable/ProjectionFromTable.h
+++ b/core/base/projectionFromTable/ProjectionFromTable.h
@@ -26,13 +26,6 @@ namespace ttk {
   public:
     ProjectionFromTable();
 
-    int preconditionTriangulation(AbstractTriangulation *triangulation) {
-      // Pre-condition functions.
-      if(triangulation) {
-      }
-      return 0;
-    }
-
     template <class triangulationType, class xDataType, class yDataType>
     void computeInputPoints(
       const triangulationType *triangulation,
@@ -50,7 +43,7 @@ namespace ttk {
       // 0 --- 2
       // |     |
       // 1 --- 3
-      std::vector<std::vector<int>> quadPoints(noPoints, std::vector<int>(4));
+      std::vector<std::array<int, 4>> quadPoints(noPoints);
       for(unsigned int i = 0; i < noPoints; ++i) {
         int i0 = 0, i1 = 0;
         for(unsigned int j = 0; j < surfaceDim[0]; ++j)
@@ -66,22 +59,21 @@ namespace ttk {
       }
 
       // Iterate through each point
-      std::vector<std::vector<double>> coef(
-        noPoints, std::vector<double>(4, 0.0));
+      std::vector<std::array<double, 4>> coef(noPoints);
       for(unsigned int i = 0; i < noPoints; ++i) {
-        std::vector<std::vector<double>> points(4, std::vector<double>(2));
+        std::vector<std::array<double, 2>> points(4);
         for(unsigned int j = 0; j < 4; ++j) {
           points[j][0] = std::get<1>(surfaceValues[quadPoints[i][j]]);
           points[j][1] = std::get<2>(surfaceValues[quadPoints[i][j]]);
         }
 
         // Find barycentric coordinates
-        std::vector<double> tableValues{static_cast<double>(tableXValues[i]),
-                                        static_cast<double>(tableYValues[i])};
-        std::vector<std::vector<double>> trianglePoints(3);
-        std::vector<int> indexes(3);
-        std::vector<double> mid{(points[3][0] - points[1][0]) / 2.0,
-                                (points[0][1] - points[1][1]) / 2.0};
+        std::array<double, 2> tableValues{static_cast<double>(tableXValues[i]),
+                                          static_cast<double>(tableYValues[i])};
+        std::vector<std::array<double, 3>> trianglePoints(3);
+        std::array<int, 3> indexes;
+        std::array<double, 2> mid{(points[3][0] - points[1][0]) / 2.0,
+                                  (points[0][1] - points[1][1]) / 2.0};
         if(tableXValues[i] > points[1][0] + mid[0]) {
           indexes[0] = 2;
           indexes[1] = 3;
@@ -99,7 +91,8 @@ namespace ttk {
         }
 
         for(unsigned int j = 0; j < 3; ++j)
-          trianglePoints[j] = points[indexes[j]];
+          for(unsigned int k = 0; k < 2; ++k)
+            trianglePoints[j][k] = points[indexes[j]][k];
 
         Geometry::computeTriangleArea(
           tableValues.data(), trianglePoints[0].data(),

--- a/core/base/projectionFromTable/ProjectionFromTable.h
+++ b/core/base/projectionFromTable/ProjectionFromTable.h
@@ -1,0 +1,132 @@
+/// \ingroup base
+/// \class ttk::ProjectionFromTable
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2022.
+///
+/// This module defines the %ProjectionFromTable class that
+/// projects on a surface points in a vtkTable.
+///
+
+#pragma once
+
+// ttk common includes
+#include <Debug.h>
+#include <Geometry.h>
+#include <Triangulation.h>
+
+namespace ttk {
+
+  /**
+   * The ProjectionFromTable class provides methods that
+   * projects on a surface points in a vtkTable.
+   */
+  class ProjectionFromTable : virtual public Debug {
+
+  protected:
+  public:
+    ProjectionFromTable();
+
+    int preconditionTriangulation(AbstractTriangulation *triangulation) {
+      // Pre-condition functions.
+      if(triangulation) {
+      }
+      return 0;
+    }
+
+    template <class triangulationType, class xDataType, class yDataType>
+    void computeInputPoints(
+      const triangulationType *triangulation,
+      std::vector<std::tuple<int, double, double>> &surfaceValues,
+      std::array<const long, 2> &surfaceDim,
+      const xDataType *const tableXValues,
+      const yDataType *const tableYValues,
+      const size_t nTableValues,
+      std::vector<std::vector<double>> &inputPoints) {
+      unsigned int noPoints = nTableValues;
+      inputPoints = std::vector<std::vector<double>>(
+        noPoints, std::vector<double>(3, 0.0));
+
+      // Find quadrant of each point
+      // 0 --- 2
+      // |     |
+      // 1 --- 3
+      std::vector<std::vector<int>> quadPoints(noPoints, std::vector<int>(4));
+      for(unsigned int i = 0; i < noPoints; ++i) {
+        int i0 = 0, i1 = 0;
+        for(unsigned int j = 0; j < surfaceDim[0]; ++j)
+          if(std::get<1>(surfaceValues[j * surfaceDim[1]]) < tableXValues[i])
+            i0 = j;
+        for(unsigned int j = 0; j < surfaceDim[1]; ++j)
+          if(std::get<2>(surfaceValues[j]) < tableYValues[i])
+            i1 = j;
+        quadPoints[i][0] = i0 * surfaceDim[1] + i1 + 1;
+        quadPoints[i][1] = i0 * surfaceDim[1] + i1;
+        quadPoints[i][2] = (i0 + 1) * surfaceDim[1] + i1 + 1;
+        quadPoints[i][3] = (i0 + 1) * surfaceDim[1] + i1;
+      }
+
+      // Iterate through each point
+      std::vector<std::vector<double>> coef(
+        noPoints, std::vector<double>(4, 0.0));
+      for(unsigned int i = 0; i < noPoints; ++i) {
+        std::vector<std::vector<double>> points(4, std::vector<double>(2));
+        for(unsigned int j = 0; j < 4; ++j) {
+          points[j][0] = std::get<1>(surfaceValues[quadPoints[i][j]]);
+          points[j][1] = std::get<2>(surfaceValues[quadPoints[i][j]]);
+        }
+
+        // Find barycentric coordinates
+        std::vector<double> tableValues{static_cast<double>(tableXValues[i]),
+                                        static_cast<double>(tableYValues[i])};
+        std::vector<std::vector<double>> trianglePoints(3);
+        std::vector<int> indexes(3);
+        std::vector<double> mid{(points[3][0] - points[1][0]) / 2.0,
+                                (points[0][1] - points[1][1]) / 2.0};
+        if(tableXValues[i] > points[1][0] + mid[0]) {
+          indexes[0] = 2;
+          indexes[1] = 3;
+          if(tableYValues[i] > points[1][1] + mid[1])
+            indexes[2] = 0;
+          else
+            indexes[2] = 1;
+        } else {
+          indexes[0] = 0;
+          indexes[1] = 1;
+          if(tableYValues[i] > points[1][1] + mid[1])
+            indexes[2] = 2;
+          else
+            indexes[2] = 3;
+        }
+
+        for(unsigned int j = 0; j < 3; ++j)
+          trianglePoints[j] = points[indexes[j]];
+
+        Geometry::computeTriangleArea(
+          tableValues.data(), trianglePoints[0].data(),
+          trianglePoints[1].data(), coef[i][indexes[2]]);
+        Geometry::computeTriangleArea(
+          tableValues.data(), trianglePoints[0].data(),
+          trianglePoints[2].data(), coef[i][indexes[1]]);
+        Geometry::computeTriangleArea(
+          tableValues.data(), trianglePoints[1].data(),
+          trianglePoints[2].data(), coef[i][indexes[0]]);
+
+        double sumArea
+          = coef[i][indexes[2]] + coef[i][indexes[1]] + coef[i][indexes[0]];
+        for(unsigned int j = 0; j < 3; ++j)
+          coef[i][indexes[j]] /= sumArea;
+
+        // Compute new point
+        for(unsigned int k = 0; k < 4; ++k) {
+          float surfacePoint[3];
+          triangulation->getVertexPoint(
+            std::get<0>(surfaceValues[quadPoints[i][k]]), surfacePoint[0],
+            surfacePoint[1], surfacePoint[2]);
+          for(unsigned int j = 0; j < 3; ++j)
+            inputPoints[i][j] += coef[i][k] * surfacePoint[j];
+        }
+      }
+    }
+  }; // ProjectionFromTable class
+
+} // namespace ttk

--- a/core/base/projectionFromTable/ProjectionFromTable.h
+++ b/core/base/projectionFromTable/ProjectionFromTable.h
@@ -70,7 +70,7 @@ namespace ttk {
         // Find barycentric coordinates
         std::array<double, 2> tableValues{static_cast<double>(tableXValues[i]),
                                           static_cast<double>(tableYValues[i])};
-        std::vector<std::array<double, 3>> trianglePoints(3);
+        std::array<std::array<double, 3>, 3> trianglePoints;
         std::array<int, 3> indexes;
         std::array<double, 2> mid{(points[3][0] - points[1][0]) / 2.0,
                                   (points[0][1] - points[1][1]) / 2.0};

--- a/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
+++ b/core/vtk/ttkPointSetToCurve/ttkPointSetToCurve.cpp
@@ -87,7 +87,8 @@ int ttkPointSetToCurve::RequestData(vtkInformation *ttkNotUsed(request),
          const std::pair<vtkIdType, double> &b) { return a.second < b.second; };
 
   // sort the vector of indices/values in ascending order
-  std::sort(orderedValues.begin(), orderedValues.end(), cmp);
+  TTK_PSORT(
+    this->threadNumber_, orderedValues.begin(), orderedValues.end(), cmp);
 
   // shallow-copy input into output
   output->ShallowCopy(input);

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -97,23 +97,32 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
     yValues[i] = std::get<2>(tup);
   }
   std::sort(xValues.begin(), xValues.end());
-  const auto nUniqueValues
+  const auto nUniqueXValues
     = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
   std::sort(yValues.begin(), yValues.end());
-  const auto nUniqueValues2
+  const auto nUniqueYValues
     = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
 
-  if(nUniqueValues * nUniqueValues2 != input->GetNumberOfPoints()) {
-    printErr("Number of values in first array times the number of values in "
-             "the second one does not equal the number of points");
+  if(nUniqueXValues * nUniqueYValues != input->GetNumberOfPoints()) {
+    printErr(
+      "Number of unique values in first array times the number of unique "
+      "values in the second one does not equal the number of points");
     return 0;
   }
 
-  // compare two pairs of index/value according to their values
-  const auto cmp = [&](const std::tuple<vtkIdType, double, double> &a,
-                       const std::tuple<vtkIdType, double, double> &b) {
-    return std::get<1>(a) * nUniqueValues2 + std::get<2>(a)
-           < std::get<1>(b) * nUniqueValues2 + std::get<2>(b);
+  // Compare two pairs of index/value according to their values
+  double yRange[2] = {*std::min_element(yValues.begin(), yValues.end()),
+                      *std::max_element(yValues.begin(), yValues.end())};
+  double minXInterval = std::numeric_limits<double>::max();
+  for(unsigned int i = 1; i < nUniqueXValues; ++i)
+    minXInterval = std::min(minXInterval, xValues[i] - xValues[i - 1]);
+  const auto normValue = [&](double v) {
+    return (v - yRange[0]) / (yRange[1] - yRange[0]) * minXInterval * 0.99;
+  };
+  const auto cmp = [&](const std::tuple<int, double, double> &a,
+                       const std::tuple<int, double, double> &b) {
+    return std::get<1>(a) + normValue(std::get<2>(a))
+           < std::get<1>(b) + normValue(std::get<2>(b));
   };
 
   // sort the vector of indices/values in ascending order
@@ -121,20 +130,20 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
 
   // Create point ids matrix
   std::vector<std::vector<vtkIdType>> orderedIds(
-    nUniqueValues, std::vector<vtkIdType>(nUniqueValues2));
-  for(unsigned int i = 0; i < nUniqueValues; ++i) {
-    for(unsigned int j = 0; j < nUniqueValues2; ++j) {
-      auto index = i * nUniqueValues2 + j;
+    nUniqueXValues, std::vector<vtkIdType>(nUniqueYValues));
+  for(unsigned int i = 0; i < nUniqueXValues; ++i) {
+    for(unsigned int j = 0; j < nUniqueYValues; ++j) {
+      auto index = i * nUniqueYValues + j;
       orderedIds[i][j] = std::get<0>(orderedValues[index]);
     }
   }
 
   // Create new grid
   vtkNew<vtkPolyData> vtkOutput{};
-  vtkOutput->ShallowCopy(input);
+  vtkOutput->DeepCopy(input);
 
-  for(unsigned int i = 0; i < nUniqueValues; ++i) {
-    for(unsigned int j = 0; j < nUniqueValues2; ++j) {
+  for(unsigned int i = 0; i < nUniqueXValues; ++i) {
+    for(unsigned int j = 0; j < nUniqueYValues; ++j) {
       if(j != 0) {
         std::array<vtkIdType, 2> linePoints{
           orderedIds[i][j - 1], orderedIds[i][j]};

--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -96,10 +96,10 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
     xValues[i] = std::get<1>(tup);
     yValues[i] = std::get<2>(tup);
   }
-  std::sort(xValues.begin(), xValues.end());
+  TTK_PSORT(this->threadNumber_, xValues.begin(), xValues.end());
   const auto nUniqueXValues
     = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
-  std::sort(yValues.begin(), yValues.end());
+  TTK_PSORT(this->threadNumber_, yValues.begin(), yValues.end());
   const auto nUniqueYValues
     = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
 
@@ -126,7 +126,8 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
   };
 
   // sort the vector of indices/values in ascending order
-  std::sort(orderedValues.begin(), orderedValues.end(), cmp);
+  TTK_PSORT(
+    this->threadNumber_, orderedValues.begin(), orderedValues.end(), cmp);
 
   // Create point ids matrix
   std::vector<std::vector<vtkIdType>> orderedIds(

--- a/core/vtk/ttkProjectionFromTable/CMakeLists.txt
+++ b/core/vtk/ttkProjectionFromTable/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkProjectionFromTable/ttk.module
+++ b/core/vtk/ttkProjectionFromTable/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkProjectionFromTable
+SOURCES
+  ttkProjectionFromTable.cpp
+HEADERS
+  ttkProjectionFromTable.h
+DEPENDS
+  projectionFromTable
+  ttkAlgorithm

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
@@ -26,9 +26,6 @@ ttkProjectionFromTable::ttkProjectionFromTable() {
   this->SetNumberOfOutputPorts(1);
 }
 
-ttkProjectionFromTable::~ttkProjectionFromTable() {
-}
-
 /**
  * Specify the required input data type of each input port
  */

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
@@ -14,6 +14,8 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
+#include <set>
+
 // A VTK macro that enables the instantiation of this class via ::New()
 // You do not have to modify this
 vtkStandardNewMacro(ttkProjectionFromTable);
@@ -159,10 +161,10 @@ int ttkProjectionFromTable::RequestData(vtkInformation *ttkNotUsed(request),
     yValues[i] = std::get<2>(tup);
   }
   std::sort(xValues.begin(), xValues.end());
-  const auto nUniqueXValues
+  const long nUniqueXValues
     = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
   std::sort(yValues.begin(), yValues.end());
-  const auto nUniqueYValues
+  const long nUniqueYValues
     = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
   std::array<const long, 2> surfaceDim{nUniqueXValues, nUniqueYValues};
 

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
@@ -83,7 +83,6 @@ int ttkProjectionFromTable::RequestData(vtkInformation *ttkNotUsed(request),
     printErr("Unable to load triangulation.");
     return 0;
   }
-  this->preconditionTriangulation(triangulation);
 
   // Get surface arrays
   const auto surfaceXArray = this->GetInputArrayToProcess(0, inputVector);

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
@@ -159,10 +159,10 @@ int ttkProjectionFromTable::RequestData(vtkInformation *ttkNotUsed(request),
     xValues[i] = std::get<1>(tup);
     yValues[i] = std::get<2>(tup);
   }
-  std::sort(xValues.begin(), xValues.end());
+  TTK_PSORT(this->threadNumber_, xValues.begin(), xValues.end());
   const long nUniqueXValues
     = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
-  std::sort(yValues.begin(), yValues.end());
+  TTK_PSORT(this->threadNumber_, yValues.begin(), yValues.end());
   const long nUniqueYValues
     = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
   std::array<const long, 2> surfaceDim{nUniqueXValues, nUniqueYValues};
@@ -190,7 +190,8 @@ int ttkProjectionFromTable::RequestData(vtkInformation *ttkNotUsed(request),
   };
 
   // sort the vector of indices/values in ascending order
-  std::sort(orderedValues.begin(), orderedValues.end(), cmp);
+  TTK_PSORT(
+    this->threadNumber_, orderedValues.begin(), orderedValues.end(), cmp);
 
   //---------------------------------------------------------------------------
   // --- Call base

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.cpp
@@ -1,0 +1,320 @@
+#include <ttkProjectionFromTable.h>
+
+#include <vtkInformation.h>
+
+#include <vtkCellData.h>
+#include <vtkCellType.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
+
+#include <ttkMacros.h>
+#include <ttkUtils.h>
+
+// A VTK macro that enables the instantiation of this class via ::New()
+// You do not have to modify this
+vtkStandardNewMacro(ttkProjectionFromTable);
+
+/**
+ * Implement the filter constructor and destructor in the cpp file.
+ */
+ttkProjectionFromTable::ttkProjectionFromTable() {
+  this->SetNumberOfInputPorts(2);
+  this->SetNumberOfOutputPorts(1);
+}
+
+ttkProjectionFromTable::~ttkProjectionFromTable() {
+}
+
+/**
+ * Specify the required input data type of each input port
+ */
+int ttkProjectionFromTable::FillInputPortInformation(int port,
+                                                     vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+  } else if(port == 1) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkTable");
+  } else
+    return 0;
+  return 1;
+}
+
+/**
+ * Specify the data object type of each output port
+ */
+int ttkProjectionFromTable::FillOutputPortInformation(int port,
+                                                      vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
+  } else
+    return 0;
+  return 1;
+}
+
+/**
+ * Pass VTK data to the base code and convert base code output to VTK
+ */
+template <typename VTK_T1, typename VTK_T2>
+void ttkProjectionFromTable::dispatch(
+  std::vector<std::tuple<int, double, double>> &storage,
+  const VTK_T1 *const values,
+  const VTK_T2 *const values2,
+  const size_t nvalues) {
+
+  for(size_t i = 0; i < nvalues; ++i) {
+    storage.emplace_back(
+      i, static_cast<double>(values[i]), static_cast<double>(values2[i]));
+  }
+}
+
+int ttkProjectionFromTable::RequestData(vtkInformation *ttkNotUsed(request),
+                                        vtkInformationVector **inputVector,
+                                        vtkInformationVector *outputVector) {
+  // --------------------------------------------------------------------------
+  // --- Get input object from input vector
+  // --------------------------------------------------------------------------
+  // Get surface
+  auto surface = vtkPolyData::GetData(inputVector[0], 0);
+  auto triangulation = ttkAlgorithm::GetTriangulation(surface);
+  if(!triangulation) {
+    printErr("Unable to load triangulation.");
+    return 0;
+  }
+  this->preconditionTriangulation(triangulation);
+
+  // Get surface arrays
+  const auto surfaceXArray = this->GetInputArrayToProcess(0, inputVector);
+  const auto surfaceYArray = this->GetInputArrayToProcess(1, inputVector);
+  if(surfaceXArray == nullptr) {
+    this->printErr("Cannot find the required surface data X array");
+    return 0;
+  }
+  if(surfaceYArray == nullptr) {
+    this->printErr("Cannot find the required surface data Y array");
+    return 0;
+  }
+
+  // Get table arrays
+  auto coefficients = vtkTable::GetData(inputVector[1], 0);
+  auto xArrayName = surfaceXArray->GetName();
+  auto tableXArray = coefficients->GetColumnByName(xArrayName);
+  if(!tableXArray) {
+    printErr("Can not find " + std::string{xArrayName} + " X array in table");
+    return 0;
+  }
+  auto tableDataXArray = vtkDataArray::SafeDownCast(tableXArray);
+  if(!tableDataXArray) {
+    printErr("Can not load " + std::string{xArrayName}
+             + " X data array in table");
+    return 0;
+  }
+  auto yArrayName = surfaceYArray->GetName();
+  auto tableYArray = coefficients->GetColumnByName(yArrayName);
+  if(!tableYArray) {
+    printErr("Can not find " + std::string{yArrayName} + " Y array in table");
+    return 0;
+  }
+  auto tableDataYArray = vtkDataArray::SafeDownCast(tableYArray);
+  if(!tableDataYArray) {
+    printErr("Can not load " + std::string{yArrayName}
+             + " Y data array in table");
+    return 0;
+  }
+
+  const auto nSurfaceValues = surfaceXArray->GetNumberOfTuples();
+  const auto nTableValues = tableDataXArray->GetNumberOfTuples();
+
+  // --------------------------------------------------------------------------
+  // --- Get ordered values
+  // --------------------------------------------------------------------------
+  // store point index <-> ordering value in vector
+  std::vector<std::tuple<int, double, double>> orderedValues;
+
+#ifndef TTK_ENABLE_DOUBLE_TEMPLATING
+  switch(surfaceXArray->GetDataType()) {
+    vtkTemplateMacro(
+      dispatch(orderedValues,
+               static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(surfaceXArray)),
+               static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(surfaceYArray)),
+               nSurfaceValues));
+  }
+#else
+  switch(vtkTemplate2PackMacro(
+    surfaceXArray->GetDataType(), surfaceYArray->GetDataType())) {
+    vtkTemplate2Macro(
+      dispatch(orderedValues,
+               static_cast<VTK_T1 *>(ttkUtils::GetVoidPointer(surfaceXArray)),
+               static_cast<VTK_T2 *>(ttkUtils::GetVoidPointer(surfaceYArray)),
+               nSurfaceValues));
+  }
+#endif // TTK_ENABLE_DOUBLE_TEMPLATING
+
+  // Get number of unique values of each array
+  std::vector<double> xValues(orderedValues.size()),
+    yValues(orderedValues.size());
+  for(unsigned int i = 0; i < orderedValues.size(); ++i) {
+    auto tup = orderedValues[i];
+    xValues[i] = std::get<1>(tup);
+    yValues[i] = std::get<2>(tup);
+  }
+  std::sort(xValues.begin(), xValues.end());
+  const auto nUniqueXValues
+    = std::unique(xValues.begin(), xValues.end()) - xValues.begin();
+  std::sort(yValues.begin(), yValues.end());
+  const auto nUniqueYValues
+    = std::unique(yValues.begin(), yValues.end()) - yValues.begin();
+  std::array<const long, 2> surfaceDim{nUniqueXValues, nUniqueYValues};
+
+  if(nUniqueXValues * nUniqueYValues != surface->GetNumberOfPoints()) {
+    printErr(
+      "Number of unique values in first array times the number of unique "
+      "values in the second one does not equal the number of points");
+    return 0;
+  }
+
+  // Compare two pairs of index/value according to their values
+  double yRange[2] = {*std::min_element(yValues.begin(), yValues.end()),
+                      *std::max_element(yValues.begin(), yValues.end())};
+  double minXInterval = std::numeric_limits<double>::max();
+  for(unsigned int i = 1; i < nUniqueXValues; ++i)
+    minXInterval = std::min(minXInterval, xValues[i] - xValues[i - 1]);
+  const auto normValue = [&](double v) {
+    return (v - yRange[0]) / (yRange[1] - yRange[0]) * minXInterval * 0.99;
+  };
+  const auto cmp = [&](const std::tuple<int, double, double> &a,
+                       const std::tuple<int, double, double> &b) {
+    return std::get<1>(a) + normValue(std::get<2>(a))
+           < std::get<1>(b) + normValue(std::get<2>(b));
+  };
+
+  // sort the vector of indices/values in ascending order
+  std::sort(orderedValues.begin(), orderedValues.end(), cmp);
+
+  //---------------------------------------------------------------------------
+  // --- Call base
+  //---------------------------------------------------------------------------
+  std::vector<std::vector<double>> inputPoints;
+#ifndef TTK_ENABLE_DOUBLE_TEMPLATING
+  switch(tableDataXArray->GetDataType()) {
+    vtkTemplateMacro(computeInputPoints(
+      triangulation, orderedValues, surfaceDim,
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(tableDataXArray)),
+      static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(tableDataYArray)),
+      nTableValues, inputPoints));
+  }
+#else
+  switch(vtkTemplate2PackMacro(
+    tableDataXArray->GetDataType(), tableDataYArray->GetDataType())) {
+    vtkTemplate2Macro(computeInputPoints(
+      triangulation, orderedValues, surfaceDim,
+      static_cast<VTK_T1 *>(ttkUtils::GetVoidPointer(tableDataXArray)),
+      static_cast<VTK_T2 *>(ttkUtils::GetVoidPointer(tableDataYArray)),
+      nTableValues, inputPoints));
+  }
+#endif // TTK_ENABLE_DOUBLE_TEMPLATING
+
+  //---------------------------------------------------------------------------
+  // --- Create output
+  //---------------------------------------------------------------------------
+  auto output = vtkPolyData::GetData(outputVector, 0);
+  output->DeepCopy(surface);
+
+  std::set<std::string> toRemove;
+  for(unsigned int i = 0; i < inputPoints.size(); ++i) {
+    double point[3];
+    for(unsigned int j = 0; j < 3; ++j) {
+      point[j] = inputPoints[i][j];
+    }
+    output->GetPoints()->InsertNextPoint(point);
+
+    // Merge data of arrays in surface also in table or add empty data
+    for(int j = 0; j < output->GetPointData()->GetNumberOfArrays(); ++j) {
+      auto outputArray = output->GetPointData()->GetAbstractArray(j);
+      std::string name = outputArray->GetName();
+      auto array = coefficients->GetColumnByName(name.c_str());
+      if(array) {
+        outputArray->InsertNextTuple(i, array);
+      } else {
+        auto dataArray = vtkDataArray::SafeDownCast(outputArray);
+        if(dataArray) {
+          const double val = std::nan("");
+          dataArray->InsertNextTuple(&val);
+        } else {
+          auto stringArray = vtkStringArray::SafeDownCast(outputArray);
+          if(stringArray)
+            stringArray->InsertNextValue("");
+          else
+            toRemove.insert(name);
+        }
+      }
+    }
+  }
+
+  int noPointsOri = output->GetNumberOfPoints() - inputPoints.size();
+
+  // Merge data of arrays in table also in surface or add empty data
+  std::set<std::string> toGet;
+  for(int j = 0; j < coefficients->GetNumberOfColumns(); ++j) {
+    auto inputArray = coefficients->GetColumn(j);
+    auto dataArray = vtkDataArray::SafeDownCast(inputArray);
+    auto stringArray = vtkStringArray::SafeDownCast(inputArray);
+    std::string name = inputArray->GetName();
+    auto array = output->GetPointData()->GetAbstractArray(name.c_str());
+    if(not array and (dataArray or stringArray))
+      toGet.insert(name);
+  }
+  vtkNew<vtkTable> tableCopy{};
+  if(toGet.size() != 0)
+    tableCopy->DeepCopy(coefficients);
+  for(auto &name : toGet) {
+    auto inputArray = tableCopy->GetColumnByName(name.c_str());
+    auto dataArray = vtkDataArray::SafeDownCast(inputArray);
+    auto stringArray = vtkStringArray::SafeDownCast(inputArray);
+    inputArray->SetNumberOfTuples(output->GetNumberOfPoints());
+    for(int i = 0; i < output->GetNumberOfPoints(); ++i) {
+      // if is surface
+      if(i < noPointsOri) {
+        if(dataArray) {
+          double val = std::nan("");
+          dataArray->SetTuple1(i, val);
+        } else if(stringArray) {
+          stringArray->SetValue(i, "");
+        } else
+          printWrn("Can not convert " + name + " to dataArray or stringArray.");
+      } else {
+        inputArray->SetTuple(
+          i, i - noPointsOri, coefficients->GetColumnByName(name.c_str()));
+      }
+    }
+    output->GetPointData()->AddArray(inputArray);
+  }
+
+  for(auto &name : toRemove)
+    output->GetPointData()->RemoveArray(name.c_str());
+
+  // Some points data
+  vtkNew<vtkIntArray> isSurfaceArray{};
+  isSurfaceArray->SetName("isSurface");
+  isSurfaceArray->SetNumberOfTuples(output->GetNumberOfPoints());
+  for(int i = 0; i < output->GetNumberOfPoints(); ++i) {
+    bool isSurface = (i < noPointsOri);
+    isSurfaceArray->SetTuple1(i, isSurface);
+  }
+  output->GetPointData()->AddArray(isSurfaceArray);
+
+  // Some cells data
+  auto noCells = output->GetNumberOfCells();
+  vtkNew<vtkIntArray> cellTypeArray{};
+  cellTypeArray->SetName("CellType");
+  cellTypeArray->SetNumberOfTuples(noCells);
+  for(int i = 0; i < noCells; ++i) {
+    cellTypeArray->SetTuple1(i, output->GetCellType(i));
+  }
+  output->GetCellData()->AddArray(cellTypeArray);
+
+  return 1;
+}

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.h
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.h
@@ -1,0 +1,98 @@
+/// \ingroup vtk
+/// \class ttkProjectionFromTable
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2022.
+///
+/// \brief TTK VTK-filter that wraps the
+/// ttk::ProjectionFromTable module.
+///
+/// This VTK filter uses the ttk::ProjectionFromTable module
+/// that projects on a surface points in a vtkTable.
+///
+/// \param Input vtkPolyData Surface
+/// \param Input vtkTable Coefficients
+/// \param Output vtkPolyData.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
+/// See the corresponding standalone program for a usage example:
+///   - standalone/ProjectionFromTable/main.cpp
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::ProjectionFromTable
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkProjectionFromTableModule.h>
+
+// VTK Includes
+#include <ttkAlgorithm.h>
+#include <vtkPolyData.h>
+#include <vtkTable.h>
+
+// TTK Base Includes
+#include <ProjectionFromTable.h>
+
+class TTKPROJECTIONFROMTABLE_EXPORT ttkProjectionFromTable
+  : public ttkAlgorithm // we inherit from the generic ttkAlgorithm class
+  ,
+    protected ttk::ProjectionFromTable // and we inherit from
+                                       // the base class
+{
+private:
+  /**
+   * Add all filter parameters only as private member variables and
+   * initialize them here.
+   */
+
+public:
+  /**
+   * Automatically generate getters and setters of filter
+   * parameters via vtkMacros.
+   */
+
+  /**
+   * This static method and the macro below are VTK conventions on how to
+   * instantiate VTK objects. You don't have to modify this.
+   */
+  static ttkProjectionFromTable *New();
+  vtkTypeMacro(ttkProjectionFromTable, ttkAlgorithm);
+
+protected:
+  /**
+   * Implement the filter constructor and destructor
+   * (see cpp file)
+   */
+  ttkProjectionFromTable();
+  ~ttkProjectionFromTable() override;
+
+  /**
+   * Specify the input data type of each input port
+   * (see cpp file)
+   */
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Specify the data object type of each output port
+   * (see cpp file)
+   */
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+  /**
+   * Pass VTK data to the base code and convert base code output to VTK
+   * (see cpp file)
+   */
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+  template <typename VTK_T1, typename VTK_T2>
+  void dispatch(std::vector<std::tuple<int, double, double>> &storage,
+                const VTK_T1 *const values,
+                const VTK_T2 *const values2,
+                const size_t nvalues);
+};

--- a/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.h
+++ b/core/vtk/ttkProjectionFromTable/ttkProjectionFromTable.h
@@ -69,7 +69,7 @@ protected:
    * (see cpp file)
    */
   ttkProjectionFromTable();
-  ~ttkProjectionFromTable() override;
+  ~ttkProjectionFromTable() override = default;
 
   /**
    * Specify the input data type of each input port

--- a/core/vtk/ttkProjectionFromTable/vtk.module
+++ b/core/vtk/ttkProjectionFromTable/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkProjectionFromTable
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/ProjectionFromTable.xml
+++ b/paraview/xmls/ProjectionFromTable.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Add widgets to the ParaView UI that control the member variables of the vtk filter -->
+<!-- NOTE: Unfortunately the widget types and their properties are not well documented. -->
+<!--       The best thing you can do is to look at filters that have similar widgets you require and copy their source code. -->
+<!--       Good resources are: IcoSphere.xml, PersistenceDiagram.xml, and ArrayEditor.xml -->
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy name="ttkProjectionFromTable" class="ttkProjectionFromTable" label="TTK ProjectionFromTable">
+      <Documentation long_help="ProjectionFromTable Long" short_help="ProjectionFromTable Short">This filter projects on a surface points in a vtkTable.</Documentation>
+
+      <!-- INPUT DATA OBJECTS -->
+      <InputProperty
+        name="Surface"
+        port_index="0"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkPolyData"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Surface" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          
+        </Documentation>
+      </InputProperty>
+      
+      <InputProperty
+        name="Coefficients"
+        port_index="1"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkTable"/>
+        </DataTypeDomain>
+        <Documentation>
+          
+        </Documentation>
+)      </InputProperty>
+
+      <!-- INPUT PARAMETER WIDGETS -->
+      <StringVectorProperty
+        name="InputSurfaceXArray"
+        command="SetInputArrayToProcess"
+        label="Input Surface X Array"
+        element_types="0 0 0 0 2"
+        number_of_elements="5"
+        default_values="0"
+        animateable="0"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0">
+          <RequiredProperties>
+            <Property name="Surface" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the input surface X array.
+        </Documentation>
+      </StringVectorProperty>
+      
+      <StringVectorProperty
+        name="InputSurfaceYArray"
+        command="SetInputArrayToProcess"
+        label="Input Surface Y Array"
+        element_types="0 0 0 0 2"
+        number_of_elements="5"
+        default_values="1"
+        animateable="0"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0">
+          <RequiredProperties>
+            <Property name="Surface" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the input surface Y array.
+        </Documentation>
+      </StringVectorProperty>
+
+      <!-- OUTPUT PARAMETER WIDGETS -->
+      
+      <!-- Create a UI group that contains all input parameter widgets -->
+      <PropertyGroup panel_widget="Line" label="Input Options">
+        <Property name="InputSurfaceXArray" />
+        <Property name="InputSurfaceYArray" />
+      </PropertyGroup>
+
+      <!-- Create a UI group that contains all output parameter widgets -->
+      <PropertyGroup panel_widget="Line" label="Output Options">
+        
+      </PropertyGroup>
+
+      <!-- DEBUG -->
+      ${DEBUG_WIDGETS}
+
+      <!-- MENU CATEGORY -->
+      <Hints>
+        <ShowInMenu category="TTK - Domain" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>


### PR DESCRIPTION
This PR adds the ProjectionFromTable filter to TTK.
It takes as input a surface (generated with PointSetToSurface for instance) and a table corresponding to points that will be projected on the surface. 
To do so, the user needs to select two ordering arrays (like PointSetToSurface) that will be used to find the 3D coordinates of the projected points given the values of these arrays for points in the surface.
Moreover, this PR fixes some things in PointSetToSurface like the sorting of the ordering arrays values.