### PR TITLE
Added rank number in log prefix and documentation of MPI

### DIFF
--- a/MPI.md
+++ b/MPI.md
@@ -1,0 +1,54 @@
+## Running TTK and Paraview with MPI
+
+### Compilation
+
+In order to use MPI, Paraview needs to be compiled with MPI support. This can be done by setting the `PARAVIEW_USE_MPI` variable to `ON`. For more information, see [Paraview's building documentation](https://gitlab.kitware.com/paraview/paraview/-/blob/master/Documentation/dev/build.md#linux). TTK also needs to be compiled with MPI support. This can be done by setting the `TTK_ENABLE_MPI` variable to `ON` during compilation. TTK is parallelized using both threads and MPI processus simultaneously. Some filters require the use of threads to function using MPI.
+
+### Environment variables
+When using Some TTK filters require a level of thread support not provided by Paraview by default. Obtaining the right level of thread support is MPI implementation depend. For OpenMPI, it is done by setting the environment variable ` OMPI_MPI_THREAD_LEVEL` to 3. For MPICH, it is done by setting the environment variable `MPIR_CVAR_DEFAULT_THREAD_LEVEL` to 3. 
+
+To specify the number of threads to use during execution, the environment variable `OMP_NUM_THREADS` can be used.
+
+### Execution
+
+To use Paraview in parallel using MPI, one has to use either `pvserver` or `pvbatch`. 
+
+#### pvserver
+The following command allows one to start `pvserver` with 4 processes and 8 threads with OpenMPI:
+
+    OMPI_MPI_THREAD_LEVEL=3 OMP_NUM_THREADS=8 mpirun -np 4 pvserver
+
+The next step is to run the Paraview client using the command:
+
+    paraview
+
+Now all that is needed is to connect to the server from the client GUI by going into File > Connect. For more information on how to create and connect to a remote Paraview server, see [Section 6.2](https://docs.paraview.org/en/latest/ReferenceManual/parallelDataVisualization.html#remote-visualization-in-paraview) and [Section 6.3](https://docs.paraview.org/en/latest/ReferenceManual/parallelDataVisualization.html#connect-to-the-remote-server) of Paraview's documentation. For more information on how to use `pvserver` and how it works, see [pvserver's documentation here](https://docs.paraview.org/en/latest/ReferenceManual/parallelDataVisualization.html#parallel-processing-in-paraview-and-pvpython).
+
+####pvbatch
+
+`pvbatch` does not require to set up a `pvserver`. However, it does require that the Paraview pipeline be executed be given in the format of a Python script. To execute the pipeline `pipeline.py` using `pvbatch` using 4 processes and 8 threads with OpenMPI, the following command can be used:
+
+    OMPI_MPI_THREAD_LEVEL=3 OMP_NUM_THREADS=8 mpirun -n 4 pvbatch pipeline.py
+
+For more information on `pvbatch`, see [pvbatch's documentation here](https://docs.paraview.org/en/latest/ReferenceManual/parallelDataVisualization.html#using-pvbatch)
+
+
+### Usage within a pipeline
+
+#### Before distribution of the data
+
+In order to obtain results strictly similar to results obtain if the pipeline is executed in sequential, the data needs to be prepared by using the filter `GenerateGlobalIds` on the data in sequential. The output of this filter should then be used for the parallel computation.
+
+#### After distribution of the data
+
+ - TTK filters require ghost cells and ghost points to be created to function correctly. Ghost cells are cells inside a data set that are copies of the interfacing cells of an adjacent data set. TTK filters require two layers of ghost cells. Ghost cells and points can be created using the [`GhostCellsGenerator` filter](https://kitware.github.io/paraview-docs/latest/python/paraview.simple.GhostCellsGenerator.html).
+
+ - The `GhostCellPreconditioning` filter can be used after the  `GhostCellsGenerator` filter to calculate which rank is the "primary" owner of each vertex.
+
+- The `ArrayPreconditioning` filter requires both of the previous filters to function correctly in parallel.
+
+### Output format
+
+- The output of TTK filters executed in parallel using MPI is usable as is in a parallel pipeline, there is no need to add ghost cells or global ids to the output of a TTK filter.
+
+- The parallel output of a TTK filter is strictly identical, regardless of how many processes are used during execution.

--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -12,8 +12,6 @@
 // ttk common includes
 #include <Debug.h>
 
-#include <MPI.h>
-
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>

--- a/core/base/common/BaseMPIClass.cpp
+++ b/core/base/common/BaseMPIClass.cpp
@@ -1,0 +1,12 @@
+#include <BaseMPIClass.h>
+
+#if TTK_ENABLE_MPI
+namespace ttk {
+  COMMON_EXPORTS int MPIrank_;
+
+  BaseMPIClass::BaseMPIClass() {
+    MPI_Comm_rank(MPI_COMM_WORLD, &MPIrank_);
+  }
+
+} // namespace ttk
+#endif

--- a/core/base/common/BaseMPIClass.h
+++ b/core/base/common/BaseMPIClass.h
@@ -1,16 +1,22 @@
 /// \ingroup base
-/// \class ttk::MPI
+/// \class ttk::BaseMPIClass
 /// \author Michael Will <mswill@rhrk.uni-kl.de>
-/// \date 2022.
+/// \author Eve Le Guillou <eve.le-guillou@lip6.fr>
+/// \date April 2022
 ///
-///\brief TTK base package for MPI related utilites.
+/// \brief Base Class and utilities for MPI implementation.
 
-#ifdef TTK_ENABLE_MPI
+#pragma once
+#include <BaseClass.h>
+#include <iostream>
+#include <vector>
+
+#if TTK_ENABLE_MPI
 #include <mpi.h>
-#endif
 
 namespace ttk {
-#ifdef TTK_ENABLE_MPI
+  COMMON_EXPORTS extern int MPIrank_;
+
   inline MPI_Datatype getMPIType(const float ttkNotUsed(val)) {
     return MPI_FLOAT;
   };
@@ -44,6 +50,13 @@ namespace ttk {
     MPI_Initialized(&flag_i);
     return flag_i;
   }
-#endif
 
+  class BaseMPIClass : public BaseClass {
+
+  public:
+    BaseMPIClass();
+    virtual ~BaseMPIClass() = default;
+  };
 } // namespace ttk
+
+#endif

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -1,15 +1,16 @@
 ttk_add_base_library(common
     SOURCES
         BaseClass.cpp
+        BaseMPIClass.cpp
         Debug.cpp
         Os.cpp
     HEADERS
         BaseClass.h
+        BaseMPIClass.h
         CommandLineParser.h
         Debug.h
         DataTypes.h
         FlatJaggedArray.h
-        MPI.h
         OpenMP.h
         OrderDisambiguation.h
         Os.h

--- a/core/base/common/Debug.cpp
+++ b/core/base/common/Debug.cpp
@@ -33,6 +33,12 @@ Debug::~Debug() {
 
 int Debug::welcomeMsg(ostream &stream) {
 
+#if TTK_ENABLE_MPI
+  if(MPIrank_ != 0) {
+    ttk::welcomeMsg_ = false;
+  }
+#endif
+
   int priorityAsInt = (int)debug::Priority::PERFORMANCE;
 
   if((ttk::welcomeMsg_) && (debugLevel_ > priorityAsInt)) {

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <BaseClass.h>
+#include <BaseMPIClass.h>
 
 #include <algorithm>
 #include <cerrno>
@@ -31,6 +32,10 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#if TTK_ENABLE_MPI
+#include <mpi.h>
+#endif
 
 namespace ttk {
 
@@ -84,7 +89,11 @@ namespace ttk {
     const int LINEWIDTH = 80;
   } // namespace debug
 
+#if TTK_ENABLE_MPI
+  class Debug : public BaseMPIClass {
+#else
   class Debug : public BaseClass {
+#endif
 
   public:
     // 1) constructors, destructors, operators, etc.
@@ -359,7 +368,14 @@ namespace ttk {
      * debug message.
      */
     inline void setDebugMsgPrefix(const std::string &prefix) {
+#if TTK_ENABLE_MPI
+      this->debugMsgPrefix_
+        = prefix.length() > 0
+            ? "[" + prefix + "-" + std::to_string(MPIrank_) + "] "
+            : "";
+#else
       this->debugMsgPrefix_ = prefix.length() > 0 ? "[" + prefix + "] " : "";
+#endif
     }
 
   protected:

--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.h
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.h
@@ -23,7 +23,6 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 
-#include <MPI.h>
 #include <vtkDataArraySelection.h>
 #include <vtkNew.h>
 


### PR DESCRIPTION
In this PR:
- A new BaseMPIClass is added that inherits from BaseClass. If the compilation variable `TTK_ENABLE_MPI` is on, the class Debug will inherit from the BaseMPIClass.
- The utilities in the MPI.h file are moved to the file of BaseMPIClass and MPI.h is deleted.
- The rank number of a process is added to the prefix of TTK messages when executed in parallel.
- The TTK logo is only printed once at the beginning in parallel.
- Documentation for the use of TTK with MPI is added in the MPI.md file.

An example of a parallel TTK pipeline can be found in the PR #761 .

