### PR TITLE
[MergeTree*] bary. size limit, new mix distances, dist.mat. double input and more

### DIFF
--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -876,8 +876,7 @@ namespace ttk {
             int index
               = getIndexNotMultiPers(children.size() - 1, tree, children);
             if(index >= 0)
-              nodeParent.push_back(
-                std::make_tuple(nodeOrigin, children[index]));
+              nodeParent.emplace_back(nodeOrigin, children[index]);
             else
               nodeParent.emplace_back(nodeOrigin, children[index]);
           } else

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -41,8 +41,12 @@ namespace ttk {
     bool normalizedWasserstein_ = true;
     bool keepSubtree_ = false;
 
-    bool distanceSquared_ = true;
+    bool distanceSquared_ = true; // squared root
     bool useFullMerge_ = false;
+
+    // Double input
+    double mixtureCoefficient_ = 0.5;
+    bool useDoubleInput_ = false;
 
     // Old
     bool progressiveComputation_ = false;
@@ -156,9 +160,39 @@ namespace ttk {
       return treesNodeCorr_;
     }
 
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // Double Input
+    // ------------------------------------------------------------------------
+    double mixDistancesMinMaxPairWeight(bool isFirstInput) {
+      return (
+        mixtureCoefficient_ == 0.0 or mixtureCoefficient_ == 1.0
+          ? (isFirstInput ? mixtureCoefficient_ : (1.0 - mixtureCoefficient_))
+          : (isFirstInput ? 1.0 / std::pow(mixDistancesWeight(isFirstInput), 2)
+                          : 0.0));
+    }
+
+    double mixDistancesWeight(bool isFirstInput) {
+      return (isFirstInput ? std::min(mixtureCoefficient_ * 2, 1.0)
+                           : std::min(-mixtureCoefficient_ * 2 + 2, 1.0));
+    }
+
+    template <class dataType>
+    double mixDistances(dataType distance1, dataType distance2) {
+      return mixDistancesWeight(true) * distance1
+             + mixDistancesWeight(false) * distance2;
+    }
+
+    void mixDistancesMatrix(std::vector<std::vector<double>> &distanceMatrix,
+                            std::vector<std::vector<double>> &distanceMatrix2) {
+      for(unsigned int i = 0; i < distanceMatrix.size(); ++i)
+        for(unsigned int j = 0; j < distanceMatrix[i].size(); ++j)
+          distanceMatrix[i][j]
+            = mixDistances<double>(distanceMatrix[i][j], distanceMatrix2[i][j]);
+    }
+
+    // ------------------------------------------------------------------------
     // Tree Preprocessing
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
     // Epsilon 1 processing
     template <class dataType>
     void mergeSaddle(ftm::FTMTree_MT *tree,
@@ -167,6 +201,9 @@ namespace ttk {
                      bool mergeByPersistence = false) {
       bool fullMerge = (epsilon == 100);
       fullMerge &= useFullMerge_;
+
+      treeNodeMerged
+        = std::vector<std::vector<ftm::idNode>>(tree->getNumberOfNodes());
 
       if(mergeByPersistence)
         ftm::computePersistencePairs<dataType>(
@@ -319,6 +356,17 @@ namespace ttk {
     }
 
     template <class dataType>
+    void keepMostImportantPairs(ftm::FTMTree_MT *tree, int n, bool useBD) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, dataType>> pairs;
+      tree->getPersistencePairsFromTree(pairs, useBD);
+      n = std::max(n, 2); // keep at least 2 pairs
+      int index = std::max((int)(pairs.size() - n), 0);
+      dataType threshold = std::get<2>(pairs[index]) * (1.0 - 1e-6)
+                           / tree->getMaximumPersistence<dataType>() * 100.0;
+      persistenceThresholding<dataType>(tree, threshold);
+    }
+
+    template <class dataType>
     void persistenceThresholding(ftm::FTMTree_MT *tree,
                                  double persistenceThresholdT,
                                  std::vector<ftm::idNode> &deletedNodes) {
@@ -327,7 +375,7 @@ namespace ttk {
 
       dataType secondMax = tree->getSecondMaximumPersistence<dataType>();
       if(threshold >= secondMax)
-        threshold = 0.99 * secondMax;
+        threshold = (1.0 - 1e-6) * secondMax;
 
       for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i) {
         dataType nodePers = tree->getNodePersistence<dataType>(i);
@@ -349,6 +397,21 @@ namespace ttk {
     template <class dataType>
     void persistenceThresholding(ftm::FTMTree_MT *tree,
                                  std::vector<ftm::idNode> &deletedNodes) {
+      persistenceThresholding<dataType>(
+        tree, persistenceThreshold_, deletedNodes);
+    }
+
+    template <class dataType>
+    void persistenceThresholding(ftm::FTMTree_MT *tree,
+                                 double persistenceThresholdT) {
+      std::vector<ftm::idNode> deletedNodes;
+      persistenceThresholding<dataType>(
+        tree, persistenceThresholdT, deletedNodes);
+    }
+
+    template <class dataType>
+    void persistenceThresholding(ftm::FTMTree_MT *tree) {
+      std::vector<ftm::idNode> deletedNodes;
       persistenceThresholding<dataType>(
         tree, persistenceThreshold_, deletedNodes);
     }
@@ -377,19 +440,30 @@ namespace ttk {
     template <class dataType>
     void preprocessTree(ftm::FTMTree_MT *tree,
                         double epsilon,
-                        std::vector<std::vector<ftm::idNode>> &treeNodeMerged) {
-      // Manage inconsistent critical points
-      // Critical points with same scalar value than parent
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-        if(!tree->isNodeAlone(i) and !tree->isRoot(i)
-           and tree->getValue<dataType>(tree->getParentSafe(i))
-                 == tree->getValue<dataType>(i))
-          tree->deleteNode(i);
-      // Valence 2 nodes
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-        if(tree->getNode(i)->getNumberOfUpSuperArcs() == 1
-           and tree->getNode(i)->getNumberOfDownSuperArcs() == 1)
-          tree->deleteNode(i);
+                        double persistenceThreshold,
+                        std::vector<std::vector<ftm::idNode>> &treeNodeMerged,
+                        bool deleteInconsistentNodes = true) {
+      if(deleteInconsistentNodes) {
+        // Manage inconsistent critical points
+        // Critical points with same scalar value than parent
+        for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+          if(!tree->isNodeAlone(i) and !tree->isRoot(i)
+             and tree->getValue<dataType>(tree->getParentSafe(i))
+                   == tree->getValue<dataType>(i)) {
+            /*printMsg("[preprocessTree] " + std::to_string(i)
+                     + " has same scalar value than parent (will be
+               deleted).");*/
+            tree->deleteNode(i);
+          }
+        // Valence 2 nodes
+        for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
+          if(tree->getNode(i)->getNumberOfUpSuperArcs() == 1
+             and tree->getNode(i)->getNumberOfDownSuperArcs() == 1) {
+            /*printMsg("[preprocessTree] " + std::to_string(i)
+                     + " has 1 up arc and 1 down arc (will be deleted).");*/
+            tree->deleteNode(i);
+          }
+      }
 
       // Compute persistence pairs
       auto pairs = ftm::computePersistencePairs<dataType>(tree);
@@ -398,7 +472,8 @@ namespace ttk {
 
       // Delete null persistence pairs and persistence thresholding
       std::vector<ftm::idNode> deletedNodes;
-      persistenceThresholding<dataType>(tree, deletedNodes);
+      persistenceThresholding<dataType>(
+        tree, persistenceThreshold, deletedNodes);
 
       // Merge saddle points according epsilon
       if(epsilon != 0)
@@ -506,28 +581,11 @@ namespace ttk {
     }
 
     template <class dataType>
-    ftm::idNode getMergedRootOrigin(ftm::FTMTree_MT *tree) {
-      ftm::idNode treeRoot = tree->getRoot();
-      bool isJt = tree->isJoinTree<dataType>();
-      ftm::idNode mergedRootOrigin = treeRoot;
-      for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
-        if(tree->getNode(i)->getOrigin() == (int)treeRoot and i != treeRoot)
-          if((isJt
-              and tree->getValue<dataType>(i)
-                    < tree->getValue<dataType>(mergedRootOrigin))
-             or (not isJt
-                 and tree->getValue<dataType>(i)
-                       > tree->getValue<dataType>(mergedRootOrigin)))
-            mergedRootOrigin = i;
-      return mergedRootOrigin;
-    }
-
-    template <class dataType>
     void dontUseMinMaxPair(ftm::FTMTree_MT *tree) {
       ftm::idNode treeRoot = tree->getRoot();
       // Full merge case, search for the origin
       if(tree->getNode(treeRoot)->getOrigin() == (int)treeRoot) {
-        ftm::idNode nodeIdToDelete = getMergedRootOrigin<dataType>(tree);
+        ftm::idNode nodeIdToDelete = tree->getMergedRootOrigin<dataType>();
         if(nodeIdToDelete != treeRoot
            and not tree->isNodeIdInconsistent(nodeIdToDelete)) {
           if(tree->isThereOnlyOnePersistencePair())
@@ -580,15 +638,18 @@ namespace ttk {
                                            bool branchDecompositionT,
                                            bool useMinMaxPairT,
                                            bool cleanTreeT,
-                                           std::vector<int> &nodeCorr) {
+                                           double persistenceThreshold,
+                                           std::vector<int> &nodeCorr,
+                                           bool deleteInconsistentNodes
+                                           = true) {
       Timer t_proc;
 
       ftm::FTMTree_MT *tree = &(mTree.tree);
 
       std::vector<std::vector<ftm::idNode>> treeNodeMerged(
         tree->getNumberOfNodes());
-
-      preprocessTree<dataType>(tree, epsilonTree, treeNodeMerged);
+      preprocessTree<dataType>(tree, epsilonTree, persistenceThreshold,
+                               treeNodeMerged, deleteInconsistentNodes);
       ftm::FTMTree_MT *treeOld = tree;
 
       // verifyPairsTree(tree);
@@ -611,17 +672,33 @@ namespace ttk {
         reverseNodeCorr(tree, nodeCorr);
       }
 
-      if(tree->getNumberOfRoot() != 1) {
+      if(tree->getNumberOfRoot() != 1)
         printErr("preprocessingPipeline tree->getNumberOfRoot() != 1");
-      }
 
       // verifyPairsTree(tree);
       auto t_preproc_time = t_proc.getElapsedTime();
       std::stringstream ss;
       ss << "TIME PREPROC.   = " << t_preproc_time;
-      printMsg(ss.str(), debug::Priority::DETAIL);
+      printMsg(ss.str(), debug::Priority::VERBOSE);
 
       return treeOld;
+    }
+
+    template <class dataType>
+    ftm::FTMTree_MT *preprocessingPipeline(ftm::MergeTree<dataType> &mTree,
+                                           double epsilonTree,
+                                           double epsilon2Tree,
+                                           double epsilon3Tree,
+                                           bool branchDecompositionT,
+                                           bool useMinMaxPairT,
+                                           bool cleanTreeT,
+                                           std::vector<int> &nodeCorr,
+                                           bool deleteInconsistentNodes
+                                           = true) {
+      return preprocessingPipeline<dataType>(
+        mTree, epsilonTree, epsilon2Tree, epsilon3Tree, branchDecompositionT,
+        useMinMaxPairT, cleanTreeT, persistenceThreshold_, nodeCorr,
+        deleteInconsistentNodes);
     }
 
     void reverseNodeCorr(ftm::FTMTree_MT *tree, std::vector<int> &nodeCorr) {
@@ -632,26 +709,74 @@ namespace ttk {
       nodeCorr = newNodeCorr;
     }
 
-    // --------------------------------------------------------------------------------
+    template <class dataType>
+    void mtFlattening(ftm::MergeTree<dataType> &mt) {
+      ftm::FTMTree_MT *tree = &(mt.tree);
+      ttk::ftm::computePersistencePairs<dataType>(tree);
+      persistenceThresholding<dataType>(tree);
+      std::vector<std::vector<ftm::idNode>> treeNodeMerged;
+      mergeSaddle<dataType>(tree, 100.0, treeNodeMerged);
+      computeBranchDecomposition<dataType>(tree, treeNodeMerged);
+    }
+
+    template <class dataType>
+    void mtsFlattening(std::vector<ftm::MergeTree<dataType>> &mts) {
+      for(auto &mt : mts)
+        mtFlattening(mt);
+    }
+
+    // ------------------------------------------------------------------------
     // Tree Postprocessing
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    template <class dataType>
+    void copyMinMaxPair(ftm::MergeTree<dataType> &mTree1,
+                        ftm::MergeTree<dataType> &mTree2,
+                        bool setOrigins = false) {
+      // Get min max pair
+      ftm::FTMTree_MT *tree1 = &(mTree1.tree);
+      ftm::idNode root = tree1->getRoot();
+      dataType newMax = tree1->getValue<dataType>(root);
+      ftm::idNode rootOrigin = tree1->getNode(root)->getOrigin();
+      dataType newMin = tree1->getValue<dataType>(rootOrigin);
+
+      // Update tree
+      ftm::idNode root2 = mTree2.tree.getRoot();
+      std::vector<dataType> newScalarsVector;
+      ftm::getTreeScalars<dataType>(mTree2, newScalarsVector);
+      newScalarsVector[root2] = newMax;
+
+      auto root2Origin = mTree2.tree.getNode(root2)->getOrigin();
+      if(root2Origin == (int)root2)
+        root2Origin = mTree2.tree.template getMergedRootOrigin<dataType>();
+      if(mTree2.tree.isNodeIdInconsistent(root2Origin))
+        newScalarsVector.push_back(newMin);
+      else
+        newScalarsVector[root2Origin] = newMin;
+
+      // Set new scalars
+      ftm::setTreeScalars<dataType>(mTree2, newScalarsVector);
+
+      // Create root origin if not already there
+      ftm::FTMTree_MT *treeNew = &(mTree2.tree);
+      if(mTree2.tree.isNodeIdInconsistent(root2Origin)) {
+        root2Origin = treeNew->getNumberOfNodes();
+        treeNew->makeNode(root2Origin);
+      }
+
+      // Manage new origins
+      if(setOrigins) {
+        treeNew->getNode(root2Origin)->setOrigin(root2);
+        treeNew->getNode(root2)->setOrigin(root2Origin);
+      }
+    }
+
     template <class dataType>
     std::tuple<int, dataType> fixMergedRootOrigin(ftm::FTMTree_MT *tree) {
       if(not tree->isFullMerge())
         return std::make_tuple(-1, -1);
 
       // Get node of the min max pair
-      dataType maxPers = 0;
-      int maxIndex = -1;
-      for(unsigned int j = 0; j < tree->getNumberOfNodes(); ++j) {
-        if(not tree->isNodeAlone(j)) {
-          dataType nodePers = tree->getNodePersistence<dataType>(j);
-          if(nodePers > maxPers) {
-            maxPers = nodePers;
-            maxIndex = j;
-          }
-        }
-      }
+      int maxIndex = tree->getMergedRootOrigin<dataType>();
 
       // Link node of the min max pair with the root
       ftm::idNode treeRoot = tree->getRoot();
@@ -676,7 +801,7 @@ namespace ttk {
       // Manage full merge and dontuseMinMaxPair_
       bool isFM = tree->isFullMerge();
       if(isFM) {
-        ftm::idNode mergedRootOrigin = getMergedRootOrigin<dataType>(tree);
+        ftm::idNode mergedRootOrigin = tree->getMergedRootOrigin<dataType>();
         if(not tree->isNodeIdInconsistent(mergedRootOrigin)
            and mergedRootOrigin != treeRoot)
           tree->getNode(treeRoot)->setOrigin(mergedRootOrigin);
@@ -696,7 +821,6 @@ namespace ttk {
                                       std::vector<ftm::idNode> &children) {
         while(treeT->isMultiPersPair(children[index]))
           --index;
-        index = std::max(0, index);
         return index;
       };
 
@@ -741,7 +865,8 @@ namespace ttk {
           if(tree->isMultiPersPair(children[i]))
             continue;
           int index = getIndexNotMultiPers(i - 1, tree, children);
-          nodeParent.emplace_back(children[i], children[index]);
+          if(index >= 0)
+            nodeParent.emplace_back(children[i], children[index]);
         }
 
         bool multiPersPair
@@ -750,7 +875,11 @@ namespace ttk {
           if(not isFM) {
             int index
               = getIndexNotMultiPers(children.size() - 1, tree, children);
-            nodeParent.emplace_back(nodeOrigin, children[index]);
+            if(index >= 0)
+              nodeParent.push_back(
+                std::make_tuple(nodeOrigin, children[index]));
+            else
+              nodeParent.emplace_back(nodeOrigin, children[index]);
           } else
             nodeParent.emplace_back(children[0], node);
         } else {
@@ -758,6 +887,10 @@ namespace ttk {
           // std::endl;
           nodeParent.emplace_back(children[0], nodeOrigin);
           int index = getIndexNotMultiPers(children.size() - 1, tree, children);
+          if(index < 0) { // should not be possible
+            printErr("[branchDecompositionToTree] index < 0");
+            index = 0;
+          }
           nodeParent.emplace_back(node, children[index]);
         }
 
@@ -774,11 +907,16 @@ namespace ttk {
       for(unsigned int i = 0; i < tree->getNumberOfNodes(); ++i)
         if(tree->getNode(i)->getNumberOfDownSuperArcs() == 1
            and tree->getNode(i)->getNumberOfUpSuperArcs() == 1) {
-          tree->printTree();
+          printMsg(tree->printTree().str());
           std::stringstream ss;
-          ss << i << " _ " << tree->getNode(i)->getOrigin();
+          auto iOrigin = tree->getNode(i)->getOrigin();
+          ss << i << " _ " << iOrigin;
+          if(tree->getNode(iOrigin)->getOrigin() != int(i))
+            ss << " _ " << tree->getNode(iOrigin)->getOrigin() << " _ "
+               << tree->getNode(tree->getNode(iOrigin)->getOrigin())
+                    ->getOrigin();
           printMsg(ss.str());
-          printErr("1 up arc and 1 down arc");
+          printErr("[branchDecompositionToTree] 1 up arc and 1 down arc");
         }
     }
 
@@ -838,66 +976,26 @@ namespace ttk {
 
     template <class dataType>
     void postprocessingPipeline(ftm::FTMTree_MT *tree) {
-      // TODO fix dont use min max pair
-      if(not branchDecomposition_ or not useMinMaxPair_)
-        fixMergedRootOrigin<dataType>(tree);
-      if(branchDecomposition_)
-        branchDecompositionToTree<dataType>(tree);
-      else
+      // if(not branchDecomposition_ or not useMinMaxPair)
+      // fixMergedRootOrigin<dataType>(tree);
+      if(tree->isFullMerge()) {
+        auto mergedRootOrigin = tree->getMergedRootOrigin<dataType>();
+        if(not tree->isNodeIdInconsistent(mergedRootOrigin))
+          tree->getNode(tree->getRoot())->setOrigin(mergedRootOrigin);
+        else
+          printErr(
+            "[postprocessingPipeline] mergedRootOrigin inconsistent id.");
+      }
+      if(branchDecomposition_) {
+        if(tree->getRealNumberOfNodes() != 0)
+          branchDecompositionToTree<dataType>(tree);
+      } else
         putBackMergedNodes<dataType>(tree);
     }
 
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
     // Output Matching
-    // --------------------------------------------------------------------------------
-    template <class dataType>
-    void computeMatching(
-      ftm::FTMTree_MT *tree1,
-      ftm::FTMTree_MT *tree2,
-      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
-      std::vector<std::vector<std::vector<std::tuple<int, int>>>>
-        &forestBackTable,
-      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &outputMatching,
-      int startR,
-      int startC) {
-      std::queue<std::tuple<int, int, bool>> backQueue;
-      backQueue.emplace(std::make_tuple(startR, startC, true));
-      while(!backQueue.empty()) {
-        std::tuple<int, int, bool> elem = backQueue.front();
-        backQueue.pop();
-        bool useTreeTable = std::get<2>(elem);
-        int i = std::get<0>(elem);
-        int j = std::get<1>(elem);
-
-        if(useTreeTable) {
-          int tupleI = std::get<0>(treeBackTable[i][j]);
-          int tupleJ = std::get<1>(treeBackTable[i][j]);
-          if(tupleI != 0 && tupleJ != 0) {
-            useTreeTable = (tupleI != i || tupleJ != j);
-            backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
-            if(not useTreeTable) { // We have matched i and j
-              ftm::idNode tree1Node = tupleI - 1;
-              ftm::idNode tree2Node = tupleJ - 1;
-              double cost = 0;
-              dataType costT
-                = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
-              cost = static_cast<double>(costT);
-              outputMatching.emplace_back(tree1Node, tree2Node, cost);
-            }
-          }
-        } else {
-          for(std::tuple<int, int> forestBackElem : forestBackTable[i][j]) {
-            int tupleI = std::get<0>(forestBackElem);
-            int tupleJ = std::get<1>(forestBackElem);
-            if(tupleI != 0 && tupleJ != 0) {
-              useTreeTable = (tupleI != i && tupleJ != j);
-              backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
-            }
-          }
-        }
-      }
-    }
-
+    // ------------------------------------------------------------------------
     template <class dataType>
     void convertBranchDecompositionMatching(
       ftm::FTMTree_MT *tree1,
@@ -978,9 +1076,9 @@ namespace ttk {
       }
     }
 
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
     // Edit Costs
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
     template <class dataType>
     dataType computeDistance(
       dataType x1, dataType x2, dataType y1, dataType y2, double power = 2) {
@@ -1111,149 +1209,58 @@ namespace ttk {
       return cost;
     }
 
-    // --------------------------------------------------------------------------------
-    // Edit Distance Dynamic Programming Equations
-    // --------------------------------------------------------------------------------
-    template <class dataType>
-    void computeEquation8(ftm::FTMTree_MT *tree1,
-                          ftm::idNode nodeI,
-                          int i,
-                          std::vector<std::vector<dataType>> &treeTable,
-                          std::vector<std::vector<dataType>> &forestTable) {
-      std::vector<ftm::idNode> children;
-      tree1->getChildren(nodeI, children);
-      forestTable[i][0] = 0;
-      for(ftm::idNode child : children)
-        forestTable[i][0] += treeTable[child + 1][0];
-    }
-
-    template <class dataType>
-    void computeEquation9(ftm::FTMTree_MT *tree1,
-                          ftm::idNode nodeI,
-                          int i,
-                          std::vector<std::vector<dataType>> &treeTable,
-                          std::vector<std::vector<dataType>> &forestTable) {
-      treeTable[i][0] = forestTable[i][0] + deleteCost<dataType>(tree1, nodeI);
-    }
-
-    template <class dataType>
-    void computeEquation10(ftm::FTMTree_MT *tree2,
-                           ftm::idNode nodeJ,
-                           int j,
-                           std::vector<std::vector<dataType>> &treeTable,
-                           std::vector<std::vector<dataType>> &forestTable) {
-      std::vector<ftm::idNode> children;
-      tree2->getChildren(nodeJ, children);
-      forestTable[0][j] = 0;
-      for(ftm::idNode child : children)
-        forestTable[0][j] += treeTable[0][child + 1];
-    }
-
-    template <class dataType>
-    void computeEquation11(ftm::FTMTree_MT *tree2,
-                           ftm::idNode nodeJ,
-                           int j,
-                           std::vector<std::vector<dataType>> &treeTable,
-                           std::vector<std::vector<dataType>> &forestTable) {
-      treeTable[0][j] = forestTable[0][j] + insertCost<dataType>(tree2, nodeJ);
-    }
-
-    // Compute first or second term of equation 12 or 13
-    template <class dataType>
-    std::tuple<dataType, ftm::idNode>
-      computeTerm1_2(std::vector<ftm::idNode> &childrens,
-                     int ind,
-                     std::vector<std::vector<dataType>> &table,
-                     bool computeTerm1) {
-      dataType tempMin = (childrens.size() == 0)
-                           ? ((computeTerm1) ? table[ind][0] : table[0][ind])
-                           : std::numeric_limits<dataType>::max();
-      ftm::idNode bestIdNode = 0;
-      for(ftm::idNode children : childrens) {
-        children += 1;
-        dataType temp;
-        if(computeTerm1) {
-          temp = table[ind][children] - table[0][children];
-        } else {
-          temp = table[children][ind] - table[children][0];
-        }
-        if(temp < tempMin) {
-          tempMin = temp;
-          bestIdNode = children;
-        }
-      }
-      return std::make_tuple(tempMin, bestIdNode);
-    }
-
-    template <class dataType>
-    void computeEquation12(
-      ftm::FTMTree_MT *tree1,
-      ftm::FTMTree_MT *tree2,
-      int i,
-      int j,
-      ftm::idNode nodeI,
-      ftm::idNode nodeJ,
-      std::vector<std::vector<dataType>> &treeTable,
-      std::vector<std::vector<dataType>> &forestTable,
-      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
-      std::vector<ftm::idNode> &children1,
-      std::vector<ftm::idNode> &children2) {
-      dataType treeTerm1, treeTerm2, treeTerm3;
-      std::tuple<dataType, ftm::idNode> treeCoTerm1, treeCoTerm2;
-      // Term 1
-      treeCoTerm1 = computeTerm1_2<dataType>(children2, i, treeTable, true);
-      treeTerm1 = treeTable[0][j] + std::get<0>(treeCoTerm1);
-
-      // Term 2
-      treeCoTerm2 = computeTerm1_2<dataType>(children1, j, treeTable, false);
-      treeTerm2 = treeTable[i][0] + std::get<0>(treeCoTerm2);
-
-      // Term 3
-      treeTerm3
-        = forestTable[i][j] + relabelCost<dataType>(tree1, nodeI, tree2, nodeJ);
-
-      // Compute table value
-      treeTable[i][j] = keepSubtree_
-                          ? std::min(std::min(treeTerm1, treeTerm2), treeTerm3)
-                          : treeTerm3;
-
-      // Add backtracking information
-      if(treeTable[i][j] == treeTerm3) {
-        treeBackTable[i][j] = std::make_tuple(i, j);
-      } else if(treeTable[i][j] == treeTerm2) {
-        treeBackTable[i][j] = std::make_tuple(std::get<1>(treeCoTerm2), j);
-      } else {
-        treeBackTable[i][j] = std::make_tuple(i, std::get<1>(treeCoTerm1));
-      }
-    }
-
-    // --------------------------------------------------------------------------------
-    // Assignment Problem Functions
-    // --------------------------------------------------------------------------------
-    template <class dataType>
-    dataType postprocessAssignment(
-      std::vector<asgnMatchingTuple> &matchings,
-      std::vector<ftm::idNode> &children1,
-      std::vector<ftm::idNode> &children2,
-      std::vector<std::tuple<int, int>> &forestAssignment) {
-      dataType cost = 0;
-      for(asgnMatchingTuple mTuple : matchings) {
-        cost += std::get<2>(mTuple);
-        if(std::get<0>(mTuple) >= (int)children1.size()
-           || std::get<1>(mTuple) >= (int)children2.size())
-          continue;
-        int tableId1 = children1[std::get<0>(mTuple)] + 1;
-        int tableId2 = children2[std::get<1>(mTuple)] + 1;
-        forestAssignment.emplace_back(tableId1, tableId2);
-      }
-      return cost;
-    }
-
-    // --------------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
     // Utils
-    // --------------------------------------------------------------------------------
-    void printTreesStats(std::vector<ftm::FTMTree_MT *> &trees) {
-      int avgNodes = 0, avgNodesT = 0;
+    // ------------------------------------------------------------------------
+    void getParamNames(std::vector<std::string> &paramNames) {
+      paramNames = std::vector<std::string>{"epsilon1",
+                                            "epsilon2",
+                                            "epsilon3",
+                                            "persistenceThreshold",
+                                            "branchDecomposition",
+                                            "normalizedWasserstein",
+                                            "keepSubtree"};
+    }
+
+    double getParamValueFromName(std::string &paramName) {
+      double value = 0.0;
+      if(paramName == "epsilon1")
+        value = epsilonTree1_;
+      else if(paramName == "epsilon2")
+        value = epsilon2Tree1_;
+      else if(paramName == "epsilon3")
+        value = epsilon3Tree1_;
+      else if(paramName == "persistenceThreshold")
+        value = persistenceThreshold_;
+      else if(paramName == "branchDecomposition")
+        value = branchDecomposition_;
+      else if(paramName == "normalizedWasserstein")
+        value = normalizedWasserstein_;
+      else if(paramName == "keepSubtree")
+        value = keepSubtree_;
+      return value;
+    }
+
+    void setParamValueFromName(std::string &paramName, double value) {
+      if(paramName == "epsilon1")
+        epsilonTree1_ = value;
+      else if(paramName == "epsilon2")
+        epsilon2Tree1_ = value;
+      else if(paramName == "epsilon3")
+        epsilon3Tree1_ = value;
+      else if(paramName == "persistenceThreshold")
+        persistenceThreshold_ = value;
+      else if(paramName == "branchDecomposition")
+        branchDecomposition_ = value;
+      else if(paramName == "normalizedWasserstein")
+        normalizedWasserstein_ = value;
+      else if(paramName == "keepSubtree")
+        keepSubtree_ = value;
+    }
+
+    void getTreesStats(std::vector<ftm::FTMTree_MT *> &trees,
+                       std::array<double, 3> &stats) {
+      double avgNodes = 0, avgNodesT = 0;
       double avgDepth = 0;
       for(unsigned int i = 0; i < trees.size(); ++i) {
         auto noNodesT = trees[i]->getNumberOfNodes();
@@ -1265,6 +1272,15 @@ namespace ttk {
       avgNodes /= trees.size();
       avgNodesT /= trees.size();
       avgDepth /= trees.size();
+
+      stats = {avgNodes, avgNodesT, avgDepth};
+    }
+
+    void printTreesStats(std::vector<ftm::FTMTree_MT *> &trees) {
+      std::array<double, 3> stats;
+      getTreesStats(trees, stats);
+      int avgNodes = stats[0], avgNodesT = stats[1];
+      double avgDepth = stats[2];
       std::stringstream ss;
       ss << trees.size() << " trees average [node: " << avgNodes << " / "
          << avgNodesT << ", depth: " << avgDepth << "]";

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -481,7 +481,7 @@ namespace ttk {
       }
 
       for(unsigned int i = 0; i < bestCentroidT.size(); ++i)
-        assignmentC.push_back(std::make_tuple(bestCentroidT[i], i));
+        assignmentC.emplace_back(bestCentroidT[i], i);
     }
 
     template <class dataType>

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -118,11 +118,11 @@ namespace ttk {
             trees, trees2, limitPercent, false);
         } else {
           // Create vector of probabilities
-          dataType sum = 0;
+          double sum = 0;
           for(auto val : distances)
             sum += val;
-          dataType bestValue = std::numeric_limits<dataType>::lowest();
-          std::vector<dataType> probabilities(trees.size());
+          double bestValue = std::numeric_limits<double>::lowest();
+          std::vector<double> probabilities(trees.size());
           for(unsigned int j = 0; j < distances.size(); ++j) {
             probabilities[j]
               = (sum != 0 ? distances[j] / sum : 1.0 / distances.size());

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -124,7 +124,8 @@ namespace ttk {
           dataType bestValue = std::numeric_limits<dataType>::lowest();
           std::vector<dataType> probabilities(trees.size());
           for(unsigned int j = 0; j < distances.size(); ++j) {
-            probabilities[j] = distances[j] / sum;
+            probabilities[j]
+              = (sum != 0 ? distances[j] / sum : 1.0 / distances.size());
             if(probabilities[j] > bestValue) {
               bestValue = probabilities[j];
               bestIndex = j;

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -48,6 +48,8 @@ namespace ttk {
     double auctionEpsilonDiviser_ = 0;
     int auctionRound_ = -1;
 
+    double minMaxPairWeight_ = 1.0;
+
     // Just to get some stats about run
     // std::map<int, int> assignmentProblemSize, assignmentProblemIter;
 
@@ -105,13 +107,17 @@ namespace ttk {
       onlyEmptyTreeDistance_ = only;
     }
 
+    void setMinMaxPairWeight(double weight) {
+      minMaxPairWeight_ = weight;
+    }
+
     /**
      * Implementation of the algorithm.
      */
 
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     // Assignment Problem
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     template <class dataType>
     void
       runAssignmentProblemSolver(std::vector<std::vector<dataType>> &costMatrix,
@@ -170,6 +176,25 @@ namespace ttk {
     }
 
     template <class dataType>
+    dataType postprocessAssignment(
+      std::vector<asgnMatchingTuple> &matchings,
+      std::vector<ftm::idNode> &children1,
+      std::vector<ftm::idNode> &children2,
+      std::vector<std::tuple<int, int>> &forestAssignment) {
+      dataType cost = 0;
+      for(asgnMatchingTuple mTuple : matchings) {
+        cost += std::get<2>(mTuple);
+        if(std::get<0>(mTuple) >= (int)children1.size()
+           || std::get<1>(mTuple) >= (int)children2.size())
+          continue;
+        int tableId1 = children1[std::get<0>(mTuple)] + 1;
+        int tableId2 = children2[std::get<1>(mTuple)] + 1;
+        forestAssignment.push_back(std::make_tuple(tableId1, tableId2));
+      }
+      return cost;
+    }
+
+    template <class dataType>
     dataType forestAssignmentProblem(
       ftm::FTMTree_MT *ttkNotUsed(tree1),
       ftm::FTMTree_MT *ttkNotUsed(tree2),
@@ -197,7 +222,7 @@ namespace ttk {
     }
 
     template <class dataType>
-    void computeEquation13(
+    void computeForestsDistance(
       ftm::FTMTree_MT *tree1,
       ftm::FTMTree_MT *tree2,
       int i,
@@ -251,9 +276,182 @@ namespace ttk {
       }
     }
 
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
+    // Edit Distance Dynamic Programming Equations
+    // ------------------------------------------------------------------------
+    template <class dataType>
+    void computeForestToEmpyDistance(
+      ftm::FTMTree_MT *tree1,
+      ftm::idNode nodeI,
+      int i,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable) {
+      std::vector<ftm::idNode> children;
+      tree1->getChildren(nodeI, children);
+      forestTable[i][0] = 0;
+      for(ftm::idNode child : children)
+        forestTable[i][0] += treeTable[child + 1][0];
+    }
+
+    template <class dataType>
+    void computeSubtreeToEmptyDistance(
+      ftm::FTMTree_MT *tree1,
+      ftm::idNode nodeI,
+      int i,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable) {
+      treeTable[i][0] = forestTable[i][0] + deleteCost<dataType>(tree1, nodeI);
+    }
+
+    template <class dataType>
+    void computeEmptyToForestDistance(
+      ftm::FTMTree_MT *tree2,
+      ftm::idNode nodeJ,
+      int j,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable) {
+      std::vector<ftm::idNode> children;
+      tree2->getChildren(nodeJ, children);
+      forestTable[0][j] = 0;
+      for(ftm::idNode child : children)
+        forestTable[0][j] += treeTable[0][child + 1];
+    }
+
+    template <class dataType>
+    void computeEmptyToSubtreeDistance(
+      ftm::FTMTree_MT *tree2,
+      ftm::idNode nodeJ,
+      int j,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable) {
+      treeTable[0][j] = forestTable[0][j] + insertCost<dataType>(tree2, nodeJ);
+    }
+
+    // Compute first or second term of forests and subtrees distance
+    template <class dataType>
+    std::tuple<dataType, ftm::idNode>
+      computeTerm1_2(std::vector<ftm::idNode> &childrens,
+                     int ind,
+                     std::vector<std::vector<dataType>> &table,
+                     bool computeTerm1) {
+      dataType tempMin = (childrens.size() == 0)
+                           ? ((computeTerm1) ? table[ind][0] : table[0][ind])
+                           : std::numeric_limits<dataType>::max();
+      ftm::idNode bestIdNode = 0;
+      for(ftm::idNode children : childrens) {
+        children += 1;
+        dataType temp;
+        if(computeTerm1) {
+          temp = table[ind][children] - table[0][children];
+        } else {
+          temp = table[children][ind] - table[children][0];
+        }
+        if(temp < tempMin) {
+          tempMin = temp;
+          bestIdNode = children;
+        }
+      }
+      return std::make_tuple(tempMin, bestIdNode);
+    }
+
+    template <class dataType>
+    void computeSubtreesDistance(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      int i,
+      int j,
+      ftm::idNode nodeI,
+      ftm::idNode nodeJ,
+      std::vector<std::vector<dataType>> &treeTable,
+      std::vector<std::vector<dataType>> &forestTable,
+      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
+      std::vector<ftm::idNode> &children1,
+      std::vector<ftm::idNode> &children2) {
+      dataType treeTerm1, treeTerm2, treeTerm3;
+      std::tuple<dataType, ftm::idNode> treeCoTerm1, treeCoTerm2;
+      // Term 1
+      treeCoTerm1 = computeTerm1_2<dataType>(children2, i, treeTable, true);
+      treeTerm1 = treeTable[0][j] + std::get<0>(treeCoTerm1);
+
+      // Term 2
+      treeCoTerm2 = computeTerm1_2<dataType>(children1, j, treeTable, false);
+      treeTerm2 = treeTable[i][0] + std::get<0>(treeCoTerm2);
+
+      // Term 3
+      treeTerm3
+        = forestTable[i][j] + relabelCost<dataType>(tree1, nodeI, tree2, nodeJ);
+
+      // Compute table value
+      treeTable[i][j] = keepSubtree_
+                          ? std::min(std::min(treeTerm1, treeTerm2), treeTerm3)
+                          : treeTerm3;
+
+      // Add backtracking information
+      if(treeTable[i][j] == treeTerm3) {
+        treeBackTable[i][j] = std::make_tuple(i, j);
+      } else if(treeTable[i][j] == treeTerm2) {
+        treeBackTable[i][j] = std::make_tuple(std::get<1>(treeCoTerm2), j);
+      } else {
+        treeBackTable[i][j] = std::make_tuple(i, std::get<1>(treeCoTerm1));
+      }
+    }
+
+    // --------------------------------------------------------------------------------
+    // Output Matching
+    // --------------------------------------------------------------------------------
+    template <class dataType>
+    void computeMatching(
+      ftm::FTMTree_MT *tree1,
+      ftm::FTMTree_MT *tree2,
+      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
+      std::vector<std::vector<std::vector<std::tuple<int, int>>>>
+        &forestBackTable,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &outputMatching,
+      int startR,
+      int startC) {
+      outputMatching.clear();
+      std::queue<std::tuple<int, int, bool>> backQueue;
+      backQueue.emplace(std::make_tuple(startR, startC, true));
+      while(!backQueue.empty()) {
+        std::tuple<int, int, bool> elem = backQueue.front();
+        backQueue.pop();
+        bool useTreeTable = std::get<2>(elem);
+        int i = std::get<0>(elem);
+        int j = std::get<1>(elem);
+
+        if(useTreeTable) {
+          int tupleI = std::get<0>(treeBackTable[i][j]);
+          int tupleJ = std::get<1>(treeBackTable[i][j]);
+          if(tupleI != 0 && tupleJ != 0) {
+            useTreeTable = (tupleI != i || tupleJ != j);
+            backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
+            if(not useTreeTable) { // We have matched i and j
+              ftm::idNode tree1Node = tupleI - 1;
+              ftm::idNode tree2Node = tupleJ - 1;
+              double cost = 0;
+              dataType costT
+                = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
+              cost = static_cast<double>(costT);
+              outputMatching.push_back(
+                std::make_tuple(tree1Node, tree2Node, cost));
+            }
+          }
+        } else {
+          for(std::tuple<int, int> forestBackElem : forestBackTable[i][j]) {
+            int tupleI = std::get<0>(forestBackElem);
+            int tupleJ = std::get<1>(forestBackElem);
+            if(tupleI != 0 && tupleJ != 0) {
+              useTreeTable = (tupleI != i && tupleJ != j);
+              backQueue.emplace(std::make_tuple(tupleI, tupleJ, useTreeTable));
+            }
+          }
+        }
+      }
+    }
+
+    // ------------------------------------------------------------------------
     // Main Functions
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     template <class dataType>
     dataType
       computeDistance(ftm::FTMTree_MT *tree1,
@@ -299,6 +497,21 @@ namespace ttk {
       dataType distance = treeTable[indR][indC];
       if(onlyEmptyTreeDistance_)
         distance = treeTable[indR][0];
+      if(branchDecomposition_) {
+        if(not useMinMaxPair_) {
+          if(onlyEmptyTreeDistance_)
+            distance -= deleteCost<dataType>(tree1, tree1->getRoot());
+          else
+            distance -= relabelCost<dataType>(
+              tree1, tree1->getRoot(), tree2, tree2->getRoot());
+        } else {
+          if(minMaxPairWeight_ != 1.0) {
+            auto cost = relabelCost<dataType>(
+              tree1, tree1->getRoot(), tree2, tree2->getRoot());
+            distance = distance - cost + minMaxPairWeight_ * cost;
+          }
+        }
+      }
       if(distanceSquared_)
         distance = std::sqrt(distance);
 
@@ -493,11 +706,12 @@ namespace ttk {
       if(processTree1) {
         if(computeEmptyTree) {
           int i = nodeI + 1;
-          // --- Equation 8
-          computeEquation8(tree1, nodeI, i, treeTable, forestTable);
+          // --- Forst to empty tree distance
+          computeForestToEmpyDistance(tree1, nodeI, i, treeTable, forestTable);
 
-          // --- Equation 9
-          computeEquation9(tree1, nodeI, i, treeTable, forestTable);
+          // --- Subtree to empty tree distance
+          computeSubtreeToEmptyDistance(
+            tree1, nodeI, i, treeTable, forestTable);
         } else
           classicEditDistance(tree1, tree2, false, false, nodeI,
                               tree2->getRoot(), treeTable, forestTable,
@@ -505,11 +719,12 @@ namespace ttk {
       } else {
         int j = nodeJ + 1;
         if(computeEmptyTree) {
-          // --- Equation 10
-          computeEquation10(tree2, nodeJ, j, treeTable, forestTable);
+          // --- Empty tree to forest distance
+          computeEmptyToForestDistance(tree2, nodeJ, j, treeTable, forestTable);
 
-          // --- Equation 11
-          computeEquation11(tree2, nodeJ, j, treeTable, forestTable);
+          // --- Empty tree to subtree distance
+          computeEmptyToSubtreeDistance(
+            tree2, nodeJ, j, treeTable, forestTable);
           //}else{
         } else if(keepSubtree_ or tree1Level_[nodeI] == tree2Level_[nodeJ]) {
           int i = nodeI + 1;
@@ -517,20 +732,21 @@ namespace ttk {
           tree1->getChildren(nodeI, children1);
           std::vector<ftm::idNode> children2;
           tree2->getChildren(nodeJ, children2);
-          // --- Equation 13
-          computeEquation13(tree1, tree2, i, j, treeTable, forestTable,
-                            forestBackTable, children1, children2);
+          // --- Forests distance
+          computeForestsDistance(tree1, tree2, i, j, treeTable, forestTable,
+                                 forestBackTable, children1, children2);
 
-          // --- Equation 12
-          computeEquation12(tree1, tree2, i, j, nodeI, nodeJ, treeTable,
-                            forestTable, treeBackTable, children1, children2);
+          // --- Subtrees distance
+          computeSubtreesDistance(tree1, tree2, i, j, nodeI, nodeJ, treeTable,
+                                  forestTable, treeBackTable, children1,
+                                  children2);
         }
       }
     }
 
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     // Parallel version
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     template <class dataType>
     void parallelEditDistance(
       ftm::FTMTree_MT *tree1,
@@ -577,7 +793,7 @@ namespace ttk {
                               treeBackTable, forestBackTable, true);
     }
 
-    // Equation 12, 13
+    // Forests and subtrees distances
     template <class dataType>
     void parallelTreeDistance_v2(
       ftm::FTMTree_MT *tree1,
@@ -624,7 +840,6 @@ namespace ttk {
                                  treeChildDone, treeNodeDone, treeQueue);
     }
 
-    // TODO verify use of first call for the distance computation only
     // (isCalled_=false)
     template <class dataType>
     void parallelTreeDistancePara(
@@ -647,9 +862,7 @@ namespace ttk {
       std::vector<bool> &treeNodeDone,
       std::queue<ftm::idNode> &treeQueue) {
 #ifdef TTK_ENABLE_OPENMP
-      unsigned int nthreads = std::thread::hardware_concurrency();
-#pragma omp parallel num_threads( \
-  this->threadNumber_) if(firstCall or (int) nthreads == this->threadNumber_)
+#pragma omp parallel num_threads(this->threadNumber_) if(firstCall)
       {
 #pragma omp single nowait
 #endif
@@ -721,14 +934,14 @@ namespace ttk {
               tree1->getChildren(nodeI, children1);
               std::vector<ftm::idNode> children2;
               tree2->getChildren(nodeT, children2);
-              // --- Equation 13
-              computeEquation13(tree1, tree2, i, j, treeTable, forestTable,
-                                forestBackTable, children1, children2);
+              // --- Forests distance
+              computeForestsDistance(tree1, tree2, i, j, treeTable, forestTable,
+                                     forestBackTable, children1, children2);
 
-              // --- Equation 12
-              computeEquation12(tree1, tree2, i, j, nodeI, nodeT, treeTable,
-                                forestTable, treeBackTable, children1,
-                                children2);
+              // --- Subtrees distance
+              computeSubtreesDistance(tree1, tree2, i, j, nodeI, nodeT,
+                                      treeTable, forestTable, treeBackTable,
+                                      children1, children2);
             }
 
             if(not isTree1 and not keepSubtree_
@@ -770,7 +983,7 @@ namespace ttk {
 #endif
     }
 
-    // Equation 8, 9, 10, 11
+    // Subtree/Forest with empty tree distances
     template <class dataType>
     void parallelEmptyTreeDistance_v2(
       ftm::FTMTree_MT *tree,
@@ -857,18 +1070,22 @@ namespace ttk {
           while((int)nodeT != -1) {
             if(isTree1) {
               int i = nodeT + 1;
-              // --- Equation 8
-              computeEquation8(tree, nodeT, i, treeTable, forestTable);
+              // --- Forest to empty tree distance
+              computeForestToEmpyDistance(
+                tree, nodeT, i, treeTable, forestTable);
 
-              // --- Equation 9
-              computeEquation9(tree, nodeT, i, treeTable, forestTable);
+              // --- Subtree to empty tree distance
+              computeSubtreeToEmptyDistance(
+                tree, nodeT, i, treeTable, forestTable);
             } else {
               int j = nodeT + 1;
-              // --- Equation 10
-              computeEquation10(tree, nodeT, j, treeTable, forestTable);
+              // --- Empty tree to forest distance
+              computeEmptyToForestDistance(
+                tree, nodeT, j, treeTable, forestTable);
 
-              // --- Equation 11
-              computeEquation11(tree, nodeT, j, treeTable, forestTable);
+              // --- Empty tree to subtree distance
+              computeEmptyToSubtreeDistance(
+                tree, nodeT, j, treeTable, forestTable);
             }
 
             // Manage parent
@@ -906,206 +1123,9 @@ namespace ttk {
       TTK_FORCE_USE(forestBackTable);
     }
 
-    // ----------------------------------------
-    // OLD v1
-    // ----------------------------------------
-    // Equation 12, 13
-    template <class dataType>
-    void parallelTreeDistance(
-      ftm::FTMTree_MT *tree1,
-      ftm::FTMTree_MT *tree2,
-      bool isTree1,
-      int i,
-      std::vector<ftm::idNode> &tree1Leaves,
-      std::vector<int> &tree1NodeChildSize,
-      std::vector<ftm::idNode> &tree2Leaves,
-      std::vector<int> &tree2NodeChildSize,
-      std::vector<std::vector<dataType>> &treeTable,
-      std::vector<std::vector<dataType>> &forestTable,
-      std::vector<std::vector<std::tuple<int, int>>> &treeBackTable,
-      std::vector<std::vector<std::vector<std::tuple<int, int>>>>
-        &forestBackTable,
-      bool firstCall = false) {
-      ftm::idNode nodeT = -1;
-      ftm::FTMTree_MT *treeT = (isTree1) ? tree1 : tree2;
-      std::vector<int> treeChildDone(treeT->getNumberOfNodes(), 0);
-      std::vector<bool> treeNodeDone(treeT->getNumberOfNodes(), false);
-      std::queue<ftm::idNode> treeQueue;
-      if(isTree1)
-        for(ftm::idNode leaf : tree1Leaves)
-          treeQueue.emplace(leaf);
-      else
-        for(ftm::idNode leaf : tree2Leaves)
-          treeQueue.emplace(leaf);
-
-#ifdef TTK_ENABLE_OPENMP
-      const int nthreads = std::thread::hardware_concurrency();
-#pragma omp parallel num_threads(                                        \
-  this->threadNumber_) if((firstCall or nthreads == this->threadNumber_) \
-                          && !isCalled_)
-      {
-#pragma omp single nowait
-#endif
-        while(!treeQueue.empty()) {
-          nodeT = treeQueue.front();
-          treeQueue.pop();
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(nodeT) \
-  UNTIED() // shared(treeTable, forestTable)//, treeBackTable,
-           // forestBackTable)
-          {
-#endif
-            std::stringstream ss;
-            ss << &treeTable[0] << " _ " << tree1 << " _ " << tree2
-               << std::endl;
-            // std::cout << ss.str();
-            while(static_cast<int>(nodeT) != -1) {
-              int t = nodeT + 1;
-
-              if(isTree1) {
-                parallelTreeDistance(tree1, tree2, false, t, tree1Leaves,
-                                     tree1NodeChildSize, tree2Leaves,
-                                     tree2NodeChildSize, treeTable, forestTable,
-                                     treeBackTable, forestBackTable);
-              } else {
-                int j = nodeT + 1;
-                ftm::idNode nodeI = i - 1;
-                std::vector<ftm::idNode> children1;
-                tree1->getChildren(nodeI, children1);
-                std::vector<ftm::idNode> children2;
-                tree2->getChildren(nodeT, children2);
-                // --- Equation 13
-                computeEquation13(tree1, tree2, i, j, treeTable, forestTable,
-                                  forestBackTable, children1, children2);
-
-                // --- Equation 12
-                computeEquation12(tree1, tree2, i, j, nodeI, nodeT, treeTable,
-                                  forestTable, treeBackTable, children1,
-                                  children2);
-              }
-
-              // Manage parent
-              ftm::idNode nodeTParent = treeT->getParentSafe(nodeT);
-              int childSize = (isTree1) ? tree1NodeChildSize[nodeTParent]
-                                        : tree2NodeChildSize[nodeTParent];
-              int oldTreeChildDone;
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp atomic capture
-              {
-#endif
-                oldTreeChildDone = treeChildDone[nodeTParent];
-                treeChildDone[nodeTParent]++;
-#ifdef TTK_ENABLE_OPENMP
-              } // pragma omp atomic capture
-#endif
-              if(not treeNodeDone[nodeTParent]
-                 and oldTreeChildDone + 1 == childSize) {
-                nodeT = nodeTParent;
-                treeNodeDone[nodeTParent] = true;
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp taskyield
-#endif
-              } else
-                nodeT = -1;
-
-            } // while nodeI loop
-#ifdef TTK_ENABLE_OPENMP
-          } // pragma omp task
-#endif
-        } // while loop
-#ifdef TTK_ENABLE_OPENMP
-      } // pragma omp parallel
-#endif
-
-      TTK_FORCE_USE(firstCall);
-    }
-
-    // Equation 8, 9, 10, 11
-    template <class dataType>
-    void parallelEmptyTreeDistance(
-      ftm::FTMTree_MT *tree,
-      bool isTree1,
-      std::vector<ftm::idNode> &treeLeaves,
-      std::vector<int> &treeNodeChildSize,
-      std::vector<std::vector<dataType>> &treeTable,
-      std::vector<std::vector<dataType>> &forestTable,
-      std::vector<std::vector<std::tuple<int, int>>> &ttkNotUsed(treeBackTable),
-      std::vector<std::vector<std::vector<std::tuple<int, int>>>> &ttkNotUsed(
-        forestBackTable)) {
-      ftm::idNode nodeT = -1;
-      std::vector<int> treeChildDone(tree->getNumberOfNodes(), 0);
-      std::vector<bool> treeNodeDone(tree->getNumberOfNodes(), false);
-      std::queue<ftm::idNode> treeQueue;
-      for(ftm::idNode leaf : treeLeaves) {
-        treeQueue.emplace(leaf);
-      }
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel num_threads(this->threadNumber_) if(not isCalled_)
-      {
-#pragma omp single nowait
-#endif
-        while(!treeQueue.empty()) {
-          nodeT = treeQueue.front();
-          treeQueue.pop();
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp task firstprivate(nodeT) \
-  UNTIED() // shared(treeTable, forestTable, treeBackTable, forestBackTable)
-          {
-#endif
-            while(static_cast<int>(nodeT) != -1) {
-              if(isTree1) {
-                int i = nodeT + 1;
-                // --- Equation 8
-                computeEquation8(tree, nodeT, i, treeTable, forestTable);
-
-                // --- Equation 9
-                computeEquation9(tree, nodeT, i, treeTable, forestTable);
-              } else {
-                int j = nodeT + 1;
-                // --- Equation 10
-                computeEquation10(tree, nodeT, j, treeTable, forestTable);
-
-                // --- Equation 11
-                computeEquation11(tree, nodeT, j, treeTable, forestTable);
-              }
-
-              // Manage parent
-              ftm::idNode nodeTParent = tree->getParentSafe(nodeT);
-              int oldTreeChildDone;
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp atomic capture
-              {
-#endif
-                oldTreeChildDone = treeChildDone[nodeTParent];
-                treeChildDone[nodeTParent]++;
-#ifdef TTK_ENABLE_OPENMP
-              } // pragma omp atomic capture
-#endif
-              if(not treeNodeDone[nodeTParent]
-                 and oldTreeChildDone + 1 == treeNodeChildSize[nodeTParent]) {
-                nodeT = nodeTParent;
-                treeNodeDone[nodeTParent] = true;
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp taskyield
-#endif
-              } else
-                nodeT = -1;
-
-            } // while nodeI loop
-#ifdef TTK_ENABLE_OPENMP
-          } // pragma omp task
-#endif
-        } // while loop
-#ifdef TTK_ENABLE_OPENMP
-      } // pragma omp parallel
-#endif
-    }
-
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     // Utils
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     void printMapIntInt(std::map<int, int> theMap) {
       for(auto itr = theMap.begin(); itr != theMap.end(); ++itr) {
         std::stringstream ss;
@@ -1149,20 +1169,20 @@ namespace ttk {
       }
 
       if(problem) {
-        printMsg("merge tree in input is not valid");
+        printErr("merge tree in input is not valid");
         for(auto tup : problemNodes) {
           std::stringstream ss;
           ss << std::get<0>(tup) << " _ " << std::get<1>(tup);
           printMsg(ss.str());
         }
-        tree->printTree();
-        tree->printTreeScalars<dataType>();
+        printMsg(tree->printTree().str());
+        printMsg(tree->printTreeScalars<dataType>().str());
       }
     }
 
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     // Testing
-    // ----------------------------------------
+    // ------------------------------------------------------------------------
     template <class dataType>
     void classicalPersistenceAssignmentProblem(ftm::FTMTree_MT *tree1,
                                                ftm::FTMTree_MT *tree2) {

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -189,7 +189,7 @@ namespace ttk {
           continue;
         int tableId1 = children1[std::get<0>(mTuple)] + 1;
         int tableId2 = children2[std::get<1>(mTuple)] + 1;
-        forestAssignment.push_back(std::make_tuple(tableId1, tableId2));
+        forestAssignment.emplace_back(tableId1, tableId2);
       }
       return cost;
     }
@@ -432,8 +432,7 @@ namespace ttk {
               dataType costT
                 = relabelCost<dataType>(tree1, tree1Node, tree2, tree2Node);
               cost = static_cast<double>(costT);
-              outputMatching.push_back(
-                std::make_tuple(tree1Node, tree2Node, cost));
+              outputMatching.emplace_back(tree1Node, tree2Node, cost);
             }
           }
         } else {

--- a/core/base/mergeTreeClustering/MergeTreeUtils.h
+++ b/core/base/mergeTreeClustering/MergeTreeUtils.h
@@ -220,4 +220,24 @@ namespace ttk {
     return tree;
   }
 
+  template <class dataType>
+  ftm::MergeTree<dataType>
+    makeFakeMergeTree(std::vector<dataType> &scalarsVector,
+                      std::vector<std::tuple<ftm::idNode, ftm::idNode>> &arcs) {
+    ftm::MergeTree<dataType> mergeTree
+      = ttk::ftm::createEmptyMergeTree<dataType>(scalarsVector.size());
+    ttk::ftm::setTreeScalars<dataType>(mergeTree, scalarsVector);
+    ftm::FTMTree_MT *tree = &(mergeTree.tree);
+
+    // Add Nodes
+    for(unsigned int i = 0; i < scalarsVector.size(); ++i)
+      tree->makeNode(i);
+
+    // Add Arcs
+    for(std::tuple<ftm::idNode, ftm::idNode> arc : arcs)
+      tree->makeSuperArc(std::get<0>(arc), std::get<1>(arc)); // (down, Up)
+
+    return mergeTree;
+  }
+
 } // namespace ttk

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -38,19 +38,28 @@ namespace ttk {
      */
     template <class dataType>
     void execute(std::vector<ftm::MergeTree<dataType>> &trees,
+                 std::vector<ftm::MergeTree<dataType>> &trees2,
                  std::vector<std::vector<double>> &distanceMatrix) {
       executePara<dataType>(trees, distanceMatrix);
+      if(trees2.size() != 0) {
+        useDoubleInput_ = true;
+        std::vector<std::vector<double>> distanceMatrix2(
+          trees2.size(), std::vector<double>(trees2.size()));
+        executePara<dataType>(trees2, distanceMatrix2, false);
+        mixDistancesMatrix(distanceMatrix, distanceMatrix2);
+      }
     }
 
     template <class dataType>
     void executePara(std::vector<ftm::MergeTree<dataType>> &trees,
-                     std::vector<std::vector<double>> &distanceMatrix) {
+                     std::vector<std::vector<double>> &distanceMatrix,
+                     bool isFirstInput = true) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel num_threads(this->threadNumber_)
       {
 #pragma omp single nowait
 #endif
-        executeParaImpl<dataType>(trees, distanceMatrix);
+        executeParaImpl<dataType>(trees, distanceMatrix, isFirstInput);
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp taskwait
       } // pragma omp parallel
@@ -59,7 +68,8 @@ namespace ttk {
 
     template <class dataType>
     void executeParaImpl(std::vector<ftm::MergeTree<dataType>> &trees,
-                         std::vector<std::vector<double>> &distanceMatrix) {
+                         std::vector<std::vector<double>> &distanceMatrix,
+                         bool isFirstInput = true) {
       for(unsigned int i = 0; i < distanceMatrix.size(); ++i) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix, trees)
@@ -100,6 +110,11 @@ namespace ttk {
             mergeTreeDistance.setCleanTree(true);
             mergeTreeDistance.setIsCalled(true);
             mergeTreeDistance.setPostprocess(false);
+            if(useDoubleInput_) {
+              double weight = mixDistancesMinMaxPairWeight(isFirstInput);
+              mergeTreeDistance.setMinMaxPairWeight(weight);
+              mergeTreeDistance.setDistanceSquared(true);
+            }
             std::vector<std::tuple<ftm::idNode, ftm::idNode>> outputMatching;
             distanceMatrix[i][j] = mergeTreeDistance.execute<dataType>(
               trees[i], trees[j], outputMatching);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -216,6 +216,9 @@ int ttkMergeTreeClustering::runCompute(
   EpsilonTree2 = EpsilonTree1;
   Epsilon2Tree2 = Epsilon2Tree1;
   Epsilon3Tree2 = Epsilon3Tree1;
+  printMsg("BranchDecomposition: " + std::to_string(BranchDecomposition));
+  printMsg("NormalizedWasserstein: " + std::to_string(NormalizedWasserstein));
+  printMsg("KeepSubtree: " + std::to_string(KeepSubtree));
 
   // Call base
   if(not ComputeBarycenter) {
@@ -267,6 +270,8 @@ int ttkMergeTreeClustering::runCompute(
       mergeTreeBarycenter.setTol(Tol);
       mergeTreeBarycenter.setAddNodes(AddNodes);
       mergeTreeBarycenter.setDeterministic(Deterministic);
+      mergeTreeBarycenter.setBarycenterSizeLimitPercent(
+        BarycenterSizeLimitPercent);
       mergeTreeBarycenter.setProgressiveBarycenter(ProgressiveBarycenter);
       mergeTreeBarycenter.setProgressiveSpeedDivisor(ProgressiveSpeedDivisor);
       mergeTreeBarycenter.setAlpha(Alpha);
@@ -302,6 +307,8 @@ int ttkMergeTreeClustering::runCompute(
       mergeTreeClustering.setAddNodes(AddNodes);
       mergeTreeClustering.setDeterministic(Deterministic);
       mergeTreeClustering.setNoCentroids(NumberOfBarycenters);
+      mergeTreeClustering.setBarycenterSizeLimitPercent(
+        BarycenterSizeLimitPercent);
       mergeTreeClustering.setProgressiveBarycenter(ProgressiveBarycenter);
       mergeTreeClustering.setProgressiveSpeedDivisor(ProgressiveSpeedDivisor);
       mergeTreeClustering.setPostprocess(OutputTrees);
@@ -503,6 +510,9 @@ int ttkMergeTreeClustering::runOutput(
       // ------------------------------------------
       output_clusters->SetNumberOfBlocks(numInputs);
       for(unsigned int c = 0; c < NumberOfBarycenters; ++c) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif
         for(int i = 0; i < numInputs; ++i) {
           if(clusteringAssignment[i] != (int)c)
             continue;
@@ -594,7 +604,7 @@ int ttkMergeTreeClustering::runOutput(
           BranchDecompositionPlanarLayout);
         visuMakerBary.setBranchSpacing(BranchSpacing);
         visuMakerBary.setRescaleTreesIndividually(RescaleTreesIndividually);
-        visuMakerBary.setOutputSegmentation(OutputSegmentation);
+        visuMakerBary.setOutputSegmentation(false);
         visuMakerBary.setDimensionSpacing(DimensionSpacing);
         visuMakerBary.setDimensionToShift(DimensionToShift);
         visuMakerBary.setImportantPairs(ImportantPairs);

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -80,6 +80,7 @@ private:
   double JoinSplitMixtureCoefficient = 0.5;
   bool ComputeBarycenter = false;
   unsigned int NumberOfBarycenters = 1;
+  double BarycenterSizeLimitPercent = 0.0;
   bool Deterministic = false;
 
   // Output Options
@@ -307,6 +308,13 @@ public:
     resetDataVisualization();
   }
   vtkGetMacro(NumberOfBarycenters, unsigned int);
+
+  void SetBarycenterSizeLimitPercent(double percent) {
+    BarycenterSizeLimitPercent = percent;
+    Modified();
+    resetDataVisualization();
+  }
+  vtkGetMacro(BarycenterSizeLimitPercent, double);
 
   // Output Options
   vtkSetMacro(BarycenterPositionAlpha, bool);

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -30,7 +30,7 @@ vtkStandardNewMacro(ttkMergeTreeDistanceMatrix);
  * to be freed when the filter is destroyed.
  */
 ttkMergeTreeDistanceMatrix::ttkMergeTreeDistanceMatrix() {
-  this->SetNumberOfInputPorts(1);
+  this->SetNumberOfInputPorts(2);
   this->SetNumberOfOutputPorts(1);
 }
 
@@ -45,9 +45,11 @@ ttkMergeTreeDistanceMatrix::~ttkMergeTreeDistanceMatrix() = default;
  */
 int ttkMergeTreeDistanceMatrix::FillInputPortInformation(int port,
                                                          vtkInformation *info) {
-  if(port == 0)
+  if(port == 0 || port == 1) {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkMultiBlockDataSet");
-  else
+    if(port == 1)
+      info->Set(vtkAlgorithm::INPUT_IS_OPTIONAL(), 1);
+  } else
     return 0;
 
   return 1;
@@ -94,20 +96,26 @@ int ttkMergeTreeDistanceMatrix::FillOutputPortInformation(
 template <class dataType>
 int ttkMergeTreeDistanceMatrix::run(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> inputTrees) {
+  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<vtkMultiBlockDataSet *> &inputTrees2) {
+
+  // Construct trees
   const int numInputs = inputTrees.size();
-  std::vector<MergeTree<dataType>> intermediateTrees(numInputs);
+  std::vector<MergeTree<dataType>> intermediateTrees, intermediateTrees2;
   constructTrees(inputTrees, intermediateTrees);
+  constructTrees(inputTrees2, intermediateTrees2);
 
   // Verify parameters
-  if(Backend == 0) {
-    branchDecomposition_ = true;
-    normalizedWasserstein_ = true;
-    keepSubtree_ = false;
-  } else if(Backend == 1) {
-    branchDecomposition_ = false;
-    normalizedWasserstein_ = false;
-    keepSubtree_ = true;
+  if(not UseFieldDataParameters) {
+    if(Backend == 0) {
+      branchDecomposition_ = true;
+      normalizedWasserstein_ = true;
+      keepSubtree_ = false;
+    } else if(Backend == 1) {
+      branchDecomposition_ = false;
+      normalizedWasserstein_ = false;
+      keepSubtree_ = true;
+    }
   }
   if(not branchDecomposition_) {
     if(normalizedWasserstein_)
@@ -125,7 +133,7 @@ int ttkMergeTreeDistanceMatrix::run(
   // --- Call base
   std::vector<std::vector<double>> treesDistMat(
     numInputs, std::vector<double>(numInputs));
-  execute<dataType>(intermediateTrees, treesDistMat);
+  execute<dataType>(intermediateTrees, intermediateTrees2, treesDistMat);
 
   // --- Create output
   auto treesDistTable = vtkTable::GetData(outputVector);
@@ -179,22 +187,44 @@ int ttkMergeTreeDistanceMatrix::RequestData(
   vtkInformation *ttkNotUsed(request),
   vtkInformationVector **inputVector,
   vtkInformationVector *outputVector) {
-
   // --- Get input object from input vector
   auto blocks = vtkMultiBlockDataSet::GetData(inputVector[0], 0);
+  auto blocks2 = vtkMultiBlockDataSet::GetData(inputVector[1], 0);
 
-  // --- Construct trees
-  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  // --- Load blocks
+  std::vector<vtkMultiBlockDataSet *> inputTrees, inputTrees2;
   loadBlocks(inputTrees, blocks);
+  loadBlocks(inputTrees2, blocks2);
 
-  int dataType = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
+  auto arrayToGet
+    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
+        ->GetPointData()
+        ->GetArray("Scalar");
+  if(arrayToGet == nullptr)
+    arrayToGet = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
                    ->GetPointData()
-                   ->GetArray("Scalar")
-                   ->GetDataType();
+                   ->GetArray("Birth");
+  int dataTypeInt = arrayToGet->GetDataType();
+
+  // --- Load field data parameters
+  if(UseFieldDataParameters) {
+    printMsg("Load parameters from field data.");
+    std::vector<std::string> paramNames;
+    getParamNames(paramNames);
+    for(auto paramName : paramNames) {
+      auto array = blocks->GetFieldData()->GetArray(paramName.c_str());
+      if(array) {
+        double value = array->GetTuple1(0);
+        setParamValueFromName(paramName, value);
+        printMsg(" - " + paramName + " = " + std::to_string(value));
+      } else
+        printMsg(" - " + paramName + " was not found in the field data.");
+    }
+  }
 
   int res = 0;
-  switch(dataType) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees));
+  switch(dataTypeInt) {
+    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees, inputTrees2));
   }
 
   return res;

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -50,6 +50,8 @@ private:
   // Execution Options
   int Backend = 0;
 
+  bool UseFieldDataParameters = false;
+
 public:
   /**
    * Automatically generate getters and setters of filter
@@ -94,14 +96,6 @@ public:
   }
   double SetPersistenceThreshold() {
     return persistenceThreshold_;
-  }
-
-  void SetUseMinMaxPair(bool useMinMaxPair) {
-    useMinMaxPair_ = useMinMaxPair;
-    Modified();
-  }
-  bool SetUseMinMaxPair() {
-    return useMinMaxPair_;
   }
 
   void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
@@ -156,6 +150,9 @@ public:
     return distanceSquared_;
   }
 
+  vtkSetMacro(UseFieldDataParameters, bool);
+  vtkGetMacro(UseFieldDataParameters, bool);
+
   /**
    * This static method and the macro below are VTK conventions on how to
    * instantiate VTK objects. You don't have to modify this.
@@ -193,5 +190,6 @@ protected:
 
   template <class dataType>
   int run(vtkInformationVector *outputVector,
-          std::vector<vtkMultiBlockDataSet *> inputTrees);
+          std::vector<vtkMultiBlockDataSet *> &inputTrees,
+          std::vector<vtkMultiBlockDataSet *> &inputTrees2);
 };

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -570,7 +570,7 @@ public:
 
     // TreeNodeIdRev
     for(int i = 0; i < numInputs; ++i) {
-      if(treesNodes[i]) {
+      if(i < (int)treesNodes.size() and treesNodes[i]) {
         auto treeNodeIdArray
           = treesNodes[i]->GetPointData()->GetArray("TreeNodeId");
         if(treeNodeIdArray) {

--- a/paraview/xmls/MergeTreeClustering.xml
+++ b/paraview/xmls/MergeTreeClustering.xml
@@ -174,6 +174,51 @@ Online examples:
                     Number of barycenters/clusters to compute (performs a KMeans with merge trees as centroids).
                   </Documentation>
                 </IntVectorProperty>
+                
+                <DoubleVectorProperty
+                name="BarycenterSizeLimitPercent"
+                command="SetBarycenterSizeLimitPercent"
+                label="Barycenter Size Limit Percent"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Hints>
+                  <PropertyWidgetDecorator type="CompositeDecorator">
+                    <Expression type="and">
+                      <Expression type="and">
+                        <Expression type="or">
+                          <Expression type="and">
+                            <PropertyWidgetDecorator type="GenericDecorator"
+                                                    mode="visibility"
+                                                    property="BranchDecomposition"
+                                                    value="1" />
+                            <PropertyWidgetDecorator type="GenericDecorator"
+                                                    mode="visibility"
+                                                    property="Backend"
+                                                    value="2" />
+                          </Expression>
+                          <PropertyWidgetDecorator type="GenericDecorator"
+                                                  mode="visibility"
+                                                  property="Backend"
+                                                  value="0" />
+                        </Expression>
+                        <PropertyWidgetDecorator type="GenericDecorator"
+                                                mode="visibility"
+                                                property="KeepSubtree"
+                                                value="0" />
+                      </Expression>
+                      <PropertyWidgetDecorator type="GenericDecorator"
+                                              mode="visibility"
+                                              property="ComputeBarycenter"
+                                              value="1" />
+                    </Expression>
+                  </PropertyWidgetDecorator>
+                  </Hints>
+                  <Documentation>
+                    
+                  </Documentation>
+                  <DoubleRangeDomain name="range" min="0" max="100" />
+                </DoubleVectorProperty>
 
                 <IntVectorProperty
                 name="Deterministic"
@@ -412,6 +457,7 @@ Online examples:
             <PropertyGroup panel_widget="Line" label="Input options">
               <Property name="ComputeBarycenter"/>
               <Property name="NumberOfBarycenters"/>
+              <Property name="BarycenterSizeLimitPercent"/>
               <Property name="Deterministic"/>
               <Property name="Alpha"/>
               <Property name="JoinSplitMixtureCoefficient"/>

--- a/paraview/xmls/MergeTreeDistanceMatrix.xml
+++ b/paraview/xmls/MergeTreeDistanceMatrix.xml
@@ -31,9 +31,42 @@ Online examples:
                     Data-set to process.
                   </Documentation>
                 </InputProperty>
+                
+                <InputProperty
+                    name="Optional Input"
+                    port_index="1"
+                    command="SetInputConnection">
+                  <ProxyGroupDomain name="groups">
+                    <Group name="sources"/>
+                    <Group name="filters"/>
+                  </ProxyGroupDomain>
+                  <DataTypeDomain name="input_type">
+                    <DataType value="vtkMultiBlockDataSet"/>
+                  </DataTypeDomain>
+                  <InputArrayDomain name="input_scalars" number_of_components="1">
+                    <Property name="Input" function="FieldDataSelection" />
+                  </InputArrayDomain>
+                  <Documentation>
+                    
+                  </Documentation>
+                </InputProperty>
 
             <!-- INPUT PARAMETER WIDGETS -->
+                <IntVectorProperty
+                name="UseFieldDataParameters"
+                command="SetUseFieldDataParameters"
+                label="Use Field Data Parameters"
+                number_of_elements="1"
+                default_values="0"
+                panel_visibility="advanced">
+                  <Documentation>
+                    
+                  </Documentation>
+                  <BooleanDomain name="bool"/>
+                </IntVectorProperty>
+                
                 ${MERGE_TREE_INPUT_WIDGETS}
+                
                 <IntVectorProperty
                 name="DistanceSquared"
                 command="SetDistanceSquared"
@@ -48,6 +81,7 @@ Online examples:
                 </IntVectorProperty>
                 
             <PropertyGroup panel_widget="Line" label="Input options">
+              <Property name="UseFieldDataParameters"/>
               <Property name="DistanceSquared"/>
             </PropertyGroup>
             ${MERGE_TREE_PREPROCESS_WIDGETS}


### PR DESCRIPTION
This PR adds some features to the merge tree filters (especially MergeTreeClustering) and correct some bugs.

Here after an almost exhaustive list of the new features:
- **MergeTreeClustering** :
  - Limit size of the barycenter with a percentage of the sum of the nodes in input
  - Better clustering first tree initilization (farest input for the first tree then kmeans++ for the other trees)
  - New mix distances when double input
  - Move functions from MergeTreeBase to MergeTreeDistance
  - Remove some old code of MergeTreeDistance
  - Fix some very particular cases when passing from BDT to MT (due to multi-persistence pairs, when a saddle is involved in more than one pair)
  - Parallelize the planar layout of all trees

- **MergeTreeDistanceMatrix** :
  - Double input: allows to take in input join and split trees (like MergeTreeClustering can do)
  - Use Field Data parameters: this check-box can be used to automatically load the parameters (persistence threshold, epsilons etc.) from the field data of the multi-block in input if they are present. Useful in order to avoid to manually copy the parameters in the GUI of a MergeTreeClustering filter for instance, and to keep the same parameters along the pipeline by specifying them at a single point.

