### PR TITLE
Bugfix for negative scalar values for MPI

### DIFF
--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -324,7 +324,7 @@ namespace ttk {
           while(finalValues.size() < totalSize) {
             // take the current maximum scalar over all ranks
             int rankIdOfMaxScalar = -1;
-            DT maxScalar = std::numeric_limits<DT>::min();
+            DT maxScalar = std::numeric_limits<DT>::lowest();
             IT maxGId = -1;
             for(int i = 0; i < numProcs; i++) {
               if(unsortedReceivedValues[i].size() > 0) {


### PR DESCRIPTION
`std::numeric_limits<T>::min()` leads to unexcpected behaviour when dealing with floating-point types, return the minimum positive normalized value. However, we want the value which has no values less than it (e.g. -FLT_MAX for floats), therefore we need `std::numeric_limits<T>::lowest()`.