### PR TITLE
Fix some memory-related issues

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -12,11 +12,11 @@
 #pragma once
 
 // base code includes
+#include <Cache.h>
 #include <Geometry.h>
 #include <Wrapper.h>
 
 #include <array>
-#include <map>
 #include <ostream>
 
 #ifdef TTK_ENABLE_KAMIKAZE
@@ -3290,10 +3290,10 @@ namespace ttk {
     /*
      * @brief Type for caching Discrete Gradient internal data structure.
      *
-     * Uses a std::map with \ref gradientKeytype as key and \ref
-     * gradientType as value types.
+     * Uses the ttk::LRUCache with \ref gradientKeytype as key and
+     * \ref gradientType as value types.
      */
-    using gradientCacheType = std::map<gradientKeyType, gradientType>;
+    using gradientCacheType = LRUCache<gradientKeyType, gradientType>;
     /*
      * @brief Access to the gradientCache_ mutable member variable
      *

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -5,6 +5,7 @@ ttk_add_base_library(common
         Os.cpp
     HEADERS
         BaseClass.h
+        Cache.h
         CommandLineParser.h
         Debug.h
         DataTypes.h

--- a/core/base/common/Cache.h
+++ b/core/base/common/Cache.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <list>
+#include <map>
+
+namespace ttk {
+  /**
+   * @brief LRU cache implementation
+   *
+   * Adapted from boost/compute/details/lru_cache.hpp
+   */
+  template <class KeyType, class ValueType>
+  class LRUCache {
+  public:
+    // default cache with at most 8 entries
+    LRUCache() : capacity_{8} {
+    }
+
+    LRUCache(const std::size_t capacity) : capacity_(capacity) {
+    }
+
+    inline bool empty() const {
+      return this->map_.empty();
+    }
+
+    inline std::size_t capacity() const {
+      return this->capacity_;
+    }
+
+    inline std::size_t size() const {
+      return this->map_.size();
+    }
+
+    inline bool contains(const KeyType &key) const {
+      return this->map_.find(key) != this->map_.end();
+    }
+
+    inline void clear() {
+      this->map_.clear();
+      this->queue_.clear();
+    }
+
+    /**
+     * @brief Insert new (key, value) entry
+     *
+     * Do nothing if key already in use
+     */
+    inline void insert(const KeyType &key, const ValueType &value) {
+      if(this->contains(key)) {
+        return; // key already in use
+      }
+
+      if(this->size() >= this->capacity_) {
+        // cache is full, evict the least recently used entry
+        this->map_.erase(this->queue_.back());
+        this->queue_.pop_back();
+      }
+
+      // insert new entry
+      this->queue_.push_front(key);
+      this->map_.emplace(key, std::make_pair(value, this->queue_.begin()));
+    }
+
+    /**
+     * @brief Get value pointer from key
+     *
+     * @return nullptr if cache miss
+     */
+    inline ValueType *get(const KeyType &key) {
+      const auto i = this->map_.find(key);
+      if(i == this->map_.end()) {
+        // cache miss, nullptr
+        return {};
+      }
+
+      // iterator to entry in LRU list
+      const auto oldIt = i->second.second;
+      if(oldIt != this->queue_.begin()) {
+        // update entry, now first in the LRU list
+        this->queue_.erase(oldIt);
+        this->queue_.push_front(key);
+
+        // update queue position in map
+        this->map_[key].second = this->queue_.begin();
+      }
+
+      // return value address
+      return &i->second.first;
+    }
+
+  private:
+    using ListType = std::list<KeyType>;
+    using MapType
+      = std::map<KeyType, std::pair<ValueType, typename ListType::iterator>>;
+
+    MapType map_;
+    ListType queue_;
+    std::size_t capacity_;
+  };
+
+} // namespace ttk

--- a/core/base/continuousScatterPlot/ContinuousScatterPlot.h
+++ b/core/base/continuousScatterPlot/ContinuousScatterPlot.h
@@ -129,8 +129,10 @@ int ttk::ContinuousScatterPlot::execute(
     delta[0] / resolutions_[0], delta[1] / resolutions_[1]};
   const double epsilon{0.000001};
 
+  std::vector<std::array<SimplexId, 3>> triangles{};
+
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp parallel for num_threads(threadNumber_) firstprivate(triangles)
 #endif
   for(SimplexId cell = 0; cell < numberOfCells; ++cell) {
     bool isDummy{};
@@ -254,9 +256,9 @@ int ttk::ContinuousScatterPlot::execute(
 
     // projection:
     double density{};
-    std::vector<std::vector<SimplexId>> triangles;
     double imaginaryPosition[3]{};
-    std::vector<SimplexId> triangle(3);
+    triangles.clear();
+    std::array<SimplexId, 3> triangle{};
     // class 0
     if(isInTriangle) {
       // mass density

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -45,18 +45,14 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
     if(this->inputScalarField_.first == nullptr) {
       return {};
     }
-    const auto pos = cacheHandler.find(this->inputScalarField_);
-    if(pos != cacheHandler.end()) {
-      return &pos->second;
-    }
-    return {};
+    return cacheHandler.get(this->inputScalarField_);
   };
 
   this->gradient_ = findGradient();
   if(this->gradient_ == nullptr) {
     // add new cache entry
-    cacheHandler[this->inputScalarField_] = {};
-    this->gradient_ = &cacheHandler[this->inputScalarField_];
+    cacheHandler.insert(this->inputScalarField_, {});
+    this->gradient_ = cacheHandler.get(this->inputScalarField_);
     // allocate gradient memory
     this->initMemory(triangulation);
 

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -22,7 +22,7 @@ int FiberSurface::getNumberOfCommonVertices(
   SimplexId commonVertexNumber = 0;
 
   for(int i = 0; i < 3; i++) {
-    vector<double> p0(3);
+    std::array<double, 3> p0{};
 
     for(int j = 0; j < 3; j++) {
       p0[j] = tetIntersections[tetId][triangleId0].p_[i][j];
@@ -30,7 +30,7 @@ int FiberSurface::getNumberOfCommonVertices(
 
     // check if this guy exists in the other triangle
     for(int j = 0; j < 3; j++) {
-      vector<double> p1(3);
+      std::array<double, 3> p1{};
 
       bool isTheSame = true;
       for(int k = 0; k < 3; k++) {
@@ -56,8 +56,8 @@ int FiberSurface::computeTriangleFiber(
   const SimplexId &triangleId,
   const pair<double, double> &intersection,
   const vector<vector<IntersectionTriangle>> &tetIntersections,
-  vector<double> &pA,
-  vector<double> &pB,
+  std::array<double, 3> &pA,
+  std::array<double, 3> &pB,
   SimplexId &pivotVertexId,
   bool &edgeFiber) const {
 
@@ -144,7 +144,7 @@ int FiberSurface::computeTriangleFiber(
 
   // compute the interpolations
   std::array<double, 2> baryCentrics0{}, baryCentrics1{};
-  vector<double> p(2), p0(2), p1(2), p2(2);
+  std::array<double, 2> p{}, p0{}, p1{}, p2{};
 
   p[0] = intersection.first;
   p[1] = intersection.second;
@@ -167,7 +167,6 @@ int FiberSurface::computeTriangleFiber(
   Geometry::computeBarycentricCoordinates(
     p0.data(), p2.data(), p.data(), baryCentrics1, 2);
 
-  pA.resize(3);
   for(int i = 0; i < 3; i++) {
     pA[i] = baryCentrics0[0]
               * tetIntersections[tetId][triangleId].p_[pivotVertexId][i]
@@ -176,7 +175,6 @@ int FiberSurface::computeTriangleFiber(
                     .p_[(pivotVertexId + 1) % 3][i];
   }
 
-  pB.resize(3);
   for(int i = 0; i < 3; i++) {
     pB[i] = baryCentrics1[0]
               * tetIntersections[tetId][triangleId].p_[pivotVertexId][i]
@@ -212,7 +210,7 @@ int FiberSurface::computeTriangleIntersection(
   }
 
   SimplexId pivotVertexIda = -1, pivotVertexIdb = -1;
-  vector<double> p0a, p1a, p0b, p1b;
+  std::array<double, 3> p0a{}, p1a{}, p0b{}, p1b{};
 
   // extract the fiber in both triangles and see if they match up
   bool edgeFiber0 = false;
@@ -256,7 +254,7 @@ int FiberSurface::computeTriangleIntersection(
   }
 
   bool foundA = false, foundB = false;
-  vector<double> pA, pB;
+  std::array<double, 3> pA{}, pB{};
 
   // test if p0a lies in [p0b, p1b]
   if(Geometry::isPointOnSegment(p0a.data(), p0b.data(), p1b.data())) {
@@ -334,8 +332,8 @@ int FiberSurface::computeTriangleIntersection(
   const SimplexId &triangleId,
   const SimplexId &polygonEdgeId,
   const std::pair<double, double> &intersection,
-  const std::vector<double> &pA,
-  const std::vector<double> &pB,
+  const std::array<double, 3> &pA,
+  const std::array<double, 3> &pB,
   const SimplexId &pivotVertexId,
   SimplexId &newVertexNumber,
   SimplexId &newTriangleNumber,
@@ -386,7 +384,7 @@ int FiberSurface::computeTriangleIntersection(
   // 2. between the two, find the closest point from the edge
   // [pivotVertexId, (pivotVertexId+2)%3]
   // that's the vertex which minimizes its coordinate [(pivotVertexId+1)%3]
-  vector<double> A = pA, B = pB;
+  std::array<double, 3> A = pA, B = pB;
   std::array<double, 3> baryA = barypA, baryB = barypB;
   if(fabs(barypB[(pivotVertexId + 1) % 3])
      < fabs(barypA[(pivotVertexId + 1) % 3])) {
@@ -662,7 +660,7 @@ int FiberSurface::flipEdges(
     // (make sure we start with bad angles)
     vector<pair<double, pair<SimplexId, SimplexId>>> localTriangles;
     for(SimplexId i = 0; i < (SimplexId)triangles.size(); i++) {
-      vector<SimplexId> vertexIds(3);
+      std::array<SimplexId, 3> vertexIds{};
 
       vertexIds[0]
         = (*polygonEdgeTriangleLists_[triangles[i].first])[triangles[i].second]
@@ -703,7 +701,7 @@ int FiberSurface::flipEdges(
 
     for(SimplexId i = 0; i < (SimplexId)triangles.size(); i++) {
 
-      vector<SimplexId> vertexIds(3);
+      std::array<SimplexId, 3> vertexIds{};
 
       vertexIds[0]
         = (*polygonEdgeTriangleLists_[triangles[i].first])[triangles[i].second]
@@ -880,7 +878,7 @@ int FiberSurface::getTriangleRangeExtremities(
   pair<double, double> &extremity0,
   pair<double, double> &extremity1) const {
 
-  vector<double> p0(2), p1(2), p(2);
+  std::array<double, 2> p0{}, p1{}, p{};
   std::array<double, 2> baryCentrics{};
   bool isInBetween = true;
 
@@ -960,10 +958,10 @@ bool FiberSurface::hasDuplicatedVertices(const double *p0,
   return false;
 }
 
-int FiberSurface::interpolateBasePoints(const vector<double> &p0,
+int FiberSurface::interpolateBasePoints(const std::array<double, 3> &p0,
                                         const pair<double, double> &uv0,
                                         const double &t0,
-                                        const vector<double> &p1,
+                                        const std::array<double, 3> &p1,
                                         const pair<double, double> &uv1,
                                         const double &t1,
                                         const double &t,
@@ -1533,7 +1531,7 @@ int FiberSurface::mergeVertices(const double &distanceThreshold) const {
     // now copy triangles over with non zero-area triangles
     // NOTE: no need to re-allocate the memory, we know we are not going to use
     // more.
-    (*polygonEdgeTriangleLists_[i]).resize(0);
+    (*polygonEdgeTriangleLists_[i]).clear();
     for(SimplexId j = 0; j < (SimplexId)tmpTriangleLists[i].size(); j++) {
 
       if(keepTriangle[i][j]) {
@@ -1628,7 +1626,7 @@ int FiberSurface::snapVertexBarycentrics(
       // check for each triangle of the tet
       double minimum = -DBL_MAX;
       std::array<double, 3> minBarycentrics{};
-      vector<SimplexId> minimizer(3);
+      std::array<SimplexId, 3> minimizer{};
 
       for(int k = 0; k < 2; k++) {
         for(int l = k + 1; l < 3; l++) {
@@ -1638,7 +1636,7 @@ int FiberSurface::snapVertexBarycentrics(
             SimplexId vertexId1 = tetList_[5 * tetId + 1 + l];
             SimplexId vertexId2 = tetList_[5 * tetId + 1 + m];
 
-            vector<double> p0(3), p1(3), p2(3);
+            std::array<double, 3> p0{}, p1{}, p2{};
 
             for(int n = 0; n < 3; n++) {
               p0[n] = pointSet_[3 * vertexId0 + n];

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -243,10 +243,10 @@ namespace ttk {
       const double &t2,
       const double &u2,
       const double &v2,
-      std::vector<std::vector<double>> &basePoints,
-      std::vector<std::pair<double, double>> &basePointProections,
-      std::vector<double> &basePointParameterization,
-      std::vector<std::pair<SimplexId, SimplexId>> &baseEdges,
+      std::array<std::array<double, 3>, 3> &basePoints,
+      std::array<std::pair<double, double>, 3> &basePointProjections,
+      std::array<double, 3> &basePointParameterization,
+      std::array<std::pair<SimplexId, SimplexId>, 3> &baseEdges,
       const triangulationType *const triangulation) const;
 
     template <class dataTypeU, class dataTYpeV, typename triangulationType>
@@ -339,8 +339,8 @@ namespace ttk {
       const SimplexId &triangleId,
       const std::pair<double, double> &intersection,
       const std::vector<std::vector<IntersectionTriangle>> &tetIntersections,
-      std::vector<double> &pA,
-      std::vector<double> &pB,
+      std::array<double, 3> &pA,
+      std::array<double, 3> &pB,
       SimplexId &pivotVertexId,
       bool &edgeFiber) const;
 
@@ -361,8 +361,8 @@ namespace ttk {
       const SimplexId &triangleId,
       const SimplexId &polygonEdgeId,
       const std::pair<double, double> &intersection,
-      const std::vector<double> &pA,
-      const std::vector<double> &pB,
+      const std::array<double, 3> &pA,
+      const std::array<double, 3> &pB,
       const SimplexId &pivotVertexId,
       SimplexId &newVertexNumber,
       SimplexId &newTriangleNumber,
@@ -403,10 +403,10 @@ namespace ttk {
                                const double *p1,
                                const double *p2) const;
 
-    int interpolateBasePoints(const std::vector<double> &p0,
+    int interpolateBasePoints(const std::array<double, 3> &p0,
                               const std::pair<double, double> &uv0,
                               const double &t0,
-                              const std::vector<double> &p1,
+                              const std::array<double, 3> &p1,
                               const std::pair<double, double> &uv1,
                               const double &t1,
                               const double &t,
@@ -432,7 +432,7 @@ namespace ttk {
       const SimplexId &vertexId1,
       const SimplexId &vertexId2) const {
 
-      std::vector<std::vector<double>> points(3);
+      std::array<std::array<double, 3>, 3> points{};
       for(int i = 0; i < 3; i++) {
         SimplexId vertexId = vertexId0;
         if(i == 1)
@@ -440,7 +440,6 @@ namespace ttk {
         if(i == 2)
           vertexId = vertexId2;
 
-        points[i].resize(3);
         if(vertexId >= 0) {
           for(int j = 0; j < 3; j++) {
             points[i][j] = tetIntersections[tetId][triangleId].p_[vertexId][j];
@@ -544,16 +543,11 @@ inline int ttk::FiberSurface::computeBaseTriangle(
   const double &t2,
   const double &u2,
   const double &v2,
-  std::vector<std::vector<double>> &basePoints,
-  std::vector<std::pair<double, double>> &basePointProjections,
-  std::vector<double> &basePointParameterization,
-  std::vector<std::pair<SimplexId, SimplexId>> &baseEdges,
+  std::array<std::array<double, 3>, 3> &basePoints,
+  std::array<std::pair<double, double>, 3> &basePointProjections,
+  std::array<double, 3> &basePointParameterization,
+  std::array<std::pair<SimplexId, SimplexId>, 3> &baseEdges,
   const triangulationType *const triangulation) const {
-
-  basePoints.resize(3);
-  basePointProjections.resize(3);
-  basePointParameterization.resize(3);
-  baseEdges.resize(3);
 
   for(int i = 0; i < 3; i++) {
 
@@ -614,7 +608,7 @@ inline int ttk::FiberSurface::computeBaseTriangle(
     }
 
     std::array<double, 2> baryCentrics{};
-    std::vector<double> p0(2), p1(2), p(2);
+    std::array<double, 2> p0{}, p1{}, p{};
     p0[0] = ((dataTypeU *)uField_)[vertexId0];
     p0[1] = ((dataTypeV *)vField_)[vertexId0];
     p1[0] = ((dataTypeU *)uField_)[vertexId1];
@@ -624,9 +618,7 @@ inline int ttk::FiberSurface::computeBaseTriangle(
     Geometry::computeBarycentricCoordinates(
       p0.data(), p1.data(), p.data(), baryCentrics, 2);
 
-    basePoints[i].resize(3);
-
-    float pA[3], pB[3];
+    std::array<float, 3> pA{}, pB{};
     if(triangulation) {
       triangulation->getVertexPoint(vertexId0, pA[0], pA[1], pA[2]);
       triangulation->getVertexPoint(vertexId1, pB[0], pB[1], pB[2]);
@@ -758,7 +750,7 @@ inline int ttk::FiberSurface::computeCase0(
     }
 
     std::array<double, 2> baryCentrics{};
-    std::vector<double> p0(2), p1(2), p(2);
+    std::array<double, 2> p0{}, p1{}, p{};
     p0[0] = ((dataTypeU *)uField_)[vertexId0];
     p0[1] = ((dataTypeV *)vField_)[vertexId0];
     p1[0] = ((dataTypeU *)uField_)[vertexId1];
@@ -880,10 +872,10 @@ inline int ttk::FiberSurface::computeCase1(
   }
 
   // compute the base triangle vertices like in case 1
-  std::vector<std::vector<double>> basePoints(3);
-  std::vector<std::pair<double, double>> basePointProjections(3);
-  std::vector<double> basePointParameterization(3);
-  std::vector<std::pair<SimplexId, SimplexId>> baseEdges(3);
+  std::array<std::array<double, 3>, 3> basePoints{};
+  std::array<std::pair<double, double>, 3> basePointProjections{};
+  std::array<double, 3> basePointParameterization{};
+  std::array<std::pair<SimplexId, SimplexId>, 3> baseEdges{};
 
   computeBaseTriangle<dataTypeU, dataTypeV>(
     tetId, localEdgeId0, t0, u0, v0, localEdgeId1, t1, u1, v1, localEdgeId2, t2,
@@ -1049,10 +1041,10 @@ inline int ttk::FiberSurface::computeCase2(
   }
 
   // compute the base triangle vertices like in case 1
-  std::vector<std::vector<double>> basePoints(3);
-  std::vector<std::pair<double, double>> basePointProjections(3);
-  std::vector<double> basePointParameterization(3);
-  std::vector<std::pair<SimplexId, SimplexId>> baseEdges(3);
+  std::array<std::array<double, 3>, 3> basePoints{};
+  std::array<std::pair<double, double>, 3> basePointProjections{};
+  std::array<double, 3> basePointParameterization{};
+  std::array<std::pair<SimplexId, SimplexId>, 3> baseEdges{};
 
   computeBaseTriangle<dataTypeU, dataTypeV>(
     tetId, localEdgeId0, t0, u0, v0, localEdgeId1, t1, u1, v1, localEdgeId2, t2,
@@ -1210,10 +1202,10 @@ inline int ttk::FiberSurface::computeCase3(
     = vertexId + 2;
 
   // compute the base triangle vertices like in case 1
-  std::vector<std::vector<double>> basePoints(3);
-  std::vector<std::pair<double, double>> basePointProjections(3);
-  std::vector<double> basePointParameterization(3);
-  std::vector<std::pair<SimplexId, SimplexId>> baseEdges(3);
+  std::array<std::array<double, 3>, 3> basePoints{};
+  std::array<std::pair<double, double>, 3> basePointProjections{};
+  std::array<double, 3> basePointParameterization{};
+  std::array<std::pair<SimplexId, SimplexId>, 3> baseEdges{};
 
   computeBaseTriangle<dataTypeU, dataTypeV>(
     tetId, localEdgeId0, t0, u0, v0, localEdgeId1, t1, u1, v1, localEdgeId2, t2,
@@ -1362,10 +1354,10 @@ inline int ttk::FiberSurface::computeCase4(
   }
 
   // compute the base triangle vertices like in case 1
-  std::vector<std::vector<double>> basePoints(3);
-  std::vector<std::pair<double, double>> basePointProjections(3);
-  std::vector<double> basePointParameterization(3);
-  std::vector<std::pair<SimplexId, SimplexId>> baseEdges(3);
+  std::array<std::array<double, 3>, 3> basePoints{};
+  std::array<std::pair<double, double>, 3> basePointProjections{};
+  std::array<double, 3> basePointParameterization{};
+  std::array<std::pair<SimplexId, SimplexId>, 3> baseEdges{};
 
   computeBaseTriangle<dataTypeU, dataTypeV>(
     tetId, localEdgeId0, t0, u0, v0, localEdgeId1, t1, u1, v1, localEdgeId2, t2,
@@ -1892,11 +1884,9 @@ inline int ttk::FiberSurface::processTetrahedron(
   if(!((upperNumber == 0) || (lowerNumber == 0))) {
 
     // the fiber surface is passing through this tetrahedron.
-    std::vector<bool> lonelyVertex(4, false);
-    std::vector<SimplexId> triangleEdgeNumbers(2, 0);
-    std::vector<std::vector<SimplexId>> triangleEdges(2);
-    triangleEdges[0].resize(3, -1);
-    triangleEdges[1].resize(3, -1);
+    std::array<SimplexId, 2> triangleEdgeNumbers{};
+    std::array<std::array<SimplexId, 3>, 2> triangleEdges{
+      {{-1, -1, -1}, {-1, -1, -1}}};
 
     // implicit edge encoding
     // 0: O-1
@@ -2024,8 +2014,8 @@ inline int ttk::FiberSurface::processTetrahedron(
     // figure 7 of the paper
     double d0, d1;
     std::pair<double, double> uv0, uv1;
-    std::vector<std::pair<double, double>> uv(3);
-    std::vector<double> t(3);
+    std::array<std::pair<double, double>, 3> uv{};
+    std::array<double, 3> t{};
 
     SimplexId createdVertices = 0;
 
@@ -2160,10 +2150,12 @@ inline int ttk::FiberSurface::processTetrahedron(
       }
 
       std::vector<bool> snappedVertices(createdVertices, false);
+      std::vector<SimplexId> colinearVertices;
+      colinearVertices.reserve(createdVertices);
 
       for(SimplexId i = 0; i < createdVertices; i++) {
+        colinearVertices.clear();
 
-        std::vector<SimplexId> colinearVertices;
         if(!snappedVertices[i]) {
           colinearVertices.push_back(i);
           for(SimplexId j = 0; j < createdVertices; j++) {
@@ -2377,7 +2369,7 @@ inline int ttk::FiberSurface::remeshIntersections() const {
 
       SimplexId tetId = (*polygonEdgeTriangleLists_[i])[j].tetId_;
 
-      tetIntersections[tetId].resize(tetIntersections[tetId].size() + 1);
+      tetIntersections[tetId].emplace_back();
 
       tetIntersections[tetId].back().caseId_
         = (*polygonEdgeTriangleLists_[i])[j].caseId_;

--- a/core/base/geometry/Geometry.cpp
+++ b/core/base/geometry/Geometry.cpp
@@ -127,6 +127,10 @@ int Geometry::computeBarycentricCoordinates(const T *p0,
                                             std::array<T, 2> &baryCentrics,
                                             const int &dimension) {
 
+  if(dimension > 3) {
+    return -1;
+  }
+
   int bestI = 0;
   T maxDenominator = 0;
 
@@ -150,7 +154,7 @@ int Geometry::computeBarycentricCoordinates(const T *p0,
   baryCentrics[1] = 1 - baryCentrics[0];
 
   // check if the point lies in the edge
-  vector<T> test(dimension);
+  std::array<T, 3> test{};
   for(int i = 0; i < dimension; i++) {
     test[i] = baryCentrics[0] * p0[i] + baryCentrics[1] * p1[i];
   }
@@ -365,40 +369,6 @@ T Geometry::dotProduct(const T *vA, const T *vB) {
 }
 
 template <typename T>
-int Geometry::getBoundingBox(const vector<vector<float>> &points,
-                             vector<std::pair<T, T>> &bBox) {
-
-  if(points.empty()) {
-    return -1;
-  }
-
-  int dimension = points[0].size();
-
-  bBox.resize(dimension);
-
-  for(SimplexId i = 0; i < static_cast<SimplexId>(points.size()); i++) {
-
-    if(i == 0) {
-      for(int j = 0; j < dimension; j++) {
-        bBox[j].first = points[i][j];
-        bBox[j].second = points[i][j];
-      }
-    } else {
-      for(int j = 0; j < dimension; j++) {
-        if(points[i][j] < bBox[j].first) {
-          bBox[j].first = points[i][j];
-        }
-        if(points[i][j] > bBox[j].second) {
-          bBox[j].second = points[i][j];
-        }
-      }
-    }
-  }
-
-  return 0;
-}
-
-template <typename T>
 bool Geometry::isPointInTriangle(const T *p0,
                                  const T *p1,
                                  const T *p2,
@@ -424,17 +394,7 @@ template <typename T>
 bool Geometry::isPointOnSegment(
   const T &x, const T &y, const T &xA, const T &yA, const T &xB, const T &yB) {
 
-  vector<T> pA(2), pB(2), p(2);
-
-  pA[0] = xA;
-  pA[1] = yA;
-
-  pB[0] = xB;
-  pB[1] = yB;
-
-  p[0] = x;
-  p[1] = y;
-
+  std::array<T, 2> pA{xA, yA}, pB{xB, yB}, p{x, y};
   return Geometry::isPointOnSegment(p.data(), pA.data(), pB.data(), 2);
 }
 
@@ -561,9 +521,6 @@ int Geometry::subtractVectors(const T *a, const T *b, T *out) {
   template TYPE Geometry::dotProduct<TYPE>(                                   \
     TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
   template TYPE Geometry::dotProduct<TYPE>(TYPE const *, TYPE const *);       \
-  template int Geometry::getBoundingBox<TYPE>(                                \
-    std::vector<std::vector<float>> const &,                                  \
-    std::vector<std::pair<TYPE, TYPE>> &);                                    \
   template bool Geometry::isPointInTriangle<TYPE>(                            \
     TYPE const *, TYPE const *, TYPE const *, TYPE const *);                  \
   template bool Geometry::isPointOnSegment<TYPE>(TYPE const &, TYPE const &,  \

--- a/core/base/geometry/Geometry.h
+++ b/core/base/geometry/Geometry.h
@@ -186,16 +186,41 @@ namespace ttk {
     T dotProduct(const T *vA, const T *vB);
 
     /// Compute the bounding box of a point set.
-    /// \param points Vector of points. Each entry is a std::vector whose size
-    /// is
-    /// equal to the dimension of the space embedding the points.
+    /// \param points Vector of points. Each entry is a
+    /// std::array<float, dim> whose size is equal to the dimension of
+    /// the space embedding the points.
     /// \param bBox Output bounding box. The number of entries in this
-    /// std::vector
-    /// is equal to the dimension of the space embedding the points.
+    /// std::array is equal to the dimension of the space embedding
+    /// the points.
     /// \return Returns 0 upon success, negative values otherwise.
-    template <typename T>
-    int getBoundingBox(const std::vector<std::vector<float>> &points,
-                       std::vector<std::pair<T, T>> &bBox);
+    template <typename T, typename Container, size_t dim>
+    int getBoundingBox(const Container &points,
+                       std::array<std::pair<T, T>, dim> &bBox) {
+      if(points.empty()) {
+        return -1;
+      }
+
+      for(size_t i = 0; i < points.size(); i++) {
+
+        if(i == 0) {
+          for(size_t j = 0; j < dim; j++) {
+            bBox[j].first = points[i][j];
+            bBox[j].second = points[i][j];
+          }
+        } else {
+          for(size_t j = 0; j < dim; j++) {
+            if(points[i][j] < bBox[j].first) {
+              bBox[j].first = points[i][j];
+            }
+            if(points[i][j] > bBox[j].second) {
+              bBox[j].second = points[i][j];
+            }
+          }
+        }
+      }
+
+      return 0;
+    }
 
     /// Check if the point \p p is inside the triangle (\p p0, \p p1, \p p2).
     /// \param p0 xyz coordinates of the first vertex of the triangle

--- a/core/base/rangeDrivenOctree/RangeDrivenOctree.cpp
+++ b/core/base/rangeDrivenOctree/RangeDrivenOctree.cpp
@@ -53,12 +53,14 @@ int RangeDrivenOctree::rangeSegmentQuery(
 
   SimplexId ret = rangeSegmentQuery(p0, p1, rootId_, cellList);
 
-  this->printMsg("Query done", 1.0, t.getElapsedTime(), this->threadNumber_,
-                 debug::LineMode::NEW, debug::Priority::DETAIL);
-  this->printMsg(
-    std::vector<std::vector<std::string>>{
-      {"#Non empty leaves", std::to_string(cellList.size())}},
-    debug::Priority::DETAIL);
+  if(debugLevel_ >= static_cast<int>(debug::Priority::DETAIL)) {
+    this->printMsg("Query done", 1.0, t.getElapsedTime(), this->threadNumber_,
+                   debug::LineMode::NEW, debug::Priority::DETAIL);
+    this->printMsg(
+      std::vector<std::vector<std::string>>{
+        {"#Non empty leaves", std::to_string(cellList.size())}},
+      debug::Priority::DETAIL);
+  }
 
   return ret;
 }
@@ -88,10 +90,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());
@@ -116,10 +120,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());
@@ -144,10 +150,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());
@@ -172,10 +180,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());
@@ -199,10 +209,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());
@@ -224,10 +236,12 @@ int RangeDrivenOctree::rangeSegmentQuery(
     } else {
       // terminal leaf
       // return our cells
-      this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
-                       + std::to_string(nodeList_[nodeId].cellList_.size())
-                       + " cells(s).",
-                     debug::Priority::VERBOSE);
+      if(debugLevel_ >= static_cast<int>(debug::Priority::VERBOSE)) {
+        this->printMsg("Node #" + std::to_string(nodeId) + " returns its "
+                         + std::to_string(nodeList_[nodeId].cellList_.size())
+                         + " cells(s).",
+                       debug::Priority::VERBOSE);
+      }
 
       cellList.insert(cellList.end(), nodeList_[nodeId].cellList_.begin(),
                       nodeList_[nodeId].cellList_.end());

--- a/core/base/rangeDrivenOctree/RangeDrivenOctree.h
+++ b/core/base/rangeDrivenOctree/RangeDrivenOctree.h
@@ -87,12 +87,12 @@ namespace ttk {
         rangeBox_{};
       std::vector<SimplexId> cellList_{};
       std::vector<SimplexId> childList_{};
-      std::vector<std::pair<float, float>> domainBox_{};
+      std::array<std::pair<float, float>, 3> domainBox_{};
     };
 
     template <class dataTypeU, class dataTypeV>
     int buildNode(const std::vector<SimplexId> &cellList,
-                  const std::vector<std::pair<float, float>> &domainBox,
+                  const std::array<std::pair<float, float>, 3> &domainBox,
                   const std::pair<std::pair<double, double>,
                                   std::pair<double, double>> &rangeBox,
                   SimplexId &nodeId);
@@ -117,7 +117,7 @@ namespace ttk {
       rootId_{};
     mutable SimplexId queryResultNumber_{};
     std::vector<OctreeNode> nodeList_{};
-    std::vector<std::vector<std::pair<float, float>>> cellDomainBox_{};
+    std::vector<std::array<std::pair<float, float>, 3>> cellDomainBox_{};
     std::vector<std::pair<std::pair<double, double>, std::pair<double, double>>>
       cellRangeBox_{};
   };
@@ -143,7 +143,7 @@ int ttk::RangeDrivenOctree::build(
     vertexNumber_ = triangulation->getNumberOfVertices();
   }
 
-  cellDomainBox_.resize(cellNumber_, std::vector<std::pair<float, float>>(3));
+  cellDomainBox_.resize(cellNumber_);
 
   cellRangeBox_.resize(cellNumber_);
 
@@ -230,7 +230,7 @@ int ttk::RangeDrivenOctree::build(
     domain[i] = i;
 
   // get global bBoxes
-  std::vector<std::pair<float, float>> domainBox(3);
+  std::array<std::pair<float, float>, 3> domainBox{};
   std::pair<std::pair<double, double>, std::pair<double, double>> rangeBox;
 
   for(SimplexId i = 0; i < vertexNumber_; i++) {
@@ -302,14 +302,14 @@ int ttk::RangeDrivenOctree::build(
 template <class dataTypeU, class dataTypeV>
 int ttk::RangeDrivenOctree::buildNode(
   const std::vector<SimplexId> &cellList,
-  const std::vector<std::pair<float, float>> &domainBox,
+  const std::array<std::pair<float, float>, 3> &domainBox,
   const std::pair<std::pair<double, double>, std::pair<double, double>>
     &rangeBox,
   SimplexId &nodeId) {
 
   nodeId = nodeList_.size();
 
-  nodeList_.resize(nodeList_.size() + 1);
+  nodeList_.emplace_back();
 
   nodeList_.back().rangeBox_ = rangeBox;
   nodeList_.back().domainBox_ = domainBox;
@@ -327,14 +327,12 @@ int ttk::RangeDrivenOctree::buildNode(
 
     nodeList_.back().childList_.resize(8);
 
-    std::vector<std::vector<std::pair<float, float>>> childDomainBox(8);
-    for(SimplexId i = 0; i < (SimplexId)childDomainBox.size(); i++) {
-      childDomainBox[i].resize(3);
-    }
-    std::vector<std::pair<std::pair<dataTypeU, dataTypeU>,
-                          std::pair<dataTypeV, dataTypeV>>>
-      childRangeBox(8);
-    std::vector<std::vector<SimplexId>> childCellList(8);
+    std::array<std::array<std::pair<float, float>, 3>, 8> childDomainBox{};
+    std::array<std::pair<std::pair<dataTypeU, dataTypeU>,
+                         std::pair<dataTypeV, dataTypeV>>,
+               8>
+      childRangeBox{};
+    std::array<std::vector<SimplexId>, 8> childCellList{};
 
     float midX
       = domainBox[0].first + (domainBox[0].second - domainBox[0].first) / 2.0;

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -325,12 +325,12 @@ namespace ttk {
     template <typename triangulationType>
     int compute3sheet(
       const SimplexId &vertexId,
-      const std::vector<std::vector<std::vector<SimplexId>>> &tetTriangles,
+      const std::vector<std::vector<std::array<SimplexId, 3>>> &tetTriangles,
       const triangulationType &triangulation);
 
     template <typename triangulationType>
     int compute3sheets(
-      std::vector<std::vector<std::vector<SimplexId>>> &tetTriangles,
+      std::vector<std::vector<std::array<SimplexId, 3>>> &tetTriangles,
       const triangulationType &triangulation);
 
     template <class dataTypeU, class dataTypeV, typename triangulationType>
@@ -467,7 +467,7 @@ inline int ttk::ReebSpace::execute(const dataTypeU *const uField,
   compute2sheets(jacobiSetClassification, uField, vField, triangulation);
   //   compute2sheetChambers<dataTypeU, dataTypeV>();
 
-  std::vector<std::vector<std::vector<SimplexId>>> tetTriangles;
+  std::vector<std::vector<std::array<SimplexId, 3>>> tetTriangles;
   compute3sheets(tetTriangles, triangulation);
 
   this->printMsg(
@@ -1207,7 +1207,7 @@ int ttk::ReebSpace::compute1sheets(
 template <typename triangulationType>
 int ttk::ReebSpace::compute3sheet(
   const SimplexId &vertexId,
-  const std::vector<std::vector<std::vector<SimplexId>>> &tetTriangles,
+  const std::vector<std::vector<std::array<SimplexId, 3>>> &tetTriangles,
   const triangulationType &triangulation) {
 
   SimplexId sheetId = originalData_.sheet3List_.size();
@@ -1317,7 +1317,7 @@ int ttk::ReebSpace::compute3sheet(
 
 template <typename triangulationType>
 int ttk::ReebSpace::compute3sheets(
-  std::vector<std::vector<std::vector<SimplexId>>> &tetTriangles,
+  std::vector<std::vector<std::array<SimplexId, 3>>> &tetTriangles,
   const triangulationType &triangulation) {
 
   Timer t;
@@ -1333,12 +1333,10 @@ int ttk::ReebSpace::compute3sheets(
         SimplexId tetId
           = originalData_.sheet2List_[i].triangleList_[j][k].tetId_;
 
-        std::vector<SimplexId> triangle(3);
-        triangle[0] = i;
-        triangle[1] = j;
-        triangle[2] = k;
-
-        tetTriangles[tetId].push_back(triangle);
+        tetTriangles[tetId].emplace_back();
+        tetTriangles[tetId].back()[0] = i;
+        tetTriangles[tetId].back()[1] = j;
+        tetTriangles[tetId].back()[2] = k;
       }
     }
   }
@@ -1576,7 +1574,7 @@ int ttk::ReebSpace::compute3sheets(
 template <typename triangulationType>
 int ttk::ReebSpace::connectSheets(const triangulationType &triangulation) {
 
-  Timer t;
+  Timer tm;
 
   for(size_t i = 0; i < originalData_.sheet2List_.size(); i++) {
     for(size_t j = 0; j < originalData_.sheet2List_[i].triangleList_.size();
@@ -1641,7 +1639,8 @@ int ttk::ReebSpace::connectSheets(const triangulationType &triangulation) {
     }
   }
 
-  this->printMsg("Sheet connectivity established.");
+  this->printMsg(
+    "Sheet connectivity established.", 1.0, tm.getElapsedTime(), 1);
 
   printConnectivity(originalData_);
 

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -754,12 +754,12 @@ inline int ttk::ReebSpace::computeGeometricalMeasures(
   for(size_t i = 0; i < sheet.tetList_.size(); i++) {
 
     SimplexId tetId = sheet.tetList_[i];
-    std::vector<std::pair<double, double>> domainBox, rangeBox;
-    std::vector<std::vector<float>> domainPoints(4), rangePoints(4);
+    std::array<std::pair<double, double>, 3> domainBox{};
+    std::array<std::pair<double, double>, 2> rangeBox;
+    std::array<std::array<float, 3>, 4> domainPoints{};
+    std::array<std::array<float, 2>, 4> rangePoints{};
 
     for(int j = 0; j < 4; j++) {
-      domainPoints[j].resize(3);
-      rangePoints[j].resize(2);
 
       SimplexId vertexId = -1;
       triangulation.getCellVertex(tetId, j, vertexId);

--- a/standalone/ContinuousScatterPlot/main.cpp
+++ b/standalone/ContinuousScatterPlot/main.cpp
@@ -140,8 +140,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < csp->GetNumberOfOutputPorts(); i++) {
       auto output = csp->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ContourAroundPoint/main.cpp
+++ b/standalone/ContourAroundPoint/main.cpp
@@ -153,8 +153,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < contourAroundPoint->GetNumberOfOutputPorts(); i++) {
       auto output = contourAroundPoint->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ContourForests/main.cpp
+++ b/standalone/ContourForests/main.cpp
@@ -124,8 +124,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < cf->GetNumberOfOutputPorts(); i++) {
       auto output = cf->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/FTMTree/main.cpp
+++ b/standalone/FTMTree/main.cpp
@@ -125,8 +125,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < ftmTree->GetNumberOfOutputPorts(); i++) {
       auto output = ftmTree->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/FTRGraph/main.cpp
+++ b/standalone/FTRGraph/main.cpp
@@ -126,8 +126,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < ftrG->GetNumberOfOutputPorts(); i++) {
       auto output = ftrG->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/HelloWorld/main.cpp
+++ b/standalone/HelloWorld/main.cpp
@@ -146,8 +146,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < helloWorld->GetNumberOfOutputPorts(); i++) {
       auto output = helloWorld->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/JacobiSet/main.cpp
+++ b/standalone/JacobiSet/main.cpp
@@ -125,8 +125,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < js->GetNumberOfOutputPorts(); i++) {
       auto output = js->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/LDistance/main.cpp
+++ b/standalone/LDistance/main.cpp
@@ -123,8 +123,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < ldist->GetNumberOfOutputPorts(); i++) {
       auto output = ldist->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/MandatoryCriticalPoints/main.cpp
+++ b/standalone/MandatoryCriticalPoints/main.cpp
@@ -118,8 +118,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < mcp->GetNumberOfOutputPorts(); i++) {
       auto output = mcp->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ManifoldCheck/main.cpp
+++ b/standalone/ManifoldCheck/main.cpp
@@ -121,8 +121,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < manifoldCheck->GetNumberOfOutputPorts(); i++) {
       auto output = manifoldCheck->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/MeshSubdivision/main.cpp
+++ b/standalone/MeshSubdivision/main.cpp
@@ -120,8 +120,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < msub->GetNumberOfOutputPorts(); i++) {
       auto output = msub->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/MetricDistortion/main.cpp
+++ b/standalone/MetricDistortion/main.cpp
@@ -147,8 +147,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < metricDistortion->GetNumberOfOutputPorts(); i++) {
       auto output = metricDistortion->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/MorseSmaleComplex/main.cpp
+++ b/standalone/MorseSmaleComplex/main.cpp
@@ -130,8 +130,8 @@ int main(int argc, char **argv) {
         continue;
       }
 
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -159,8 +159,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < persistenceDiagram->GetNumberOfOutputPorts(); i++) {
       auto output = persistenceDiagram->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/PointMerger/main.cpp
+++ b/standalone/PointMerger/main.cpp
@@ -123,8 +123,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < pmerg->GetNumberOfOutputPorts(); i++) {
       auto output = pmerg->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ReebSpace/main.cpp
+++ b/standalone/ReebSpace/main.cpp
@@ -124,8 +124,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < rs->GetNumberOfOutputPorts(); i++) {
       auto output = rs->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ScalarFieldCriticalPoints/main.cpp
+++ b/standalone/ScalarFieldCriticalPoints/main.cpp
@@ -161,8 +161,8 @@ int main(int argc, char **argv) {
     for(int i = 0; i < scalarFieldCriticalPoints->GetNumberOfOutputPorts();
         i++) {
       auto output = scalarFieldCriticalPoints->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."

--- a/standalone/ScalarFieldSmoother/main.cpp
+++ b/standalone/ScalarFieldSmoother/main.cpp
@@ -143,8 +143,8 @@ int main(int argc, char **argv) {
   if(!outputPathPrefix.empty()) {
     for(int i = 0; i < scalarFieldSmoother->GetNumberOfOutputPorts(); i++) {
       auto output = scalarFieldSmoother->GetOutputDataObject(i);
-      auto writer
-        = vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType());
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
 
       std::string outputFileName = outputPathPrefix + "_port_"
                                    + std::to_string(i) + "."


### PR DESCRIPTION
This PR fixes some memory-related issues (mostly found thank to [heaptrack](https://apps.kde.org/fr/heaptrack/)).
Among them:
* a memory leak was fixed in the standalones by wrapping a naked pointer into a `vtkSmartPointer`,
* to reduce the memory taken by the `DiscreteGradient` cache in a iterative context (Catalyst), the cache has been reimplemented with a LRU (Least-Recently Used) approach,
* the last dynamic allocations were removed from `Geometry`,
* `std::vector`s were replaced with `std::array`s in `FiberSurface`, `RangeDrivenOctree`, `ReebSpace` & `ContinuousScatterPlot`,
* in `JacobiSet`, `reserve` has been called before filling a vector in a loop,
* in `RangeDrivenOctree`, guards were placed around `printMsg` calls to avoid string concatenations.

The last changes should slightly improve the performance of the mentioned filters (nothing revolutionary though).

Enjoy,
Pierre