### PR TITLE
Fix (most of) implicit triangulation performance loss

### DIFF
--- a/core/base/implicitTriangulation/ImplicitPreconditions.h
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.h
@@ -6,37 +6,41 @@ namespace ttk {
   /**
    * @brief Implicit Triangulation class with preconditioning
    */
-  class ImplicitWithPreconditions final : public ImplicitTriangulation {
+  class ImplicitWithPreconditions final
+    : public ImplicitTriangulationCRTP<ImplicitWithPreconditions> {
   public:
+    ImplicitWithPreconditions() {
+      this->setDebugMsgPrefix("ImplicitTriangulationWithPreconditions");
+    }
+
     int preconditionVerticesInternal() override;
     int preconditionEdgesInternal() override;
     int preconditionTrianglesInternal() override;
     int preconditionTetrahedronsInternal() override;
 
-    inline VertexPosition getVertexPosition(const SimplexId v) const override {
+    inline VertexPosition getVertexPosition(const SimplexId v) const {
       return this->vertexPositions_[v];
     }
-    inline std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const override {
+    inline std::array<SimplexId, 3> const &
+      getVertexCoords(const SimplexId v) const {
       return this->vertexCoords_[v];
     }
-    inline EdgePosition getEdgePosition(const SimplexId e) const override {
+    inline EdgePosition getEdgePosition(const SimplexId e) const {
       return this->edgePositions_[e];
     }
-    inline std::array<SimplexId, 3>
-      getEdgeCoords(const SimplexId e) const override {
+    inline std::array<SimplexId, 3> const &
+      getEdgeCoords(const SimplexId e) const {
       return this->edgeCoords_[e];
     }
-    inline TrianglePosition
-      getTrianglePosition(const SimplexId t) const override {
+    inline TrianglePosition getTrianglePosition(const SimplexId t) const {
       return this->trianglePositions_[t];
     }
-    inline std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const override {
+    inline std::array<SimplexId, 3> const &
+      getTriangleCoords(const SimplexId t) const {
       return this->triangleCoords_[t];
     }
-    inline std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const override {
+    inline const std::array<SimplexId, 3> &
+      getTetrahedronCoords(const SimplexId t) const {
       return this->tetrahedronCoords_[t];
     }
 
@@ -72,8 +76,13 @@ namespace ttk {
   /**
    * @brief Implicit Triangulation class without preconditioning
    */
-  class ImplicitNoPreconditions final : public ImplicitTriangulation {
+  class ImplicitNoPreconditions final
+    : public ImplicitTriangulationCRTP<ImplicitNoPreconditions> {
   public:
+    ImplicitNoPreconditions() {
+      this->setDebugMsgPrefix("ImplicitTriangulationNoPreconditions");
+    }
+
     inline int preconditionVerticesInternal() override {
       return 0;
     }
@@ -87,10 +96,9 @@ namespace ttk {
       return 0;
     }
 
-    VertexPosition getVertexPosition(const SimplexId v) const override;
+    VertexPosition getVertexPosition(const SimplexId v) const;
 
-    inline std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const override {
+    inline std::array<SimplexId, 3> getVertexCoords(const SimplexId v) const {
       std::array<SimplexId, 3> p{};
       if(this->dimensionality_ == 2) {
         this->vertexToPosition2d(v, p.data());
@@ -100,14 +108,13 @@ namespace ttk {
       return p;
     }
 
-    EdgePosition getEdgePosition(const SimplexId e) const override;
-    std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const override;
-    TrianglePosition getTrianglePosition(const SimplexId t) const override;
-    std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const override;
+    EdgePosition getEdgePosition(const SimplexId e) const;
+    std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const;
+    TrianglePosition getTrianglePosition(const SimplexId t) const;
+    std::array<SimplexId, 3> getTriangleCoords(const SimplexId t) const;
 
     inline std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const override {
+      getTetrahedronCoords(const SimplexId t) const {
       std::array<SimplexId, 3> p{};
       this->tetrahedronToPosition(t, p.data());
       return p;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -328,7 +328,7 @@ bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
 #endif // !TTK_ENABLE_KAMIKAZE
 
   if(dimensionality_ == 3)
-    return (getTriangleStarNumber(triangleId) == 1);
+    return (TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(triangleId) == 1);
 
   return false;
 }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -470,7 +470,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() {
-  if(!vertexNeighborList_.size()) {
+  if(vertexNeighborList_.empty()) {
     Timer t;
     vertexNeighborList_.resize(vertexNumber_);
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
@@ -644,7 +644,7 @@ int ImplicitTriangulation::getVertexEdgeInternal(const SimplexId &vertexId,
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::getVertexEdgesInternal() {
-  if(!vertexEdgeList_.size()) {
+  if(vertexEdgeList_.empty()) {
     Timer t;
 
     vertexEdgeList_.resize(vertexNumber_);
@@ -813,7 +813,7 @@ int ImplicitTriangulation::getVertexTriangleInternal(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::getVertexTrianglesInternal() {
-  if(!vertexTriangleList_.size()) {
+  if(vertexTriangleList_.empty()) {
     Timer t;
 
     vertexTriangleList_.resize(vertexNumber_);
@@ -964,7 +964,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLinks)() {
-  if(!vertexLinkList_.size()) {
+  if(vertexLinkList_.empty()) {
     Timer t;
 
     vertexLinkList_.resize(vertexNumber_);
@@ -1171,7 +1171,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStars)() {
 
-  if(!vertexStarList_.size()) {
+  if(vertexStarList_.empty()) {
     Timer t;
     vertexStarList_.resize(vertexNumber_);
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
@@ -1313,7 +1313,7 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
 const vector<std::array<SimplexId, 2>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
 
-  if(!edgeList_.size()) {
+  if(edgeList_.empty()) {
     Timer t;
 
     edgeList_.resize(edgeNumber_);
@@ -1553,7 +1553,7 @@ int ImplicitTriangulation::getEdgeTriangleInternal(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::getEdgeTrianglesInternal() {
-  if(!edgeTriangleList_.size()) {
+  if(edgeTriangleList_.empty()) {
     Timer t;
 
     edgeTriangleList_.resize(edgeNumber_);
@@ -1629,7 +1629,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() {
 
-  if(!edgeLinkList_.size()) {
+  if(edgeLinkList_.empty()) {
     Timer t;
 
     edgeLinkList_.resize(edgeNumber_);
@@ -1767,7 +1767,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStars)() {
 
-  if(!edgeStarList_.size()) {
+  if(edgeStarList_.empty()) {
     Timer t;
 
     edgeStarList_.resize(edgeNumber_);
@@ -1964,7 +1964,7 @@ const vector<vector<SimplexId>> *
 const vector<std::array<SimplexId, 3>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
 
-  if(!triangleList_.size()) {
+  if(triangleList_.empty()) {
     Timer t;
 
     triangleList_.resize(triangleNumber_);
@@ -2026,7 +2026,7 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() {
-  if(!triangleLinkList_.size()) {
+  if(triangleLinkList_.empty()) {
     Timer t;
 
     triangleLinkList_.resize(triangleNumber_);
@@ -2112,7 +2112,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStars)() {
 
-  if(!triangleStarList_.size()) {
+  if(triangleStarList_.empty()) {
     Timer t;
 
     triangleStarList_.resize(triangleNumber_);
@@ -2644,7 +2644,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellNeighbor)(
 
 const vector<vector<SimplexId>> *
   ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getCellNeighbors)() {
-  if(!cellNeighborList_.size()) {
+  if(cellNeighborList_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -273,15 +273,16 @@ bool ImplicitTriangulation::isPowerOfTwo(unsigned long long int v,
   return false;
 }
 
-bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
-  const SimplexId &vertexId) const {
+template <typename Derived>
+bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  isVertexOnBoundary)(const SimplexId &vertexId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return false;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
     case VertexPosition::CENTER_2D:
     case VertexPosition::CENTER_1D:
@@ -291,15 +292,16 @@ bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
   }
 }
 
-bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
-  const SimplexId &edgeId) const {
+template <typename Derived>
+bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  isEdgeOnBoundary)(const SimplexId &edgeId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return false;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_xnn_3D:
     case EdgePosition::H_nyn_3D:
     case EdgePosition::P_nnz_3D:
@@ -331,10 +333,11 @@ bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
   return false;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
-  const SimplexId &vertexId,
-  const int &localNeighborId,
-  SimplexId &neighborId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexNeighbor)(const SimplexId &vertexId,
+                     const int &localNeighborId,
+                     SimplexId &neighborId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localNeighborId < 0
@@ -342,7 +345,7 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
     return -1;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       neighborId = vertexId + this->vertexNeighborABCDEFGH_[localNeighborId];
       break;
@@ -491,9 +494,9 @@ SimplexId ImplicitTriangulation::getVertexEdgeNumberInternal(
   return TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(vertexId);
 }
 
-int ImplicitTriangulation::getVertexEdgeInternal(const SimplexId &vertexId,
-                                                 const int &localEdgeId,
-                                                 SimplexId &edgeId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getVertexEdgeInternal(
+  const SimplexId &vertexId, const int &localEdgeId, SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localEdgeId < 0 or localEdgeId >= getVertexEdgeNumberInternal(vertexId))
     return -1;
@@ -515,9 +518,9 @@ int ImplicitTriangulation::getVertexEdgeInternal(const SimplexId &vertexId,
   // D3: diagonale3 (type be)
   // D4: diagonale4 (type bg)
 
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       edgeId = getVertexEdgeABCDEFGH(p.data(), localEdgeId);
       break;
@@ -661,14 +664,15 @@ const vector<vector<SimplexId>> *
   return &vertexEdgeList_;
 }
 
-SimplexId ImplicitTriangulation::getVertexTriangleNumberInternal(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::getVertexTriangleNumberInternal(
   const SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       return 36;
     case VertexPosition::FRONT_FACE_3D:
@@ -709,7 +713,8 @@ SimplexId ImplicitTriangulation::getVertexTriangleNumberInternal(
   return 0;
 }
 
-int ImplicitTriangulation::getVertexTriangleInternal(
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getVertexTriangleInternal(
   const SimplexId &vertexId,
   const int &localTriangleId,
   SimplexId &triangleId) const {
@@ -719,9 +724,9 @@ int ImplicitTriangulation::getVertexTriangleInternal(
     return -1;
 #endif
 
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       triangleId = getVertexTriangleABCDEFGH(p.data(), localTriangleId);
       break;
@@ -835,17 +840,20 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(vertexId);
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
-  const SimplexId &vertexId, const int &localLinkId, SimplexId &linkId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexLink)(const SimplexId &vertexId,
+                 const int &localLinkId,
+                 SimplexId &linkId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getVertexLinkNumber(vertexId))
     return -1;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       linkId = getVertexLinkABCDEFGH(p.data(), localLinkId);
       break;
@@ -981,7 +989,8 @@ const vector<vector<SimplexId>> *
   return &vertexLinkList_;
 }
 
-SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
   getVertexStarNumber)(const SimplexId &vertexId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -989,7 +998,7 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     return -1;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       return 24;
     case VertexPosition::FRONT_FACE_3D:
@@ -1041,17 +1050,20 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
-  const SimplexId &vertexId, const int &localStarId, SimplexId &starId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexStar)(const SimplexId &vertexId,
+                 const int &localStarId,
+                 SimplexId &starId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getVertexStarNumber(vertexId))
     return -1;
 #endif // !TTK_ENABLE_KAMIKAZE
 
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
-  switch(this->getVertexPosition(vertexId)) {
+  switch(this->underlying().getVertexPosition(vertexId)) {
     case VertexPosition::CENTER_3D:
       starId = getVertexStarABCDEFGH(p.data(), localStarId);
       break;
@@ -1187,17 +1199,21 @@ const vector<vector<SimplexId>> *
   return &vertexStarList_;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
-  const SimplexId &vertexId, float &x, float &y, float &z) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexPoint)(const SimplexId &vertexId,
+                  float &x,
+                  float &y,
+                  float &z) const {
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getVertexCoords(vertexId);
+    const auto &p = this->underlying().getVertexCoords(vertexId);
 
     x = origin_[0] + spacing_[0] * p[0];
     y = origin_[1] + spacing_[1] * p[1];
     z = origin_[2] + spacing_[2] * p[2];
   } else if(dimensionality_ == 2) {
-    const auto &p = this->getVertexCoords(vertexId);
+    const auto &p = this->underlying().getVertexCoords(vertexId);
 
     if(dimensions_[0] > 1 and dimensions_[1] > 1) {
       x = origin_[0] + spacing_[0] * p[0];
@@ -1231,9 +1247,11 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
   return 0;
 }
 
-int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
-                                                 const int &localVertexId,
-                                                 SimplexId &vertexId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getEdgeVertexInternal(
+  const SimplexId &edgeId,
+  const int &localVertexId,
+  SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
@@ -1241,7 +1259,7 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
     return -2;
 #endif
 
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
   const auto helper3d = [&](const SimplexId a, const SimplexId b) -> SimplexId {
     if(isAccelerated_) {
@@ -1263,7 +1281,7 @@ int ImplicitTriangulation::getEdgeVertexInternal(const SimplexId &edgeId,
     }
   };
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
   CASE_EDGE_POSITION_L_3D:
     vertexId = helper3d(0, 1);
     break;
@@ -1331,14 +1349,15 @@ const vector<std::array<SimplexId, 2>> *
   return &edgeList_;
 }
 
-SimplexId ImplicitTriangulation::getEdgeTriangleNumberInternal(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::getEdgeTriangleNumberInternal(
   const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_xnn_3D:
     case EdgePosition::H_nyn_3D:
     case EdgePosition::P_nnz_3D:
@@ -1396,7 +1415,8 @@ SimplexId ImplicitTriangulation::getEdgeTriangleNumberInternal(
   return 0;
 }
 
-int ImplicitTriangulation::getEdgeTriangleInternal(
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getEdgeTriangleInternal(
   const SimplexId &edgeId,
   const int &localTriangleId,
   SimplexId &triangleId) const {
@@ -1406,9 +1426,9 @@ int ImplicitTriangulation::getEdgeTriangleInternal(
     return -1;
 #endif
 
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_xnn_3D:
       triangleId = getEdgeTriangleL_xnn(p.data(), localTriangleId);
       break;
@@ -1575,7 +1595,8 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
   return TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(edgeId);
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
   const SimplexId &edgeId, const int &localLinkId, SimplexId &linkId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -1583,9 +1604,9 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
     return -1;
 #endif
 
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
   CASE_EDGE_POSITION_L_3D:
     linkId = getEdgeLinkL(p.data(), localLinkId);
     break;
@@ -1646,15 +1667,16 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
-  const SimplexId &edgeId) const {
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getEdgeStarNumber)(const SimplexId &edgeId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_xnn_3D:
     case EdgePosition::H_nyn_3D:
     case EdgePosition::P_nnz_3D:
@@ -1712,7 +1734,8 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
   const SimplexId &edgeId, const int &localStarId, SimplexId &starId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -1720,9 +1743,9 @@ int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
     return -1;
 #endif
 
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
   CASE_EDGE_POSITION_L_3D:
     starId = getEdgeStarL(p.data(), localStarId);
     break;
@@ -1784,7 +1807,8 @@ const vector<vector<SimplexId>> *
   return &edgeStarList_;
 }
 
-int ImplicitTriangulation::getTriangleVertexInternal(
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTriangleVertexInternal(
   const SimplexId &triangleId,
   const int &localVertexId,
   SimplexId &vertexId) const {
@@ -1811,10 +1835,10 @@ int ImplicitTriangulation::getTriangleVertexInternal(
   // D2: diagonale2 (type abg/bgh)
   // D3: diagonale3 (type bcg/bfg)
 
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
   vertexId = -1;
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       vertexId = getTriangleVertexF(p.data(), localVertexId);
       break;
@@ -1865,9 +1889,11 @@ int ImplicitTriangulation::getTriangleVertexInternal(
   return 0;
 }
 
-int ImplicitTriangulation::getTriangleEdgeInternal(const SimplexId &triangleId,
-                                                   const int &localEdgeId,
-                                                   SimplexId &edgeId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTriangleEdgeInternal(
+  const SimplexId &triangleId,
+  const int &localEdgeId,
+  SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return -1;
@@ -1875,11 +1901,11 @@ int ImplicitTriangulation::getTriangleEdgeInternal(const SimplexId &triangleId,
     return -2;
 #endif
 
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
   const auto par = triangleId % 2;
   edgeId = -1;
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       edgeId = (par == 1) ? getTriangleEdgeF_1(p.data(), localEdgeId)
                           : getTriangleEdgeF_0(p.data(), localEdgeId);
@@ -1980,19 +2006,20 @@ const vector<std::array<SimplexId, 3>> *
   return &triangleList_;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
-  const SimplexId &triangleId,
-  const int &localLinkId,
-  SimplexId &linkId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getTriangleLink)(const SimplexId &triangleId,
+                   const int &localLinkId,
+                   SimplexId &linkId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getTriangleLinkNumber(triangleId))
     return -1;
 #endif
 
-  const auto p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       linkId = getTriangleLinkF(p.data(), localLinkId);
       break;
@@ -2042,7 +2069,8 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
   getTriangleStarNumber)(const SimplexId &triangleId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2050,9 +2078,9 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     return -1;
 #endif
 
-  const auto p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       return (p[2] > 0 and p[2] < nbvoxels_[2]) ? 2 : 1;
     case TrianglePosition::H_3D:
@@ -2070,19 +2098,20 @@ SimplexId ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return 0;
 }
 
-int ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
-  const SimplexId &triangleId,
-  const int &localStarId,
-  SimplexId &starId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getTriangleStar)(const SimplexId &triangleId,
+                   const int &localStarId,
+                   SimplexId &starId) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getTriangleStarNumber(triangleId))
     return -1;
 #endif
 
-  const auto p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       starId = getTriangleStarF(p.data(), localStarId);
       break;
@@ -2128,7 +2157,8 @@ const vector<vector<SimplexId>> *
   return &triangleStarList_;
 }
 
-SimplexId ImplicitTriangulation::getTriangleNeighborNumber(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::getTriangleNeighborNumber(
   const SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
@@ -2136,7 +2166,7 @@ SimplexId ImplicitTriangulation::getTriangleNeighborNumber(
 #endif
 
   if(dimensionality_ == 2) {
-    const auto p = this->getTriangleCoords(triangleId);
+    const auto &p = this->underlying().getTriangleCoords(triangleId);
     const SimplexId id = triangleId % 2;
 
     if(id) {
@@ -2159,9 +2189,11 @@ SimplexId ImplicitTriangulation::getTriangleNeighborNumber(
   return 0;
 }
 
-int ImplicitTriangulation::getTriangleNeighbor(const SimplexId &triangleId,
-                                               const int &localNeighborId,
-                                               SimplexId &neighborId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTriangleNeighbor(
+  const SimplexId &triangleId,
+  const int &localNeighborId,
+  SimplexId &neighborId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localNeighborId < 0
      or localNeighborId >= getTriangleNeighborNumber(triangleId))
@@ -2171,7 +2203,7 @@ int ImplicitTriangulation::getTriangleNeighbor(const SimplexId &triangleId,
   neighborId = -1;
 
   if(dimensionality_ == 2) {
-    const auto p = this->getTriangleCoords(triangleId);
+    const auto &p = this->underlying().getTriangleCoords(triangleId);
     const SimplexId id = triangleId % 2;
 
     if(id) {
@@ -2259,9 +2291,9 @@ int ImplicitTriangulation::getTriangleNeighbors(
   return 0;
 }
 
-int ImplicitTriangulation::getTetrahedronVertex(const SimplexId &tetId,
-                                                const int &localVertexId,
-                                                SimplexId &vertexId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTetrahedronVertex(
+  const SimplexId &tetId, const int &localVertexId, SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
     return -1;
@@ -2273,7 +2305,7 @@ int ImplicitTriangulation::getTetrahedronVertex(const SimplexId &tetId,
 
   if(dimensionality_ == 3) {
     const SimplexId id = tetId % 6;
-    const auto c = this->getTetrahedronCoords(tetId);
+    const auto &c = this->underlying().getTetrahedronCoords(tetId);
     const auto p{c.data()};
 
     switch(id) {
@@ -2300,9 +2332,9 @@ int ImplicitTriangulation::getTetrahedronVertex(const SimplexId &tetId,
   return 0;
 }
 
-int ImplicitTriangulation::getTetrahedronEdge(const SimplexId &tetId,
-                                              const int &localEdgeId,
-                                              SimplexId &edgeId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTetrahedronEdge(
+  const SimplexId &tetId, const int &localEdgeId, SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
     return -1;
@@ -2314,7 +2346,7 @@ int ImplicitTriangulation::getTetrahedronEdge(const SimplexId &tetId,
 
   if(dimensionality_ == 3) {
     const SimplexId id = tetId % 6;
-    const auto c = this->getTetrahedronCoords(tetId);
+    const auto &c = this->underlying().getTetrahedronCoords(tetId);
     const auto p{c.data()};
 
     switch(id) {
@@ -2354,9 +2386,11 @@ int ImplicitTriangulation::getTetrahedronEdges(
   return 0;
 }
 
-int ImplicitTriangulation::getTetrahedronTriangle(const SimplexId &tetId,
-                                                  const int &localTriangleId,
-                                                  SimplexId &triangleId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTetrahedronTriangle(
+  const SimplexId &tetId,
+  const int &localTriangleId,
+  SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
     return -1;
@@ -2368,7 +2402,7 @@ int ImplicitTriangulation::getTetrahedronTriangle(const SimplexId &tetId,
 
   if(dimensionality_ == 3) {
     const SimplexId id = tetId % 6;
-    const auto c = this->getTetrahedronCoords(tetId);
+    const auto &c = this->underlying().getTetrahedronCoords(tetId);
     const auto p{c.data()};
 
     switch(id) {
@@ -2408,7 +2442,8 @@ int ImplicitTriangulation::getTetrahedronTriangles(
   return 0;
 }
 
-SimplexId ImplicitTriangulation::getTetrahedronNeighborNumber(
+template <typename Derived>
+SimplexId ImplicitTriangulationCRTP<Derived>::getTetrahedronNeighborNumber(
   const SimplexId &tetId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
@@ -2417,7 +2452,7 @@ SimplexId ImplicitTriangulation::getTetrahedronNeighborNumber(
 
   if(dimensionality_ == 3) {
     const SimplexId id = tetId % 6;
-    const auto c = this->getTetrahedronCoords(tetId);
+    const auto &c = this->underlying().getTetrahedronCoords(tetId);
     const auto p{c.data()};
 
     switch(id) {
@@ -2475,9 +2510,11 @@ SimplexId ImplicitTriangulation::getTetrahedronNeighborNumber(
   return 0;
 }
 
-int ImplicitTriangulation::getTetrahedronNeighbor(const SimplexId &tetId,
-                                                  const int &localNeighborId,
-                                                  SimplexId &neighborId) const {
+template <typename Derived>
+int ImplicitTriangulationCRTP<Derived>::getTetrahedronNeighbor(
+  const SimplexId &tetId,
+  const int &localNeighborId,
+  SimplexId &neighborId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localNeighborId < 0
      or localNeighborId >= getTetrahedronNeighborNumber(tetId))
@@ -2488,7 +2525,7 @@ int ImplicitTriangulation::getTetrahedronNeighbor(const SimplexId &tetId,
 
   if(dimensionality_ == 3) {
     const SimplexId id = tetId % 6;
-    const auto c = this->getTetrahedronCoords(tetId);
+    const auto &c = this->underlying().getTetrahedronCoords(tetId);
     const auto p{c.data()};
 
     switch(id) {
@@ -3006,3 +3043,7 @@ int ImplicitTriangulation::preconditionVertexNeighborsInternal() {
 
   return 0;
 }
+
+// explicit instantiations
+template class ttk::ImplicitTriangulationCRTP<ttk::ImplicitWithPreconditions>;
+template class ttk::ImplicitTriangulationCRTP<ttk::ImplicitNoPreconditions>;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -83,41 +83,17 @@ namespace ttk {
       return dimensionality_;
     }
 
-    int
-      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
-                                              const int &localLinkId,
-                                              SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
       const SimplexId &edgeId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() override;
 
-    int
-      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
-                                              const int &localStarId,
-                                              SimplexId &starId) const override;
-
-    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
-      const SimplexId &edgeId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getEdgeStars)() override;
 
-    int getEdgeTriangleInternal(const SimplexId &edgeId,
-                                const int &id,
-                                SimplexId &triangleId) const override;
-
-    SimplexId
-      getEdgeTriangleNumberInternal(const SimplexId &edgeId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       getEdgeTrianglesInternal() override;
-
-    int getEdgeVertexInternal(const SimplexId &edgeId,
-                              const int &localVertexId,
-                              SimplexId &vertexId) const override;
 
     const std::vector<std::array<SimplexId, 2>> *
       TTK_TRIANGULATION_INTERNAL(getEdges)() override;
@@ -138,34 +114,31 @@ namespace ttk {
       return vertexNumber_;
     }
 
-    int getTetrahedronEdge(const SimplexId &tetId,
-                           const int &id,
-                           SimplexId &edgeId) const;
+    virtual int getTetrahedronEdge(const SimplexId &tetId,
+                                   const int &id,
+                                   SimplexId &edgeId) const = 0;
 
     int getTetrahedronEdges(std::vector<std::vector<SimplexId>> &edges) const;
 
-    int getTetrahedronTriangle(const SimplexId &tetId,
-                               const int &id,
-                               SimplexId &triangleId) const;
+    virtual int getTetrahedronTriangle(const SimplexId &tetId,
+                                       const int &id,
+                                       SimplexId &triangleId) const = 0;
 
     int getTetrahedronTriangles(
       std::vector<std::vector<SimplexId>> &triangles) const;
 
-    int getTetrahedronNeighbor(const SimplexId &tetId,
-                               const int &localNeighborId,
-                               SimplexId &neighborId) const;
+    virtual int getTetrahedronNeighbor(const SimplexId &tetId,
+                                       const int &localNeighborId,
+                                       SimplexId &neighborId) const = 0;
 
-    SimplexId getTetrahedronNeighborNumber(const SimplexId &tetId) const;
+    virtual SimplexId
+      getTetrahedronNeighborNumber(const SimplexId &tetId) const = 0;
 
     int getTetrahedronNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-    int getTetrahedronVertex(const SimplexId &tetId,
-                             const int &localVertexId,
-                             SimplexId &vertexId) const;
-
-    int getTriangleEdgeInternal(const SimplexId &triangleId,
-                                const int &id,
-                                SimplexId &edgeId) const override;
+    virtual int getTetrahedronVertex(const SimplexId &tetId,
+                                     const int &localVertexId,
+                                     SimplexId &vertexId) const = 0;
 
     SimplexId getTriangleEdgeNumberInternal(
       const SimplexId & /*triangleId*/) const override {
@@ -180,46 +153,26 @@ namespace ttk {
     int getTriangleEdgesInternal(
       std::vector<std::vector<SimplexId>> &edges) const;
 
-    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
-      const SimplexId &triangleId,
-      const int &localLinkId,
-      SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
       const SimplexId &triangleId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() override;
 
-    int getTriangleNeighbor(const SimplexId &triangleId,
-                            const int &localNeighborId,
-                            SimplexId &neighborId) const;
+    virtual int getTriangleNeighbor(const SimplexId &triangleId,
+                                    const int &localNeighborId,
+                                    SimplexId &neighborId) const = 0;
 
-    SimplexId getTriangleNeighborNumber(const SimplexId &triangleId) const;
+    virtual SimplexId
+      getTriangleNeighborNumber(const SimplexId &triangleId) const = 0;
 
     int getTriangleNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
-
-    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
-      const SimplexId &triangleId,
-      const int &localStarId,
-      SimplexId &starId) const override;
-
-    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
-      const SimplexId &triangleId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getTriangleStars)() override;
 
-    int getTriangleVertexInternal(const SimplexId &triangleId,
-                                  const int &localVertexId,
-                                  SimplexId &vertexId) const override;
-
     const std::vector<std::array<SimplexId, 3>> *
       TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
-
-    int getVertexEdgeInternal(const SimplexId &vertexId,
-                              const int &id,
-                              SimplexId &edgeId) const override;
 
     SimplexId
       getVertexEdgeNumberInternal(const SimplexId &vertexId) const override;
@@ -227,115 +180,20 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() override;
 
-    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
-      const SimplexId &vertexId,
-      const int &localLinkId,
-      SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
       const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexLinks)() override;
 
-    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
-      const SimplexId &vertexId,
-      const int &localNeighborId,
-      SimplexId &neighborId) const override;
-
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
-      const SimplexId &vertexId) const override {
-
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(vertexId < 0 or vertexId >= vertexNumber_)
-        return -1;
-#endif // !TTK_ENABLE_KAMIKAZE
-
-      switch(this->getVertexPosition(vertexId)) {
-        case VertexPosition::CENTER_3D:
-          return 14;
-        case VertexPosition::FRONT_FACE_3D:
-        case VertexPosition::BACK_FACE_3D:
-        case VertexPosition::TOP_FACE_3D:
-        case VertexPosition::BOTTOM_FACE_3D:
-        case VertexPosition::LEFT_FACE_3D:
-        case VertexPosition::RIGHT_FACE_3D:
-          return 10;
-        case VertexPosition::TOP_FRONT_EDGE_3D: // ab
-        case VertexPosition::RIGHT_FRONT_EDGE_3D: // bd
-        case VertexPosition::BOTTOM_BACK_EDGE_3D: // gh
-        case VertexPosition::LEFT_BACK_EDGE_3D: // eg
-        case VertexPosition::BOTTOM_LEFT_EDGE_3D: // cg
-        case VertexPosition::TOP_RIGHT_EDGE_3D: // bf
-          return 8;
-        case VertexPosition::TOP_RIGHT_FRONT_CORNER_3D: // b
-        case VertexPosition::BOTTOM_LEFT_BACK_CORNER_3D: // g
-          return 7;
-        case VertexPosition::TOP_BACK_EDGE_3D: // ef
-        case VertexPosition::BOTTOM_FRONT_EDGE_3D: // cd
-        case VertexPosition::LEFT_FRONT_EDGE_3D: // ac
-        case VertexPosition::TOP_LEFT_EDGE_3D: // ae
-        case VertexPosition::RIGHT_BACK_EDGE_3D: // fh
-        case VertexPosition::BOTTOM_RIGHT_EDGE_3D: // dh
-        case VertexPosition::CENTER_2D:
-          return 6;
-        case VertexPosition::TOP_LEFT_FRONT_CORNER_3D: // a
-        case VertexPosition::BOTTOM_LEFT_FRONT_CORNER_3D: // c
-        case VertexPosition::BOTTOM_RIGHT_FRONT_CORNER_3D: // d
-        case VertexPosition::TOP_LEFT_BACK_CORNER_3D: // e
-        case VertexPosition::TOP_RIGHT_BACK_CORNER_3D: // f
-        case VertexPosition::BOTTOM_RIGHT_BACK_CORNER_3D: // h
-        case VertexPosition::TOP_EDGE_2D:
-        case VertexPosition::BOTTOM_EDGE_2D:
-        case VertexPosition::LEFT_EDGE_2D:
-        case VertexPosition::RIGHT_EDGE_2D:
-          return 4;
-        case VertexPosition::TOP_RIGHT_CORNER_2D: // b
-        case VertexPosition::BOTTOM_LEFT_CORNER_2D: // c
-          return 3;
-        case VertexPosition::TOP_LEFT_CORNER_2D: // a
-        case VertexPosition::BOTTOM_RIGHT_CORNER_2D: // d
-        case VertexPosition::CENTER_1D:
-          return 2;
-        case VertexPosition::LEFT_CORNER_1D:
-        case VertexPosition::RIGHT_CORNER_1D:
-          return 1;
-      }
-
-      return -1;
-    }
-
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() override;
-
-    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
-                                                   float &x,
-                                                   float &y,
-                                                   float &z) const override;
-
-    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
-      const SimplexId &vertexId,
-      const int &localStarId,
-      SimplexId &starId) const override;
-
-    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
-      const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexStars)() override;
 
-    int getVertexTriangleInternal(const SimplexId &vertexId,
-                                  const int &id,
-                                  SimplexId &triangleId) const override;
-
-    SimplexId
-      getVertexTriangleNumberInternal(const SimplexId &vertexId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       getVertexTrianglesInternal() override;
-
-    bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
-      const SimplexId &edgeId) const override;
 
     inline bool isEmpty() const override {
       return !vertexNumber_;
@@ -343,9 +201,6 @@ namespace ttk {
 
     bool TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
       const SimplexId &triangleId) const override;
-
-    bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
-      const SimplexId &vertexId) const override;
 
     int setInputGrid(const float &xOrigin,
                      const float &yOrigin,
@@ -453,11 +308,6 @@ namespace ttk {
       CENTER_3D,
       // total: 27 3D cases
     };
-
-    // for every vertex, its position on the grid
-    std::vector<VertexPosition> vertexPositions_{};
-    // for  every vertex, its coordinates on the grid
-    std::vector<std::array<SimplexId, 3>> vertexCoords_{};
 
     // vertex neighbor shifts
     std::array<SimplexId, 14> vertexNeighborABCDEFGH_{};
@@ -574,11 +424,6 @@ namespace ttk {
       CENTER_1D,
     };
 
-    // for every edge, its position on the grid
-    std::vector<EdgePosition> edgePositions_{};
-    // for every edge, its coordinates on the grid
-    std::vector<std::array<SimplexId, 3>> edgeCoords_{};
-
     enum class TrianglePosition : char {
       //    e--------f
       //   /|       /|
@@ -599,14 +444,6 @@ namespace ttk {
       TOP_2D, // abc
       BOTTOM_2D, // bcd
     };
-
-    // for every triangle, its position on the grid
-    std::vector<TrianglePosition> trianglePositions_{};
-    // for every triangle, its coordinates on the grid
-    std::vector<std::array<SimplexId, 3>> triangleCoords_{};
-
-    // for every tetrahedron, its coordinates on the grid
-    std::vector<std::array<SimplexId, 3>> tetrahedronCoords_{};
 
     bool hasPreconditionedVerticesAndCells_{false};
 
@@ -650,17 +487,6 @@ namespace ttk {
     // acceleration functions
     int checkAcceleration();
     bool isPowerOfTwo(unsigned long long int v, unsigned long long int &r);
-
-    virtual VertexPosition getVertexPosition(const SimplexId v) const = 0;
-    virtual std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const = 0;
-    virtual EdgePosition getEdgePosition(const SimplexId e) const = 0;
-    virtual std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const = 0;
-    virtual TrianglePosition getTrianglePosition(const SimplexId t) const = 0;
-    virtual std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const = 0;
-    virtual std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const = 0;
 
     //\cond
     // 2D //
@@ -982,6 +808,190 @@ namespace ttk {
                                          const SimplexId p[3],
                                          const int id) const;
     //\endcond
+  };
+
+  template <typename Derived>
+  class ImplicitTriangulationCRTP : public ImplicitTriangulation {
+    inline Derived &underlying() {
+      return static_cast<Derived &>(*this);
+    }
+    inline Derived const &underlying() const {
+      return static_cast<Derived const &>(*this);
+    }
+
+  public:
+    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
+      const SimplexId &vertexId) const override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(vertexId < 0 or vertexId >= vertexNumber_)
+        return -1;
+#endif // !TTK_ENABLE_KAMIKAZE
+
+      switch(this->underlying().getVertexPosition(vertexId)) {
+        case VertexPosition::CENTER_3D:
+          return 14;
+        case VertexPosition::FRONT_FACE_3D:
+        case VertexPosition::BACK_FACE_3D:
+        case VertexPosition::TOP_FACE_3D:
+        case VertexPosition::BOTTOM_FACE_3D:
+        case VertexPosition::LEFT_FACE_3D:
+        case VertexPosition::RIGHT_FACE_3D:
+          return 10;
+        case VertexPosition::TOP_FRONT_EDGE_3D: // ab
+        case VertexPosition::RIGHT_FRONT_EDGE_3D: // bd
+        case VertexPosition::BOTTOM_BACK_EDGE_3D: // gh
+        case VertexPosition::LEFT_BACK_EDGE_3D: // eg
+        case VertexPosition::BOTTOM_LEFT_EDGE_3D: // cg
+        case VertexPosition::TOP_RIGHT_EDGE_3D: // bf
+          return 8;
+        case VertexPosition::TOP_RIGHT_FRONT_CORNER_3D: // b
+        case VertexPosition::BOTTOM_LEFT_BACK_CORNER_3D: // g
+          return 7;
+        case VertexPosition::TOP_BACK_EDGE_3D: // ef
+        case VertexPosition::BOTTOM_FRONT_EDGE_3D: // cd
+        case VertexPosition::LEFT_FRONT_EDGE_3D: // ac
+        case VertexPosition::TOP_LEFT_EDGE_3D: // ae
+        case VertexPosition::RIGHT_BACK_EDGE_3D: // fh
+        case VertexPosition::BOTTOM_RIGHT_EDGE_3D: // dh
+        case VertexPosition::CENTER_2D:
+          return 6;
+        case VertexPosition::TOP_LEFT_FRONT_CORNER_3D: // a
+        case VertexPosition::BOTTOM_LEFT_FRONT_CORNER_3D: // c
+        case VertexPosition::BOTTOM_RIGHT_FRONT_CORNER_3D: // d
+        case VertexPosition::TOP_LEFT_BACK_CORNER_3D: // e
+        case VertexPosition::TOP_RIGHT_BACK_CORNER_3D: // f
+        case VertexPosition::BOTTOM_RIGHT_BACK_CORNER_3D: // h
+        case VertexPosition::TOP_EDGE_2D:
+        case VertexPosition::BOTTOM_EDGE_2D:
+        case VertexPosition::LEFT_EDGE_2D:
+        case VertexPosition::RIGHT_EDGE_2D:
+          return 4;
+        case VertexPosition::TOP_RIGHT_CORNER_2D: // b
+        case VertexPosition::BOTTOM_LEFT_CORNER_2D: // c
+          return 3;
+        case VertexPosition::TOP_LEFT_CORNER_2D: // a
+        case VertexPosition::BOTTOM_RIGHT_CORNER_2D: // d
+        case VertexPosition::CENTER_1D:
+          return 2;
+        case VertexPosition::LEFT_CORNER_1D:
+        case VertexPosition::RIGHT_CORNER_1D:
+          return 1;
+      }
+
+      return -1;
+    }
+
+    bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
+      const SimplexId &vertexId) const override;
+
+    bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
+      const SimplexId &edgeId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
+      const SimplexId &vertexId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
+
+    int getVertexEdgeInternal(const SimplexId &vertexId,
+                              const int &id,
+                              SimplexId &edgeId) const override;
+
+    SimplexId
+      getVertexTriangleNumberInternal(const SimplexId &vertexId) const override;
+
+    int getVertexTriangleInternal(const SimplexId &vertexId,
+                                  const int &id,
+                                  SimplexId &triangleId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
+      const SimplexId &vertexId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
+      const SimplexId &vertexId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
+      const SimplexId &vertexId,
+      const int &localStarId,
+      SimplexId &starId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
+                                                   float &x,
+                                                   float &y,
+                                                   float &z) const override;
+
+    int getEdgeVertexInternal(const SimplexId &edgeId,
+                              const int &localVertexId,
+                              SimplexId &vertexId) const override;
+
+    SimplexId
+      getEdgeTriangleNumberInternal(const SimplexId &edgeId) const override;
+
+    int getEdgeTriangleInternal(const SimplexId &edgeId,
+                                const int &id,
+                                SimplexId &triangleId) const override;
+
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                              const int &localLinkId,
+                                              SimplexId &linkId) const override;
+
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                              const int &localStarId,
+                                              SimplexId &starId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+      const SimplexId &edgeId) const override;
+
+    int getTriangleVertexInternal(const SimplexId &triangleId,
+                                  const int &localVertexId,
+                                  SimplexId &vertexId) const override;
+
+    int getTriangleEdgeInternal(const SimplexId &triangleId,
+                                const int &id,
+                                SimplexId &edgeId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
+      const SimplexId &triangleId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
+      const SimplexId &triangleId,
+      const int &localStarId,
+      SimplexId &starId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
+      const SimplexId &triangleId) const override;
+
+    int getTriangleNeighbor(const SimplexId &triangleId,
+                            const int &localNeighborId,
+                            SimplexId &neighborId) const override;
+
+    SimplexId
+      getTriangleNeighborNumber(const SimplexId &triangleId) const override;
+
+    int getTetrahedronVertex(const SimplexId &tetId,
+                             const int &localVertexId,
+                             SimplexId &vertexId) const override;
+
+    int getTetrahedronEdge(const SimplexId &tetId,
+                           const int &id,
+                           SimplexId &edgeId) const override;
+
+    int getTetrahedronTriangle(const SimplexId &tetId,
+                               const int &id,
+                               SimplexId &triangleId) const override;
+
+    SimplexId
+      getTetrahedronNeighborNumber(const SimplexId &tetId) const override;
+
+    int getTetrahedronNeighbor(const SimplexId &tetId,
+                               const int &localNeighborId,
+                               SimplexId &neighborId) const override;
   };
 } // namespace ttk
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -329,7 +329,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     getVertexNeighbors)() {
-  if(!vertexNeighborList_.size()) {
+  if(vertexNeighborList_.empty()) {
     Timer t;
     vertexNeighborList_.resize(vertexNumber_);
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
@@ -382,7 +382,7 @@ int PeriodicImplicitTriangulation::getVertexEdgeInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getVertexEdgesInternal() {
-  if(!vertexEdgeList_.size()) {
+  if(vertexEdgeList_.empty()) {
     Timer t;
 
     vertexEdgeList_.resize(vertexNumber_);
@@ -437,7 +437,7 @@ int PeriodicImplicitTriangulation::getVertexTriangleInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getVertexTrianglesInternal() {
-  if(!vertexTriangleList_.size()) {
+  if(vertexTriangleList_.empty()) {
     Timer t;
 
     vertexTriangleList_.resize(vertexNumber_);
@@ -480,7 +480,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLinks)() {
-  if(!vertexLinkList_.size()) {
+  if(vertexLinkList_.empty()) {
     Timer t;
 
     vertexLinkList_.resize(vertexNumber_);
@@ -536,7 +536,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStars)() {
-  if(!vertexStarList_.size()) {
+  if(vertexStarList_.empty()) {
     Timer t;
     vertexStarList_.resize(vertexNumber_);
     for(SimplexId i = 0; i < vertexNumber_; ++i) {
@@ -680,7 +680,7 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
 const vector<std::array<SimplexId, 2>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdges)() {
 
-  if(!edgeList_.size()) {
+  if(edgeList_.empty()) {
     Timer t;
 
     edgeList_.resize(edgeNumber_);
@@ -777,7 +777,7 @@ int PeriodicImplicitTriangulation::getEdgeTriangleInternal(
 
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::getEdgeTrianglesInternal() {
-  if(!edgeTriangleList_.size()) {
+  if(edgeTriangleList_.empty()) {
     Timer t;
 
     edgeTriangleList_.resize(edgeNumber_);
@@ -851,7 +851,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() {
 
-  if(!edgeLinkList_.size()) {
+  if(edgeLinkList_.empty()) {
     Timer t;
 
     edgeLinkList_.resize(edgeNumber_);
@@ -948,7 +948,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
 const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStars)() {
 
-  if(!edgeStarList_.size()) {
+  if(edgeStarList_.empty()) {
     Timer t;
 
     edgeStarList_.resize(edgeNumber_);
@@ -1122,7 +1122,7 @@ const vector<vector<SimplexId>> *
 const vector<std::array<SimplexId, 3>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangles)() {
 
-  if(!triangleList_.size()) {
+  if(triangleList_.empty()) {
     Timer t;
 
     triangleList_.resize(triangleNumber_);
@@ -1186,7 +1186,7 @@ const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     getTriangleLinks)() {
 
-  if(!triangleLinkList_.size()) {
+  if(triangleLinkList_.empty()) {
     Timer t;
 
     triangleLinkList_.resize(triangleNumber_);
@@ -1259,7 +1259,7 @@ const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     getTriangleStars)() {
 
-  if(!triangleStarList_.size()) {
+  if(triangleStarList_.empty()) {
     Timer t;
 
     triangleStarList_.resize(triangleNumber_);
@@ -1742,7 +1742,7 @@ const vector<vector<SimplexId>> *
   PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
     getCellNeighbors)() {
 
-  if(!cellNeighborList_.size()) {
+  if(cellNeighborList_.empty()) {
     Timer t;
 
     if(dimensionality_ == 3)

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -286,7 +286,8 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return -1;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
   getVertexNeighbor)(const SimplexId &vertexId,
                      const int &localNeighborId,
                      SimplexId &neighborId) const {
@@ -297,7 +298,7 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
 #endif
 
   neighborId = -1;
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
   if(dimensionality_ == 3) {
     neighborId = getVertexNeighbor3d(p.data(), vertexId, localNeighborId);
@@ -350,7 +351,8 @@ SimplexId PeriodicImplicitTriangulation::getVertexEdgeNumberInternal(
   return getVertexNeighborNumber(vertexId);
 }
 
-int PeriodicImplicitTriangulation::getVertexEdgeInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getVertexEdgeInternal(
   const SimplexId &vertexId, const int &localEdgeId, SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localEdgeId < 0 or localEdgeId >= getVertexEdgeNumberInternal(vertexId))
@@ -358,7 +360,7 @@ int PeriodicImplicitTriangulation::getVertexEdgeInternal(
 #endif
 
   edgeId = -1;
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
   if(dimensionality_ == 3) {
     edgeId = getVertexEdge3d(p.data(), localEdgeId);
@@ -415,7 +417,8 @@ SimplexId PeriodicImplicitTriangulation::getVertexTriangleNumberInternal(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getVertexTriangleInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getVertexTriangleInternal(
   const SimplexId &vertexId,
   const int &localTriangleId,
   SimplexId &triangleId) const {
@@ -426,7 +429,7 @@ int PeriodicImplicitTriangulation::getVertexTriangleInternal(
 #endif
   triangleId = -1;
 
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
   if(dimensionality_ == 3) {
     triangleId = getVertexTriangle3d(p.data(), localTriangleId);
@@ -459,15 +462,18 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return getVertexStarNumber(vertexId);
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexLink)(
-  const SimplexId &vertexId, const int &localLinkId, SimplexId &linkId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexLink)(const SimplexId &vertexId,
+                 const int &localLinkId,
+                 SimplexId &linkId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getVertexLinkNumber(vertexId))
     return -1;
 #endif
 
   linkId = -1;
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
   if(dimensionality_ == 3) {
     linkId = getVertexLink3d(p.data(), localLinkId);
@@ -515,15 +521,18 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexStar)(
-  const SimplexId &vertexId, const int &localStarId, SimplexId &starId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexStar)(const SimplexId &vertexId,
+                 const int &localStarId,
+                 SimplexId &starId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getVertexStarNumber(vertexId))
     return -1;
 #endif
 
   starId = -1;
-  const auto &p = this->getVertexCoords(vertexId);
+  const auto &p = this->underlying().getVertexCoords(vertexId);
 
   if(dimensionality_ == 3) {
     starId = getVertexStar3d(p.data(), localStarId);
@@ -552,21 +561,25 @@ const vector<vector<SimplexId>> *
   return &vertexStarList_;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
-  const SimplexId &vertexId, float &x, float &y, float &z) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getVertexPoint)(const SimplexId &vertexId,
+                  float &x,
+                  float &y,
+                  float &z) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
     return -1;
 #endif
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getVertexCoords(vertexId);
+    const auto &p = this->underlying().getVertexCoords(vertexId);
 
     x = origin_[0] + spacing_[0] * p[0];
     y = origin_[1] + spacing_[1] * p[1];
     z = origin_[2] + spacing_[2] * p[2];
   } else if(dimensionality_ == 2) {
-    const auto &p = this->getVertexCoords(vertexId);
+    const auto &p = this->underlying().getVertexCoords(vertexId);
 
     if(dimensions_[0] > 1 and dimensions_[1] > 1) {
       x = origin_[0] + spacing_[0] * p[0];
@@ -600,7 +613,8 @@ int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getVertexPoint)(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getEdgeVertexInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getEdgeVertexInternal(
   const SimplexId &edgeId,
   const int &localVertexId,
   SimplexId &vertexId) const {
@@ -612,13 +626,13 @@ int PeriodicImplicitTriangulation::getEdgeVertexInternal(
 #endif
 
   vertexId = -1;
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
   const SimplexId wrapXRight = (p[0] == nbvoxels_[0] ? -wrap_[0] : 0);
   const SimplexId wrapYBottom = (p[1] == nbvoxels_[1] ? -wrap_[1] : 0);
   const SimplexId wrapZFront = (p[2] == nbvoxels_[2] ? -wrap_[2] : 0);
-  const auto a = p[0] + this->getEdgeVertexAccelerated(edgeId);
+  const auto a = p[0] + this->underlying().getEdgeVertexAccelerated(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
       vertexId = a + (localVertexId == 0 ? 0 : (1 + wrapXRight));
       break;
@@ -698,14 +712,16 @@ const vector<std::array<SimplexId, 2>> *
   return &edgeList_;
 }
 
-SimplexId PeriodicImplicitTriangulation::getEdgeTriangleNumberInternal(
-  const SimplexId &edgeId) const {
+template <typename Derived>
+SimplexId
+  PeriodicImplicitTriangulationCRTP<Derived>::getEdgeTriangleNumberInternal(
+    const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
     case EdgePosition::H_3D:
     case EdgePosition::P_3D:
@@ -724,7 +740,8 @@ SimplexId PeriodicImplicitTriangulation::getEdgeTriangleNumberInternal(
   }
 }
 
-int PeriodicImplicitTriangulation::getEdgeTriangleInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getEdgeTriangleInternal(
   const SimplexId &edgeId,
   const int &localTriangleId,
   SimplexId &triangleId) const {
@@ -735,9 +752,9 @@ int PeriodicImplicitTriangulation::getEdgeTriangleInternal(
 #endif
 
   triangleId = -1;
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
       triangleId = getEdgeTriangle3dL(p.data(), localTriangleId);
       break;
@@ -800,17 +817,20 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return getEdgeStarNumber(edgeId);
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeLink)(
-  const SimplexId &edgeId, const int &localLinkId, SimplexId &linkId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getEdgeLink)(const SimplexId &edgeId,
+               const int &localLinkId,
+               SimplexId &linkId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getEdgeLinkNumber(edgeId))
     return -1;
 #endif
 
   linkId = -1;
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
       linkId = getEdgeLinkL(p.data(), localLinkId);
       break;
@@ -868,14 +888,16 @@ const vector<vector<SimplexId>> *
   return &edgeLinkList_;
 }
 
-SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
-  getEdgeStarNumber)(const SimplexId &edgeId) const {
+template <typename Derived>
+SimplexId
+  PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+    getEdgeStarNumber)(const SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
     return -1;
 #endif
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
     case EdgePosition::H_3D:
     case EdgePosition::P_3D:
@@ -896,17 +918,20 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getEdgeStar)(
-  const SimplexId &edgeId, const int &localStarId, SimplexId &starId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getEdgeStar)(const SimplexId &edgeId,
+               const int &localStarId,
+               SimplexId &starId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getEdgeStarNumber(edgeId))
     return -1;
 #endif
 
   starId = -1;
-  const auto &p = this->getEdgeCoords(edgeId);
+  const auto &p = this->underlying().getEdgeCoords(edgeId);
 
-  switch(this->getEdgePosition(edgeId)) {
+  switch(this->underlying().getEdgePosition(edgeId)) {
     case EdgePosition::L_3D:
       starId = getEdgeStarL(p.data(), localStarId);
       break;
@@ -965,7 +990,8 @@ const vector<vector<SimplexId>> *
   return &edgeStarList_;
 }
 
-int PeriodicImplicitTriangulation::getTriangleVertexInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTriangleVertexInternal(
   const SimplexId &triangleId,
   const int &localVertexId,
   SimplexId &vertexId) const {
@@ -977,11 +1003,11 @@ int PeriodicImplicitTriangulation::getTriangleVertexInternal(
 #endif
 
   vertexId = -1;
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
   const SimplexId wrapXRight = (p[0] / 2 == nbvoxels_[Di_]) ? -wrap_[0] : 0;
   const SimplexId wrapYBottom = (p[1] == nbvoxels_[Dj_]) ? -wrap_[1] : 0;
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       vertexId = getTriangleVertexF(p.data(), localVertexId);
       break;
@@ -1026,7 +1052,8 @@ int PeriodicImplicitTriangulation::getTriangleVertexInternal(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTriangleEdgeInternal(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTriangleEdgeInternal(
   const SimplexId &triangleId,
   const int &localEdgeId,
   SimplexId &edgeId) const {
@@ -1038,12 +1065,12 @@ int PeriodicImplicitTriangulation::getTriangleEdgeInternal(
 #endif
 
   edgeId = -1;
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
   const SimplexId wrapXRight = (p[0] / 2 == nbvoxels_[Di_]) ? -wrap_[0] : 0;
   const SimplexId wrapYBottom = (p[1] == nbvoxels_[Dj_]) ? -wrap_[1] : 0;
   const SimplexId id = triangleId % 2;
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       edgeId = (id == 1) ? getTriangleEdgeF_1(p.data(), localEdgeId)
                          : getTriangleEdgeF_0(p.data(), localEdgeId);
@@ -1138,19 +1165,20 @@ const vector<std::array<SimplexId, 3>> *
   return &triangleList_;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
-  const SimplexId &triangleId,
-  const int &localLinkId,
-  SimplexId &linkId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getTriangleLink)(const SimplexId &triangleId,
+                   const int &localLinkId,
+                   SimplexId &linkId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localLinkId < 0 or localLinkId >= getTriangleLinkNumber(triangleId))
     return -1;
 #endif
 
   linkId = -1;
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       linkId = getTriangleLinkF(p.data(), localLinkId);
       break;
@@ -1202,8 +1230,10 @@ const vector<vector<SimplexId>> *
   return &triangleLinkList_;
 }
 
-SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
-  getTriangleStarNumber)(const SimplexId &triangleId) const {
+template <typename Derived>
+SimplexId
+  PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+    getTriangleStarNumber)(const SimplexId &triangleId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)
     return -1;
@@ -1217,19 +1247,20 @@ SimplexId PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
-  const SimplexId &triangleId,
-  const int &localStarId,
-  SimplexId &starId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
+  getTriangleStar)(const SimplexId &triangleId,
+                   const int &localStarId,
+                   SimplexId &starId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(localStarId < 0 or localStarId >= getTriangleStarNumber(triangleId))
     return -1;
 #endif
 
   starId = -1;
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::F_3D:
       starId = getTriangleStarF(p.data(), localStarId);
       break;
@@ -1290,7 +1321,8 @@ SimplexId PeriodicImplicitTriangulation::getTriangleNeighborNumber(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTriangleNeighbor(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTriangleNeighbor(
   const SimplexId &triangleId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
@@ -1301,9 +1333,9 @@ int PeriodicImplicitTriangulation::getTriangleNeighbor(
 #endif
 
   neighborId = -1;
-  const auto &p = this->getTriangleCoords(triangleId);
+  const auto &p = this->underlying().getTriangleCoords(triangleId);
 
-  switch(this->getTrianglePosition(triangleId)) {
+  switch(this->underlying().getTrianglePosition(triangleId)) {
     case TrianglePosition::BOTTOM_2D:
 
       if(p[0] / 2 == nbvoxels_[Di_] and p[1] == nbvoxels_[Dj_]) {
@@ -1401,7 +1433,8 @@ int PeriodicImplicitTriangulation::getTriangleNeighbors(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTetrahedronVertex(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTetrahedronVertex(
   const SimplexId &tetId, const int &localVertexId, SimplexId &vertexId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
@@ -1413,7 +1446,7 @@ int PeriodicImplicitTriangulation::getTetrahedronVertex(
   vertexId = -1;
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getTetrahedronCoords(tetId);
+    const auto &p = this->underlying().getTetrahedronCoords(tetId);
     const SimplexId id = tetId % 6;
 
     switch(id) {
@@ -1440,9 +1473,9 @@ int PeriodicImplicitTriangulation::getTetrahedronVertex(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTetrahedronEdge(const SimplexId &tetId,
-                                                      const int &localEdgeId,
-                                                      SimplexId &edgeId) const {
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTetrahedronEdge(
+  const SimplexId &tetId, const int &localEdgeId, SimplexId &edgeId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
   if(tetId < 0 or tetId >= tetrahedronNumber_)
     return -1;
@@ -1453,7 +1486,7 @@ int PeriodicImplicitTriangulation::getTetrahedronEdge(const SimplexId &tetId,
   edgeId = -1;
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getTetrahedronCoords(tetId);
+    const auto &p = this->underlying().getTetrahedronCoords(tetId);
     const SimplexId id = tetId % 6;
 
     switch(id) {
@@ -1493,7 +1526,8 @@ int PeriodicImplicitTriangulation::getTetrahedronEdges(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTetrahedronTriangle(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTetrahedronTriangle(
   const SimplexId &tetId,
   const int &localTriangleId,
   SimplexId &triangleId) const {
@@ -1507,7 +1541,7 @@ int PeriodicImplicitTriangulation::getTetrahedronTriangle(
   triangleId = -1;
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getTetrahedronCoords(tetId);
+    const auto &p = this->underlying().getTetrahedronCoords(tetId);
     const SimplexId id = tetId % 6;
 
     switch(id) {
@@ -1562,7 +1596,8 @@ SimplexId PeriodicImplicitTriangulation::getTetrahedronNeighborNumber(
   return 0;
 }
 
-int PeriodicImplicitTriangulation::getTetrahedronNeighbor(
+template <typename Derived>
+int PeriodicImplicitTriangulationCRTP<Derived>::getTetrahedronNeighbor(
   const SimplexId &tetId,
   const int &localNeighborId,
   SimplexId &neighborId) const {
@@ -1575,7 +1610,7 @@ int PeriodicImplicitTriangulation::getTetrahedronNeighbor(
   neighborId = -1;
 
   if(dimensionality_ == 3) {
-    const auto &p = this->getTetrahedronCoords(tetId);
+    const auto &p = this->underlying().getTetrahedronCoords(tetId);
     const SimplexId id = tetId % 6;
 
     switch(id) {
@@ -1760,3 +1795,9 @@ const vector<vector<SimplexId>> *
 
   return &cellNeighborList_;
 }
+
+// explicit instantiations
+template class ttk::PeriodicImplicitTriangulationCRTP<
+  ttk::PeriodicWithPreconditions>;
+template class ttk::PeriodicImplicitTriangulationCRTP<
+  ttk::PeriodicNoPreconditions>;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -79,41 +79,17 @@ namespace ttk {
       return dimensionality_;
     }
 
-    int
-      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
-                                              const int &localLinkId,
-                                              SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLinkNumber)(
       const SimplexId &edgeId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getEdgeLinks)() override;
 
-    int
-      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
-                                              const int &localStarId,
-                                              SimplexId &starId) const override;
-
-    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
-      const SimplexId &edgeId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getEdgeStars)() override;
 
-    int getEdgeTriangleInternal(const SimplexId &edgeId,
-                                const int &id,
-                                SimplexId &triangleId) const override;
-
-    SimplexId
-      getEdgeTriangleNumberInternal(const SimplexId &edgeId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       getEdgeTrianglesInternal() override;
-
-    int getEdgeVertexInternal(const SimplexId &edgeId,
-                              const int &localVertexId,
-                              SimplexId &vertexId) const override;
 
     const std::vector<std::array<SimplexId, 2>> *
       TTK_TRIANGULATION_INTERNAL(getEdges)() override;
@@ -134,34 +110,30 @@ namespace ttk {
       return vertexNumber_;
     }
 
-    int getTetrahedronEdge(const SimplexId &tetId,
-                           const int &id,
-                           SimplexId &edgeId) const;
+    virtual int getTetrahedronEdge(const SimplexId &tetId,
+                                   const int &id,
+                                   SimplexId &edgeId) const = 0;
 
     int getTetrahedronEdges(std::vector<std::vector<SimplexId>> &edges) const;
 
-    int getTetrahedronTriangle(const SimplexId &tetId,
-                               const int &id,
-                               SimplexId &triangleId) const;
+    virtual int getTetrahedronTriangle(const SimplexId &tetId,
+                                       const int &id,
+                                       SimplexId &triangleId) const = 0;
 
     int getTetrahedronTriangles(
       std::vector<std::vector<SimplexId>> &triangles) const;
 
-    int getTetrahedronNeighbor(const SimplexId &tetId,
-                               const int &localNeighborId,
-                               SimplexId &neighborId) const;
+    virtual int getTetrahedronNeighbor(const SimplexId &tetId,
+                                       const int &localNeighborId,
+                                       SimplexId &neighborId) const = 0;
 
     SimplexId getTetrahedronNeighborNumber(const SimplexId &tetId) const;
 
     int getTetrahedronNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-    int getTetrahedronVertex(const SimplexId &tetId,
-                             const int &localVertexId,
-                             SimplexId &vertexId) const;
-
-    int getTriangleEdgeInternal(const SimplexId &triangleId,
-                                const int &id,
-                                SimplexId &edgeId) const override;
+    virtual int getTetrahedronVertex(const SimplexId &tetId,
+                                     const int &localVertexId,
+                                     SimplexId &vertexId) const = 0;
 
     SimplexId getTriangleEdgeNumberInternal(
       const SimplexId &ttkNotUsed(triangleId)) const override {
@@ -176,46 +148,25 @@ namespace ttk {
     int getTriangleEdgesInternal(
       std::vector<std::vector<SimplexId>> &edges) const;
 
-    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
-      const SimplexId &triangleId,
-      const int &localLinkId,
-      SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
       const SimplexId &triangleId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getTriangleLinks)() override;
 
-    int getTriangleNeighbor(const SimplexId &triangleId,
-                            const int &localNeighborId,
-                            SimplexId &neighborId) const;
+    virtual int getTriangleNeighbor(const SimplexId &triangleId,
+                                    const int &localNeighborId,
+                                    SimplexId &neighborId) const = 0;
 
     SimplexId getTriangleNeighborNumber(const SimplexId &triangleId) const;
 
     int getTriangleNeighbors(std::vector<std::vector<SimplexId>> &neighbors);
 
-    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
-      const SimplexId &triangleId,
-      const int &localStarId,
-      SimplexId &starId) const override;
-
-    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
-      const SimplexId &triangleId) const override;
-
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getTriangleStars)() override;
 
-    int getTriangleVertexInternal(const SimplexId &triangleId,
-                                  const int &localVertexId,
-                                  SimplexId &vertexId) const override;
-
     const std::vector<std::array<SimplexId, 3>> *
       TTK_TRIANGULATION_INTERNAL(getTriangles)() override;
-
-    int getVertexEdgeInternal(const SimplexId &vertexId,
-                              const int &id,
-                              SimplexId &edgeId) const override;
 
     SimplexId
       getVertexEdgeNumberInternal(const SimplexId &vertexId) const override;
@@ -223,21 +174,11 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       getVertexEdgesInternal() override;
 
-    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
-      const SimplexId &vertexId,
-      const int &localLinkId,
-      SimplexId &linkId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
       const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexLinks)() override;
-
-    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
-      const SimplexId &vertexId,
-      const int &localNeighborId,
-      SimplexId &neighborId) const override;
 
     SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
       const SimplexId &vertexId) const override;
@@ -245,25 +186,11 @@ namespace ttk {
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexNeighbors)() override;
 
-    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
-                                                   float &x,
-                                                   float &y,
-                                                   float &z) const override;
-
-    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
-      const SimplexId &vertexId,
-      const int &localStarId,
-      SimplexId &starId) const override;
-
     SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
       const SimplexId &vertexId) const override;
 
     const std::vector<std::vector<SimplexId>> *
       TTK_TRIANGULATION_INTERNAL(getVertexStars)() override;
-
-    int getVertexTriangleInternal(const SimplexId &vertexId,
-                                  const int &id,
-                                  SimplexId &triangleId) const override;
 
     SimplexId
       getVertexTriangleNumberInternal(const SimplexId &vertexId) const override;
@@ -314,130 +241,6 @@ namespace ttk {
         this->preconditionVerticesInternal();
         this->preconditionCellsInternal();
         this->hasPreconditionedVerticesAndCells_ = true;
-      }
-      return 0;
-    }
-
-    /**
-     * Compute the barycenter of the points of the given edge identifier.
-     */
-    virtual int getEdgeIncenter(SimplexId edgeId, float incenter[3]) const {
-      SimplexId v0{}, v1{};
-      getEdgeVertexInternal(edgeId, 0, v0);
-      getEdgeVertexInternal(edgeId, 1, v1);
-
-      std::array<float, 3> p0{}, p1{};
-      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
-      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
-
-      const auto &ind0 = this->getVertexCoords(v0);
-      const auto &ind1 = this->getVertexCoords(v1);
-
-      for(int i = 0; i < dimensionality_; ++i) {
-        if(ind1[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind0[i] == nbvoxels_[i]) {
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-        }
-      }
-
-      for(int i = 0; i < 3; ++i) {
-        incenter[i] = 0.5f * (p0[i] + p1[i]);
-      }
-
-      return 0;
-    }
-
-    /**
-     * Compute the incenter of the points of the given triangle
-     * identifier.
-     */
-    virtual int getTriangleIncenter(SimplexId triangleId,
-                                    float incenter[3]) const {
-
-      SimplexId v0{}, v1{}, v2{};
-      getTriangleVertexInternal(triangleId, 0, v0);
-      getTriangleVertexInternal(triangleId, 1, v1);
-      getTriangleVertexInternal(triangleId, 2, v2);
-
-      std::array<float, 3> p0{}, p1{}, p2{};
-      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
-      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
-      getVertexPointInternal(v2, p2[0], p2[1], p2[2]);
-
-      const auto &ind0 = this->getVertexCoords(v0);
-      const auto &ind1 = this->getVertexCoords(v1);
-      const auto &ind2 = this->getVertexCoords(v2);
-
-      for(int i = 0; i < dimensionality_; ++i) {
-        if(ind0[i] == nbvoxels_[i]) {
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind1[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind2[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-        }
-      }
-
-      std::array<float, 3> d{Geometry::distance(p1.data(), p2.data()),
-                             Geometry::distance(p2.data(), p0.data()),
-                             Geometry::distance(p0.data(), p1.data())};
-      const float sum = d[0] + d[1] + d[2];
-      for(int i = 0; i < 3; ++i) {
-        incenter[i] = (d[0] * p0[i] + d[1] * p1[i] + d[2] * p2[i]) / sum;
-      }
-
-      return 0;
-    }
-
-    /**
-     * Compute the barycenter of the incenters of the triangles of the
-     * given tetra identifier.
-     */
-    virtual int getTetraIncenter(SimplexId tetraId, float incenter[3]) const {
-
-      SimplexId v0{}, v1{}, v2{}, v3{};
-      getCellVertexInternal(tetraId, 0, v0);
-      getCellVertexInternal(tetraId, 1, v1);
-      getCellVertexInternal(tetraId, 2, v2);
-      getCellVertexInternal(tetraId, 3, v3);
-
-      std::array<float, 3> p0{}, p1{}, p2{}, p3{};
-      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
-      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
-      getVertexPointInternal(v2, p2[0], p2[1], p2[2]);
-      getVertexPointInternal(v3, p3[0], p3[1], p3[2]);
-
-      const auto &ind0 = this->getVertexCoords(v0);
-      const auto &ind1 = this->getVertexCoords(v1);
-      const auto &ind2 = this->getVertexCoords(v2);
-      const auto &ind3 = this->getVertexCoords(v3);
-
-      for(int i = 0; i < dimensionality_; ++i) {
-        if(ind0[i] == nbvoxels_[i]) {
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
-          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind1[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
-          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind2[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
-        } else if(ind3[i] == nbvoxels_[i]) {
-          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
-          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
-          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
-        }
-      }
-
-      for(int i = 0; i < 3; ++i) {
-        incenter[i] = 0.25f * (p0[i] + p1[i] + p2[i] + p3[i]);
       }
       return 0;
     }
@@ -544,17 +347,6 @@ namespace ttk {
     // acceleration functions
     int checkAcceleration();
     bool isPowerOfTwo(unsigned long long int v, unsigned long long int &r);
-
-    virtual std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const = 0;
-    virtual EdgePosition getEdgePosition(const SimplexId e) const = 0;
-    virtual std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const = 0;
-    virtual TrianglePosition getTrianglePosition(const SimplexId t) const = 0;
-    virtual std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const = 0;
-    virtual std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const = 0;
-    virtual SimplexId getEdgeVertexAccelerated(const SimplexId e) const = 0;
 
     //\cond
     // 2D //
@@ -709,6 +501,236 @@ namespace ttk {
                                          const int id) const;
     //\endcond
   };
+
+  template <typename Derived>
+  class PeriodicImplicitTriangulationCRTP
+    : public PeriodicImplicitTriangulation {
+    inline Derived &underlying() {
+      return static_cast<Derived &>(*this);
+    }
+    inline Derived const &underlying() const {
+      return static_cast<Derived const &>(*this);
+    }
+
+  public:
+    int TTK_TRIANGULATION_INTERNAL(getVertexNeighbor)(
+      const SimplexId &vertexId,
+      const int &localNeighborId,
+      SimplexId &neighborId) const override;
+
+    int getVertexEdgeInternal(const SimplexId &vertexId,
+                              const int &id,
+                              SimplexId &edgeId) const override;
+
+    int getVertexTriangleInternal(const SimplexId &vertexId,
+                                  const int &id,
+                                  SimplexId &triangleId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexLink)(
+      const SimplexId &vertexId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexStar)(
+      const SimplexId &vertexId,
+      const int &localStarId,
+      SimplexId &starId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getVertexPoint)(const SimplexId &vertexId,
+                                                   float &x,
+                                                   float &y,
+                                                   float &z) const override;
+
+    int getEdgeVertexInternal(const SimplexId &edgeId,
+                              const int &localVertexId,
+                              SimplexId &vertexId) const override;
+
+    SimplexId
+      getEdgeTriangleNumberInternal(const SimplexId &edgeId) const override;
+
+    int getEdgeTriangleInternal(const SimplexId &edgeId,
+                                const int &id,
+                                SimplexId &triangleId) const override;
+
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeLink)(const SimplexId &edgeId,
+                                              const int &localLinkId,
+                                              SimplexId &linkId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(
+      const SimplexId &edgeId) const override;
+
+    int
+      TTK_TRIANGULATION_INTERNAL(getEdgeStar)(const SimplexId &edgeId,
+                                              const int &localStarId,
+                                              SimplexId &starId) const override;
+
+    int getTriangleVertexInternal(const SimplexId &triangleId,
+                                  const int &localVertexId,
+                                  SimplexId &vertexId) const override;
+
+    int getTriangleEdgeInternal(const SimplexId &triangleId,
+                                const int &id,
+                                SimplexId &edgeId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getTriangleLink)(
+      const SimplexId &triangleId,
+      const int &localLinkId,
+      SimplexId &linkId) const override;
+
+    int TTK_TRIANGULATION_INTERNAL(getTriangleStar)(
+      const SimplexId &triangleId,
+      const int &localStarId,
+      SimplexId &starId) const override;
+
+    SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
+      const SimplexId &triangleId) const override;
+
+    int getTriangleNeighbor(const SimplexId &triangleId,
+                            const int &localNeighborId,
+                            SimplexId &neighborId) const override;
+
+    int getTetrahedronVertex(const SimplexId &tetId,
+                             const int &localVertexId,
+                             SimplexId &vertexId) const override;
+
+    int getTetrahedronEdge(const SimplexId &tetId,
+                           const int &id,
+                           SimplexId &edgeId) const override;
+
+    int getTetrahedronTriangle(const SimplexId &tetId,
+                               const int &id,
+                               SimplexId &triangleId) const override;
+
+    int getTetrahedronNeighbor(const SimplexId &tetId,
+                               const int &localNeighborId,
+                               SimplexId &neighborId) const override;
+
+    /**
+     * Compute the barycenter of the points of the given edge identifier.
+     */
+    virtual int getEdgeIncenter(SimplexId edgeId, float incenter[3]) const {
+      SimplexId v0{}, v1{};
+      getEdgeVertexInternal(edgeId, 0, v0);
+      getEdgeVertexInternal(edgeId, 1, v1);
+
+      std::array<float, 3> p0{}, p1{};
+      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
+      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
+
+      const auto &ind0 = this->underlying().getVertexCoords(v0);
+      const auto &ind1 = this->underlying().getVertexCoords(v1);
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind1[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind0[i] == nbvoxels_[i]) {
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = 0.5f * (p0[i] + p1[i]);
+      }
+
+      return 0;
+    }
+
+    /**
+     * Compute the incenter of the points of the given triangle
+     * identifier.
+     */
+    virtual int getTriangleIncenter(SimplexId triangleId,
+                                    float incenter[3]) const {
+
+      SimplexId v0{}, v1{}, v2{};
+      getTriangleVertexInternal(triangleId, 0, v0);
+      getTriangleVertexInternal(triangleId, 1, v1);
+      getTriangleVertexInternal(triangleId, 2, v2);
+
+      std::array<float, 3> p0{}, p1{}, p2{};
+      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
+      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
+      getVertexPointInternal(v2, p2[0], p2[1], p2[2]);
+
+      const auto &ind0 = this->underlying().getVertexCoords(v0);
+      const auto &ind1 = this->underlying().getVertexCoords(v1);
+      const auto &ind2 = this->underlying().getVertexCoords(v2);
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind0[i] == nbvoxels_[i]) {
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind1[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind2[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      std::array<float, 3> d{Geometry::distance(p1.data(), p2.data()),
+                             Geometry::distance(p2.data(), p0.data()),
+                             Geometry::distance(p0.data(), p1.data())};
+      const float sum = d[0] + d[1] + d[2];
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = (d[0] * p0[i] + d[1] * p1[i] + d[2] * p2[i]) / sum;
+      }
+
+      return 0;
+    }
+
+    /**
+     * Compute the barycenter of the incenters of the triangles of the
+     * given tetra identifier.
+     */
+    virtual int getTetraIncenter(SimplexId tetraId, float incenter[3]) const {
+
+      SimplexId v0{}, v1{}, v2{}, v3{};
+      getCellVertexInternal(tetraId, 0, v0);
+      getCellVertexInternal(tetraId, 1, v1);
+      getCellVertexInternal(tetraId, 2, v2);
+      getCellVertexInternal(tetraId, 3, v3);
+
+      std::array<float, 3> p0{}, p1{}, p2{}, p3{};
+      getVertexPointInternal(v0, p0[0], p0[1], p0[2]);
+      getVertexPointInternal(v1, p1[0], p1[1], p1[2]);
+      getVertexPointInternal(v2, p2[0], p2[1], p2[2]);
+      getVertexPointInternal(v3, p3[0], p3[1], p3[2]);
+
+      const auto &ind0 = this->underlying().getVertexCoords(v0);
+      const auto &ind1 = this->underlying().getVertexCoords(v1);
+      const auto &ind2 = this->underlying().getVertexCoords(v2);
+      const auto &ind3 = this->underlying().getVertexCoords(v3);
+
+      for(int i = 0; i < dimensionality_; ++i) {
+        if(ind0[i] == nbvoxels_[i]) {
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind1[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind2[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p3[i] += (ind3[i] == 0) * dimensions_[i] * spacing_[i];
+        } else if(ind3[i] == nbvoxels_[i]) {
+          p0[i] += (ind0[i] == 0) * dimensions_[i] * spacing_[i];
+          p1[i] += (ind1[i] == 0) * dimensions_[i] * spacing_[i];
+          p2[i] += (ind2[i] == 0) * dimensions_[i] * spacing_[i];
+        }
+      }
+
+      for(int i = 0; i < 3; ++i) {
+        incenter[i] = 0.25f * (p0[i] + p1[i] + p2[i] + p3[i]);
+      }
+      return 0;
+    }
+  };
+
 } // namespace ttk
 
 /// @cond

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
@@ -6,38 +6,41 @@ namespace ttk {
   /**
    * @brief Periodic implicit Triangulation class with preconditioning
    */
-  class PeriodicWithPreconditions final : public PeriodicImplicitTriangulation {
+  class PeriodicWithPreconditions final
+    : public PeriodicImplicitTriangulationCRTP<PeriodicWithPreconditions> {
   public:
+    PeriodicWithPreconditions() {
+      this->setDebugMsgPrefix("PeriodicTriangulationWithPreconditions");
+    }
+
     int preconditionVerticesInternal() override;
     int preconditionEdgesInternal() override;
     int preconditionTrianglesInternal() override;
     int preconditionTetrahedronsInternal() override;
 
-    inline std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const override {
+    inline std::array<SimplexId, 3> const &
+      getVertexCoords(const SimplexId v) const {
       return this->vertexCoords_[v];
     }
-    inline EdgePosition getEdgePosition(const SimplexId e) const override {
+    inline EdgePosition getEdgePosition(const SimplexId e) const {
       return this->edgePositions_[e];
     }
-    inline std::array<SimplexId, 3>
-      getEdgeCoords(const SimplexId e) const override {
+    inline std::array<SimplexId, 3> const &
+      getEdgeCoords(const SimplexId e) const {
       return this->edgeCoords_[e];
     }
-    inline TrianglePosition
-      getTrianglePosition(const SimplexId t) const override {
+    inline TrianglePosition getTrianglePosition(const SimplexId t) const {
       return this->trianglePositions_[t];
     }
-    inline std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const override {
+    inline std::array<SimplexId, 3> const &
+      getTriangleCoords(const SimplexId t) const {
       return this->triangleCoords_[t];
     }
-    inline std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const override {
+    inline std::array<SimplexId, 3> const &
+      getTetrahedronCoords(const SimplexId t) const {
       return this->tetrahedronCoords_[t];
     }
-    inline SimplexId
-      getEdgeVertexAccelerated(const SimplexId e) const override {
+    inline SimplexId getEdgeVertexAccelerated(const SimplexId e) const {
       return this->edgeVertexAccelerated_[e];
     }
 
@@ -74,8 +77,13 @@ namespace ttk {
   /**
    * @brief Periodic implicit Triangulation class without preconditioning
    */
-  class PeriodicNoPreconditions final : public PeriodicImplicitTriangulation {
+  class PeriodicNoPreconditions final
+    : public PeriodicImplicitTriangulationCRTP<PeriodicNoPreconditions> {
   public:
+    PeriodicNoPreconditions() {
+      this->setDebugMsgPrefix("PeriodicTriangulationNoPreconditions");
+    }
+
     inline int preconditionVerticesInternal() override {
       return 0;
     }
@@ -89,8 +97,7 @@ namespace ttk {
       return 0;
     }
 
-    inline std::array<SimplexId, 3>
-      getVertexCoords(const SimplexId v) const override {
+    inline std::array<SimplexId, 3> getVertexCoords(const SimplexId v) const {
       std::array<SimplexId, 3> p{};
       if(this->dimensionality_ == 2) {
         this->vertexToPosition2d(v, p.data());
@@ -100,21 +107,19 @@ namespace ttk {
       return p;
     }
 
-    EdgePosition getEdgePosition(const SimplexId e) const override;
-    std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const override;
-    TrianglePosition getTrianglePosition(const SimplexId t) const override;
-    std::array<SimplexId, 3>
-      getTriangleCoords(const SimplexId t) const override;
+    EdgePosition getEdgePosition(const SimplexId e) const;
+    std::array<SimplexId, 3> getEdgeCoords(const SimplexId e) const;
+    TrianglePosition getTrianglePosition(const SimplexId t) const;
+    std::array<SimplexId, 3> getTriangleCoords(const SimplexId t) const;
 
     inline std::array<SimplexId, 3>
-      getTetrahedronCoords(const SimplexId t) const override {
+      getTetrahedronCoords(const SimplexId t) const {
       std::array<SimplexId, 3> p{};
       this->tetrahedronToPosition(t, p.data());
       return p;
     }
 
-    inline SimplexId
-      getEdgeVertexAccelerated(const SimplexId e) const override {
+    inline SimplexId getEdgeVertexAccelerated(const SimplexId e) const {
       const auto p{this->getEdgeCoords(e)};
       if(this->isAccelerated_) {
         return (p[1] << this->div_[0]) + (p[2] << this->div_[1]);

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -536,10 +536,10 @@ void ttk::PersistenceDiagram::checkProgressivityRequirement(
 
   if((BackEnd == BACKEND::PROGRESSIVE_TOPOLOGY
       || BackEnd == BACKEND::APPROXIMATE_TOPOLOGY)
-     && !std::is_base_of<ttk::ImplicitTriangulation,
-                         triangulationType>::value) {
+     && !std::is_same<ttk::ImplicitWithPreconditions, triangulationType>::value
+     && !std::is_same<ttk::ImplicitNoPreconditions, triangulationType>::value) {
 
-    printWrn("Explicit triangulation detected.");
+    printWrn("Explicit, Compact or Periodic triangulation detected.");
     printWrn("Defaulting to the FTM backend.");
 
     BackEnd = BACKEND::FTM;

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -540,20 +540,13 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
 template <class triangulationType>
 void ttk::ScalarFieldCriticalPoints::checkProgressivityRequirement(
   const triangulationType *ttkNotUsed(triangulation)) {
-  if(BackEnd == BACKEND::PROGRESSIVE_TOPOLOGY) {
-    if(std::is_same<triangulationType, ttk::CompactTriangulation>::value) {
+  if(BackEnd == BACKEND::PROGRESSIVE_TOPOLOGY
+     && !std::is_same<ttk::ImplicitWithPreconditions, triangulationType>::value
+     && !std::is_same<ttk::ImplicitNoPreconditions, triangulationType>::value) {
 
-      printWrn("CompactTriangulation detected.");
-      printWrn("Defaulting to the generic backend.");
+    printWrn("Explicit, Compact or Periodic triangulation detected.");
+    printWrn("Defaulting to the generic backend.");
 
-      BackEnd = BACKEND::GENERIC;
-    } else if(!std::is_base_of<ttk::ImplicitTriangulation,
-                               triangulationType>::value) {
-
-      printWrn("Explicit triangulation detected.");
-      printWrn("Defaulting to the generic backend.");
-
-      BackEnd = BACKEND::GENERIC;
-    }
+    BackEnd = BACKEND::GENERIC;
   }
 }

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -137,15 +137,21 @@ using ttkSimplexIdTypeArray = vtkIntArray;
     call;                                          \
   } break;
 
-#define ttkTypeMacroT(group, call)                                 \
-  switch(group) {                                                  \
-    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,           \
-                     ttk::ExplicitTriangulation, 0, call);         \
-    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,           \
-                     ttk::ImplicitTriangulation, 0, call);         \
-    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,           \
-                     ttk::PeriodicImplicitTriangulation, 0, call); \
-    ttkTypeMacroErrorCase(0, group);                               \
+#define ttkTypeMacroT(group, call)                                            \
+  switch(group) {                                                             \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,                      \
+                     ttk::ExplicitTriangulation, 0, call);                    \
+    ttkTypeMacroCase(                                                         \
+      ttk::Triangulation::Type::COMPACT, ttk::CompactTriangulation, 0, call); \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,                      \
+                     ttk::ImplicitNoPreconditions, 0, call);                  \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_IMPLICIT,               \
+                     ttk::ImplicitWithPreconditions, 0, call);                \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,                      \
+                     ttk::PeriodicNoPreconditions, 0, call);                  \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_PERIODIC,               \
+                     ttk::PeriodicWithPreconditions, 0, call);                \
+    ttkTypeMacroErrorCase(0, group);                                          \
   }
 
 #define ttkTypeMacroR(group, call)                 \
@@ -187,46 +193,73 @@ using ttkSimplexIdTypeArray = vtkIntArray;
     ttkTypeMacroErrorCase(0, group);                                       \
   }
 
-#define ttkTypeMacroAT(group0, group1, call)                \
-  switch(group1) {                                          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
-                     ttk::ExplicitTriangulation, 1,         \
-                     ttkTypeMacroA(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
-                     ttk::ImplicitTriangulation, 1,         \
-                     ttkTypeMacroA(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
-                     ttk::PeriodicImplicitTriangulation, 1, \
-                     ttkTypeMacroA(group0, call));          \
-    ttkTypeMacroErrorCase(1, group1);                       \
+#define ttkTypeMacroAT(group0, group1, call)                    \
+  switch(group1) {                                              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,        \
+                     ttk::ExplicitTriangulation, 1,             \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::COMPACT,         \
+                     ttk::CompactTriangulation, 1,              \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,        \
+                     ttk::ImplicitNoPreconditions, 1,           \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_IMPLICIT, \
+                     ttk::ImplicitWithPreconditions, 1,         \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,        \
+                     ttk::PeriodicNoPreconditions, 1,           \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_PERIODIC, \
+                     ttk::PeriodicWithPreconditions, 1,         \
+                     ttkTypeMacroA(group0, call));              \
+    ttkTypeMacroErrorCase(1, group1);                           \
   }
 
-#define ttkTypeMacroRT(group0, group1, call)                \
-  switch(group1) {                                          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
-                     ttk::ExplicitTriangulation, 1,         \
-                     ttkTypeMacroR(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
-                     ttk::ImplicitTriangulation, 1,         \
-                     ttkTypeMacroR(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
-                     ttk::PeriodicImplicitTriangulation, 1, \
-                     ttkTypeMacroR(group0, call));          \
-    ttkTypeMacroErrorCase(1, group1);                       \
+#define ttkTypeMacroRT(group0, group1, call)                    \
+  switch(group1) {                                              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,        \
+                     ttk::ExplicitTriangulation, 1,             \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::COMPACT,         \
+                     ttk::CompactTriangulation, 1,              \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,        \
+                     ttk::ImplicitNoPreconditions, 1,           \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_IMPLICIT, \
+                     ttk::ImplicitWithPreconditions, 1,         \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,        \
+                     ttk::PeriodicNoPreconditions, 1,           \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_PERIODIC, \
+                     ttk::PeriodicWithPreconditions, 1,         \
+                     ttkTypeMacroR(group0, call));              \
+    ttkTypeMacroErrorCase(1, group1);                           \
   }
 
-#define ttkTypeMacroIT(group0, group1, call)                \
-  switch(group1) {                                          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,    \
-                     ttk::ExplicitTriangulation, 1,         \
-                     ttkTypeMacroI(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,    \
-                     ttk::ImplicitTriangulation, 1,         \
-                     ttkTypeMacroI(group0, call));          \
-    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,    \
-                     ttk::PeriodicImplicitTriangulation, 1, \
-                     ttkTypeMacroI(group0, call));          \
-    ttkTypeMacroErrorCase(1, group1);                       \
+#define ttkTypeMacroIT(group0, group1, call)                    \
+  switch(group1) {                                              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,        \
+                     ttk::ExplicitTriangulation, 1,             \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::COMPACT,         \
+                     ttk::CompactTriangulation, 1,              \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::IMPLICIT,        \
+                     ttk::ImplicitNoPreconditions, 1,           \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_IMPLICIT, \
+                     ttk::ImplicitWithPreconditions, 1,         \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::PERIODIC,        \
+                     ttk::PeriodicNoPreconditions, 1,           \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroCase(ttk::Triangulation::Type::HYBRID_PERIODIC, \
+                     ttk::PeriodicWithPreconditions, 1,         \
+                     ttkTypeMacroI(group0, call));              \
+    ttkTypeMacroErrorCase(1, group1);                           \
   }
 
 #define ttkTypeMacroAI(group0, group1, call)                                  \

--- a/core/vtk/ttkAlgorithm/ttkMacros.h
+++ b/core/vtk/ttkAlgorithm/ttkMacros.h
@@ -193,6 +193,27 @@ using ttkSimplexIdTypeArray = vtkIntArray;
     ttkTypeMacroErrorCase(0, group);                                       \
   }
 
+#ifdef TTK_REDUCE_TEMPLATE_INSTANTIATIONS
+// reduced list of template instantiations by redefining ttkTypeMacroI
+// & ttkTypeMacroA
+#undef ttkTypeMacroI
+#define ttkTypeMacroI(group, call)                       \
+  switch(group) {                                        \
+    ttkTypeMacroCase(VTK_INT, int, 0, call);             \
+    ttkTypeMacroCase(VTK_LONG_LONG, long long, 0, call); \
+    ttkTypeMacroErrorCase(0, group);                     \
+  }
+#undef ttkTypeMacroA
+#define ttkTypeMacroA(group, call)                       \
+  switch(group) {                                        \
+    ttkTypeMacroCase(VTK_FLOAT, float, 0, call);         \
+    ttkTypeMacroCase(VTK_DOUBLE, double, 0, call);       \
+    ttkTypeMacroCase(VTK_INT, int, 0, call);             \
+    ttkTypeMacroCase(VTK_LONG_LONG, long long, 0, call); \
+    ttkTypeMacroErrorCase(0, group);                     \
+  }
+#endif // TTK_REDUCE_TEMPLATE_INSTANTIATIONS
+
 #define ttkTypeMacroAT(group0, group1, call)                    \
   switch(group1) {                                              \
     ttkTypeMacroCase(ttk::Triangulation::Type::EXPLICIT,        \


### PR DESCRIPTION
Following #750, a drop in the implicit triangulation performance was detected. The performance loss seems to be coming from the 
use of virtual functions (preventing method inlining) and returning copies instead of references (due to inheritance).

This PR uses [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) to circumvent the use of virtual functions  and to allow to return either references or copies. The changes should restore the majority of the performance loss  (we should be at most 5% slower than before #750) and have been applied to `ImplicitTriangulation` and `PeriodicImplicitTriangulation`.

`ttkUtils`' macros, `PersistenceDiagram` and `ScalarFieldCriticalPoints` progressivity checks were updated to better take into account the new triangulations.

Enjoy,
Pierre