### PR TITLE
Fix GCC 12 includes

### DIFF
--- a/core/base/assignmentSolver/AssignmentMunkresImpl.h
+++ b/core/base/assignmentSolver/AssignmentMunkresImpl.h
@@ -2,6 +2,8 @@
 
 #include <AssignmentMunkres.h>
 
+#include <tuple>
+
 template <typename dataType>
 int ttk::AssignmentMunkres<dataType>::run(
   std::vector<asgnMatchingTuple> &matchings) {

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -11,10 +11,10 @@
 // base code includes
 #include <Debug.h>
 #include <Geometry.h> // for pow
+
 #include <algorithm>
-#include <cmath>
-#include <iostream>
 #include <limits>
+#include <memory>
 
 namespace ttk {
   template <typename dataType>

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -1,6 +1,5 @@
 #include <RipsComplex.h>
 
-#include <array>
 #include <limits>
 
 ttk::RipsComplex::RipsComplex() {

--- a/core/base/ripsComplex/RipsComplex.h
+++ b/core/base/ripsComplex/RipsComplex.h
@@ -19,6 +19,8 @@
 
 #include <Debug.h>
 
+#include <array>
+
 namespace ttk {
 
   class RipsComplex : virtual public Debug {

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.h
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.h
@@ -3,8 +3,10 @@
 #include <ttkAlgorithmModule.h>
 
 #include <Debug.h>
-#include <unordered_map>
 #include <vtkType.h>
+
+#include <memory>
+#include <unordered_map>
 
 class vtkDataSet;
 class vtkImageData;


### PR DESCRIPTION
GCC 12 is now available in ArchLinux and, like every major GCC update, there are issues. This time, several includes were missing. Contrary to the GCC 10 -> 11 update (c.f. https://github.com/topology-tool-kit/ttk/pull/613), only TTK is affected this time (ParaView builds fine and ParaView headers are unaffected).

This PR adds the missing standard library includes to make it build correctly with GCC 12. Sadly, there's no way today to ensure that further PRs won't break the build since GCC 12 is not available yet in the GitHub Actions CI.

Enjoy,
Pierre