### PR TITLE
[MPI] Added MPI support for ScalarFieldNormalizer

### DIFF
--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -64,6 +64,15 @@ int ttkScalarFieldNormalizer::normalize(vtkDataArray *input,
     }
   }
 
+#ifdef TTK_ENABLE_MPI
+  if(ttk::isRunningWithMPI()) {
+    // if we are built with MPI and are running with MPI, we need to calculate
+    // the min and max over all ranks. we do this by using MPI_Allreduce
+    MPI_Allreduce(MPI_IN_PLACE, &min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+  }
+#endif
+
   for(SimplexId i = 0; i < input->GetNumberOfTuples(); i++) {
     double value = input->GetTuple1(i);
 


### PR DESCRIPTION
As discussed for one filter of low MPI communication, I have added simple MPI support for the ScalarFieldNormalizer filter. In addition, this could be seen as a minimal example how to check for:

1. whether TTK was build with MPI
2. whether TTK is running with MPI

Another note: the ScalarFieldNormalizer filter itself was, as far as I can see, written a long time ago and not really updated. Bringing it up to modern standards could be a PR by itself, then maybe for the dev branch.