### PR TITLE
TriangulationRequest: Extract simplices on domain boundary

### DIFF
--- a/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
+++ b/core/vtk/ttkTriangulationRequest/ttkTriangulationRequest.h
@@ -45,6 +45,7 @@ public:
     COMPUTE_COFACET = 2,
     COMPUTE_STAR = 3,
     COMPUTE_LINK = 4,
+    COMPUTE_BOUNDARY = 5,
   };
 
   static ttkTriangulationRequest *New();

--- a/paraview/xmls/TriangulationRequest.xml
+++ b/paraview/xmls/TriangulationRequest.xml
@@ -52,6 +52,13 @@
         number_of_elements="1"
         default_values="0"
         panel_visibility="default">
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="RequestType"
+                                   value="5"
+                                   inverse="1" />
+        </Hints>
         <Documentation>
           Output simplex identifiers (comma-separated list).
         </Documentation>
@@ -81,6 +88,7 @@
           <Entry value="2" text="Cofacet"/>
           <Entry value="3" text="Star"/>
           <Entry value="4" text="Link"/>
+          <Entry value="5" text="Domain Boundary"/>
         </EnumerationDomain>
         <Documentation>
           Output request.


### PR DESCRIPTION
This PR extends the `TriangulationRequests` filter to extract simplices on the domain boundary (or, for simplices of the highest dimension, the cells that have a face on the boundary). It leverages the `isVertexOnBoundary`, `isEdgeOnBoundary` & `isTriangleOnBoundary` Triangulation methods.

The goal of this PR is to get an alternative to the `FeatureEdges` ParaView filter, which has a way larger memory footprint, in the relevant ttk-data state files.

Enjoy,
Pierre