### PR TITLE
PersistenceDiagramClustering: Fix (VTU) format of centroids diagrams

### DIFF
--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -140,9 +140,8 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
   return distMat;
 }
 
-template <typename T>
 double PersistenceDiagramDistanceMatrix::getMostPersistent(
-  const std::vector<T> &bidder_diags) const {
+  const std::vector<BidderDiagram<double>> &bidder_diags) const {
 
   double max_persistence = 0;
 
@@ -158,10 +157,8 @@ double PersistenceDiagramDistanceMatrix::getMostPersistent(
   return max_persistence;
 }
 
-template <typename T>
-double
-  PersistenceDiagramDistanceMatrix::computePowerDistance(const T &D1,
-                                                         const T &D2) const {
+double PersistenceDiagramDistanceMatrix::computePowerDistance(
+  const BidderDiagram<double> &D1, const BidderDiagram<double> &D2) const {
 
   GoodDiagram<double> D2_bis{};
   for(int i = 0; i < D2.size(); i++) {
@@ -178,13 +175,12 @@ double
   return auction.run();
 }
 
-template <typename T>
 void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
   const std::array<size_t, 2> &nInputs,
   std::vector<std::vector<double>> &distanceMatrix,
-  const std::vector<T> &diags_min,
-  const std::vector<T> &diags_sad,
-  const std::vector<T> &diags_max) const {
+  const std::vector<BidderDiagram<double>> &diags_min,
+  const std::vector<BidderDiagram<double>> &diags_sad,
+  const std::vector<BidderDiagram<double>> &diags_max) const {
 
   distanceMatrix.resize(nInputs[0]);
 
@@ -244,11 +240,10 @@ void PersistenceDiagramDistanceMatrix::getDiagramsDistMat(
   }
 }
 
-template <typename T>
 void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   const size_t nInputs,
   std::vector<Diagram> &inputDiagrams,
-  std::vector<T> &bidder_diags) const {
+  std::vector<BidderDiagram<double>> &bidder_diags) const {
 
   bidder_diags.resize(nInputs);
 
@@ -269,10 +264,9 @@ void PersistenceDiagramDistanceMatrix::setBidderDiagrams(
   }
 }
 
-template <typename T>
 void PersistenceDiagramDistanceMatrix::enrichCurrentBidderDiagrams(
-  const std::vector<T> &bidder_diags,
-  std::vector<T> &current_bidder_diags,
+  const std::vector<BidderDiagram<double>> &bidder_diags,
+  std::vector<BidderDiagram<double>> &current_bidder_diags,
   const std::vector<double> &maxDiagPersistence) const {
 
   current_bidder_diags.resize(bidder_diags.size());

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.h
@@ -50,6 +50,11 @@ namespace ttk {
 
   using Diagram = std::vector<DiagramTuple>;
 
+  // forward declaration
+  // (keeps the #include <PersistenceDiagramAuction.h> inside the .cpp)
+  template <typename T>
+  class BidderDiagram;
+
   class PersistenceDiagramDistanceMatrix : virtual public Debug {
 
   public:
@@ -99,24 +104,23 @@ namespace ttk {
     }
 
   protected:
-    template <typename T>
-    double getMostPersistent(const std::vector<T> &bidder_diags) const;
-    template <typename T>
-    double computePowerDistance(const T &D1, const T &D2) const;
-    template <typename T>
-    void getDiagramsDistMat(const std::array<size_t, 2> &nInputs,
-                            std::vector<std::vector<double>> &distanceMatrix,
-                            const std::vector<T> &diags_min,
-                            const std::vector<T> &diags_sad,
-                            const std::vector<T> &diags_max) const;
-    template <typename T>
-    void setBidderDiagrams(const size_t nInputs,
-                           std::vector<Diagram> &inputDiagrams,
-                           std::vector<T> &bidder_diags) const;
-    template <typename T>
+    double getMostPersistent(
+      const std::vector<BidderDiagram<double>> &bidder_diags) const;
+    double computePowerDistance(const BidderDiagram<double> &D1,
+                                const BidderDiagram<double> &D2) const;
+    void getDiagramsDistMat(
+      const std::array<size_t, 2> &nInputs,
+      std::vector<std::vector<double>> &distanceMatrix,
+      const std::vector<BidderDiagram<double>> &diags_min,
+      const std::vector<BidderDiagram<double>> &diags_sad,
+      const std::vector<BidderDiagram<double>> &diags_max) const;
+    void
+      setBidderDiagrams(const size_t nInputs,
+                        std::vector<Diagram> &inputDiagrams,
+                        std::vector<BidderDiagram<double>> &bidder_diags) const;
     void enrichCurrentBidderDiagrams(
-      const std::vector<T> &bidder_diags,
-      std::vector<T> &current_bidder_diags,
+      const std::vector<BidderDiagram<double>> &bidder_diags,
+      std::vector<BidderDiagram<double>> &current_bidder_diags,
       const std::vector<double> &maxDiagPersistence) const;
 
     int Wasserstein{2};


### PR DESCRIPTION
This PR adds missing data arrays to the centroids diagrams of the `PersistenceDiagramClustering` filter. These data arrays have been missing following since #745. This is needed for instance to compute the distance matrix between centroids.

In a second commit, as a follow-up to #717, I modified the base module API of the `PersistenceDiagramDistanceMatrix` module to replace obscure template parameters with fully-qualified types using forward declaration. This helps readability while keeping the dependency to the `Auction` module in the .cpp file.

Enjoy,
Pierre