### PR TITLE
Smoothers: Also use current vertex value

### DIFF
--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -115,16 +115,16 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
         continue;
 
       for(int j = 0; j < dimensionNumber_; j++) {
-        tmpData[dimensionNumber_ * i + j] = 0;
+        const auto curr{dimensionNumber_ * i + j};
+        tmpData[curr] = outputData[curr];
 
-        SimplexId neighborNumber = triangulation->getVertexNeighborNumber(i);
+        const auto neighborNumber = triangulation->getVertexNeighborNumber(i);
         for(SimplexId k = 0; k < neighborNumber; k++) {
           SimplexId neighborId = -1;
           triangulation->getVertexNeighbor(i, k, neighborId);
-          tmpData[dimensionNumber_ * i + j]
-            += outputData[dimensionNumber_ * (neighborId) + j];
+          tmpData[curr] += outputData[dimensionNumber_ * (neighborId) + j];
         }
-        tmpData[dimensionNumber_ * i + j] /= ((double)neighborNumber);
+        tmpData[curr] /= static_cast<double>(neighborNumber + 1);
       }
     }
 

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
@@ -137,14 +137,14 @@ namespace ttk {
       relax(const SimplexId a,
             std::vector<ttk::SurfaceGeometrySmoother::Point> &outputPoints,
             const triangulationType &triangulationToSmooth) const {
-      Point relaxed{};
+      Point relaxed{outputPoints[a]};
       const auto nneigh{triangulationToSmooth.getVertexNeighborNumber(a)};
       for(SimplexId i = 0; i < nneigh; ++i) {
         SimplexId neigh{};
         triangulationToSmooth.getVertexNeighbor(a, i, neigh);
         relaxed = relaxed + outputPoints[neigh];
       }
-      return relaxed * (1.0F / static_cast<float>(nneigh));
+      return relaxed * (1.0F / static_cast<float>(nneigh + 1));
     }
 
     /**


### PR DESCRIPTION
This PR alters the `ScalarFieldSmoother`, `GeometrySmoother` and `SurfaceGeometrySmoother` filters by extending the sliding window on vertices to also take the current vertex into account (currently only the neighbors scalar field values/coordinates are used).

While these modifications may reduce the effect of individual iterations, it fixes instabilities in 1D when points/scalar field follow a triangle wave pattern: `/\/\/\` currently becomes `\/\/\/` at the next `GeometrySmoother`/`ScalarFieldSmoother` iteration. 

With this PR, the filters should behave closer to traditional mean filters.

Since these filters are largely used in the ttk-data state files & Python scripts, errors in the relevant CI workflow are expected (and should be fixed in a further ttk-data PR).

Enjoy,
Pierre
