### PR TITLE
Merge Tree filters new input format

### DIFF
--- a/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
@@ -85,23 +85,33 @@ namespace ttk {
       return mergeTree;
     }
 
-    inline void loadBlocks(std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                           vtkMultiBlockDataSet *blocks) {
+    inline void
+      loadBlocks(std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+                 vtkMultiBlockDataSet *blocks) {
       if(blocks != nullptr) {
-        inputTrees.resize(blocks->GetNumberOfBlocks());
+        inputTrees.resize(
+          vtkMultiBlockDataSet::SafeDownCast(blocks->GetBlock(0))
+            ->GetNumberOfBlocks());
         for(size_t i = 0; i < inputTrees.size(); ++i) {
-          inputTrees[i]
-            = vtkMultiBlockDataSet::SafeDownCast(blocks->GetBlock(i));
+          vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock
+            = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+          vtkBlock->SetNumberOfBlocks(blocks->GetNumberOfBlocks());
+          for(unsigned int j = 0; j < blocks->GetNumberOfBlocks(); ++j)
+            vtkBlock->SetBlock(
+              j, vtkMultiBlockDataSet::SafeDownCast(blocks->GetBlock(j))
+                   ->GetBlock(i));
+          inputTrees[i] = vtkBlock;
         }
       }
     }
 
     template <class dataType>
-    void constructTrees(std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                        std::vector<MergeTree<dataType>> &intermediateTrees,
-                        std::vector<vtkUnstructuredGrid *> &treesNodes,
-                        std::vector<vtkUnstructuredGrid *> &treesArcs,
-                        std::vector<vtkDataSet *> &treesSegmentation) {
+    void constructTrees(
+      std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+      std::vector<MergeTree<dataType>> &intermediateTrees,
+      std::vector<vtkUnstructuredGrid *> &treesNodes,
+      std::vector<vtkUnstructuredGrid *> &treesArcs,
+      std::vector<vtkDataSet *> &treesSegmentation) {
       const int numInputs = inputTrees.size();
       intermediateTrees = std::vector<MergeTree<dataType>>(numInputs);
       treesNodes = std::vector<vtkUnstructuredGrid *>(numInputs);
@@ -120,8 +130,9 @@ namespace ttk {
     }
 
     template <class dataType>
-    void constructTrees(std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                        std::vector<MergeTree<dataType>> &intermediateTrees) {
+    void constructTrees(
+      std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+      std::vector<MergeTree<dataType>> &intermediateTrees) {
       std::vector<vtkUnstructuredGrid *> treesNodes;
       std::vector<vtkUnstructuredGrid *> treesArcs;
       std::vector<vtkDataSet *> treesSegmentation;

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -714,12 +714,12 @@ int ttkMergeTreeClustering::runOutput(
             = vtkSmartPointer<vtkUnstructuredGrid>::New();
           vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode1
             = vtkUnstructuredGrid::SafeDownCast(
-              vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(i))
-                ->GetBlock(0));
+              vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(0))
+                ->GetBlock(i));
           vtkSmartPointer<vtkUnstructuredGrid> vtkOutputNode2
             = vtkUnstructuredGrid::SafeDownCast(
-              vtkMultiBlockDataSet::SafeDownCast(output_centroids->GetBlock(c))
-                ->GetBlock(0));
+              vtkMultiBlockDataSet::SafeDownCast(output_centroids->GetBlock(0))
+                ->GetBlock(c));
 
           // Fill vtk objects
           ttkMergeTreeVisualization visuMakerMatching;

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -390,9 +390,11 @@ int ttkMergeTreeClustering::runOutput(
       vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation2
         = vtkSmartPointer<vtkUnstructuredGrid>::New();
 
-      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock1
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockNodes
         = vtkSmartPointer<vtkMultiBlockDataSet>::New();
-      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock2
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockArcs
+        = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockSegs
         = vtkSmartPointer<vtkMultiBlockDataSet>::New();
 
       // Fill vtk objects
@@ -445,25 +447,37 @@ int ttkMergeTreeClustering::runOutput(
       nodeCorr.push_back(visuMaker.getNodeCorr()[0]);
 
       // Field data
-      vtkBlock1->GetFieldData()->ShallowCopy(inputTrees[0]->GetFieldData());
-      vtkBlock2->GetFieldData()->ShallowCopy(inputTrees[1]->GetFieldData());
+      vtkOutputNode1->GetFieldData()->ShallowCopy(
+        treesNodes[0]->GetFieldData());
+      vtkOutputNode2->GetFieldData()->ShallowCopy(
+        treesNodes[1]->GetFieldData());
+      vtkOutputArc1->GetFieldData()->ShallowCopy(treesArcs[0]->GetFieldData());
+      vtkOutputArc2->GetFieldData()->ShallowCopy(treesArcs[1]->GetFieldData());
+      if(OutputSegmentation) {
+        vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
+          treesSegmentation[0]->GetFieldData());
+        vtkOutputSegmentation2->GetFieldData()->ShallowCopy(
+          treesSegmentation[1]->GetFieldData());
+      }
 
       // Construct multiblock
-      vtkBlock1->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
-      vtkBlock1->SetBlock(0, vtkOutputNode1);
-      vtkBlock1->SetBlock(1, vtkOutputArc1);
-      if(OutputSegmentation)
-        vtkBlock1->SetBlock(2, vtkOutputSegmentation1);
+      vtkBlockNodes->SetNumberOfBlocks(2);
+      vtkBlockNodes->SetBlock(0, vtkOutputNode1);
+      vtkBlockNodes->SetBlock(1, vtkOutputNode2);
 
-      vtkBlock2->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
-      vtkBlock2->SetBlock(0, vtkOutputNode2);
-      vtkBlock2->SetBlock(1, vtkOutputArc2);
-      if(OutputSegmentation)
-        vtkBlock2->SetBlock(2, vtkOutputSegmentation2);
+      vtkBlockArcs->SetNumberOfBlocks(2);
+      vtkBlockArcs->SetBlock(0, vtkOutputArc1);
+      vtkBlockArcs->SetBlock(1, vtkOutputArc2);
 
-      output_clusters->SetNumberOfBlocks(2);
-      output_clusters->SetBlock(0, vtkBlock1);
-      output_clusters->SetBlock(1, vtkBlock2);
+      output_clusters->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
+      output_clusters->SetBlock(0, vtkBlockNodes);
+      output_clusters->SetBlock(1, vtkBlockArcs);
+      if(OutputSegmentation) {
+        vtkBlockSegs->SetNumberOfBlocks(2);
+        vtkBlockSegs->SetBlock(0, vtkOutputSegmentation1);
+        vtkBlockSegs->SetBlock(1, vtkOutputSegmentation2);
+        output_clusters->SetBlock(2, vtkBlockSegs);
+      }
 
       // ------------------------------------------
       // --- Matching
@@ -508,7 +522,21 @@ int ttkMergeTreeClustering::runOutput(
       // ------------------------------------------
       // --- Input trees
       // ------------------------------------------
-      output_clusters->SetNumberOfBlocks(numInputs);
+      output_clusters->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockNodes
+        = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+      vtkBlockNodes->SetNumberOfBlocks(numInputs);
+      output_clusters->SetBlock(0, vtkBlockNodes);
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockArcs
+        = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+      vtkBlockArcs->SetNumberOfBlocks(numInputs);
+      output_clusters->SetBlock(1, vtkBlockArcs);
+      if(OutputSegmentation) {
+        vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockSegs
+          = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+        vtkBlockSegs->SetNumberOfBlocks(numInputs);
+        output_clusters->SetBlock(2, vtkBlockSegs);
+      }
       for(unsigned int c = 0; c < NumberOfBarycenters; ++c) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
@@ -524,8 +552,6 @@ int ttkMergeTreeClustering::runOutput(
             = vtkSmartPointer<vtkUnstructuredGrid>::New();
           vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation1
             = vtkSmartPointer<vtkUnstructuredGrid>::New();
-          vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock1
-            = vtkSmartPointer<vtkMultiBlockDataSet>::New();
 
           // Fill vtk objects
           ttkMergeTreeVisualization visuMaker;
@@ -564,27 +590,47 @@ int ttkMergeTreeClustering::runOutput(
           nodeCorr[i] = nodeCorrT[i];
 
           // Field data
-          vtkBlock1->GetFieldData()->ShallowCopy(inputTrees[i]->GetFieldData());
           vtkNew<vtkDoubleArray> vtkClusterAssignment{};
           vtkClusterAssignment->SetName("ClusterAssignment");
           vtkClusterAssignment->SetNumberOfTuples(1);
           vtkClusterAssignment->SetTuple1(0, clusteringAssignment[i]);
-          vtkBlock1->GetFieldData()->AddArray(vtkClusterAssignment);
+
+          vtkOutputNode1->GetFieldData()->ShallowCopy(
+            treesNodes[i]->GetFieldData());
+          vtkOutputNode1->GetFieldData()->AddArray(vtkClusterAssignment);
+          vtkOutputArc1->GetFieldData()->ShallowCopy(
+            treesArcs[i]->GetFieldData());
+          vtkOutputArc1->GetFieldData()->AddArray(vtkClusterAssignment);
+          if(OutputSegmentation) {
+            vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
+              treesSegmentation[i]->GetFieldData());
+            vtkOutputSegmentation1->GetFieldData()->AddArray(
+              vtkClusterAssignment);
+          }
 
           // Construct multiblock
-          vtkBlock1->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
-          vtkBlock1->SetBlock(0, vtkOutputNode1);
-          vtkBlock1->SetBlock(1, vtkOutputArc1);
+          vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(0))
+            ->SetBlock(i, vtkOutputNode1);
+          vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(1))
+            ->SetBlock(i, vtkOutputArc1);
           if(OutputSegmentation)
-            vtkBlock1->SetBlock(2, vtkOutputSegmentation1);
-          output_clusters->SetBlock(i, vtkBlock1);
+            vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(2))
+              ->SetBlock(i, vtkOutputSegmentation1);
         }
       }
 
       // ------------------------------------------
       // --- Barycenter(s)
       // ------------------------------------------
-      output_centroids->SetNumberOfBlocks(NumberOfBarycenters);
+      output_centroids->SetNumberOfBlocks(2);
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockNodes2
+        = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+      vtkBlockNodes2->SetNumberOfBlocks(NumberOfBarycenters);
+      output_centroids->SetBlock(0, vtkBlockNodes2);
+      vtkSmartPointer<vtkMultiBlockDataSet> vtkBlockArcs2
+        = vtkSmartPointer<vtkMultiBlockDataSet>::New();
+      vtkBlockArcs2->SetNumberOfBlocks(NumberOfBarycenters);
+      output_centroids->SetBlock(1, vtkBlockArcs2);
       for(unsigned int c = 0; c < NumberOfBarycenters; ++c) {
 
         // Declare vtk objects
@@ -594,8 +640,6 @@ int ttkMergeTreeClustering::runOutput(
           = vtkSmartPointer<vtkUnstructuredGrid>::New();
         vtkSmartPointer<vtkUnstructuredGrid> vtkOutputSegmentation2
           = vtkSmartPointer<vtkUnstructuredGrid>::New();
-        vtkSmartPointer<vtkMultiBlockDataSet> vtkBlock2
-          = vtkSmartPointer<vtkMultiBlockDataSet>::New();
 
         // Fill vtk objects
         ttkMergeTreeVisualization visuMakerBary;
@@ -645,15 +689,15 @@ int ttkMergeTreeClustering::runOutput(
         vtkClusterAssignment->SetName("ClusterAssignment");
         vtkClusterAssignment->SetNumberOfTuples(1);
         vtkClusterAssignment->SetTuple1(0, c);
-        vtkBlock2->GetFieldData()->AddArray(vtkClusterAssignment);
+
+        vtkOutputNode2->GetFieldData()->AddArray(vtkClusterAssignment);
+        vtkOutputArc2->GetFieldData()->AddArray(vtkClusterAssignment);
 
         // Construct multiblock
-        vtkBlock2->SetNumberOfBlocks((OutputSegmentation ? 3 : 2));
-        vtkBlock2->SetBlock(0, vtkOutputNode2);
-        vtkBlock2->SetBlock(1, vtkOutputArc2);
-        if(OutputSegmentation)
-          vtkBlock2->SetBlock(2, vtkOutputSegmentation2);
-        output_centroids->SetBlock(c, vtkBlock2);
+        vtkMultiBlockDataSet::SafeDownCast(output_centroids->GetBlock(0))
+          ->SetBlock(c, vtkOutputNode2);
+        vtkMultiBlockDataSet::SafeDownCast(output_centroids->GetBlock(1))
+          ->SetBlock(c, vtkOutputArc2);
       }
 
       // ------------------------------------------

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -121,7 +121,7 @@ int ttkMergeTreeClustering::RequestData(vtkInformation *ttkNotUsed(request),
   // ------------------------------------------------------------------------------------
   // --- Load blocks
   // ------------------------------------------------------------------------------------
-  std::vector<vtkMultiBlockDataSet *> inputTrees, inputTrees2;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees, inputTrees2;
   loadBlocks(inputTrees, blocks);
   loadBlocks(inputTrees2, blocks2);
   int dataTypeInt
@@ -144,8 +144,8 @@ int ttkMergeTreeClustering::RequestData(vtkInformation *ttkNotUsed(request),
 template <class dataType>
 int ttkMergeTreeClustering::run(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees2) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2) {
   if(not isDataVisualizationFilled())
     runCompute<dataType>(outputVector, inputTrees, inputTrees2);
   runOutput<dataType>(outputVector, inputTrees, inputTrees2);
@@ -155,8 +155,8 @@ int ttkMergeTreeClustering::run(
 template <class dataType>
 int ttkMergeTreeClustering::runCompute(
   vtkInformationVector *ttkNotUsed(outputVector),
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees2) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2) {
   // ------------------------------------------------------------------------------------
   // --- Construct trees
   // ------------------------------------------------------------------------------------
@@ -341,8 +341,8 @@ int ttkMergeTreeClustering::runCompute(
 template <class dataType>
 int ttkMergeTreeClustering::runOutput(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
-  std::vector<vtkMultiBlockDataSet *> &ttkNotUsed(inputTrees2)) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &ttkNotUsed(inputTrees2)) {
   std::vector<MergeTree<dataType>> intermediateMTrees;
   mergeTreesDoubleToTemplate<dataType>(intermediateSTrees, intermediateMTrees);
   std::vector<FTMTree_MT *> intermediateTrees;

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -19,7 +19,6 @@
 #include <vtkInformationVector.h>
 #include <vtkMultiBlockDataSet.h>
 #include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 #include <string>

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -590,23 +590,19 @@ int ttkMergeTreeClustering::runOutput(
           nodeCorr[i] = nodeCorrT[i];
 
           // Field data
+          vtkOutputNode1->GetFieldData()->ShallowCopy(
+            treesNodes[i]->GetFieldData());
+          vtkOutputArc1->GetFieldData()->ShallowCopy(
+            treesArcs[i]->GetFieldData());
+          if(OutputSegmentation)
+            vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
+              treesSegmentation[i]->GetFieldData());
+
           vtkNew<vtkDoubleArray> vtkClusterAssignment{};
           vtkClusterAssignment->SetName("ClusterAssignment");
           vtkClusterAssignment->SetNumberOfTuples(1);
           vtkClusterAssignment->SetTuple1(0, clusteringAssignment[i]);
-
-          vtkOutputNode1->GetFieldData()->ShallowCopy(
-            treesNodes[i]->GetFieldData());
           vtkOutputNode1->GetFieldData()->AddArray(vtkClusterAssignment);
-          vtkOutputArc1->GetFieldData()->ShallowCopy(
-            treesArcs[i]->GetFieldData());
-          vtkOutputArc1->GetFieldData()->AddArray(vtkClusterAssignment);
-          if(OutputSegmentation) {
-            vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
-              treesSegmentation[i]->GetFieldData());
-            vtkOutputSegmentation1->GetFieldData()->AddArray(
-              vtkClusterAssignment);
-          }
 
           // Construct multiblock
           vtkMultiBlockDataSet::SafeDownCast(output_clusters->GetBlock(0))

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -427,16 +427,18 @@ protected:
 
   template <class dataType>
   int run(vtkInformationVector *outputVector,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees2);
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2);
 
   template <class dataType>
-  int runCompute(vtkInformationVector *outputVector,
-                 std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                 std::vector<vtkMultiBlockDataSet *> &inputTrees2);
+  int runCompute(
+    vtkInformationVector *outputVector,
+    std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+    std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2);
 
   template <class dataType>
-  int runOutput(vtkInformationVector *outputVector,
-                std::vector<vtkMultiBlockDataSet *> &inputTrees,
-                std::vector<vtkMultiBlockDataSet *> &inputTrees2);
+  int runOutput(
+    vtkInformationVector *outputVector,
+    std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+    std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2);
 };

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -42,6 +42,7 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 #include <vtkMultiBlockDataSet.h>
+#include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
 
 // TTK Base Includes

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -96,8 +96,8 @@ int ttkMergeTreeDistanceMatrix::FillOutputPortInformation(
 template <class dataType>
 int ttkMergeTreeDistanceMatrix::run(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees2) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2) {
 
   // Construct trees
   const int numInputs = inputTrees.size();
@@ -192,7 +192,7 @@ int ttkMergeTreeDistanceMatrix::RequestData(
   auto blocks2 = vtkMultiBlockDataSet::GetData(inputVector[1], 0);
 
   // --- Load blocks
-  std::vector<vtkMultiBlockDataSet *> inputTrees, inputTrees2;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees, inputTrees2;
   loadBlocks(inputTrees, blocks);
   loadBlocks(inputTrees2, blocks2);
 

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -8,6 +8,7 @@
 
 #include <vtkDoubleArray.h>
 #include <vtkInformation.h>
+#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 using namespace ttk;

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -169,10 +169,10 @@ int ttkMergeTreeDistanceMatrix::run(
 
   // aggregate input field data
   vtkNew<vtkFieldData> fd{};
-  fd->CopyStructure(inputTrees[0]->GetFieldData());
+  fd->CopyStructure(inputTrees[0]->GetBlock(0)->GetFieldData());
   fd->SetNumberOfTuples(inputTrees.size());
   for(size_t i = 0; i < inputTrees.size(); ++i) {
-    fd->SetTuple(i, 0, inputTrees[i]->GetFieldData());
+    fd->SetTuple(i, 0, inputTrees[i]->GetBlock(0)->GetFieldData());
   }
 
   // copy input field data to output row data

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -8,7 +8,6 @@
 
 #include <vtkDoubleArray.h>
 #include <vtkInformation.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 using namespace ttk;

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -33,6 +33,7 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 #include <vtkMultiBlockDataSet.h>
+#include <vtkSmartPointer.h>
 
 // TTK Base Includes
 #include <MergeTreeDistanceMatrix.h>

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -190,6 +190,6 @@ protected:
 
   template <class dataType>
   int run(vtkInformationVector *outputVector,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees2);
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees2);
 };

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -98,8 +98,8 @@ public:
     return persistenceThreshold_;
   }
 
-  void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
-    deleteMultiPersPairs_ = deleteMultiPersPairs;
+  void SetDeleteMultiPersPairs(bool doDelete) {
+    deleteMultiPersPairs_ = doDelete;
     Modified();
   }
   bool SetDeleteMultiPersPairs() {

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -9,7 +9,6 @@
 #include <vtkDataSet.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 #include <ttkMacros.h>

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -199,7 +199,7 @@ int ttkMergeTreeTemporalReductionDecoding::runCompute(
   for(size_t i = 0; i < allMT_T.size(); ++i) {
     MergeTree<double> tree;
     mergeTreeTemplateToDouble<dataType>(allMT_T[i], tree);
-    intermediateSTrees.push_back(tree);
+    intermediateSTrees.emplace_back(tree);
   }
 
   return 1;
@@ -230,18 +230,18 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
   size_t cpt = 0;
   while(cpt < coefs.size()) {
     while(cpt < coefs.size() and std::get<2>(coefs[cpt]) <= index) {
-      treesNodesT.push_back(nullptr);
-      treesArcsT.push_back(nullptr);
-      treesSegmentationT.push_back(nullptr);
+      treesNodesT.emplace_back(nullptr);
+      treesArcsT.emplace_back(nullptr);
+      treesSegmentationT.emplace_back(nullptr);
       treesNodeCorrMeshT.emplace_back();
-      inputTreesT.push_back(nullptr);
+      inputTreesT.emplace_back(nullptr);
       ++cpt;
     }
-    treesNodesT.push_back(treesNodes[index]);
-    treesArcsT.push_back(treesArcs[index]);
-    treesSegmentationT.push_back(treesSegmentation[index]);
-    treesNodeCorrMeshT.push_back(treesNodeCorrMesh[index]);
-    inputTreesT.push_back(inputTrees[index]);
+    treesNodesT.emplace_back(treesNodes[index]);
+    treesArcsT.emplace_back(treesArcs[index]);
+    treesSegmentationT.emplace_back(treesSegmentation[index]);
+    treesNodeCorrMeshT.emplace_back(treesNodeCorrMesh[index]);
+    inputTreesT.emplace_back(inputTrees[index]);
     ++index;
   }
   treesNodes.swap(treesNodesT);
@@ -386,8 +386,8 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
         vtkMultiBlockDataSet::SafeDownCast(output_sequence->GetBlock(0))
           ->GetBlock(i + 1));
     std::vector<std::vector<SimplexId>> nodeCorrTemp;
-    nodeCorrTemp.push_back(nodeCorr[i]);
-    nodeCorrTemp.push_back(nodeCorr[i + 1]);
+    nodeCorrTemp.emplace_back(nodeCorr[i]);
+    nodeCorrTemp.emplace_back(nodeCorr[i + 1]);
 
     // Fill vtk objects
     ttkMergeTreeVisualization visuMakerMatching;

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -112,7 +112,7 @@ int ttkMergeTreeTemporalReductionDecoding::RequestData(
   // --- Load blocks
   // ------------------------------------------------------------------------------------
   printMsg("Load Blocks", debug::Priority::VERBOSE);
-  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees;
   loadBlocks(inputTrees, blocks);
   printMsg("Load Blocks done.", debug::Priority::VERBOSE);
   int dataTypeInt
@@ -160,7 +160,7 @@ int ttkMergeTreeTemporalReductionDecoding::RequestData(
 template <class dataType>
 int ttkMergeTreeTemporalReductionDecoding::run(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
   std::vector<std::tuple<double, int, int, int, int>> &coefs,
   std::vector<bool> &interpolatedTrees) {
   if(not isDataVisualizationFilled())
@@ -171,7 +171,7 @@ int ttkMergeTreeTemporalReductionDecoding::run(
 
 template <class dataType>
 int ttkMergeTreeTemporalReductionDecoding::runCompute(
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
   std::vector<std::tuple<double, int, int, int, int>> &coefs) {
   // ------------------------------------------------------------------------------------
   // --- Construct trees
@@ -208,7 +208,7 @@ int ttkMergeTreeTemporalReductionDecoding::runCompute(
 template <class dataType>
 int ttkMergeTreeTemporalReductionDecoding::runOutput(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
   std::vector<std::tuple<double, int, int, int, int>> &coefs,
   std::vector<bool> &interpolatedTrees) {
   // ------------------------------------------------------------------------------------
@@ -224,7 +224,7 @@ int ttkMergeTreeTemporalReductionDecoding::runOutput(
   std::vector<vtkUnstructuredGrid *> treesArcsT;
   std::vector<vtkDataSet *> treesSegmentationT;
   std::vector<std::vector<int>> treesNodeCorrMeshT;
-  std::vector<vtkMultiBlockDataSet *> inputTreesT;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTreesT;
   int index = 0;
   size_t cpt = 0;
   while(cpt < coefs.size()) {

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -227,17 +227,17 @@ protected:
 
   template <class dataType>
   int run(vtkInformationVector *outputVector,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees,
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
           std::vector<std::tuple<double, int, int, int, int>> &coefs,
           std::vector<bool> &interpolatedTrees);
 
   template <class dataType>
-  int runCompute(std::vector<vtkMultiBlockDataSet *> &inputTrees,
+  int runCompute(std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
                  std::vector<std::tuple<double, int, int, int, int>> &coefs);
 
   template <class dataType>
   int runOutput(vtkInformationVector *outputVector,
-                std::vector<vtkMultiBlockDataSet *> &inputTrees,
+                std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees,
                 std::vector<std::tuple<double, int, int, int, int>> &coefs,
                 std::vector<bool> &interpolatedTrees);
 };

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.h
@@ -40,6 +40,7 @@
 
 // VTK Includes
 #include <ttkAlgorithm.h>
+#include <vtkSmartPointer.h>
 
 /* Note on including VTK modules
  *

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -11,7 +11,6 @@
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkResampleToImage.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 #include <ttkMacros.h>

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -153,11 +153,11 @@ std::vector<vtkSmartPointer<vtkDataSet>>
       // images.push_back(resampleFilterOut);
       vtkSmartPointer<vtkDataSet> image = vtkSmartPointer<vtkImageData>::New();
       image->DeepCopy(resampleFilterOut);
-      images.push_back(image);
+      images.emplace_back(image);
     } else {
       vtkSmartPointer<vtkDataSet> image;
       image.TakeReference(treesSegmentation[i]);
-      images.push_back(image);
+      images.emplace_back(image);
     }
   }
   return images;
@@ -186,7 +186,7 @@ int ttkMergeTreeTemporalReductionEncoding::runCompute(
     for(size_t i = 0; i < images.size(); ++i) {
       auto array = images[i]->GetPointData()->GetArray("Scalars");
       for(vtkIdType j = 0; j < array->GetNumberOfTuples(); ++j)
-        fieldL2_[i].push_back(array->GetTuple1(j));
+        fieldL2_[i].emplace_back(array->GetTuple1(j));
     }
   }
 
@@ -223,7 +223,7 @@ int ttkMergeTreeTemporalReductionEncoding::runCompute(
     if((int)i != removed[indexRemoved]) {
       MergeTree<double> keyFrame;
       mergeTreeTemplateToDouble<dataType>(intermediateMTrees[i], keyFrame);
-      keyFrames.push_back(keyFrame);
+      keyFrames.emplace_back(keyFrame);
     } else
       ++indexRemoved;
   }
@@ -249,7 +249,7 @@ int ttkMergeTreeTemporalReductionEncoding::runOutput(
   int indexRemoved = 0;
   for(size_t i = 0; i < inputTrees.size(); ++i)
     if((int)i != removed[indexRemoved]) {
-      keyFramesIndex.push_back(i);
+      keyFramesIndex.emplace_back(i);
     } else
       ++indexRemoved;
 
@@ -259,11 +259,11 @@ int ttkMergeTreeTemporalReductionEncoding::runOutput(
   std::vector<std::vector<int>> treesNodeCorrMeshT;
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTreesT;
   for(size_t i = 0; i < keyFramesIndex.size(); ++i) {
-    treesNodesT.push_back(treesNodes[keyFramesIndex[i]]);
-    treesArcsT.push_back(treesArcs[keyFramesIndex[i]]);
-    treesSegmentationT.push_back(treesSegmentation[keyFramesIndex[i]]);
-    treesNodeCorrMeshT.push_back(treesNodeCorrMesh[keyFramesIndex[i]]);
-    inputTreesT.push_back(inputTrees[keyFramesIndex[i]]);
+    treesNodesT.emplace_back(treesNodes[keyFramesIndex[i]]);
+    treesArcsT.emplace_back(treesArcs[keyFramesIndex[i]]);
+    treesSegmentationT.emplace_back(treesSegmentation[keyFramesIndex[i]]);
+    treesNodeCorrMeshT.emplace_back(treesNodeCorrMesh[keyFramesIndex[i]]);
+    inputTreesT.emplace_back(inputTrees[keyFramesIndex[i]]);
   }
   treesNodes.swap(treesNodesT);
   treesArcs.swap(treesArcsT);

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -105,7 +105,7 @@ int ttkMergeTreeTemporalReductionEncoding::RequestData(
   // --- Load blocks
   // ------------------------------------------------------------------------------------
   printMsg("Load blocks", ttk::debug::Priority::VERBOSE);
-  std::vector<vtkMultiBlockDataSet *> inputTrees;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees;
   loadBlocks(inputTrees, blocks);
   printMsg("Load blocks done.", debug::Priority::VERBOSE);
   int dataTypeInt
@@ -129,7 +129,7 @@ int ttkMergeTreeTemporalReductionEncoding::RequestData(
 template <class dataType>
 int ttkMergeTreeTemporalReductionEncoding::run(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees) {
   if(not isDataVisualizationFilled())
     runCompute<dataType>(inputTrees);
   runOutput<dataType>(outputVector, inputTrees);
@@ -165,7 +165,7 @@ std::vector<vtkSmartPointer<vtkDataSet>>
 
 template <class dataType>
 int ttkMergeTreeTemporalReductionEncoding::runCompute(
-  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees) {
   // ------------------------------------------------------------------------------------
   // --- Construct trees
   // ------------------------------------------------------------------------------------
@@ -234,7 +234,7 @@ int ttkMergeTreeTemporalReductionEncoding::runCompute(
 template <class dataType>
 int ttkMergeTreeTemporalReductionEncoding::runOutput(
   vtkInformationVector *outputVector,
-  std::vector<vtkMultiBlockDataSet *> &inputTrees) {
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees) {
   // ------------------------------------------------------------------------------------
   // --- Create output
   // ------------------------------------------------------------------------------------
@@ -256,7 +256,7 @@ int ttkMergeTreeTemporalReductionEncoding::runOutput(
   std::vector<vtkUnstructuredGrid *> treesArcsT;
   std::vector<vtkDataSet *> treesSegmentationT;
   std::vector<std::vector<int>> treesNodeCorrMeshT;
-  std::vector<vtkMultiBlockDataSet *> inputTreesT;
+  std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTreesT;
   for(size_t i = 0; i < keyFramesIndex.size(); ++i) {
     treesNodesT.push_back(treesNodes[keyFramesIndex[i]]);
     treesArcsT.push_back(treesArcs[keyFramesIndex[i]]);

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -41,6 +41,7 @@
 // VTK Includes
 #include <ttkAlgorithm.h>
 #include <vtkMultiBlockDataSet.h>
+#include <vtkSmartPointer.h>
 #include <vtkUnstructuredGrid.h>
 
 // TTK Base Includes

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -153,8 +153,8 @@ public:
     return useMinMaxPair_;
   }
 
-  void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
-    deleteMultiPersPairs_ = deleteMultiPersPairs;
+  void SetDeleteMultiPersPairs(bool doDelete) {
+    deleteMultiPersPairs_ = doDelete;
     Modified();
     resetDataVisualization();
   }

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.h
@@ -245,12 +245,13 @@ protected:
 
   template <class dataType>
   int run(vtkInformationVector *outputVector,
-          std::vector<vtkMultiBlockDataSet *> &inputTrees);
+          std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees);
 
   template <class dataType>
-  int runCompute(std::vector<vtkMultiBlockDataSet *> &inputTrees);
+  int runCompute(
+    std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees);
 
   template <class dataType>
   int runOutput(vtkInformationVector *outputVector,
-                std::vector<vtkMultiBlockDataSet *> &inputTrees);
+                std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> &inputTrees);
 };


### PR DESCRIPTION
This PR modifies the mergeTree filters of TTK to change the format of the input.
Instead of having a multiblock of multiblock where each inner block is the nodes, arcs and segmentation (optional) of a tree, we now have a multiblock of three multiblocks, the first one contains all the nodes, the second one all the arcs and finally all the segmentations (optional) in the last inner multiblock.

This allows to be closer to the way ParaView/VTK manages filters output of a multiblock (e.g. computing a FTMTree of a cinema database).