### PR TITLE
[MPI] Fix for rare RankArray errors

### DIFF
--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -152,7 +152,8 @@ int ttkGhostCellPreconditioning::RequestData(
           }
         }
       }
-
+      // free the communicator once we are done with everything MPI
+      MPI_Comm_free(&ttkGhostCellPreconditioningComm);
       output->GetPointData()->AddArray(rankArray);
 
       this->printMsg("Preprocessed RankArray", 1.0, tm.getElapsedTime(),

--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -67,27 +67,22 @@ int ttkGhostCellPreconditioning::RequestData(
   if(vtkGlobalPointIds != nullptr && vtkGhostCells != nullptr) {
 #ifdef TTK_ENABLE_MPI
     if(ttk::isRunningWithMPI()) {
-      int numProcs;
-      int rank;
-      MPI_Comm_size(MPI_COMM_WORLD, &numProcs);
-      MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-      if(rank == 0)
+      MPI_Comm ttkGhostCellPreconditioningComm;
+      MPI_Comm_dup(MPI_COMM_WORLD, &ttkGhostCellPreconditioningComm);
+
+      if(ttk::MPIrank_ == 0)
         this->printMsg(
           "Global Point Ids and Ghost Cells exist, therefore we can continue!");
-      this->printMsg("#Ranks " + std::to_string(numProcs) + ", this is rank "
-                     + std::to_string(rank));
+      this->printMsg("#Ranks " + std::to_string(ttk::MPIsize_)
+                     + ", this is rank " + std::to_string(ttk::MPIrank_));
 
-#ifdef TTK_ENABLE_64BIT_IDS
-      MPI_Datatype MIT = MPI_LONG_LONG_INT;
-#else
-      MPI_Datatype MIT = MPI_INT;
-#endif
+      MPI_Datatype MIT = ttk::getMPIType(static_cast<ttk::SimplexId>(0));
       vtkNew<vtkIntArray> rankArray{};
       rankArray->SetName("RankArray");
       rankArray->SetNumberOfComponents(1);
       rankArray->SetNumberOfTuples(nVertices);
       std::vector<ttk::SimplexId> currentRankUnknownIds;
-      std::vector<std::vector<ttk::SimplexId>> allUnknownIds(numProcs);
+      std::vector<std::vector<ttk::SimplexId>> allUnknownIds(ttk::MPIsize_);
       std::unordered_set<ttk::SimplexId> gIdSet;
       std::unordered_map<ttk::SimplexId, ttk::SimplexId> gIdToLocalMap;
       for(int i = 0; i < nVertices; i++) {
@@ -96,7 +91,7 @@ int ttkGhostCellPreconditioning::RequestData(
         if(ghostCellVal == 0) {
           // if the ghost cell value is 0, then this vertex mainly belongs to
           // this rank
-          rankArray->SetComponent(i, 0, rank);
+          rankArray->SetComponent(i, 0, ttk::MPIrank_);
           gIdSet.insert(globalId);
         } else {
           // otherwise the vertex belongs to another rank and we need to find
@@ -106,54 +101,55 @@ int ttkGhostCellPreconditioning::RequestData(
           gIdToLocalMap[globalId] = i;
         }
       }
-      allUnknownIds[rank] = currentRankUnknownIds;
+      allUnknownIds[ttk::MPIrank_] = currentRankUnknownIds;
       ttk::SimplexId sizeOfCurrentRank;
       // first each rank gets the information which rank needs which globalid
-      for(int r = 0; r < numProcs; r++) {
-        if(r == rank)
+      for(int r = 0; r < ttk::MPIsize_; r++) {
+        if(r == ttk::MPIrank_)
           sizeOfCurrentRank = currentRankUnknownIds.size();
-        MPI_Bcast(&sizeOfCurrentRank, 1, MIT, r, MPI_COMM_WORLD);
-        allUnknownIds[r].resize(sizeOfCurrentRank);
         MPI_Bcast(
-          allUnknownIds[r].data(), sizeOfCurrentRank, MIT, r, MPI_COMM_WORLD);
+          &sizeOfCurrentRank, 1, MIT, r, ttkGhostCellPreconditioningComm);
+        allUnknownIds[r].resize(sizeOfCurrentRank);
+        MPI_Bcast(allUnknownIds[r].data(), sizeOfCurrentRank, MIT, r,
+                  ttkGhostCellPreconditioningComm);
       }
 
       // then we check if the needed globalid values are present in the local
       // globalid map if so, we send the rank value to the requesting rank
-      std::vector<std::vector<ttk::SimplexId>> gIdsToSend;
-      MPI_Request req;
-      gIdsToSend.resize(numProcs);
-      for(int r = 0; r < numProcs; r++) {
-        if(r != rank) {
+      std::vector<ttk::SimplexId> gIdsToSend;
+      for(int r = 0; r < ttk::MPIsize_; r++) {
+        if(r != ttk::MPIrank_) {
+          // send the needed values to r
+          gIdsToSend.clear();
           for(ttk::SimplexId gId : allUnknownIds[r]) {
             if(gIdSet.count(gId)) {
               // add the value to the vector which will be sent
-              gIdsToSend[r].push_back(gId);
+              gIdsToSend.push_back(gId);
             }
           }
           // send whole vector of data
-          MPI_Isend(gIdsToSend[r].data(), gIdsToSend[r].size(), MIT, r, 101,
-                    MPI_COMM_WORLD, &req);
-          MPI_Request_free(&req);
-        }
-      }
-
-      // receive a variable amount of values from different ranks
-      size_t i = 0;
-      while(i < allUnknownIds[rank].size()) {
-        std::vector<ttk::SimplexId> receivedGlobals;
-        receivedGlobals.resize(allUnknownIds[rank].size());
-        MPI_Status status;
-        int amount;
-        MPI_Recv(receivedGlobals.data(), allUnknownIds[rank].size(), MIT,
-                 MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &status);
-        int sourceRank = status.MPI_SOURCE;
-        MPI_Get_count(&status, MIT, &amount);
-        receivedGlobals.resize(amount);
-        for(ttk::SimplexId receivedGlobal : receivedGlobals) {
-          ttk::SimplexId localVal = gIdToLocalMap[receivedGlobal];
-          rankArray->SetComponent(localVal, 0, sourceRank);
-          i++;
+          MPI_Send(gIdsToSend.data(), gIdsToSend.size(), MIT, r, 101,
+                   ttkGhostCellPreconditioningComm);
+        } else {
+          // receive a variable amount of values from different ranks
+          size_t i = 0;
+          std::vector<ttk::SimplexId> receivedGlobals;
+          while(i < allUnknownIds[ttk::MPIrank_].size()) {
+            receivedGlobals.resize(allUnknownIds[ttk::MPIrank_].size());
+            MPI_Status status;
+            int amount;
+            MPI_Recv(receivedGlobals.data(),
+                     allUnknownIds[ttk::MPIrank_].size(), MIT, MPI_ANY_SOURCE,
+                     MPI_ANY_TAG, ttkGhostCellPreconditioningComm, &status);
+            int sourceRank = status.MPI_SOURCE;
+            MPI_Get_count(&status, MIT, &amount);
+            receivedGlobals.resize(amount);
+            for(ttk::SimplexId receivedGlobal : receivedGlobals) {
+              ttk::SimplexId localVal = gIdToLocalMap[receivedGlobal];
+              rankArray->SetComponent(localVal, 0, sourceRank);
+              i++;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
This PR should fix issue #783 by restructuring the GhostCellPreconditioning to work with MPI_Send instead of MPI_Isend.

It also modernizes the MPI usage in the module a bit, especially by not using MPI_COMM_WORLD, but instead duplicating it and therefore using a unique communicator for this module so no interference from the outside can happen. While this was not the source of error for this issue. This may have caused other issues in other modules and having an unique communicator should therefore be preferred. Whether there is _one_ TTK communicator or a new communicator for every module can be discussed in the future.

