### PR TITLE
[MPI] Changing MPI_COMM_WORLD to unique TTK Communicator

### DIFF
--- a/core/base/common/BaseClass.cpp
+++ b/core/base/common/BaseClass.cpp
@@ -8,6 +8,9 @@ COMMON_EXPORTS int ttk::globalThreadNumber_ = 1;
 
 COMMON_EXPORTS int ttk::MPIrank_ = -1;
 COMMON_EXPORTS int ttk::MPIsize_ = -1;
+#ifdef TTK_ENABLE_MPI
+COMMON_EXPORTS MPI_Comm ttk::MPIcomm_;
+#endif
 
 using namespace ttk;
 
@@ -21,6 +24,8 @@ BaseClass::BaseClass() : lastObject_{false}, wrapper_{nullptr} {
     if(flag) {
       MPI_Comm_rank(MPI_COMM_WORLD, &ttk::MPIrank_);
       MPI_Comm_size(MPI_COMM_WORLD, &ttk::MPIsize_);
+      if(ttk::MPIsize_ > 1)
+        MPI_Comm_dup(MPI_COMM_WORLD, &ttk::MPIcomm_);
     } else {
       ttk::MPIrank_ = 0;
       ttk::MPIsize_ = 0;

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -14,6 +14,10 @@
 
 #include <DataTypes.h>
 #include <OpenMP.h>
+#if TTK_ENABLE_MPI
+#define OMPI_SKIP_MPICXX 1
+#include <mpi.h>
+#endif
 
 #if defined(_MSC_VER) && defined(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 #if defined(common_EXPORTS)
@@ -57,6 +61,9 @@ namespace ttk {
   COMMON_EXPORTS extern int globalThreadNumber_;
   COMMON_EXPORTS extern int MPIrank_;
   COMMON_EXPORTS extern int MPIsize_;
+#ifdef TTK_ENABLE_MPI
+  COMMON_EXPORTS extern MPI_Comm MPIcomm_;
+#endif
 
   class Wrapper;
 
@@ -89,5 +96,4 @@ namespace ttk {
     Wrapper *wrapper_;
   };
 } // namespace ttk
-
 #include <MPIUtils.h>

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -52,7 +52,7 @@ namespace ttk {
 
   inline int startMPITimer(Timer &t, int rank, int size) {
     if(size > 0) {
-      MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(ttk::MPIcomm_);
       if(rank == 0) {
         t.reStart();
       }
@@ -63,7 +63,7 @@ namespace ttk {
   inline double endMPITimer(Timer &t, int rank, int size) {
     double elapsedTime = 0;
     if(size > 0) {
-      MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(ttk::MPIcomm_);
       if(rank == 0) {
         elapsedTime = t.getElapsedTime();
       }
@@ -100,7 +100,7 @@ namespace ttk {
     const unsigned long localSize = src.size();
     // gather src sizes on destRank
     MPI_Gather(&localSize, 1, MPI_UNSIGNED_LONG, vecSizes.data(), 1,
-               MPI_UNSIGNED_LONG, destRank, MPI_COMM_WORLD);
+               MPI_UNSIGNED_LONG, destRank, ttk::MPIcomm_);
 
     if(ttk::MPIrank_ == destRank) {
       // allocate dst with vecSizes
@@ -117,14 +117,14 @@ namespace ttk {
         }
         // receive src content from other ranks
         MPI_Recv(dst[i].data(), dst[i].size(), ttk::getMPIType(src[0]), i,
-                 MPI_ANY_TAG, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                 MPI_ANY_TAG, ttk::MPIcomm_, MPI_STATUS_IGNORE);
       }
       dst[destRank] = std::move(src);
 
     } else {
       // send src content to destRank
       MPI_Send(src.data(), src.size(), ttk::getMPIType(src[0]), destRank, 0,
-               MPI_COMM_WORLD);
+               ttk::MPIcomm_);
     }
 
     return 0;
@@ -145,7 +145,7 @@ namespace ttk {
    * @param[in] rankToSend Destination process identifier
    * @param[in] nVerts number of vertices in the arrays
    * @param[in] communicator the communicator over which the ranks are connected
-   * (most likely MPI_COMM_WORLD)
+   * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
   template <typename DT, typename IT>
@@ -274,7 +274,7 @@ namespace ttk {
    * rank-based ids
    * @param[in] nVerts number of vertices in the arrays
    * @param[in] communicator the communicator over which the ranks are connected
-   * (most likely MPI_COMM_WORLD)
+   * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
   template <typename DT, typename IT>

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -679,10 +679,10 @@ int preconditionDistributedIntermediate(size_t &globalCount,
         // send to relevant process
         std::array<unsigned long, 3> toSend{globalCount, gcid, endCurrRank};
         MPI_Send(toSend.data(), 3, MPI_UNSIGNED_LONG, currRank, COMPUTE,
-                 MPI_COMM_WORLD);
+                 ttk::MPIcomm_);
         // receive updated edgeCount
         MPI_Recv(&globalCount, 1, MPI_UNSIGNED_LONG, currRank, MPI_ANY_TAG,
-                 MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
       }
 
       gcid = endCurrRank;
@@ -691,7 +691,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
     // send STOP signal to break infinite loop
     std::array<unsigned long, 3> dummy{};
     for(int i = 1; i < ttk::MPIsize_; ++i) {
-      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, MPI_COMM_WORLD);
+      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, ttk::MPIcomm_);
     }
 
   } else {
@@ -700,7 +700,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
       std::array<unsigned long, 3> toRecv{};
       MPI_Status status;
       MPI_Recv(toRecv.data(), 3, MPI_UNSIGNED_LONG, 0, MPI_ANY_TAG,
-               MPI_COMM_WORLD, &status);
+               ttk::MPIcomm_, &status);
       if(status.MPI_TAG == STOP) {
         break;
       }
@@ -708,7 +708,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
       globalCount = toRecv[0];
       processCells(toRecv[1], toRecv[2], globalCount);
       // send back updated edgeCount to rank 0
-      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, MPI_COMM_WORLD);
+      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, ttk::MPIcomm_);
     }
   }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3153,10 +3153,10 @@ int preconditionDistributedIntermediate(size_t &globalCount,
         // send to relevant process
         std::array<unsigned long, 3> toSend{globalCount, gcid, endCurrRank};
         MPI_Send(toSend.data(), 3, MPI_UNSIGNED_LONG, currRank, COMPUTE,
-                 MPI_COMM_WORLD);
+                 ttk::MPIcomm_);
         // receive updated edgeCount
         MPI_Recv(&globalCount, 1, MPI_UNSIGNED_LONG, currRank, MPI_ANY_TAG,
-                 MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
       }
 
       gcid = endCurrRank;
@@ -3165,7 +3165,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
     // send STOP signal to break infinite loop
     std::array<unsigned long, 3> dummy{};
     for(int i = 1; i < ttk::MPIsize_; ++i) {
-      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, MPI_COMM_WORLD);
+      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, ttk::MPIcomm_);
     }
 
   } else {
@@ -3174,7 +3174,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
       std::array<unsigned long, 3> toRecv{};
       MPI_Status status;
       MPI_Recv(toRecv.data(), 3, MPI_UNSIGNED_LONG, 0, MPI_ANY_TAG,
-               MPI_COMM_WORLD, &status);
+               ttk::MPIcomm_, &status);
       if(status.MPI_TAG == STOP) {
         break;
       }
@@ -3182,7 +3182,7 @@ int preconditionDistributedIntermediate(size_t &globalCount,
       globalCount = toRecv[0];
       processCells(toRecv[1], toRecv[2], globalCount);
       // send back updated edgeCount to rank 0
-      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, MPI_COMM_WORLD);
+      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, ttk::MPIcomm_);
     }
   }
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -157,7 +157,7 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
       std::unordered_map<SimplexId, SimplexId> map;
       triangulation->getVertexGlobalIdMap(map);
       exchangeGhostCells<dataType, SimplexId>(
-        outputData, rankArray, globalIds, map, vertexNumber, MPI_COMM_WORLD);
+        outputData, rankArray, globalIds, map, vertexNumber, ttk::MPIcomm_);
     }
 #endif
 

--- a/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
+++ b/core/vtk/ttkScalarFieldNormalizer/ttkScalarFieldNormalizer.cpp
@@ -68,8 +68,8 @@ int ttkScalarFieldNormalizer::normalize(vtkDataArray *input,
   if(ttk::isRunningWithMPI()) {
     // if we are built with MPI and are running with MPI, we need to calculate
     // the min and max over all ranks. we do this by using MPI_Allreduce
-    MPI_Allreduce(MPI_IN_PLACE, &min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
-    MPI_Allreduce(MPI_IN_PLACE, &max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE, &min, 1, MPI_DOUBLE, MPI_MIN, ttk::MPIcomm_);
+    MPI_Allreduce(MPI_IN_PLACE, &max, 1, MPI_DOUBLE, MPI_MAX, ttk::MPIcomm_);
   }
 #endif
 


### PR DESCRIPTION
Using MPI_COMM_WORLD may lead to interference from VTK / Paraview / other applications using MPI, which may have already led to a few problems where we then maybe fixed the symptoms and not the cause (e.g. going from send / recv to gather / scatter). 
For using distinct communicators we have two possibilities:

1. Using one "TTK Communicator" which is created when TTK is first started and destroyed when finalizing MPI ( currently implemented in the commits)
2. creating a new communicator at the beginning of each filter and freeing it when the filter is finished. 

While creating new communicators for each filter may be cleaner, I don't think multiple filters run at the same time (which could create the same interferences between them) and additionally, creating new communicators may incur additional performance costs.

We should definitely move away from MPI_COMM_WORLD, this PR may be used as a place for discussion how exactly we will do that.