### PR TITLE
Fix ReturnSaddleConnectors interactions with DiscreteGradient cache

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -337,7 +337,8 @@ saddle-connectors.
 triangulation.
        */
       template <typename triangulationType>
-      int buildGradient(const triangulationType &triangulation);
+      int buildGradient(const triangulationType &triangulation,
+                        const bool bypassCache = false);
 
       /**
        * Automatic detection of the PL critical points and simplification
@@ -916,7 +917,12 @@ gradient, false otherwise.
       std::vector<SimplexId> dmt2Saddle2PL_{};
       std::vector<std::array<Cell, 2>> *outputPersistencePairs_{};
 
+      // spare storage (bypass cache) for gradient internal structure
+      AbstractTriangulation::gradientType localGradient_{};
+      // cache key (scalar field pointer + timestamp)
       AbstractTriangulation::gradientKeyType inputScalarField_{};
+      // pointer to either cache entry corresponding to inputScalarField_ or
+      // localGradient_ (if cache is bypassed)
       AbstractTriangulation::gradientType *gradient_{};
       const SimplexId *inputOffsets_{};
     };

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -37,7 +37,8 @@ dataType DiscreteGradient::getPersistence(
 }
 
 template <typename triangulationType>
-int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
+int DiscreteGradient::buildGradient(const triangulationType &triangulation,
+                                    const bool bypassCache) {
 
   auto &cacheHandler = *triangulation.getGradientCacheHandler();
   const auto findGradient
@@ -48,11 +49,15 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation) {
     return cacheHandler.get(this->inputScalarField_);
   };
 
-  this->gradient_ = findGradient();
-  if(this->gradient_ == nullptr) {
-    // add new cache entry
-    cacheHandler.insert(this->inputScalarField_, {});
-    this->gradient_ = cacheHandler.get(this->inputScalarField_);
+  this->gradient_ = bypassCache ? &this->localGradient_ : findGradient();
+  if(this->gradient_ == nullptr || bypassCache) {
+
+    if(!bypassCache) {
+      // add new cache entry
+      cacheHandler.insert(this->inputScalarField_, {});
+      this->gradient_ = cacheHandler.get(this->inputScalarField_);
+    }
+
     // allocate gradient memory
     this->initMemory(triangulation);
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -439,7 +439,8 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   this->discreteGradient_.setDebugLevel(debugLevel_);
   this->discreteGradient_.setInputScalarField(scalars, scalarsMTime);
   this->discreteGradient_.setInputOffsets(offsets);
-  this->discreteGradient_.buildGradient(triangulation);
+  this->discreteGradient_.buildGradient(
+    triangulation, this->ReturnSaddleConnectors);
 
   if(dim == 3 && ReturnSaddleConnectors) {
     discreteGradient_.reverseGradient<dataType>(triangulation);


### PR DESCRIPTION
Since the ReturnSaddleConnectors algorithm modifies in-place the DiscreteGradient internal structure, it is not compatible with the DiscreteGradient cache added in #744 .

To fix this issue, this PR introduces a optional bypass of the DiscreteGradient cache. The internal structure is, in this case, stored in the DiscreteGradient instance (identical to before #744). This way, using ReturnSaddleConnectors will recompute the DiscreteGradient each time and will not clobber the cache.

Enjoy,
Pierre