### PR TITLE
[MPI] Reworked GhostCellPreconditioning to use neighborhood relations and MPI_Sendrecv

### DIFF
--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -43,6 +43,18 @@ int ttkGhostCellPreconditioning::FillOutputPortInformation(
   return 0;
 }
 
+// returns true if bounding boxes intersect, false if not
+bool checkForIntersection(double *myBB, double *theirBB) {
+  return !(
+    myBB[0] > theirBB[1] // my left side is right of their right side
+    || myBB[1] < theirBB[0] // my right side is left of their left side
+    || myBB[2] > theirBB[3] // my bottom side is above their top side
+    || myBB[3] < theirBB[2] // my top side is under their bottom side
+    || myBB[4] > theirBB[5] // my front side is behind their back side
+    || myBB[5] < theirBB[4] // my back side is in front of their front side
+  );
+}
+
 int ttkGhostCellPreconditioning::RequestData(
   vtkInformation *ttkNotUsed(request),
   vtkInformationVector **inputVector,
@@ -67,12 +79,37 @@ int ttkGhostCellPreconditioning::RequestData(
   if(vtkGlobalPointIds != nullptr && vtkGhostCells != nullptr) {
 #ifdef TTK_ENABLE_MPI
     if(ttk::isRunningWithMPI()) {
-
       if(ttk::MPIrank_ == 0)
         this->printMsg(
           "Global Point Ids and Ghost Cells exist, therefore we can continue!");
       this->printMsg("#Ranks " + std::to_string(ttk::MPIsize_)
                      + ", this is rank " + std::to_string(ttk::MPIrank_));
+      double *boundingBox = input->GetBounds();
+      std::vector<double *> rankBoundingBoxes(ttk::MPIsize_);
+      rankBoundingBoxes[ttk::MPIrank_] = boundingBox;
+      for(int r = 0; r < ttk::MPIsize_; r++) {
+        if(r != ttk::MPIrank_)
+          rankBoundingBoxes[r] = (double *)malloc(6 * sizeof(double));
+        MPI_Bcast(rankBoundingBoxes[r], 6, MPI_DOUBLE, r, ttk::MPIcomm_);
+      }
+
+      double epsilon = 0.00001;
+      // inflate our own bounding box by epsilon
+      for(int i = 0; i < 6; i++) {
+        if(i % 2 == 0)
+          boundingBox[i] -= epsilon;
+        if(i % 2 == 1)
+          boundingBox[i] += epsilon;
+      }
+      std::vector<int> neighbors;
+      for(int i = 0; i < ttk::MPIsize_; i++) {
+        if(i != ttk::MPIrank_) {
+          double *theirBoundingBox = rankBoundingBoxes[i];
+          if(checkForIntersection(boundingBox, theirBoundingBox)) {
+            neighbors.push_back(i);
+          }
+        }
+      }
 
       MPI_Datatype MIT = ttk::getMPIType(static_cast<ttk::SimplexId>(0));
       vtkNew<vtkIntArray> rankArray{};
@@ -80,9 +117,9 @@ int ttkGhostCellPreconditioning::RequestData(
       rankArray->SetNumberOfComponents(1);
       rankArray->SetNumberOfTuples(nVertices);
       std::vector<ttk::SimplexId> currentRankUnknownIds;
-      std::vector<std::vector<ttk::SimplexId>> allUnknownIds(ttk::MPIsize_);
       std::unordered_set<ttk::SimplexId> gIdSet;
       std::unordered_map<ttk::SimplexId, ttk::SimplexId> gIdToLocalMap;
+
       for(int i = 0; i < nVertices; i++) {
         int ghostCellVal = vtkGhostCells->GetComponent(i, 0);
         ttk::SimplexId globalId = vtkGlobalPointIds->GetComponent(i, 0);
@@ -99,56 +136,54 @@ int ttkGhostCellPreconditioning::RequestData(
           gIdToLocalMap[globalId] = i;
         }
       }
-      allUnknownIds[ttk::MPIrank_] = currentRankUnknownIds;
-      ttk::SimplexId sizeOfCurrentRank;
-      // first each rank gets the information which rank needs which globalid
-      for(int r = 0; r < ttk::MPIsize_; r++) {
-        if(r == ttk::MPIrank_)
-          sizeOfCurrentRank = currentRankUnknownIds.size();
-        MPI_Bcast(&sizeOfCurrentRank, 1, MIT, r, ttk::MPIcomm_);
-        allUnknownIds[r].resize(sizeOfCurrentRank);
-        MPI_Bcast(
-          allUnknownIds[r].data(), sizeOfCurrentRank, MIT, r, ttk::MPIcomm_);
-      }
 
-      // then we check if the needed globalid values are present in the local
-      // globalid map if so, we send the rank value to the requesting rank
+      ttk::SimplexId sizeOfCurrentRank = currentRankUnknownIds.size();
       std::vector<ttk::SimplexId> gIdsToSend;
-      for(int r = 0; r < ttk::MPIsize_; r++) {
-        if(r != ttk::MPIrank_) {
-          // send the needed values to r
-          gIdsToSend.clear();
-          for(ttk::SimplexId gId : allUnknownIds[r]) {
-            if(gIdSet.count(gId)) {
-              // add the value to the vector which will be sent
-              gIdsToSend.push_back(gId);
-            }
-          }
-          // send whole vector of data
-          MPI_Send(
-            gIdsToSend.data(), gIdsToSend.size(), MIT, r, 101, ttk::MPIcomm_);
-        } else {
-          // receive a variable amount of values from different ranks
-          size_t i = 0;
-          std::vector<ttk::SimplexId> receivedGlobals;
-          while(i < allUnknownIds[ttk::MPIrank_].size()) {
-            receivedGlobals.resize(allUnknownIds[ttk::MPIrank_].size());
-            MPI_Status status;
-            int amount;
-            MPI_Recv(receivedGlobals.data(),
-                     allUnknownIds[ttk::MPIrank_].size(), MIT, MPI_ANY_SOURCE,
-                     MPI_ANY_TAG, ttk::MPIcomm_, &status);
-            int sourceRank = status.MPI_SOURCE;
-            MPI_Get_count(&status, MIT, &amount);
-            receivedGlobals.resize(amount);
-            for(ttk::SimplexId receivedGlobal : receivedGlobals) {
-              ttk::SimplexId localVal = gIdToLocalMap[receivedGlobal];
-              rankArray->SetComponent(localVal, 0, sourceRank);
-              i++;
-            }
+      std::vector<ttk::SimplexId> receivedGlobals;
+      receivedGlobals.resize(sizeOfCurrentRank);
+      ttk::SimplexId sizeOfNeighbor;
+      std::vector<ttk::SimplexId> neighborUnknownIds;
+      for(int neighbor : neighbors) {
+        // we first send the size and then all needed ids to the neighbor
+        MPI_Sendrecv(&sizeOfCurrentRank, 1, MIT, neighbor, ttk::MPIrank_,
+                     &sizeOfNeighbor, 1, MIT, neighbor, neighbor, ttk::MPIcomm_,
+                     MPI_STATUS_IGNORE);
+        neighborUnknownIds.resize(sizeOfNeighbor);
+        gIdsToSend.reserve(sizeOfNeighbor);
+
+        MPI_Sendrecv(currentRankUnknownIds.data(), sizeOfCurrentRank, MIT,
+                     neighbor, ttk::MPIrank_, neighborUnknownIds.data(),
+                     sizeOfNeighbor, MIT, neighbor, neighbor, ttk::MPIcomm_,
+                     MPI_STATUS_IGNORE);
+
+        // then we check if the needed globalid values are present in the local
+        // globalid set if so, we send the rank value to the requesting rank
+        for(ttk::SimplexId gId : neighborUnknownIds) {
+          if(gIdSet.count(gId)) {
+            // add the value to the vector which will be sent
+            gIdsToSend.push_back(gId);
           }
         }
+        MPI_Status status;
+        int amount;
+
+        MPI_Sendrecv(gIdsToSend.data(), gIdsToSend.size(), MIT, neighbor,
+                     ttk::MPIrank_, receivedGlobals.data(),
+                     currentRankUnknownIds.size(), MIT, neighbor, neighbor,
+                     ttk::MPIcomm_, &status);
+
+        MPI_Get_count(&status, MIT, &amount);
+        receivedGlobals.resize(amount);
+
+        for(ttk::SimplexId receivedGlobal : receivedGlobals) {
+          ttk::SimplexId localVal = gIdToLocalMap[receivedGlobal];
+          rankArray->SetComponent(localVal, 0, neighbor);
+        }
+        // cleanup
+        gIdsToSend.clear();
+        receivedGlobals.resize(sizeOfCurrentRank);
       }
+
       // free the communicator once we are done with everything MPI
       output->GetPointData()->AddArray(rankArray);
 


### PR DESCRIPTION
This PR reworks GhostCellPreconditioning to already use rank neighborhood relations which can be calculated by putting a bounding box around the points of every rank, inflating it by an epsilon and checking for overlaps. This allows us to move away from broadcasting the needed ids to every other rank and from awaiting an unknown number of receives until we have enough rankArray values. Instead we know that we expect to send one message to each neighbor and receive one message from one neighbor, which can be done with MPI_Sendrecv. 

This may allow for performance increases depending on the rank layout and the amount of ranks. In theory it would be possible to remove the received values from `currentRankUnknownIds` after each receive, but when testing we found that removing the values introduced a bigger overhead than what was gained by sending fewer values.