### PR TITLE
[MPI] Add RankArray to MPI preconditioning

### DIFF
--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -325,7 +325,8 @@ namespace ttk {
                                unsigned char *ghostCells,
                                int nVertices,
                                double *boundingBox) {
-    std::vector<std::array<double, 6>> rankBoundingBoxes(ttk::MPIsize_);
+    std::vector<std::array<double, 6>> rankBoundingBoxes(
+      ttk::MPIsize_, std::array<double, 6>({}));
     std::copy(
       boundingBox, boundingBox + 6, rankBoundingBoxes[ttk::MPIrank_].begin());
     for(int r = 0; r < ttk::MPIsize_; r++) {

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -9,6 +9,7 @@
 
 #include <BaseClass.h>
 #include <Timer.h>
+#include <array>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -9,7 +9,6 @@
 
 #include <BaseClass.h>
 #include <Timer.h>
-#include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -312,8 +312,6 @@ namespace ttk {
                                unsigned char *ghostCells,
                                int nVertices) {
     MPI_Datatype MIT = ttk::getMPIType(static_cast<ttk::SimplexId>(0));
-    MPI_Comm ttkGhostCellPreconditioningComm;
-    MPI_Comm_dup(MPI_COMM_WORLD, &ttkGhostCellPreconditioningComm);
     std::vector<ttk::SimplexId> currentRankUnknownIds;
     std::vector<std::vector<ttk::SimplexId>> allUnknownIds(ttk::MPIsize_);
     std::unordered_set<ttk::SimplexId> gIdSet;

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -404,7 +404,6 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
   vtkNew<vtkGenerateGlobalIds> globalIds;
   // If the global point id array doesn't exist, it is created
   if(input->GetPointData()->GetGlobalIds() == nullptr) {
-    printMsg("create globalIds");
     printWrn("Global ids haven't been produced in sequential, the parallel "
              "result may be different");
     globalIds->SetInputData(input);
@@ -414,7 +413,6 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
 
     vtkNew<vtkGhostCellsGenerator> generator;
     if(!input->HasAnyGhostCells()) {
-      printMsg("Create Ghost array");
       generator->SetInputData(input);
       generator->BuildIfRequiredOff();
       generator->SetNumberOfGhostLayers(2);
@@ -428,7 +426,6 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
 
     // If the RankArray array doesn't exist, it is created
     if(input->GetPointData()->GetArray("RankArray") == nullptr) {
-      printMsg("create rankArray");
       int vertexNumber = input->GetNumberOfPoints();
       std::vector<int> rankArray(vertexNumber, 0);
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include <vtkCommand.h>
 #include <vtkDataSet.h>
 #if TTK_ENABLE_MPI
+#include <vtkCellData.h>
 #include <vtkGenerateGlobalIds.h>
 #include <vtkGhostCellsGenerator.h>
 #endif
@@ -39,9 +40,20 @@ ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
   this->printMsg("Requesting triangulation for '"
                    + std::string(dataSet->GetClassName()) + "'",
                  ttk::debug::Priority::DETAIL);
-
+#if TTK_ENABLE_MPI
+  if(ttk::isRunningWithMPI()) {
+    this->MPIPipelinePreconditioning(dataSet);
+  }
+#endif
   auto triangulation = ttkTriangulationFactory::GetTriangulation(
     this->debugLevel_, this->CompactTriangulationCacheSize, dataSet);
+#if TTK_ENABLE_MPI
+  if(ttk::isRunningWithMPI()) {
+    if(triangulation) {
+      this->MPITriangulationPreconditioning(triangulation, dataSet);
+    }
+  }
+#endif
   if(triangulation)
     return triangulation;
 
@@ -387,38 +399,80 @@ int ttkAlgorithm::RequestDataObject(vtkInformation *ttkNotUsed(request),
 }
 
 #if TTK_ENABLE_MPI
-void ttkAlgorithm::MPIPreconditioning(vtkDataSet *input) {
-  ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
-  triangulation->setGlobalIdsArray(
-    static_cast<long int *>(ttkUtils::GetVoidPointer(
-      input->GetPointData()->GetArray("GlobalPointIds"))));
-  if(!triangulation->getGlobalIdsArray()) {
+void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
+
+  vtkNew<vtkGenerateGlobalIds> globalIds;
+  // If the global point id array doesn't exist, it is created
+  if(input->GetPointData()->GetGlobalIds() == nullptr) {
+    printMsg("create globalIds");
     printWrn("Global ids haven't been produced in sequential, the parallel "
              "result may be different");
-    vtkNew<vtkGenerateGlobalIds> globalIds;
     globalIds->SetInputData(input);
     globalIds->Update();
     input->ShallowCopy(globalIds->GetOutputDataObject(0));
-    triangulation->setGlobalIdsArray(
-      static_cast<long int *>(ttkUtils::GetVoidPointer(
-        input->GetPointData()->GetArray("GlobalPointIds"))));
   }
-  triangulation->preconditionDistributedVertices();
 
-  if(!input->HasAnyGhostPoints()) {
     vtkNew<vtkGhostCellsGenerator> generator;
-    generator->SetInputData(input);
-    generator->BuildIfRequiredOff();
-    generator->SetNumberOfGhostLayers(2);
-    generator->Update();
-    input->ShallowCopy(generator->GetOutputDataObject(0));
-  }
+    if(!input->HasAnyGhostCells()) {
+      printMsg("Create Ghost array");
+      generator->SetInputData(input);
+      generator->BuildIfRequiredOff();
+      generator->SetNumberOfGhostLayers(2);
+      generator->Update();
+      input->ShallowCopy(generator->GetOutputDataObject(0));
+      input->GetPointData()->AddArray(
+        generator->GetOutputDataObject(0)->GetGhostArray(0));
+      input->GetCellData()->AddArray(
+        generator->GetOutputDataObject(0)->GetGhostArray(1));
+    }
 
+    // If the RankArray array doesn't exist, it is created
+    if(input->GetPointData()->GetArray("RankArray") == nullptr) {
+      printMsg("create rankArray");
+      int vertexNumber = input->GetNumberOfPoints();
+      std::vector<int> rankArray(vertexNumber, 0);
+
+      ttk::produceRankArray(
+        rankArray,
+        static_cast<long int *>(
+          ttkUtils::GetVoidPointer(input->GetPointData()->GetGlobalIds())),
+        static_cast<unsigned char *>(ttkUtils::GetVoidPointer(
+          input->GetPointData()->GetArray("vtkGhostType"))),
+        vertexNumber);
+
+      vtkNew<vtkIntArray> vtkRankArray{};
+      vtkRankArray->SetName("RankArray");
+      vtkRankArray->SetNumberOfComponents(1);
+      vtkRankArray->SetNumberOfTuples(vertexNumber);
+
+      for(int i = 0; i < vertexNumber; i++) {
+        vtkRankArray->SetComponent(i, 0, rankArray[i]);
+      }
+
+      input->GetPointData()->AddArray(vtkRankArray);
+    }
+}
+
+void ttkAlgorithm::MPITriangulationPreconditioning(
+  ttk::Triangulation *triangulation, vtkDataSet *input) {
+  triangulation->setGlobalIdsArray(static_cast<long int *>(
+    ttkUtils::GetVoidPointer(input->GetPointData()->GetGlobalIds())));
+  triangulation->setGlobalIdsArray(static_cast<long int *>(
+    ttkUtils::GetVoidPointer(input->GetPointData()->GetGlobalIds())));
+  triangulation->preconditionDistributedVertices();
   triangulation->setRankArray(static_cast<int *>(
     ttkUtils::GetVoidPointer(input->GetPointData()->GetArray("RankArray"))));
-  if(!triangulation->getRankArray()) {
-    printWrn("RankArray has not been defined. Use the "
-             "ttkGhostCellPreconditioning filter to do so.");
+  // provide "GlobalCellIds" & "vtkGhostType" cell data array to
+  // the triangulation
+  const auto cd{input->GetCellData()};
+  if(cd == nullptr) {
+    triangulation->printWrn("No cell data on input object");
+  }
+  if(cd != nullptr) {
+    triangulation->setGlobalIds(
+      ttkUtils::GetPointer<ttk::LongSimplexId>(cd->GetGlobalIds()),
+      ttkUtils::GetPointer<unsigned char>(
+        cd->GetArray(vtkCellData::GhostArrayName())));
   }
 }
 #endif
@@ -474,11 +528,6 @@ int ttkAlgorithm::ProcessRequest(vtkInformation *request,
   if(request->Has(vtkCompositeDataPipeline::REQUEST_DATA())) {
     this->printMsg("Processing REQUEST_DATA", ttk::debug::Priority::VERBOSE);
     this->printMsg(ttk::debug::Separator::L0);
-#if TTK_ENABLE_MPI
-    if(ttk::isRunningWithMPI()) {
-      this->MPIPreconditioning(vtkDataSet::GetData(inputVector[0]));
-    }
-#endif
     return this->RequestData(request, inputVector, outputVector);
   }
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -210,11 +210,21 @@ protected:
   ~ttkAlgorithm() override;
 
   /**
-   * This method is called in ProcessRequest, when the request is of type
-   * RequestData. It verifies that several attributes necessary for MPI
-   * computation are computed and if not, computes them.
+   * This method is called in GetTriangulation, after the triangulation as been
+   * created. It verifies that several attributes necessary for MPI computation
+   * are present in the pipeline and if not, computes them.
    */
-  void MPIPreconditioning(vtkDataSet *input);
+  void MPIPipelinePreconditioning(vtkDataSet *input);
+
+  /**
+   * This method is called in GetTriangulation, after the triangulation as been
+   * created. It retrieves several attributes from the pipeline to precondition
+   * the triangulation for MPI computation.
+   */
+
+  void MPITriangulationPreconditioning(ttk::Triangulation *triangulation,
+                                       vtkDataSet *input);
+
   /**
    * This method is called during the first pipeline pass in
    * ProcessRequest() to create empty output data objects. The data type of

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -358,22 +358,6 @@ ttk::Triangulation *ttkTriangulationFactory::GetTriangulation(
       instance->registry.emplace(std::piecewise_construct,
                                  std::forward_as_tuple(key),
                                  std::forward_as_tuple(object, triangulation));
-#ifdef TTK_ENABLE_MPI
-      if(ttk::isRunningWithMPI()) {
-        // provide "GlobalCellIds" & "vtkGhostType" cell data array to
-        // the triangulation
-        const auto cd{object->GetCellData()};
-        if(cd == nullptr) {
-          instance->printWrn("No cell data on input object");
-        }
-        if(cd != nullptr) {
-          triangulation->setGlobalIds(
-            ttkUtils::GetPointer<ttk::LongSimplexId>(cd->GetGlobalIds()),
-            ttkUtils::GetPointer<unsigned char>(
-              cd->GetArray(vtkCellData::GhostArrayName())));
-        }
-      }
-#endif // TTK_ENABLE_MPI
     }
   }
 

--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -55,106 +55,38 @@ int ttkGhostCellPreconditioning::RequestData(
   if(input == nullptr || output == nullptr) {
     return 0;
   }
-
   output->ShallowCopy(input);
 
   auto pointData = input->GetPointData();
   ttk::SimplexId nVertices = input->GetNumberOfPoints();
   this->printMsg("#Points: " + std::to_string(nVertices));
 
-  auto vtkGlobalPointIds = pointData->GetGlobalIds();
-  auto vtkGhostCells = pointData->GetArray("vtkGhostType");
-  if(vtkGlobalPointIds != nullptr && vtkGhostCells != nullptr) {
+  long int *globalIds = static_cast<long int *>(
+    ttkUtils::GetVoidPointer(pointData->GetGlobalIds()));
+  unsigned char *ghostCells = static_cast<unsigned char *>(
+    ttkUtils::GetVoidPointer(pointData->GetArray("vtkGhostType")));
+  if(globalIds != nullptr && ghostCells != nullptr) {
 #ifdef TTK_ENABLE_MPI
     if(ttk::isRunningWithMPI()) {
-      MPI_Comm ttkGhostCellPreconditioningComm;
-      MPI_Comm_dup(MPI_COMM_WORLD, &ttkGhostCellPreconditioningComm);
-
       if(ttk::MPIrank_ == 0)
         this->printMsg(
           "Global Point Ids and Ghost Cells exist, therefore we can continue!");
       this->printMsg("#Ranks " + std::to_string(ttk::MPIsize_)
                      + ", this is rank " + std::to_string(ttk::MPIrank_));
+      std::vector<int> rankArray(nVertices, 0);
 
-      MPI_Datatype MIT = ttk::getMPIType(static_cast<ttk::SimplexId>(0));
-      vtkNew<vtkIntArray> rankArray{};
-      rankArray->SetName("RankArray");
-      rankArray->SetNumberOfComponents(1);
-      rankArray->SetNumberOfTuples(nVertices);
-      std::vector<ttk::SimplexId> currentRankUnknownIds;
-      std::vector<std::vector<ttk::SimplexId>> allUnknownIds(ttk::MPIsize_);
-      std::unordered_set<ttk::SimplexId> gIdSet;
-      std::unordered_map<ttk::SimplexId, ttk::SimplexId> gIdToLocalMap;
+      ttk::produceRankArray(rankArray, globalIds, ghostCells, nVertices);
+
+      vtkNew<vtkIntArray> vtkRankArray{};
+      vtkRankArray->SetName("RankArray");
+      vtkRankArray->SetNumberOfComponents(1);
+      vtkRankArray->SetNumberOfTuples(nVertices);
+
       for(int i = 0; i < nVertices; i++) {
-        int ghostCellVal = vtkGhostCells->GetComponent(i, 0);
-        ttk::SimplexId globalId = vtkGlobalPointIds->GetComponent(i, 0);
-        if(ghostCellVal == 0) {
-          // if the ghost cell value is 0, then this vertex mainly belongs to
-          // this rank
-          rankArray->SetComponent(i, 0, ttk::MPIrank_);
-          gIdSet.insert(globalId);
-        } else {
-          // otherwise the vertex belongs to another rank and we need to find
-          // out to which one this needs to be done by broadcasting the global
-          // id and hoping for some other rank to answer
-          currentRankUnknownIds.push_back(globalId);
-          gIdToLocalMap[globalId] = i;
-        }
-      }
-      allUnknownIds[ttk::MPIrank_] = currentRankUnknownIds;
-      ttk::SimplexId sizeOfCurrentRank;
-      // first each rank gets the information which rank needs which globalid
-      for(int r = 0; r < ttk::MPIsize_; r++) {
-        if(r == ttk::MPIrank_)
-          sizeOfCurrentRank = currentRankUnknownIds.size();
-        MPI_Bcast(
-          &sizeOfCurrentRank, 1, MIT, r, ttkGhostCellPreconditioningComm);
-        allUnknownIds[r].resize(sizeOfCurrentRank);
-        MPI_Bcast(allUnknownIds[r].data(), sizeOfCurrentRank, MIT, r,
-                  ttkGhostCellPreconditioningComm);
+        vtkRankArray->SetComponent(i, 0, rankArray[i]);
       }
 
-      // then we check if the needed globalid values are present in the local
-      // globalid map if so, we send the rank value to the requesting rank
-      std::vector<ttk::SimplexId> gIdsToSend;
-      for(int r = 0; r < ttk::MPIsize_; r++) {
-        if(r != ttk::MPIrank_) {
-          // send the needed values to r
-          gIdsToSend.clear();
-          for(ttk::SimplexId gId : allUnknownIds[r]) {
-            if(gIdSet.count(gId)) {
-              // add the value to the vector which will be sent
-              gIdsToSend.push_back(gId);
-            }
-          }
-          // send whole vector of data
-          MPI_Send(gIdsToSend.data(), gIdsToSend.size(), MIT, r, 101,
-                   ttkGhostCellPreconditioningComm);
-        } else {
-          // receive a variable amount of values from different ranks
-          size_t i = 0;
-          std::vector<ttk::SimplexId> receivedGlobals;
-          while(i < allUnknownIds[ttk::MPIrank_].size()) {
-            receivedGlobals.resize(allUnknownIds[ttk::MPIrank_].size());
-            MPI_Status status;
-            int amount;
-            MPI_Recv(receivedGlobals.data(),
-                     allUnknownIds[ttk::MPIrank_].size(), MIT, MPI_ANY_SOURCE,
-                     MPI_ANY_TAG, ttkGhostCellPreconditioningComm, &status);
-            int sourceRank = status.MPI_SOURCE;
-            MPI_Get_count(&status, MIT, &amount);
-            receivedGlobals.resize(amount);
-            for(ttk::SimplexId receivedGlobal : receivedGlobals) {
-              ttk::SimplexId localVal = gIdToLocalMap[receivedGlobal];
-              rankArray->SetComponent(localVal, 0, sourceRank);
-              i++;
-            }
-          }
-        }
-      }
-      // free the communicator once we are done with everything MPI
-      MPI_Comm_free(&ttkGhostCellPreconditioningComm);
-      output->GetPointData()->AddArray(rankArray);
+      output->GetPointData()->AddArray(vtkRankArray);
 
       this->printMsg("Preprocessed RankArray", 1.0, tm.getElapsedTime(),
                      this->threadNumber_);


### PR DESCRIPTION
This Pull Request improves the preconditioning for MPI by automatically computing ghost points, ghost cells, global ids and the RankArray array if they are not already computed when the execution is in parallel.

The MPI preconditioning is moved from the ProcessRequest function to the GetTriangulation function in the ttkAlgorithm class.
Two functions are added to ttkAlgorithm:
- MPIPipelinePreconditioning: before the creation/retrieval of a triangulation, ghosts, global ids and the RankArray array are added to the pipeline if not already present.
- MPITriangulationPreconditioning: after the creation/retrieval of a triangulation, informations for ghosts, global ids and the RankArray array are retrieved from the pipeline and added to TTK objects. The vertex preconditioning is executed here as well.

In order to be able to produce the RankArray from within ttkAlgorithm, the heart of the TTKGhostCellPreconditioning filter is moved to MPIUtils.h. The filter is still there and still allows of the computation of the RankArray array.

To execute a filter in parallel, such as TTKArrayPreconditioning and ScalarFieldCriticalPoints, one would now need the following pipeline:

        #### import the simple module from the paraview
        from paraview.simple import *
        
        # create a new 'Wavelet'
        wavelet1 = Wavelet(registrationName='Wavelet1')
        
        # create a new 'TTK ArrayPreconditioning'
        tTKArrayPreconditioning1 = TTKArrayPreconditioning(registrationName='TTKArrayPreconditioning1', Input=wavelet1)
        tTKArrayPreconditioning1.PointDataArrays = ['RTData']
        
        # create a new 'TTK ScalarFieldCriticalPoints'
        tTKScalarFieldCriticalPoints1 = TTKScalarFieldCriticalPoints(registrationName='TTKScalarFieldCriticalPoints1', Input=tTKArrayPreconditioning1)
        tTKScalarFieldCriticalPoints1.ScalarField = ['POINTS', 'RTData']
        tTKScalarFieldCriticalPoints1.InputOffsetField = ['POINTS', 'RTData']
        tTKScalarFieldCriticalPoints1.Backend = 'Default generic backend'
        
        UpdatePipeline(time=0.0, proxy=tTKScalarFieldCriticalPoints1)
      
Please note that the computation of the global ids in parallel will raise a warning as it won't produce a result strictly identical to the result on one process in terms of global identifiers.