### PR TITLE
PersistenceDiagramClustering: Reset diagram position before translation

### DIFF
--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -7,6 +7,8 @@
 #include <vtkFloatArray.h>
 #include <vtkPointData.h>
 #include <vtkThreshold.h>
+#include <vtkTransform.h>
+#include <vtkTransformFilter.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
@@ -431,6 +433,65 @@ int ProjectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
 
   dbg.printMsg("Projected Persistence Diagram back to 2D", 1.0,
                tm.getElapsedTime(), dbg.getThreadNumber());
+
+  return 0;
+}
+
+int TranslateDiagram(vtkUnstructuredGrid *const diagram,
+                     const std::array<double, 3> &trans) {
+
+  vtkNew<vtkUnstructuredGrid> tmp{};
+  tmp->ShallowCopy(diagram);
+
+  vtkNew<vtkTransform> tr{};
+  tr->Translate(trans.data());
+
+  vtkNew<vtkTransformFilter> trf{};
+  trf->SetTransform(tr);
+  trf->SetInputData(tmp);
+  trf->Update();
+
+  diagram->ShallowCopy(trf->GetOutputDataObject(0));
+
+  return 0;
+}
+
+int ResetDiagramPosition(vtkUnstructuredGrid *const diagram,
+                         const ttk::Debug &dbg) {
+
+  const bool embedded
+    = diagram->GetPointData()->GetArray(ttk::PersistenceCoordinatesName)
+      == nullptr;
+
+  if(embedded) {
+    dbg.printWrn("Cannot reset embedded diagram position");
+    return 1;
+  }
+
+  // position of first point in diagram
+  std::array<double, 3> pos{};
+  diagram->GetPoint(diagram->GetCell(0)->GetPointId(0), pos.data());
+
+  // birth value of the first cell in the diagram
+  const auto firstBirth{
+    diagram->GetCellData()->GetArray(ttk::PersistenceBirthName)->GetTuple1(0)};
+
+  if((pos[0] != pos[1] && pos[0] != firstBirth) || pos[2] != 0) {
+    vtkNew<vtkUnstructuredGrid> tmp{};
+    tmp->ShallowCopy(diagram);
+
+    vtkNew<vtkTransform> tr{};
+    tr->Translate(firstBirth - pos[0], firstBirth - pos[1], -pos[2]);
+
+    vtkNew<vtkTransformFilter> trf{};
+    trf->SetTransform(tr);
+    trf->SetInputData(tmp);
+    trf->Update();
+
+    diagram->ShallowCopy(trf->GetOutputDataObject(0));
+
+    dbg.printMsg("Diagram reset to initial position");
+  }
 
   return 0;
 }

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.h
@@ -71,3 +71,27 @@ int ProjectDiagramInsideDomain(vtkUnstructuredGrid *const inputDiagram,
 int ProjectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
                        vtkUnstructuredGrid *const outputDiagram,
                        const ttk::Debug &dbg);
+
+/**
+ * @brief Translate a diagram to a new position.
+ *
+ * @param[in,out] diagram Input diagram in its spatial embedding form
+ * @param[in] trans Translation vector
+ *
+ * @return 0 in case of success
+ */
+int TranslateDiagram(vtkUnstructuredGrid *const diagram,
+                     const std::array<double, 3> &trans);
+
+/**
+ * @brief Translate back a canonical diagram into its original position.
+ *
+ * Use the cellData array `Birth` as original coordinates
+ *
+ * @param[in,out] diagram Input diagram in its spatial embedding form
+ * @param[in] dbg Debug instance (for logging and access to threadNumber_)
+ *
+ * @return 0 in case of success
+ */
+int ResetDiagramPosition(vtkUnstructuredGrid *const diagram,
+                         const ttk::Debug &dbg);

--- a/core/vtk/ttkPersistenceDiagram/vtk.module
+++ b/core/vtk/ttkPersistenceDiagram/vtk.module
@@ -2,3 +2,5 @@ NAME
  ttkPersistenceDiagram
 DEPENDS
  ttkAlgorithm
+PRIVATE_DEPENDS
+  VTK::FiltersGeneral

--- a/core/vtk/ttkPersistenceDiagramClustering/ttk.module
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttk.module
@@ -6,4 +6,5 @@ HEADERS
   ttkPersistenceDiagramClustering.h
 DEPENDS
   ttkAlgorithm
+  ttkPersistenceDiagram
   persistenceDiagramClustering

--- a/core/vtk/ttkPersistenceDiagramClustering/vtk.module
+++ b/core/vtk/ttkPersistenceDiagramClustering/vtk.module
@@ -2,5 +2,3 @@ NAME
  ttkPersistenceDiagramClustering
 DEPENDS
   ttkAlgorithm
-PRIVATE_DEPENDS
-  VTK::FiltersGeneral


### PR DESCRIPTION
This PR introduces new methods in `ttkPersistenceDiagramUtils` that take care of translating a VTU diagram (in its canonical form) and resetting its position. 

This way, it is possible to apply the `PersistenceDiagramClustering` filter on the output of a previous `PersistenceDiagramClustering` instance, using the `Clusters as stars` representation, without messing with the diagram positions.

Enjoy,
Pierre
