### PR TITLE
[MergeTreeDistanceMatrix] fix division by zero

### DIFF
--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -75,7 +75,7 @@ namespace ttk {
 #pragma omp task firstprivate(i) UNTIED() shared(distanceMatrix, trees)
         {
 #endif
-          if(i % (distanceMatrix.size() / 10) == 0) {
+          if(i % std::max(int(distanceMatrix.size() / 10), 1) == 0) {
             std::stringstream stream;
             stream << i << " / " << distanceMatrix.size();
             printMsg(stream.str());


### PR DESCRIPTION
When computing a distance matrix of an ensemble of less than 10 merge trees, a modulo operation (here to print the progress of the computation) causes a division by zero.

This PR fixes this problem.