### PR TITLE
Add DiscreteMorseSandwich, PersistentGenerators

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -376,8 +376,7 @@ according to them.
        */
       inline void preconditionTriangulation(AbstractTriangulation *const data) {
         if(data != nullptr) {
-          dimensionality_ = data->getCellVertexNumber(0) - 1;
-          numberOfVertices_ = data->getNumberOfVertices();
+          const auto dim{data->getDimensionality()};
 
           data->preconditionBoundaryVertices();
           data->preconditionVertexNeighbors();
@@ -385,12 +384,12 @@ according to them.
           data->preconditionVertexStars();
           data->preconditionEdges();
           data->preconditionEdgeStars();
-          if(dimensionality_ >= 2) {
+          if(dim >= 2) {
             data->preconditionBoundaryEdges();
           }
-          if(dimensionality_ == 2) {
+          if(dim == 2) {
             data->preconditionCellEdges();
-          } else if(dimensionality_ == 3) {
+          } else if(dim == 3) {
             data->preconditionBoundaryTriangles();
             data->preconditionVertexTriangles();
             data->preconditionEdgeTriangles();

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -338,7 +338,7 @@ triangulation.
        */
       template <typename triangulationType>
       int buildGradient(const triangulationType &triangulation,
-                        const bool bypassCache = false);
+                        bool bypassCache = false);
 
       /**
        * Automatic detection of the PL critical points and simplification

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -49,6 +49,10 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation,
     return cacheHandler.get(this->inputScalarField_);
   };
 
+  // set member variables at each buildGradient() call
+  this->dimensionality_ = triangulation.getCellVertexNumber(0) - 1;
+  this->numberOfVertices_ = triangulation.getNumberOfVertices();
+
   this->gradient_ = bypassCache ? &this->localGradient_ : findGradient();
   if(this->gradient_ == nullptr || bypassCache) {
 

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -38,7 +38,7 @@ dataType DiscreteGradient::getPersistence(
 
 template <typename triangulationType>
 int DiscreteGradient::buildGradient(const triangulationType &triangulation,
-                                    const bool bypassCache) {
+                                    bool bypassCache) {
 
   auto &cacheHandler = *triangulation.getGradientCacheHandler();
   const auto findGradient
@@ -48,6 +48,14 @@ int DiscreteGradient::buildGradient(const triangulationType &triangulation,
     }
     return cacheHandler.get(this->inputScalarField_);
   };
+
+#ifdef TTK_ENABLE_OPENMP
+  if(!bypassCache && omp_in_parallel()) {
+    this->printWrn(
+      "buildGradient() called inside a parallel region, disabling cache...");
+    bypassCache = true;
+  }
+#endif // TTK_ENABLE_OPENMP
 
   // set member variables at each buildGradient() call
   this->dimensionality_ = triangulation.getCellVertexNumber(0) - 1;

--- a/core/base/discreteMorseSandwich/CMakeLists.txt
+++ b/core/base/discreteMorseSandwich/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(discreteMorseSandwich
+  SOURCES
+    DiscreteMorseSandwich.cpp
+  HEADERS
+    DiscreteMorseSandwich.h
+  DEPENDS
+    discreteGradient
+)

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.cpp
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.cpp
@@ -1,0 +1,173 @@
+#include <DiscreteMorseSandwich.h>
+
+ttk::DiscreteMorseSandwich::DiscreteMorseSandwich() {
+  this->setDebugMsgPrefix("DiscreteMorseSandwich");
+}
+
+void ttk::DiscreteMorseSandwich::tripletsToPersistencePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<bool> &pairedExtrema,
+  std::vector<bool> &pairedSaddles,
+  std::vector<SimplexId> &reps,
+  std::vector<tripletType> &triplets,
+  const SimplexId *const saddlesOrder,
+  const SimplexId *const extremaOrder,
+  const SimplexId pairDim) const {
+
+  // comparison functions
+  const auto cmpSadMax
+    = [=](const tripletType &t0, const tripletType &t1) -> bool {
+    const auto s0 = t0[0];
+    const auto s1 = t1[0];
+    const auto m0 = t0[2];
+    const auto m1 = t1[2];
+    if(s0 != s1)
+      return saddlesOrder[s0] > saddlesOrder[s1];
+    else
+      return extremaOrder[m0] < extremaOrder[m1];
+  };
+
+  const auto cmpSadMin
+    = [=](const tripletType &t0, const tripletType &t1) -> bool {
+    const auto s0 = t0[0];
+    const auto s1 = t1[0];
+    const auto m0 = t0[2];
+    const auto m1 = t1[2];
+    if(s0 != s1)
+      return saddlesOrder[s0] < saddlesOrder[s1];
+    else
+      return extremaOrder[m0] > extremaOrder[m1];
+  };
+
+  // sort triplets
+  if(pairDim == 0) {
+    TTK_PSORT(this->threadNumber_, triplets.begin(), triplets.end(), cmpSadMin);
+  } else {
+    // saddle-saddle pairs from 1-saddles to 2-saddles
+    TTK_PSORT(this->threadNumber_, triplets.begin(), triplets.end(), cmpSadMax);
+  }
+
+  // get representative of current extremum
+  const auto getRep = [&reps](SimplexId v) -> SimplexId {
+    auto r = reps[v];
+    while(r != v) {
+      v = r;
+      r = reps[v];
+    }
+    return r;
+  };
+
+  const bool increasing = (pairDim > 0);
+
+  const auto addPair = [&pairs, &pairedExtrema, &pairedSaddles, increasing,
+                        pairDim](const SimplexId sad, const SimplexId extr) {
+    if(increasing) {
+      pairs.emplace_back(sad, extr, pairDim);
+    } else {
+      pairs.emplace_back(extr, sad, pairDim);
+    }
+    pairedSaddles[sad] = true;
+    pairedExtrema[extr] = true;
+  };
+
+  for(const auto &t : triplets) {
+    const auto sv = t[0];
+
+    auto r1 = getRep(t[1]);
+
+    if(t[2] < 0) {
+      // deal with "shadow" triplets (a 2-saddle with only one
+      // ascending 1-separatrix leading to an unique maximum)
+      if(!pairedExtrema[r1] && !pairedSaddles[sv]) {
+        // when considering the boundary, the "-1" of the triplets
+        // indicate a virtual maximum of infinite persistence on the
+        // boundary component. a pair is created with the other
+        // maximum
+        addPair(sv, r1);
+      }
+
+      continue;
+    }
+
+    auto r2 = getRep(t[2]);
+
+    if(r1 != r2) {
+      if(((extremaOrder[r1] > extremaOrder[r2]) == increasing
+          || pairedExtrema[r1])
+         && !pairedExtrema[r2]) {
+        std::swap(r1, r2);
+      }
+      if(!pairedExtrema[r1]) {
+        addPair(sv, r1);
+        reps[t[1]] = r2;
+        reps[r1] = r2;
+      }
+    }
+  }
+}
+
+void ttk::DiscreteMorseSandwich::displayStats(
+  const std::vector<PersistencePair> &pairs,
+  const std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+  const std::vector<bool> &pairedMinima,
+  const std::vector<bool> &paired1Saddles,
+  const std::vector<bool> &paired2Saddles,
+  const std::vector<bool> &pairedMaxima) const {
+
+  const auto dim = this->dg_.getDimensionality();
+
+  // display number of pairs per pair type
+  std::vector<std::vector<std::string>> rows{
+    {" #Min-saddle pairs",
+     std::to_string(
+       std::count_if(pairs.begin(), pairs.end(),
+                     [](const PersistencePair &a) { return a.type == 0; }))},
+    {" #Saddle-saddle pairs",
+     std::to_string(dim == 3 ? std::count_if(
+                      pairs.begin(), pairs.end(),
+                      [](const PersistencePair &a) { return a.type == 1; })
+                             : 0)},
+    {" #Saddle-max pairs",
+     std::to_string(std::count_if(
+       pairs.begin(), pairs.end(),
+       [dim](const PersistencePair &a) { return a.type == dim - 1; }))},
+  };
+
+  // display number of critical cells (paired and unpaired)
+  std::vector<size_t> nCritCells(dim + 1);
+  std::vector<size_t> nNonPairedCritCells(dim + 1);
+
+  for(int i = 0; i < dim + 1; ++i) {
+    nCritCells[i] = criticalCellsByDim[i].size();
+    size_t nNonPaired{};
+    for(size_t j = 0; j < criticalCellsByDim[i].size(); ++j) {
+      const auto cell = criticalCellsByDim[i][j];
+      if((i == 0 && !pairedMinima[cell]) || (i == 1 && !paired1Saddles[cell])
+         || (i == 2 && dim == 3 && !paired2Saddles[cell])
+         || (i == dim && !pairedMaxima[cell])) {
+        nNonPaired++;
+      }
+    }
+    nNonPairedCritCells[i] = nNonPaired;
+  }
+
+  std::vector<std::string> critCellsLabels{"Minima"};
+  if(dim >= 2) {
+    critCellsLabels.emplace_back("1-saddles");
+  }
+  if(dim >= 3) {
+    critCellsLabels.emplace_back("2-saddles");
+  }
+  critCellsLabels.emplace_back("Maxima");
+
+  for(int i = 0; i < dim + 1; ++i) {
+    const std::string unpaired{nNonPairedCritCells[i] == 0
+                                 ? " (all paired)"
+                                 : " (" + std::to_string(nNonPairedCritCells[i])
+                                     + " unpaired)"};
+
+    rows.emplace_back(std::vector<std::string>{
+      " #" + critCellsLabels[i], std::to_string(nCritCells[i]) + unpaired});
+  }
+  this->printMsg(rows, debug::Priority::DETAIL);
+}

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -1,0 +1,1093 @@
+/// \ingroup baseCode
+/// \class ttk::DiscreteMorseSandwich
+/// \author Julien Tierny <julien.tierny@lip6.fr>
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date January 2021.
+///
+/// \brief TTK %DiscreteMorseSandwich processing package.
+///
+/// %DiscreteMorseSandwich compute a Persistence Diagram by using the
+/// %Discrete Morse-Theory %DiscreteGradient algorithms.
+///
+/// \sa ttk::dcg::DiscreteGradient
+
+#pragma once
+
+#include <DiscreteGradient.h>
+
+#include <numeric>
+
+namespace ttk {
+  class DiscreteMorseSandwich : virtual public Debug {
+  public:
+    DiscreteMorseSandwich();
+
+    /**
+     * @brief Persistence pair struct as exported by DiscreteGradient
+     */
+    struct PersistencePair {
+      /** first (lower/birth) simplex cell id */
+      SimplexId birth;
+      /** second (higher/death) simplex cell id */
+      SimplexId death;
+      /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
+      int type;
+
+      PersistencePair(SimplexId b, SimplexId d, int t)
+        : birth{b}, death{d}, type{t} {
+      }
+    };
+
+    inline void preconditionTriangulation(AbstractTriangulation *const data) {
+      this->dg_.preconditionTriangulation(data);
+    }
+
+    inline void setInputOffsets(const SimplexId *const offsets) {
+      this->dg_.setInputOffsets(offsets);
+    }
+
+    template <typename triangulationType>
+    inline int buildGradient(const SimplexId *const offsets,
+                             const triangulationType &triangulation) {
+      this->dg_.setInputOffsets(offsets);
+      return this->dg_.buildGradient(triangulation);
+    }
+
+    template <typename triangulationType>
+    inline SimplexId
+      getCellGreaterVertex(const dcg::Cell &c,
+                           const triangulationType &triangulation) {
+      return this->dg_.getCellGreaterVertex(c, triangulation);
+    }
+
+    /**
+     * @brief Compute the persistence pairs from the discrete gradient
+     *
+     * @pre @ref buildGradient and @ref preconditionTriangulation
+     * should be called prior to this function
+     *
+     * @param[out] pairs Output persistence pairs
+     * @param[in] offsets Order field
+     * @param[in] triangulation Preconditionned triangulation
+     * @param[in] ignoreBoundary Ignore the boundary component
+     *
+     * @return 0 when success
+     */
+    template <typename triangulationType>
+    int computePersistencePairs(std::vector<PersistencePair> &pairs,
+                                const SimplexId *const offsets,
+                                const triangulationType &triangulation,
+                                const bool ignoreBoundary);
+
+  private:
+    /**
+     * @brief Follow the descending 1-separatrices to compute the saddles ->
+     * minima association
+     *
+     * @param[in] criticalEdges Critical edges identifiers
+     * @param[in] triangulation Triangulation
+     *
+     * @return a vector of minima per 1-saddle
+     */
+    template <typename triangulationType>
+    std::vector<std::vector<SimplexId>>
+      getSaddle1ToMinima(const std::vector<SimplexId> &criticalEdges,
+                         const triangulationType &triangulation) const;
+
+    /**
+     * @brief Follow the ascending 1-separatrices to compute the saddles ->
+     * maxima association
+     *
+     * @param[in] criticalCells Critical cells identifiers
+     * @param[in] getFaceStar Either getEdgeStar (in 2D) or getTriangleStar
+     * (in 3D)
+     * @param[in] getFaceStarNumber Either getEdgeStarNumber (in 2D) or
+     * getTriangleStarNumber (in 3D)
+     * @param[in] isOnBoundary Either isEdgeOnBoundary (in 2D) or
+     * isTriangleOnBoundary (in 3D)
+     * @param[in] triangulation Triangulation
+     * @param[in] ignoreBoundary FTM compatibility (ignore saddles on
+     * boundary)
+     *
+     * @return a vector of maxima per 2-saddle
+     */
+    template <typename triangulationType,
+              typename GFS,
+              typename GFSN,
+              typename OB>
+    std::vector<std::vector<SimplexId>>
+      getSaddle2ToMaxima(const std::vector<SimplexId> &criticalCells,
+                         const GFS &getFaceStar,
+                         const GFSN &getFaceStarNumber,
+                         const OB &isOnBoundary,
+                         const triangulationType &triangulation,
+                         const bool ignoreBoundary) const;
+
+    /**
+     * @brief Compute the pairs of dimension 0
+     *
+     * @param[out] pairs Output persistence pairs
+     * @param[in] pairedMinima If minima are paired
+     * @param[in] paired1Saddles If 1-saddles (or maxima in 1D) are paired
+     * @param[in] criticalEdges List of 1-saddles (or maxima in 1D)
+     * @param[in] critEdgesOrder Filtration order on critical edges
+     * @param[in] offsets Vertex offset field
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void getMinSaddlePairs(std::vector<PersistencePair> &pairs,
+                           std::vector<bool> &pairedMinima,
+                           std::vector<bool> &paired1Saddles,
+                           const std::vector<SimplexId> &criticalEdges,
+                           const std::vector<SimplexId> &critEdgesOrder,
+                           const SimplexId *const offsets,
+                           const triangulationType &triangulation) const;
+
+    /**
+     * @brief Compute the pairs of dimension dim - 1
+     *
+     * @param[out] pairs Output persistence pairs
+     * @param[in] pairedMaxima If maxima are paired
+     * @param[in] pairedSaddles If 2-saddles (or 1-saddles in 2D) are paired
+     * @param[in] criticalSaddles List of 2-saddles (or 1-saddles in 2D)
+     * @param[in] critSaddlesOrder Filtration order on critical saddles
+     * @param[in] critMaxsOrder Filtration order on maxima
+     * @param[in] triangulation Triangulation
+     * @param[in] ignoreBoundary Ignore the boundary component
+     */
+    template <typename triangulationType>
+    void getMaxSaddlePairs(std::vector<PersistencePair> &pairs,
+                           std::vector<bool> &pairedMaxima,
+                           std::vector<bool> &pairedSaddles,
+                           const std::vector<SimplexId> &criticalSaddles,
+                           const std::vector<SimplexId> &critSaddlesOrder,
+                           const std::vector<SimplexId> &critMaxsOrder,
+                           const triangulationType &triangulation,
+                           const bool ignoreBoundary) const;
+
+    /**
+     * @brief Compute the saddle-saddle pairs (in 3D)
+     *
+     * @param[out] pairs Output persistence pairs
+     * @param[in] paired1Saddles If 1-saddles are paired
+     * @param[in] paired2Saddles If 2-saddles are paired
+     * @param[in] exportBoundaries If 2-saddles boundaries must be exported
+     * @param[out] boundaries Vector of 2-saddles boundaries
+     * @param[in] critical1Saddles Full list of 1-saddles
+     * @param[in] critical2Saddles Full list of 2-saddles
+     * @param[in] crit1SaddlesOrder Filtration order on 1-saddles
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void getSaddleSaddlePairs(std::vector<PersistencePair> &pairs,
+                              std::vector<bool> &paired1Saddles,
+                              std::vector<bool> &paired2Saddles,
+                              const std::vector<SimplexId> &critical1Saddles,
+                              const std::vector<SimplexId> &critical2Saddles,
+                              const std::vector<SimplexId> &crit1SaddlesOrder,
+                              const triangulationType &triangulation) const;
+
+    /**
+     * @brief Extract & sort critical cell from the DiscreteGradient
+     *
+     * @param[out] criticalCellsByDim Store critical cells ids per dimension
+     * @param[out] critCellsOrder Filtration order on critical cells
+     * @param[in] offsets Vertex offset field
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void extractCriticalCells(
+      std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+      std::array<std::vector<SimplexId>, 4> &critCellsOrder,
+      const SimplexId *const offsets,
+      const triangulationType &triangulation) const;
+
+    /**
+     * @brief Print number of pairs, critical cells per dimension & unpaired
+     * cells
+     *
+     * @param[in] pairs Computed persistence pairs
+     * @param[in] criticalCellsByDim Store critical cells ids per dimension
+     * @param[in] pairedMinima If minima are paired
+     * @param[in] paired1Saddles If 1-saddles are paired
+     * @param[in] paired2Saddles If 2-saddles are paired
+     * @param[in] pairedMaxima If maxima are paired
+     */
+    void displayStats(
+      const std::vector<PersistencePair> &pairs,
+      const std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+      const std::vector<bool> &pairedMinima,
+      const std::vector<bool> &paired1Saddles,
+      const std::vector<bool> &paired2Saddles,
+      const std::vector<bool> &pairedMaxima) const;
+
+    /**
+     * @brief Triplet type for persistence pairs
+     *
+     * [0]: saddle cell id
+     * [1]: extremum 1 cell id
+     * [2]: extremum 2 cell id
+     */
+    using tripletType = std::array<SimplexId, 3>;
+
+    /**
+     * @brief Compute persistence pairs from triplets
+     *
+     * @param[out] pairs Store generated persistence pairs
+     * @param[in,out] pairedExtrema If critical extrema are paired
+     * @param[in,out] pairedSaddles If critical saddles are paired
+     * @param[in,out] reps Extrema representatives
+     * @param[in] triplets Input triplets (saddle, extremum, extremum)
+     * @param[in] saddlesOrder Order on saddles
+     * @param[in] extremaOrder Order on extrema
+     * @param[in] pairDim Pair birth simplex dimension
+     */
+    void tripletsToPersistencePairs(std::vector<PersistencePair> &pairs,
+                                    std::vector<bool> &pairedExtrema,
+                                    std::vector<bool> &pairedSaddles,
+                                    std::vector<SimplexId> &reps,
+                                    std::vector<tripletType> &triplets,
+                                    const SimplexId *const saddlesOrder,
+                                    const SimplexId *const extremaOrder,
+                                    const SimplexId pairDim) const;
+
+    /**
+     * @brief Detect 1-saddles paired to a given 2-saddle
+     *
+     * Adapted version of ttk::PersistentSimplexPairs::eliminateBoundaries()
+     *
+     * @param[in] s2 Input 2-saddle (critical triangle)
+     * @param[in,out] onBoundary Propagation mask
+     * @param[in,out] s2Boundaries Boundaries storage (compact)
+     * @param[in] s2Mapping From (critical) triangle id to compact id in
+     * s2Boundaries
+     * @param[in] partners Get 2-saddles paired to 1-saddles on boundary
+     * @param[in] triangulation Simplicial complex
+     *
+     * @return Identifier of paired 1-saddle or -1
+     */
+    template <typename triangulationType, typename Container>
+    SimplexId
+      eliminateBoundariesSandwich(const SimplexId s2,
+                                  std::vector<bool> &onBoundary,
+                                  std::vector<Container> &s2Boundaries,
+                                  const std::vector<SimplexId> &s2Mapping,
+                                  const std::vector<SimplexId> &partners,
+                                  const triangulationType &triangulation) const;
+
+    /**
+     * @brief Ad-hoc struct for sorting simplices
+     *
+     * Adapted version of ttk::PersistentSimplexPairs::Simplex
+     */
+    template <size_t n>
+    struct Simplex {
+      /** Index in the triangulation */
+      SimplexId id_{};
+      /** Order field value of the simplex vertices, sorted in
+          decreasing order */
+      std::array<SimplexId, n> vertsOrder_{};
+      /** To compare two vertices according to the filtration (lexicographic
+       * order) */
+      friend bool operator<(const Simplex<n> &lhs, const Simplex<n> &rhs) {
+        return lhs.vertsOrder_ < rhs.vertsOrder_;
+      }
+    };
+
+    /**
+     * @brief \ref Simplex adaptation for edges
+     */
+    struct EdgeSimplex : Simplex<2> {
+      template <typename triangulationType>
+      void fillEdge(const SimplexId id,
+                    const SimplexId *const offsets,
+                    const triangulationType &triangulation) {
+        this->id_ = id;
+        triangulation.getEdgeVertex(id, 0, this->vertsOrder_[0]);
+        triangulation.getEdgeVertex(id, 1, this->vertsOrder_[1]);
+        this->vertsOrder_[0] = offsets[this->vertsOrder_[0]];
+        this->vertsOrder_[1] = offsets[this->vertsOrder_[1]];
+        // sort vertices in decreasing order
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+    };
+
+    /**
+     * @brief \ref Simplex adaptation for triangles
+     */
+    struct TriangleSimplex : Simplex<3> {
+      template <typename triangulationType>
+      void fillTriangle(const SimplexId id,
+                        const SimplexId *const offsets,
+                        const triangulationType &triangulation) {
+        this->id_ = id;
+        triangulation.getTriangleVertex(id, 0, this->vertsOrder_[0]);
+        triangulation.getTriangleVertex(id, 1, this->vertsOrder_[1]);
+        triangulation.getTriangleVertex(id, 2, this->vertsOrder_[2]);
+        this->vertsOrder_[0] = offsets[this->vertsOrder_[0]];
+        this->vertsOrder_[1] = offsets[this->vertsOrder_[1]];
+        this->vertsOrder_[2] = offsets[this->vertsOrder_[2]];
+        // sort vertices in decreasing order
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+    };
+
+    /**
+     * @brief \ref Simplex adaptation for tetrahedra
+     */
+    struct TetraSimplex : Simplex<4> {
+      template <typename triangulationType>
+      void fillTetra(const SimplexId id,
+                     const SimplexId *const offsets,
+                     const triangulationType &triangulation) {
+        this->id_ = id;
+        triangulation.getCellVertex(id, 0, this->vertsOrder_[0]);
+        triangulation.getCellVertex(id, 1, this->vertsOrder_[1]);
+        triangulation.getCellVertex(id, 2, this->vertsOrder_[2]);
+        triangulation.getCellVertex(id, 3, this->vertsOrder_[3]);
+        this->vertsOrder_[0] = offsets[this->vertsOrder_[0]];
+        this->vertsOrder_[1] = offsets[this->vertsOrder_[1]];
+        this->vertsOrder_[2] = offsets[this->vertsOrder_[2]];
+        this->vertsOrder_[3] = offsets[this->vertsOrder_[3]];
+        // sort vertices in decreasing order
+        std::sort(this->vertsOrder_.rbegin(), this->vertsOrder_.rend());
+      }
+    };
+
+    template <typename triangulationType>
+    void alloc(const triangulationType &triangulation) {
+      Timer tm{};
+      const auto dim{this->dg_.getDimensionality()};
+      this->firstRepMin_.resize(triangulation.getNumberOfVertices());
+      if(dim > 1) {
+        this->firstRepMax_.resize(triangulation.getNumberOfCells());
+      }
+      if(dim > 2) {
+        this->critEdges_.resize(triangulation.getNumberOfEdges());
+        this->edgeTrianglePartner_.resize(triangulation.getNumberOfEdges(), -1);
+        this->onBoundary_.resize(triangulation.getNumberOfEdges(), false);
+        this->s2Mapping_.resize(triangulation.getNumberOfTriangles(), -1);
+      }
+      for(int i = 0; i < dim + 1; ++i) {
+        this->pairedCritCells_[i].resize(
+          this->dg_.getNumberOfCells(i, triangulation), false);
+      }
+      for(int i = 1; i < dim + 1; ++i) {
+        this->critCellsOrder_[i].resize(
+          this->dg_.getNumberOfCells(i, triangulation), -1);
+      }
+      this->printMsg("Memory allocations", 1.0, tm.getElapsedTime(), 1,
+                     debug::LineMode::NEW, debug::Priority::DETAIL);
+    }
+
+    void clear() {
+      Timer tm{};
+      this->firstRepMin_ = {};
+      this->firstRepMax_ = {};
+      this->edgeTrianglePartner_ = {};
+      this->s2Mapping_ = {};
+      this->critEdges_ = {};
+      this->pairedCritCells_ = {};
+      this->onBoundary_ = {};
+      this->critCellsOrder_ = {};
+      this->printMsg("Memory cleanup", 1.0, tm.getElapsedTime(), 1,
+                     debug::LineMode::NEW, debug::Priority::DETAIL);
+    }
+
+    dcg::DiscreteGradient dg_{};
+
+    // factor memory allocations outside computation loops
+    mutable std::vector<SimplexId> firstRepMin_{}, firstRepMax_{},
+      edgeTrianglePartner_{}, s2Mapping_{};
+    mutable std::vector<EdgeSimplex> critEdges_{};
+    mutable std::array<std::vector<bool>, 4> pairedCritCells_{};
+    mutable std::vector<bool> onBoundary_{};
+    mutable std::array<std::vector<SimplexId>, 4> critCellsOrder_{};
+  };
+} // namespace ttk
+
+template <typename triangulationType>
+std::vector<std::vector<SimplexId>>
+  ttk::DiscreteMorseSandwich::getSaddle1ToMinima(
+    const std::vector<SimplexId> &criticalEdges,
+    const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  std::vector<std::vector<SimplexId>> res(criticalEdges.size());
+
+  // follow vpaths from 1-saddles to minima
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(size_t i = 0; i < criticalEdges.size(); ++i) {
+    auto &mins = res[i];
+
+    const auto followVPath = [this, &mins, &triangulation](const SimplexId v) {
+      std::vector<Cell> vpath{};
+      this->dg_.getDescendingPath(Cell{0, v}, vpath, triangulation);
+      Cell &lastCell = vpath.back();
+      if(lastCell.dim_ == 0 && this->dg_.isCellCritical(lastCell)) {
+        mins.emplace_back(lastCell.id_);
+      }
+    };
+
+    // critical edge vertices
+    SimplexId v0{}, v1{};
+    triangulation.getEdgeVertex(criticalEdges[i], 0, v0);
+    triangulation.getEdgeVertex(criticalEdges[i], 1, v1);
+
+    // follow vpath from each vertex of the critical edge
+    followVPath(v0);
+    followVPath(v1);
+  }
+
+  this->printMsg("Computed the descending 1-separatrices", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+
+  return res;
+}
+
+template <typename triangulationType, typename GFS, typename GFSN, typename OB>
+std::vector<std::vector<SimplexId>>
+  ttk::DiscreteMorseSandwich::getSaddle2ToMaxima(
+    const std::vector<SimplexId> &criticalCells,
+    const GFS &getFaceStar,
+    const GFSN &getFaceStarNumber,
+    const OB &isOnBoundary,
+    const triangulationType &triangulation,
+    const bool ignoreBoundary) const {
+
+  Timer tm{};
+
+  const auto dim = this->dg_.getDimensionality();
+  std::vector<std::vector<SimplexId>> res(criticalCells.size());
+
+  // follow vpaths from 2-saddles to maxima
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(size_t i = 0; i < criticalCells.size(); ++i) {
+    const auto sid = criticalCells[i];
+    auto &maxs = res[i];
+
+    const auto followVPath
+      = [this, dim, &maxs, &triangulation](const SimplexId v) {
+          std::vector<Cell> vpath{};
+          this->dg_.getAscendingPath(Cell{dim, v}, vpath, triangulation);
+          Cell &lastCell = vpath.back();
+          if(lastCell.dim_ == dim && this->dg_.isCellCritical(lastCell)) {
+            maxs.emplace_back(lastCell.id_);
+          } else if(lastCell.dim_ == dim - 1) {
+            maxs.emplace_back(-1);
+          }
+        };
+
+    const auto starNumber = getFaceStarNumber(sid);
+
+    for(SimplexId j = 0; j < starNumber; ++j) {
+      SimplexId cellId{};
+      getFaceStar(sid, j, cellId);
+      followVPath(cellId);
+    }
+
+    // ignoreBoundary: skip triplets with saddles on boundary
+    if(!ignoreBoundary && isOnBoundary(sid)) {
+      // critical saddle is on boundary
+      maxs.emplace_back(-1);
+    }
+  }
+
+  this->printMsg("Computed the ascending 1-separatrices", 1.0,
+                 tm.getElapsedTime(), this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+
+  return res;
+}
+
+template <typename triangulationType>
+void ttk::DiscreteMorseSandwich::getMinSaddlePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<bool> &pairedMinima,
+  std::vector<bool> &paired1Saddles,
+  const std::vector<SimplexId> &criticalEdges,
+  const std::vector<SimplexId> &critEdgesOrder,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  auto saddle1ToMinima = getSaddle1ToMinima(criticalEdges, triangulation);
+
+  Timer tmseq{};
+
+  auto &firstRep{this->firstRepMin_};
+  std::iota(firstRep.begin(), firstRep.end(), 0);
+  std::vector<tripletType> sadMinTriplets{};
+
+  for(size_t i = 0; i < saddle1ToMinima.size(); ++i) {
+    auto &mins = saddle1ToMinima[i];
+    const auto s1 = criticalEdges[i];
+    // remove duplicates
+    TTK_PSORT(this->threadNumber_, mins.begin(), mins.end());
+    const auto last = std::unique(mins.begin(), mins.end());
+    mins.erase(last, mins.end());
+    if(mins.size() != 2) {
+      continue;
+    }
+    sadMinTriplets.emplace_back(tripletType{s1, mins[0], mins[1]});
+  }
+
+  tripletsToPersistencePairs(pairs, pairedMinima, paired1Saddles, firstRep,
+                             sadMinTriplets, critEdgesOrder.data(), offsets, 0);
+
+  const auto nMinSadPairs = pairs.size();
+
+  this->printMsg(
+    "Computed " + std::to_string(nMinSadPairs) + " min-saddle pairs", 1.0,
+    tm.getElapsedTime(), this->threadNumber_);
+
+  this->printMsg("min-saddle pairs sequential part", 1.0,
+                 tmseq.getElapsedTime(), 1, debug::LineMode::NEW,
+                 debug::Priority::VERBOSE);
+}
+
+template <typename triangulationType>
+void ttk::DiscreteMorseSandwich::getMaxSaddlePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<bool> &pairedMaxima,
+  std::vector<bool> &pairedSaddles,
+  const std::vector<SimplexId> &criticalSaddles,
+  const std::vector<SimplexId> &critSaddlesOrder,
+  const std::vector<SimplexId> &critMaxsOrder,
+  const triangulationType &triangulation,
+  const bool ignoreBoundary) const {
+
+  Timer tm{};
+
+  const auto dim = this->dg_.getDimensionality();
+
+  auto saddle2ToMaxima
+    = dim == 3
+        ? getSaddle2ToMaxima(
+          criticalSaddles,
+          [&triangulation](const SimplexId a, const SimplexId i, SimplexId &r) {
+            return triangulation.getTriangleStar(a, i, r);
+          },
+          [&triangulation](const SimplexId a) {
+            return triangulation.getTriangleStarNumber(a);
+          },
+          [&triangulation](const SimplexId a) {
+            return triangulation.isTriangleOnBoundary(a);
+          },
+          triangulation, ignoreBoundary)
+        : getSaddle2ToMaxima(
+          criticalSaddles,
+          [&triangulation](const SimplexId a, const SimplexId i, SimplexId &r) {
+            return triangulation.getEdgeStar(a, i, r);
+          },
+          [&triangulation](const SimplexId a) {
+            return triangulation.getEdgeStarNumber(a);
+          },
+          [&triangulation](const SimplexId a) {
+            return triangulation.isEdgeOnBoundary(a);
+          },
+          triangulation, ignoreBoundary);
+
+  Timer tmseq{};
+
+  auto &firstRep{this->firstRepMax_};
+  std::iota(firstRep.begin(), firstRep.end(), 0);
+  std::vector<tripletType> sadMaxTriplets{};
+
+  for(size_t i = 0; i < saddle2ToMaxima.size(); ++i) {
+    auto &maxs = saddle2ToMaxima[i];
+    // remove duplicates
+    TTK_PSORT(this->threadNumber_, maxs.begin(), maxs.end(),
+              [](const SimplexId a, const SimplexId b) {
+                // positive values (actual maxima) before negative ones
+                // (boundary component id)
+                if(a * b >= 0) {
+                  return a < b;
+                } else {
+                  return a > b;
+                }
+              });
+    const auto last = std::unique(maxs.begin(), maxs.end());
+    maxs.erase(last, maxs.end());
+
+    // remove "doughnut" configurations: two ascending separatrices
+    // leading to the same maximum/boundary component
+    if(maxs.size() != 2) {
+      continue;
+    }
+
+    const auto s2 = criticalSaddles[i];
+    if(!pairedSaddles[s2]) {
+      sadMaxTriplets.emplace_back(tripletType{s2, maxs[0], maxs[1]});
+    }
+  }
+
+  const auto nMinSadPairs = pairs.size();
+
+  tripletsToPersistencePairs(pairs, pairedMaxima, pairedSaddles, firstRep,
+                             sadMaxTriplets, critSaddlesOrder.data(),
+                             critMaxsOrder.data(), dim - 1);
+
+  const auto nSadMaxPairs = pairs.size() - nMinSadPairs;
+
+  this->printMsg(
+    "Computed " + std::to_string(nSadMaxPairs) + " saddle-max pairs", 1.0,
+    tm.getElapsedTime(), this->threadNumber_);
+
+  this->printMsg("saddle-max pairs sequential part", 1.0,
+                 tmseq.getElapsedTime(), 1, debug::LineMode::NEW,
+                 debug::Priority::VERBOSE);
+}
+
+template <typename triangulationType, typename Container>
+SimplexId ttk::DiscreteMorseSandwich::eliminateBoundariesSandwich(
+  const SimplexId s2,
+  std::vector<bool> &onBoundary,
+  std::vector<Container> &s2Boundaries,
+  const std::vector<SimplexId> &s2Mapping,
+  const std::vector<SimplexId> &partners,
+  const triangulationType &triangulation) const {
+
+  auto &boundaryIds{s2Boundaries[s2Mapping[s2]]};
+  const auto addBoundary = [&boundaryIds, &onBoundary](const SimplexId e) {
+    // add edge e to boundaryIds/onBoundary modulo 2
+    if(!onBoundary[e]) {
+      boundaryIds.emplace(e);
+      onBoundary[e] = true;
+    } else {
+      const auto it = boundaryIds.find(e);
+      boundaryIds.erase(it);
+      onBoundary[e] = false;
+    }
+  };
+
+  if(!boundaryIds.empty()) {
+    // restore previously computed s2 boundary
+    for(const auto e : boundaryIds) {
+      onBoundary[e] = true;
+    }
+  } else {
+    // init cascade with s2 triangle boundary (3 edges)
+    for(SimplexId i = 0; i < 3; ++i) {
+      SimplexId e{};
+      triangulation.getTriangleEdge(s2, i, e);
+      addBoundary(e);
+    }
+  }
+
+  while(!boundaryIds.empty()) {
+    // tau: youngest edge on boundary
+    const auto tau{*boundaryIds.begin()};
+    // use the Discrete Gradient to find a triangle paired to tau
+    auto pTau{this->dg_.getPairedCell(Cell{1, tau}, triangulation)};
+    bool critical{false};
+    if(pTau == -1) {
+      // maybe tau is critical and paired to a critical triangle
+      pTau = partners[tau];
+      critical = true;
+    }
+    if(pTau == -1) {
+      // tau is critical and not paired
+      return tau;
+    }
+    // expand boundary
+    if(critical && s2Mapping[pTau] != -1) { // pTau is a non-paired 2-saddle
+      // merge pTau boundary into s2 boundary
+      for(const auto e : s2Boundaries[s2Mapping[pTau]]) {
+        addBoundary(e);
+      }
+    } else { // pTau is a regular triangle
+      // add pTau triangle boundary (3 edges)
+      for(SimplexId i = 0; i < 3; ++i) {
+        SimplexId e{};
+        triangulation.getTriangleEdge(pTau, i, e);
+        addBoundary(e);
+      }
+    }
+  }
+
+  return -1;
+}
+
+template <typename triangulationType>
+void ttk::DiscreteMorseSandwich::getSaddleSaddlePairs(
+  std::vector<PersistencePair> &pairs,
+  std::vector<bool> &paired1Saddles,
+  std::vector<bool> &paired2Saddles,
+  const std::vector<SimplexId> &critical1Saddles,
+  const std::vector<SimplexId> &critical2Saddles,
+  const std::vector<SimplexId> &crit1SaddlesOrder,
+  const triangulationType &triangulation) const {
+
+  Timer tm2{};
+  const auto nSadExtrPairs = pairs.size();
+
+  // 1- and 2-saddles yet to be paired
+  std::vector<SimplexId> saddles1{}, saddles2{};
+  // filter out already paired 1-saddles (edge id)
+  for(const auto s1 : critical1Saddles) {
+    if(!paired1Saddles[s1]) {
+      saddles1.emplace_back(s1);
+    }
+  }
+  // filter out already paired 2-saddles (triangle id)
+  for(const auto s2 : critical2Saddles) {
+    if(!paired2Saddles[s2]) {
+      saddles2.emplace_back(s2);
+    }
+  }
+
+  Timer tmpar{};
+
+  // sort every triangulation edges by filtration order
+  const auto &edgesFiltrOrder{crit1SaddlesOrder};
+
+  auto &onBoundary{this->onBoundary_};
+  auto &edgeTrianglePartner{this->edgeTrianglePartner_};
+
+  const auto cmpEdges
+    = [&edgesFiltrOrder](const SimplexId a, const SimplexId b) {
+        return edgesFiltrOrder[a] > edgesFiltrOrder[b];
+      };
+  using Container = std::set<SimplexId, decltype(cmpEdges)>;
+  std::vector<Container> s2Boundaries(saddles2.size(), Container(cmpEdges));
+  // unpaired critical triangle id -> index in saddle2 vector
+  auto &s2Mapping{this->s2Mapping_};
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < saddles2.size(); ++i) {
+    s2Mapping[saddles2[i]] = i;
+  }
+
+  // first parallel pass to pre-determine the boundary of every
+  // unpaired 2-saddle to the first unpaired 1-saddle on its wall
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic) \
+  firstprivate(onBoundary)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < saddles2.size(); ++i) {
+    // 2-saddles sorted in increasing order
+    const auto s2 = saddles2[i];
+    this->eliminateBoundariesSandwich(s2, onBoundary, s2Boundaries, s2Mapping,
+                                      edgeTrianglePartner, triangulation);
+    // reset onBoundary to false
+    for(const auto e : s2Boundaries[i]) {
+      onBoundary[e] = false;
+    }
+  }
+
+  this->printMsg("Precomputed 2-saddle boundaries", 1.0, tmpar.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+
+  Timer tmseq{};
+
+  for(size_t i = 0; i < saddles2.size(); ++i) {
+    // 2-saddles sorted in increasing order
+    const auto s2 = saddles2[i];
+    SimplexId s1{-1};
+
+    if(edgeTrianglePartner[*s2Boundaries[i].begin()] == -1) {
+      // use shortcut if first 1-saddle on wall is non-paired
+      s1 = *s2Boundaries[i].begin();
+    } else {
+      s1 = this->eliminateBoundariesSandwich(s2, onBoundary, s2Boundaries,
+                                             s2Mapping, edgeTrianglePartner,
+                                             triangulation);
+    }
+
+    if(s1 != -1) {
+      // we found a pair
+      pairs.emplace_back(s1, s2, 1);
+      paired1Saddles[s1] = true;
+      paired2Saddles[s2] = true;
+      edgeTrianglePartner[s1] = s2;
+      // reset onBoundary to false
+      for(const auto e : s2Boundaries[i]) {
+        onBoundary[e] = false;
+      }
+    }
+  }
+
+  const auto nSadSadPairs = pairs.size() - nSadExtrPairs;
+
+  this->printMsg(
+    "Computed " + std::to_string(nSadSadPairs) + " saddle-saddle pairs", 1.0,
+    tm2.getElapsedTime(), this->threadNumber_);
+
+  this->printMsg("saddle-saddle pairs sequential part", 1.0,
+                 tmseq.getElapsedTime(), 1, debug::LineMode::NEW,
+                 debug::Priority::VERBOSE);
+}
+
+template <typename triangulationType>
+void ttk::DiscreteMorseSandwich::extractCriticalCells(
+  std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+  std::array<std::vector<SimplexId>, 4> &critCellsOrder,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) const {
+
+  Timer tm{};
+  const auto dim = this->dg_.getDimensionality();
+
+  for(int i = 0; i < dim + 1; ++i) {
+
+    // map: store critical cell per dimension per thread
+    std::vector<std::vector<SimplexId>> critCellsPerThread(this->threadNumber_);
+
+    const SimplexId numberOfCells
+      = this->dg_.getNumberOfCells(i, triangulation);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId j = 0; j < numberOfCells; ++j) {
+#ifdef TTK_ENABLE_OPENMP
+      const auto tid = omp_get_thread_num();
+#else
+      const auto tid = 0;
+#endif // TTK_ENABLE_OPENMP
+      if(this->dg_.isCellCritical(i, j)) {
+        critCellsPerThread[tid].emplace_back(j);
+      }
+    }
+
+    // reduce: aggregate critical cells per thread
+    criticalCellsByDim[i] = std::move(critCellsPerThread[0]);
+    for(size_t j = 1; j < critCellsPerThread.size(); ++j) {
+      const auto &vec{critCellsPerThread[j]};
+      criticalCellsByDim[i].insert(
+        criticalCellsByDim[i].end(), vec.begin(), vec.end());
+    }
+  }
+
+  this->printMsg("Extracted critical cells", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::VERBOSE);
+
+  // memory allocations
+  auto &critEdges{this->critEdges_};
+  if(dim < 3) {
+    critEdges.resize(criticalCellsByDim[1].size());
+  }
+  std::vector<TriangleSimplex> critTriangles(criticalCellsByDim[2].size());
+  std::vector<TetraSimplex> critTetras(criticalCellsByDim[3].size());
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  {
+    if(dim == 3) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+      for(size_t i = 0; i < critEdges.size(); ++i) {
+        critEdges[i].fillEdge(i, offsets, triangulation);
+      }
+    } else {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+      for(size_t i = 0; i < critEdges.size(); ++i) {
+        critEdges[i].fillEdge(criticalCellsByDim[1][i], offsets, triangulation);
+      }
+    }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critTriangles.size(); ++i) {
+      critTriangles[i].fillTriangle(
+        criticalCellsByDim[2][i], offsets, triangulation);
+    }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critTetras.size(); ++i) {
+      critTetras[i].fillTetra(criticalCellsByDim[3][i], offsets, triangulation);
+    }
+  }
+
+  TTK_PSORT(this->threadNumber_, critEdges.begin(), critEdges.end());
+  TTK_PSORT(this->threadNumber_, critTriangles.begin(), critTriangles.end());
+  TTK_PSORT(this->threadNumber_, critTetras.begin(), critTetras.end());
+
+  if(dim == 3) {
+    TTK_PSORT(this->threadNumber_, criticalCellsByDim[1].begin(),
+              criticalCellsByDim[1].end(),
+              [&critCellsOrder](const SimplexId a, const SimplexId b) {
+                return critCellsOrder[1][a] < critCellsOrder[1][b];
+              });
+  } else {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critEdges.size(); ++i) {
+      criticalCellsByDim[1][i] = critEdges[i].id_;
+    }
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critEdges.size(); ++i) {
+      critCellsOrder[1][critEdges[i].id_] = i;
+    }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critTriangles.size(); ++i) {
+      criticalCellsByDim[2][i] = critTriangles[i].id_;
+      critCellsOrder[2][critTriangles[i].id_] = i;
+    }
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critTetras.size(); ++i) {
+      criticalCellsByDim[3][i] = critTetras[i].id_;
+      critCellsOrder[3][critTetras[i].id_] = i;
+    }
+  }
+
+  this->printMsg("Extracted & sorted critical cells", 1.0, tm.getElapsedTime(),
+                 this->threadNumber_, debug::LineMode::NEW,
+                 debug::Priority::DETAIL);
+}
+
+template <typename triangulationType>
+int ttk::DiscreteMorseSandwich::computePersistencePairs(
+  std::vector<PersistencePair> &pairs,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation,
+  const bool ignoreBoundary) {
+
+  // allocate memory
+  this->alloc(triangulation);
+
+  Timer tm{};
+  pairs.clear();
+  const auto dim = this->dg_.getDimensionality();
+
+  // get every critical cell sorted them by dimension
+  std::array<std::vector<SimplexId>, 4> criticalCellsByDim{};
+  // holds the critical cells order
+  auto &critCellsOrder{this->critCellsOrder_};
+
+  this->extractCriticalCells(
+    criticalCellsByDim, critCellsOrder, offsets, triangulation);
+
+  // if minima are paired
+  auto &pairedMinima{this->pairedCritCells_[0]};
+  // if 1-saddles are paired
+  auto &paired1Saddles{this->pairedCritCells_[1]};
+  // if 2-saddles are paired
+  auto &paired2Saddles{this->pairedCritCells_[dim - 1]};
+  // if maxima are paired
+  auto &pairedMaxima{this->pairedCritCells_[dim]};
+
+  // minima - saddle pairs
+  this->getMinSaddlePairs(pairs, pairedMinima, paired1Saddles,
+                          criticalCellsByDim[1], critCellsOrder[1], offsets,
+                          triangulation);
+
+  // connected components (global min/max pair)
+  size_t nConnComp{};
+  for(const auto min : criticalCellsByDim[0]) {
+    if(!pairedMinima[min]) {
+      pairs.emplace_back(min, -1, 0);
+      pairedMinima[min] = true;
+      nConnComp++;
+    }
+  }
+
+  if(dim == 1) {
+    // early return in 1D
+    this->printMsg(
+      "Computed " + std::to_string(pairs.size()) + " persistence pairs", 1.0,
+      tm.getElapsedTime(), this->threadNumber_);
+    return 0;
+  }
+
+  // saddle - maxima pairs
+  this->getMaxSaddlePairs(pairs, pairedMaxima, paired2Saddles,
+                          criticalCellsByDim[dim - 1], critCellsOrder[dim - 1],
+                          critCellsOrder[dim], triangulation, ignoreBoundary);
+
+  // saddle - saddle pairs
+  if(dim == 3 && !criticalCellsByDim[1].empty()
+     && !criticalCellsByDim[2].empty()) {
+    this->getSaddleSaddlePairs(pairs, paired1Saddles, paired2Saddles,
+                               criticalCellsByDim[1], criticalCellsByDim[2],
+                               critCellsOrder[1], triangulation);
+  }
+
+  if(std::is_same<triangulationType, ttk::ExplicitTriangulation>::value) {
+    // create infinite pairs from non-paired 1-saddles
+    size_t nHandles{}, nCavities{}, nNonPairedMax{};
+    if((dim == 2 && !ignoreBoundary) || dim == 3) {
+      for(const auto s1 : criticalCellsByDim[1]) {
+        if(!paired1Saddles[s1]) {
+          paired1Saddles[s1] = true;
+          // topological handles
+          pairs.emplace_back(s1, -1, 1);
+          nHandles++;
+        }
+      }
+    }
+    if(dim == 3 && !ignoreBoundary) {
+      for(const auto s2 : criticalCellsByDim[2]) {
+        if(!paired2Saddles[s2]) {
+          paired2Saddles[s2] = true;
+          // cavities
+          pairs.emplace_back(s2, -1, 2);
+          nCavities++;
+        }
+      }
+    }
+    if(dim == 2 && !ignoreBoundary) {
+      for(const auto max : criticalCellsByDim[dim]) {
+        if(!pairedMaxima[max]) {
+          pairs.emplace_back(max, -1, 2);
+          nNonPairedMax++;
+        }
+      }
+    }
+
+    // print Betti numbers
+    std::vector<std::vector<std::string>> rows{
+      {" #Connected components", std::to_string(nConnComp)},
+      {" #Topological handles", std::to_string(nHandles)},
+      {" #Cavities", std::to_string(nCavities)},
+      {" #Boundary components", std::to_string((dim == 3 ? nCavities : nHandles)
+                                               + nConnComp - nNonPairedMax)},
+    };
+
+    this->printMsg(rows, debug::Priority::DETAIL);
+  }
+
+  this->printMsg(
+    "Computed " + std::to_string(pairs.size()) + " persistence pairs", 1.0,
+    tm.getElapsedTime(), this->threadNumber_);
+
+  this->displayStats(pairs, criticalCellsByDim, pairedMinima, paired1Saddles,
+                     paired2Saddles, pairedMaxima);
+
+  // free memory
+  this->clear();
+
+  return 0;
+}

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -47,9 +47,14 @@ namespace ttk {
     }
 
     template <typename triangulationType>
-    inline int buildGradient(const SimplexId *const offsets,
+    inline int buildGradient(const void *const scalars,
+                             const size_t scalarsMTime,
+                             const SimplexId *const offsets,
                              const triangulationType &triangulation) {
+      this->dg_.setDebugLevel(this->debugLevel_);
+      this->dg_.setThreadNumber(this->threadNumber_);
       this->dg_.setInputOffsets(offsets);
+      this->dg_.setInputScalarField(scalars, scalarsMTime);
       return this->dg_.buildGradient(triangulation);
     }
 

--- a/core/base/persistenceDiagram/CMakeLists.txt
+++ b/core/base/persistenceDiagram/CMakeLists.txt
@@ -5,10 +5,10 @@ ttk_add_base_library(persistenceDiagram
     PersistenceDiagram.h
     PersistenceDiagramUtils.h
   DEPENDS
-    discreteGradient
     triangulation
     ftmTreePP
     persistentSimplexPairs
     progressiveTopology
     approximateTopology
+    discreteMorseSandwich
     )

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -142,6 +142,7 @@ namespace ttk {
     template <typename scalarType, class triangulationType>
     int executeDiscreteMorseSandwich(std::vector<PersistencePair> &CTDiagram,
                                      const scalarType *inputScalars,
+                                     const size_t scalarsMTime,
                                      const SimplexId *inputOffsets,
                                      const triangulationType *triangulation);
 
@@ -276,7 +277,7 @@ int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
       break;
     case BACKEND::DISCRETE_MORSE_SANDWICH:
       executeDiscreteMorseSandwich(
-        CTDiagram, inputScalars, inputOffsets, triangulation);
+        CTDiagram, inputScalars, scalarsMTime, inputOffsets, triangulation);
       break;
     case BACKEND::PROGRESSIVE_TOPOLOGY:
       executeProgressiveTopology(
@@ -384,13 +385,14 @@ template <typename scalarType, class triangulationType>
 int ttk::PersistenceDiagram::executeDiscreteMorseSandwich(
   std::vector<PersistencePair> &CTDiagram,
   const scalarType *inputScalars,
+  const size_t scalarsMTime,
   const SimplexId *inputOffsets,
   const triangulationType *triangulation) {
 
   Timer tm{};
   const auto dim = triangulation->getDimensionality();
 
-  dms_.buildGradient(inputOffsets, *triangulation);
+  dms_.buildGradient(inputScalars, scalarsMTime, inputOffsets, *triangulation);
   std::vector<DiscreteMorseSandwich::PersistencePair> dms_pairs{};
   dms_.computePersistencePairs(
     dms_pairs, inputOffsets, *triangulation, this->IgnoreBoundary);

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -198,7 +198,7 @@ namespace ttk {
     DiscreteMorseSandwich dms_{};
 
     // int BackEnd{0};
-    BACKEND BackEnd{BACKEND::FTM};
+    BACKEND BackEnd{BACKEND::DISCRETE_MORSE_SANDWICH};
     // progressivity
     ttk::ProgressiveTopology progT_{};
     ttk::ApproximateTopology approxT_{};

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -270,6 +270,8 @@ int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
 
   checkProgressivityRequirement(triangulation);
 
+  Timer tm{};
+
   switch(BackEnd) {
     case BACKEND::PERSISTENT_SIMPLEX:
       executePersistentSimplex(
@@ -294,6 +296,8 @@ int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
     default:
       printErr("No method was selected");
   }
+
+  this->printMsg("Complete", 1.0, tm.getElapsedTime(), this->threadNumber_);
 
   // finally sort the diagram
   sortPersistenceDiagram(CTDiagram, inputOffsets);

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -86,6 +86,9 @@ namespace ttk {
     inline void setComputeSaddleConnectors(bool state) {
       ComputeSaddleConnectors = state;
     }
+    inline void setBackend(const BACKEND be) {
+      this->BackEnd = be;
+    }
 
     ttk::CriticalType getNodeType(ftm::FTMTree_MT *tree,
                                   ftm::TreeType treeType,

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -193,7 +193,7 @@ namespace ttk {
     }
 
   protected:
-    bool IgnoreBoundary{true};
+    bool IgnoreBoundary{false};
     bool ComputeSaddleConnectors{false};
     ftm::FTMTreePP contourTree_{};
     dcg::DiscreteGradient dcg_{};

--- a/core/base/persistentGenerators/CMakeLists.txt
+++ b/core/base/persistentGenerators/CMakeLists.txt
@@ -1,0 +1,9 @@
+ttk_add_base_library(persistentGenerators
+  SOURCES
+    PersistentGenerators.cpp
+  HEADERS
+    PersistentGenerators.h
+  DEPENDS
+    discreteMorseSandwich
+    unionFind
+)

--- a/core/base/persistentGenerators/PersistentGenerators.cpp
+++ b/core/base/persistentGenerators/PersistentGenerators.cpp
@@ -1,0 +1,41 @@
+#include <PersistentGenerators.h>
+#include <UnionFind.h>
+
+ttk::PersistentGenerators::PersistentGenerators() {
+  this->setDebugMsgPrefix("PersistentGenerators");
+}
+
+void ttk::PersistentGenerators::getConnectedComponents(
+  const std::vector<std::array<SimplexId, 2>> &edgeNeighs,
+  std::vector<SimplexId> &connComp) const {
+
+  // use Union-Find to get connected components
+  std::vector<ttk::UnionFind> uf(connComp.size());
+
+  // initialize UFs
+  for(size_t j = 0; j < edgeNeighs.size(); ++j) {
+    uf[j].setRank(j);
+  }
+
+  // Union between adjacent edges
+  for(size_t j = 0; j < edgeNeighs.size(); ++j) {
+    ttk::UnionFind::makeUnion(&uf[j], &uf[edgeNeighs[j][0]]);
+    ttk::UnionFind::makeUnion(&uf[j], &uf[edgeNeighs[j][1]]);
+  }
+
+  // UF rank -> componend id mapping
+  std::vector<SimplexId> connCompIds(edgeNeighs.size(), -1);
+  size_t nConnComps{};
+
+  // find connected component ids
+  for(size_t j = 0; j < edgeNeighs.size(); ++j) {
+    const auto root{uf[j].find()};
+    if(root != nullptr) {
+      const auto rank{root->getRank()};
+      if(connCompIds[rank] == -1) {
+        connCompIds[rank] = nConnComps++;
+      }
+      connComp[j] = connCompIds[rank];
+    }
+  }
+}

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -1,0 +1,472 @@
+/// \ingroup baseCode
+/// \class ttk::PersistentGenerators
+/// \author Julien Tierny <julien.tierny@lip6.fr>
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date March 2021.
+///
+/// \brief TTK %PersistentGenerators processing package.
+///
+/// ttk::PersistentGenerators uses ttk::discreteMorseSandwich to
+/// compute generators for persistence pairs of dimensions 1.
+///
+/// \sa ttk::DiscreteMorseSandwich
+
+#pragma once
+
+#include <DiscreteMorseSandwich.h>
+
+#include <limits>
+
+namespace ttk {
+  class PersistentGenerators : virtual public DiscreteMorseSandwich {
+  public:
+    PersistentGenerators();
+
+    /**
+     * @brief Compute the persistence generators from the discrete gradient
+     *
+     * @pre @ref buildGradient and @ref preconditionTriangulation
+     * should be called prior to this function
+     *
+     * @param[out] generators Persistent generators
+     * @param[out] connComps Generators connected components
+     * @param[in] offsets Order field
+     * @param[in] triangulation Preconditionned triangulation
+     *
+     * @return 0 when success
+     */
+    template <typename triangulationType>
+    int computePersistentGenerators(
+      std::vector<GeneratorType> &generators,
+      std::vector<std::vector<SimplexId>> &connComps,
+      const SimplexId *const offsets,
+      const triangulationType &triangulation);
+
+  private:
+    /**
+     * @brief Use Union-Find to get connected components
+     *
+     * @param[in] edgeNeighs Graph of edge neighbors
+     * @param[out] connComp Edges connected component id
+     */
+    void getConnectedComponents(
+      const std::vector<std::array<SimplexId, 2>> &edgeNeighs,
+      std::vector<SimplexId> &connComp) const;
+
+    /**
+     * @brief Detect connected components of persistent generators
+     *
+     * @param[out] connComps Connected component id per edge
+     * @param[in] generators Pre-computed persistent generators
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void findGeneratorsConnectedComponents(
+      std::vector<std::vector<SimplexId>> &connComps,
+      const std::vector<GeneratorType> &generators,
+      const triangulationType &triangulation) const;
+
+    /**
+     * @brief Find generators corresponding to infinite pairs of
+     * dimension 1 (topological handles)
+     *
+     * @param[out] generators Persistent generators to compute
+     * @param[in] inf1saddles Unpaired 1-saddles (infinite pairs)
+     * @param[in] minSadPairs Propagate on simplified topology
+     * @param[in] offsets Order field
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void findHandlesGenerators(std::vector<GeneratorType> &generators,
+                               const std::vector<SimplexId> &inf1Saddles,
+                               const std::vector<PersistencePair> &minSadPairs,
+                               const SimplexId *const offsets,
+                               const triangulationType &triangulation) const;
+
+    /**
+     * @brief Clean a topogical handle generator by removing extra branches
+     *
+     * Performs a Dijkstra shortest path between the two vertices of
+     * the critical edge marking the topogical handle
+     *
+     * @param[in,out] generator Generator to be pruned
+     * @param[in,out] genMask Mask generator edges
+     * @param[in,out] pathVerts Mask shortest path vertices
+     * @param[in,out] preds Vertex predecessor (for Dijkstra)
+     * @param[in,out] preds Vertex distance to critical edge (for Dijkstra)
+     * @param[in] s1 Critical edge of the topogical handle
+     * @param[in] triangulation Triangulation
+     */
+    template <typename triangulationType>
+    void pruneHandleGenerator(std::vector<SimplexId> &generator,
+                              std::vector<bool> &genMask,
+                              std::vector<bool> &pathVerts,
+                              std::vector<SimplexId> &preds,
+                              std::vector<size_t> &dists,
+                              const SimplexId &s1,
+                              const triangulationType &triangulation) const;
+
+  protected:
+    bool PruneHandlesGenerators{false};
+  };
+} // namespace ttk
+
+template <typename triangulationType>
+void ttk::PersistentGenerators::findGeneratorsConnectedComponents(
+  std::vector<std::vector<SimplexId>> &connComps,
+  const std::vector<GeneratorType> &generators,
+  const triangulationType &triangulation) const {
+
+  connComps.resize(generators.size());
+
+  // global edge id -> local generator id mapping
+  std::vector<SimplexId> isVisited(triangulation.getNumberOfEdges(), -1);
+
+  for(size_t i = 0; i < generators.size(); ++i) {
+    const auto &genEdges{generators[i].boundary};
+    auto &connComp{connComps[i]};
+    if(genEdges.empty()) {
+      continue;
+    }
+    connComp.resize(genEdges.size(), -1);
+    // fill isVisited for the local generator
+    // (cleanup at iteration end)
+    for(size_t j = 0; j < genEdges.size(); ++j) {
+      isVisited[genEdges[j]] = j;
+    }
+
+    // for each generator edge, the local neighbor ids
+    // (assumption: exactly 2 neighboring edges per generator edge)
+    std::vector<std::array<SimplexId, 2>> edgeNeighs(genEdges.size());
+
+    for(size_t j = 0; j < genEdges.size(); ++j) {
+      const auto edge{genEdges[j]};
+      for(size_t k = 0; k < 2; ++k) {
+        SimplexId v{};
+        triangulation.getEdgeVertex(edge, k, v);
+        const auto nneighs{triangulation.getVertexEdgeNumber(v)};
+        for(SimplexId l = 0; l < nneighs; ++l) {
+          SimplexId neigh{};
+          triangulation.getVertexEdge(v, l, neigh);
+          const auto neighId{isVisited[neigh]};
+          if(neigh == edge || neighId == -1) {
+            continue;
+          }
+          edgeNeighs[j][k] = neighId;
+          break; // go to next vertex
+        }
+      }
+    }
+
+    this->getConnectedComponents(edgeNeighs, connComp);
+
+    // clean isVisited
+    for(const auto e : genEdges) {
+      isVisited[e] = -1;
+    }
+  }
+}
+
+template <typename triangulationType>
+void ttk::PersistentGenerators::findHandlesGenerators(
+  std::vector<GeneratorType> &generators,
+  const std::vector<SimplexId> &inf1Saddles,
+  const std::vector<PersistencePair> &minSadPairs,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  // minimum vertex id -> paired 1-saddle edge id mapping
+  std::vector<SimplexId> min2sad(triangulation.getNumberOfVertices(), -1);
+  for(const auto &p : minSadPairs) {
+    min2sad[p.birth] = p.death;
+  }
+
+  // global maximum
+  const auto globMax{std::distance(
+    offsets,
+    std::max_element(offsets, offsets + triangulation.getNumberOfVertices()))};
+
+  // storage (allocated once, cleaned after each iteration)
+  std::vector<bool> genMask(triangulation.getNumberOfEdges(), false);
+  std::vector<size_t> dists(
+    triangulation.getNumberOfVertices(), std::numeric_limits<size_t>::max());
+  std::vector<SimplexId> preds(triangulation.getNumberOfVertices(), -1);
+  std::vector<bool> pathVerts(triangulation.getNumberOfVertices(), false);
+
+  // follow descending 1-separatrices to find representative generator
+  for(const auto s1 : inf1Saddles) {
+    std::vector<SimplexId> generator{};
+    std::set<SimplexId> visited1Sads{};
+
+    std::queue<SimplexId> toPropage{};
+    toPropage.push(s1);
+
+    while(!toPropage.empty()) {
+      // current 1-saddle
+      const auto curr{toPropage.front()};
+      toPropage.pop();
+      visited1Sads.emplace(curr);
+
+      if(curr != s1) {
+        generator.emplace_back(curr);
+      }
+
+      for(SimplexId i = 0; i < 2; ++i) {
+        SimplexId currVert{};
+        triangulation.getEdgeVertex(curr, i, currVert);
+        std::vector<Cell> vpath{};
+        SimplexId min{-1};
+        this->dg_.getDescendingPath(Cell{0, currVert}, vpath, triangulation);
+        const auto &lastCell = vpath.back();
+        if(lastCell.dim_ == 0) {
+          min = lastCell.id_;
+        }
+
+        if(min == -1) {
+          // separatrix leads to nowhere
+          continue;
+        }
+
+        // store vpath
+        for(const auto &c : vpath) {
+          if(c.dim_ == 1) {
+            generator.emplace_back(c.id_);
+          }
+        }
+
+        if(min2sad[min] == -1) {
+          // global minimum ?
+          continue;
+        }
+
+        const auto next{min2sad[min]};
+        if(visited1Sads.find(next) == visited1Sads.end()) {
+          toPropage.push(next);
+        }
+      }
+    }
+
+    // remove duplicates
+    TTK_PSORT(this->threadNumber_, generator.begin(), generator.end());
+    const auto last = std::unique(generator.begin(), generator.end());
+    generator.erase(last, generator.end());
+
+    if(this->PruneHandlesGenerators) {
+      // post-process: Dijkstra from one 1-saddle vertex to the other
+      this->pruneHandleGenerator(
+        generator, genMask, pathVerts, preds, dists, s1, triangulation);
+    }
+
+    // ensure unpaired 1-saddle is first
+    generator.emplace_back(s1);
+    std::swap(generator[0], generator.back());
+
+    generators.emplace_back(GeneratorType{
+      generator, -1,
+      std::array<SimplexId, 2>{
+        static_cast<SimplexId>(globMax),
+        this->dg_.getCellGreaterVertex(Cell{1, s1}, triangulation),
+      }});
+  }
+
+  this->printMsg("Computed " + std::to_string(inf1Saddles.size())
+                   + " topological handle generators",
+                 1.0, tm.getElapsedTime(), this->threadNumber_);
+}
+
+template <typename triangulationType>
+void ttk::PersistentGenerators::pruneHandleGenerator(
+  std::vector<SimplexId> &generator,
+  std::vector<bool> &genMask,
+  std::vector<bool> &pathVerts,
+  std::vector<SimplexId> &preds,
+  std::vector<size_t> &dists,
+  const SimplexId &s1,
+  const triangulationType &triangulation) const {
+
+  // store generator vertices for faster cleanup
+  std::vector<SimplexId> genVerts{};
+  genVerts.reserve(2 * generator.size());
+
+  for(const auto e : generator) {
+    genMask[e] = true;
+  }
+
+  using PQueueElem = std::pair<size_t, SimplexId>;
+  using PQueue = std::priority_queue<PQueueElem, std::vector<PQueueElem>,
+                                     std::greater<PQueueElem>>;
+  PQueue pq{};
+  // try to find the shortest path between seed0 & seed1 (the
+  // vertices of the critical edge marking the topological handle)
+  // on generator \ {s1}
+  SimplexId seed0{}, seed1{};
+  triangulation.getEdgeVertex(s1, 0, seed0);
+  triangulation.getEdgeVertex(s1, 1, seed1);
+  genVerts.emplace_back(seed0);
+  genVerts.emplace_back(seed1);
+  pq.emplace(0, seed0);
+  dists[seed0] = 0;
+
+  while(!pq.empty()) {
+    const auto curr{pq.top()};
+    genVerts.emplace_back(curr.second);
+    pq.pop();
+
+    const auto nneighs{triangulation.getVertexNeighborNumber(curr.second)};
+    dists[curr.second] = curr.first;
+
+    for(SimplexId i = 0; i < nneighs; ++i) {
+      SimplexId neigh{}, edge{};
+      // vertex neighbor & corresponding edge are at the same index
+      triangulation.getVertexNeighbor(curr.second, i, neigh);
+      triangulation.getVertexEdge(curr.second, i, edge);
+      // stay on generator edges
+      if(!genMask[edge]) {
+        continue;
+      }
+      // skip critical edge
+      if(curr.second == seed0 && neigh == seed1) {
+        continue;
+      }
+      if(dists[neigh] > curr.first + 1) {
+        dists[neigh] = curr.first + 1;
+        preds[neigh] = curr.second;
+        pq.emplace(dists[neigh], neigh);
+      }
+    }
+  }
+
+  // extract shortest path
+  SimplexId curr{seed1};
+  while(curr != seed0) {
+    pathVerts[curr] = true;
+    curr = preds[curr];
+  }
+  pathVerts[seed0] = true;
+  pathVerts[seed1] = true;
+
+  std::vector<SimplexId> prunedGenerator{};
+  prunedGenerator.reserve(generator.size());
+  for(const auto e : generator) {
+    SimplexId v0{}, v1{};
+    triangulation.getEdgeVertex(e, 0, v0);
+    triangulation.getEdgeVertex(e, 1, v1);
+    if(pathVerts[v0] && pathVerts[v1]) {
+      prunedGenerator.emplace_back(e);
+    }
+  }
+  std::swap(generator, prunedGenerator);
+
+  // cleanup: reset large vectors
+  for(const auto e : prunedGenerator) {
+    genMask[e] = false;
+  }
+  for(const auto v : genVerts) {
+    preds[v] = -1;
+    dists[v] = std::numeric_limits<size_t>::max();
+    pathVerts[v] = false;
+  }
+}
+
+template <typename triangulationType>
+int ttk::PersistentGenerators::computePersistentGenerators(
+  std::vector<GeneratorType> &generators,
+  std::vector<std::vector<SimplexId>> &connComps,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) {
+
+  // allocate memory
+  this->alloc(triangulation);
+
+  Timer tm{};
+  const auto dim = this->dg_.getDimensionality();
+  if(dim < 2) {
+    this->printWrn("Cannot compute cycles for 1D datasets");
+    return 0;
+  }
+  if(dim == 2) {
+    // fix container size for 2D datasets (use
+    // eliminateBoundariesSandwich for saddle-max instead of
+    // tripletsToPersistencePairs)
+    this->critEdges_.resize(triangulation.getNumberOfEdges());
+    this->edgeTrianglePartner_.resize(triangulation.getNumberOfEdges(), -1);
+    this->onBoundary_.resize(triangulation.getNumberOfEdges(), false);
+    this->s2Mapping_.resize(triangulation.getNumberOfTriangles(), -1);
+  }
+
+  // get every critical cell sorted them by dimension
+  std::array<std::vector<SimplexId>, 4> criticalCellsByDim{};
+  // holds the critical cells order
+  auto &critCellsOrder{this->critCellsOrder_};
+
+  this->extractCriticalCells(
+    criticalCellsByDim, critCellsOrder, offsets, triangulation, true);
+
+  // if minima are paired
+  auto &pairedMinima{this->pairedCritCells_[0]};
+  // if 1-saddles are paired
+  auto &paired1Saddles{this->pairedCritCells_[1]};
+  // if 2-saddles are paired
+  auto &paired2Saddles{this->pairedCritCells_[dim - 1]};
+  // if maxima are paired
+  auto &pairedMaxima{this->pairedCritCells_[dim]};
+
+  // minima - saddle pairs
+  // we need the min-saddle pairs to get the infinite pairs of
+  // dimension 1 (topological handles)
+  std::vector<PersistencePair> minSadPairs{};
+  this->getMinSaddlePairs(minSadPairs, pairedMinima, paired1Saddles,
+                          criticalCellsByDim[1], critCellsOrder[1], offsets,
+                          triangulation);
+
+  if(dim == 3) {
+    // saddle - maxima pairs
+    // this should fasten the computation of saddle-saddle pairs
+    // (sandwich)
+    std::vector<PersistencePair> sadMaxPairs{};
+    this->getMaxSaddlePairs(
+      sadMaxPairs, pairedMaxima, paired2Saddles, criticalCellsByDim[dim - 1],
+      critCellsOrder[dim - 1], critCellsOrder[dim], triangulation, false);
+  }
+
+  if(!criticalCellsByDim[1].empty() && !criticalCellsByDim[2].empty()) {
+    // compute saddle-saddle pairs, extract generators/cycles
+    // (eliminateBoundariesSandwich boundaries right before
+    // simplification)
+    std::vector<PersistencePair> sadSadPairs{};
+    this->getSaddleSaddlePairs(sadSadPairs, paired1Saddles, paired2Saddles,
+                               true, generators, criticalCellsByDim[1],
+                               criticalCellsByDim[2], critCellsOrder[1],
+                               triangulation);
+  }
+
+  // detect topological handles
+  std::vector<SimplexId> inf1Saddles{};
+  for(const auto s1 : criticalCellsByDim[1]) {
+    if(!paired1Saddles[s1]) {
+      inf1Saddles.emplace_back(s1);
+    }
+  }
+
+  if(!inf1Saddles.empty()) {
+    this->findHandlesGenerators(
+      generators, inf1Saddles, minSadPairs, offsets, triangulation);
+  }
+
+  if(!generators.empty()) {
+    // detect connected components in cycles
+    this->findGeneratorsConnectedComponents(
+      connComps, generators, triangulation);
+  }
+
+  this->printMsg(
+    "Computed " + std::to_string(generators.size()) + " persistent generators",
+    1.0, tm.getElapsedTime(), this->threadNumber_);
+
+  // free memory
+  this->clear();
+
+  return 0;
+}

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -93,6 +93,7 @@ int ttk::TrackingFromFields::performDiagramComputation(
   for(int i = 0; i < fieldNumber; ++i) {
     ttk::PersistenceDiagram persistenceDiagram;
     persistenceDiagram.setThreadNumber(1);
+    persistenceDiagram.setBackend(PersistenceDiagram::BACKEND::FTM);
 
     // std::vector<std::tuple<ttk::dcg::Cell, ttk::dcg::Cell>> dmt_pairs;
     // persistenceDiagram.setDMTPairs(&dmt_pairs);

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -168,6 +168,9 @@ public:
   vtkGetMacro(Epsilon, double);
   vtkSetMacro(Epsilon, double);
 
+  vtkSetMacro(IgnoreBoundary, bool);
+  vtkGetMacro(IgnoreBoundary, bool);
+
 protected:
   ttkPersistenceDiagram();
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -268,7 +268,8 @@ int DiagramToVTU(vtkUnstructuredGrid *vtu,
     persistence->SetTuple1(i, pair.persistence);
     birthScalars->SetTuple1(i, pair.birth.sfValue);
     isFinite->SetTuple1(i, pair.isFinite);
-    pairsDim->SetTuple1(i, pair.dim == 2 ? dim - 1 : pair.dim);
+    pairsDim->SetTuple1(
+      i, (pair.dim == 2 && pair.isFinite) ? dim - 1 : pair.dim);
   }
   offsets->SetTuple1(diagram.size(), connectivity->GetNumberOfTuples());
 

--- a/core/vtk/ttkPersistentGenerators/CMakeLists.txt
+++ b/core/vtk/ttkPersistentGenerators/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkPersistentGenerators/ttk.module
+++ b/core/vtk/ttkPersistentGenerators/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkPersistentGenerators
+SOURCES
+  ttkPersistentGenerators.cpp
+HEADERS
+  ttkPersistentGenerators.h
+DEPENDS
+  persistentGenerators
+  ttkAlgorithm

--- a/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.cpp
+++ b/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.cpp
@@ -1,0 +1,213 @@
+#include <vtkCellData.h>
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
+#include <vtkInformation.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSignedCharArray.h>
+#include <vtkSmartPointer.h>
+#include <vtkUnsignedCharArray.h>
+
+#include <ttkPersistentGenerators.h>
+#include <ttkUtils.h>
+
+vtkStandardNewMacro(ttkPersistentGenerators);
+
+ttkPersistentGenerators::ttkPersistentGenerators() {
+  this->setDebugMsgPrefix("PersistentGenerators");
+  SetNumberOfInputPorts(1);
+  SetNumberOfOutputPorts(1);
+}
+
+int ttkPersistentGenerators::FillInputPortInformation(int port,
+                                                      vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkPersistentGenerators::FillOutputPortInformation(int port,
+                                                       vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
+    return 1;
+  }
+  return 0;
+}
+
+template <typename triangulationType>
+int ttkPersistentGenerators::dispatch(vtkPolyData *output,
+                                      vtkDataArray *const inputScalarsArray,
+                                      const SimplexId *const inputOrder,
+                                      const triangulationType &triangulation) {
+
+  this->buildGradient(ttkUtils::GetVoidPointer(inputScalarsArray),
+                      inputScalarsArray->GetMTime(), inputOrder, triangulation);
+  std::vector<GeneratorType> cycles{};
+  std::vector<std::vector<SimplexId>> connComps{};
+  this->computePersistentGenerators(
+    cycles, connComps, inputOrder, triangulation);
+
+  const SimplexId numberOfVertices = triangulation.getNumberOfVertices();
+  std::vector<SimplexId> isVisited(numberOfVertices, -1);
+  std::vector<SimplexId> visitedIds{};
+
+  vtkNew<vtkPoints> points{};
+  vtkNew<vtkCellArray> cells{};
+
+  vtkNew<ttkSimplexIdTypeArray> cycleId{};
+  cycleId->SetName("CycleId");
+  vtkNew<ttkSimplexIdTypeArray> edgeId{};
+  edgeId->SetName("EdgeId");
+  vtkNew<ttkSimplexIdTypeArray> birthId{};
+  birthId->SetName("BirthId");
+  vtkNew<ttkSimplexIdTypeArray> deathId{};
+  deathId->SetName("DeathId");
+  vtkNew<ttkSimplexIdTypeArray> ccId{};
+  ccId->SetName("ComponentId");
+  vtkNew<vtkUnsignedCharArray> iFin{};
+  iFin->SetName(ttk::PersistenceIsFinite);
+  vtkSmartPointer<vtkDataArray> pers{inputScalarsArray->NewInstance()};
+  pers->SetName(ttk::PersistenceName);
+  vtkNew<vtkSignedCharArray> mask{};
+  mask->SetName(ttk::MaskScalarFieldName);
+  vtkNew<ttkSimplexIdTypeArray> vertsId{};
+  vertsId->SetName(ttk::VertexScalarFieldName);
+  vtkSmartPointer<vtkDataArray> sf{inputScalarsArray->NewInstance()};
+  sf->SetName(inputScalarsArray->GetName());
+  vtkNew<vtkSignedCharArray> nbOnBoundary{};
+  nbOnBoundary->SetNumberOfComponents(1);
+  nbOnBoundary->SetName(ttk::MorseSmaleCriticalPointsOnBoundaryName);
+
+  const auto addVertex = [&](const SimplexId v) {
+    if(v == -1) {
+      return vtkIdType(-1);
+    }
+    std::array<float, 3> p{};
+    triangulation.getVertexPoint(v, p[0], p[1], p[2]);
+    return points->InsertNextPoint(p.data());
+  };
+
+  const auto addEdge = [&](const SimplexId e) {
+    std::array<vtkIdType, 2> pts{};
+    for(int i = 0; i < 2; ++i) {
+      SimplexId v{};
+      triangulation.getEdgeVertex(e, i, v);
+      if(isVisited[v] == -1) {
+        pts[i] = addVertex(v);
+        isVisited[v] = pts[i];
+        visitedIds.emplace_back(v);
+      } else {
+        pts[i] = isVisited[v];
+      }
+    }
+    cells->InsertNextCell(2, pts.data());
+  };
+
+  for(size_t i = 0; i < cycles.size(); ++i) {
+    if(cycles[i].boundary.empty()) {
+      continue;
+    }
+
+    const auto &cycle{cycles[i]};
+    const auto cbirth{cycle.boundary[0]};
+    const auto cdeath{cycle.critTriangleId};
+    const auto cpers{inputScalarsArray->GetTuple1(cycle.critVertsIds[0])
+                     - inputScalarsArray->GetTuple1(cycle.critVertsIds[1])};
+
+    for(const auto e : cycle.boundary) {
+      addEdge(e);
+      cycleId->InsertNextTuple1(i);
+      edgeId->InsertNextTuple1(e);
+      birthId->InsertNextTuple1(cbirth);
+      deathId->InsertNextTuple1(cdeath);
+      pers->InsertNextTuple1(cpers);
+      iFin->InsertNextTuple1(cdeath != -1);
+      nbOnBoundary->InsertNextTuple1(
+        triangulation.isEdgeOnBoundary(cbirth)
+        + (cdeath != -1 && triangulation.getDimensionality() == 3
+             ? triangulation.isTriangleOnBoundary(cdeath)
+             : 0));
+    }
+    for(const auto cc : connComps[i]) {
+      ccId->InsertNextTuple1(cc);
+    }
+
+    // copy input scalar field
+    for(const auto v : visitedIds) {
+      vertsId->InsertNextTuple1(v);
+      sf->InsertNextTuple1(inputScalarsArray->GetTuple1(v));
+      mask->InsertNextTuple1(1);
+    }
+
+    // fill mask (0 on critical edge greater vertex, 1 on other vertices)
+    SimplexId v0{}, v1{};
+    triangulation.getEdgeVertex(cbirth, 0, v0);
+    triangulation.getEdgeVertex(cbirth, 1, v1);
+    mask->SetTuple1(isVisited[v0], 0);
+    mask->SetTuple1(isVisited[v1], 0);
+
+    // ensure cycles don't share points
+    for(const auto v : visitedIds) {
+      isVisited[v] = -1;
+    }
+    visitedIds.clear();
+  }
+
+  output->SetPoints(points);
+  output->GetPointData()->AddArray(sf);
+  output->GetPointData()->AddArray(mask);
+  output->GetPointData()->AddArray(vertsId);
+  output->SetLines(cells);
+  output->GetCellData()->AddArray(cycleId);
+  output->GetCellData()->AddArray(edgeId);
+  output->GetCellData()->AddArray(birthId);
+  output->GetCellData()->AddArray(deathId);
+  output->GetCellData()->AddArray(ccId);
+  output->GetCellData()->AddArray(iFin);
+  output->GetCellData()->AddArray(pers);
+  output->GetCellData()->AddArray(nbOnBoundary);
+
+  return 1;
+}
+
+int ttkPersistentGenerators::RequestData(vtkInformation *ttkNotUsed(request),
+                                         vtkInformationVector **inputVector,
+                                         vtkInformationVector *outputVector) {
+
+  auto *input = vtkDataSet::GetData(inputVector[0]);
+  auto *output = vtkPolyData::GetData(outputVector, 0);
+
+  ttk::Triangulation *triangulation = ttkAlgorithm::GetTriangulation(input);
+  if(triangulation == nullptr) {
+    this->printErr("Wrong triangulation");
+    return 0;
+  }
+  this->preconditionTriangulation(triangulation);
+
+  vtkDataArray *inputScalars = this->GetInputArrayToProcess(0, inputVector);
+  if(inputScalars == nullptr) {
+    this->printErr("Wrong input scalars");
+    return 0;
+  }
+
+  vtkDataArray *offsetField
+    = this->GetOrderArray(input, 0, 1, ForceInputOffsetScalarField);
+  if(offsetField == nullptr) {
+    this->printErr("Wrong input offsets");
+    return 0;
+  }
+
+  ttkTemplateMacro(
+    triangulation->getType(),
+    this->dispatch(output, inputScalars,
+                   ttkUtils::GetPointer<SimplexId>(offsetField),
+                   *static_cast<TTK_TT *>(triangulation->getData())));
+
+  return 1;
+}

--- a/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
+++ b/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
@@ -1,0 +1,55 @@
+/// \ingroup vtk
+/// \class ttkPersistentGenerators
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
+/// \date February 2022.
+///
+/// \brief TTK VTK-filter for the computation of persistent generators.
+
+#pragma once
+
+// VTK includes
+#include <vtkDataArray.h>
+#include <vtkPolyData.h>
+
+// VTK Module
+#include <ttkPersistentGeneratorsModule.h>
+
+// ttk code includes
+#include <PersistentGenerators.h>
+#include <ttkAlgorithm.h>
+#include <ttkMacros.h>
+
+class TTKPERSISTENTGENERATORS_EXPORT ttkPersistentGenerators
+  : public ttkAlgorithm,
+    protected ttk::PersistentGenerators {
+
+public:
+  static ttkPersistentGenerators *New();
+
+  vtkTypeMacro(ttkPersistentGenerators, ttkAlgorithm);
+
+  vtkSetMacro(PruneHandlesGenerators, bool);
+  vtkGetMacro(PruneHandlesGenerators, bool);
+
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
+
+protected:
+  ttkPersistentGenerators();
+
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+
+private:
+  template <typename triangulationType>
+  int dispatch(vtkPolyData *output,
+               vtkDataArray *const inputScalarsArray,
+               const SimplexId *const inputOrder,
+               const triangulationType &triangulation);
+
+  bool ForceInputOffsetScalarField{false};
+};

--- a/core/vtk/ttkPersistentGenerators/vtk.module
+++ b/core/vtk/ttkPersistentGenerators/vtk.module
@@ -1,0 +1,4 @@
+NAME
+ ttkPersistentGenerators
+DEPENDS
+ ttkAlgorithm

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -338,7 +338,7 @@
           name="Ignore Boundary"
           command="SetIgnoreBoundary"
           number_of_elements="1"
-          default_values="1" panel_visibility="advanced">
+          default_values="0" panel_visibility="advanced">
         <BooleanDomain name="bool"/>
         <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -209,7 +209,7 @@
            label="Backend"
            command="SetBackEnd"
            number_of_elements="1"
-           default_values="0"
+           default_values="2"
            panel_visibility="advanced" >
          <EnumerationDomain name="enum">
           <Entry value="0" text="FTM (IEEE TPSD 2019)"/>

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -87,8 +87,8 @@
 
         - https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/
 
-        - https://topology-tool-kit.github.io/examples/2manifoldLearning/        
-        
+        - https://topology-tool-kit.github.io/examples/2manifoldLearning/
+
         - https://topology-tool-kit.github.io/examples/ctBones/
 
         - https://topology-tool-kit.github.io/examples/dragon/
@@ -100,7 +100,7 @@
         - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
-        
+
         - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
 
         - https://topology-tool-kit.github.io/examples/persistenceClustering0/
@@ -116,10 +116,10 @@
         - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
 
         - https://topology-tool-kit.github.io/examples/uncertainStartingVortex/
-        
+
         - https://topology-tool-kit.github.io/examples/interactionSites/
 
-                
+
       </Documentation>
 
       <InputProperty
@@ -205,17 +205,18 @@
       </StringVectorProperty>
 
        <IntVectorProperty
-          name="BackEnd"
-          label="Backend"
-          command="SetBackEnd"
-          number_of_elements="1"
-         default_values="0"
-         panel_visibility="advanced" >
+           name="BackEnd"
+           label="Backend"
+           command="SetBackEnd"
+           number_of_elements="1"
+           default_values="0"
+           panel_visibility="advanced" >
          <EnumerationDomain name="enum">
           <Entry value="0" text="FTM (IEEE TPSD 2019)"/>
           <Entry value="1" text="Progressive Approach (IEEE TVCG 2020)"/>
-          <Entry value="2" text="Persistent Simplex (Zomorodian 2010)"/>
+          <Entry value="2" text="Discrete Morse Sandwich"/>
           <Entry value="3" text="Approximation Approach (IEEE LDAV 2021)"/>
+          <Entry value="4" text="Persistent Simplex (Zomorodian 2010)"/>
         </EnumerationDomain>
         <Documentation>
             Backend for the computation of the persistence diagram.
@@ -292,7 +293,7 @@
         <Documentation>
             Tolerance on the maximal relative Bottleneck error.
             Corresponds to the parameter Epsilon in the publication.
-            An error of 0.05 denotes a maximal relative error of 5%. 
+            An error of 0.05 denotes a maximal relative error of 5%.
         </Documentation>
       </DoubleVectorProperty>
 
@@ -333,6 +334,23 @@
         </Documentation>
       </IntVectorProperty>
 
+      <IntVectorProperty
+          name="Ignore Boundary"
+          command="SetIgnoreBoundary"
+          number_of_elements="1"
+          default_values="1" panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="BackEnd"
+                                   value="2" />
+        </Hints>
+        <Documentation>
+          Ignore the boundary component.
+        </Documentation>
+      </IntVectorProperty>
+
       <IntVectorProperty name="ShowInsideDomain"
                          label="Embed in Domain"
                          command="SetShowInsideDomain"
@@ -346,9 +364,9 @@
       </IntVectorProperty>
 
       <PropertyGroup panel_widget="Line" label="Input options">
-          <Property name="ScalarFieldNew" />
-          <Property name="ForceInputOffsetScalarField"/>
-          <Property name="InputOffsetScalarFieldNameNew"/>
+        <Property name="ScalarFieldNew" />
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="InputOffsetScalarFieldNameNew"/>
         <Property name="BackEnd" />
         <Property name="StartingResolutionLevel" />
         <Property name="StoppingResolutionLevel" />
@@ -362,6 +380,7 @@
 
       <PropertyGroup panel_widget="Line" label="Output options">
         <Property name="SaddleConnectors" />
+        <Property name="Ignore Boundary" />
         <Property name="ShowInsideDomain" />
       </PropertyGroup>
 

--- a/paraview/xmls/PersistentGenerators.xml
+++ b/paraview/xmls/PersistentGenerators.xml
@@ -1,0 +1,124 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+        name="ttkPersistentGenerators"
+        class="ttkPersistentGenerators"
+        label="TTK PersistentGenerators">
+      <Documentation
+          long_help="TTK plugin for the computation of persistence cycles."
+          short_help="TTK plugin for the computation of persistence cycles.">
+        TTK plugin for the computation of persistence cycles.
+      </Documentation>
+
+      <InputProperty
+          name="Input"
+          command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+        </Documentation>
+      </InputProperty>
+
+      <StringVectorProperty
+          name="ScalarFieldNew"
+          label="Scalar Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="0"
+          >
+        <ArrayListDomain
+            name="array_list"
+            default_values="0">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the scalar field to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+          name="ForceInputOffsetScalarField"
+          command="SetForceInputOffsetScalarField"
+          label="Force Input Offset Field"
+          number_of_elements="1"
+          panel_visibility="advanced"
+          default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box to force the usage of a specific input scalar field
+          as vertex offset (used to disambiguate flat plateaus).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+          name="InputOffsetScalarFieldNameNew"
+          label="Input Offset Field"
+          command="SetInputArrayToProcess"
+          element_types="0 0 0 0 2"
+          number_of_elements="5"
+          default_values="1"
+          panel_visibility="advanced"
+          >
+        <ArrayListDomain
+            name="array_list"
+            default_values="1"
+            >
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="ForceInputOffsetScalarField"
+                                   value="1" />
+        </Hints>
+        <Documentation>
+          Select the input offset field (used to disambiguate flat plateaus).
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+          name="PruneHandlesGenerators"
+          command="SetPruneHandlesGenerators"
+          label="Prune Handles Generators"
+          number_of_elements="1"
+          panel_visibility="advanced"
+          default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          On an Unstructured Grid dataset with topological handles,
+          check this box to prune handles generators queues.
+        </Documentation>
+      </IntVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="ScalarFieldNew" />
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="InputOffsetScalarFieldNameNew"/>
+      </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="PruneHandlesGenerators" />
+      </PropertyGroup>
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -45,10 +45,11 @@ int main(int argc, char **argv) {
     parser.setArgument("a", &inputArrayNames, "Input array names", true);
     parser.setArgument(
       "o", &outputPathPrefix, "Output file prefix (no extension)", true);
-    parser.setArgument("B", &backEnd,
-                       "Method (0: FTM, 1: progressive, 2: persistent simplex, "
-                       "3: approximation)",
-                       true);
+    parser.setArgument(
+      "B", &backEnd,
+      "Method (0: FTM, 1: progressive, 2: DiscreteMorseSandwich, 3: "
+      "approximation, 4: persistent simplex)",
+      true);
     parser.setArgument("S", &startingRL,
                        "Starting Resolution Level for progressive "
                        "multiresolution scheme (-1: finest level)",
@@ -151,6 +152,8 @@ int main(int argc, char **argv) {
   persistenceDiagram->SetStartingResolutionLevel(startingRL);
   persistenceDiagram->SetStoppingResolutionLevel(stoppingRL);
   persistenceDiagram->SetEpsilon(epsilon);
+  persistenceDiagram->SetIgnoreBoundary(false);
+
   persistenceDiagram->Update();
 
   // ---------------------------------------------------------------------------

--- a/standalone/PersistenceDiagram/main.cpp
+++ b/standalone/PersistenceDiagram/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   std::vector<std::string> inputFilePaths;
   std::vector<std::string> inputArrayNames;
   std::string outputPathPrefix{"output"};
-  int backEnd = 0;
+  int backEnd = 2;
   int startingRL = 0;
   int stoppingRL = -1;
   double tl = 0.0;


### PR DESCRIPTION
This PR adds the new DiscreteMorseSandwich backend to the PersistenceDiagram module. Also included in this PR is the PersistentGenerators module.

This new backend has been set to be the default one for the PersistenceDiagram filter and standalone. This will cause errors in the CI but a later ttk-data PR should revert the PersistenceDiagram backend of relevant state files & Python scripts to FTM.

Some tweaks in the DiscreteGradient module should help it being more resilient when called inside a parallel region (the cache is disabled) or when the `preconditionTriangulation` and the `buildGradient` methods are not called from the same DiscreteGradient instance.

Enjoy,
Pierre