### PR TITLE
Improve FlatJaggedArray API

### DIFF
--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -29,6 +29,14 @@ namespace ttk {
       this->offsets_ = std::move(offsets);
     }
 
+    /**
+     * @brief Clear the underlaying vectors
+     */
+    inline void clear() {
+      this->data_.clear();
+      this->offsets_.clear();
+    }
+
     // ############################## //
     // Mimic the vector of vector API //
     // ############################## //
@@ -100,9 +108,6 @@ namespace ttk {
       return {0, *this};
     }
     inline Iterator end() const {
-      if(this->empty()) {
-        return {0, *this};
-      }
       return {this->subvectorsNumber(), *this};
     }
 
@@ -156,6 +161,9 @@ namespace ttk {
      * @brief Returns the number of sub-vectors
      */
     inline size_t subvectorsNumber() const {
+      if(this->empty()) {
+        return 0;
+      }
       return this->offsets_.size() - 1;
     }
 
@@ -214,14 +222,14 @@ namespace ttk {
                 int threadNumber = 1) const {
       dst.resize(this->subvectorsNumber());
       for(size_t i = 0; i < this->subvectorsNumber(); ++i) {
-        dst[i].resize(this->size(i));
+        dst[i].resize((*this)[i].size());
       }
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber)
 #endif // TTK_ENABLE_OPENMP
       for(size_t i = 0; i < this->subvectorsNumber(); ++i) {
         for(size_t j = 0; j < dst[i].size(); ++j) {
-          dst[i][j] = this->get(i, j);
+          dst[i][j] = (*this)[i][j];
         }
       }
       TTK_FORCE_USE(threadNumber);
@@ -236,9 +244,9 @@ namespace ttk {
      */
     inline void writeToFile(const std::string &fName) const {
       std::ofstream out(fName);
-      for(size_t i = 0; i < this->subvectorsNumber(); ++i) {
-        for(SimplexId j = 0; j < this->size(i); ++j) {
-          out << this->get(i, j) << " ";
+      for(const auto &slice : *this) {
+        for(const auto el : slice) {
+          out << el << " ";
         }
         out << '\n';
       }

--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -57,6 +57,64 @@ namespace ttk {
       return this->offsets_[id];
     }
 
+    struct Slice {
+      const SimplexId *const ptr;
+      const SimplexId len;
+      inline SimplexId operator[](const SimplexId id) {
+#ifndef TTK_ENABLE_KAMIKAZE
+        if(id < 0 || id >= len) {
+          return -1;
+        }
+#endif
+        return ptr[id];
+      }
+      inline const SimplexId *data() const {
+        return ptr;
+      }
+      inline const SimplexId *begin() const {
+        return ptr;
+      }
+      inline const SimplexId *end() const {
+        return ptr + len;
+      }
+      inline SimplexId size() const {
+        return this->len;
+      }
+    };
+
+    struct Iterator {
+      size_t id;
+      const FlatJaggedArray &parent;
+      inline void operator++() {
+        this->id++;
+      }
+      inline Slice operator*() const {
+        return parent[id];
+      }
+      inline bool operator!=(const Iterator &other) const {
+        return this->id != other.id;
+      }
+    };
+
+    inline Iterator begin() const {
+      return {0, *this};
+    }
+    inline Iterator end() const {
+      if(this->empty()) {
+        return {0, *this};
+      }
+      return {this->subvectorsNumber(), *this};
+    }
+
+    inline Slice operator[](const SimplexId id) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(id < 0 || id >= (SimplexId)offsets_.size()) {
+        return {nullptr, 0};
+      }
+#endif
+      return {this->get_ptr(id, 0), this->size(id)};
+    }
+
     /**
      * @brief Returns the data inside the sub-vectors
      */

--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -108,7 +108,7 @@ namespace ttk {
       return {0, *this};
     }
     inline Iterator end() const {
-      return {this->subvectorsNumber(), *this};
+      return {this->size(), *this};
     }
 
     inline Slice operator[](const SimplexId id) const {
@@ -160,7 +160,7 @@ namespace ttk {
     /**
      * @brief Returns the number of sub-vectors
      */
-    inline size_t subvectorsNumber() const {
+    inline size_t size() const {
       if(this->empty()) {
         return 0;
       }
@@ -220,14 +220,14 @@ namespace ttk {
      */
     void copyTo(std::vector<std::vector<SimplexId>> &dst,
                 int threadNumber = 1) const {
-      dst.resize(this->subvectorsNumber());
-      for(size_t i = 0; i < this->subvectorsNumber(); ++i) {
+      dst.resize(this->size());
+      for(size_t i = 0; i < this->size(); ++i) {
         dst[i].resize((*this)[i].size());
       }
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber)
 #endif // TTK_ENABLE_OPENMP
-      for(size_t i = 0; i < this->subvectorsNumber(); ++i) {
+      for(size_t i = 0; i < this->size(); ++i) {
         for(size_t j = 0; j < dst[i].size(); ++j) {
           dst[i][j] = (*this)[i][j];
         }

--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -70,20 +70,20 @@ namespace ttk {
       const SimplexId len;
       inline SimplexId operator[](const SimplexId id) {
 #ifndef TTK_ENABLE_KAMIKAZE
-        if(id < 0 || id >= len) {
+        if(id < 0 || id >= this->len) {
           return -1;
         }
 #endif
-        return ptr[id];
+        return this->ptr[id];
       }
       inline const SimplexId *data() const {
-        return ptr;
+        return this->ptr;
       }
       inline const SimplexId *begin() const {
-        return ptr;
+        return this->ptr;
       }
       inline const SimplexId *end() const {
-        return ptr + len;
+        return this->ptr + this->len;
       }
       inline SimplexId size() const {
         return this->len;
@@ -97,7 +97,7 @@ namespace ttk {
         this->id++;
       }
       inline Slice operator*() const {
-        return parent[id];
+        return this->parent[this->id];
       }
       inline bool operator!=(const Iterator &other) const {
         return this->id != other.id;
@@ -113,7 +113,7 @@ namespace ttk {
 
     inline Slice operator[](const SimplexId id) const {
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(id < 0 || id >= (SimplexId)offsets_.size()) {
+      if(id < 0 || id >= (SimplexId)this->offsets_.size()) {
         return {nullptr, 0};
       }
 #endif

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -70,7 +70,7 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
 
   if(getDimensionality() == 2) {
     preconditionEdgeStarsInternal();
-    for(SimplexId i = 0; i < (SimplexId)edgeStarData_.subvectorsNumber(); i++) {
+    for(SimplexId i = 0; i < (SimplexId)edgeStarData_.size(); i++) {
       if(edgeStarData_[i].size() == 1) {
         boundaryEdges_[i] = true;
       }
@@ -79,7 +79,7 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     preconditionTriangleStarsInternal();
     preconditionTriangleEdgesInternal();
 
-    for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
+    for(size_t i = 0; i < triangleStarData_.size(); i++) {
       if(triangleStarData_[i].size() == 1) {
         for(int j = 0; j < 3; j++) {
           boundaryEdges_[triangleEdgeList_[i][j]] = true;
@@ -120,7 +120,7 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
   if(getDimensionality() == 3) {
     preconditionTriangleStarsInternal();
 
-    for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
+    for(size_t i = 0; i < triangleStarData_.size(); i++) {
       if(triangleStarData_[i].size() == 1) {
         boundaryTriangles_[i] = true;
       }
@@ -156,7 +156,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
   // look for singletons
   if(getDimensionality() == 1) {
     preconditionVertexStarsInternal();
-    for(size_t i = 0; i < vertexStarData_.subvectorsNumber(); i++) {
+    for(size_t i = 0; i < vertexStarData_.size(); i++) {
       if(vertexStarData_[i].size() == 1) {
         boundaryVertices_[i] = true;
       }
@@ -165,7 +165,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     preconditionEdgesInternal();
     preconditionEdgeStarsInternal();
 
-    for(SimplexId i = 0; i < (SimplexId)edgeStarData_.subvectorsNumber(); i++) {
+    for(SimplexId i = 0; i < (SimplexId)edgeStarData_.size(); i++) {
       if(edgeStarData_[i].size() == 1) {
         boundaryVertices_[edgeList_[i][0]] = true;
         boundaryVertices_[edgeList_[i][1]] = true;
@@ -175,7 +175,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     preconditionTrianglesInternal();
     preconditionTriangleStarsInternal();
 
-    for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
+    for(size_t i = 0; i < triangleStarData_.size(); i++) {
       if(triangleStarData_[i].size() == 1) {
         boundaryVertices_[triangleList_[i][0]] = true;
         boundaryVertices_[triangleList_[i][1]] = true;
@@ -464,7 +464,7 @@ int ExplicitTriangulation::preconditionVertexEdgesInternal() {
     return 1;
   }
 
-  if((SimplexId)vertexEdgeData_.subvectorsNumber() != vertexNumber_) {
+  if((SimplexId)vertexEdgeData_.size() != vertexNumber_) {
     ZeroSkeleton zeroSkeleton;
 
     if(edgeList_.empty()) {
@@ -485,7 +485,7 @@ int ExplicitTriangulation::preconditionVertexLinksInternal() {
     return 1;
   }
 
-  if((SimplexId)vertexLinkData_.subvectorsNumber() != vertexNumber_) {
+  if((SimplexId)vertexLinkData_.size() != vertexNumber_) {
 
     if(getDimensionality() == 2) {
       preconditionEdgesInternal();
@@ -519,7 +519,7 @@ int ExplicitTriangulation::preconditionVertexNeighborsInternal() {
     return 1;
   }
 
-  if((SimplexId)vertexNeighborData_.subvectorsNumber() != vertexNumber_) {
+  if((SimplexId)vertexNeighborData_.size() != vertexNumber_) {
     this->preconditionEdgesInternal();
     ZeroSkeleton zeroSkeleton;
     zeroSkeleton.setWrapper(this);
@@ -536,7 +536,7 @@ int ExplicitTriangulation::preconditionVertexStarsInternal() {
     return 1;
   }
 
-  if((SimplexId)vertexStarData_.subvectorsNumber() != vertexNumber_) {
+  if((SimplexId)vertexStarData_.size() != vertexNumber_) {
     ZeroSkeleton zeroSkeleton;
     zeroSkeleton.setWrapper(this);
 
@@ -553,7 +553,7 @@ int ExplicitTriangulation::preconditionVertexTrianglesInternal() {
     return 1;
   }
 
-  if((SimplexId)vertexTriangleData_.subvectorsNumber() != vertexNumber_) {
+  if((SimplexId)vertexTriangleData_.size() != vertexNumber_) {
 
     preconditionTrianglesInternal();
 
@@ -658,7 +658,7 @@ int ExplicitTriangulation::writeToFile(std::ofstream &stream) const {
   const auto write_variable = [&stream](const FlatJaggedArray &arr) {
     // empty array guard
     WRITE_GUARD(arr);
-    writeBinArray(stream, arr.offset_ptr(), arr.subvectorsNumber() + 1);
+    writeBinArray(stream, arr.offset_ptr(), arr.size() + 1);
     writeBinArray(stream, arr.get_ptr(0, 0), arr.dataSize());
   };
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -71,7 +71,7 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
   if(getDimensionality() == 2) {
     preconditionEdgeStarsInternal();
     for(SimplexId i = 0; i < (SimplexId)edgeStarData_.subvectorsNumber(); i++) {
-      if(edgeStarData_.size(i) == 1) {
+      if(edgeStarData_[i].size() == 1) {
         boundaryEdges_[i] = true;
       }
     }
@@ -80,7 +80,7 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     preconditionTriangleEdgesInternal();
 
     for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
-      if(triangleStarData_.size(i) == 1) {
+      if(triangleStarData_[i].size() == 1) {
         for(int j = 0; j < 3; j++) {
           boundaryEdges_[triangleEdgeList_[i][j]] = true;
         }
@@ -121,7 +121,7 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     preconditionTriangleStarsInternal();
 
     for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
-      if(triangleStarData_.size(i) == 1) {
+      if(triangleStarData_[i].size() == 1) {
         boundaryTriangles_[i] = true;
       }
     }
@@ -157,7 +157,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
   if(getDimensionality() == 1) {
     preconditionVertexStarsInternal();
     for(size_t i = 0; i < vertexStarData_.subvectorsNumber(); i++) {
-      if(vertexStarData_.size(i) == 1) {
+      if(vertexStarData_[i].size() == 1) {
         boundaryVertices_[i] = true;
       }
     }
@@ -166,7 +166,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     preconditionEdgeStarsInternal();
 
     for(SimplexId i = 0; i < (SimplexId)edgeStarData_.subvectorsNumber(); i++) {
-      if(edgeStarData_.size(i) == 1) {
+      if(edgeStarData_[i].size() == 1) {
         boundaryVertices_[edgeList_[i][0]] = true;
         boundaryVertices_[edgeList_[i][1]] = true;
       }
@@ -176,7 +176,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     preconditionTriangleStarsInternal();
 
     for(size_t i = 0; i < triangleStarData_.subvectorsNumber(); i++) {
-      if(triangleStarData_.size(i) == 1) {
+      if(triangleStarData_[i].size() == 1) {
         boundaryVertices_[triangleList_[i][0]] = true;
         boundaryVertices_[triangleList_[i][1]] = true;
         boundaryVertices_[triangleList_[i][2]] = true;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -79,7 +79,7 @@ namespace ttk {
       const int &localNeighborId,
       SimplexId &neighborId) const override {
 
-      neighborId = cellNeighborData_.get(cellId, localNeighborId);
+      neighborId = cellNeighborData_[cellId][localNeighborId];
       return 0;
     }
 
@@ -163,7 +163,7 @@ namespace ttk {
       const int &localLinkId,
       SimplexId &linkId) const override {
 
-      linkId = edgeLinkData_.get(edgeId, localLinkId);
+      linkId = edgeLinkData_[edgeId][localLinkId];
       return 0;
     }
 
@@ -183,7 +183,7 @@ namespace ttk {
       const int &localStarId,
       SimplexId &starId) const override {
 
-      starId = edgeStarData_.get(edgeId, localStarId);
+      starId = edgeStarData_[edgeId][localStarId];
       return 0;
     }
 
@@ -201,7 +201,7 @@ namespace ttk {
     inline int getEdgeTriangleInternal(const SimplexId &edgeId,
                                        const int &localTriangleId,
                                        SimplexId &triangleId) const override {
-      triangleId = edgeTriangleData_.get(edgeId, localTriangleId);
+      triangleId = edgeTriangleData_[edgeId][localTriangleId];
       return 0;
     }
 
@@ -296,13 +296,13 @@ namespace ttk {
       const int &localLinkId,
       SimplexId &linkId) const override {
 
-      linkId = triangleLinkData_.get(triangleId, localLinkId);
+      linkId = triangleLinkData_[triangleId][localLinkId];
       return 0;
     }
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLinkNumber)(
       const SimplexId &triangleId) const override {
-      return triangleLinkData_.size(triangleId);
+      return triangleLinkData_[triangleId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -315,13 +315,13 @@ namespace ttk {
       const SimplexId &triangleId,
       const int &localStarId,
       SimplexId &starId) const override {
-      starId = triangleStarData_.get(triangleId, localStarId);
+      starId = triangleStarData_[triangleId][localStarId];
       return 0;
     }
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(
       const SimplexId &triangleId) const override {
-      return triangleStarData_.size(triangleId);
+      return triangleStarData_[triangleId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -347,13 +347,13 @@ namespace ttk {
     inline int getVertexEdgeInternal(const SimplexId &vertexId,
                                      const int &localEdgeId,
                                      SimplexId &edgeId) const override {
-      edgeId = vertexEdgeData_.get(vertexId, localEdgeId);
+      edgeId = vertexEdgeData_[vertexId][localEdgeId];
       return 0;
     }
 
     inline SimplexId
       getVertexEdgeNumberInternal(const SimplexId &vertexId) const override {
-      return vertexEdgeData_.size(vertexId);
+      return vertexEdgeData_[vertexId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -367,13 +367,13 @@ namespace ttk {
       const int &localLinkId,
       SimplexId &linkId) const override {
 
-      linkId = vertexLinkData_.get(vertexId, localLinkId);
+      linkId = vertexLinkData_[vertexId][localLinkId];
       return 0;
     }
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLinkNumber)(
       const SimplexId &vertexId) const override {
-      return vertexLinkData_.size(vertexId);
+      return vertexLinkData_[vertexId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -387,13 +387,13 @@ namespace ttk {
       const int &localNeighborId,
       SimplexId &neighborId) const override {
 
-      neighborId = vertexNeighborData_.get(vertexId, localNeighborId);
+      neighborId = vertexNeighborData_[vertexId][localNeighborId];
       return 0;
     }
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexNeighborNumber)(
       const SimplexId &vertexId) const override {
-      return vertexNeighborData_.size(vertexId);
+      return vertexNeighborData_[vertexId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -426,13 +426,13 @@ namespace ttk {
       const SimplexId &vertexId,
       const int &localStarId,
       SimplexId &starId) const override {
-      starId = vertexStarData_.get(vertexId, localStarId);
+      starId = vertexStarData_[vertexId][localStarId];
       return 0;
     }
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexStarNumber)(
       const SimplexId &vertexId) const override {
-      return vertexStarData_.size(vertexId);
+      return vertexStarData_[vertexId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *
@@ -444,13 +444,13 @@ namespace ttk {
     inline int getVertexTriangleInternal(const SimplexId &vertexId,
                                          const int &localTriangleId,
                                          SimplexId &triangleId) const override {
-      triangleId = vertexTriangleData_.get(vertexId, localTriangleId);
+      triangleId = vertexTriangleData_[vertexId][localTriangleId];
       return 0;
     }
 
     inline SimplexId getVertexTriangleNumberInternal(
       const SimplexId &vertexId) const override {
-      return vertexTriangleData_.size(vertexId);
+      return vertexTriangleData_[vertexId].size();
     }
 
     inline const std::vector<std::vector<SimplexId>> *

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -17,13 +17,13 @@ int OneSkeleton::buildEdgeLinks(
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeList.empty())
     return -1;
-  if(edgeStars.subvectorsNumber() != edgeList.size())
+  if(edgeStars.size() != edgeList.size())
     return -2;
 #endif
 
   Timer t;
 
-  const SimplexId edgeNumber = edgeStars.subvectorsNumber();
+  const SimplexId edgeNumber = edgeStars.size();
   std::vector<SimplexId> offsets(edgeNumber + 1);
   // one vertex per star
   std::vector<SimplexId> links(edgeStars.dataSize());
@@ -72,7 +72,7 @@ int OneSkeleton::buildEdgeLinks(
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeList.empty())
     return -1;
-  if((edgeStars.empty()) || (edgeStars.subvectorsNumber() != edgeList.size()))
+  if((edgeStars.empty()) || (edgeStars.size() != edgeList.size()))
     return -2;
   if(cellEdges.empty())
     return -3;
@@ -80,7 +80,7 @@ int OneSkeleton::buildEdgeLinks(
 
   Timer t;
 
-  const SimplexId edgeNumber = edgeStars.subvectorsNumber();
+  const SimplexId edgeNumber = edgeStars.size();
   std::vector<SimplexId> offsets(edgeNumber + 1);
   // one edge per star
   std::vector<SimplexId> links(edgeStars.dataSize());

--- a/core/base/skeleton/ThreeSkeleton.cpp
+++ b/core/base/skeleton/ThreeSkeleton.cpp
@@ -33,7 +33,7 @@ int ThreeSkeleton::buildCellNeighborsFromTriangles(
   printMsg("Building cell neighbors", 0, 0, 1, ttk::debug::LineMode::REPLACE);
 
   const SimplexId cellNumber = cellArray.getNbCells();
-  const SimplexId triangleNumber = localTriangleStars->subvectorsNumber();
+  const SimplexId triangleNumber = localTriangleStars->size();
   std::vector<SimplexId> offsets(cellNumber + 1);
   // number of neighbors processed per cell
   std::vector<SimplexId> neighborsId(cellNumber);

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -17,7 +17,7 @@ int TwoSkeleton::buildCellNeighborsFromEdges(
   printMsg("Building cell neighbors", 0, 0, 1, debug::LineMode::REPLACE);
 
   const SimplexId cellNumber = cellArray.getNbCells();
-  const SimplexId edgeNumber = edgeStars.subvectorsNumber();
+  const SimplexId edgeNumber = edgeStars.size();
   std::vector<SimplexId> offsets(cellNumber + 1);
   // number of neigbhors processed per cell
   std::vector<SimplexId> neighborsId(cellNumber);
@@ -481,8 +481,7 @@ int TwoSkeleton::buildTriangleLinks(
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleList.empty())
     return -1;
-  if((triangleStars.empty())
-     || (triangleStars.subvectorsNumber() != triangleList.size()))
+  if((triangleStars.empty()) || (triangleStars.size() != triangleList.size()))
     return -2;
 #endif
 

--- a/core/base/skeleton/ZeroSkeleton.cpp
+++ b/core/base/skeleton/ZeroSkeleton.cpp
@@ -73,7 +73,7 @@ int ZeroSkeleton::buildVertexLinks(
 
   Timer t;
 
-  const SimplexId vertexNumber = vertexStars.subvectorsNumber();
+  const SimplexId vertexNumber = vertexStars.size();
   std::vector<SimplexId> offsets(vertexNumber + 1);
   // one edge per star
   std::vector<SimplexId> links(vertexStars.dataSize());
@@ -130,7 +130,7 @@ int ZeroSkeleton::buildVertexLinks(
 
   Timer tm;
 
-  const SimplexId vertexNumber = vertexStars.subvectorsNumber();
+  const SimplexId vertexNumber = vertexStars.size();
   std::vector<SimplexId> offsets(vertexNumber + 1);
   // one triangle per star
   std::vector<SimplexId> links(vertexStars.dataSize());


### PR DESCRIPTION
This PR extends the FlatJaggedArray API to support double indexing (`array[i][j]`) and range-based for loops (`for(auto &vec: array) {for(auto elem: vec){}}`) and make it closer to the `std::vector<std::vector<SimplexId>>` API.

The ExplicitTriangulation now makes extensive use of this new API (which is quite close to what was there before the introduction of FlatJaggedArray), without any noticeable performance impact (tested with DiscreteGradient).

Enjoy,
Pierre