### PR TITLE
MorseSmaleComplex: Display CellDimension, SeparatrixType by default

### DIFF
--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -114,7 +114,7 @@ int ttkDiscreteGradient::fillCriticalPoints(
   }
 #endif
 
-  pointData->AddArray(cellDimensions);
+  pointData->SetScalars(cellDimensions);
   pointData->AddArray(cellIds);
   pointData->AddArray(cellScalars);
   pointData->AddArray(isOnBoundary);
@@ -198,7 +198,7 @@ int ttkDiscreteGradient::fillGradientGlyphs(
 #endif
 
   pointData->AddArray(pairOrigins);
-  cellData->AddArray(pairTypes);
+  cellData->SetScalars(pairTypes);
 
   this->printMsg(
     "Computed gradient glyphs", 1.0, tm.getElapsedTime(), this->threadNumber_);

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.cpp
@@ -140,7 +140,7 @@ int ttkMorseSmaleComplex::dispatch(vtkDataArray *const inputScalars,
     }
 #endif
 
-    pointData->AddArray(cellDimensions);
+    pointData->SetScalars(cellDimensions);
     pointData->AddArray(cellIds);
     pointData->AddArray(cellScalars);
     pointData->AddArray(isOnBoundary);
@@ -278,7 +278,7 @@ int ttkMorseSmaleComplex::dispatch(vtkDataArray *const inputScalars,
     cellData->AddArray(sourceIds);
     cellData->AddArray(destinationIds);
     cellData->AddArray(separatrixIds);
-    cellData->AddArray(separatrixTypes);
+    cellData->SetScalars(separatrixTypes);
     cellData->AddArray(separatrixFunctionMaxima);
     cellData->AddArray(separatrixFunctionMinima);
     cellData->AddArray(separatrixFunctionDiffs);
@@ -520,8 +520,6 @@ int ttkMorseSmaleComplex::RequestData(vtkInformation *ttkNotUsed(request),
     if(ComputeAscendingSegmentation and ComputeDescendingSegmentation
        and ComputeFinalSegmentation)
       pointData->AddArray(morseSmaleManifold);
-
-    pointData->AddArray(inputOffsets);
   }
 
   return !ret;


### PR DESCRIPTION
This PR uses `vtkDataSetAttributes::SetScalars` to set the default scalar field for DiscreteGradient critical points (CellDimension), DiscreteGradient glyphs (PairType), Morse-Smale Complex critical points (CellDimension) and Morse-Smale Complex 1-separatrices (SeparatrixType). The FTMTree filter already makes use of these methods to provide a default coloring of nodes & arcs.

Since the filter's output are modified, changes in the Python CI hashes are expected.

Enjoy,
Pierre