### PR TITLE
kdTree: Remove dynamic allocation

### DIFF
--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -337,13 +337,8 @@ namespace ttk {
       costs.push_back(cost);
     } else {
       // 1.1- Find the most costly amongst neighbours
-      std::vector<int> idx(k);
-      for(unsigned int i = 0; i < k; i++) {
-        idx[i] = i;
-      }
-      int idx_max_cost = *std::max_element(
-        idx.begin(), idx.end(),
-        [&costs](int &a, int &b) { return costs[a] < costs[b]; });
+      const auto idx_max_cost = std::distance(
+        costs.begin(), std::max_element(costs.begin(), costs.begin() + k));
       dataType max_cost = costs[idx_max_cost];
 
       // 1.2- If the current KDTree is less costly, put it in the neighbours and


### PR DESCRIPTION
This PR replaces a dynamic allocation occuring in a hot path in the KDTree module with equivalent code that computes the index of the maximum cost in the range [|0, k|].

This modification increases the performance of the PersistenceDiagramClustering & PersistenceDiagramDistanceMatrix by up to +40%.

Since more computation is available for a given time period, the PersistenceDiagramClustering state file output goes one iteration further (screenshots have to/will be updated).

Enjoy,
Pierre