### PR TITLE
MorseSmaleQuadrangulation: Remove excess points when DualQuadrangulate

### DIFF
--- a/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
+++ b/core/base/morseSmaleQuadrangulation/MorseSmaleQuadrangulation.h
@@ -1072,8 +1072,12 @@ int ttk::MorseSmaleQuadrangulation::execute(
     }
   }
 
-  this->printMsg("Produced " + std::to_string(outputCells_.size()) + " ("
-                   + std::to_string(ndegen) + " degenerated)",
+  std::string s_degen{
+    ndegen > 0 ? "(" + std::to_string(ndegen) + " degenerated) " : ""};
+
+  this->printMsg("Produced " + std::to_string(this->outputCells_.size())
+                   + " quads " + s_degen + "("
+                   + std::to_string(this->outputPointsIds_.size()) + " points)",
                  1.0, tm.getElapsedTime(), this->threadNumber_);
 
   return 0;


### PR DESCRIPTION
The DualQuadrangulation option of the MorseSmaleQuadrangulation filter generates a coarser quadrangulation from the Morse-Smale Complex. However, it kept the same points as the non-dual quadrangulation even though some of them have no neighbors in the dual quadrangulation.

This PR post-processes the dual quadrangulation, removing these points that have no neighbor. These additional points would have been projected to coordinates (nan, nan, nan) by the QuadrangulationSubdivision filter.

Hashes of the morseSmaleQuadrangulation.py Python script are expected to change (200 points removed).

Enjoy,
Pierre
