### PR TITLE
Fix GCC12 warnings, remove explicit O3 flag

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -85,9 +85,10 @@ function(ttk_add_base_template_library library)
   if(uppercase_CMAKE_BUILD_TYPE MATCHES RELEASE)
     if(TTK_ENABLE_CPU_OPTIMIZATION AND NOT MSVC)
       if (CMAKE_OSX_ARCHITECTURES MATCHES arm64) # Apple Silicon
-        target_compile_options(${library} INTERFACE -mcpu=apple-m1 -O3)
+        target_compile_options(${library} INTERFACE -mcpu=apple-m1)
       else()
-        target_compile_options(${library} INTERFACE -march=native -O3)
+        # -O3 already enabled by CMake's Release configuration
+        target_compile_options(${library} INTERFACE -march=native)
       endif()
     endif()
   endif()

--- a/core/base/approximateTopology/ApproximateTopology.h
+++ b/core/base/approximateTopology/ApproximateTopology.h
@@ -305,7 +305,7 @@ int ttk::ApproximateTopology::executeApproximateTopology(
 
   Timer timer;
 
-  SimplexId *const vertsOrder = static_cast<SimplexId *>(outputOffsets);
+  SimplexId *const vertsOrder = outputOffsets;
 
   decimationLevel_ = startingDecimationLevel_;
   multiresTriangulation_.setTriangulation(triangulation_);

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1084,6 +1084,9 @@ namespace ttk {
       SimplexId nid = vertexIndices_[vertexId];
       SimplexId localVertexId = vertexId - vertexIntervals_[nid - 1] - 1;
       ImplicitCluster *exnode = searchCache(nid);
+      if(exnode == nullptr) {
+        return -1;
+      }
       if(exnode->vertexNeighbors_.empty()) {
         getClusterVertexNeighbors(exnode);
       }

--- a/core/base/connectedComponents/ConnectedComponents.h
+++ b/core/base/connectedComponents/ConnectedComponents.h
@@ -82,7 +82,7 @@ namespace ttk {
         // add neihbors
         size_t nNeighbors = triangulation->getVertexNeighborNumber(cIndex);
         for(size_t i = 0; i < nNeighbors; i++) {
-          TID nIndex;
+          TID nIndex{-1};
           triangulation->getVertexNeighbor(cIndex, i, nIndex);
           if(labels[nIndex] == this->UNLABELED) {
             labels[nIndex] = componentId;

--- a/core/base/contourForestsTree/DeprecatedSegmentation.cpp
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.cpp
@@ -126,6 +126,9 @@ void ArcRegion::createSegmentation(const idSuperArc &thisArc) {
   while(added) {
     added = false;
     for(unsigned i = 0; i < nbSegments; i++) {
+      if(i >= ends.size()) {
+        break;
+      }
       auto &&head = heads[i];
       auto &&end = ends[i];
       // find next potential vertex

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -305,7 +305,7 @@ namespace ttk {
 
         // values added
         for(std::pair<SimplexId, bool> *vertices : vertLists) {
-          const SimplexId &size = vertSizes.front();
+          const SimplexId size = vertSizes.front();
           vertSizes.pop_front();
           for(SimplexId i = 0; i < size; ++i) {
             tmpVert[pos++] = vertices[i];

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -1005,7 +1005,7 @@ namespace ttk {
 
       idSuperArc currentArc;
       idNode closingNode, currentNode;
-      SimplexId neighbor;
+      SimplexId neighbor{-1};
 
       // Check UF in neighborhood
       for(SimplexId n = 0; n < neighborNumber; ++n) {

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -444,11 +444,16 @@ namespace ttk {
     }
 
     inline const Node *getVertexNode(const int &vertexId) const {
+#ifndef TTK_ENABLE_KAMIKAZE
       if((vertexId < 0) || (vertexId >= vertexNumber_))
-        return nullptr;
-      if(vertex2node_[vertexId] != -1)
-        return &(nodeList_[vertex2node_[vertexId]]);
-      return nullptr;
+        this->printErr("Out-of-bounds access in getVertexNode: element "
+                       + std::to_string(vertexId) + " in list of size "
+                       + std::to_string(vertexNumber_));
+      if(vertex2node_[vertexId] == -1)
+        this->printErr("Invalid node id value in getVertexNode at index"
+                       + std::to_string(vertexId));
+#endif // !TTK_ENABLE_KAMIKAZE
+      return &(nodeList_[vertex2node_[vertexId]]);
     }
 
     inline int getVertexNodeId(const int &vertexId) const {

--- a/core/base/ftmTree/FTMTree_CT_Template.h
+++ b/core/base/ftmTree/FTMTree_CT_Template.h
@@ -127,7 +127,7 @@ int FTMTree_CT::leafSearch(const triangulationType *mesh) {
         valence downval = 0;
 
         for(valence n = 0; n < neighNumb; ++n) {
-          SimplexId neigh;
+          SimplexId neigh{-1};
           mesh->getVertexNeighbor(v, n, neigh);
           if(scalars_->isLower(neigh, v)) {
             ++downval;

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -102,7 +102,7 @@ namespace ttk {
               valence val = 0;
 
               for(valence n = 0; n < neighNumb; ++n) {
-                SimplexId neigh;
+                SimplexId neigh{-1};
                 mesh->getVertexNeighbor(v, n, neigh);
                 comp_.vertLower(neigh, v) && ++val;
               }
@@ -352,7 +352,7 @@ namespace ttk {
 
       // propagation / is saddle
       for(valence n = 0; n < nbNeigh; ++n) {
-        SimplexId neigh;
+        SimplexId neigh{-1};
         mesh->getVertexNeighbor(currentState.vertex, n, neigh);
 
         if(comp_.vertLower(neigh, currentState.vertex)) {
@@ -460,7 +460,7 @@ namespace ttk {
       // Union of the UF coming here (merge propagation and closing arcs)
       const auto &nbNeigh = mesh->getVertexNeighborNumber(saddleVert);
       for(valence n = 0; n < nbNeigh; ++n) {
-        SimplexId neigh;
+        SimplexId neigh{-1};
         mesh->getVertexNeighbor(saddleVert, n, neigh);
 
         if(comp_.vertLower(neigh, saddleVert)) {
@@ -489,7 +489,7 @@ namespace ttk {
       // Union of the UF coming here (merge propagation and closing arcs)
       const auto &nbNeigh = mesh->getVertexNeighborNumber(saddleVert);
       for(valence n = 0; n < nbNeigh; ++n) {
-        SimplexId neigh;
+        SimplexId neigh{-1};
         mesh->getVertexNeighbor(saddleVert, n, neigh);
 
         if(comp_.vertLower(neigh, saddleVert)) {

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -75,7 +75,8 @@ namespace ttk {
       }
 
       idSuperArc getSubtreeArc(const std::size_t nid) const {
-        return getNode(nid)->findRootArc();
+        const auto node{getNode(nid)};
+        return node != nullptr ? node->findRootArc() : nullSuperArc;
       }
 
       idSuperArc getCorArc(const std::size_t nid) const {

--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -138,7 +138,9 @@ void ttk::ftr::FTRGraph<ScalarType, triangulationType>::growthFromSeed(
     } else {
       // locally apply the lazy one the current growing arc
       for(const idEdge e : star.lower) {
-        const idSuperArc a = dynGraph(localProp).getNode(e)->findRootArc();
+        const auto node{dynGraph(localProp).getNode(e)};
+        const idSuperArc a
+          = node != nullptr ? node->findRootArc() : nullSuperArc;
         if(a != nullSuperArc && graph_.getArc(a).isVisible()
            && graph_.getArc(a).getPropagation()->getId()
                 == localProp->getId()) {

--- a/core/base/helloWorld/HelloWorld.h
+++ b/core/base/helloWorld/HelloWorld.h
@@ -94,7 +94,7 @@ namespace ttk {
 
           // add neighbor values to average
           size_t nNeighbors = triangulation->getVertexNeighborNumber(i);
-          ttk::SimplexId neighborId;
+          ttk::SimplexId neighborId{-1};
           for(size_t j = 0; j < nNeighbors; j++) {
             triangulation->getVertexNeighbor(i, j, neighborId);
             outputData[i] += inputData[neighborId];

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -140,7 +140,7 @@ int ttk::IntegralLines::execute(const triangulationType *triangulation) const {
       float fnext = std::numeric_limits<float>::min();
       SimplexId neighborNumber = triangulation->getVertexNeighborNumber(v);
       for(SimplexId k = 0; k < neighborNumber; ++k) {
-        SimplexId n;
+        SimplexId n{-1};
         triangulation->getVertexNeighbor(v, k, n);
 
         if((direction_ == static_cast<int>(Direction::Forward))

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -164,7 +164,7 @@ namespace ttk {
           const IT &vOrder = order[v];
           const IT nNeighbors = triangulation->getVertexNeighborNumber(v);
           for(IT n = 0; n < nNeighbors; n++) {
-            IT u;
+            IT u{-1};
             triangulation->getVertexNeighbor(v, n, u);
             if(vOrder < order[u]) {
               hasLargerNeighbor = true;
@@ -264,7 +264,7 @@ namespace ttk {
           IT numberOfLargerNeighbors = 0;
           IT numberOfLargerNeighborsThisThreadVisited = 0;
           for(IT n = 0; n < nNeighbors; n++) {
-            IT u;
+            IT u{-1};
             triangulation->getVertexNeighbor(v, n, u);
 
             const IT &orderU = order[u];
@@ -308,7 +308,7 @@ namespace ttk {
             std::vector<Propagation<IT> *> neighborPropagations(
               nNeighbors, nullptr);
             for(IT n = 0; n < nNeighbors; n++) {
-              IT u;
+              IT u{-1};
               triangulation->getVertexNeighbor(v, n, u);
               if(propagationMask[u] != nullptr) {
                 auto &neighborPropagation = neighborPropagations[n];
@@ -398,7 +398,7 @@ namespace ttk {
           IT numberOfLargerNeighbors = 0;
           IT numberOfLargerNeighborsThisThreadVisited = 0;
           for(IT n = 0; n < nNeighbors; n++) {
-            IT u;
+            IT u{-1};
             triangulation->getVertexNeighbor(v, n, u);
 
             const IT &orderU = order[u];
@@ -442,7 +442,7 @@ namespace ttk {
             std::vector<Propagation<IT> *> neighborPropagations(
               nNeighbors, nullptr);
             for(IT n = 0; n < nNeighbors; n++) {
-              IT u;
+              IT u{-1};
               triangulation->getVertexNeighbor(v, n, u);
               if(propagationMask[u] != nullptr) {
                 auto &neighborPropagation = neighborPropagations[n];
@@ -637,7 +637,7 @@ namespace ttk {
 
             IT nNeighbors = triangulation->getVertexNeighborNumber(v);
             for(IT n = 0; n < nNeighbors; n++) {
-              IT u;
+              IT u{-1};
               triangulation->getVertexNeighbor(v, n, u);
               auto &s = segmentation[u];
               if(s >= 0 && order[u] > saddleOrder) {
@@ -771,7 +771,7 @@ namespace ttk {
 
           IT nNeighbors = triangulation->getVertexNeighborNumber(v);
           for(IT n = 0; n < nNeighbors; n++) {
-            IT u;
+            IT u{-1};
             triangulation->getVertexNeighbor(v, n, u);
 
             // if u is in segment and has not already been added to the queue
@@ -858,7 +858,7 @@ namespace ttk {
 
             IT nNeighbors = triangulation->getVertexNeighborNumber(v);
             for(IT n = 0; n < nNeighbors; n++) {
-              IT u;
+              IT u{-1};
               triangulation->getVertexNeighbor(v, n, u);
 
               if(u == saddleIndex) {

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
@@ -999,7 +999,7 @@ int ttk::MandatoryCriticalPoints::buildSubTrees(
     bool isUpperMax = true;
     SimplexId neighborNumber = triangulation.getVertexNeighborNumber(i);
     for(SimplexId j = 0; j < neighborNumber; j++) {
-      SimplexId neighborId;
+      SimplexId neighborId{-1};
       triangulation.getVertexNeighbor(i, j, neighborId);
       if((lowerVertexScalars_[neighborId] < lowerVertexScalars_[i])
          || ((lowerVertexScalars_[neighborId] == lowerVertexScalars_[i])

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -875,10 +875,7 @@ namespace ttk {
           if(not isFM) {
             int index
               = getIndexNotMultiPers(children.size() - 1, tree, children);
-            if(index >= 0)
-              nodeParent.emplace_back(nodeOrigin, children[index]);
-            else
-              nodeParent.emplace_back(nodeOrigin, children[index]);
+            nodeParent.emplace_back(nodeOrigin, children[index]);
           } else
             nodeParent.emplace_back(children[0], node);
         } else {

--- a/core/base/morphologicalOperators/MorphologicalOperators.h
+++ b/core/base/morphologicalOperators/MorphologicalOperators.h
@@ -162,7 +162,7 @@ int ttk::MorphologicalOperators::performElementaryMorphoOp(
             // check neighbors if they need to be dilated
             const SimplexId nNeighbors
               = triangulation->getVertexNeighborNumber(i);
-            SimplexId nIndex;
+            SimplexId nIndex{-1};
             for(SimplexId n = 0; n < nNeighbors; n++) {
               triangulation->getVertexNeighbor(i, n, nIndex);
               if(source[nIndex] == pivotLabel) {
@@ -187,7 +187,7 @@ int ttk::MorphologicalOperators::performElementaryMorphoOp(
             // check neighbors if neighbors have a non-eroded label
             const SimplexId nNeighbors
               = triangulation->getVertexNeighborNumber(i);
-            SimplexId nIndex;
+            SimplexId nIndex{-1};
             DT maxNeighborLabel = minLabel;
             for(SimplexId n = 0; n < nNeighbors; n++) {
               triangulation->getVertexNeighbor(i, n, nIndex);

--- a/core/base/octree/Octree.cpp
+++ b/core/base/octree/Octree.cpp
@@ -47,7 +47,7 @@ void Octree::initialize(const AbstractTriangulation *t, const int k) {
  */
 bool Octree::empty() {
   OctreeNode *root = lookupNode(1);
-  if(root->vertexIds_.empty() && !root->childExists_) {
+  if(root != nullptr && root->vertexIds_.empty() && !root->childExists_) {
     return true;
   }
 

--- a/core/base/skeleton/TwoSkeleton.cpp
+++ b/core/base/skeleton/TwoSkeleton.cpp
@@ -247,8 +247,9 @@ int TwoSkeleton::buildTriangleList(
 
   // check parameters consistency (this method is useless in 2D)
   const auto dim = cellArray.getCellVertexNumber(0) - 1;
-  if(dim == 2) {
-    this->printWrn("Calling buildTriangleList is useless in 2D, skipping...");
+  if(dim < 3) {
+    this->printWrn("Calling buildTriangleList is useless in "
+                   + std::to_string(dim) + "D, skipping...");
     return -1;
   }
 

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -146,7 +146,7 @@ int ttk::TopologicalCompression::PerformSimplification(
     // Smoothe neighborhood (along with offsets).
     SimplexId neighborNumber = triangulation.getVertexNeighborNumber(id);
     for(SimplexId j = 0; j < neighborNumber; ++j) {
-      SimplexId neighbor;
+      SimplexId neighbor{-1};
       triangulation.getVertexNeighbor(id, j, neighbor);
 
       if(type == 1) { // Local_maximum.
@@ -720,7 +720,7 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
         SimplexId neighborNumber
           = triangulation.getVertexNeighborNumber(vertex);
         for(SimplexId j = 0; j < neighborNumber; ++j) {
-          SimplexId neighbor;
+          SimplexId neighbor{-1};
           triangulation.getVertexNeighbor(vertex, j, neighbor);
 
           // Add current neighbor to processing stack.

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -143,7 +143,7 @@ int ttk::TopologicalSimplification::getCriticalType(
   bool isMaxima{true};
   SimplexId neighborNumber = triangulation.getVertexNeighborNumber(vertex);
   for(SimplexId i = 0; i < neighborNumber; ++i) {
-    SimplexId neighbor;
+    SimplexId neighbor{-1};
     triangulation.getVertexNeighbor(vertex, i, neighbor);
 
     if(offsets[neighbor] < offsets[vertex])
@@ -344,7 +344,7 @@ int ttk::TopologicalSimplification::execute(
         SimplexId neighborNumber
           = triangulation.getVertexNeighborNumber(vertexId);
         for(SimplexId k = 0; k < neighborNumber; ++k) {
-          SimplexId neighbor;
+          SimplexId neighbor{-1};
           triangulation.getVertexNeighbor(vertexId, k, neighbor);
           if(!visitedVertices[neighbor]) {
             sweepFront.emplace(

--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -53,6 +53,11 @@ int ttkCinemaQuery::RequestData(vtkInformation *ttkNotUsed(request),
   // ===========================================================================
   // Convert Input Tables to SQL Tables
   auto nTables = inputVector[0]->GetNumberOfInformationObjects();
+  if(nTables == 0) {
+    this->printErr("No input vtkTable found");
+    return 0;
+  }
+
   std::vector<vtkTable *> inTables(nTables);
   for(int i = 0; i < nTables; ++i) {
     inTables[i] = vtkTable::GetData(inputVector[0], i);

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -262,6 +262,7 @@ int ttkFTRGraph::dispatch(Graph &graph) {
 
   // common parameters
   ftrGraph_.setParams(params_);
+  ftrGraph_.setDebugLevel(this->debugLevel_);
   // reeb graph parameters
   ftrGraph_.setScalars(ttkUtils::GetVoidPointer(inputScalars_));
   // TODO: SimplexId -> template to int + long long?

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -151,11 +151,11 @@ int ttkTriangulationManager::processExplicit(
 
   // insert cells in the output mesh
   output->Allocate(cells.size());
-  int dimension = triangulation.getCellVertexNumber(0);
+  const size_t dimension = triangulation.getCellVertexNumber(0);
 
   for(unsigned int i = 0; i < cells.size(); i++) {
     std::array<vtkIdType, 4> cell{};
-    for(int j = 0; j < dimension; j++) {
+    for(size_t j = 0; j < dimension; j++) {
       ttk::SimplexId vertexId;
       triangulation.getCellVertex(cells[i], j, vertexId);
       cell[j] = vertexMap[vertexId];

--- a/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
+++ b/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
@@ -398,11 +398,15 @@ int ttkWebSocketIO::SendVtkDataObject(vtkDataObject *object) {
 
       if(block->IsA("vtkUnstructuredGrid")) {
         auto blockAsUG = vtkUnstructuredGrid::SafeDownCast(block);
-        cells = blockAsUG->GetCells();
+        if(blockAsUG != nullptr) {
+          cells = blockAsUG->GetCells();
+        }
       } else if(block->IsA("vtkPolyData")) {
         auto blockAsPD = vtkPolyData::SafeDownCast(block);
-        cells = blockAsPD->GetPolys() ? blockAsPD->GetPolys()
-                                      : blockAsPD->GetLines();
+        if(blockAsPD != nullptr) {
+          cells = blockAsPD->GetPolys() ? blockAsPD->GetPolys()
+                                        : blockAsPD->GetLines();
+        }
       }
 
       if(cells) {
@@ -465,6 +469,9 @@ int ttkWebSocketIO::SendVtkDataObject(vtkDataObject *object) {
 
           if(array->IsA("vtkDataArray")) {
             auto dataArray = vtkDataArray::SafeDownCast(array);
+            if(dataArray == nullptr) {
+              continue;
+            }
             this->queueMessage(
               "{"
               "\"target\":\""


### PR DESCRIPTION
This PR fixes several GCC 12 warnings (-Wuse-after-free, -Warray-bounds, -Wuseless-cast, -Wmaybe-uninitialized, -Wnull-dereference, -Wduplicated-branches). This should hopefully make TTK safer.

In addition, a `-O3` flag has been removed in BaseCode.cmake that prevented users to override the optimization level for individual TTK targets (using `target_compile_options` in modules's CMakeLists.txt), which is useful for debugging modules without recompiling the whole TTK (and still keeping some level of performance).

Enjoy,
Pierre