### PR TITLE
[MPI] Optimization in VertexGlobalIdMap and ScalarFieldSmoother

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2617,8 +2617,8 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getVertexGlobalIdInternal(leid);
     }
-    virtual inline int getVertexGlobalIdMap(
-      std::unordered_map<SimplexId, SimplexId> *map) const {
+    virtual inline const std::unordered_map<SimplexId, SimplexId> *
+      getVertexGlobalIdMap() const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 1 && this->getDimensionality() != 2
          && this->getDimensionality() != 3) {
@@ -2632,7 +2632,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->getVertexGlobalIdMapInternal(*map);
+      return this->getVertexGlobalIdMapInternal();
     }
     virtual inline SimplexId getVertexLocalId(const SimplexId &geid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2672,8 +2672,8 @@ namespace ttk {
       getVertexGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) const {
       return 0;
     }
-    virtual inline int getVertexGlobalIdMapInternal(
-      std::unordered_map<SimplexId, SimplexId> &ttkNotUsed(*map)) const {
+    virtual inline const std::unordered_map<SimplexId, SimplexId> *
+      getVertexGlobalIdMapInternal() const {
       return 0;
     }
     virtual inline SimplexId

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2618,7 +2618,7 @@ namespace ttk {
       return this->getVertexGlobalIdInternal(leid);
     }
     virtual inline int getVertexGlobalIdMap(
-      std::unordered_map<SimplexId, SimplexId> &map) const {
+      std::unordered_map<SimplexId, SimplexId> *map) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 1 && this->getDimensionality() != 2
          && this->getDimensionality() != 3) {
@@ -2632,7 +2632,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->getVertexGlobalIdMapInternal(map);
+      return this->getVertexGlobalIdMapInternal(*map);
     }
     virtual inline SimplexId getVertexLocalId(const SimplexId &geid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2673,7 +2673,7 @@ namespace ttk {
       return 0;
     }
     virtual inline int getVertexGlobalIdMapInternal(
-      std::unordered_map<SimplexId, SimplexId> &ttkNotUsed(&map)) const {
+      std::unordered_map<SimplexId, SimplexId> &ttkNotUsed(*map)) const {
       return 0;
     }
     virtual inline SimplexId

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2623,13 +2623,13 @@ namespace ttk {
       if(this->getDimensionality() != 1 && this->getDimensionality() != 2
          && this->getDimensionality() != 3) {
         this->printErr("Only 1D, 2D and 3D datasets are supported");
-        return -1;
+        return nullptr;
       }
       if(!this->hasPreconditionedDistributedVertices_) {
         this->printErr("VertexGlobalMap query without pre-process!");
         this->printErr(
           "Please call preconditionDistributedVertices() in a pre-process.");
-        return -1;
+        return nullptr;
       }
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getVertexGlobalIdMapInternal();
@@ -2674,7 +2674,7 @@ namespace ttk {
     }
     virtual inline const std::unordered_map<SimplexId, SimplexId> *
       getVertexGlobalIdMapInternal() const {
-      return 0;
+      return nullptr;
     }
     virtual inline SimplexId
       getVertexLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) const {

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -282,7 +282,7 @@ namespace ttk {
   int exchangeGhostCells(DT *scalarArray,
                          const int *const rankArray,
                          const IT *const globalIds,
-                         const std::unordered_map<IT, IT> gidToLidMap,
+                         const std::unordered_map<IT, IT> &gidToLidMap,
                          const IT nVerts,
                          MPI_Comm communicator) {
     if(!ttk::isRunningWithMPI()) {

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1338,10 +1338,9 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertexLidToGid_[ltid];
     }
-    inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> *map) const override {
-      map = &this->vertexGidToLid_;
-      return 1;
+    inline const std::unordered_map<SimplexId, SimplexId> *
+      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
+      return &this->vertexGidToLid_;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1339,8 +1339,8 @@ namespace ttk {
       return this->vertexLidToGid_[ltid];
     }
     inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> &map) const override {
-      map = this->vertexGidToLid_;
+      std::unordered_map<SimplexId, SimplexId> *map) const override {
+      map = &this->vertexGidToLid_;
       return 1;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -567,10 +567,9 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertexLidToGid_[ltid];
     }
-    inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> *map) const override {
-      map = &this->vertexGidToLid_;
-      return 1;
+    inline const std::unordered_map<SimplexId, SimplexId> *
+      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
+      return &this->vertexGidToLid_;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -568,8 +568,8 @@ namespace ttk {
       return this->vertexLidToGid_[ltid];
     }
     inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> &map) const override {
-      map = this->vertexGidToLid_;
+      std::unordered_map<SimplexId, SimplexId> *map) const override {
+      map = &this->vertexGidToLid_;
       return 1;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -289,10 +289,9 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertexLidToGid_[ltid];
     }
-    inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> *map) const override {
-      map = &this->vertexGidToLid_;
-      return 1;
+    inline const std::unordered_map<SimplexId, SimplexId> *
+      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
+      return &this->vertexGidToLid_;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -290,8 +290,8 @@ namespace ttk {
       return this->vertexLidToGid_[ltid];
     }
     inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> &map) const override {
-      map = this->vertexGidToLid_;
+      std::unordered_map<SimplexId, SimplexId> *map) const override {
+      map = &this->vertexGidToLid_;
       return 1;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -258,8 +258,8 @@ namespace ttk {
       return this->vertexLidToGid_[ltid];
     }
     inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> &map) const override {
-      map = this->vertexGidToLid_;
+      std::unordered_map<SimplexId, SimplexId> *map) const override {
+      map = &this->vertexGidToLid_;
       return 1;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -257,10 +257,9 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertexLidToGid_[ltid];
     }
-    inline int TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)(
-      std::unordered_map<SimplexId, SimplexId> *map) const override {
-      map = &this->vertexGidToLid_;
-      return 1;
+    inline const std::unordered_map<SimplexId, SimplexId> *
+      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
+      return &this->vertexGidToLid_;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -68,9 +68,7 @@ namespace ttk {
 // template functions
 template <class dataType, class triangulationType>
 int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
-                                     const int &numberOfIterations,
-                                     const int *rankArray,
-                                     const SimplexId *globalIds) const {
+                                     const int &numberOfIterations) const {
 
   Timer t;
 
@@ -85,13 +83,17 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     return -4;
 #endif
   bool useMPI = false;
+  std::unordered_map<SimplexId, SimplexId> map;
   TTK_FORCE_USE(useMPI);
+  TTK_FORCE_USE(map);
   TTK_FORCE_USE(rankArray);
   TTK_FORCE_USE(globalIds);
 
 #if TTK_ENABLE_MPI
   if(ttk::isRunningWithMPI() && rankArray != nullptr && globalIds != nullptr)
     useMPI = true;
+  triangulation->getVertexGlobalIdMap(map);
+
 #endif
   SimplexId vertexNumber = triangulation->getNumberOfVertices();
 
@@ -154,8 +156,6 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      std::unordered_map<SimplexId, SimplexId> map;
-      triangulation->getVertexGlobalIdMap(map);
       exchangeGhostCells<dataType, SimplexId>(
         outputData, rankArray, globalIds, map, vertexNumber, ttk::MPIcomm_);
     }

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -80,28 +80,21 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
   if(!outputData_)
     return -4;
 #endif
-  int *rankArray_{nullptr};
-  SimplexId *globalIds_{nullptr};
+  int *rankArray{nullptr};
+  SimplexId *globalIds{nullptr};
   bool useMPI = false;
   const std::unordered_map<SimplexId, SimplexId> *map = nullptr;
   TTK_FORCE_USE(useMPI);
   TTK_FORCE_USE(map);
-  TTK_FORCE_USE(rankArray_);
-  TTK_FORCE_USE(globalIds_);
+  TTK_FORCE_USE(rankArray);
+  TTK_FORCE_USE(globalIds);
 
 #if TTK_ENABLE_MPI
-  rankArray_ = triangulation->getRankArray();
-  globalIds_ = (SimplexId *)triangulation->getGlobalIdsArray();
-  if(ttk::isRunningWithMPI() && rankArray_ != nullptr
-     && globalIds_ != nullptr) {
+  rankArray = triangulation->getRankArray();
+  globalIds = (SimplexId *)triangulation->getGlobalIdsArray();
+  if(ttk::isRunningWithMPI() && rankArray != nullptr && globalIds != nullptr) {
     useMPI = true;
     map = triangulation->getVertexGlobalIdMap();
-    if(map != nullptr) {
-      std::unordered_map<SimplexId, SimplexId> testmap = *map;
-      this->printMsg("Map size: " + std::to_string(testmap.size()));
-    } else {
-      this->printMsg("Map is nullptr!");
-    }
   }
 
 #endif
@@ -167,7 +160,7 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
       exchangeGhostCells<dataType, SimplexId>(
-        outputData, rankArray_, globalIds_, *map, vertexNumber, ttk::MPIcomm_);
+        outputData, rankArray, globalIds, *map, vertexNumber, ttk::MPIcomm_);
     }
 #endif
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1399,7 +1399,7 @@ namespace ttk {
     /// \param map the std::unordered_map<SimplexId, SimplexId> in which we want
     /// our GidToLidMap. \return 0 if succesful, -1 else.
     inline int getVertexGlobalIdMap(
-      std::unordered_map<SimplexId, SimplexId> &map) const override {
+      std::unordered_map<SimplexId, SimplexId> *map) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2690,7 +2690,7 @@ namespace ttk {
         this->abstractTriangulation_->setRankArray(rankArray);
     }
 
-    inline int *getRankArray() {
+    inline int *getRankArray() const {
       if(this->abstractTriangulation_)
         return this->abstractTriangulation_->getRankArray();
 
@@ -2702,7 +2702,7 @@ namespace ttk {
         this->abstractTriangulation_->setGlobalIdsArray(globalIds);
     }
 
-    inline long int *getGlobalIdsArray() {
+    inline long int *getGlobalIdsArray() const {
       if(this->abstractTriangulation_)
         return this->abstractTriangulation_->getGlobalIdsArray();
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1398,13 +1398,13 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param map the std::unordered_map<SimplexId, SimplexId> in which we want
     /// our GidToLidMap. \return 0 if succesful, -1 else.
-    inline int getVertexGlobalIdMap(
-      std::unordered_map<SimplexId, SimplexId> *map) const override {
+    inline const std::unordered_map<SimplexId, SimplexId> *
+      getVertexGlobalIdMap() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
 #endif
-      return abstractTriangulation_->getVertexGlobalIdMap(map);
+      return abstractTriangulation_->getVertexGlobalIdMap();
     }
 
     /// Get the corresponding local id for a given global id of a vertex.

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1402,7 +1402,7 @@ namespace ttk {
       getVertexGlobalIdMap() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return -1;
+        return nullptr;
 #endif
       return abstractTriangulation_->getVertexGlobalIdMap();
     }

--- a/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
+++ b/core/vtk/ttkScalarFieldSmoother/ttkScalarFieldSmoother.cpp
@@ -94,21 +94,7 @@ int ttkScalarFieldSmoother::RequestData(vtkInformation *ttkNotUsed(request),
   this->setOutputDataPointer(ttkUtils::GetVoidPointer(outputArray));
   this->setMaskDataPointer(inputMaskPtr);
 
-#ifdef TTK_ENABLE_MPI
-  if(ttk::isRunningWithMPI()) {
-    auto pointData = input->GetPointData();
-    auto vtkGlobalPointIds = pointData->GetGlobalIds();
-    auto rankArray = pointData->GetArray("RankArray");
-
-    ttkTypeMacroAT(inputScalarField->GetDataType(), triangulation->getType(),
-                   (smooth<T0, T1>(
-                     static_cast<const T1 *>(triangulation->getData()),
-                     NumberOfIterations, ttkUtils::GetPointer<int>(rankArray),
-                     ttkUtils::GetPointer<ttk::SimplexId>(vtkGlobalPointIds))));
-    return 1;
-  }
-#endif // TTK_ENABLE_MPI
-  // calling the smoothing package sequentially
+  // calling the smoothing package
   ttkTypeMacroAT(
     inputScalarField->GetDataType(), triangulation->getType(),
     (smooth<T0, T1>(


### PR DESCRIPTION
This PR changes some copy based parameters to only return pointers, moves the vertexGlobalIdMap in ScalarFieldSmoother out of the loop and removes some unneeded parameters which can be retrieved from the triangulation instead. Due to the changes in `ttkAlgorithm.cpp` which added `MPIPipelinePreconditioning`, this filter can now be used on loaded data directly, without any manual preprocessing.
On my machine this leads to a speedup of factor 3-5, when smoothing a scalar field with 1.000.000 vertices which is smoothed in 100 iterations. 

