### PR TITLE
[PersistentGenerators, PersistenceDiagramClustering] Updated documentation

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -13,6 +13,20 @@
 ///
 /// \sa ttk::Triangulation
 /// \sa ttkDimensionReduction.cpp %for a usage example.
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions//">Karhunen-Love
+///   Digits 64-Dimensions example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/1manifoldLearning/">1-Manifold
+///   Learning example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge
+///   Tree Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///
 
 #pragma once
 

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -24,8 +24,12 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge
 ///   Tree Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent
+///   Generators Household Analysis example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent
+///   Generators Periodic Picture example</a> \n
 ///
 
 #pragma once

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -19,6 +19,41 @@
 ///
 /// \sa ttk::Triangulation
 /// \sa ttkMorseSmaleComplex.cpp %for a usage example.
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/1manifoldLearning/">1-Manifold
+///   Learning example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/">1-Manifold
+///   Learning Circles example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/2manifoldLearning/">
+///   2-Manifold Learning example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/">Karhunen-Love
+///   Digits 64-Dimensions example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseMolecule/">Morse
+///   molecule example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 0 example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
+///
 
 #pragma once
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -48,8 +48,12 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent
+///   Generators AT example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent
+///   Generators DarkSky example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -16,8 +16,12 @@
 /// \sa ttkPersistenceDiagramClustering
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence
+///   Diagram Clustering example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence
+///   Diagram Distance example</a> \n
 ///
 
 #pragma once

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.h
@@ -14,6 +14,11 @@
 /// IEEE Transactions on Visualization and Computer Graphics, 2019.
 ///
 /// \sa ttkPersistenceDiagramClustering
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///
 
 #pragma once
 

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -16,6 +16,16 @@
 /// Technical Report, arXiv:2206.13932, 2022
 ///
 /// \sa ttk::DiscreteMorseSandwich
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///
 
 #pragma once
 

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -18,13 +18,27 @@
 /// \sa ttk::DiscreteMorseSandwich
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent
+///   Generators AT example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent
+///   Generators DarkSky example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent
+///   Generators Casting example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent
+///   Generators Fertility example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent
+///   Generators Household Analysis example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent
+///   Generators Periodic Picture example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent
+///   Generators Skull example</a> \n
 ///
 
 #pragma once

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
@@ -10,6 +10,11 @@
 /// closed triangulated surface.
 ///
 /// \sa ttkSurfaceGeometrySmoother.cpp %for a usage example.
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
 
 #pragma once
 

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
@@ -12,9 +12,15 @@
 /// \sa ttkSurfaceGeometrySmoother.cpp %for a usage example.
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent
+///   Generators Casting example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent
+///   Generators Fertility example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent
+///   Generators Skull example</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -17,8 +17,12 @@
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/cinemaIO/">Cinema
 ///   IO example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence
+///   Diagram Clustering example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence
+///   Diagram Distance example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
+++ b/core/vtk/ttkCinemaProductReader/ttkCinemaProductReader.h
@@ -17,6 +17,9 @@
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/cinemaIO/">Cinema
 ///   IO example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkCinemaReader/ttkCinemaReader.h
+++ b/core/vtk/ttkCinemaReader/ttkCinemaReader.h
@@ -14,8 +14,12 @@
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/cinemaIO/">Cinema
 ///   IO example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence
+///   Diagram Clustering example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence
+///   Diagram Distance example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkCinemaReader/ttkCinemaReader.h
+++ b/core/vtk/ttkCinemaReader/ttkCinemaReader.h
@@ -14,6 +14,9 @@
 /// \b Online \b examples: \n
 ///   - <a href="https://topology-tool-kit.github.io/examples/cinemaIO/">Cinema
 ///   IO example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -29,8 +29,12 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge
 ///   Tree Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent
+///   Generators Household Analysis example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent
+///   Generators Periodic Picture example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -29,6 +29,9 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge
 ///   Tree Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -78,8 +78,12 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent
+///   Generators AT example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent
+///   Generators DarkSky example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -78,6 +78,8 @@
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
 ///   clustering 0 example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
 ///   - <a
 ///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
 ///   Puzzle example</a> \n

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -14,6 +14,11 @@
 /// IEEE Transactions on Visualization and Computer Graphics, 2019.
 ///
 /// \sa PersistenceDiagramClustering
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -1,5 +1,5 @@
-/// \ingroup base
-/// \class ttk::ttkPersistenceDiagramBarycenter
+/// \ingroup vtk
+/// \class ttkPersistenceDiagramClustering
 /// \author Jules Vidal <jules.vidal@lip6.fr>
 /// \author Joseph Budin <joseph.budin@polytechnique.edu>
 /// \date September 2019

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.h
@@ -16,8 +16,12 @@
 /// \sa PersistenceDiagramClustering
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence Diagram Clustering example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence Diagram Distance example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/">Persistence
+///   Diagram Clustering example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/">Persistence
+///   Diagram Distance example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
+++ b/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
@@ -11,6 +11,15 @@
 /// Pierre Guillou, Jules Vidal, Julien Tierny \n
 /// Technical Report, arXiv:2206.13932, 2022
 ///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
+++ b/core/vtk/ttkPersistentGenerators/ttkPersistentGenerators.h
@@ -12,13 +12,27 @@
 /// Technical Report, arXiv:2206.13932, 2022
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent Generators AT example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent Generators DarkSky example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_at/">Persistent
+///   Generators AT example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/">Persistent
+///   Generators DarkSky example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent
+///   Generators Casting example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent
+///   Generators Fertility example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent
+///   Generators Household Analysis example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent
+///   Generators Periodic Picture example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent
+///   Generators Skull example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
@@ -37,9 +37,15 @@
 /// \sa ttk::SurfaceGeometrySmoother
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent
+///   Generators Casting example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent
+///   Generators Fertility example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent
+///   Generators Skull example</a> \n
 ///
 
 #pragma once

--- a/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
+++ b/core/vtk/ttkSurfaceGeometrySmoother/ttkSurfaceGeometrySmoother.h
@@ -36,6 +36,11 @@
 /// \sa vtkGeometrySmoother
 /// \sa ttk::SurfaceGeometrySmoother
 ///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_casting/">Persistent Generators Casting example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/">Persistent Generators Fertility example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_skull/">Persistent Generators Skull example</a> \n
+///
 
 #pragma once
 

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
@@ -6,6 +6,10 @@
 /// \brief Computes a distance matrix using LDistance from a vtkTable
 ///
 /// \sa LDistanceMatrix
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.h
@@ -8,8 +8,12 @@
 /// \sa LDistanceMatrix
 ///
 /// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent Generators Household Analysis example</a> \n
-///   - <a href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent Generators Periodic Picture example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_houseHoldAnalysis/">Persistent
+///   Generators Household Analysis example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/">Persistent
+///   Generators Periodic Picture example</a> \n
 
 #pragma once
 

--- a/paraview/xmls/CinemaReader.xml
+++ b/paraview/xmls/CinemaReader.xml
@@ -8,6 +8,13 @@
                 Online examples:
                 
                 - https://topology-tool-kit.github.io/examples/cinemaIO/
+
+                - https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/
+
+                - https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/
+
+                - https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/
+
             </Documentation>
 
             <StringVectorProperty name="DatabasePath" label="Database Path" animateable="0" command="SetDatabasePath" number_of_elements="1">

--- a/paraview/xmls/DataSetToTable.xml
+++ b/paraview/xmls/DataSetToTable.xml
@@ -11,7 +11,12 @@
       <Documentation
         long_help="TTK fieldSelector plugin."
         short_help="TTK fieldSelector plugin.">
-        TTK fieldSelector plugin documentation.
+       TTK fieldSelector plugin documentation.
+
+       Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/DimensionReduction.xml
+++ b/paraview/xmls/DimensionReduction.xml
@@ -22,6 +22,10 @@
         
         - https://topology-tool-kit.github.io/examples/mergeTreeClustering/
 
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_householdAnalysis/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/
+
       </Documentation>
       <InputProperty
         name="Input"

--- a/paraview/xmls/MorseSmaleComplex.xml
+++ b/paraview/xmls/MorseSmaleComplex.xml
@@ -30,7 +30,7 @@
         - https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/
 
         - https://topology-tool-kit.github.io/examples/2manifoldLearning/
-        
+
         - https://topology-tool-kit.github.io/examples/imageProcessing/
         
         - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
@@ -50,6 +50,10 @@
         - https://topology-tool-kit.github.io/examples/persistenceClustering3/
         
         - https://topology-tool-kit.github.io/examples/persistenceClustering4/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_at/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/
 
         - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
         

--- a/paraview/xmls/PersistenceDiagramClustering.xml
+++ b/paraview/xmls/PersistenceDiagramClustering.xml
@@ -29,6 +29,13 @@
        Proceedings of IEEE VIS 2019.
 
        See also PersistenceDiagram, BottleneckDistance
+
+       Online examples:
+        
+       - https://topology-tool-kit.github.io/examples/persistenceDiagramClustering/
+
+       - https://topology-tool-kit.github.io/examples/persistenceDiagramDistance/
+
     </Documentation>
 
      <InputProperty

--- a/paraview/xmls/PersistentGenerators.xml
+++ b/paraview/xmls/PersistentGenerators.xml
@@ -13,6 +13,23 @@
         'Discrete Morse Sandwich: Fast Computation of Persistence Diagrams for Scalar Data -- An Algorithm and A Benchmark'
         Pierre Guillou, Jules Vidal, Julien Tierny
         Technical Report, arXiv:2206.13932, 2022
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_at/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_casting/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_householdAnalysis/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_skull/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/SurfaceGeometrySmoother.xml
+++ b/paraview/xmls/SurfaceGeometrySmoother.xml
@@ -10,7 +10,16 @@
         GeometrySmoother with a twist!
 
         This class smoothes and projects a 1D or a 2D mesh onto a 2D
-        closed triangulated surface.
+        closed triangulated surface
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_casting/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_fertility/
+
+        - https://topology-tool-kit.github.io/examples/persistentGenerators_skull/
+
       </Documentation>
 
       <InputProperty

--- a/paraview/xmls/TableDistanceMatrix.xml
+++ b/paraview/xmls/TableDistanceMatrix.xml
@@ -9,6 +9,12 @@
        shorthelp="Table Distance Matrix."
        >
        TTK Table Distance Matrix.
+
+       Online examples:
+
+       - https://topology-tool-kit.github.io/examples/persistentGenerators_householdAnalysis/
+
+       - https://topology-tool-kit.github.io/examples/persistentGenerators_periodicPicture/
     </Documentation>
 
      <InputProperty


### PR DESCRIPTION
Hi Julien,
This PR adds links in the documentation of PersistentGenerators and PersistenceDiagramClustering to the recently added ttk-data examples. 
Links were added in the xml files, vtk headers and base headers.
I also referenced the examples in the other modules when applicable, such as CinemaReader,  MorseSmaleComplex, DimensionReduction and SurfaceGeometrySmoother. 
Let me know if I missed something !
best,
Jules