### PR TITLE
Fix CI after new state files additions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,7 +134,11 @@ jobs:
       run: |
         VERS=$(hostnamectl | grep "Operating System")
         # Ubuntu 22.04 OOM killer also kills the parent process...
-        [[ "$VERS" == *"22.04"* ]] && rm ttk-data/states/mergeTreeClustering.pvsm
+        if [[ "$VERS" == *"22.04"* ]]; then
+          rm ttk-data/states/mergeTreeClustering.pvsm
+          rm ttk-data/states/mergeTreeTemporalReduction.pvsm
+          rm ttk-data/states/persistentGenerators_darkSky.pvsm
+        fi
 
         cd ttk-data/tests
         mkdir output_screenshots

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -466,10 +466,10 @@ int ttk::PersistentGenerators::computePersistentGenerators(
     // (eliminateBoundariesSandwich boundaries right before
     // simplification)
     std::vector<PersistencePair> sadSadPairs{};
-    this->getSaddleSaddlePairs(sadSadPairs, paired1Saddles, paired2Saddles,
-                               true, generators, criticalCellsByDim[1],
-                               criticalCellsByDim[2], critCellsOrder[1],
-                               triangulation);
+    this->getSaddleSaddlePairs(
+      sadSadPairs, paired1Saddles, dim == 3 ? paired2Saddles : pairedMaxima,
+      true, generators, criticalCellsByDim[1], criticalCellsByDim[2],
+      critCellsOrder[1], triangulation);
   }
 
   // detect topological handles


### PR DESCRIPTION
Following the introduction of new state files in ttk-data (in particular relative to `PersistentGenerators`), this PR skips running some memory-overflowing state files in Ubuntu 22.04 that may crash the whole workflow.

Additionally, an out-of-bound memory read has been fixed in `PersistentGenerators`: the wrong boolean vector was passed to the `DiscreteMorseSandwich` module in dimension 2, leading to reads of garbage memory. This was causing non-deterministic outputs in the relevant Python scripts.

Enjoy,
Pierre