### PR TITLE
[MPI] Fixed bug when completing onesided neighbors

### DIFF
--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -313,7 +313,7 @@ namespace ttk {
       // now we need to check for each rank if they are a neighbor of any other
       // rank. If so, we need to add those to the neighbors
       for(int i = 0; i < ttk::MPIsize_; i++) {
-        for(int j = 0; i < ttk::MPIsize_; i++) {
+        for(int j = 0; j < ttk::MPIsize_; j++) {
           if(setsFromRanks[j].find(i) != setsFromRanks[j].end()) {
             setsFromRanks[i].emplace(j);
           }

--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -148,12 +148,13 @@ void Segments::sortAll(const Scalars *s) {
 // ----------
 // Arc Region
 // ----------
-
-ArcRegion::ArcRegion() {
 #ifndef TTK_ENABLE_KAMIKAZE
+ArcRegion::ArcRegion() {
   segmented_ = false;
-#endif
 }
+#else
+ArcRegion::ArcRegion() = default;
+#endif
 
 ArcRegion::ArcRegion(const segm_it &begin, const segm_it &end) : ArcRegion() {
   concat(begin, end);


### PR DESCRIPTION
Hello,

this PR fixes an oversight when calculating neighborhood relations between ranks. Depending on the number of ghost layers, ranks can have onesided relations e.g. rank A knows that it needs information from rank B, but rank B does not know that it needs to send information to rank A. There was a bug in the code calculating this, which is now fixed.

