### PR TITLE
Fix build without MPI

### DIFF
--- a/CMake/VTKModule.cmake
+++ b/CMake/VTKModule.cmake
@@ -117,7 +117,7 @@ function(ttk_get_target ttk_module ttk_target)
 
   # dependencies check
   ttk_parse_module_file(${VTKWRAPPER_DIR}/${ttk_module}/vtk.module)
-  cmake_parse_arguments("VTK" "" "NAME" "DEPENDS;PRIVATE_DEPENDS" ${moduleFileContent})
+  cmake_parse_arguments("VTK" "" "NAME" "DEPENDS;PRIVATE_DEPENDS;OPTIONAL_DEPENDS" ${moduleFileContent})
   foreach(VTK_DEP_TARGET ${VTK_DEPENDS})
     # Check VTK targets are available (Assume VTK use the VTK namespace)
     string(REGEX MATCH "VTK::.*" TARGET_VTK ${VTK_DEP_TARGET})

--- a/core/vtk/ttkAlgorithm/vtk.module
+++ b/core/vtk/ttkAlgorithm/vtk.module
@@ -4,4 +4,5 @@ DEPENDS
   VTK::FiltersCore
 PRIVATE_DEPENDS
   VTK::CommonCore
+OPTIONAL_DEPENDS
   VTK::FiltersParallelDIY2


### PR DESCRIPTION
`ttkAlgorithm` currently depends on `VTK::FiltersParallelDIY2`, but this dependency is only required for MPI builds and may not be available if VTK was built without MPI.

This PR makes the dependency optional, which allows the VTK module system to silently skip linking against `VTK::FiltersParallelDIY2` if it is not available.
If the module is not required (building without MPI) but available, it is linked without being used, but I think this is the most simple solution.

See https://github.com/conda-forge/topologytoolkit-feedstock/pull/28