### PR TITLE
Add a CMake preset that can be use to release or help benchmark

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,41 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "TTK-Default",
+      "hidden": true,
+      "binaryDir": "build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "TTK_ENABLE_DOUBLE_TEMPLATING": "ON"
+      }
+    },
+    {
+      "name": "TTK-Release",
+      "inherits": "TTK-Default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "TTK_ENABLE_CPU_OPTIMIZATION": "OFF",
+        "TTK_ENABLE_MPI": "OFF",
+        "TTK_ENABLE_KAMIKAZE": "ON"
+      }
+    },
+    {
+      "name": "TTK-Perf",
+      "inherits": "TTK-Default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "TTK_ENABLE_CPU_OPTIMIZATION": "ON",
+        "TTK_ENABLE_KAMIKAZE": "ON"
+      }
+    },
+    {
+      "name": "TTK-Debug",
+      "inherits": "TTK-Default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "TTK_ENABLE_KAMIKAZE": "OFF"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Dear Julien,

This PR is a first attempt at a `CMakePreset.json`.
The goal is to help people compiling TTK to have the right default values for some variable, like the Kamikaze mode on when trying to benchmark. It may also help having a Release mode that would give users the same configuration than the release, for reproducibility or simply for testing.

All the variable I have added here are subject to discussion, so feel free to tell me for better defaults.

Best,
Charles 