### PR TITLE
Triangulation: Improve MPI support

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2555,17 +2555,7 @@ namespace ttk {
       return this->cellRankArray_;
     }
 
-    // precondition methods for distributed meshes
-
-    virtual int preconditionDistributedCells() {
-      return 0;
-    }
-    virtual int preconditionDistributedEdges() {
-      return 0;
-    }
-    virtual int preconditionDistributedTriangles() {
-      return 0;
-    }
+    // public precondition method (used in Triangulation/ttkAlgorithm)
     virtual int preconditionDistributedVertices() {
       return 0;
     }
@@ -3551,6 +3541,18 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> triangleEdgeVector_{};
 
 #ifdef TTK_ENABLE_MPI
+
+    // precondition methods for distributed meshes
+
+    virtual int preconditionDistributedCells() {
+      return 0;
+    }
+    virtual int preconditionDistributedEdges() {
+      return 0;
+    }
+    virtual int preconditionDistributedTriangles() {
+      return 0;
+    }
 
     // "GlobalCellIds" from "Generate Global Ids"
     // (warning: for Implicit/Periodic triangulations, concerns

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2522,11 +2522,40 @@ namespace ttk {
     }
 
 #ifdef TTK_ENABLE_MPI
-    inline void setGlobalIds(const LongSimplexId *const cellGid,
-                             const unsigned char *const ghostCellMask) {
+
+    // GlobalPointIds, GlobalCellIds
+
+    inline void setCellsGlobalIds(const LongSimplexId *const cellGid) {
       this->cellGid_ = cellGid;
-      this->ghostCellMask_ = ghostCellMask;
     }
+    inline const LongSimplexId *getCellsGlobalIds() const {
+      return this->cellGid_;
+    }
+
+    inline void setVertsGlobalIds(const LongSimplexId *array) {
+      this->vertGid_ = array;
+    }
+    inline const LongSimplexId *getVertsGlobalIds() const {
+      return this->vertGid_;
+    }
+
+    // RankArray on points & cells
+
+    inline void setVertRankArray(const int *const rankArray) {
+      this->vertRankArray_ = rankArray;
+    }
+    inline const int *getVertRankArray() const {
+      return this->vertRankArray_;
+    }
+
+    inline void setCellRankArray(const int *const rankArray) {
+      this->cellRankArray_ = rankArray;
+    }
+    inline const int *getCellRankArray() const {
+      return this->cellRankArray_;
+    }
+
+    // precondition methods for distributed meshes
 
     virtual int preconditionDistributedCells() {
       return 0;
@@ -2540,6 +2569,8 @@ namespace ttk {
     virtual int preconditionDistributedVertices() {
       return 0;
     }
+
+    // global <-> local id mappings
 
     virtual inline SimplexId getEdgeGlobalId(const SimplexId &leid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -3419,55 +3450,36 @@ namespace ttk {
     std::vector<std::vector<SimplexId>> triangleEdgeVector_{};
 
 #ifdef TTK_ENABLE_MPI
+
     // "GlobalCellIds" from "Generate Global Ids"
+    // (warning: for Implicit/Periodic triangulations, concerns
+    // "squares"/"cubes" and not "triangles"/"tetrahedron")
     const LongSimplexId *cellGid_{};
-    // "vtkGhostType" from "Ghost Cells Generator"
-    const unsigned char *ghostCellMask_{};
+    // "GlobalPointIds" from "Generate Global Ids"
+    const LongSimplexId *vertGid_{};
+    // PointData "RankArray" from "TTKGhostCellPreconditioning"
+    const int *vertRankArray_{};
+    // CellData "RankArray" from "TTKGhostCellPreconditioning"
+    // (warning: for Implicit/Periodic triangulations, concerns
+    // "squares"/"cubes" and not "triangles"/"tetrahedron")
+    const int *cellRankArray_{};
 
     // global cell id -> owner rank (filled/used only by rank 0)
     std::vector<int> cellGidToRank_{};
+    // inverse of cellGid_
     std::unordered_map<SimplexId, SimplexId> cellGidToLid_{};
+    // inverse of vertGid_
+    std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
 
     std::vector<SimplexId> edgeLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> edgeGidToLid_{};
     std::vector<SimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
-    std::vector<SimplexId> vertexLidToGid_{};
-    std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
 
     bool hasPreconditionedDistributedCells_{false};
     bool hasPreconditionedDistributedEdges_{false};
     bool hasPreconditionedDistributedTriangles_{false};
     bool hasPreconditionedDistributedVertices_{false};
-
-    long int *globalIdsArray_{nullptr};
-    int *vertRankArray_{nullptr};
-    int *cellRankArray_{nullptr};
-
-  public:
-    void setGlobalIdsArray(long int *array) {
-      this->globalIdsArray_ = array;
-    }
-
-    const long int *getGlobalIdsArray() const {
-      return this->globalIdsArray_;
-    }
-
-    void setVertRankArray(int *rankArray) {
-      this->vertRankArray_ = rankArray;
-    }
-
-    const int *getVertRankArray() const {
-      return this->vertRankArray_;
-    }
-
-    void setCellRankArray(int *rankArray) {
-      this->cellRankArray_ = rankArray;
-    }
-
-    int *getCellRankArray() const {
-      return this->cellRankArray_;
-    }
 
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2541,7 +2541,7 @@ namespace ttk {
       return 0;
     }
 
-    virtual inline SimplexId getEdgeGlobalId(const SimplexId &leid) {
+    virtual inline SimplexId getEdgeGlobalId(const SimplexId &leid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
         this->printErr("Only 2D and 3D datasets are supported");
@@ -2556,7 +2556,7 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getEdgeGlobalIdInternal(leid);
     }
-    virtual inline SimplexId getEdgeLocalId(const SimplexId &geid) {
+    virtual inline SimplexId getEdgeLocalId(const SimplexId &geid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
         this->printErr("Only 2D and 3D datasets are supported");
@@ -2571,7 +2571,7 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getEdgeLocalIdInternal(geid);
     }
-    virtual inline SimplexId getTriangleGlobalId(const SimplexId &ltid) {
+    virtual inline SimplexId getTriangleGlobalId(const SimplexId &ltid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 3) {
         this->printErr("Only 3D datasets are supported");
@@ -2586,7 +2586,7 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getTriangleGlobalIdInternal(ltid);
     }
-    virtual inline SimplexId getTriangleLocalId(const SimplexId &gtid) {
+    virtual inline SimplexId getTriangleLocalId(const SimplexId &gtid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 3) {
         this->printErr("Only 3D datasets are supported");
@@ -2653,19 +2653,19 @@ namespace ttk {
 
   protected:
     virtual inline SimplexId
-      getEdgeGlobalIdInternal(const SimplexId &ttkNotUsed(leid)) {
+      getEdgeGlobalIdInternal(const SimplexId &ttkNotUsed(leid)) const {
       return 0;
     }
     virtual inline SimplexId
-      getEdgeLocalIdInternal(const SimplexId &ttkNotUsed(geid)) {
+      getEdgeLocalIdInternal(const SimplexId &ttkNotUsed(geid)) const {
       return 0;
     }
     virtual inline SimplexId
-      getTriangleGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) {
+      getTriangleGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) const {
       return 0;
     }
     virtual inline SimplexId
-      getTriangleLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) {
+      getTriangleLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) const {
       return 0;
     }
     virtual inline SimplexId

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2648,22 +2648,20 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->getVertexGlobalIdInternal(leid);
     }
-    virtual inline const std::unordered_map<SimplexId, SimplexId> *
+    virtual inline const std::unordered_map<SimplexId, SimplexId> &
       getVertexGlobalIdMap() const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 1 && this->getDimensionality() != 2
          && this->getDimensionality() != 3) {
         this->printErr("Only 1D, 2D and 3D datasets are supported");
-        return nullptr;
       }
       if(!this->hasPreconditionedDistributedVertices_) {
         this->printErr("VertexGlobalMap query without pre-process!");
         this->printErr(
           "Please call preconditionDistributedVertices() in a pre-process.");
-        return nullptr;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->getVertexGlobalIdMapInternal();
+      return this->vertexGidToLid_;
     }
     virtual inline SimplexId getVertexLocalId(const SimplexId &geid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2702,10 +2700,6 @@ namespace ttk {
     virtual inline SimplexId
       getVertexGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) const {
       return 0;
-    }
-    virtual inline const std::unordered_map<SimplexId, SimplexId> *
-      getVertexGlobalIdMapInternal() const {
-      return nullptr;
     }
     virtual inline SimplexId
       getVertexLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) const {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3441,23 +3441,32 @@ namespace ttk {
     bool hasPreconditionedDistributedVertices_{false};
 
     long int *globalIdsArray_{nullptr};
-    int *rankArray_{nullptr};
+    int *vertRankArray_{nullptr};
+    int *cellRankArray_{nullptr};
 
   public:
     void setGlobalIdsArray(long int *array) {
       this->globalIdsArray_ = array;
     }
 
-    long int *getGlobalIdsArray() const {
+    const long int *getGlobalIdsArray() const {
       return this->globalIdsArray_;
     }
 
-    void setRankArray(int *rankArray) {
-      this->rankArray_ = rankArray;
+    void setVertRankArray(int *rankArray) {
+      this->vertRankArray_ = rankArray;
     }
 
-    int *getRankArray() const {
-      return this->rankArray_;
+    const int *getVertRankArray() const {
+      return this->vertRankArray_;
+    }
+
+    void setCellRankArray(int *rankArray) {
+      this->cellRankArray_ = rankArray;
+    }
+
+    int *getCellRankArray() const {
+      return this->cellRankArray_;
     }
 
 #endif // TTK_ENABLE_MPI

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2572,67 +2572,7 @@ namespace ttk {
 
     // global <-> local id mappings
 
-    virtual inline SimplexId getEdgeGlobalId(const SimplexId &leid) const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
-        this->printErr("Only 2D and 3D datasets are supported");
-        return -1;
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("EdgeGlobalId query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedEdges() in a pre-process.");
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->getEdgeGlobalIdInternal(leid);
-    }
-    virtual inline SimplexId getEdgeLocalId(const SimplexId &geid) const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
-        this->printErr("Only 2D and 3D datasets are supported");
-        return -1;
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("EdgeLocalId query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedEdges() in a pre-process.");
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->getEdgeLocalIdInternal(geid);
-    }
-    virtual inline SimplexId getTriangleGlobalId(const SimplexId &ltid) const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 3) {
-        this->printErr("Only 3D datasets are supported");
-        return -1;
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("TriangleGlobalId query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedTriangles() in a pre-process.");
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->getTriangleGlobalIdInternal(ltid);
-    }
-    virtual inline SimplexId getTriangleLocalId(const SimplexId &gtid) const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 3) {
-        this->printErr("Only 3D datasets are supported");
-        return -1;
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("TriangleLocalId query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedTriangles() in a pre-process.");
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->getTriangleLocalIdInternal(gtid);
-    }
-    virtual inline SimplexId getVertexGlobalId(const SimplexId &leid) const {
+    virtual inline SimplexId getVertexGlobalId(const SimplexId lvid) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(this->getDimensionality() != 1 && this->getDimensionality() != 2
          && this->getDimensionality() != 3) {
@@ -2645,9 +2585,157 @@ namespace ttk {
           "Please call preconditionDistributedVertices() in a pre-process.");
         return -1;
       }
+      if(lvid < 0 || lvid >= this->getNumberOfVertices()) {
+        return -1;
+      }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->getVertexGlobalIdInternal(leid);
+      return this->getVertexGlobalIdInternal(lvid);
     }
+    virtual inline SimplexId getVertexLocalId(const SimplexId gvid) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedVertices_) {
+        this->printErr("VertexLocalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedVertices() in a pre-process.");
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->getVertexLocalIdInternal(gvid);
+    }
+
+    virtual inline SimplexId getCellGlobalId(const SimplexId lcid) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedCells_) {
+        this->printErr("CellGlobalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedCells() in a pre-process.");
+        return -1;
+      }
+      if(lcid < 0 || lcid >= this->getNumberOfCells()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->getCellGlobalIdInternal(lcid);
+    }
+    virtual inline SimplexId getCellLocalId(const SimplexId gcid) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedCells_) {
+        this->printErr("CellLocalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedCells() in a pre-process.");
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->getCellLocalIdInternal(gcid);
+    }
+
+    virtual inline SimplexId getEdgeGlobalId(const SimplexId leid) const {
+      const auto dim{this->getDimensionality()};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(dim != 1 && dim != 2 && dim != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("EdgeGlobalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedEdges() in a pre-process.");
+        return -1;
+      }
+      if(leid < 0 || leid >= this->getNumberOfEdges()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(dim == 2 || dim == 3) {
+        return this->getEdgeGlobalIdInternal(leid);
+      } else if(dim == 1) {
+        return this->getCellGlobalIdInternal(leid);
+      }
+      return -1;
+    }
+    virtual inline SimplexId getEdgeLocalId(const SimplexId geid) const {
+      const auto dim{this->getDimensionality()};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(dim != 1 && dim != 2 && dim != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("EdgeLocalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedEdges() in a pre-process.");
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(dim == 2 || dim == 3) {
+        return this->getEdgeLocalIdInternal(geid);
+      } else if(dim == 1) {
+        return this->getCellLocalIdInternal(geid);
+      }
+      return -1;
+    }
+
+    virtual inline SimplexId getTriangleGlobalId(const SimplexId ltid) const {
+      const auto dim{this->getDimensionality()};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(dim != 3 && dim != 2) {
+        this->printErr("Only 2D and  3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("TriangleGlobalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedTriangles() in a pre-process.");
+        return -1;
+      }
+      if(ltid < 0 || ltid >= this->getNumberOfTriangles()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(dim == 3) {
+        return this->getTriangleGlobalIdInternal(ltid);
+      } else if(dim == 2) {
+        return this->getCellGlobalIdInternal(ltid);
+      }
+      return -1;
+    }
+    virtual inline SimplexId getTriangleLocalId(const SimplexId gtid) const {
+      const auto dim{this->getDimensionality()};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(dim != 3 && dim != 2) {
+        this->printErr("Only 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("TriangleLocalId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedTriangles() in a pre-process.");
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(dim == 3) {
+        return this->getTriangleLocalIdInternal(gtid);
+      } else if(dim == 2) {
+        return this->getCellLocalIdInternal(gtid);
+      }
+      return -1;
+    }
+
     virtual inline const std::unordered_map<SimplexId, SimplexId> &
       getVertexGlobalIdMap() const {
 #ifndef TTK_ENABLE_KAMIKAZE
@@ -2663,47 +2751,66 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertexGidToLid_;
     }
-    virtual inline SimplexId getVertexLocalId(const SimplexId &geid) const {
+
+  protected:
+    inline SimplexId getVertexGlobalIdInternal(const SimplexId lvid) const {
+      return this->vertGid_[lvid];
+    }
+
+    inline SimplexId getVertexLocalIdInternal(const SimplexId gvid) const {
+      const auto it{this->vertexGidToLid_.find(gvid)};
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
-         && this->getDimensionality() != 3) {
-        this->printErr("Only 1D, 2D and 3D datasets are supported");
-        return -1;
-      }
-      if(!this->hasPreconditionedDistributedVertices_) {
-        this->printErr("VertexLocalId query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedVertices() in a pre-process.");
+      if(it == this->vertexGidToLid_.end()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->getVertexLocalIdInternal(geid);
+      return it->second;
     }
 
-  protected:
+    // overriden in ImplicitTriangulation &
+    // PeriodicImplicitTriangulation (where cellGid_ refers to
+    // squares/cubes and not triangles/tetrahedron)
     virtual inline SimplexId
-      getEdgeGlobalIdInternal(const SimplexId &ttkNotUsed(leid)) const {
-      return 0;
+      getCellGlobalIdInternal(const SimplexId lcid) const {
+      return this->cellGid_[lcid];
     }
-    virtual inline SimplexId
-      getEdgeLocalIdInternal(const SimplexId &ttkNotUsed(geid)) const {
-      return 0;
+
+    inline SimplexId getCellLocalIdInternal(const SimplexId gcid) const {
+      const auto it{this->cellGidToLid_.find(gcid)};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(it == this->cellGidToLid_.end()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return it->second;
     }
-    virtual inline SimplexId
-      getTriangleGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) const {
-      return 0;
+
+    inline SimplexId getEdgeGlobalIdInternal(const SimplexId leid) const {
+      return this->edgeLidToGid_[leid];
     }
-    virtual inline SimplexId
-      getTriangleLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) const {
-      return 0;
+
+    inline SimplexId getEdgeLocalIdInternal(const SimplexId geid) const {
+      const auto it = this->edgeGidToLid_.find(geid);
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(it == this->edgeGidToLid_.end()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return it->second;
     }
-    virtual inline SimplexId
-      getVertexGlobalIdInternal(const SimplexId &ttkNotUsed(ltid)) const {
-      return 0;
+
+    inline SimplexId getTriangleGlobalIdInternal(const SimplexId ltid) const {
+      return this->triangleLidToGid_[ltid];
     }
-    virtual inline SimplexId
-      getVertexLocalIdInternal(const SimplexId &ttkNotUsed(gtid)) const {
-      return 0;
+
+    inline SimplexId getTriangleLocalIdInternal(const SimplexId gtid) const {
+      const auto it = this->triangleGidToLid_.find(gtid);
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(it == this->triangleGidToLid_.end()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return it->second;
     }
 
 #endif // TTK_ENABLE_MPI

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -9,14 +9,19 @@
 
 #include <BaseClass.h>
 #include <Timer.h>
+
 #include <algorithm>
 #include <array>
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 #if TTK_ENABLE_MPI
+
+// disable the MPI C++ API
 #define OMPI_SKIP_MPICXX 1
+
 #include <mpi.h>
 
 namespace ttk {
@@ -163,12 +168,13 @@ namespace ttk {
   template <typename DT, typename IT>
   int getGhostCellScalars(DT *scalarArray,
                           const int *const rankArray,
-                          const IT *const globalIds,
+                          const LongSimplexId *const globalIds,
                           const std::unordered_map<IT, IT> &gidToLidMap,
                           const std::unordered_set<int> &neighbors,
                           const int rankToSend,
                           const IT nVerts,
                           MPI_Comm communicator) {
+
     if(!ttk::isRunningWithMPI()) {
       return -1;
     }
@@ -368,7 +374,7 @@ namespace ttk {
   template <typename DT, typename IT>
   int exchangeGhostCells(DT *scalarArray,
                          const int *const rankArray,
-                         const IT *const globalIds,
+                         const LongSimplexId *const globalIds,
                          const std::unordered_map<IT, IT> &gidToLidMap,
                          const IT nVerts,
                          MPI_Comm communicator) {
@@ -407,7 +413,7 @@ namespace ttk {
    * @param[in] nVertices number of vertices in the arrays
    */
   void inline produceRankArray(std::vector<int> &rankArray,
-                               long int *globalIds,
+                               LongSimplexId *globalIds,
                                unsigned char *ghostCells,
                                int nVertices,
                                double *boundingBox) {
@@ -696,7 +702,7 @@ namespace ttk {
                       std::unordered_map<IT, IT> &gidToLidMap,
                       const size_t nVerts,
                       const DT *const scalars,
-                      const IT *const globalIds,
+                      const LongSimplexId *const globalIds,
                       const int *const rankArray) {
     for(size_t i = 0; i < nVerts; i++) {
       IT globalId = globalIds[i];

--- a/core/base/compactTriangulation/CompactTriangulation.cpp
+++ b/core/base/compactTriangulation/CompactTriangulation.cpp
@@ -2512,34 +2512,3 @@ int CompactTriangulation::getBoundaryCells(ImplicitCluster *const nodePtr,
 
   return 0;
 }
-#if TTK_ENABLE_MPI
-int CompactTriangulation::preconditionDistributedVertices() {
-  if(this->hasPreconditionedDistributedVertices_) {
-    return 0;
-  }
-  if(!isRunningWithMPI()) {
-    return -1;
-  }
-  if(this->vertGid_ == nullptr) {
-    this->printWrn("Missing global identifiers array!");
-    return -2;
-  }
-
-  // allocate memory
-  this->vertexGidToLid_.reserve(this->vertexNumber_);
-
-  for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexGidToLid_[this->vertGid_[i]] = i;
-  }
-
-  if(MPIrank_ == 0) {
-    this->printMsg("Domain contains "
-                   + std::to_string(this->getNumberOfVerticesInternal())
-                   + " vertices");
-  }
-
-  this->hasPreconditionedDistributedVertices_ = true;
-
-  return 0;
-}
-#endif // TTK_ENABLE_MPI

--- a/core/base/compactTriangulation/CompactTriangulation.cpp
+++ b/core/base/compactTriangulation/CompactTriangulation.cpp
@@ -2520,18 +2520,16 @@ int CompactTriangulation::preconditionDistributedVertices() {
   if(!isRunningWithMPI()) {
     return -1;
   }
-  if(this->globalIdsArray_ == nullptr) {
+  if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;
   }
 
   // allocate memory
-  this->vertexLidToGid_.resize(this->vertexNumber_, -1);
   this->vertexGidToLid_.reserve(this->vertexNumber_);
 
   for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexLidToGid_[i] = this->globalIdsArray_[i];
-    this->vertexGidToLid_[this->globalIdsArray_[i]] = i;
+    this->vertexGidToLid_[this->vertGid_[i]] = i;
   }
 
   if(MPIrank_ == 0) {

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1338,10 +1338,6 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertGid_[ltid];
     }
-    inline const std::unordered_map<SimplexId, SimplexId> *
-      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
-      return &this->vertexGidToLid_;
-    }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1336,7 +1336,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexLidToGid_[ltid];
+      return this->vertGid_[ltid];
     }
     inline const std::unordered_map<SimplexId, SimplexId> *
       TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1328,25 +1328,9 @@ namespace ttk {
     }
 
 #ifdef TTK_ENABLE_MPI
+
     int preconditionDistributedVertices() override;
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfVerticesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
-      const SimplexId &gtid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->vertexGidToLid_.find(gtid) == this->vertexGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_.at(gtid);
-    }
+
 #endif // TTK_ENABLE_MPI
 
     inline int preconditionBoundaryEdgesInternal() override {

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1327,12 +1327,6 @@ namespace ttk {
       return (exnode->boundaryVertices_)[localVertexId];
     }
 
-#ifdef TTK_ENABLE_MPI
-
-    int preconditionDistributedVertices() override;
-
-#endif // TTK_ENABLE_MPI
-
     inline int preconditionBoundaryEdgesInternal() override {
       return 0;
     }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -1,9 +1,12 @@
 #include <ExplicitTriangulation.h>
+
 #include <OneSkeleton.h>
 #include <ThreeSkeleton.h>
 #include <TwoSkeleton.h>
 #include <ZeroSkeleton.h>
+
 #include <cstring>
+#include <numeric>
 
 using namespace ttk;
 
@@ -611,15 +614,10 @@ int ExplicitTriangulation::preconditionDistributedCells() {
     this->cellGidToLid_[this->cellGid_[lcid]] = lcid;
   }
 
-  // global cell ids for cell owned by current rank
-  std::vector<LongSimplexId> globalCellsInRank{};
-  globalCellsInRank.reserve(nLocCells);
   this->ghostCellPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
-    if(this->cellRankArray_[lcid] == ttk::MPIrank_) {
-      globalCellsInRank.emplace_back(this->cellGid_[lcid]);
-    } else {
+    if(this->cellRankArray_[lcid] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
       this->ghostCellPerOwner_[this->cellRankArray_[lcid]].emplace_back(
         this->cellGid_[lcid]);
@@ -630,26 +628,6 @@ int ExplicitTriangulation::preconditionDistributedCells() {
   for(size_t i = 0; i < this->ghostCellPerOwner_.size(); ++i) {
     if(!this->ghostCellPerOwner_[i].empty()) {
       this->neighborRanks_.emplace_back(i);
-    }
-  }
-
-  // global cell ids per rank (used by rank 0)
-  std::vector<std::vector<LongSimplexId>> cellsRankPerProc{};
-
-  gatherVectors(cellsRankPerProc, globalCellsInRank, 0);
-
-  if(ttk::MPIrank_ == 0) {
-    // global number of cells
-    auto nGlobalCells = cellsRankPerProc[0].size();
-    for(int i = 1; i < MPIsize_; ++i) {
-      nGlobalCells += cellsRankPerProc[i].size();
-    }
-
-    this->cellGidToRank_.resize(nGlobalCells, -1);
-    for(int i = 0; i < MPIsize_; ++i) {
-      for(const auto gcid : cellsRankPerProc[i]) {
-        this->cellGidToRank_[gcid] = i;
-      }
     }
   }
 
@@ -676,86 +654,170 @@ int ExplicitTriangulation::preconditionDistributedCells() {
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
 
+  this->preconditionDistributedCellRanges();
+
   this->hasPreconditionedDistributedCells_ = true;
 
   if(ttk::MPIrank_ == 0) {
     this->printMsg("Domain contains "
-                     + std::to_string(this->cellGidToRank_.size()) + " cells",
+                     + std::to_string(this->gatheredCellRanges_.back().end + 1)
+                     + " cells",
                    1.0, tm.getElapsedTime(), this->threadNumber_);
   }
 
   return 0;
 }
 
-template <typename Func>
-int preconditionDistributedIntermediate(size_t &globalCount,
-                                        const std::vector<int> &cellGidToRank,
-                                        const Func &processCells) {
+int ttk::ExplicitTriangulation::preconditionDistributedCellRanges() {
 
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
+  // 1. store all local cells owned by current rank by global id
+
+  std::vector<SimplexId> localCellIds{};
+  localCellIds.reserve(this->getNumberOfCells());
+  for(SimplexId i = 0; i < this->getNumberOfCells(); ++i) {
+    if(this->cellRankArray_[i] == ttk::MPIrank_) {
+      localCellIds.emplace_back(i);
+    }
   }
 
-  const int COMPUTE = 1, STOP = 2;
+  TTK_PSORT(this->threadNumber_, localCellIds.begin(), localCellIds.end(),
+            [this](const SimplexId a, const SimplexId b) {
+              return this->cellGid_[a] < this->cellGid_[b];
+            });
+
+  // 2. determine ranges of contiguous cell global ids
+
+  size_t begRange{};
+  while(begRange < localCellIds.size()) {
+    size_t endRange{begRange + 1};
+
+    if(begRange < localCellIds.size() - 1) {
+      for(size_t j = begRange + 1; j < localCellIds.size(); ++j) {
+        if(this->cellGid_[localCellIds[j]]
+           > this->cellGid_[localCellIds[j - 1]] + 1) {
+          endRange = j;
+          break;
+        }
+      }
+      if(endRange == begRange + 1
+         && this->cellGid_[localCellIds[endRange]]
+              == this->cellGid_[localCellIds[endRange - 1]] + 1) {
+        endRange = localCellIds.size();
+      }
+    }
+
+    const size_t gbeg = this->cellGid_[localCellIds[begRange]];
+    const size_t gend = this->cellGid_[localCellIds[endRange - 1]];
+    const auto nRanges{this->localCellRanges_.size()};
+
+    // inclusive range
+    this->localCellRanges_.emplace_back(
+      CellRange{nRanges, gbeg, gend, static_cast<size_t>(ttk::MPIrank_)});
+
+    begRange = endRange;
+  }
+
+  // 3. send to rank 0 the vector of ranges so it can compute range offsets
 
   if(ttk::MPIrank_ == 0) {
-    size_t gcid{};
-    while(gcid < cellGidToRank.size()) {
-      const auto currRank{cellGidToRank[gcid]};
-      size_t endCurrRank{gcid + 1};
-      if(gcid < cellGidToRank.size() - 1) {
-        for(size_t j = gcid + 1; j < cellGidToRank.size(); ++j) {
-          if(cellGidToRank[j] != currRank) {
-            endCurrRank = j;
-            break;
-          }
-        }
-        if(endCurrRank == gcid + 1 && cellGidToRank[endCurrRank] == currRank) {
-          endCurrRank = cellGidToRank.size();
-        }
-      }
+    this->nRangesPerRank_.resize(ttk::MPIsize_);
+  }
 
-      if(currRank == 0) {
-        // process local edges
-        processCells(gcid, endCurrRank, globalCount);
-      } else {
-        // send to relevant process
-        std::array<unsigned long, 3> toSend{globalCount, gcid, endCurrRank};
-        MPI_Send(toSend.data(), 3, MPI_UNSIGNED_LONG, currRank, COMPUTE,
-                 ttk::MPIcomm_);
-        // receive updated edgeCount
-        MPI_Recv(&globalCount, 1, MPI_UNSIGNED_LONG, currRank, MPI_ANY_TAG,
-                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
-      }
+  const int rangeSize = this->localCellRanges_.size();
+  MPI_Gather(&rangeSize, 1, ttk::getMPIType(rangeSize),
+             this->nRangesPerRank_.data(), 1, ttk::getMPIType(rangeSize), 0,
+             ttk::MPIcomm_);
 
-      gcid = endCurrRank;
+  std::vector<int> displacements{};
+
+  if(ttk::MPIrank_ == 0) {
+    const auto nRanges{std::accumulate(
+      this->nRangesPerRank_.begin(), this->nRangesPerRank_.end(), 0)};
+    this->gatheredCellRanges_.resize(nRanges);
+    displacements.resize(this->nRangesPerRank_.size());
+
+    for(size_t i = 0; i < this->nRangesPerRank_.size() - 1; ++i) {
+      displacements[i + 1] = displacements[i] + this->nRangesPerRank_[i];
     }
+  }
 
-    // send STOP signal to break infinite loop
-    std::array<unsigned long, 3> dummy{};
-    for(int i = 1; i < ttk::MPIsize_; ++i) {
-      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, ttk::MPIcomm_);
-    }
+  auto cellRangeDT{CellRange::getMPIType()};
+  MPI_Type_commit(&cellRangeDT);
 
-  } else {
-    while(true) {
-      // receive data
-      std::array<unsigned long, 3> toRecv{};
-      MPI_Status status;
-      MPI_Recv(toRecv.data(), 3, MPI_UNSIGNED_LONG, 0, MPI_ANY_TAG,
-               ttk::MPIcomm_, &status);
-      if(status.MPI_TAG == STOP) {
-        break;
-      }
-      // process local edges
-      globalCount = toRecv[0];
-      processCells(toRecv[1], toRecv[2], globalCount);
-      // send back updated edgeCount to rank 0
-      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, ttk::MPIcomm_);
-    }
+  MPI_Gatherv(this->localCellRanges_.data(), this->localCellRanges_.size(),
+              cellRangeDT, this->gatheredCellRanges_.data(),
+              this->nRangesPerRank_.data(), displacements.data(), cellRangeDT,
+              0, ttk::MPIcomm_);
+
+  MPI_Type_free(&cellRangeDT);
+
+  // 4. sort range vector on rank 0
+
+  if(ttk::MPIrank_ == 0) {
+    TTK_PSORT(
+      this->threadNumber_, this->gatheredCellRanges_.begin(),
+      this->gatheredCellRanges_.end(),
+      [](const CellRange &a, const CellRange &b) { return a.begin < b.begin; });
   }
 
   return 0;
+}
+
+size_t ttk::ExplicitTriangulation::computeCellRangeOffsets(
+  std::vector<size_t> &nSimplicesPerRange) const {
+
+  // 1. send to rank 0 number of edges per cell range
+
+  std::vector<std::vector<size_t>> nSimplicesPerRangePerRank{};
+
+  if(ttk::MPIrank_ == 0) {
+    nSimplicesPerRangePerRank.resize(this->nRangesPerRank_.size());
+    for(int i = 0; i < ttk::MPIsize_; ++i) {
+      nSimplicesPerRangePerRank[i].resize(this->nRangesPerRank_[i]);
+    }
+    for(int i = 0; i < ttk::MPIsize_; ++i) {
+      if(i == 0) {
+        continue;
+      }
+      // receive src content from other ranks
+      MPI_Recv(nSimplicesPerRangePerRank[i].data(),
+               nSimplicesPerRangePerRank[i].size(), ttk::getMPIType(size_t{}),
+               i, MPI_ANY_TAG, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    }
+    std::swap(nSimplicesPerRangePerRank[0], nSimplicesPerRange);
+  } else {
+    MPI_Send(nSimplicesPerRange.data(), nSimplicesPerRange.size(),
+             ttk::getMPIType(size_t{}), 0, 0, ttk::MPIcomm_);
+  }
+
+  // 2. compute range offsets on rank 0
+
+  size_t nSimplices{};
+  if(ttk::MPIrank_ == 0) {
+
+    for(const auto &range : this->gatheredCellRanges_) {
+      auto &pSum{nSimplicesPerRangePerRank[range.rank][range.id]};
+      std::swap(pSum, nSimplices);
+      nSimplices += pSum;
+    }
+  }
+
+  // 3. send back range offsets to other ranks
+
+  if(ttk::MPIrank_ == 0) {
+    for(int i = 1; i < ttk::MPIsize_; ++i) {
+      MPI_Send(nSimplicesPerRangePerRank[i].data(),
+               nSimplicesPerRangePerRank[i].size(), ttk::getMPIType(size_t{}),
+               i, 0, ttk::MPIcomm_);
+    }
+    std::swap(nSimplicesPerRange, nSimplicesPerRangePerRank[0]);
+  } else {
+    MPI_Recv(nSimplicesPerRange.data(), nSimplicesPerRange.size(),
+             ttk::getMPIType(size_t{}), MPI_ANY_TAG, 0, ttk::MPIcomm_,
+             MPI_STATUS_IGNORE);
+  }
+
+  return nSimplices;
 }
 
 template <typename Func0, typename Func1, typename Func2>
@@ -859,15 +921,21 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
     return -3;
   }
 
+  Timer tm{};
+
   this->preconditionDistributedCells();
 
   // allocate memory
   this->edgeLidToGid_.resize(this->getNumberOfEdgesInternal(), -1);
   this->edgeGidToLid_.reserve(this->getNumberOfEdgesInternal());
 
-  const auto processEdge = [this](const SimplexId leid, const SimplexId lcid,
-                                  size_t &edgeCount) {
-    bool alreadyProcessed{false};
+  // 1. for every range of local cells, number the edges locally
+
+  std::vector<SimplexId> edgeLidToRangeId(this->getNumberOfEdgesInternal(), -1);
+  std::vector<size_t> nEdgesPerRange(this->localCellRanges_.size());
+
+  const auto edgeAlreadyProcessed = [this](const SimplexId leid,
+                                           const SimplexId lcid) {
     const auto nStar{this->TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(leid)};
     for(SimplexId i = 0; i < nStar; ++i) {
       SimplexId sid{-1};
@@ -878,44 +946,71 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
       // rule: an edge is owned by the cell in its star with the
       // lowest global id
       if(this->cellGid_[sid] < this->cellGid_[lcid]) {
-        alreadyProcessed = true;
+        return true;
         break;
       }
     }
-    if(!alreadyProcessed) {
-      this->edgeLidToGid_[leid] = edgeCount;
-      this->edgeGidToLid_[edgeCount] = leid;
-      edgeCount++;
-    }
+    return false;
   };
 
-  const auto processCellsEdges
-    = [this, &processEdge](
-        const size_t gcid, const size_t endCurrRank, size_t &edgeCount) {
-        for(size_t j = gcid; j < endCurrRank; ++j) {
-          // local cell id
-          const auto lcid{this->cellGidToLid_[j]};
-          SimplexId nEdges{};
-          if(this->getDimensionality() == 3) {
-            nEdges = this->getCellEdgeNumberInternal(lcid);
-          } else if(this->getDimensionality() == 2) {
-            nEdges = this->getTriangleEdgeNumberInternal(lcid);
+  const auto countCellEdges
+    = [this, &edgeAlreadyProcessed](const SimplexId lcid,
+                                    std::vector<SimplexId> &edgeGid,
+                                    std::vector<SimplexId> &edgeRangeId,
+                                    const size_t rangeId, size_t &edgeCount) {
+        SimplexId nEdges{};
+        if(this->maxCellDim_ == 3) {
+          nEdges = this->getCellEdgeNumberInternal(lcid);
+        } else if(this->maxCellDim_ == 2) {
+          nEdges = this->getTriangleEdgeNumberInternal(lcid);
+        }
+        for(SimplexId k = 0; k < nEdges; ++k) {
+          SimplexId leid{-1};
+          if(this->maxCellDim_ == 3) {
+            this->getCellEdgeInternal(lcid, k, leid);
+          } else if(this->maxCellDim_ == 2) {
+            this->getTriangleEdge(lcid, k, leid);
           }
-          for(SimplexId i = 0; i < nEdges; ++i) {
-            SimplexId leid{-1};
-            if(this->getDimensionality() == 3) {
-              this->getCellEdgeInternal(lcid, i, leid);
-            } else if(this->getDimensionality() == 2) {
-              this->getTriangleEdgeInternal(lcid, i, leid);
-            }
-            processEdge(leid, lcid, edgeCount);
+          const auto alreadyProcessed = edgeAlreadyProcessed(leid, lcid);
+          if(!alreadyProcessed) {
+            edgeGid[leid] = edgeCount;
+            edgeRangeId[leid] = rangeId;
+            edgeCount++;
           }
         }
       };
 
-  size_t edgeCount{};
-  preconditionDistributedIntermediate(
-    edgeCount, this->cellGidToRank_, processCellsEdges);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < this->localCellRanges_.size(); ++i) {
+    auto &range{this->localCellRanges_[i]};
+    range.id = i;
+    for(size_t j = range.begin; j <= range.end; ++j) {
+      // local cell id
+      const auto lcid{this->cellGidToLid_[j]};
+      countCellEdges(lcid, this->edgeLidToGid_, edgeLidToRangeId, range.id,
+                     nEdgesPerRange[i]);
+    }
+  }
+
+  // 2. compute range offset on rank 0
+  const auto nEdges = this->computeCellRangeOffsets(nEdgesPerRange);
+
+  // 3. locally edit the edge global id with range offsets
+
+  for(SimplexId leid = 0; leid < this->getNumberOfEdgesInternal(); ++leid) {
+    if(this->edgeLidToGid_[leid] == -1) {
+      // not owned by a cell of this rank
+      continue;
+    }
+    const auto geid{this->edgeLidToGid_[leid]
+                    + nEdgesPerRange[edgeLidToRangeId[leid]]};
+    this->edgeLidToGid_[leid] = geid;
+    this->edgeGidToLid_[geid] = leid;
+  }
+
+  // 4. exchange global ids between ghost cells
 
   const auto nEdgesPerCell{this->getDimensionality() == 3 ? 6 : 3};
   this->exchangeDistributedInternal(
@@ -940,7 +1035,8 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
     nEdgesPerCell);
 
   if(MPIrank_ == 0) {
-    this->printMsg("Domain contains " + std::to_string(edgeCount) + " edges");
+    this->printMsg("Domain contains " + std::to_string(nEdges) + " edges", 1.0,
+                   tm.getElapsedTime(), 1);
   }
 
   this->hasPreconditionedDistributedEdges_ = true;
@@ -964,55 +1060,89 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
     return -3;
   }
 
+  Timer tm{};
+
   this->preconditionDistributedCells();
 
   // allocate memory
   this->triangleLidToGid_.resize(this->getNumberOfTrianglesInternal(), -1);
   this->triangleGidToLid_.reserve(this->getNumberOfTrianglesInternal());
 
-  const auto processTriangle =
-    [this](const SimplexId ltid, const SimplexId lcid, size_t &triangleCount) {
-      bool alreadyProcessed{false};
-      const auto nStar{
-        this->TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(ltid)};
-      for(SimplexId i = 0; i < nStar; ++i) {
-        SimplexId sid{-1};
-        this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(ltid, i, sid);
-        if(sid == -1 || sid == lcid) {
-          continue;
-        }
-        // rule: an edge is owned by the cell in its star with the
-        // lowest global id
-        if(this->cellGid_[sid] < this->cellGid_[lcid]) {
-          alreadyProcessed = true;
-          break;
-        }
-      }
-      if(!alreadyProcessed) {
-        this->triangleLidToGid_[ltid] = triangleCount;
-        this->triangleGidToLid_[triangleCount] = ltid;
-        triangleCount++;
-      }
-    };
+  // 1. for every range of local cells, number the edges locally
 
-  const auto processCellsTriangles
-    = [this, &processTriangle](
-        const size_t gcid, const size_t endCurrRank, size_t &triangleCount) {
-        for(size_t j = gcid; j < endCurrRank; ++j) {
-          // local cell id
-          const auto lcid{this->cellGidToLid_[j]};
-          for(SimplexId i = 0; i < this->getCellTriangleNumberInternal(lcid);
-              ++i) {
-            SimplexId ltid{-1};
-            this->getCellTriangleInternal(lcid, i, ltid);
-            processTriangle(ltid, lcid, triangleCount);
+  std::vector<SimplexId> triangleLidToRangeId(
+    this->getNumberOfTrianglesInternal(), -1);
+  std::vector<size_t> nTrianglesPerRange(this->localCellRanges_.size());
+
+  const auto triangleAlreadyProcessed
+    = [this](const SimplexId leid, const SimplexId lcid) {
+        const auto nStar{
+          this->TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(leid)};
+        for(SimplexId i = 0; i < nStar; ++i) {
+          SimplexId sid{-1};
+          this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(leid, i, sid);
+          if(sid == -1 || sid == lcid) {
+            continue;
+          }
+          // rule: an triangle is owned by the cell in its star with the
+          // lowest global id
+          if(this->cellGid_[sid] < this->cellGid_[lcid]) {
+            return true;
+            break;
+          }
+        }
+        return false;
+      };
+
+  const auto countCellTriangles
+    = [this, &triangleAlreadyProcessed](
+        const SimplexId lcid, std::vector<SimplexId> &triangleGid,
+        std::vector<SimplexId> &triangleRangeId, const size_t rangeId,
+        size_t &triangleCount) {
+        const auto nTriangles{this->getCellTriangleNumberInternal(lcid)};
+        for(SimplexId k = 0; k < nTriangles; ++k) {
+          SimplexId leid{-1};
+          this->getCellTriangleInternal(lcid, k, leid);
+          const auto alreadyProcessed = triangleAlreadyProcessed(leid, lcid);
+          if(!alreadyProcessed) {
+            triangleGid[leid] = triangleCount;
+            triangleRangeId[leid] = rangeId;
+            triangleCount++;
           }
         }
       };
 
-  size_t triangleCount{};
-  preconditionDistributedIntermediate(
-    triangleCount, this->cellGidToRank_, processCellsTriangles);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < this->localCellRanges_.size(); ++i) {
+    auto &range{this->localCellRanges_[i]};
+    range.id = i;
+    for(size_t j = range.begin; j <= range.end; ++j) {
+      // local cell id
+      const auto lcid{this->cellGidToLid_[j]};
+      countCellTriangles(lcid, this->triangleLidToGid_, triangleLidToRangeId,
+                         range.id, nTrianglesPerRange[i]);
+    }
+  }
+
+  // 2. compute range offset on rank 0
+  const auto nTriangles = this->computeCellRangeOffsets(nTrianglesPerRange);
+
+  // 3. locally edit the triangle global id with range offsets
+
+  for(SimplexId leid = 0; leid < this->getNumberOfTrianglesInternal(); ++leid) {
+    if(this->triangleLidToGid_[leid] == -1) {
+      // not owned by a cell of this rank
+      continue;
+    }
+    const auto geid{this->triangleLidToGid_[leid]
+                    + nTrianglesPerRange[triangleLidToRangeId[leid]]};
+    this->triangleLidToGid_[leid] = geid;
+    this->triangleGidToLid_[geid] = leid;
+  }
+
+  // 4. exchange global ids between ghost cells
 
   const auto nTrianglesPerCell{4};
   this->exchangeDistributedInternal(
@@ -1037,8 +1167,9 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
     nTrianglesPerCell);
 
   if(MPIrank_ == 0) {
-    this->printMsg("Domain contains " + std::to_string(triangleCount)
-                   + " triangles");
+    this->printMsg(
+      "Domain contains " + std::to_string(nTriangles) + " triangles", 1.0,
+      tm.getElapsedTime(), 1);
   }
 
   this->hasPreconditionedDistributedTriangles_ = true;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -595,8 +595,8 @@ int ExplicitTriangulation::preconditionDistributedCells() {
     this->printWrn("Missing global identifiers on cells");
     return -2;
   }
-  if(this->ghostCellMask_ == nullptr) {
-    this->printWrn("Missing ghost mask on cells");
+  if(this->cellRankArray_ == nullptr) {
+    this->printWrn("Missing RankArray on cells");
     return -3;
   }
 
@@ -614,7 +614,7 @@ int ExplicitTriangulation::preconditionDistributedCells() {
   globalCellsInRank.reserve(nLocCells);
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
-    if(this->ghostCellMask_[lcid] == 0) {
+    if(this->cellRankArray_[lcid] == ttk::MPIrank_) {
       globalCellsInRank.emplace_back(this->cellGid_[lcid]);
     }
   }
@@ -871,18 +871,16 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
   if(!isRunningWithMPI()) {
     return -1;
   }
-  if(this->globalIdsArray_ == nullptr) {
+  if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;
   }
 
   // allocate memory
-  this->vertexLidToGid_.resize(this->vertexNumber_, -1);
   this->vertexGidToLid_.reserve(this->vertexNumber_);
 
   for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexLidToGid_[i] = this->globalIdsArray_[i];
-    this->vertexGidToLid_[this->globalIdsArray_[i]] = i;
+    this->vertexGidToLid_[this->vertGid_[i]] = i;
   }
 
   if(MPIrank_ == 0) {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -767,9 +767,19 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
         for(size_t j = gcid; j < endCurrRank; ++j) {
           // local cell id
           const auto lcid{this->cellGidToLid_[j]};
-          for(SimplexId i = 0; i < this->getCellEdgeNumberInternal(lcid); ++i) {
+          SimplexId nEdges{};
+          if(this->getDimensionality() == 3) {
+            nEdges = this->getCellEdgeNumberInternal(lcid);
+          } else if(this->getDimensionality() == 2) {
+            nEdges = this->getTriangleEdgeNumberInternal(lcid);
+          }
+          for(SimplexId i = 0; i < nEdges; ++i) {
             SimplexId leid{-1};
-            this->getCellEdgeInternal(lcid, i, leid);
+            if(this->getDimensionality() == 3) {
+              this->getCellEdgeInternal(lcid, i, leid);
+            } else if(this->getDimensionality() == 2) {
+              this->getTriangleEdgeInternal(lcid, i, leid);
+            }
             processEdge(leid, lcid, edgeCount);
           }
         }

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -515,23 +515,6 @@ namespace ttk {
     int preconditionVertexStarsInternal() override;
     int preconditionVertexTrianglesInternal() override;
 
-#ifdef TTK_ENABLE_MPI
-
-  protected:
-    template <typename Func0, typename Func1, typename Func2>
-    int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,
-                                    const Func1 &storeGlobalSimplexId,
-                                    const Func2 &iterCond,
-                                    const int nSimplicesPerCell);
-
-  public:
-    int preconditionDistributedCells() override;
-    int preconditionDistributedEdges() override;
-    int preconditionDistributedVertices() override;
-    int preconditionDistributedTriangles() override;
-
-#endif // TTK_ENABLE_MPI
-
 #ifdef TTK_CELL_ARRAY_NEW
     // Layout with connectivity + offset array (new)
     inline int setInputCells(const SimplexId &cellNumber,
@@ -630,6 +613,26 @@ namespace ttk {
      * Use a custom binary format for fast loading
      */
     int readFromFile(std::ifstream &stream);
+
+#ifdef TTK_ENABLE_MPI
+
+  protected:
+    template <typename Func0, typename Func1, typename Func2>
+    int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,
+                                    const Func1 &storeGlobalSimplexId,
+                                    const Func2 &iterCond,
+                                    const int nSimplicesPerCell);
+
+    int preconditionDistributedCellRanges();
+    size_t
+      computeCellRangeOffsets(std::vector<size_t> &nSimplicesPerRange) const;
+
+    int preconditionDistributedCells() override;
+    int preconditionDistributedEdges() override;
+    int preconditionDistributedVertices() override;
+    int preconditionDistributedTriangles() override;
+
+#endif // TTK_ENABLE_MPI
 
   private:
     bool doublePrecision_;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -517,6 +517,14 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_MPI
 
+  protected:
+    template <typename Func0, typename Func1, typename Func2>
+    int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,
+                                    const Func1 &storeGlobalSimplexId,
+                                    const Func2 &iterCond,
+                                    const int nSimplicesPerCell);
+
+  public:
     int preconditionDistributedCells() override;
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -523,7 +523,7 @@ namespace ttk {
     int preconditionDistributedTriangles() override;
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeGlobalId)(
-      const SimplexId &leid) override {
+      const SimplexId &leid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(leid < 0 || leid >= this->getNumberOfEdgesInternal()) {
         return -1;
@@ -532,16 +532,17 @@ namespace ttk {
       return this->edgeLidToGid_[leid];
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLocalId)(
-      const SimplexId &geid) override {
+      const SimplexId &geid) const override {
+      const auto it = this->edgeGidToLid_.find(geid);
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(this->edgeGidToLid_.find(geid) == this->edgeGidToLid_.end()) {
+      if(it == this->edgeGidToLid_.end()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->edgeGidToLid_[geid];
+      return it->second;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleGlobalId)(
-      const SimplexId &ltid) override {
+      const SimplexId &ltid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(ltid < 0 || ltid >= this->getNumberOfTrianglesInternal()) {
         return -1;
@@ -550,13 +551,14 @@ namespace ttk {
       return this->triangleLidToGid_[ltid];
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLocalId)(
-      const SimplexId &gtid) override {
+      const SimplexId &gtid) const override {
+      const auto it = this->triangleGidToLid_.find(gtid);
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(this->triangleGidToLid_.find(gtid) == this->triangleGidToLid_.end()) {
+      if(it == this->triangleGidToLid_.end()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->triangleGidToLid_[gtid];
+      return it->second;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
       const SimplexId &ltid) const override {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -567,7 +567,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexLidToGid_[ltid];
+      return this->vertGid_[ltid];
     }
     inline const std::unordered_map<SimplexId, SimplexId> *
       TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -522,63 +522,6 @@ namespace ttk {
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
 
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeGlobalId)(
-      const SimplexId &leid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(leid < 0 || leid >= this->getNumberOfEdgesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->edgeLidToGid_[leid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLocalId)(
-      const SimplexId &geid) const override {
-      const auto it = this->edgeGidToLid_.find(geid);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->edgeGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfTrianglesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->triangleLidToGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLocalId)(
-      const SimplexId &gtid) const override {
-      const auto it = this->triangleGidToLid_.find(gtid);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->triangleGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfVerticesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
-      const SimplexId &gtid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->vertexGidToLid_.find(gtid) == this->vertexGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_.at(gtid);
-    }
-
 #endif // TTK_ENABLE_MPI
 
 #ifdef TTK_CELL_ARRAY_NEW

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -569,10 +569,6 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertGid_[ltid];
     }
-    inline const std::unordered_map<SimplexId, SimplexId> *
-      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
-      return &this->vertexGidToLid_;
-    }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/implicitTriangulation/ImplicitPreconditions.cpp
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.cpp
@@ -132,6 +132,7 @@ int ttk::ImplicitWithPreconditions::preconditionVerticesInternal() {
       }
     }
   }
+
 #ifdef TTK_ENABLE_MPI
   return this->preconditionDistributedVertices();
 #endif // TTK_ENABLE_MPI

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3062,6 +3062,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
     return -3;
   }
 
+  Timer tm{};
+
   // number of local cells (with ghost cells...)
   const auto nLocCells{this->getNumberOfCells()};
 
@@ -3086,11 +3088,23 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
   // global cell ids for cell owned by current rank
   std::vector<LongSimplexId> globalCellsInRank{};
   globalCellsInRank.reserve(nLocCells);
+  this->ghostCellPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
     const auto locCubeId{lcid / nTetraPerCube};
     if(this->cellRankArray_[locCubeId] == ttk::MPIrank_) {
       globalCellsInRank.emplace_back(this->cellLidToGid_[lcid]);
+    } else {
+      // store ghost cell global ids (per rank)
+      this->ghostCellPerOwner_[this->cellRankArray_[locCubeId]].emplace_back(
+        this->cellLidToGid_[lcid]);
+    }
+  }
+
+  // store neighboring ranks
+  for(size_t i = 0; i < this->ghostCellPerOwner_.size(); ++i) {
+    if(!this->ghostCellPerOwner_[i].empty()) {
+      this->neighborRanks_.emplace_back(i);
     }
   }
 
@@ -3114,7 +3128,36 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
     }
   }
 
+  // for each rank, store the global id of local cells that are ghost cells of
+  // other ranks.
+  const auto MIT{ttk::getMPIType(ttk::SimplexId{})};
+  this->remoteGhostCells_.resize(ttk::MPIsize_);
+  // number of owned cells that are ghost cells of other ranks
+  std::vector<size_t> nOwnedGhostCellsPerRank(ttk::MPIsize_);
+
+  for(const auto neigh : this->neighborRanks_) {
+    // 1. send to neigh number of ghost cells owned by neigh
+    const auto nCells{this->ghostCellPerOwner_[neigh].size()};
+    MPI_Sendrecv(&nCells, 1, ttk::getMPIType(nCells), neigh, ttk::MPIrank_,
+                 &nOwnedGhostCellsPerRank[neigh], 1, ttk::getMPIType(nCells),
+                 neigh, neigh, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    this->remoteGhostCells_[neigh].resize(nOwnedGhostCellsPerRank[neigh]);
+
+    // 2. send to neigh list of ghost cells owned by neigh
+    MPI_Sendrecv(this->ghostCellPerOwner_[neigh].data(),
+                 this->ghostCellPerOwner_[neigh].size(), MIT, neigh,
+                 ttk::MPIrank_, this->remoteGhostCells_[neigh].data(),
+                 this->remoteGhostCells_[neigh].size(), MIT, neigh, neigh,
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
+  }
+
   this->hasPreconditionedDistributedCells_ = true;
+
+  if(ttk::MPIrank_ == 0) {
+    this->printMsg("Domain contains "
+                     + std::to_string(this->cellGidToRank_.size()) + " cells",
+                   1.0, tm.getElapsedTime(), this->threadNumber_);
+  }
 
   return 0;
 }
@@ -3190,6 +3233,91 @@ int preconditionDistributedIntermediate(size_t &globalCount,
   return 0;
 }
 
+template <typename Func0, typename Func1, typename Func2>
+int ttk::ImplicitTriangulation::exchangeDistributedInternal(
+  const Func0 &getGlobalSimplexId,
+  const Func1 &storeGlobalSimplexId,
+  const Func2 &iterCond,
+  const int nSimplicesPerCell) {
+
+  // per neighbor, owned ghost cell simplex global ids to transfer back
+  std::vector<std::vector<SimplexId>> globalIdPerOwnedGhostCell(ttk::MPIsize_);
+  // per neighbor, non-owned ghost cell simplex global ids to transfer back
+  std::vector<std::vector<SimplexId>> globalIdPerLocalGhostCell(ttk::MPIsize_);
+
+  const auto MIT{ttk::getMPIType(ttk::SimplexId{})};
+
+  // make sure that all simplices are correctly labelled: for a given
+  // rank, a simplex can be owned by a ghost cell from a neighboring
+  // rank but in reality can be owned by another ghost cell in a third
+  // rank
+  bool doIter{true};
+
+  while(doIter) {
+
+    doIter = false;
+
+    // 3. for each list of ghost cell, accumulate the global simplex id
+    for(const auto neigh : this->neighborRanks_) {
+      // sending side
+      globalIdPerOwnedGhostCell[neigh].resize(
+        nSimplicesPerCell * this->remoteGhostCells_[neigh].size());
+      for(size_t i = 0; i < this->remoteGhostCells_[neigh].size(); ++i) {
+        const auto lcid{this->cellGidToLid_[this->remoteGhostCells_[neigh][i]]};
+        for(int j = 0; j < nSimplicesPerCell; ++j) {
+          globalIdPerOwnedGhostCell[neigh][nSimplicesPerCell * i + j]
+            = getGlobalSimplexId(lcid, j);
+        }
+      }
+      // receiving side
+      globalIdPerLocalGhostCell[neigh].resize(
+        nSimplicesPerCell * this->ghostCellPerOwner_[neigh].size());
+
+      // 4. transfer back global simplex ids
+      MPI_Sendrecv(globalIdPerOwnedGhostCell[neigh].data(),
+                   globalIdPerOwnedGhostCell[neigh].size(), MIT, neigh,
+                   ttk::MPIrank_, globalIdPerLocalGhostCell[neigh].data(),
+                   globalIdPerLocalGhostCell[neigh].size(), MIT, neigh, neigh,
+                   ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    }
+
+    // 5. extend local <-> global simplex ids mappings
+    for(const auto neigh : this->neighborRanks_) {
+      for(size_t i = 0; i < this->ghostCellPerOwner_[neigh].size(); ++i) {
+        const auto gcid{this->ghostCellPerOwner_[neigh][i]};
+        const auto lcid{this->cellGidToLid_[gcid]};
+        for(int j = 0; j < nSimplicesPerCell; ++j) {
+          const auto geid{
+            globalIdPerLocalGhostCell[neigh][nSimplicesPerCell * i + j]};
+          storeGlobalSimplexId(lcid, geid, j);
+        }
+      }
+    }
+
+    // do an additional transmission if there still is some locally
+    // non-labelled simplices
+    int doNextIter{0};
+    if(iterCond()) {
+      doNextIter = 1;
+      doIter = true;
+    }
+    for(int i = 0; i < ttk::MPIsize_; ++i) {
+      if(doIter) {
+        // reset doNextIter (might have been erased by the MPI_Bcast)
+        doNextIter = 1;
+      }
+      MPI_Bcast(&doNextIter, 1, ttk::getMPIType(doNextIter), i, ttk::MPIcomm_);
+      doIter |= (doNextIter == 1);
+    }
+
+    if(doIter && ttk::MPIrank_ == 0) {
+      this->printMsg("Re-sending global ids to neighbors...");
+    }
+  }
+
+  return 0;
+}
+
 int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   if(this->hasPreconditionedDistributedEdges_) {
     return 0;
@@ -3205,6 +3333,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
     return -3;
   }
+
+  Timer tm{};
 
   this->preconditionDistributedCells();
 
@@ -3271,8 +3401,31 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   preconditionDistributedIntermediate(
     edgeCount, this->cellGidToRank_, processCellsEdges);
 
+  const auto nEdgesPerCell{this->getDimensionality() == 3 ? 6 : 3};
+  this->exchangeDistributedInternal(
+    [this](const SimplexId lcid, const int j) {
+      SimplexId leid{};
+      this->getCellEdgeInternal(lcid, j, leid);
+      return this->edgeLidToGid_[leid];
+    },
+    [this](const SimplexId lcid, const SimplexId geid, const int j) {
+      SimplexId leid{};
+      this->getCellEdgeInternal(lcid, j, leid);
+      if(this->edgeLidToGid_[leid] == -1 && geid != -1) {
+        this->edgeLidToGid_[leid] = geid;
+        this->edgeGidToLid_[geid] = leid;
+      }
+    },
+    [this]() {
+      return std::count(
+               this->edgeLidToGid_.begin(), this->edgeLidToGid_.end(), -1)
+             > 0;
+    },
+    nEdgesPerCell);
+
   if(MPIrank_ == 0) {
-    this->printMsg("Domain contains " + std::to_string(edgeCount) + " edges");
+    this->printMsg("Domain contains " + std::to_string(edgeCount) + " edges",
+                   1.0, tm.getElapsedTime(), 1);
   }
 
   this->hasPreconditionedDistributedEdges_ = true;
@@ -3298,6 +3451,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
   if(this->getDimensionality() != 3) {
     return -3;
   }
+
+  Timer tm{};
 
   this->preconditionDistributedCells();
 
@@ -3352,9 +3507,32 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
   preconditionDistributedIntermediate(
     triangleCount, this->cellGidToRank_, processCellsTriangles);
 
+  const auto nTrianglesPerCell{4};
+  this->exchangeDistributedInternal(
+    [this](const SimplexId lcid, const int j) {
+      SimplexId ltid{};
+      this->getCellTriangleInternal(lcid, j, ltid);
+      return this->triangleLidToGid_[ltid];
+    },
+    [this](const SimplexId lcid, const SimplexId gtid, const int j) {
+      SimplexId ltid{};
+      this->getCellTriangleInternal(lcid, j, ltid);
+      if(this->triangleLidToGid_[ltid] == -1 && gtid != -1) {
+        this->triangleLidToGid_[ltid] = gtid;
+        this->triangleGidToLid_[gtid] = ltid;
+      }
+    },
+    [this]() {
+      return std::count(this->triangleLidToGid_.begin(),
+                        this->triangleLidToGid_.end(), -1)
+             > 0;
+    },
+    nTrianglesPerCell);
+
   if(MPIrank_ == 0) {
-    this->printMsg("Domain contains " + std::to_string(triangleCount)
-                   + " triangles");
+    this->printMsg(
+      "Domain contains " + std::to_string(triangleCount) + " triangles", 1.0,
+      tm.getElapsedTime(), 1);
   }
 
   this->hasPreconditionedDistributedTriangles_ = true;
@@ -3382,16 +3560,11 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
     this->vertexGidToLid_[this->vertGid_[i]] = i;
   }
 
-  if(MPIrank_ == 0) {
-    this->printMsg("Domain contains "
-                   + std::to_string(this->getNumberOfVerticesInternal())
-                   + " vertices");
-  }
-
   this->hasPreconditionedDistributedVertices_ = true;
 
   return 0;
 }
+
 #endif // TTK_ENABLE_MPI
 
 // explicit instantiations

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3057,8 +3057,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
     this->printWrn("Missing global identifiers on cells");
     return -2;
   }
-  if(this->ghostCellMask_ == nullptr) {
-    this->printWrn("Missing ghost mask on cells");
+  if(this->cellRankArray_ == nullptr) {
+    this->printWrn("Missing RankArray on cells");
     return -3;
   }
 
@@ -3088,7 +3088,7 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
     const auto locCubeId{lcid / nTetraPerCube};
-    if(this->ghostCellMask_[locCubeId] == 0) {
+    if(this->cellRankArray_[locCubeId] == ttk::MPIrank_) {
       globalCellsInRank.emplace_back(this->cellLidToGid_[lcid]);
     }
   }
@@ -3345,18 +3345,16 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   if(!isRunningWithMPI()) {
     return -1;
   }
-  if(this->globalIdsArray_ == nullptr) {
+  if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;
   }
 
   // allocate memory
-  this->vertexLidToGid_.resize(this->vertexNumber_, -1);
   this->vertexGidToLid_.reserve(this->vertexNumber_);
 
   for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexLidToGid_[i] = this->globalIdsArray_[i];
-    this->vertexGidToLid_[this->globalIdsArray_[i]] = i;
+    this->vertexGidToLid_[this->vertGid_[i]] = i;
   }
 
   if(MPIrank_ == 0) {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1,5 +1,7 @@
 #include <ImplicitTriangulation.h>
 
+#include <numeric>
+
 using namespace std;
 using namespace ttk;
 
@@ -3085,16 +3087,11 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
     this->cellLidToGid_[lcid] = globCellId;
   }
 
-  // global cell ids for cell owned by current rank
-  std::vector<LongSimplexId> globalCellsInRank{};
-  globalCellsInRank.reserve(nLocCells);
   this->ghostCellPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
     const auto locCubeId{lcid / nTetraPerCube};
-    if(this->cellRankArray_[locCubeId] == ttk::MPIrank_) {
-      globalCellsInRank.emplace_back(this->cellLidToGid_[lcid]);
-    } else {
+    if(this->cellRankArray_[locCubeId] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
       this->ghostCellPerOwner_[this->cellRankArray_[locCubeId]].emplace_back(
         this->cellLidToGid_[lcid]);
@@ -3105,26 +3102,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
   for(size_t i = 0; i < this->ghostCellPerOwner_.size(); ++i) {
     if(!this->ghostCellPerOwner_[i].empty()) {
       this->neighborRanks_.emplace_back(i);
-    }
-  }
-
-  // global cell ids per rank (used by rank 0)
-  std::vector<std::vector<LongSimplexId>> cellsRankPerProc{};
-
-  gatherVectors(cellsRankPerProc, globalCellsInRank, 0);
-
-  if(ttk::MPIrank_ == 0) {
-    // global number of cells
-    auto nGlobalCells = cellsRankPerProc[0].size();
-    for(int i = 1; i < MPIsize_; ++i) {
-      nGlobalCells += cellsRankPerProc[i].size();
-    }
-
-    this->cellGidToRank_.resize(nGlobalCells, -1);
-    for(int i = 0; i < MPIsize_; ++i) {
-      for(const auto gcid : cellsRankPerProc[i]) {
-        this->cellGidToRank_[gcid] = i;
-      }
     }
   }
 
@@ -3151,86 +3128,174 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
 
+  this->preconditionDistributedCellRanges();
+
   this->hasPreconditionedDistributedCells_ = true;
 
   if(ttk::MPIrank_ == 0) {
     this->printMsg("Domain contains "
-                     + std::to_string(this->cellGidToRank_.size()) + " cells",
+                     + std::to_string(this->gatheredCellRanges_.back().end + 1)
+                     + " cells",
                    1.0, tm.getElapsedTime(), this->threadNumber_);
   }
 
   return 0;
 }
 
-template <typename Func>
-int preconditionDistributedIntermediate(size_t &globalCount,
-                                        const std::vector<int> &cellGidToRank,
-                                        const Func &processCells) {
+int ttk::ImplicitTriangulation::preconditionDistributedCellRanges() {
 
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
+  // 1. store all local cells owned by current rank by global id
+
+  // there are 6 tetrahedra per cubic cell (and 2 triangles per square)
+  const int nTetraPerCube{ImplicitTriangulation::getDimensionality() == 3 ? 6
+                                                                          : 2};
+
+  std::vector<SimplexId> localCellIds{};
+  localCellIds.reserve(this->getNumberOfCells());
+  for(SimplexId i = 0; i < this->getNumberOfCells(); ++i) {
+    if(this->cellRankArray_[i / nTetraPerCube] == ttk::MPIrank_) {
+      localCellIds.emplace_back(i);
+    }
   }
 
-  const int COMPUTE = 1, STOP = 2;
+  TTK_PSORT(this->threadNumber_, localCellIds.begin(), localCellIds.end(),
+            [this](const SimplexId a, const SimplexId b) {
+              return this->cellLidToGid_[a] < this->cellLidToGid_[b];
+            });
+
+  // 2. determine ranges of contiguous cell global ids
+
+  size_t begRange{};
+  while(begRange < localCellIds.size()) {
+    size_t endRange{begRange + 1};
+
+    if(begRange < localCellIds.size() - 1) {
+      for(size_t j = begRange + 1; j < localCellIds.size(); ++j) {
+        if(this->cellLidToGid_[localCellIds[j]]
+           > this->cellLidToGid_[localCellIds[j - 1]] + 1) {
+          endRange = j;
+          break;
+        }
+      }
+      if(endRange == begRange + 1
+         && this->cellLidToGid_[localCellIds[endRange]]
+              == this->cellLidToGid_[localCellIds[endRange - 1]] + 1) {
+        endRange = localCellIds.size();
+      }
+    }
+
+    const size_t gbeg = this->cellLidToGid_[localCellIds[begRange]];
+    const size_t gend = this->cellLidToGid_[localCellIds[endRange - 1]];
+    const auto nRanges{this->localCellRanges_.size()};
+
+    // inclusive range
+    this->localCellRanges_.emplace_back(
+      CellRange{nRanges, gbeg, gend, static_cast<size_t>(ttk::MPIrank_)});
+
+    begRange = endRange;
+  }
+
+  // 3. send to rank 0 the vector of ranges so it can compute range offsets
 
   if(ttk::MPIrank_ == 0) {
-    size_t gcid{};
-    while(gcid < cellGidToRank.size()) {
-      const auto currRank{cellGidToRank[gcid]};
-      size_t endCurrRank{gcid + 1};
-      if(gcid < cellGidToRank.size() - 1) {
-        for(size_t j = gcid + 1; j < cellGidToRank.size(); ++j) {
-          if(cellGidToRank[j] != currRank) {
-            endCurrRank = j;
-            break;
-          }
-        }
-        if(endCurrRank == gcid + 1 && cellGidToRank[endCurrRank] == currRank) {
-          endCurrRank = cellGidToRank.size();
-        }
-      }
+    this->nRangesPerRank_.resize(ttk::MPIsize_);
+  }
 
-      if(currRank == 0) {
-        // process local edges
-        processCells(gcid, endCurrRank, globalCount);
-      } else {
-        // send to relevant process
-        std::array<unsigned long, 3> toSend{globalCount, gcid, endCurrRank};
-        MPI_Send(toSend.data(), 3, MPI_UNSIGNED_LONG, currRank, COMPUTE,
-                 ttk::MPIcomm_);
-        // receive updated edgeCount
-        MPI_Recv(&globalCount, 1, MPI_UNSIGNED_LONG, currRank, MPI_ANY_TAG,
-                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
-      }
+  const int rangeSize = this->localCellRanges_.size();
+  MPI_Gather(&rangeSize, 1, ttk::getMPIType(rangeSize),
+             this->nRangesPerRank_.data(), 1, ttk::getMPIType(rangeSize), 0,
+             ttk::MPIcomm_);
 
-      gcid = endCurrRank;
+  std::vector<int> displacements{};
+
+  if(ttk::MPIrank_ == 0) {
+    const auto nRanges{std::accumulate(
+      this->nRangesPerRank_.begin(), this->nRangesPerRank_.end(), 0)};
+    this->gatheredCellRanges_.resize(nRanges);
+    displacements.resize(this->nRangesPerRank_.size());
+
+    for(size_t i = 0; i < this->nRangesPerRank_.size() - 1; ++i) {
+      displacements[i + 1] = displacements[i] + this->nRangesPerRank_[i];
     }
+  }
 
-    // send STOP signal to break infinite loop
-    std::array<unsigned long, 3> dummy{};
-    for(int i = 1; i < ttk::MPIsize_; ++i) {
-      MPI_Send(dummy.data(), 3, MPI_UNSIGNED_LONG, i, STOP, ttk::MPIcomm_);
-    }
+  auto cellRangeDT{CellRange::getMPIType()};
+  MPI_Type_commit(&cellRangeDT);
 
-  } else {
-    while(true) {
-      // receive data
-      std::array<unsigned long, 3> toRecv{};
-      MPI_Status status;
-      MPI_Recv(toRecv.data(), 3, MPI_UNSIGNED_LONG, 0, MPI_ANY_TAG,
-               ttk::MPIcomm_, &status);
-      if(status.MPI_TAG == STOP) {
-        break;
-      }
-      // process local edges
-      globalCount = toRecv[0];
-      processCells(toRecv[1], toRecv[2], globalCount);
-      // send back updated edgeCount to rank 0
-      MPI_Send(&globalCount, 1, MPI_UNSIGNED_LONG, 0, 1, ttk::MPIcomm_);
-    }
+  MPI_Gatherv(this->localCellRanges_.data(), this->localCellRanges_.size(),
+              cellRangeDT, this->gatheredCellRanges_.data(),
+              this->nRangesPerRank_.data(), displacements.data(), cellRangeDT,
+              0, ttk::MPIcomm_);
+
+  MPI_Type_free(&cellRangeDT);
+
+  // 4. sort range vector on rank 0
+
+  if(ttk::MPIrank_ == 0) {
+    TTK_PSORT(
+      this->threadNumber_, this->gatheredCellRanges_.begin(),
+      this->gatheredCellRanges_.end(),
+      [](const CellRange &a, const CellRange &b) { return a.begin < b.begin; });
   }
 
   return 0;
+}
+
+size_t ttk::ImplicitTriangulation::computeCellRangeOffsets(
+  std::vector<size_t> &nSimplicesPerRange) const {
+
+  // 1. send to rank 0 number of edges per cell range
+
+  std::vector<std::vector<size_t>> nSimplicesPerRangePerRank{};
+
+  if(ttk::MPIrank_ == 0) {
+    nSimplicesPerRangePerRank.resize(this->nRangesPerRank_.size());
+    for(int i = 0; i < ttk::MPIsize_; ++i) {
+      nSimplicesPerRangePerRank[i].resize(this->nRangesPerRank_[i]);
+    }
+    for(int i = 0; i < ttk::MPIsize_; ++i) {
+      if(i == 0) {
+        continue;
+      }
+      // receive src content from other ranks
+      MPI_Recv(nSimplicesPerRangePerRank[i].data(),
+               nSimplicesPerRangePerRank[i].size(), ttk::getMPIType(size_t{}),
+               i, MPI_ANY_TAG, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    }
+    std::swap(nSimplicesPerRangePerRank[0], nSimplicesPerRange);
+  } else {
+    MPI_Send(nSimplicesPerRange.data(), nSimplicesPerRange.size(),
+             ttk::getMPIType(size_t{}), 0, 0, ttk::MPIcomm_);
+  }
+
+  // 2. compute range offsets on rank 0
+
+  size_t nSimplices{};
+  if(ttk::MPIrank_ == 0) {
+
+    for(const auto &range : this->gatheredCellRanges_) {
+      auto &pSum{nSimplicesPerRangePerRank[range.rank][range.id]};
+      std::swap(pSum, nSimplices);
+      nSimplices += pSum;
+    }
+  }
+
+  // 3. send back range offsets to other ranks
+
+  if(ttk::MPIrank_ == 0) {
+    for(int i = 1; i < ttk::MPIsize_; ++i) {
+      MPI_Send(nSimplicesPerRangePerRank[i].data(),
+               nSimplicesPerRangePerRank[i].size(), ttk::getMPIType(size_t{}),
+               i, 0, ttk::MPIcomm_);
+    }
+    std::swap(nSimplicesPerRange, nSimplicesPerRangePerRank[0]);
+  } else {
+    MPI_Recv(nSimplicesPerRange.data(), nSimplicesPerRange.size(),
+             ttk::getMPIType(size_t{}), MPI_ANY_TAG, 0, ttk::MPIcomm_,
+             MPI_STATUS_IGNORE);
+  }
+
+  return nSimplices;
 }
 
 template <typename Func0, typename Func1, typename Func2>
@@ -3349,9 +3414,13 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   this->edgeLidToGid_.resize(this->getNumberOfEdgesInternal(), -1);
   this->edgeGidToLid_.reserve(this->getNumberOfEdgesInternal());
 
-  const auto processEdge = [this](const SimplexId leid, const SimplexId lcid,
-                                  size_t &edgeCount) {
-    bool alreadyProcessed{false};
+  // 1. for every range of local cells, number the edges locally
+
+  std::vector<SimplexId> edgeLidToRangeId(this->getNumberOfEdgesInternal(), -1);
+  std::vector<size_t> nEdgesPerRange(this->localCellRanges_.size());
+
+  const auto edgeAlreadyProcessed = [this](const SimplexId leid,
+                                           const SimplexId lcid) {
     const auto nStar{this->TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(leid)};
     for(SimplexId i = 0; i < nStar; ++i) {
       SimplexId sid{-1};
@@ -3362,44 +3431,71 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
       // rule: an edge is owned by the cell in its star with the
       // lowest global id
       if(this->cellLidToGid_[sid] < this->cellLidToGid_[lcid]) {
-        alreadyProcessed = true;
+        return true;
         break;
       }
     }
-    if(!alreadyProcessed) {
-      this->edgeLidToGid_[leid] = edgeCount;
-      this->edgeGidToLid_[edgeCount] = leid;
-      edgeCount++;
-    }
+    return false;
   };
 
-  const auto processCellsEdges
-    = [this, &processEdge](
-        const size_t gcid, const size_t endCurrRank, size_t &edgeCount) {
-        for(size_t j = gcid; j < endCurrRank; ++j) {
-          // local cell id
-          const auto lcid{this->cellGidToLid_[j]};
-          SimplexId nEdges{};
+  const auto countCellEdges
+    = [this, &edgeAlreadyProcessed](const SimplexId lcid,
+                                    std::vector<SimplexId> &edgeGid,
+                                    std::vector<SimplexId> &edgeRangeId,
+                                    const size_t rangeId, size_t &edgeCount) {
+        SimplexId nEdges{};
+        if(this->dimensionality_ == 3) {
+          nEdges = this->getCellEdgeNumberInternal(lcid);
+        } else if(this->dimensionality_ == 2) {
+          nEdges = this->getTriangleEdgeNumberInternal(lcid);
+        }
+        for(SimplexId k = 0; k < nEdges; ++k) {
+          SimplexId leid{-1};
           if(this->dimensionality_ == 3) {
-            nEdges = this->getCellEdgeNumberInternal(lcid);
+            this->getCellEdgeInternal(lcid, k, leid);
           } else if(this->dimensionality_ == 2) {
-            nEdges = this->getTriangleEdgeNumberInternal(lcid);
+            this->getTriangleEdge(lcid, k, leid);
           }
-          for(SimplexId i = 0; i < nEdges; ++i) {
-            SimplexId leid{-1};
-            if(this->dimensionality_ == 3) {
-              this->getCellEdgeInternal(lcid, i, leid);
-            } else if(this->dimensionality_ == 2) {
-              this->getTriangleEdge(lcid, i, leid);
-            }
-            processEdge(leid, lcid, edgeCount);
+          const auto alreadyProcessed = edgeAlreadyProcessed(leid, lcid);
+          if(!alreadyProcessed) {
+            edgeGid[leid] = edgeCount;
+            edgeRangeId[leid] = rangeId;
+            edgeCount++;
           }
         }
       };
 
-  size_t edgeCount{};
-  preconditionDistributedIntermediate(
-    edgeCount, this->cellGidToRank_, processCellsEdges);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < this->localCellRanges_.size(); ++i) {
+    auto &range{this->localCellRanges_[i]};
+    range.id = i;
+    for(size_t j = range.begin; j <= range.end; ++j) {
+      // local cell id
+      const auto lcid{this->cellGidToLid_[j]};
+      countCellEdges(lcid, this->edgeLidToGid_, edgeLidToRangeId, range.id,
+                     nEdgesPerRange[i]);
+    }
+  }
+
+  // 2. compute range offset on rank 0
+  const auto nEdges = this->computeCellRangeOffsets(nEdgesPerRange);
+
+  // 3. locally edit the edge global id with range offsets
+
+  for(SimplexId leid = 0; leid < this->getNumberOfEdgesInternal(); ++leid) {
+    if(this->edgeLidToGid_[leid] == -1) {
+      // not owned by a cell of this rank
+      continue;
+    }
+    const auto geid{this->edgeLidToGid_[leid]
+                    + nEdgesPerRange[edgeLidToRangeId[leid]]};
+    this->edgeLidToGid_[leid] = geid;
+    this->edgeGidToLid_[geid] = leid;
+  }
+
+  // 4. exchange global ids between ghost cells
 
   const auto nEdgesPerCell{this->getDimensionality() == 3 ? 6 : 3};
   this->exchangeDistributedInternal(
@@ -3424,8 +3520,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
     nEdgesPerCell);
 
   if(MPIrank_ == 0) {
-    this->printMsg("Domain contains " + std::to_string(edgeCount) + " edges",
-                   1.0, tm.getElapsedTime(), 1);
+    this->printMsg("Domain contains " + std::to_string(nEdges) + " edges", 1.0,
+                   tm.getElapsedTime(), 1);
   }
 
   this->hasPreconditionedDistributedEdges_ = true;
@@ -3463,49 +3559,81 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
   bool localHasPrecTriangleStars{this->hasPreconditionedTriangleStars_};
   this->hasPreconditionedTriangleStars_ = true;
 
-  const auto processTriangle =
-    [this](const SimplexId ltid, const SimplexId lcid, size_t &triangleCount) {
-      bool alreadyProcessed{false};
-      const auto nStar{
-        this->TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(ltid)};
-      for(SimplexId i = 0; i < nStar; ++i) {
-        SimplexId sid{-1};
-        this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(ltid, i, sid);
-        if(sid == -1 || sid == lcid) {
-          continue;
-        }
-        // rule: an edge is owned by the cell in its star with the
-        // lowest global id
-        if(this->cellLidToGid_[sid] < this->cellLidToGid_[lcid]) {
-          alreadyProcessed = true;
-          break;
-        }
-      }
-      if(!alreadyProcessed) {
-        this->triangleLidToGid_[ltid] = triangleCount;
-        this->triangleGidToLid_[triangleCount] = ltid;
-        triangleCount++;
-      }
-    };
+  // 1. for every range of local cells, number the edges locally
 
-  const auto processCellsTriangles
-    = [this, &processTriangle](
-        const size_t gcid, const size_t endCurrRank, size_t &triangleCount) {
-        for(size_t j = gcid; j < endCurrRank; ++j) {
-          // local cell id
-          const auto lcid{this->cellGidToLid_[j]};
-          for(SimplexId i = 0; i < this->getCellTriangleNumberInternal(lcid);
-              ++i) {
-            SimplexId ltid{-1};
-            this->getCellTriangleInternal(lcid, i, ltid);
-            processTriangle(ltid, lcid, triangleCount);
+  std::vector<SimplexId> triangleLidToRangeId(
+    this->getNumberOfTrianglesInternal(), -1);
+  std::vector<size_t> nTrianglesPerRange(this->localCellRanges_.size());
+
+  const auto triangleAlreadyProcessed
+    = [this](const SimplexId leid, const SimplexId lcid) {
+        const auto nStar{
+          this->TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(leid)};
+        for(SimplexId i = 0; i < nStar; ++i) {
+          SimplexId sid{-1};
+          this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(leid, i, sid);
+          if(sid == -1 || sid == lcid) {
+            continue;
+          }
+          // rule: an triangle is owned by the cell in its star with the
+          // lowest global id
+          if(this->cellLidToGid_[sid] < this->cellLidToGid_[lcid]) {
+            return true;
+            break;
+          }
+        }
+        return false;
+      };
+
+  const auto countCellTriangles
+    = [this, &triangleAlreadyProcessed](
+        const SimplexId lcid, std::vector<SimplexId> &triangleGid,
+        std::vector<SimplexId> &triangleRangeId, const size_t rangeId,
+        size_t &triangleCount) {
+        const auto nTriangles{this->getCellTriangleNumberInternal(lcid)};
+        for(SimplexId k = 0; k < nTriangles; ++k) {
+          SimplexId leid{-1};
+          this->getCellTriangleInternal(lcid, k, leid);
+          const auto alreadyProcessed = triangleAlreadyProcessed(leid, lcid);
+          if(!alreadyProcessed) {
+            triangleGid[leid] = triangleCount;
+            triangleRangeId[leid] = rangeId;
+            triangleCount++;
           }
         }
       };
 
-  size_t triangleCount{};
-  preconditionDistributedIntermediate(
-    triangleCount, this->cellGidToRank_, processCellsTriangles);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+  for(size_t i = 0; i < this->localCellRanges_.size(); ++i) {
+    auto &range{this->localCellRanges_[i]};
+    range.id = i;
+    for(size_t j = range.begin; j <= range.end; ++j) {
+      // local cell id
+      const auto lcid{this->cellGidToLid_[j]};
+      countCellTriangles(lcid, this->triangleLidToGid_, triangleLidToRangeId,
+                         range.id, nTrianglesPerRange[i]);
+    }
+  }
+
+  // 2. compute range offset on rank 0
+  const auto nTriangles = this->computeCellRangeOffsets(nTrianglesPerRange);
+
+  // 3. locally edit the triangle global id with range offsets
+
+  for(SimplexId leid = 0; leid < this->getNumberOfTrianglesInternal(); ++leid) {
+    if(this->triangleLidToGid_[leid] == -1) {
+      // not owned by a cell of this rank
+      continue;
+    }
+    const auto geid{this->triangleLidToGid_[leid]
+                    + nTrianglesPerRange[triangleLidToRangeId[leid]]};
+    this->triangleLidToGid_[leid] = geid;
+    this->triangleGidToLid_[geid] = leid;
+  }
+
+  // 4. exchange global ids between ghost cells
 
   const auto nTrianglesPerCell{4};
   this->exchangeDistributedInternal(
@@ -3531,7 +3659,7 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
 
   if(MPIrank_ == 0) {
     this->printMsg(
-      "Domain contains " + std::to_string(triangleCount) + " triangles", 1.0,
+      "Domain contains " + std::to_string(nTriangles) + " triangles", 1.0,
       tm.getElapsedTime(), 1);
   }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -246,6 +246,10 @@ namespace ttk {
                                     const Func2 &iterCond,
                                     const int nSimplicesPerCell);
 
+    int preconditionDistributedCellRanges();
+    size_t
+      computeCellRangeOffsets(std::vector<size_t> &nSimplicesPerRange) const;
+
   public:
     int preconditionDistributedCells() override;
     int preconditionDistributedEdges() override;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -291,10 +291,6 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertGid_[ltid];
     }
-    inline const std::unordered_map<SimplexId, SimplexId> *
-      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
-      return &this->vertexGidToLid_;
-    }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -245,7 +245,7 @@ namespace ttk {
     int preconditionDistributedTriangles() override;
 
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeGlobalId)(
-      const SimplexId &leid) override {
+      const SimplexId &leid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(leid < 0 || leid >= this->getNumberOfEdgesInternal()) {
         return -1;
@@ -254,16 +254,17 @@ namespace ttk {
       return this->edgeLidToGid_[leid];
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLocalId)(
-      const SimplexId &geid) override {
+      const SimplexId &geid) const override {
+      const auto it = this->edgeGidToLid_.find(geid);
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(this->edgeGidToLid_.find(geid) == this->edgeGidToLid_.end()) {
+      if(it == this->edgeGidToLid_.end()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->edgeGidToLid_[geid];
+      return it->second;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleGlobalId)(
-      const SimplexId &ltid) override {
+      const SimplexId &ltid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(ltid < 0 || ltid >= this->getNumberOfTrianglesInternal()) {
         return -1;
@@ -272,13 +273,14 @@ namespace ttk {
       return this->triangleLidToGid_[ltid];
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLocalId)(
-      const SimplexId &gtid) override {
+      const SimplexId &gtid) const override {
+      const auto it = this->triangleGidToLid_.find(gtid);
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(this->triangleGidToLid_.find(gtid) == this->triangleGidToLid_.end()) {
+      if(it == this->triangleGidToLid_.end()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->triangleGidToLid_[gtid];
+      return it->second;
     }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
       const SimplexId &ltid) const override {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -289,7 +289,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexLidToGid_[ltid];
+      return this->vertGid_[ltid];
     }
     inline const std::unordered_map<SimplexId, SimplexId> *
       TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -250,12 +250,12 @@ namespace ttk {
     size_t
       computeCellRangeOffsets(std::vector<size_t> &nSimplicesPerRange) const;
 
-  public:
     int preconditionDistributedCells() override;
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
 
+  public:
     inline SimplexId
       getCellGlobalIdInternal(const SimplexId lcid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -239,6 +239,14 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_MPI
 
+  protected:
+    template <typename Func0, typename Func1, typename Func2>
+    int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,
+                                    const Func1 &storeGlobalSimplexId,
+                                    const Func2 &iterCond,
+                                    const int nSimplicesPerCell);
+
+  public:
     int preconditionDistributedCells() override;
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -244,61 +244,14 @@ namespace ttk {
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
 
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeGlobalId)(
-      const SimplexId &leid) const override {
+    inline SimplexId
+      getCellGlobalIdInternal(const SimplexId lcid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(leid < 0 || leid >= this->getNumberOfEdgesInternal()) {
+      if(lcid < 0 || lcid >= this->getNumberOfCellsInternal()) {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->edgeLidToGid_[leid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getEdgeLocalId)(
-      const SimplexId &geid) const override {
-      const auto it = this->edgeGidToLid_.find(geid);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->edgeGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfTrianglesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->triangleLidToGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getTriangleLocalId)(
-      const SimplexId &gtid) const override {
-      const auto it = this->triangleGidToLid_.find(gtid);
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->triangleGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfVerticesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
-      const SimplexId &gtid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->vertexGidToLid_.find(gtid) == this->vertexGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_.at(gtid);
+      return this->cellLidToGid_[lcid];
     }
 
 #endif // TTK_ENABLE_MPI

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1795,37 +1795,6 @@ const vector<vector<SimplexId>> *
 
   return &cellNeighborList_;
 }
-#if TTK_ENABLE_MPI
-int PeriodicImplicitTriangulation::preconditionDistributedVertices() {
-  if(this->hasPreconditionedDistributedVertices_) {
-    return 0;
-  }
-  if(!isRunningWithMPI()) {
-    return -1;
-  }
-  if(this->vertGid_ == nullptr) {
-    this->printWrn("Missing global identifiers array!");
-    return -2;
-  }
-
-  // allocate memory
-  this->vertexGidToLid_.reserve(this->vertexNumber_);
-
-  for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexGidToLid_[this->vertGid_[i]] = i;
-  }
-
-  if(MPIrank_ == 0) {
-    this->printMsg("Domain contains "
-                   + std::to_string(this->getNumberOfVerticesInternal())
-                   + " vertices");
-  }
-
-  this->hasPreconditionedDistributedVertices_ = true;
-
-  return 0;
-}
-#endif // TTK_ENABLE_MPI
 
 // explicit instantiations
 template class ttk::PeriodicImplicitTriangulationCRTP<

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1803,18 +1803,16 @@ int PeriodicImplicitTriangulation::preconditionDistributedVertices() {
   if(!isRunningWithMPI()) {
     return -1;
   }
-  if(this->globalIdsArray_ == nullptr) {
+  if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;
   }
 
   // allocate memory
-  this->vertexLidToGid_.resize(this->vertexNumber_, -1);
   this->vertexGidToLid_.reserve(this->vertexNumber_);
 
   for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexLidToGid_[i] = this->globalIdsArray_[i];
-    this->vertexGidToLid_[this->globalIdsArray_[i]] = i;
+    this->vertexGidToLid_[this->vertGid_[i]] = i;
   }
 
   if(MPIrank_ == 0) {

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -245,29 +245,6 @@ namespace ttk {
       return 0;
     }
 
-#ifdef TTK_ENABLE_MPI
-    int preconditionDistributedVertices() override;
-
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexGlobalId)(
-      const SimplexId &ltid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(ltid < 0 || ltid >= this->getNumberOfVerticesInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertGid_[ltid];
-    }
-    inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
-      const SimplexId &gtid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->vertexGidToLid_.find(gtid) == this->vertexGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_.at(gtid);
-    }
-#endif // TTK_ENABLE_MPI
-
   protected:
     int dimensionality_; //
     float origin_[3]; //

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -255,7 +255,7 @@ namespace ttk {
         return -1;
       }
 #endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexLidToGid_[ltid];
+      return this->vertGid_[ltid];
     }
     inline const std::unordered_map<SimplexId, SimplexId> *
       TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -257,10 +257,6 @@ namespace ttk {
 #endif // TTK_ENABLE_KAMIKAZE
       return this->vertGid_[ltid];
     }
-    inline const std::unordered_map<SimplexId, SimplexId> *
-      TTK_TRIANGULATION_INTERNAL(getVertexGlobalIdMap)() const override {
-      return &this->vertexGidToLid_;
-    }
     inline SimplexId TTK_TRIANGULATION_INTERNAL(getVertexLocalId)(
       const SimplexId &gtid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
@@ -27,9 +27,6 @@ int ttk::PeriodicWithPreconditions::preconditionVerticesInternal() {
       vertexToPosition(i, p.data());
     }
   }
-#ifdef TTK_ENABLE_MPI
-  return this->preconditionDistributedVertices();
-#endif // TTK_ENABLE_MPI
 
   return 0;
 }

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
@@ -85,10 +85,6 @@ namespace ttk {
     }
 
     inline int preconditionVerticesInternal() override {
-#ifdef TTK_ENABLE_MPI
-      return this->preconditionDistributedVertices();
-#endif // TTK_ENABLE_MPI
-
       return 0;
     }
     inline int preconditionEdgesInternal() override {

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -229,7 +229,7 @@ int ttk::ScalarFieldCriticalPoints::executeLegacy(
     vertexNumber_ = triangulation->getNumberOfVertices();
     dimension_ = triangulation->getCellVertexNumber(0) - 1;
 #if TTK_ENABLE_MPI
-    rankArray_ = triangulation->getRankArray();
+    rankArray_ = triangulation->getVertRankArray();
 #endif
   }
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -101,23 +101,12 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
   if(!outputData_)
     return -4;
 #endif
-  int *rankArray{nullptr};
-  SimplexId *globalIds{nullptr};
-  bool useMPI = false;
-  const std::unordered_map<SimplexId, SimplexId> *map = nullptr;
-  TTK_FORCE_USE(useMPI);
-  TTK_FORCE_USE(map);
-  TTK_FORCE_USE(rankArray);
-  TTK_FORCE_USE(globalIds);
 
 #if TTK_ENABLE_MPI
-  rankArray = triangulation->getRankArray();
-  globalIds = (SimplexId *)triangulation->getGlobalIdsArray();
-  if(ttk::isRunningWithMPI() && rankArray != nullptr && globalIds != nullptr) {
+  bool useMPI{false};
+  if(ttk::isRunningWithMPI() && triangulation->getVertRankArray() != nullptr
+     && triangulation->getVertsGlobalIds() != nullptr)
     useMPI = true;
-    map = triangulation->getVertexGlobalIdMap();
-  }
-
 #endif
   SimplexId vertexNumber = triangulation->getNumberOfVertices();
 
@@ -180,9 +169,10 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      const auto &map = triangulation->getVertexGlobalIdMap();
       exchangeGhostCells<dataType, SimplexId>(
-        outputData, rankArray, globalIds, map, vertexNumber, ttk::MPIcomm_);
+        outputData, triangulation->getVertRankArray(),
+        triangulation->getVertsGlobalIds(),
+        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_);
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -180,8 +180,9 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
+      const auto &map = triangulation->getVertexGlobalIdMap();
       exchangeGhostCells<dataType, SimplexId>(
-        outputData, rankArray, globalIds, *map, vertexNumber, ttk::MPIcomm_);
+        outputData, rankArray, globalIds, map, vertexNumber, ttk::MPIcomm_);
     }
 #endif
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2681,46 +2681,40 @@ namespace ttk {
     }
 
 #ifdef TTK_ENABLE_MPI
-    inline void setGlobalIds(const LongSimplexId *const cellGid,
-                             const unsigned char *const ghostCellMask) {
-      this->abstractTriangulation_->setGlobalIds(cellGid, ghostCellMask);
-    }
 
-    inline void setVertRankArray(int *rankArray) {
-      if(this->abstractTriangulation_)
-        this->abstractTriangulation_->setVertRankArray(rankArray);
-    }
+    // support TriangulationManager by setting "RankArray" & "Global
+    // Ids" arrays in all triangulation instances
 
-    inline const int *getVertRankArray() const {
-      if(this->abstractTriangulation_)
-        return this->abstractTriangulation_->getVertRankArray();
+#define TTK_GET_SET_ARRAYS(FNAME, TYPE)                         \
+  inline void set##FNAME(const TYPE *const data) {              \
+    if(data == nullptr) {                                       \
+      return;                                                   \
+    }                                                           \
+    this->explicitTriangulation_.set##FNAME(data);              \
+    this->compactTriangulation_.set##FNAME(data);               \
+    this->implicitTriangulation_.set##FNAME(data);              \
+    this->implicitPreconditionsTriangulation_.set##FNAME(data); \
+    this->periodicImplicitTriangulation_.set##FNAME(data);      \
+    this->periodicPreconditionsTriangulation_.set##FNAME(data); \
+  }                                                             \
+  inline const TYPE *get##FNAME() const {                       \
+    if(this->abstractTriangulation_ != nullptr) {               \
+      return this->abstractTriangulation_->get##FNAME();        \
+    }                                                           \
+    return {};                                                  \
+  }
 
-      return nullptr;
-    }
+    // GlobalPointIds, GlobalCellIds
 
-    inline void setCellRankArray(int *rankArray) {
-      if(this->abstractTriangulation_)
-        this->abstractTriangulation_->setCellRankArray(rankArray);
-    }
+    TTK_GET_SET_ARRAYS(VertsGlobalIds, LongSimplexId);
+    TTK_GET_SET_ARRAYS(CellsGlobalIds, LongSimplexId);
 
-    inline const int *getCellRankArray() const {
-      if(this->abstractTriangulation_)
-        return this->abstractTriangulation_->getCellRankArray();
+    // RankArray on points & cells
 
-      return nullptr;
-    }
+    TTK_GET_SET_ARRAYS(VertRankArray, int);
+    TTK_GET_SET_ARRAYS(CellRankArray, int);
 
-    inline void setGlobalIdsArray(long int *globalIds) {
-      if(this->abstractTriangulation_)
-        this->abstractTriangulation_->setGlobalIdsArray(globalIds);
-    }
-
-    inline const long int *getGlobalIdsArray() const {
-      if(this->abstractTriangulation_)
-        return this->abstractTriangulation_->getGlobalIdsArray();
-
-      return nullptr;
-    }
+#undef TTK_GET_SET_ARRAYS
 
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1398,11 +1398,11 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param map the std::unordered_map<SimplexId, SimplexId> in which we want
     /// our GidToLidMap. \return 0 if succesful, -1 else.
-    inline const std::unordered_map<SimplexId, SimplexId> *
+    inline const std::unordered_map<SimplexId, SimplexId> &
       getVertexGlobalIdMap() const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
-        return nullptr;
+        return this->getVertexGlobalIdMap();
 #endif
       return abstractTriangulation_->getVertexGlobalIdMap();
     }

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2415,6 +2415,7 @@ namespace ttk {
     /// Tune the debug level (default: 0)
     inline int setDebugLevel(const int &debugLevel) override {
       explicitTriangulation_.setDebugLevel(debugLevel);
+      compactTriangulation_.setDebugLevel(debugLevel);
       implicitTriangulation_.setDebugLevel(debugLevel);
       implicitPreconditionsTriangulation_.setDebugLevel(debugLevel);
       periodicImplicitTriangulation_.setDebugLevel(debugLevel);

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2686,14 +2686,26 @@ namespace ttk {
       this->abstractTriangulation_->setGlobalIds(cellGid, ghostCellMask);
     }
 
-    inline void setRankArray(int *rankArray) {
+    inline void setVertRankArray(int *rankArray) {
       if(this->abstractTriangulation_)
-        this->abstractTriangulation_->setRankArray(rankArray);
+        this->abstractTriangulation_->setVertRankArray(rankArray);
     }
 
-    inline int *getRankArray() const {
+    inline const int *getVertRankArray() const {
       if(this->abstractTriangulation_)
-        return this->abstractTriangulation_->getRankArray();
+        return this->abstractTriangulation_->getVertRankArray();
+
+      return nullptr;
+    }
+
+    inline void setCellRankArray(int *rankArray) {
+      if(this->abstractTriangulation_)
+        this->abstractTriangulation_->setCellRankArray(rankArray);
+    }
+
+    inline const int *getCellRankArray() const {
+      if(this->abstractTriangulation_)
+        return this->abstractTriangulation_->getCellRankArray();
 
       return nullptr;
     }
@@ -2703,7 +2715,7 @@ namespace ttk {
         this->abstractTriangulation_->setGlobalIdsArray(globalIds);
     }
 
-    inline long int *getGlobalIdsArray() const {
+    inline const long int *getGlobalIdsArray() const {
       if(this->abstractTriangulation_)
         return this->abstractTriangulation_->getGlobalIdsArray();
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1379,7 +1379,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param leid Input local vertex identifier.
     /// \return vertexId Input global vertex identifier.
-    inline SimplexId getVertexGlobalId(const SimplexId &leid) const override {
+    inline SimplexId getVertexGlobalId(const SimplexId leid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
@@ -1418,7 +1418,7 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param geid Input global vertex identifier.
     /// \return vertexId Input local vertex identifier.
-    inline SimplexId getVertexLocalId(const SimplexId &geid) const override {
+    inline SimplexId getVertexLocalId(const SimplexId geid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1367,11 +1367,12 @@ namespace ttk {
       return abstractTriangulation_->getVertexEdges();
     }
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
+
     /// Get the corresponding global id for a given local id of a vertex.
     ///    ///
     /// \pre For this function to behave correctly,
-    /// preconditonDistributedVertices() needs to be called
+    /// preconditionDistributedVertices() needs to be called
     /// on this object prior to any traversal, in a clearly distinct
     /// pre-processing step that involves no traversal at all. An error will
     /// be returned otherwise.
@@ -1390,7 +1391,7 @@ namespace ttk {
     /// Get the global id to local id map for the triangulation.
     ///
     /// \pre For this function to behave correctly,
-    /// preconditonDistributedVertices() needs to be called
+    /// preconditionDistributedVertices() needs to be called
     /// on this object prior to any traversal, in a clearly distinct
     /// pre-processing step that involves no traversal at all. An error will
     /// be returned otherwise.
@@ -1410,7 +1411,7 @@ namespace ttk {
     /// Get the corresponding local id for a given global id of a vertex.
     ///
     /// \pre For this function to behave correctly,
-    /// preconditonDistributedVertices() needs to be called
+    /// preconditionDistributedVertices() needs to be called
     /// on this object prior to any traversal, in a clearly distinct
     /// pre-processing step that involves no traversal at all. An error will
     /// be returned otherwise.

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -177,12 +177,12 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
         this->MPIPipelinePreconditioning(inputData);
         auto vtkGlobalPointIds = inputData->GetPointData()->GetGlobalIds();
         auto rankArray = inputData->GetPointData()->GetArray("RankArray");
-        ttkTypeMacroAI(
-          scalarArray->GetDataType(), vtkGlobalPointIds->GetDataType(),
-          (ttk::produceOrdering<T0, T1>(
+        ttkTypeMacroA(
+          scalarArray->GetDataType(),
+          (ttk::produceOrdering<T0>(
             ttkUtils::GetPointer<ttk::SimplexId>(newOrderArray),
             ttkUtils::GetPointer<T0>(scalarArray),
-            ttkUtils::GetPointer<T1>(vtkGlobalPointIds),
+            ttkUtils::GetPointer<ttk::LongSimplexId>(vtkGlobalPointIds),
             ttkUtils::GetPointer<int>(rankArray), nVertices, 500)));
       } else {
         switch(scalarArray->GetDataType()) {
@@ -453,10 +453,10 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
     std::vector<int> rankArray(vertexNumber, 0);
     double *boundingBox = input->GetBounds();
     ttk::produceRankArray(rankArray,
-                          static_cast<long int *>(ttkUtils::GetVoidPointer(
-                            input->GetPointData()->GetGlobalIds())),
-                          static_cast<unsigned char *>(ttkUtils::GetVoidPointer(
-                            input->GetPointData()->GetArray("vtkGhostType"))),
+                          ttkUtils::GetPointer<ttk::LongSimplexId>(
+                            input->GetPointData()->GetGlobalIds()),
+                          ttkUtils::GetPointer<unsigned char>(
+                            input->GetPointData()->GetArray("vtkGhostType")),
                           vertexNumber, boundingBox);
 
     vtkNew<vtkIntArray> vtkRankArray{};
@@ -477,10 +477,10 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
     std::vector<int> cellsRankArray(cellNumber, 0);
     double *boundingBox = input->GetBounds();
     ttk::produceRankArray(cellsRankArray,
-                          static_cast<long int *>(ttkUtils::GetVoidPointer(
-                            input->GetCellData()->GetGlobalIds())),
-                          static_cast<unsigned char *>(ttkUtils::GetVoidPointer(
-                            input->GetCellData()->GetArray("vtkGhostType"))),
+                          ttkUtils::GetPointer<ttk::LongSimplexId>(
+                            input->GetCellData()->GetGlobalIds()),
+                          ttkUtils::GetPointer<unsigned char>(
+                            input->GetCellData()->GetArray("vtkGhostType")),
                           cellNumber, boundingBox);
 
     vtkNew<vtkIntArray> vtkCellsRankArray{};

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -498,13 +498,15 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
 
 void ttkAlgorithm::MPITriangulationPreconditioning(
   ttk::Triangulation *triangulation, vtkDataSet *input) {
-  triangulation->setGlobalIdsArray(static_cast<long int *>(
-    ttkUtils::GetVoidPointer(input->GetPointData()->GetGlobalIds())));
-  triangulation->setGlobalIdsArray(static_cast<long int *>(
-    ttkUtils::GetVoidPointer(input->GetPointData()->GetGlobalIds())));
+  triangulation->setGlobalIdsArray(
+    ttkUtils::GetPointer<long int>(input->GetPointData()->GetGlobalIds()));
+  triangulation->setGlobalIdsArray(
+    ttkUtils::GetPointer<long int>(input->GetPointData()->GetGlobalIds()));
   triangulation->preconditionDistributedVertices();
-  triangulation->setRankArray(static_cast<int *>(
-    ttkUtils::GetVoidPointer(input->GetPointData()->GetArray("RankArray"))));
+  triangulation->setVertRankArray(
+    ttkUtils::GetPointer<int>(input->GetPointData()->GetArray("RankArray")));
+  triangulation->setCellRankArray(
+    ttkUtils::GetPointer<int>(input->GetCellData()->GetArray("RankArray")));
   // provide "GlobalCellIds" & "vtkGhostType" cell data array to
   // the triangulation
   const auto cd{input->GetCellData()};

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -101,12 +101,12 @@ int ttkArrayPreconditioning::RequestData(vtkInformation *ttkNotUsed(request),
           orderArray->SetNumberOfTuples(nVertices);
 
           this->printMsg(std::to_string(scalarArray->GetDataType()));
-          ttkTypeMacroAI(
-            scalarArray->GetDataType(), vtkGlobalPointIds->GetDataType(),
-            (status = processScalarArray<T0, T1>(
+          ttkTypeMacroA(
+            scalarArray->GetDataType(),
+            (status = processScalarArray(
                ttkUtils::GetPointer<ttk::SimplexId>(orderArray),
                ttkUtils::GetPointer<T0>(scalarArray),
-               ttkUtils::GetPointer<T1>(vtkGlobalPointIds),
+               ttkUtils::GetPointer<ttk::LongSimplexId>(vtkGlobalPointIds),
                ttkUtils::GetPointer<int>(rankArray), nVertices, BurstSize)));
 
           // On error cancel filter execution

--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -64,14 +64,14 @@ int ttkGhostCellPreconditioning::RequestData(
   this->printMsg("#Points: " + std::to_string(nVertices));
   this->printMsg("#Cells: " + std::to_string(nCells));
 
-  long int *verticesGlobalIds = static_cast<long int *>(
-    ttkUtils::GetVoidPointer(pointData->GetGlobalIds()));
-  unsigned char *verticesGhostCells = static_cast<unsigned char *>(
-    ttkUtils::GetVoidPointer(pointData->GetArray("vtkGhostType")));
-  long int *cellsGlobalIds = static_cast<long int *>(
-    ttkUtils::GetVoidPointer(cellData->GetGlobalIds()));
-  unsigned char *cellsGhostCells = static_cast<unsigned char *>(
-    ttkUtils::GetVoidPointer(cellData->GetArray("vtkGhostType")));
+  auto *verticesGlobalIds
+    = ttkUtils::GetPointer<ttk::LongSimplexId>(pointData->GetGlobalIds());
+  auto *verticesGhostCells
+    = ttkUtils::GetPointer<unsigned char>(pointData->GetArray("vtkGhostType"));
+  auto *cellsGlobalIds
+    = ttkUtils::GetPointer<ttk::LongSimplexId>(cellData->GetGlobalIds());
+  auto *cellsGhostCells
+    = ttkUtils::GetPointer<unsigned char>(cellData->GetArray("vtkGhostType"));
 
   if(verticesGlobalIds != nullptr && verticesGhostCells != nullptr
      && cellsGlobalIds != nullptr && cellsGhostCells != nullptr) {

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -153,7 +153,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
     vertexIds->SetNumberOfTuples(criticalPoints_.size());
     vertexIds->SetName(ttk::VertexScalarFieldName);
 #if TTK_ENABLE_MPI
-    long int *globalIds = triangulation->getGlobalIdsArray();
+    const auto *globalIds = triangulation->getVertsGlobalIds();
 #endif
     for(size_t i = 0; i < criticalPoints_.size(); i++) {
 #if TTK_ENABLE_MPI

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -89,6 +89,16 @@ int ttkTriangulationManager::processExplicit(
   }
   ttk::Timer tm{};
 
+#ifdef TTK_ENABLE_MPI
+  if(ttk::isRunningWithMPI()) {
+    this->printErr(
+      "Compact triangulation not (yet) supported in an MPI context!");
+    this->printErr("Keeping the Explicit triangulation.");
+    output->ShallowCopy(input);
+    return 0;
+  }
+#endif // TTK_ENABLE_MPI
+
   // If all checks pass then log which array is going to be processed.
   this->printMsg("Compact explicit triangulation...");
   int status = 0; // this integer checks if the base code returns an error


### PR DESCRIPTION
This PR reworks the MPI support inside the Triangulation modules to enable full local to global and global to local identifiers mappings for edges and triangles. It extends #773 by exchanging missing identifier mappings between neighboring ranks. The algorithm introduced in #773 to label local edges & triangles with global identifiers has been overhauled and is now better MPI-parallel.

This new additions only work well in practice for `ImplicitTriangulation`. VTU files are currently not distributed correctly between ranks by ParaView: applying `Ghost Cells Generator` after `Redistribute Dataset` generates duplicate points that share the same global id in the same rank (implicit grids are not affected).

MPI support has been removed from `PeriodicImplicitTriangulation` since the periodic triangulation model does not fit the data distribution done by ParaView. Similarly, the few MPI support in `CompactTriangulation` has been removed (no idea in how to implement it in practice). An error message is displayed in `TriangulationManager` when trying to convert to these two Triangulation types in an MPI context.

`AbstractTriangulation` now holds the accessor methods to convert between local and global indices (except for local to global cell indices for implicit grids). Useless triangulation members have been removed (`ghostCellMask_` has been replaced by `cellRankArray_`, `vertexLidToGid_` is a copy of `vertGid_`...). The global identifiers arrays pointers types (`cellGid_` and `vertGid_`) have been switched from `long int` to `LongSimplexId`/`vtkIdType` to better match the output of the `Generate Global Ids` ParaView filter. This has led to some type modifications in `MPIUtils.h` methods, I hope without consequences.

The `ScalarFieldCriticalPoints` and `ScalarFieldSmoother` modules have been marginally modified to reduce the MPI code footprint and better take advantage of the new triangulation methods. Both should work as expected.

Enjoy,
Pierre

