### PR TITLE
MultiresTriangulation: Fix typo

### DIFF
--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -820,7 +820,7 @@ namespace ttk {
         if(dimensionality_ == 2) {
           if(gridDimensions_[0] == 1) {
             Di_ = 1;
-            Di_ = 2;
+            Dj_ = 2;
           } else if(gridDimensions_[1] == 1) {
             Di_ = 0;
             Dj_ = 2;


### PR DESCRIPTION
Avoid garbage value in the `Dj_` member variable.

