### PR TITLE
GitHub Actions: Workaround Python 3.10 on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,18 +196,17 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout TTK source code
 
-    - name: Remove hosted Python
-      run: |
-        sudo rm -rf /usr/local/Frameworks/Python.framework
-
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp ninja python open-mpi
+        brew uninstall --ignore-dependencies python@3.10
+        brew install wget libomp ninja python@3.9 open-mpi
+        # force brew's Python 3.9 as default Python
+        echo "$(brew --prefix)/opt/python@3.9/libexec/bin" >> $GITHUB_PATH
         # TTK dependencies
         brew install boost eigen graphviz numpy embree ccache
-        python3 -m pip install scikit-learn packaging
+        python3.9 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -365,7 +365,7 @@ jobs:
   - script: |
       brew install --cask xquartz
       brew install wget libomp mesa glew boost ccache ninja python
-      python3 -m pip install scikit-learn packaging
+      python3.8 -m pip install scikit-learn packaging
     displayName: 'Install dependencies'
 
   - script: |
@@ -468,7 +468,7 @@ jobs:
     displayName: 'Test TTKVTK Example'
 
   - script: |
-      export PYTHONPATH=$(Build.ArtifactStagingDirectory)/ttk-install/lib/python3.9/site-packages:$(Build.ArtifactStagingDirectory)/pv-install/lib/python3.9/site-packages
+      export PYTHONPATH=$(Build.ArtifactStagingDirectory)/ttk-install/lib/python3.8/site-packages:$(Build.ArtifactStagingDirectory)/pv-install/lib/python3.8/site-packages
       export DYLD_LIBRARY_PATH=$(Build.ArtifactStagingDirectory)/pv-install/lib:$(Build.ArtifactStagingDirectory)/ttk-install/lib
       $(Build.ArtifactStagingDirectory)/pv-install/bin/pvpython ./example.py ../data/inputData.vtu
       if [ ! -f curve.vtk ] || [ ! -f separatrices.vtp ] || [ ! -f segmentation.vtu ] ; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,7 +347,7 @@ jobs:
 - job:
   condition: true
   displayName: MacOS-PV-Python3-OpenMP-Ninja
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
 
   variables:
     CMakeArgs: ''


### PR DESCRIPTION
Last month, macOS brew Python has been updated from 3.9 to 3.10. Since our precompiled `ttk-paraview` used in the TTK CI depends on Python 3.9 (the Python files are installed under `$prefix/lib/python3.9/site-packages`), the TTK CI fails when trying to use the `vtk` or `paraview.simple` Python modules.

This PR offers a simple hotfix that consists in temporarily rolling back to Python 3.9 on macOS. A better fix IMO would be to recompile the `ttk-paraview` headless packages with the current macOS/brew software stack (this can be done in a later step with a revert of this commit).

Enjoy,
Pierre