### PR TITLE
DiscreteMorseSandwich: Fix IgnoreBoundary

### DIFF
--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -1060,18 +1060,12 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
     }
   }
 
-  if(dim == 1) {
-    // early return in 1D
-    this->printMsg(
-      "Computed " + std::to_string(pairs.size()) + " persistence pairs", 1.0,
-      tm.getElapsedTime(), this->threadNumber_);
-    return 0;
+  if(dim > 1) {
+    // saddle - maxima pairs
+    this->getMaxSaddlePairs(
+      pairs, pairedMaxima, paired2Saddles, criticalCellsByDim[dim - 1],
+      critCellsOrder[dim - 1], critCellsOrder[dim], triangulation);
   }
-
-  // saddle - maxima pairs
-  this->getMaxSaddlePairs(pairs, pairedMaxima, paired2Saddles,
-                          criticalCellsByDim[dim - 1], critCellsOrder[dim - 1],
-                          critCellsOrder[dim], triangulation);
 
   if(ignoreBoundary) {
     // post-process saddle-max pairs: remove the one with the global

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -458,7 +458,7 @@ int ttk::PersistentGenerators::computePersistentGenerators(
     std::vector<PersistencePair> sadMaxPairs{};
     this->getMaxSaddlePairs(
       sadMaxPairs, pairedMaxima, paired2Saddles, criticalCellsByDim[dim - 1],
-      critCellsOrder[dim - 1], critCellsOrder[dim], triangulation, false);
+      critCellsOrder[dim - 1], critCellsOrder[dim], triangulation);
   }
 
   if(!criticalCellsByDim[1].empty() && !criticalCellsByDim[2].empty()) {


### PR DESCRIPTION
This PR modifies the handling of the `IgnoreBoundary` option. Now, the option removes only the saddle-max pair that involves the global maximum of the dataset. This should reduce the distance to FTM diagrams.

Also, a bug involving (non) memory cleanup for 1D datasets was fixed.

Enjoy,
Pierre