### PR TITLE
DiscreteGradient: Add cell ids to gradient glyphs

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -594,6 +594,8 @@ in the gradient.
       int setGradientGlyphs(std::vector<std::array<float, 3>> &points,
                             std::vector<char> &points_pairOrigins,
                             std::vector<char> &cells_pairTypes,
+                            std::vector<SimplexId> &cellsIds,
+                            std::vector<char> &cellsDimensions,
                             const triangulationType &triangulation) const;
 
     private:

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -2160,47 +2160,8 @@ bool DiscreteGradient::isBoundary(
     return false;
   }
 
-  if(cell.dim_ == 0) {
-    return triangulation.isVertexOnBoundary(cell.id_);
-  }
-
-  if(cell.dim_ == 1) {
-    if(this->dimensionality_ > 1) {
-      return triangulation.isEdgeOnBoundary(cell.id_);
-    }
-    for(int i = 0; i < 2; ++i) {
-      SimplexId v{};
-      triangulation.getEdgeVertex(cell.id_, i, v);
-      if(triangulation.isVertexOnBoundary(v)) {
-        return true;
-      }
-    }
-  }
-
-  if(cell.dim_ == 2) {
-    if(this->dimensionality_ > 2) {
-      return triangulation.isTriangleOnBoundary(cell.id_);
-    }
-    for(int i = 0; i < 3; ++i) {
-      SimplexId e{};
-      triangulation.getCellEdge(cell.id_, i, e);
-      if(triangulation.isEdgeOnBoundary(e)) {
-        return true;
-      }
-    }
-  }
-
-  if(cell.dim_ == 3) {
-    for(int i = 0; i < 4; ++i) {
-      SimplexId t{};
-      triangulation.getCellTriangle(cell.id_, i, t);
-      if(triangulation.isTriangleOnBoundary(t)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+  const auto vert{this->getCellGreaterVertex(cell, triangulation)};
+  return triangulation.isVertexOnBoundary(vert);
 }
 
 template <typename triangulationType>

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -17,7 +17,6 @@
 #include <DiscreteGradient.h>
 
 using ttk::SimplexId;
-using ttk::VisitedMask;
 using ttk::dcg::Cell;
 using ttk::dcg::CellExt;
 using ttk::dcg::CriticalPoint;
@@ -1938,8 +1937,6 @@ inline void
       }
     }
   }
-
-  return;
 }
 
 template <typename triangulationType>
@@ -3090,6 +3087,8 @@ int DiscreteGradient::setGradientGlyphs(
   std::vector<std::array<float, 3>> &points,
   std::vector<char> &points_pairOrigins,
   std::vector<char> &cells_pairTypes,
+  std::vector<SimplexId> &cellIds,
+  std::vector<char> &cellDimensions,
   const triangulationType &triangulation) const {
 
   const auto nDims = this->getNumberOfDimensions();
@@ -3122,6 +3121,8 @@ int DiscreteGradient::setGradientGlyphs(
   points.resize(2 * nGlyphs);
   points_pairOrigins.resize(2 * nGlyphs);
   cells_pairTypes.resize(nGlyphs);
+  cellIds.resize(2 * nGlyphs);
+  cellDimensions.resize(2 * nGlyphs);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
@@ -3141,6 +3142,10 @@ int DiscreteGradient::setGradientGlyphs(
         points_pairOrigins[2 * nProcessedGlyphs] = 0;
         points_pairOrigins[2 * nProcessedGlyphs + 1] = 1;
         cells_pairTypes[nProcessedGlyphs] = i;
+        cellIds[2 * nProcessedGlyphs + 0] = j;
+        cellIds[2 * nProcessedGlyphs + 1] = pcid;
+        cellDimensions[2 * nProcessedGlyphs + 0] = i;
+        cellDimensions[2 * nProcessedGlyphs + 1] = i + 1;
         nProcessedGlyphs++;
       }
     }

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -136,10 +136,13 @@ int ttkDiscreteGradient::fillGradientGlyphs(
   std::vector<std::array<float, 3>> gradientGlyphs_points;
   std::vector<char> gradientGlyphs_points_pairOrigins;
   std::vector<char> gradientGlyphs_cells_pairTypes;
+  std::vector<SimplexId> gradientGlyphs_point_ids{};
+  std::vector<char> gradientGlyphs_point_dimensions{};
 
-  this->setGradientGlyphs(gradientGlyphs_points,
-                          gradientGlyphs_points_pairOrigins,
-                          gradientGlyphs_cells_pairTypes, triangulation);
+  this->setGradientGlyphs(
+    gradientGlyphs_points, gradientGlyphs_points_pairOrigins,
+    gradientGlyphs_cells_pairTypes, gradientGlyphs_point_ids,
+    gradientGlyphs_point_dimensions, triangulation);
 
   const auto nPoints = gradientGlyphs_points.size();
 
@@ -170,6 +173,14 @@ int ttkDiscreteGradient::fillGradientGlyphs(
   pairTypes->SetNumberOfComponents(1);
   pairTypes->SetName("PairType");
   pairTypes->SetNumberOfTuples(nCells);
+  vtkNew<ttkSimplexIdTypeArray> cellIds{};
+  cellIds->SetNumberOfComponents(1);
+  cellIds->SetName("CellId");
+  cellIds->SetNumberOfTuples(2 * nCells);
+  vtkNew<vtkSignedCharArray> cellDimensions{};
+  cellDimensions->SetNumberOfComponents(1);
+  cellDimensions->SetName("CellDimension");
+  cellDimensions->SetNumberOfTuples(2 * nCells);
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
@@ -180,6 +191,12 @@ int ttkDiscreteGradient::fillGradientGlyphs(
     connectivity->SetTuple1(2 * i, 2 * i);
     connectivity->SetTuple1(2 * i + 1, 2 * i + 1);
     pairTypes->SetTuple1(i, gradientGlyphs_cells_pairTypes[i]);
+    cellIds->SetTuple1(2 * i + 0, gradientGlyphs_point_ids[2 * i + 0]);
+    cellIds->SetTuple1(2 * i + 1, gradientGlyphs_point_ids[2 * i + 1]);
+    cellDimensions->SetTuple1(
+      2 * i + 0, gradientGlyphs_point_dimensions[2 * i + 0]);
+    cellDimensions->SetTuple1(
+      2 * i + 1, gradientGlyphs_point_dimensions[2 * i + 1]);
   }
   offsets->SetTuple1(nCells, connectivity->GetNumberOfTuples());
 
@@ -198,6 +215,8 @@ int ttkDiscreteGradient::fillGradientGlyphs(
 #endif
 
   pointData->AddArray(pairOrigins);
+  pointData->AddArray(cellIds);
+  pointData->AddArray(cellDimensions);
   cellData->SetScalars(pairTypes);
 
   this->printMsg(


### PR DESCRIPTION
This PR extends the Gradient Glyphs output of the DiscreteGradient module with 2 new PointData arrays: CellIds and CellDimension (similar arrays are already on the Critical Points output). This is a way to expose the internal structure of the DiscreteGradient to the VTK layer.

Enjoy,
Pierre