### PR TITLE
Fix segfault, other small changes

### DIFF
--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -25,6 +25,7 @@
 #include <BaseClass.h>
 
 #include <algorithm>
+#include <array>
 #include <cerrno>
 #include <fstream>
 #include <iostream>
@@ -180,7 +181,7 @@ namespace ttk {
          && (globalDebugLevel_ < (int)priority))
         return 0;
 
-      std::vector<std::string> chunks(4);
+      std::array<std::string, 4> chunks{};
       size_t q = 0;
 
       if(memory >= 0)

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -359,8 +359,7 @@ namespace ttk {
                                unsigned char *ghostCells,
                                int nVertices,
                                double *boundingBox) {
-    std::vector<std::array<double, 6>> rankBoundingBoxes(
-      ttk::MPIsize_, std::array<double, 6>({}));
+    std::vector<std::array<double, 6>> rankBoundingBoxes(ttk::MPIsize_);
     std::copy(
       boundingBox, boundingBox + 6, rankBoundingBoxes[ttk::MPIrank_].begin());
     for(int r = 0; r < ttk::MPIsize_; r++) {
@@ -384,7 +383,7 @@ namespace ttk {
         }
       }
     }
-    MPI_Datatype MIT = ttk::getMPIType(static_cast<ttk::SimplexId>(0));
+    MPI_Datatype MIT = ttk::getMPIType(ttk::SimplexId{});
     std::vector<ttk::SimplexId> currentRankUnknownIds;
     std::vector<std::vector<ttk::SimplexId>> allUnknownIds(ttk::MPIsize_);
     std::unordered_set<ttk::SimplexId> gIdSet;

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -538,7 +538,7 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
     return (char)(CriticalType::Regular);
   } else {
     // saddles
-    if(dimension_ == 2) {
+    if(dimension_ == 2 || dimension_ == 1) {
       if((lowerComponentNumber == 2 && upperComponentNumber == 1)
          || (lowerComponentNumber == 1 && upperComponentNumber == 2)
          || (lowerComponentNumber == 2 && upperComponentNumber == 2)) {

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -281,14 +281,16 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
         continue;
       }
 
-      const auto &p1{diag[bidderId]};
-      if(p1.birth.type == ttk::CriticalType::Local_minimum) {
-        minSadCost += std::get<2>(m);
-      } else if(p1.birth.type == ttk::CriticalType::Saddle1
-                && p1.death.type == ttk::CriticalType::Saddle2) {
-        sadSadCost += std::get<2>(m);
-      } else if(p1.death.type == ttk::CriticalType::Local_maximum) {
-        sadMaxCost += std::get<2>(m);
+      if(bidderId > 0) {
+        const auto &p1{diag[bidderId]};
+        if(p1.birth.type == ttk::CriticalType::Local_minimum) {
+          minSadCost += std::get<2>(m);
+        } else if(p1.birth.type == ttk::CriticalType::Saddle1
+                  && p1.death.type == ttk::CriticalType::Saddle2) {
+          sadSadCost += std::get<2>(m);
+        } else if(p1.death.type == ttk::CriticalType::Local_maximum) {
+          sadMaxCost += std::get<2>(m);
+        }
       }
     }
 


### PR DESCRIPTION
This PR fixes a buffer overflow introduced in #818 in `PersistenceDiagramClustering` (when aggregating matchings costs per diagram).


Other small fixes include:
* removal of useless casts in `MPIUtils.h`,
* removal of a dynamic allocation in `Debug.h`,
* `ScalarFieldCriticalPoints` now correctly identifies saddles on (non-manifold) 1D datasets.

Enjoy,
Pierre