### PR TITLE
MergeTreeClustering and MergeTreeDistanceMatrix field data

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -337,6 +337,14 @@ int ttkMergeTreeClustering::runCompute(
   return 1;
 }
 
+void addFieldData(vtkDataSet *in, vtkDataSet *out) {
+  auto inFieldData = in->GetFieldData();
+  auto outFieldData = out->GetFieldData();
+  for(int i = 0; i < inFieldData->GetNumberOfArrays(); ++i) {
+    outFieldData->AddArray(inFieldData->GetAbstractArray(i));
+  }
+}
+
 template <class dataType>
 int ttkMergeTreeClustering::runOutput(
   vtkInformationVector *outputVector,
@@ -452,6 +460,10 @@ int ttkMergeTreeClustering::runOutput(
         treesNodes[1]->GetFieldData());
       vtkOutputArc1->GetFieldData()->ShallowCopy(treesArcs[0]->GetFieldData());
       vtkOutputArc2->GetFieldData()->ShallowCopy(treesArcs[1]->GetFieldData());
+      if(treesSegmentation[0])
+        addFieldData(treesSegmentation[0], vtkOutputNode1);
+      if(treesSegmentation[1])
+        addFieldData(treesSegmentation[1], vtkOutputNode2);
       if(OutputSegmentation) {
         vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
           treesSegmentation[0]->GetFieldData());
@@ -593,6 +605,8 @@ int ttkMergeTreeClustering::runOutput(
             treesNodes[i]->GetFieldData());
           vtkOutputArc1->GetFieldData()->ShallowCopy(
             treesArcs[i]->GetFieldData());
+          if(treesSegmentation[i])
+            addFieldData(treesSegmentation[i], vtkOutputNode1);
           if(OutputSegmentation)
             vtkOutputSegmentation1->GetFieldData()->ShallowCopy(
               treesSegmentation[i]->GetFieldData());

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -168,16 +168,18 @@ int ttkMergeTreeDistanceMatrix::run(
   treesDistTable->AddColumn(treeIds);
 
   // aggregate input field data
-  vtkNew<vtkFieldData> fd{};
-  fd->CopyStructure(inputTrees[0]->GetBlock(0)->GetFieldData());
-  fd->SetNumberOfTuples(inputTrees.size());
-  for(size_t i = 0; i < inputTrees.size(); ++i) {
-    fd->SetTuple(i, 0, inputTrees[i]->GetBlock(0)->GetFieldData());
-  }
+  for(unsigned int b = 0; b < inputTrees[0]->GetNumberOfBlocks(); ++b) {
+    vtkNew<vtkFieldData> fd{};
+    fd->CopyStructure(inputTrees[0]->GetBlock(b)->GetFieldData());
+    fd->SetNumberOfTuples(inputTrees.size());
+    for(size_t i = 0; i < inputTrees.size(); ++i) {
+      fd->SetTuple(i, 0, inputTrees[i]->GetBlock(b)->GetFieldData());
+    }
 
-  // copy input field data to output row data
-  for(int i = 0; i < fd->GetNumberOfArrays(); ++i) {
-    treesDistTable->AddColumn(fd->GetAbstractArray(i));
+    // copy input field data to output row data
+    for(int i = 0; i < fd->GetNumberOfArrays(); ++i) {
+      treesDistTable->AddColumn(fd->GetAbstractArray(i));
+    }
   }
 
   return 1;


### PR DESCRIPTION
This PR fixes the field data output of the `MergeTreeClustering` and `MergeTreeDistanceMatrix` filters.

Before, only the nodes field data were copied to the output. Since `FTMTree` copies the field data in the segmentation output it could result in a loss of information during the pipeline.

Now, the field data of the segmentation output are also copied. However, the segmentation is optional for these two filters mentioned at the beginning, therefore a user that wants to keep the field data should provide the segmentation to these filters (no impact on the performance).