### PR TITLE
Enable per-dimension computation for DiscreteMorseSandwich Persistence Diagrams

### DIFF
--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -53,6 +53,16 @@ namespace ttk {
       this->dg_.setInputOffsets(offsets);
     }
 
+    inline void setComputeMinSad(const bool data) {
+      this->ComputeMinSad = data;
+    }
+    inline void setComputeSadSad(const bool data) {
+      this->ComputeSadSad = data;
+    }
+    inline void setComputeSadMax(const bool data) {
+      this->ComputeSadMax = data;
+    }
+
     template <typename triangulationType>
     inline int buildGradient(const void *const scalars,
                              const size_t scalarsMTime,
@@ -430,6 +440,10 @@ namespace ttk {
     mutable std::array<std::vector<bool>, 4> pairedCritCells_{};
     mutable std::vector<bool> onBoundary_{};
     mutable std::array<std::vector<SimplexId>, 4> critCellsOrder_{};
+
+    bool ComputeMinSad{true};
+    bool ComputeSadSad{true};
+    bool ComputeSadMax{true};
   };
 } // namespace ttk
 
@@ -1045,22 +1059,26 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
   // if maxima are paired
   auto &pairedMaxima{this->pairedCritCells_[dim]};
 
-  // minima - saddle pairs
-  this->getMinSaddlePairs(pairs, pairedMinima, paired1Saddles,
-                          criticalCellsByDim[1], critCellsOrder[1], offsets,
-                          triangulation);
-
   // connected components (global min/max pair)
   size_t nConnComp{};
-  for(const auto min : criticalCellsByDim[0]) {
-    if(!pairedMinima[min]) {
-      pairs.emplace_back(min, -1, 0);
-      pairedMinima[min] = true;
-      nConnComp++;
+
+  if(this->ComputeMinSad) {
+    // minima - saddle pairs
+    this->getMinSaddlePairs(pairs, pairedMinima, paired1Saddles,
+                            criticalCellsByDim[1], critCellsOrder[1], offsets,
+                            triangulation);
+
+    // non-paired minima
+    for(const auto min : criticalCellsByDim[0]) {
+      if(!pairedMinima[min]) {
+        pairs.emplace_back(min, -1, 0);
+        pairedMinima[min] = true;
+        nConnComp++;
+      }
     }
   }
 
-  if(dim > 1) {
+  if(dim > 1 && this->ComputeSadMax) {
     // saddle - maxima pairs
     this->getMaxSaddlePairs(
       pairs, pairedMaxima, paired2Saddles, criticalCellsByDim[dim - 1],
@@ -1077,10 +1095,7 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
           }
           const Cell cmax{dim, p.death};
           const auto vmax{this->getCellGreaterVertex(cmax, triangulation)};
-          if(offsets[vmax] == triangulation.getNumberOfVertices() - 1) {
-            return true;
-          }
-          return false;
+          return offsets[vmax] == triangulation.getNumberOfVertices() - 1;
         });
 
     if(it != pairs.end()) {
@@ -1093,7 +1108,7 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
 
   // saddle - saddle pairs
   if(dim == 3 && !criticalCellsByDim[1].empty()
-     && !criticalCellsByDim[2].empty()) {
+     && !criticalCellsByDim[2].empty() && this->ComputeSadSad) {
     std::vector<GeneratorType> tmp{};
     this->getSaddleSaddlePairs(
       pairs, paired1Saddles, paired2Saddles, false, tmp, criticalCellsByDim[1],
@@ -1101,9 +1116,12 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
   }
 
   if(std::is_same<triangulationType, ttk::ExplicitTriangulation>::value) {
-    // create infinite pairs from non-paired 1-saddles
+    // create infinite pairs from non-paired 1-saddles, 2-saddles and maxima
     size_t nHandles{}, nCavities{}, nNonPairedMax{};
-    if((dim == 2 && !ignoreBoundary) || dim == 3) {
+    if((dim == 2 && !ignoreBoundary && this->ComputeMinSad
+        && this->ComputeSadMax)
+       || (dim == 3 && this->ComputeMinSad && this->ComputeSadSad)) {
+      // non-paired 1-saddles
       for(const auto s1 : criticalCellsByDim[1]) {
         if(!paired1Saddles[s1]) {
           paired1Saddles[s1] = true;
@@ -1113,7 +1131,9 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
         }
       }
     }
-    if(dim == 3 && !ignoreBoundary) {
+    if(dim == 3 && !ignoreBoundary && this->ComputeSadMax
+       && this->ComputeSadSad) {
+      // non-paired 2-saddles
       for(const auto s2 : criticalCellsByDim[2]) {
         if(!paired2Saddles[s2]) {
           paired2Saddles[s2] = true;
@@ -1123,7 +1143,8 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
         }
       }
     }
-    if(dim == 2 && !ignoreBoundary) {
+    if(dim == 2 && !ignoreBoundary && this->ComputeSadMax) {
+      // non-paired maxima
       for(const auto max : criticalCellsByDim[dim]) {
         if(!pairedMaxima[max]) {
           pairs.emplace_back(max, -1, 2);

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -22,6 +22,7 @@
 
 #include <DiscreteGradient.h>
 
+#include <algorithm>
 #include <numeric>
 
 namespace ttk {
@@ -1076,6 +1077,16 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
         nConnComp++;
       }
     }
+  } else {
+    // still extract the global pair
+    const auto globMin{*std::min_element(
+      criticalCellsByDim[0].begin(), criticalCellsByDim[0].end(),
+      [offsets](const SimplexId a, const SimplexId b) {
+        return offsets[a] < offsets[b];
+      })};
+    pairs.emplace_back(globMin, -1, 0);
+    pairedMinima[globMin] = true;
+    nConnComp++;
   }
 
   if(dim > 1 && this->ComputeSadMax) {

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -163,6 +163,16 @@ namespace ttk {
       this->BackEnd = be;
     }
 
+    inline void setComputeMinSad(const bool data) {
+      this->dms_.setComputeMinSad(data);
+    }
+    inline void setComputeSadSad(const bool data) {
+      this->dms_.setComputeSadSad(data);
+    }
+    inline void setComputeSadMax(const bool data) {
+      this->dms_.setComputeSadMax(data);
+    }
+
     ttk::CriticalType getNodeType(ftm::FTMTree_MT *tree,
                                   ftm::TreeType treeType,
                                   const SimplexId vertexId) const;

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -196,6 +196,19 @@ public:
   vtkSetMacro(IgnoreBoundary, bool);
   vtkGetMacro(IgnoreBoundary, bool);
 
+  inline void SetComputeMinSad(const bool data) {
+    this->setComputeMinSad(data);
+    this->Modified();
+  }
+  inline void SetComputeSadSad(const bool data) {
+    this->setComputeSadSad(data);
+    this->Modified();
+  }
+  inline void SetComputeSadMax(const bool data) {
+    this->setComputeSadMax(data);
+    this->Modified();
+  }
+
 protected:
   ttkPersistenceDiagram();
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -198,14 +198,23 @@ public:
 
   inline void SetComputeMinSad(const bool data) {
     this->setComputeMinSad(data);
+    this->dmsDimsCache[0] = data;
     this->Modified();
   }
   inline void SetComputeSadSad(const bool data) {
     this->setComputeSadSad(data);
+    this->dmsDimsCache[1] = data;
     this->Modified();
   }
   inline void SetComputeSadMax(const bool data) {
     this->setComputeSadMax(data);
+    this->dmsDimsCache[2] = data;
+    this->Modified();
+  }
+  inline void SetDMSDimensions(const int data) {
+    this->setComputeMinSad(data == 0 ? true : this->dmsDimsCache[0]);
+    this->setComputeSadSad(data == 0 ? true : this->dmsDimsCache[1]);
+    this->setComputeSadMax(data == 0 ? true : this->dmsDimsCache[2]);
     this->Modified();
   }
 
@@ -232,4 +241,7 @@ private:
 
   bool ForceInputOffsetScalarField{false};
   bool ShowInsideDomain{false};
+  // stores the values of Compute[Min|Sad][Sad|Max] GUI checkboxes
+  // when "All Dimensions" is selected
+  std::array<bool, 3> dmsDimsCache{true, true, true};
 };

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -374,6 +374,7 @@
       <IntVectorProperty
           name="DMSDimensions"
           label="Dimensions"
+          command="SetDMSDimensions"
           number_of_elements="1"
           default_values="0"
           panel_visibility="advanced" >

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -371,6 +371,108 @@
         </Documentation>
       </IntVectorProperty>
 
+      <IntVectorProperty
+          name="DMSDimensions"
+          label="Dimensions"
+          number_of_elements="1"
+          default_values="0"
+          panel_visibility="advanced" >
+         <EnumerationDomain name="enum">
+          <Entry value="0" text="All Dimensions"/>
+          <Entry value="1" text="Selected Dimensions (no infinite pairs)"/>
+        </EnumerationDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="BackEnd"
+                                   value="2" />
+        </Hints>
+        <Documentation>
+          Should we compute all pairs with DiscreteMorseSandwich or a selection?
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+          name="ComputeMinSad"
+          label="Minimum-saddle diagram (dimension 0)"
+          command="SetComputeMinSad"
+          number_of_elements="1"
+          default_values="1"
+          panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="BackEnd"
+                                       value="2" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="DMSDimensions"
+                                       value="1" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          Compute the minimum-saddle pairs.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+          name="ComputeSadSad"
+          label="Saddle-saddle diagram (dimension 1, slowest)"
+          command="SetComputeSadSad"
+          number_of_elements="1"
+          default_values="1"
+          panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="BackEnd"
+                                       value="2" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="DMSDimensions"
+                                       value="1" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          Compute the saddle-saddle pairs.
+        </Documentation>
+      </IntVectorProperty>
+
+      <IntVectorProperty
+          name="ComputeSadMax"
+          label="Saddle-maximum diagram (dimension d - 1)"
+          command="SetComputeSadMax"
+          number_of_elements="1"
+          default_values="1"
+          panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="CompositeDecorator">
+            <Expression type="and">
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="BackEnd"
+                                       value="2" />
+              <PropertyWidgetDecorator type="GenericDecorator"
+                                       mode="visibility"
+                                       property="DMSDimensions"
+                                       value="1" />
+            </Expression>
+          </PropertyWidgetDecorator>
+        </Hints>
+        <Documentation>
+          Compute the saddle-maximum pairs.
+        </Documentation>
+      </IntVectorProperty>
+
       <IntVectorProperty name="ShowInsideDomain"
                          label="Embed in Domain"
                          command="SetShowInsideDomain"
@@ -401,6 +503,10 @@
       <PropertyGroup panel_widget="Line" label="Output options">
         <Property name="SaddleConnectors" />
         <Property name="Ignore Boundary" />
+        <Property name="DMSDimensions" />
+        <Property name="ComputeMinSad" />
+        <Property name="ComputeSadSad" />
+        <Property name="ComputeSadMax" />
         <Property name="ShowInsideDomain" />
       </PropertyGroup>
 


### PR DESCRIPTION
This PR enables per-dimension computation of the persistence pairs for the DiscreteMorseSandwich backend of the PersistenceDiagram module.

This behavior is controlled in the GUI by a dropdown menu that let the user choose between computing pairs of all dimensions or if specific dimensions should be requested. If the second option is chosen, three checkbox appear (one to select each dimension/pair type).

Enjoy,
Pierre