### PR TITLE
PersistenceDiagramDistanceMatrix: Ensure all FieldData arrays are forwarded

### DIFF
--- a/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
+++ b/core/vtk/ttkCinemaQuery/ttkCinemaQuery.cpp
@@ -177,6 +177,8 @@ int ttkCinemaQuery::RequestData(vtkInformation *ttkNotUsed(request),
                 // convert char/signed char to int to get its value
                 // instead of its char representation
                 sqlInsertStatement += std::to_string(var.ToInt());
+              } else if(std::isnan(var.ToDouble())) {
+                sqlInsertStatement += "'NaN'";
               } else {
                 sqlInsertStatement += var.ToString();
               }


### PR DESCRIPTION
This PR extends #827 to the PersistenceDiagramDistanceMatrix filter. Also, the CinemaQuery filters now supports NaN values.

Enjoy,
Pierre

