### PR TITLE
[Triangulation] Add getCellVTKID to access VTK cell ids from TTK cell ids

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3490,7 +3490,7 @@ namespace ttk {
 
     virtual inline int getCellVTKIDInternal(const int &ttkId,
                                             int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
       if(ttkId < 0) {
         return -1;
       }

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2521,6 +2521,15 @@ namespace ttk {
       return 0;
     }
 
+    virtual inline int getCellVTKID(const int &ttkId, int &vtkId) const {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      // initialize output variable before early return
+      vtkId = -1;
+#endif
+      return getCellVTKIDInternal(ttkId, vtkId);
+    }
+
 #ifdef TTK_ENABLE_MPI
 
     // GlobalPointIds, GlobalCellIds
@@ -3476,6 +3485,17 @@ namespace ttk {
     }
 
     virtual inline int preconditionVertexTrianglesInternal() {
+      return 0;
+    }
+
+    virtual inline int getCellVTKIDInternal(const int &ttkId,
+                                            int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+      if(ttkId < 0) {
+        return -1;
+      }
+#endif
+      vtkId = ttkId;
       return 0;
     }
 

--- a/core/base/implicitTriangulation/ImplicitPreconditions.cpp
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.cpp
@@ -704,3 +704,29 @@ std::array<ttk::SimplexId, 3>
   }
   return p;
 }
+
+int ttk::ImplicitWithPreconditions::getCellVTKIDInternal(const int &ttkId,
+                                                         int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{
+    ImplicitWithPreconditions::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}
+
+int ttk::ImplicitNoPreconditions::getCellVTKIDInternal(const int &ttkId,
+                                                       int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{
+    ImplicitNoPreconditions::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}

--- a/core/base/implicitTriangulation/ImplicitPreconditions.cpp
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.cpp
@@ -713,7 +713,9 @@ int ttk::ImplicitWithPreconditions::getCellVTKIDInternal(const int &ttkId,
   }
 #endif
   const int nSimplexPerCell{
-    ImplicitWithPreconditions::getDimensionality() == 3 ? 6 : 2};
+    ImplicitWithPreconditions::getDimensionality() == 3   ? 6
+    : ImplicitWithPreconditions::getDimensionality() == 2 ? 2
+                                                          : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
@@ -726,7 +728,9 @@ int ttk::ImplicitNoPreconditions::getCellVTKIDInternal(const int &ttkId,
   }
 #endif
   const int nSimplexPerCell{
-    ImplicitNoPreconditions::getDimensionality() == 3 ? 6 : 2};
+    ImplicitNoPreconditions::getDimensionality() == 3   ? 6
+    : ImplicitNoPreconditions::getDimensionality() == 2 ? 2
+                                                        : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/implicitTriangulation/ImplicitPreconditions.cpp
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.cpp
@@ -707,26 +707,26 @@ std::array<ttk::SimplexId, 3>
 
 int ttk::ImplicitWithPreconditions::getCellVTKIDInternal(const int &ttkId,
                                                          int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{
+  const int nSimplexPerCell{
     ImplicitWithPreconditions::getDimensionality() == 3 ? 6 : 2};
-  vtkId = ttkId / nTetraPerCube;
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
 
 int ttk::ImplicitNoPreconditions::getCellVTKIDInternal(const int &ttkId,
                                                        int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{
+  const int nSimplexPerCell{
     ImplicitNoPreconditions::getDimensionality() == 3 ? 6 : 2};
-  vtkId = ttkId / nTetraPerCube;
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/implicitTriangulation/ImplicitPreconditions.h
+++ b/core/base/implicitTriangulation/ImplicitPreconditions.h
@@ -55,6 +55,7 @@ namespace ttk {
       hasPreconditionedVerticesAndCells_ = false;
       return AbstractTriangulation::clear();
     }
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
 
   private:
     // for every vertex, its position on the grid
@@ -128,6 +129,7 @@ namespace ttk {
       this->tetrahedronToPosition(t, p.data());
       return p;
     }
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
   };
 
 } // namespace ttk

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3048,14 +3048,14 @@ int ImplicitTriangulation::preconditionVertexNeighborsInternal() {
 
 int ImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
                                                 int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{ImplicitTriangulation::getDimensionality() == 3 ? 6
-                                                                          : 2};
-  vtkId = ttkId / nTetraPerCube;
+  const int nSimplexPerCell{
+    ImplicitTriangulation::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3053,8 +3053,10 @@ int ImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
     return -1;
   }
 #endif
-  const int nSimplexPerCell{
-    ImplicitTriangulation::getDimensionality() == 3 ? 6 : 2};
+  const int nSimplexPerCell{ImplicitTriangulation::getDimensionality() == 3 ? 6
+                            : ImplicitTriangulation::getDimensionality() == 2
+                              ? 2
+                              : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3046,6 +3046,19 @@ int ImplicitTriangulation::preconditionVertexNeighborsInternal() {
   return 0;
 }
 
+int ImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
+                                                int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{ImplicitTriangulation::getDimensionality() == 3 ? 6
+                                                                          : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}
+
 #ifdef TTK_ENABLE_MPI
 
 int ttk::ImplicitTriangulation::preconditionDistributedCells() {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -237,6 +237,8 @@ namespace ttk {
       return 0;
     }
 
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
+
 #ifdef TTK_ENABLE_MPI
 
   protected:

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1796,6 +1796,19 @@ const vector<vector<SimplexId>> *
   return &cellNeighborList_;
 }
 
+int ttk::PeriodicImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
+                                                             int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{
+    PeriodicImplicitTriangulation::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}
+
 // explicit instantiations
 template class ttk::PeriodicImplicitTriangulationCRTP<
   ttk::PeriodicWithPreconditions>;

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1804,7 +1804,9 @@ int ttk::PeriodicImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
   }
 #endif
   const int nSimplexPerCell{
-    PeriodicImplicitTriangulation::getDimensionality() == 3 ? 6 : 2};
+    PeriodicImplicitTriangulation::getDimensionality() == 3   ? 6
+    : PeriodicImplicitTriangulation::getDimensionality() == 2 ? 2
+                                                              : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.cpp
@@ -1798,14 +1798,14 @@ const vector<vector<SimplexId>> *
 
 int ttk::PeriodicImplicitTriangulation::getCellVTKIDInternal(const int &ttkId,
                                                              int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{
+  const int nSimplexPerCell{
     PeriodicImplicitTriangulation::getDimensionality() == 3 ? 6 : 2};
-  vtkId = ttkId / nTetraPerCube;
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
 

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -244,6 +244,7 @@ namespace ttk {
       }
       return 0;
     }
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
 
   protected:
     int dimensionality_; //

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
@@ -318,26 +318,26 @@ std::array<ttk::SimplexId, 3>
 
 int ttk::PeriodicNoPreconditions::getCellVTKIDInternal(const int &ttkId,
                                                        int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{
+  const int nSimplexPerCell{
     PeriodicNoPreconditions::getDimensionality() == 3 ? 6 : 2};
-  vtkId = ttkId / nTetraPerCube;
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
 
 int ttk::PeriodicWithPreconditions::getCellVTKIDInternal(const int &ttkId,
                                                          int &vtkId) const {
-#ifdef TTK_ENABLE_KAMIZE
+#ifndef TTK_ENABLE_KAMIKAZE
   if(ttkId < 0) {
     return -1;
   }
 #endif
-  const int nTetraPerCube{
+  const int nSimplexPerCell{
     PeriodicWithPreconditions::getDimensionality() == 3 ? 6 : 2};
-  vtkId = ttkId / nTetraPerCube;
+  vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
@@ -324,7 +324,9 @@ int ttk::PeriodicNoPreconditions::getCellVTKIDInternal(const int &ttkId,
   }
 #endif
   const int nSimplexPerCell{
-    PeriodicNoPreconditions::getDimensionality() == 3 ? 6 : 2};
+    PeriodicNoPreconditions::getDimensionality() == 3   ? 6
+    : PeriodicNoPreconditions::getDimensionality() == 2 ? 2
+                                                        : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }
@@ -337,7 +339,9 @@ int ttk::PeriodicWithPreconditions::getCellVTKIDInternal(const int &ttkId,
   }
 #endif
   const int nSimplexPerCell{
-    PeriodicWithPreconditions::getDimensionality() == 3 ? 6 : 2};
+    PeriodicWithPreconditions::getDimensionality() == 3   ? 6
+    : PeriodicWithPreconditions::getDimensionality() == 2 ? 2
+                                                          : 1};
   vtkId = ttkId / nSimplexPerCell;
   return 0;
 }

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.cpp
@@ -315,3 +315,29 @@ std::array<ttk::SimplexId, 3>
   }
   return p;
 }
+
+int ttk::PeriodicNoPreconditions::getCellVTKIDInternal(const int &ttkId,
+                                                       int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{
+    PeriodicNoPreconditions::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}
+
+int ttk::PeriodicWithPreconditions::getCellVTKIDInternal(const int &ttkId,
+                                                         int &vtkId) const {
+#ifdef TTK_ENABLE_KAMIZE
+  if(ttkId < 0) {
+    return -1;
+  }
+#endif
+  const int nTetraPerCube{
+    PeriodicWithPreconditions::getDimensionality() == 3 ? 6 : 2};
+  vtkId = ttkId / nTetraPerCube;
+  return 0;
+}

--- a/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicPreconditions.h
@@ -56,6 +56,8 @@ namespace ttk {
       return AbstractTriangulation::clear();
     }
 
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
+
   private:
     // for  every vertex, its coordinates on the grid
     std::vector<std::array<SimplexId, 3>> vertexCoords_{};
@@ -127,6 +129,8 @@ namespace ttk {
         return p[1] * this->vshift_[0] + p[2] * this->vshift_[1];
       }
     }
+
+    int getCellVTKIDInternal(const int &ttkId, int &vtkId) const override;
   };
 
 } // namespace ttk

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2279,6 +2279,26 @@ namespace ttk {
       return abstractTriangulation_->preconditionVertexEdges();
     }
 
+    ///
+    /// \pre Get the VTK ID of a cell using the TTK ID of a cell.
+    /// For implicit triangulations, VTK cells are squares or cubes,
+    /// whereas TTK cells are triangles and tetrahedron.
+    /// For other triangulations, the TTK and VTK cells coincide.
+    ///
+    /// \param ttkId TTK cell id
+    /// \param vtkId Output VTK cell id
+    /// \return Returns 0 upon success, negative values otherwise.
+    ///
+    inline int getCellVTKID(const int &ttkId, int &vtkId) const override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+
+      return abstractTriangulation_->getCellVTKID(ttkId, vtkId);
+    }
+
 #if TTK_ENABLE_MPI
     /// Pre-process the distributed vertex ids.
     ///

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2280,7 +2280,7 @@ namespace ttk {
     }
 
     ///
-    /// \pre Get the VTK ID of a cell using the TTK ID of a cell.
+    /// \pre Get the VTK id of a cell using the TTK id of a cell.
     /// For implicit triangulations, VTK cells are squares or cubes,
     /// whereas TTK cells are triangles and tetrahedron.
     /// For other triangulations, the TTK and VTK cells coincide.


### PR DESCRIPTION
Add the method getCellVTKID to get the VTK ID of a cell using the TTK ID of a cell. 

For implicit triangulations, VTK cells are squares or cubes, whereas TTK cells are triangles and tetrahedron (corresponding to subdivided simplices of the VTK cells).  For other triangulations, the TTK and VTK cells coincide.  

By default the returned vtk id is equal to the ttk id. For implicit triangulations, the vtk id is equal to the ttk id divided by 2 (in 2D) or 6 (in 3D).

Best regards,
Eve