### PR TITLE
[MPI] Added dimensionNumber to exchangeGhostCells

### DIFF
--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -172,7 +172,8 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
       exchangeGhostCells<dataType, SimplexId>(
         outputData, triangulation->getVertRankArray(),
         triangulation->getVertsGlobalIds(),
-        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_);
+        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
+        dimensionNumber_);
     }
 #endif
 


### PR DESCRIPTION
This PR extends the exchangeGhostCells function to use the optional dimensionNumber parameter. Similarly to the `ttkGeometrySmoother` filter, this allows it to be used for exchanging e.g. 3D point arrays which are compressed into an 1D array.
