### PR TITLE
GitHub Actions: Enforce correct execution of Python scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,12 +154,16 @@ jobs:
             # Ubuntu 22.04 performs more iterations in
             # PersistenceDiagramClustering than older Ubuntu VMs
             rm -f output_screenshots/persistenceDiagramClustering*.png
+            # EigenField output not deterministic...
+            rm -f output_screenshots/persistentGenerators_skull_1.png
           fi
           # HarmonicField output not deterministic...
           rm -f output_screenshots/harmonicSkeleton_0.png
           rm -f output_screenshots/harmonicSkeleton_1.png
           # ViscousFingering plot rendering issues
           rm -rf output_screenshots/viscousFingering_0.png
+          # EigenField output not deterministic...
+          rm -rf output_screenshots/persistentGenerators_fertility_1.png
 
           if [ "$(ls -A output_screenshots)" ]; then
             tar zcf screenshots.tar.gz output_screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,15 +174,19 @@ jobs:
         name: screenshots-${{ matrix.os }}.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
 
-    - name: Run ttk-data Python scripts [NOT ENFORCED]
-      continue-on-error: true
+    - name: Run ttk-data Python scripts
       run: |
         cd ttk-data
         python3 -u python/run.py
-        cat python/res.json
-        diff python/hashes/${{ matrix.os }}.json python/res.json
       env:
         OMP_NUM_THREADS: 1
+
+    - name: Test ttk-data Python scripts results [NOT ENFORCED]
+      continue-on-error: true
+      run: |
+        cd ttk-data
+        cat python/res.json
+        diff python/hashes/${{ matrix.os }}.json python/res.json
 
 
   # -----------------#
@@ -288,16 +292,20 @@ jobs:
         name: screenshots-macOS.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
 
-    - name: Run ttk-data Python scripts [NOT ENFORCED]
-      continue-on-error: true
+    - name: Run ttk-data Python scripts
       run: |
         cd ttk-data
         python3 -u python/run.py
-        cat python/res.json
-        diff python/hashes/macOS.json python/res.json
       env:
         PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
         OMP_NUM_THREADS: 1
+
+    - name: Test ttk-data Python scripts results [NOT ENFORCED]
+      continue-on-error: true
+      run: |
+        cd ttk-data
+        cat python/res.json
+        diff python/hashes/macOS.json python/res.json
 
 
   # ------------------ #
@@ -423,15 +431,20 @@ jobs:
         path: "ttk-data"
       name: Checkout ttk-data
 
-    - name: Run ttk-data Python scripts [NOT ENFORCED]
-      continue-on-error: true
+    - name: Run ttk-data Python scripts
       shell: cmd
       run: |
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib
         set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
         cd ttk-data
         python -u python\run.py
-        type python\res.json
-        FC python\hashes\windows.json python\res.json
       env:
         OMP_NUM_THREADS: 1
+
+    - name: Test ttk-data Python scripts results [NOT ENFORCED]
+      continue-on-error: true
+      shell: cmd
+      run: |
+        cd ttk-data
+        type python\res.json
+        FC python\hashes\windows.json python\res.json

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingVTK.cpp
@@ -162,6 +162,12 @@ int ttk::ttkCinemaImagingVTK::RenderVTKObject(
   auto windowScalars = vtkSmartPointer<vtkRenderWindow>::New();
   this->setupWindow(windowScalars, rendererScalars, resolution);
 
+  if(windowScalars->SupportsOpenGL() == 0) {
+    // MS Windows in a VM does not support OpenGL
+    this->printErr("RenderWindow does not support OpenGL");
+    return 0;
+  }
+
   auto valuePassCollection = vtkSmartPointer<vtkRenderPassCollection>::New();
   std::vector<std::string> valuePassNames;
   size_t firstValuePassIndex = 0;


### PR DESCRIPTION
This PR splits the CI steps that concerns ttk-data Python scripts in two:
1. the first step is to check that all Python scripts run without segfaults, otherwise it will stop the CI with an error
2. the second step will check the outputs of the Python scripts and compare them to the hashes database. If a difference is detected, the current behavior applies: the CI will exit without an error (`continue-on-error: true`), but the workflow summary will still display the errors.

The `geometryApproximation` Python script has been troublesome on Windows, since no OpenGL implementation was available on GitHub's VMs. To avoid segfaults in this particular case, a new check has been added to the `CinemaImaging` module.

Some non-deterministic state file outputs were disabled to avoid overloading the CI servers.

Enjoy,
Pierre