### PR TITLE
Fixes for DiscreteMorseSandwich in ttk-data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,8 +182,6 @@ jobs:
       run: |
         cd ttk-data
         python3 -u python/run.py
-      env:
-        OMP_NUM_THREADS: 1
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]
       continue-on-error: true
@@ -302,7 +300,6 @@ jobs:
         python3 -u python/run.py
       env:
         PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
-        OMP_NUM_THREADS: 1
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]
       continue-on-error: true
@@ -455,8 +452,6 @@ jobs:
         set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
         cd ttk-data
         python -u python\run.py
-      env:
-        OMP_NUM_THREADS: 1
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]
       continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,9 @@ jobs:
             # KarhunenLove screenshots
             rm -f output_screenshots/karhunenLoveDigits64Dimensions_1.png
             rm -f output_screenshots/karhunenLoveDigits64Dimensions_2.png
+            # Weird things with HarmonicSkeleton (old GCC version?)
+            rm -f output_screenshots/harmonicSkeleton_0.png
+            rm -f output_screenshots/harmonicSkeleton_1.png
           fi
           if [[ "$VERS" == *"22.04"* ]]; then
             # Ubuntu 22.04 performs more iterations in
@@ -157,9 +160,6 @@ jobs:
             # EigenField output not deterministic...
             rm -f output_screenshots/persistentGenerators_skull_1.png
           fi
-          # HarmonicField output not deterministic...
-          rm -f output_screenshots/harmonicSkeleton_0.png
-          rm -f output_screenshots/harmonicSkeleton_1.png
           # ViscousFingering plot rendering issues
           rm -rf output_screenshots/viscousFingering_0.png
           # EigenField output not deterministic...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -435,6 +435,19 @@ jobs:
         path: "ttk-data"
       name: Checkout ttk-data
 
+    - name: Resample large datasets
+      shell: python
+      working-directory: ./ttk-data
+      run: |
+        from paraview import simple
+        for ds in ["ctBones.vti"]:
+            vti = simple.XMLImageDataReader(FileName=ds)
+            rsi = simple.ResampleToImage(Input=vti)
+            rsi.SamplingDimensions = [128, 128, 128]
+            simple.SaveData(ds, rsi)
+      env:
+        PYTHONPATH: ${{ env.PV_DIR }}\bin\Lib\site-packages
+
     - name: Run ttk-data Python scripts
       shell: cmd
       run: |

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3642,6 +3642,8 @@ namespace ttk {
     friend class ttk::dcg::DiscreteGradient;
 
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
+    // might no be sufficient for Rips complexes, where a vertex can
+    // have more than 128 neighbors
     using gradIdType = char;
 #else
     using gradIdType = SimplexId;

--- a/core/base/bottleneckDistance/BottleneckDistance.cpp
+++ b/core/base/bottleneckDistance/BottleneckDistance.cpp
@@ -12,6 +12,11 @@ int ttk::BottleneckDistance::execute(const ttk::DiagramType &diag0,
                                      std::vector<MatchingType> &matchings) {
   Timer t;
 
+  if(diag0.empty() || diag1.empty()) {
+    this->printErr("Empty input diagrams");
+    return -1;
+  }
+
   bool fromParaView = this->PVAlgorithm >= 0;
   if(fromParaView) {
     switch(this->PVAlgorithm) {

--- a/core/base/bottleneckDistance/BottleneckDistance.cpp
+++ b/core/base/bottleneckDistance/BottleneckDistance.cpp
@@ -96,7 +96,7 @@ void ttk::BottleneckDistance::buildCostMatrices(
   int sadI = 0, sadJ = 0;
 
   for(const auto &p1 : CTDiagram1) {
-    if(std::abs(p1.persistence) < zeroThresh)
+    if(std::abs(p1.persistence()) < zeroThresh)
       continue;
 
     bool isMin1 = (p1.birth.type == CriticalType::Local_minimum
@@ -118,7 +118,7 @@ void ttk::BottleneckDistance::buildCostMatrices(
     sadJ = 0;
 
     for(const auto &p2 : CTDiagram2) {
-      if(std::abs(p2.persistence) < zeroThresh)
+      if(std::abs(p2.persistence()) < zeroThresh)
         continue;
 
       bool isMin2 = (p2.birth.type == CriticalType::Local_minimum
@@ -196,7 +196,7 @@ void ttk::BottleneckDistance::buildCostMatrices(
 
   // Last row: match remaining J components with diagonal.
   for(const auto &p3 : CTDiagram2) {
-    if(std::abs(p3.persistence) < zeroThresh)
+    if(std::abs(p3.persistence()) < zeroThresh)
       continue;
 
     bool isMin2 = (p3.birth.type == CriticalType::Local_minimum
@@ -309,11 +309,11 @@ double ttk::BottleneckDistance::computeMinimumRelevantPersistence(
   std::vector<double> toSort(CTDiagram1.size() + CTDiagram2.size());
   for(size_t i = 0; i < CTDiagram1.size(); ++i) {
     const auto &t = CTDiagram1[i];
-    toSort[i] = std::abs(t.persistence);
+    toSort[i] = std::abs(t.persistence());
   }
   for(size_t i = 0; i < CTDiagram2.size(); ++i) {
     const auto &t = CTDiagram2[i];
-    toSort[CTDiagram1.size() + i] = std::abs(t.persistence);
+    toSort[CTDiagram1.size() + i] = std::abs(t.persistence());
   }
 
   const auto minVal = *std::min_element(toSort.begin(), toSort.end());
@@ -335,7 +335,7 @@ void ttk::BottleneckDistance::computeMinMaxSaddleNumberAndMapping(
     const auto &t = CTDiagram[i];
     const auto nt1 = t.birth.type;
     const auto nt2 = t.death.type;
-    const auto dt = t.persistence;
+    const auto dt = t.persistence();
     if(std::abs(dt) < zeroThresh)
       continue;
 
@@ -479,7 +479,7 @@ double ttk::BottleneckDistance::diagonalDistanceFunction(
   const bool isMin1 = a.birth.type == CriticalType::Local_minimum;
   const bool isMax1 = a.death.type == CriticalType::Local_maximum;
   const double infDistance = (isMin1 || isMax1 ? this->PE : this->PS)
-                             * Geometry::pow(std::abs(a.persistence), w);
+                             * Geometry::pow(std::abs(a.persistence()), w);
   const double geoDistance
     = (this->PX
          * Geometry::pow(std::abs(a.death.coords[0] - a.birth.coords[0]), w)

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -403,6 +403,11 @@ according to them.
         }
       }
 
+      static inline void
+        clearCache(const AbstractTriangulation &triangulation) {
+        triangulation.gradientCache_.clear();
+      }
+
       /**
        * Set the input offset function.
        *

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1960,6 +1960,7 @@ inline void DiscreteGradient::pairCells(
       triangulation.getVertexEdge(alpha.id_, i, b);
       if(b == beta.id_) {
         localBId = i;
+        break;
       }
     }
   } else if(beta.dim_ == 2) {
@@ -1975,6 +1976,7 @@ inline void DiscreteGradient::pairCells(
       triangulation.getEdgeTriangle(alpha.id_, i, b);
       if(b == beta.id_) {
         localBId = i;
+        break;
       }
     }
   } else {
@@ -1990,6 +1992,7 @@ inline void DiscreteGradient::pairCells(
       triangulation.getTriangleStar(alpha.id_, i, b);
       if(b == beta.id_) {
         localBId = i;
+        break;
       }
     }
   }

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -2189,7 +2189,10 @@ SimplexId
   if(cell.dim_ == 0) {
     if(!isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getVertexEdge(cell.id_, (*gradient_)[0][cell.id_], id);
+      const auto locId{(*gradient_)[0][cell.id_]};
+      if(locId != -1) {
+        triangulation.getVertexEdge(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[0][cell.id_];
 #endif
@@ -2199,13 +2202,19 @@ SimplexId
   else if(cell.dim_ == 1) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getEdgeVertex(cell.id_, (*gradient_)[1][cell.id_], id);
+      const auto locId{(*gradient_)[1][cell.id_]};
+      if(locId != -1) {
+        triangulation.getEdgeVertex(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[1][cell.id_];
 #endif
     } else {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getEdgeTriangle(cell.id_, (*gradient_)[2][cell.id_], id);
+      const auto locId{(*gradient_)[2][cell.id_]};
+      if(locId != -1) {
+        triangulation.getEdgeTriangle(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[2][cell.id_];
 #endif
@@ -2215,13 +2224,19 @@ SimplexId
   else if(cell.dim_ == 2) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getTriangleEdge(cell.id_, (*gradient_)[3][cell.id_], id);
+      const auto locId{(*gradient_)[3][cell.id_]};
+      if(locId != -1) {
+        triangulation.getTriangleEdge(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[3][cell.id_];
 #endif
     } else {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getTriangleStar(cell.id_, (*gradient_)[4][cell.id_], id);
+      const auto locId{(*gradient_)[4][cell.id_]};
+      if(locId != -1) {
+        triangulation.getTriangleStar(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[4][cell.id_];
 #endif
@@ -2231,7 +2246,10 @@ SimplexId
   else if(cell.dim_ == 3) {
     if(isReverse) {
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
-      triangulation.getCellTriangle(cell.id_, (*gradient_)[5][cell.id_], id);
+      const auto locId{(*gradient_)[5][cell.id_]};
+      if(locId != -1) {
+        triangulation.getCellTriangle(cell.id_, locId, id);
+      }
 #else
       id = (*gradient_)[5][cell.id_];
 #endif

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.cpp
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.cpp
@@ -21,6 +21,14 @@ void ttk::DiscreteMorseSandwich::tripletsToPersistencePairs(
     const auto s1 = t1[0];
     const auto m0 = t0[2];
     const auto m1 = t1[2];
+
+#ifdef _LIBCPP_VERSION
+    // libc++'s std::sort compares an entry to itself
+    if(&t0 == &t1) {
+      return true;
+    }
+#endif // _LIBCPP_VERSION
+
     if(s0 != s1)
       return saddlesOrder[s0] > saddlesOrder[s1];
     else

--- a/core/base/eigenField/EigenField.cpp
+++ b/core/base/eigenField/EigenField.cpp
@@ -38,7 +38,7 @@ int ttk::EigenField::execute(const TriangulationType &triangulation,
   // graph laplacian of current mesh
   SpMat lap;
   // compute graph laplacian using cotangent weights
-  Laplacian::cotanWeights<T>(lap, triangulation);
+  Laplacian::cotanWeights<T>(lap, *this, triangulation);
   // lap is square
   eigen_plain_assert(lap.cols() == lap.rows());
 

--- a/core/base/eigenField/EigenField.h
+++ b/core/base/eigenField/EigenField.h
@@ -41,9 +41,7 @@ namespace ttk {
 
     inline void
       preconditionTriangulation(AbstractTriangulation &triangulation) const {
-      triangulation.preconditionVertexNeighbors();
-      // cotan weights method needs more pre-processing
-      triangulation.preconditionEdgeTriangles();
+      Laplacian::preconditionTriangulation(triangulation);
     }
 
     template <typename T, class TriangulationType = AbstractTriangulation>

--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -1,5 +1,4 @@
 #include <HarmonicField.h>
-#include <Laplacian.h>
 #include <set>
 
 #ifdef TTK_ENABLE_EIGEN

--- a/core/base/harmonicField/HarmonicField.cpp
+++ b/core/base/harmonicField/HarmonicField.cpp
@@ -120,9 +120,9 @@ int ttk::HarmonicField::execute(const TriangulationType &triangulation,
   // graph laplacian of current mesh
   SpMat lap;
   if(useCotanWeights) {
-    Laplacian::cotanWeights<T>(lap, triangulation);
+    Laplacian::cotanWeights<T>(lap, *this, triangulation);
   } else {
-    Laplacian::discreteLaplacian<T>(lap, triangulation);
+    Laplacian::discreteLaplacian<T>(lap, *this, triangulation);
   }
 
   // constraints vector

--- a/core/base/harmonicField/HarmonicField.h
+++ b/core/base/harmonicField/HarmonicField.h
@@ -19,6 +19,7 @@
 #pragma once
 
 // base code includes
+#include <Laplacian.h>
 #include <Triangulation.h>
 
 namespace ttk {
@@ -33,14 +34,9 @@ namespace ttk {
       this->setDebugMsgPrefix("HarmonicField");
     }
 
-    inline void preconditionTriangulation(AbstractTriangulation &triangulation,
-                                          const bool cotanWeights) {
-      triangulation.preconditionVertexNeighbors();
-      triangulation.preconditionEdges();
-      if(cotanWeights) {
-        // cotan weights method needs more pre-processing
-        triangulation.preconditionEdgeTriangles();
-      }
+    inline void
+      preconditionTriangulation(AbstractTriangulation &triangulation) const {
+      Laplacian::preconditionTriangulation(triangulation);
     }
 
     template <class T, class TriangulationType = AbstractTriangulation>

--- a/core/base/laplacian/Laplacian.cpp
+++ b/core/base/laplacian/Laplacian.cpp
@@ -13,6 +13,8 @@ int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
                                       const Debug &dbg,
                                       const TriangulationType &triangulation) {
 
+  Timer tm{};
+
   using Triplet = Eigen::Triplet<T>;
   const auto vertexNumber = triangulation.getNumberOfVertices();
   const auto edgeNumber = triangulation.getNumberOfEdges();
@@ -22,9 +24,7 @@ int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
     return -1;
   }
 
-#ifdef TTK_ENABLE_OPENMP
   const auto threadNumber = dbg.getThreadNumber();
-#endif // TTK_ENABLE_OPENMP
 
   // clear output
   output.resize(vertexNumber, vertexNumber);
@@ -64,6 +64,9 @@ int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
   output.setFromTriplets(triplets.begin(), triplets.end());
 #endif // __clang_analyzer__
 
+  dbg.printMsg(
+    "Computed Discrete Laplacian", 1.0, tm.getElapsedTime(), threadNumber);
+
   return 0;
 }
 
@@ -74,13 +77,13 @@ int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
                                  const Debug &dbg,
                                  const TriangulationType &triangulation) {
 
+  Timer tm{};
+
   using Triplet = Eigen::Triplet<T>;
   const auto vertexNumber = triangulation.getNumberOfVertices();
   const auto edgeNumber = triangulation.getNumberOfEdges();
 
-#ifdef TTK_ENABLE_OPENMP
   const auto threadNumber = dbg.getThreadNumber();
-#endif // TTK_ENABLE_OPENMP
 
   // early return when input graph is empty
   if(vertexNumber <= 0) {
@@ -183,6 +186,9 @@ int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
 #ifndef __clang_analyzer__
   output.setFromTriplets(triplets.begin(), triplets.end());
 #endif // __clang_analyzer__
+
+  dbg.printMsg("Computed Laplacian with Cotan Weights", 1.0,
+               tm.getElapsedTime(), threadNumber);
 
   return 0;
 }

--- a/core/base/laplacian/Laplacian.cpp
+++ b/core/base/laplacian/Laplacian.cpp
@@ -10,6 +10,7 @@ template <typename T,
           class TriangulationType,
           typename SparseMatrixType = Eigen::SparseMatrix<T>>
 int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
+                                      const Debug &dbg,
                                       const TriangulationType &triangulation) {
 
   using Triplet = Eigen::Triplet<T>;
@@ -22,8 +23,7 @@ int ttk::Laplacian::discreteLaplacian(SparseMatrixType &output,
   }
 
 #ifdef TTK_ENABLE_OPENMP
-  // get thread number from triangulation?
-  const auto threadNumber = triangulation.getThreadNumber();
+  const auto threadNumber = dbg.getThreadNumber();
 #endif // TTK_ENABLE_OPENMP
 
   // clear output
@@ -71,6 +71,7 @@ template <typename T,
           class TriangulationType,
           typename SparseMatrixType = Eigen::SparseMatrix<T>>
 int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
+                                 const Debug &dbg,
                                  const TriangulationType &triangulation) {
 
   using Triplet = Eigen::Triplet<T>;
@@ -78,8 +79,7 @@ int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
   const auto edgeNumber = triangulation.getNumberOfEdges();
 
 #ifdef TTK_ENABLE_OPENMP
-  // get thread number from triangulation?
-  const auto threadNumber = triangulation.getThreadNumber();
+  const auto threadNumber = dbg.getThreadNumber();
 #endif // TTK_ENABLE_OPENMP
 
   // early return when input graph is empty
@@ -187,11 +187,11 @@ int ttk::Laplacian::cotanWeights(SparseMatrixType &output,
   return 0;
 }
 
-#define LAPLACIAN_SPECIALIZE(TYPE)                       \
-  template int ttk::Laplacian::discreteLaplacian<TYPE>(  \
-    Eigen::SparseMatrix<TYPE> &, const Triangulation &); \
-  template int ttk::Laplacian::cotanWeights<TYPE>(       \
-    Eigen::SparseMatrix<TYPE> &, const Triangulation &)
+#define LAPLACIAN_SPECIALIZE(TYPE)                                         \
+  template int ttk::Laplacian::discreteLaplacian<TYPE>(                    \
+    Eigen::SparseMatrix<TYPE> &, const Debug &dbg, const Triangulation &); \
+  template int ttk::Laplacian::cotanWeights<TYPE>(                         \
+    Eigen::SparseMatrix<TYPE> &, const Debug &dbg, const Triangulation &)
 
 // explicit intantiations for floating-point types
 LAPLACIAN_SPECIALIZE(float);

--- a/core/base/laplacian/Laplacian.h
+++ b/core/base/laplacian/Laplacian.h
@@ -4,6 +4,18 @@
 
 namespace ttk {
   namespace Laplacian {
+
+    /**
+     * @brief Triangulation precondition function
+     */
+    inline void
+      preconditionTriangulation(AbstractTriangulation &triangulation) {
+      triangulation.preconditionVertexNeighbors();
+      triangulation.preconditionVertexEdges();
+      triangulation.preconditionTriangles();
+      triangulation.preconditionEdgeTriangles();
+    }
+
     /**
      * @brief Compute the Laplacian matrix of the graph
      *

--- a/core/base/laplacian/Laplacian.h
+++ b/core/base/laplacian/Laplacian.h
@@ -8,6 +8,7 @@ namespace ttk {
      * @brief Compute the Laplacian matrix of the graph
      *
      * @param[out] output Laplacian matrix
+     * @param[in] dbg Debug instance
      * @param[in] triangulation Access to neighbor vertices, should be already
      * preprocessed
      *
@@ -17,6 +18,7 @@ namespace ttk {
               class TriangulationType = AbstractTriangulation,
               typename SparseMatrixType>
     int discreteLaplacian(SparseMatrixType &output,
+                          const Debug &dbg,
                           const TriangulationType &triangulation);
 
     /**
@@ -24,6 +26,7 @@ namespace ttk {
      * cotangente weights method
      *
      * @param[out] output Laplacian matrix
+     * @param[in] dbg Debug instance
      * @param[in] triangulation Access to neighbor vertices, should be already
      * preprocessed
      *
@@ -33,6 +36,7 @@ namespace ttk {
               class TriangulationType = AbstractTriangulation,
               typename SparseMatrixType>
     int cotanWeights(SparseMatrixType &output,
+                     const Debug &dbg,
                      const TriangulationType &triangulation);
 
   } // namespace Laplacian

--- a/core/base/persistenceDiagram/PersistenceDiagramUtils.h
+++ b/core/base/persistenceDiagram/PersistenceDiagramUtils.h
@@ -30,8 +30,6 @@ namespace ttk {
     ttk::CriticalVertex birth;
     /** pair death */
     ttk::CriticalVertex death;
-    /** pair persistence (death.sfValue - birth.sfValue) */
-    double persistence;
     /** pair dimension */
     ttk::SimplexId dim;
     /** to help distinguish homology classes with infinite persistence
@@ -44,6 +42,13 @@ namespace ttk {
      */
     bool operator<(const PersistencePair &rhs) const {
       return this->birth.sfValue < rhs.birth.sfValue;
+    }
+
+    /**
+     * @brief Return the topological persistence of the pair
+     */
+    inline double persistence() const {
+      return this->death.sfValue - this->birth.sfValue;
     }
   };
 

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -626,9 +626,9 @@ std::vector<std::vector<ttk::MatchingType>>
     barycenter.clear();
     for(size_t j = 0; j < barycenter_goods_[0].size(); j++) {
       Good &g = barycenter_goods_[0].at(j);
-      barycenter.emplace_back(PersistencePair{
-        CriticalVertex{0, nt1_, g.x_, {}}, CriticalVertex{0, nt2_, g.y_, {}},
-        g.getPersistence(), diagramType_, true});
+      barycenter.emplace_back(PersistencePair{CriticalVertex{0, nt1_, g.x_, {}},
+                                              CriticalVertex{0, nt2_, g.y_, {}},
+                                              diagramType_, true});
     }
 
     runMatchingAuction(&total_cost, sizes, *pair.first, pair.second,
@@ -675,9 +675,9 @@ std::vector<std::vector<ttk::MatchingType>>
   barycenter.resize(0);
   for(size_t j = 0; j < barycenter_goods_[0].size(); j++) {
     Good &g = barycenter_goods_[0].at(j);
-    barycenter.emplace_back(PersistencePair{
-      CriticalVertex{0, nt1_, g.x_, {}}, CriticalVertex{0, nt2_, g.y_, {}},
-      g.getPersistence(), diagramType_, true});
+    barycenter.emplace_back(PersistencePair{CriticalVertex{0, nt1_, g.x_, {}},
+                                            CriticalVertex{0, nt2_, g.y_, {}},
+                                            diagramType_, true});
   }
 
   cost_ = sqrt(total_cost);

--- a/core/base/persistenceDiagramClustering/PDClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PDClustering.cpp
@@ -427,16 +427,16 @@ std::vector<int> ttk::PDClustering::execute(
       const auto &critCoords = g.GetCriticalCoordinates();
       final_centroids[c].emplace_back(PersistencePair{
         CriticalVertex{0, CriticalType::Local_minimum, g.x_, critCoords},
-        CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords},
-        g.getPersistence(), 0, false});
+        CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords}, 0,
+        false});
       addedFirstPairMax = 1;
     } else if(do_min_) {
       Good &g = centroids_min_[c].at(0);
       const auto &critCoords = g.GetCriticalCoordinates();
       final_centroids[c].emplace_back(PersistencePair{
         CriticalVertex{0, CriticalType::Local_minimum, g.x_, critCoords},
-        CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords},
-        g.getPersistence(), 0, false});
+        CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords}, 0,
+        false});
       addedFirstPairMin = 1;
     }
 
@@ -446,8 +446,7 @@ std::vector<int> ttk::PDClustering::execute(
         const auto &critCoords = g.GetCriticalCoordinates();
         final_centroids[c].emplace_back(PersistencePair{
           CriticalVertex{0, CriticalType::Local_minimum, g.x_, critCoords},
-          CriticalVertex{0, CriticalType::Saddle1, g.y_, critCoords},
-          g.getPersistence(), 0, true});
+          CriticalVertex{0, CriticalType::Saddle1, g.y_, critCoords}, 0, true});
         if(g.getPersistence() > 1000) {
           this->printMsg("Found a anormally high persistence in min diagram",
                          debug::Priority::WARNING);
@@ -461,8 +460,7 @@ std::vector<int> ttk::PDClustering::execute(
         const auto &critCoords = g.GetCriticalCoordinates();
         final_centroids[c].emplace_back(PersistencePair{
           CriticalVertex{0, CriticalType::Saddle1, g.x_, critCoords},
-          CriticalVertex{0, CriticalType::Saddle2, g.y_, critCoords},
-          g.getPersistence(), 1, true});
+          CriticalVertex{0, CriticalType::Saddle2, g.y_, critCoords}, 1, true});
         if(g.getPersistence() > 1000) {
           this->printMsg("Found a anormally high persistence in sad diagram",
                          debug::Priority::WARNING);
@@ -482,8 +480,8 @@ std::vector<int> ttk::PDClustering::execute(
 
         final_centroids[c].emplace_back(PersistencePair{
           CriticalVertex{0, saddle_type, g.x_, critCoords},
-          CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords},
-          g.getPersistence(), 2, true});
+          CriticalVertex{0, CriticalType::Local_maximum, g.y_, critCoords}, 2,
+          true});
 
         if(g.getPersistence() > 1000) {
           this->printMsg("Found a anormally high persistence in min diagram",

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
@@ -32,7 +32,7 @@ void ttk::PersistenceDiagramBarycenter::execute(
       ttk::CriticalType nt1 = t.birth.type;
       ttk::CriticalType nt2 = t.death.type;
 
-      double dt = t.persistence;
+      double dt = t.persistence();
       // if (abs<double>(dt) < zeroThresh) continue;
       if(dt > 0) {
         if(nt1 == ttk::CriticalType::Local_minimum

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramClustering.cpp
@@ -35,7 +35,7 @@ std::vector<int> ttk::PersistenceDiagramClustering::execute(
       ttk::CriticalType nt1 = t.birth.type;
       ttk::CriticalType nt2 = t.death.type;
 
-      double dt = t.persistence;
+      double dt = t.persistence();
       // if (abs<double>(dt) < zeroThresh) continue;
       if(dt > 0) {
         if(nt1 == ttk::CriticalType::Local_minimum

--- a/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
+++ b/core/base/persistenceDiagramDistanceMatrix/PersistenceDiagramDistanceMatrix.cpp
@@ -43,9 +43,9 @@ std::vector<std::vector<double>> PersistenceDiagramDistanceMatrix::execute(
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nDiags; i++) {
     for(const auto &p : intermediateDiagrams[i]) {
-      maxDiagPersistence[i] = std::max(p.persistence, maxDiagPersistence[i]);
+      maxDiagPersistence[i] = std::max(p.persistence(), maxDiagPersistence[i]);
 
-      if(p.persistence > 0) {
+      if(p.persistence() > 0) {
         if(p.birth.type == CriticalType::Local_minimum
            && p.death.type == CriticalType::Local_maximum) {
           inputDiagramsMax[i].emplace_back(p);

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -128,7 +128,7 @@ int ttk::TrackingFromFields::performDiagramComputation(
       persistenceDiagrams[i][j] = PersistencePair{
         CriticalVertex{currentTuple.birth.id, currentTuple.birth.type, sa, p},
         CriticalVertex{currentTuple.death.id, currentTuple.death.type, sb, q},
-        currentTuple.persistence, currentTuple.dim, true};
+        currentTuple.dim, true};
     }
   }
 

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -98,36 +98,18 @@ int ttk::TrackingFromFields::performDiagramComputation(
   for(int i = 0; i < fieldNumber; ++i) {
     ttk::PersistenceDiagram persistenceDiagram;
     persistenceDiagram.setThreadNumber(1);
+    persistenceDiagram.execute(persistenceDiagrams[i],
+                               (dataType *)(inputData_[i]), 0, inputOffsets_[i],
+                               triangulation);
 
-    // std::vector<std::tuple<ttk::dcg::Cell, ttk::dcg::Cell>> dmt_pairs;
-    // persistenceDiagram.setDMTPairs(&dmt_pairs);
-    // persistenceDiagram.setInputScalars(inputData_[i]);
-    // persistenceDiagram.setInputOffsets(inputOffsets_);
-    persistenceDiagram.setComputeSaddleConnectors(false);
-    ttk::DiagramType CTDiagram{};
-
-    // persistenceDiagram.setOutputCTDiagram(&CTDiagram);
-    persistenceDiagram.execute<dataType, triangulationType>(
-      CTDiagram, (dataType *)(inputData_[i]), 0, inputOffsets_[i],
-      triangulation);
-
-    // Copy diagram into augmented diagram.
-    persistenceDiagrams[i].resize(CTDiagram.size());
-
-    for(int j = 0; j < (int)CTDiagram.size(); ++j) {
-      std::array<float, 3> p{};
-      std::array<float, 3> q{};
-      auto currentTuple = CTDiagram[j];
-      const int a = currentTuple.birth.id;
-      const int b = currentTuple.death.id;
-      triangulation->getVertexPoint(a, p[0], p[1], p[2]);
-      triangulation->getVertexPoint(b, q[0], q[1], q[2]);
-      const double sa = ((double *)inputData_[i])[a];
-      const double sb = ((double *)inputData_[i])[b];
-      persistenceDiagrams[i][j] = PersistencePair{
-        CriticalVertex{currentTuple.birth.id, currentTuple.birth.type, sa, p},
-        CriticalVertex{currentTuple.death.id, currentTuple.death.type, sb, q},
-        currentTuple.dim, true};
+    // Augment diagram.
+    for(auto &pair : persistenceDiagrams[i]) {
+      triangulation->getVertexPoint(pair.birth.id, pair.birth.coords[0],
+                                    pair.birth.coords[1], pair.birth.coords[2]);
+      triangulation->getVertexPoint(pair.death.id, pair.death.coords[0],
+                                    pair.death.coords[1], pair.death.coords[2]);
+      pair.birth.sfValue = static_cast<double *>(inputData_[i])[pair.birth.id];
+      pair.death.sfValue = static_cast<double *>(inputData_[i])[pair.death.id];
     }
   }
 

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -98,7 +98,6 @@ int ttk::TrackingFromFields::performDiagramComputation(
   for(int i = 0; i < fieldNumber; ++i) {
     ttk::PersistenceDiagram persistenceDiagram;
     persistenceDiagram.setThreadNumber(1);
-    persistenceDiagram.setBackend(PersistenceDiagram::BACKEND::FTM);
 
     // std::vector<std::tuple<ttk::dcg::Cell, ttk::dcg::Cell>> dmt_pairs;
     // persistenceDiagram.setDMTPairs(&dmt_pairs);

--- a/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
+++ b/core/vtk/ttkHarmonicField/ttkHarmonicField.cpp
@@ -50,7 +50,7 @@ int ttkHarmonicField::RequestData(vtkInformation *ttkNotUsed(request),
     this->printErr("No triangulation");
     return 0;
   }
-  this->preconditionTriangulation(*triangulation, UseCotanWeights);
+  this->preconditionTriangulation(*triangulation);
 
   vtkDataArray *inputField = this->GetInputArrayToProcess(0, identifiers);
   std::vector<ttk::SimplexId> idSpareStorage{};

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -82,6 +82,11 @@ int ttkPersistenceDiagram::dispatch(
 
   outputCTPersistenceDiagram->ShallowCopy(vtu);
 
+  if(this->ClearDGCache && this->BackEnd == BACKEND::DISCRETE_MORSE_SANDWICH) {
+    this->printMsg("Clearing DiscreteGradient cache...");
+    ttk::dcg::DiscreteGradient::clearCache(*triangulation);
+  }
+
   return 1;
 }
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -221,6 +221,9 @@ public:
     this->Modified();
   }
 
+  vtkSetMacro(ClearDGCache, bool);
+  vtkGetMacro(ClearDGCache, bool);
+
 protected:
   ttkPersistenceDiagram();
 
@@ -247,4 +250,6 @@ private:
   // stores the values of Compute[Min|Sad][Sad|Max] GUI checkboxes
   // when "All Dimensions" is selected
   std::array<bool, 3> dmsDimsCache{true, true, true};
+  // clear DiscreteGradient cache after computation
+  bool ClearDGCache{false};
 };

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -146,8 +146,7 @@ int VTUToDiagram(ttk::DiagramType &diagram,
     // put pairs in diagram
     diagram[i] = ttk::PersistencePair{
       ttk::CriticalVertex{v0, ct0, birth, coordsBirth},
-      ttk::CriticalVertex{v1, ct1, birth + pers, coordsDeath}, pers, pType,
-      isFin};
+      ttk::CriticalVertex{v1, ct1, birth + pers, coordsDeath}, pType, isFin};
   }
 
   return 0;
@@ -266,7 +265,7 @@ int DiagramToVTU(vtkUnstructuredGrid *vtu,
 
     // cell data
     pairsId->SetTuple1(i, i);
-    persistence->SetTuple1(i, pair.persistence);
+    persistence->SetTuple1(i, pair.persistence());
     birthScalars->SetTuple1(i, pair.birth.sfValue);
     isFinite->SetTuple1(i, pair.isFinite);
     pairsDim->SetTuple1(
@@ -290,7 +289,7 @@ int DiagramToVTU(vtkUnstructuredGrid *vtu,
     pairsDim->InsertTuple1(diagram.size(), -1);
     isFinite->InsertTuple1(diagram.size(), false);
     // persistence of global min-max pair
-    const auto maxPersistence = diagram[0].persistence;
+    const auto maxPersistence = diagram[0].persistence();
     persistence->InsertTuple1(diagram.size(), 2 * maxPersistence);
     // birth == death == 0
     birthScalars->InsertTuple1(diagram.size(), 0);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -112,7 +112,7 @@ int ttkPersistenceDiagramClustering::RequestData(
         diag.back().birth.type = ttk::CriticalType::Saddle1;
         diag.back().death.type = ttk::CriticalType::Local_maximum;
       }
-      max_persistences[i] = diag[0].persistence;
+      max_persistences[i] = diag[0].persistence();
     }
 
     this->max_dimension_total_

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
   std::vector<float> simplifiedHeight = height;
   std::vector<ttk::SimplexId> authorizedCriticalPoints, simplifiedOrder = order;
   for(int i = 0; i < (int)diagramOutput.size(); i++) {
-    if(diagramOutput[i].persistence > 0.05) {
+    if(diagramOutput[i].persistence() > 0.05) {
       // 5. selecting the most persistent pairs
       authorizedCriticalPoints.push_back(diagramOutput[i].birth.id);
       authorizedCriticalPoints.push_back(diagramOutput[i].death.id);

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -488,6 +488,25 @@
         </Documentation>
       </IntVectorProperty>
 
+      <IntVectorProperty
+          name="ClearDGCache"
+          label="Clear DiscreteGradient Cache"
+          command="SetClearDGCache"
+          number_of_elements="1"
+          default_values="0"
+          panel_visibility="advanced" >
+        <BooleanDomain name="bool"/>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+                                   mode="visibility"
+                                   property="BackEnd"
+                                   value="2" />
+        </Hints>
+        <Documentation>
+          To clear the DiscreteGradient cache after computation (releases memory).
+        </Documentation>
+      </IntVectorProperty>
+
       <PropertyGroup panel_widget="Line" label="Input options">
         <Property name="ScalarFieldNew" />
         <Property name="ForceInputOffsetScalarField"/>
@@ -510,6 +529,7 @@
         <Property name="ComputeMinSad" />
         <Property name="ComputeSadSad" />
         <Property name="ComputeSadMax" />
+        <Property name="ClearDGCache" />
         <Property name="ShowInsideDomain" />
       </PropertyGroup>
 


### PR DESCRIPTION
This PR contains fixes that allow the FTM to DMS switch in the ttk-data state files and Python scripts. This is the companion PR to https://github.com/topology-tool-kit/ttk-data/pull/134.

Among those fixes:
* a new option for the `PersistenceDiagram` filter allows to clear the `DiscreteGradient` cache after the computation in order to release memory;
* a segfault in libc++ `std::sort` has been fixed in `DiscreteMorseSandwich`;
* `TrackingFromFields` now uses `DiscreteMorseSandwich` instead of FTM;
* the `Laplacian` module now correctly uses the calling module thread numbers and a critical section in the main parallel loop has been removed, making the filter more deterministic;
* checks were added for the `TTK_DCG_OPTIMIZE_MEMORY` option of the DiscreteGradient module, ensuring that only valid local simplex indices were passed to the triangulation;
* for the GitHub Actions Windows job, the `ctBones.vti` dataset has been resampled to reduce it size (the VMs don't have enough RAM);
* the GitHub Actions CI now executes the Python scripts in parallel.

This PR also includes a change in the internal structure of the Persistence Diagram: the `persistence` class member has been removed; instead, an accessor returns the `death - birth` in order to enforce this invariant.

Enjoy,
Pierre