### PR TITLE
PersistenceCurve: Take PersistenceDiagram as input

### DIFF
--- a/core/base/persistenceCurve/CMakeLists.txt
+++ b/core/base/persistenceCurve/CMakeLists.txt
@@ -4,7 +4,6 @@ ttk_add_base_library(persistenceCurve
   HEADERS
     PersistenceCurve.h
   DEPENDS
-    discreteGradient
-    triangulation
-    ftmTreePP
+    persistenceDiagram
+    geometry
     )

--- a/core/base/persistenceCurve/PersistenceCurve.cpp
+++ b/core/base/persistenceCurve/PersistenceCurve.cpp
@@ -1,5 +1,53 @@
+#include <Geometry.h>
 #include <PersistenceCurve.h>
 
 ttk::PersistenceCurve::PersistenceCurve() {
   setDebugMsgPrefix("PersistenceCurve");
+}
+
+int ttk::PersistenceCurve::execute(std::array<PlotType, 4> &plots,
+                                   const DiagramType &diagram) const {
+
+  const auto epsilon{Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS)};
+
+  // copy input diagram and sort the copy by pair persistence
+  auto sortedDiagram{diagram};
+
+  TTK_PSORT(this->threadNumber_, sortedDiagram.begin(), sortedDiagram.end(),
+            [](const PersistencePair &a, const PersistencePair &b) {
+              return a.persistence() < b.persistence();
+            });
+
+  for(const auto &pair : sortedDiagram) {
+    // per dimension
+    plots[pair.dim].emplace_back(
+      std::max(pair.persistence(), epsilon), plots[pair.dim].size());
+    // all pairs
+    plots[3].emplace_back(
+      std::max(pair.persistence(), epsilon), plots[3].size());
+  }
+
+  for(auto &plot : plots) {
+    for(auto &el : plot) {
+      el.second = plot.size() - el.second;
+    }
+  }
+
+  // look at the first finite pair of dimension 1
+  const auto firstPairDim1 = std::find_if(
+    diagram.begin(), diagram.end(),
+    [](const PersistencePair &p) { return p.dim == 1 && p.isFinite; });
+
+  // if critical type of death is maximum, the diagram was computed on
+  // a 2D dataset
+  const auto datasetIs2D
+    = firstPairDim1 != diagram.end()
+      && firstPairDim1->death.type == ttk::CriticalType::Local_maximum;
+
+  // enforce plots[2] is for saddle-max pairs
+  if(datasetIs2D) {
+    plots[2] = std::move(plots[1]);
+  }
+
+  return 0;
 }

--- a/core/base/persistenceCurve/PersistenceCurve.h
+++ b/core/base/persistenceCurve/PersistenceCurve.h
@@ -2,13 +2,14 @@
 /// \class ttk::PersistenceCurve
 /// \author Guillaume Favelier <guillaume.favelier@lip6.fr>
 /// \author Julien Tierny <julien.tierny@lip6.fr>
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
 /// \date September 2016.
 ///
 /// \brief TTK processing package for the computation of persistence curves.
 ///
-/// This package computes the list of extremum-saddle pairs and computes the
-/// number of pairs as a function of persistence (i.e. the number of pairs
-/// whose persistence is higher than a threshold).
+/// This package takes a \ref ttk::DiagramType as input and computes
+/// the number of pairs as a function of persistence (i.e. the number
+/// of pairs whose persistence is higher than a threshold).
 ///
 /// These curves provide useful visual clues in order to fine-tune persistence
 /// simplification thresholds.
@@ -31,195 +32,29 @@
 #pragma once
 
 // base code includes
-#include <DiscreteGradient.h>
-#include <FTMTreePP.h>
-#include <Triangulation.h>
+#include <Debug.h>
+#include <PersistenceDiagramUtils.h>
 
 namespace ttk {
-
-  /**
-   * Compute the persistence curve of a function on a triangulation.
-   * TTK assumes that the input dataset is made of only one connected component.
-   */
   class PersistenceCurve : virtual public Debug {
-
   public:
     PersistenceCurve();
 
-    inline void setComputeSaddleConnectors(bool state) {
-      ComputeSaddleConnectors = state;
-    }
-
-    template <typename scalarType>
-    int computePersistencePlot(
-      const std::vector<std::tuple<SimplexId, SimplexId, scalarType>> &pairs,
-      std::vector<std::pair<scalarType, SimplexId>> &plot) const;
+    /**
+     * Plot of (Persistence, Number of Pairs)
+     */
+    using PlotType = std::vector<std::pair<double, SimplexId>>;
 
     /**
-     * @pre For this function to behave correctly in the absence of
-     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
-     * called to fill the @p inputOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
-     * automatically generate such a preconditioned buffer).
-     * @see examples/c++/main.cpp for an example use.
+     * @brief Compute the Persistence Curve from the input Diagram
+     *
+     * @param[out] plots Array of 4 PlotTypes: minimum-saddle plot,
+     * saddle-saddle plot, saddle-maximum plot and all pairs plot
+     * @param[in] diagram Input Persistence Diagram
+     *
+     * @return 0 in case of success
      */
-    template <typename scalarType,
-              class triangulationType = ttk::AbstractTriangulation>
-    int execute(const scalarType *inputScalars,
-                const size_t scalarsMTime,
-                const SimplexId *inputOffsets,
-                const triangulationType *triangulation);
-
-    inline void
-      preconditionTriangulation(AbstractTriangulation *const triangulation) {
-      if(triangulation) {
-        triangulation->preconditionBoundaryVertices();
-        contourTree_.setDebugLevel(debugLevel_);
-        contourTree_.preconditionTriangulation(triangulation);
-        if(this->ComputeSaddleConnectors) {
-          dcg_.setDebugLevel(debugLevel_);
-          dcg_.setThreadNumber(threadNumber_);
-          dcg_.preconditionTriangulation(triangulation);
-        }
-      }
-    }
-
-    inline void setOutputJTPlot(void *const data) {
-      JTPlot_ = data;
-    }
-    inline void setOutputSTPlot(void *const data) {
-      STPlot_ = data;
-    }
-    inline void setOutputCTPlot(void *const data) {
-      CTPlot_ = data;
-    }
-    inline void setOutputMSCPlot(void *const data) {
-      MSCPlot_ = data;
-    }
-
-  protected:
-    void *JTPlot_{};
-    void *STPlot_{};
-    void *CTPlot_{};
-    void *MSCPlot_{};
-    bool ComputeSaddleConnectors{false};
-    ftm::FTMTreePP contourTree_{};
-    dcg::DiscreteGradient dcg_{};
+    int execute(std::array<PlotType, 4> &plots,
+                const DiagramType &diagram) const;
   };
 } // namespace ttk
-
-template <typename scalarType>
-int ttk::PersistenceCurve::computePersistencePlot(
-  const std::vector<std::tuple<SimplexId, SimplexId, scalarType>> &pairs,
-  std::vector<std::pair<scalarType, SimplexId>> &plot) const {
-
-  SimplexId nbElmnt = pairs.size();
-  plot.resize(nbElmnt);
-
-  // build curve
-  const scalarType epsilon
-    = static_cast<scalarType>(Geometry::powIntTen(-REAL_SIGNIFICANT_DIGITS));
-  for(SimplexId i = 0; i < nbElmnt; ++i) {
-    plot[i].first = std::max(std::get<2>(pairs[i]), epsilon);
-    plot[i].second = pairs.size() - i;
-  }
-
-  return 0;
-}
-
-template <typename scalarType, class triangulationType>
-int ttk::PersistenceCurve::execute(const scalarType *inputScalars,
-                                   const size_t scalarsMTime,
-                                   const SimplexId *inputOffsets,
-                                   const triangulationType *triangulation) {
-
-  printMsg(ttk::debug::Separator::L1);
-
-  Timer timer;
-
-  using plotType = std::vector<std::pair<scalarType, SimplexId>>;
-
-  auto JTPlot = static_cast<plotType *>(JTPlot_);
-  auto STPlot = static_cast<plotType *>(STPlot_);
-  auto CTPlot = static_cast<plotType *>(CTPlot_);
-  auto MSCPlot = static_cast<plotType *>(MSCPlot_);
-
-  contourTree_.setVertexScalars(inputScalars);
-  contourTree_.setTreeType(ftm::TreeType::Join_Split);
-  contourTree_.setVertexSoSoffsets(inputOffsets);
-  contourTree_.setSegmentation(false);
-  contourTree_.setThreadNumber(threadNumber_);
-  contourTree_.build<scalarType>(triangulation);
-
-  // get persistence pairs
-  std::vector<std::tuple<SimplexId, SimplexId, scalarType>> JTPairs;
-  std::vector<std::tuple<SimplexId, SimplexId, scalarType>> STPairs;
-  contourTree_.computePersistencePairs<scalarType>(JTPairs, true);
-  contourTree_.computePersistencePairs<scalarType>(STPairs, false);
-
-  // merge pairs
-  std::vector<std::tuple<SimplexId, SimplexId, scalarType>> CTPairs(
-    JTPairs.size() + STPairs.size());
-  std::copy(JTPairs.begin(), JTPairs.end(), CTPairs.begin());
-  std::copy(STPairs.begin(), STPairs.end(), CTPairs.begin() + JTPairs.size());
-  {
-    auto cmp = [](const std::tuple<SimplexId, SimplexId, scalarType> &a,
-                  const std::tuple<SimplexId, SimplexId, scalarType> &b) {
-      return std::get<2>(a) < std::get<2>(b);
-    };
-    std::sort(CTPairs.begin(), CTPairs.end(), cmp);
-  }
-
-  // get the saddle-saddle pairs
-  const int dimensionality = triangulation->getDimensionality();
-  if(dimensionality == 3 and ComputeSaddleConnectors and MSCPlot_ != nullptr) {
-    std::vector<std::tuple<SimplexId, SimplexId, scalarType>>
-      pl_saddleSaddlePairs;
-    dcg_.setInputScalarField(inputScalars, scalarsMTime);
-    dcg_.setInputOffsets(inputOffsets);
-    dcg_.computeSaddleSaddlePersistencePairs<scalarType>(
-      pl_saddleSaddlePairs, *triangulation);
-
-    // sort the saddle-saddle pairs by persistence value and compute curve
-    {
-      auto cmp = [](const std::tuple<SimplexId, SimplexId, scalarType> &a,
-                    const std::tuple<SimplexId, SimplexId, scalarType> &b) {
-        return std::get<2>(a) < std::get<2>(b);
-      };
-      std::sort(pl_saddleSaddlePairs.begin(), pl_saddleSaddlePairs.end(), cmp);
-    }
-
-    computePersistencePlot<scalarType>(pl_saddleSaddlePairs, *MSCPlot);
-  }
-
-  // get persistence curves
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel sections
-#endif
-  {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp section
-#endif
-    if(JTPlot_ != nullptr) {
-      computePersistencePlot<scalarType>(JTPairs, *JTPlot);
-    }
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp section
-#endif
-    if(STPlot_ != nullptr) {
-      computePersistencePlot<scalarType>(STPairs, *STPlot);
-    }
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp section
-#endif
-    if(CTPlot_ != nullptr) {
-      computePersistencePlot<scalarType>(CTPairs, *CTPlot);
-    }
-  }
-
-  printMsg(
-    "Base execution completed", 1, timer.getElapsedTime(), threadNumber_);
-  printMsg(ttk::debug::Separator::L1);
-
-  return 0;
-}

--- a/core/vtk/ttkPersistenceCurve/ttk.module
+++ b/core/vtk/ttkPersistenceCurve/ttk.module
@@ -7,3 +7,4 @@ HEADERS
 DEPENDS
   persistenceCurve
   ttkAlgorithm
+  ttkPersistenceDiagram

--- a/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
+++ b/core/vtk/ttkPersistenceCurve/ttkPersistenceCurve.h
@@ -1,25 +1,28 @@
 /// \ingroup vtk
 /// \class ttkPersistenceCurve
 /// \author Guillaume Favelier <guillaume.favelier@lip6.fr>
+/// \author Pierre Guillou <pierre.guillou@lip6.fr>
 /// \date September 2016.
 ///
 /// \brief TTK VTK-filter for the computation of persistence curves.
 ///
-/// This filter computes the list of extremum-saddle pairs and computes the
-/// number of pairs as a function of persistence (i.e. the number of pairs
-/// whose persistence is higher than a threshold).
+/// This filter takes a persistence diagram as input and computes the
+/// number of pairs as a function of persistence (i.e. the number of
+/// pairs whose persistence is higher than a threshold).
 ///
 /// These curves provide useful visual clues in order to fine-tune persistence
 /// simplification thresholds.
 ///
-/// \param Input Input scalar field, either 2D or 3D, regular grid or
-/// triangulation (vtkDataSet)
+/// \param Input Input Persistence Diagram as computed by the
+/// \ref ttkPersistenceDiagram module
 /// \param Output0 Table giving the number of persistent minimum-saddle pairs
 /// as a function of persistence (vtkTable)
-/// \param Output1 Table giving the number of persistent saddle-maximum pairs
+/// \param Output1 Table giving the number of persistent saddle-saddle pairs
 /// as a function of persistence (vtkTable)
-/// \param Output2 Table giving the number of persistent all extremum-saddle
-/// pairs as a function of persistence (vtkTable)
+/// \param Output2 Table giving the number of persistent saddle-maximum pairs
+/// as a function of persistence (vtkTable)
+/// \param Output3 Table giving the number of all persistent pairs as
+/// a function of persistence (vtkTable)
 ///
 /// This filter can be used as any other VTK filter (for instance, by using the
 /// sequence of calls SetInputData(), Update(), GetOutput()).
@@ -49,13 +52,8 @@
 #pragma once
 
 // VTK includes
-#include <vtkDataArray.h>
-#include <vtkDataSet.h>
-#include <vtkDoubleArray.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
-#include <vtkPointData.h>
-#include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
 // VTK Module
@@ -74,18 +72,12 @@ public:
 
   vtkTypeMacro(ttkPersistenceCurve, ttkAlgorithm);
 
-  vtkSetMacro(ForceInputOffsetScalarField, bool);
-  vtkGetMacro(ForceInputOffsetScalarField, bool);
-
-  vtkSetMacro(ComputeSaddleConnectors, bool);
-  vtkGetMacro(ComputeSaddleConnectors, bool);
-
   vtkTable *GetOutput();
   vtkTable *GetOutput(int);
 
 protected:
   ttkPersistenceCurve();
-  ~ttkPersistenceCurve() override;
+  ~ttkPersistenceCurve() override = default;
 
   int RequestData(vtkInformation *request,
                   vtkInformationVector **inputVector,
@@ -94,28 +86,4 @@ protected:
   int FillInputPortInformation(int port, vtkInformation *info) override;
 
   int FillOutputPortInformation(int port, vtkInformation *info) override;
-
-  template <typename vtkArrayType, typename scalarType>
-  int getPersistenceCurve(
-    vtkTable *outputCurve,
-    ttk::ftm::TreeType treeType,
-    const std::vector<std::pair<scalarType, ttk::SimplexId>> &plot);
-
-  template <typename vtkArrayType, typename scalarType>
-  int getMSCPersistenceCurve(
-    vtkTable *outputCurve,
-    const std::vector<std::pair<scalarType, ttk::SimplexId>> &plot);
-
-private:
-  bool ForceInputOffsetScalarField{false};
-
-  template <typename VTK_TT, typename TTK_TT>
-  int dispatch(vtkTable *outputJTPersistenceCurve,
-               vtkTable *outputMSCPersistenceCurve,
-               vtkTable *outputSTPersistenceCurve,
-               vtkTable *outputCTPersistenceCurve,
-               const VTK_TT *inputScalars,
-               const size_t scalarsMTime,
-               const void *inputOffsets,
-               const TTK_TT *triangulation);
 };

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -53,22 +53,6 @@ int VTUToDiagram(ttk::DiagramType &diagram,
 
   const bool embed = coords == nullptr;
 
-  int nPairs = pairId->GetNumberOfTuples();
-
-  // compact pairIds in [0, nPairs - 1] (diagonal excepted)
-  for(int i = 0; i < nPairs; i++) {
-    if(pairId->GetTuple1(i) != -1) {
-      pairId->SetTuple1(i, i);
-    } else {
-      // detect diagram diagonal
-      nPairs -= 1;
-    }
-  }
-
-  if(nPairs < 1) {
-    dbg.printErr("Diagram has no pairs");
-    return -4;
-  }
   if(pairId == nullptr) {
     dbg.printErr("Missing PairIdentifier cell data array");
     return -5;
@@ -96,6 +80,23 @@ int VTUToDiagram(ttk::DiagramType &diagram,
   if(isFinite == nullptr) {
     dbg.printErr("Missing IsFinite cell data array");
     return -12;
+  }
+
+  int nPairs = pairId->GetNumberOfTuples();
+
+  // compact pairIds in [0, nPairs - 1] (diagonal excepted)
+  for(int i = 0; i < nPairs; i++) {
+    if(pairId->GetTuple1(i) != -1) {
+      pairId->SetTuple1(i, i);
+    } else {
+      // detect diagram diagonal
+      nPairs -= 1;
+    }
+  }
+
+  if(nPairs < 1) {
+    dbg.printErr("Diagram has no pairs");
+    return -4;
   }
 
   diagram.resize(nPairs);

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -186,19 +186,17 @@ int main(int argc, char **argv) {
   // precondition/fill in the order array according to the elevation field
   ttk::preconditionOrderArray(height.size(), height.data(), order.data());
 
-  // 2. computing the persistence curve
-  ttk::PersistenceCurve curve;
-  std::vector<std::pair<float, ttk::SimplexId>> outputCurve;
-  curve.preconditionTriangulation(&triangulation);
-  curve.setOutputCTPlot(&outputCurve);
-  curve.execute<float>(height.data(), 0, order.data(), &triangulation);
-
-  // 3. computing the persistence diagram
+  // 2. computing the persistence diagram
   ttk::PersistenceDiagram diagram;
   std::vector<ttk::PersistencePair> diagramOutput;
   diagram.preconditionTriangulation(&triangulation);
   diagram.execute(
     diagramOutput, height.data(), 0, order.data(), &triangulation);
+
+  // 3. computing the persistence curve from the persistence diagram
+  ttk::PersistenceCurve curve;
+  std::array<ttk::PersistenceCurve::PlotType, 4> outputCurve;
+  curve.execute(outputCurve, diagramOutput);
 
   // 4. selecting the critical point pairs
   std::vector<float> simplifiedHeight = height;

--- a/examples/pvpython/example.py
+++ b/examples/pvpython/example.py
@@ -44,13 +44,12 @@ else:
 # 1. loading the input data
 inputData = XMLUnstructuredGridReader(FileName=[inputFilePath])
 
-# 2. computing the persistence curve
-persistenceCurve = TTKPersistenceCurve(inputData)
-persistenceCurve.ScalarField = ["POINTS", "data"]
-
-# 3. computing the persistence diagram
+# 2. computing the persistence diagram
 persistenceDiagram = TTKPersistenceDiagram(inputData)
 persistenceDiagram.ScalarField = ["POINTS", "data"]
+
+# 3. computing the persistence curve from the persistence diagram
+persistenceCurve = TTKPersistenceCurve(persistenceDiagram)
 
 # 4. selecting the critical point pairs
 criticalPointPairs = Threshold(persistenceDiagram)

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -47,17 +47,16 @@ else:
 reader = vtkXMLUnstructuredGridReader()
 reader.SetFileName(inputFilePath)
 
-# 2. computing the persistence curve
-curve = ttkPersistenceCurve()
-curve.SetInputConnection(reader.GetOutputPort())
-curve.SetInputArrayToProcess(0, 0, 0, 0, "data")
-curve.SetDebugLevel(3)
-
-# 3. computing the persistence diagram
+# 2. computing the persistence diagram
 diagram = ttkPersistenceDiagram()
 diagram.SetInputConnection(reader.GetOutputPort())
 diagram.SetInputArrayToProcess(0, 0, 0, 0, "data")
 diagram.SetDebugLevel(3)
+
+# 3. computing the persistence curve from the persistence diagram
+curve = ttkPersistenceCurve()
+curve.SetInputConnection(diagram.GetOutputPort())
+curve.SetDebugLevel(3)
 
 # 4. selecting the critical point pairs
 criticalPairs = vtkThreshold()

--- a/examples/vtk-c++/main.cpp
+++ b/examples/vtk-c++/main.cpp
@@ -46,17 +46,15 @@ int main(int argc, char **argv) {
   vtkNew<vtkXMLUnstructuredGridReader> reader{};
   reader->SetFileName(inputFilePath.data());
 
-  // 2. computing the persistence curve
-  vtkNew<ttkPersistenceCurve> curve{};
-  curve->SetInputConnection(reader->GetOutputPort());
-  curve->SetInputArrayToProcess(
-    0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, "data");
-
-  // 3. computing the persistence diagram
+  // 2. computing the persistence diagram
   vtkNew<ttkPersistenceDiagram> diagram{};
   diagram->SetInputConnection(reader->GetOutputPort());
   diagram->SetInputArrayToProcess(
     0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, "data");
+
+  // 3. computing the persistence curve from the persistence diagram
+  vtkNew<ttkPersistenceCurve> curve{};
+  curve->SetInputConnection(diagram->GetOutputPort());
 
   // 4. selecting the critical point pairs
   vtkNew<vtkThreshold> criticalPairs{};

--- a/paraview/xmls/PersistenceCurve.xml
+++ b/paraview/xmls/PersistenceCurve.xml
@@ -1,4 +1,3 @@
-
 <ServerManagerConfiguration>
   <!-- This is the server manager configuration XML. It defines the interface to
        our new filter. As a rule of thumb, try to locate the configuration for
@@ -14,7 +13,7 @@
         short_help="TTK plugin for the computation of persistence curves.">
         TTK plugin for the computation of persistence curves.
 
-        This plugin computes the list of extremum-saddle pairs and computes the
+        This plugin takes a persistence diagram as input and computes the
 number of pairs as a function of persistence (i.e. the number of pairs
 whose persistence is higher than a threshold). The plugin produces tables.
 
@@ -36,9 +35,6 @@ See also ContourForests, PersistenceDiagram, ScalarFieldCriticalPoints, Topologi
         - https://topology-tool-kit.github.io/examples/interactionSites/
 
         - https://topology-tool-kit.github.io/examples/morsePersistence/
-        
-
-
 
       </Documentation>
 
@@ -50,99 +46,12 @@ See also ContourForests, PersistenceDiagram, ScalarFieldCriticalPoints, Topologi
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkDataSet"/>
+          <DataType value="vtkUnstructuredGrid"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
-          <Property name="Input" function="FieldDataSelection" />
-        </InputArrayDomain>
         <Documentation>
-          Data-set to process.
-          TTK assumes that the input dataset is made of only one connected component.
-          If it's not the case, you can use the filter "Connectivity" (and select "Extract Largest Region").
+          Input Persistence Diagram as computed by the TTKPersistenceDiagram filter.
         </Documentation>
       </InputProperty>
-
-      <StringVectorProperty
-        name="ScalarFieldNew"
-        label="Scalar Field"
-        command="SetInputArrayToProcess"
-        element_types="0 0 0 0 2"
-        number_of_elements="5"
-        default_values="0"
-        >
-        <ArrayListDomain attribute_type="Scalars" name="array_list">
-          <RequiredProperties>
-            <Property function="Input" name="Input" />
-          </RequiredProperties>
-        </ArrayListDomain>
-        <Documentation>
-          Select the scalar field to process.
-        </Documentation>
-      </StringVectorProperty>
-
-      <IntVectorProperty
-         name="ForceInputOffsetScalarField"
-         command="SetForceInputOffsetScalarField"
-         label="Force Input Offset Field"
-         number_of_elements="1"
-         panel_visibility="advanced"
-         default_values="0">
-        <BooleanDomain name="bool"/>
-         <Documentation>
-          Check this box to force the usage of a specific input scalar field
-          as vertex offset (used to disambiguate flat plateaus).
-         </Documentation>
-      </IntVectorProperty>
-
-      <StringVectorProperty
-        name="InputOffsetScalarFieldNameNew"
-        label="Input Offset Field"
-        command="SetInputArrayToProcess"
-        element_types="0 0 0 0 2"
-        number_of_elements="5"
-        default_values="1"
-        panel_visibility="advanced"
-        >
-        <ArrayListDomain
-          name="array_list"
-          default_values="1"
-          >
-          <RequiredProperties>
-            <Property name="Input" function="Input" />
-          </RequiredProperties>
-        </ArrayListDomain>
-        <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-            mode="visibility"
-            property="ForceInputOffsetScalarField"
-            value="1" />
-        </Hints>
-        <Documentation>
-          Select the input offset field (used to disambiguate flat plateaus).
-        </Documentation>
-      </StringVectorProperty>
-
-      <IntVectorProperty
-         name="SaddleConnectors"
-         command="SetComputeSaddleConnectors"
-         label="Compute saddle-saddle pairs (SLOW!)"
-         number_of_elements="1"
-         default_values="0" panel_visibility="advanced">
-        <BooleanDomain name="bool"/>
-         <Documentation>
-          Add saddle-saddle pairs in the diagram (SLOW!).
-         </Documentation>
-      </IntVectorProperty>
-
-      <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="ScalarFieldNew" />
-        <Property name="ForceInputOffsetScalarField"/>
-        <Property name="InputOffsetScalarFieldNameNew"/>
-      </PropertyGroup>
-
-      <PropertyGroup panel_widget="Line" label="Output options">
-        <Property name="SaddleConnectors" />
-      </PropertyGroup>
 
       ${DEBUG_WIDGETS}
 


### PR DESCRIPTION
This PR does breaking changes to the `PersistenceCurve` filter: now, it applies only on Persistence Diagrams (instead of computing them internally). This allows to get rid of a lot of code (which was in fact a duplicate of `PersistenceDiagram`).

Some checks in `ttkPersistenceDiagramUtils` have been moved up since segfaults could occur before hitting them...

A corresponding ttk-data PR should follow shortly.

Enjoy,
Pierre
