### PR TITLE
GitHub Actions: Fasten Windows builds with sccache

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -275,6 +275,19 @@ jobs:
     needs: [ccache-ubuntu, ccache-macos, ccache-windows]
     steps:
 
+    - name: Delete previous release
+      uses: actions/github-script@v6
+      continue-on-error: true
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          const { data: { id } } = await github.rest.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag: "ccache"
+          })
+          await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -171,12 +171,108 @@ jobs:
         name: ttk-ccache-macOS
         path: /Users/runner/work/ttk/ttk-ccache.tar.gz
 
+  # ------- #
+  # Windows #
+  # ------- #
+  ccache-windows:
+    runs-on: windows-latest
+    env:
+      CONDA_ROOT: C:\Miniconda
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout TTK source code
+
+    - uses: s-weigand/setup-conda@v1
+
+    - name: Install dependencies with conda
+      shell: bash
+      run: |
+        conda install -c conda-forge boost glew eigen spectralib zfp \
+          scikit-learn packaging openmp graphviz ninja sccache
+        # add sccache to PATH
+        echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
+
+    - name: Remove hosted Python
+      shell: bash
+      run: |
+        rm -rf C:/hostedtoolcache/windows/Python
+
+    - name: Fetch TTK-ParaView headless Windows installer
+      run: |
+        Invoke-WebRequest `
+        -OutFile ttk-paraview-headless.exe `
+        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.exe
+
+    - name: Install ParaView
+      shell: cmd
+      run: |
+        ttk-paraview-headless.exe /S
+
+    - name: Create & configure TTK build directory
+      shell: cmd
+      run: |
+        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake
+        set CC=clang-cl.exe
+        set CXX=clang-cl.exe
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        sccache --stop-server
+        sccache --start-server
+        mkdir build
+        cd build
+        cmake ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
+          -DBUILD_SHARED_LIBS:BOOL=TRUE ^
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
+          -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
+          -DGraphviz_INCLUDE_DIR="%CONDA_ROOT%\Library\include\graphviz" ^
+          -DGraphviz_CDT_LIBRARY="%CONDA_ROOT%\Library\lib\cdt.lib" ^
+          -DGraphviz_GVC_LIBRARY="%CONDA_ROOT%\Library\lib\gvc.lib" ^
+          -DGraphviz_CGRAPH_LIBRARY="%CONDA_ROOT%\Library\lib\cgraph.lib" ^
+          -DGraphviz_PATHPLAN_LIBRARY="%CONDA_ROOT%\Library\lib\pathplan.lib" ^
+          -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE ^
+          -DTTK_BUILD_VTK_WRAPPERS=TRUE ^
+          -DTTK_BUILD_STANDALONE_APPS=TRUE ^
+          -DTTK_ENABLE_KAMIKAZE=TRUE ^
+          -DTTK_ENABLE_OPENMP=TRUE ^
+          -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE ^
+          -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE ^
+          -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 ^
+          -GNinja ^
+          ..
+
+    - name: Fix clang-cl OpenMP flags in build.ninja
+      shell: bash
+      run: |
+        sed -i 's/-Xclang -fopenmp/-openmp/' build/build.ninja
+
+    - name: Build & install TTK
+      shell: cmd
+      run: |
+        cd build
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        cmake --build . --config Release --parallel --target install
+
+    - name: Archive cache
+      shell: bash
+      run: |
+        cd /c/Users/runneradmin/AppData/Local/Mozilla/sccache
+        tar czf ttk-sccache.tar.gz cache
+
+    - name: Upload sccache archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: ttk-sccache-windows
+        path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\ttk-sccache.tar.gz
+
+
   # --------------------- #
   # Upload release assets #
   # --------------------- #
   create-release:
     runs-on: ubuntu-latest
-    needs: [ccache-ubuntu, ccache-macos]
+    needs: [ccache-ubuntu, ccache-macos, ccache-windows]
     steps:
 
     - name: Create Release
@@ -224,3 +320,11 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk-ccache-macOS/ttk-ccache.tar.gz
         asset_name: ttk-ccache-macOS.tar.gz
+
+    - name: Upload sccache Windows archive
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-sccache-windows/ttk-sccache.tar.gz
+        asset_name: ttk-sccache-windows.tar.gz

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -320,7 +320,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
-          scikit-learn packaging openmp "graphviz>=2.50"
+          scikit-learn packaging openmp graphviz
 
     - name: Remove hosted Python
       shell: bash
@@ -410,7 +410,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
-          scikit-learn packaging openmp "graphviz>=2.50"
+          scikit-learn packaging openmp graphviz
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,12 +328,35 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz
+          scikit-learn packaging openmp graphviz ninja sccache
+        # add sccache to PATH
+        echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
+        # add TTK & ParaView install folders to PATH
+        echo "$PV_DIR/bin" >> $GITHUB_PATH
+        echo "$TTK_DIR/bin" >> $GITHUB_PATH
 
     - name: Remove hosted Python
       shell: bash
       run: |
         rm -rf C:/hostedtoolcache/windows/Python
+
+    - uses: dsaltares/fetch-gh-release-asset@master
+      continue-on-error: true
+      name: Fetch archived ccache
+      with:
+        repo: "topology-tool-kit/ttk"
+        version: "tags/ccache"
+        file: "ttk-sccache-windows.tar.gz"
+        target: "ttk-sccache.tar.gz"
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Decompress ccache archive
+      continue-on-error: true
+      shell: bash
+      run: |
+        tar xzf ttk-sccache.tar.gz
+        mkdir -p /c/Users/runneradmin/AppData/Local/Mozilla/sccache
+        mv cache /c/Users/runneradmin/AppData/Local/Mozilla/sccache
 
     - name: Fetch TTK-ParaView headless Windows installer
       run: |
@@ -350,11 +373,19 @@ jobs:
       shell: cmd
       run: |
         set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake
+        set CC=clang-cl.exe
+        set CXX=clang-cl.exe
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        sccache --stop-server
+        sccache --start-server
         mkdir build
         cd build
         cmake ^
+          -DCMAKE_BUILD_TYPE=Release ^
           -DCMAKE_POLICY_DEFAULT_CMP0092=NEW ^
           -DBUILD_SHARED_LIBS:BOOL=TRUE ^
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache ^
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ^
           -DPython3_ROOT_DIR="%CONDA_ROOT%" ^
           -DGraphviz_INCLUDE_DIR="%CONDA_ROOT%\Library\include\graphviz" ^
           -DGraphviz_CDT_LIBRARY="%CONDA_ROOT%\Library\lib\cdt.lib" ^
@@ -369,40 +400,48 @@ jobs:
           -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE ^
           -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE ^
           -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 ^
-          -G"Visual Studio 17 2022" ^
-          -Tclangcl ^
+          -GNinja ^
           ..
 
-    - name: Build & install TTK
+    - name: Fix clang-cl OpenMP flags in build.ninja
       shell: bash
       run: |
+        sed -i 's/-Xclang -fopenmp/-openmp/' build/build.ninja
+
+    - name: Build & install TTK
+      shell: cmd
+      run: |
         cd build
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cmake --build . --config Release --parallel --target install
-        # set PATH environment variable
-        echo "$PV_DIR/bin" >> $GITHUB_PATH
-        echo "$TTK_DIR/bin" >> $GITHUB_PATH
 
     - name: Test C++ example
       shell: cmd
       run: |
+        set CC=clang-cl.exe
+        set CXX=clang-cl.exe
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         set CMAKE_PREFIX_PATH=%TTK_DIR%\lib\cmake;%PV_DIR%\lib\cmake
         cd %GITHUB_WORKSPACE%\examples\c++
         mkdir build
         cd build
-        cmake -G"Visual Studio 17 2022" -Tclangcl ..
+        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
         cmake --build . --config Release --parallel
-        Release\ttkExample-c++.exe -i ..\..\data\inputData.off
+        ttkExample-c++.exe -i ..\..\data\inputData.off
 
     - name: Test VTK-C++ example
       shell: cmd
       run: |
+        set CC=clang-cl.exe
+        set CXX=clang-cl.exe
+        call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         set CMAKE_PREFIX_PATH=%TTK_DIR%\lib\cmake;%PV_DIR%\lib\cmake
         cd %GITHUB_WORKSPACE%\examples\vtk-c++
         mkdir build
         cd build
-        cmake -G"Visual Studio 17 2022" -Tclangcl ..
+        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
         cmake --build . --config Release --parallel
-        Release\ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
+        ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
 
     - name: Test Python example
       shell: cmd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp "graphviz>=2.50"
+          scikit-learn packaging openmp graphviz
 
     - name: Remove hosted Python
       shell: bash

--- a/core/base/lDistanceMatrix/LDistanceMatrix.h
+++ b/core/base/lDistanceMatrix/LDistanceMatrix.h
@@ -53,8 +53,7 @@ int ttk::LDistanceMatrix::execute(std::vector<std::vector<double>> &output,
 
   // compute matrix upper triangle
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_) schedule(dynamic) \
-  firstprivate(worker)
+#pragma omp parallel for num_threads(this->threadNumber_) firstprivate(worker)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nInputs; ++i) {
     for(size_t j = i + 1; j < nInputs; ++j) {


### PR DESCRIPTION
This PR uses [sccache](https://github.com/mozilla/sccache) in the Windows jobs of the `test_build ` and `store_ccache` workflows to cache generated binary files between workflow runs. This is useful to reduce the time spent waiting for the CI to complete.

To do so, CMake must use Ninja as its generator. To keep OpenMP multithreading working, the `clang-cl` compiler is manually set and compiler flags are edited in the generated `build.ninja` file.
Binary examples also need to be built with the same compiler and flags in order to prevent mixing the LLVM and the MSVC OpenMP libraries.

This compiler change did cause an unexpected segfault in the `LDistanceMatrix` filter (through the `persistentGenerators_householdAnalysis.py` script) that involves two nested parallel loops: the inner in `LDistance` performs a reduction over two datasets and the outer in `LDistanceMatrix` is parallel over the (upper) distance matrix. Although the inner loop parallelism should be disabled (`LDistance::threadNumber_` is set to 1), a segfault occurs because, among others, the outer loop uses the dynamic schedule. This PR fixes the segfault by switching back to the default schedule for the outer loop.

The `store_ccache` workflow now automatically deletes the `ccache` Release of the current repository before creating it.
Since the default graphviz package provided by conda is already at 2.5.0, there is no need to force its version anymore.

Enjoy,
Pierre
