### PR TITLE
ExplicitTriangulation: Add ASCII writer

### DIFF
--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -66,11 +66,11 @@ namespace ttk {
     }
 
     struct Slice {
+      const size_t len;
       const SimplexId *const ptr;
-      const SimplexId len;
-      inline SimplexId operator[](const SimplexId id) {
+      inline SimplexId operator[](const size_t id) const {
 #ifndef TTK_ENABLE_KAMIKAZE
-        if(id < 0 || id >= this->len) {
+        if(id >= this->len) {
           return -1;
         }
 #endif
@@ -85,7 +85,7 @@ namespace ttk {
       inline const SimplexId *end() const {
         return this->ptr + this->len;
       }
-      inline SimplexId size() const {
+      inline size_t size() const {
         return this->len;
       }
     };
@@ -111,13 +111,13 @@ namespace ttk {
       return {this->size(), *this};
     }
 
-    inline Slice operator[](const SimplexId id) const {
+    inline Slice operator[](const size_t id) const {
 #ifndef TTK_ENABLE_KAMIKAZE
-      if(id < 0 || id >= (SimplexId)this->offsets_.size()) {
-        return {nullptr, 0};
+      if(id >= this->offsets_.size()) {
+        return {0, nullptr};
       }
 #endif
-      return {this->get_ptr(id, 0), this->size(id)};
+      return {static_cast<size_t>(this->size(id)), this->get_ptr(id, 0)};
     }
 
     /**
@@ -184,7 +184,7 @@ namespace ttk {
     /**
      * @brief Computes the memory footprint of the array
      */
-    inline std::size_t footprint() const {
+    inline size_t footprint() const {
       return (this->data_.size() + this->offsets_.size()) * sizeof(SimplexId);
     }
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -1222,9 +1222,10 @@ const unsigned long ExplicitTriangulation::formatVersion_ = 1;
 int ExplicitTriangulation::writeToFile(std::ofstream &stream) const {
 
   // 1. magic bytes (char *)
-  stream.write(this->magicBytes_, std::strlen(this->magicBytes_));
+  stream.write(ttk::ExplicitTriangulation::magicBytes_,
+               std::strlen(ttk::ExplicitTriangulation::magicBytes_));
   // 2. format version (unsigned long)
-  writeBin(stream, this->formatVersion_);
+  writeBin(stream, ttk::ExplicitTriangulation::formatVersion_);
   // 3. dimensionality (int)
   const auto dim = this->getDimensionality();
   writeBin(stream, dim);
@@ -1353,10 +1354,12 @@ void readBinArray(std::ifstream &stream, T *const res, const size_t size) {
 int ExplicitTriangulation::readFromFile(std::ifstream &stream) {
 
   // 1. magic bytes (char *)
-  const auto magicBytesLen = std::strlen(this->magicBytes_);
+  const auto magicBytesLen
+    = std::strlen(ttk::ExplicitTriangulation::magicBytes_);
   std::vector<char> mBytes(magicBytesLen + 1);
   stream.read(mBytes.data(), magicBytesLen);
-  const auto hasMagicBytes = std::strcmp(mBytes.data(), this->magicBytes_) == 0;
+  const auto hasMagicBytes
+    = std::strcmp(mBytes.data(), ttk::ExplicitTriangulation::magicBytes_) == 0;
   if(!hasMagicBytes) {
     this->printErr("Could not find magic bytes in input files!");
     this->printErr("Aborting...");
@@ -1365,10 +1368,11 @@ int ExplicitTriangulation::readFromFile(std::ifstream &stream) {
   // 2. format version (unsigned long)
   unsigned long version{};
   readBin(stream, version);
-  if(version != this->formatVersion_) {
+  if(version != ttk::ExplicitTriangulation::formatVersion_) {
     this->printWrn("File format version (" + std::to_string(version)
                    + ") and software version ("
-                   + std::to_string(this->formatVersion_) + ") are different!");
+                   + std::to_string(ttk::ExplicitTriangulation::formatVersion_)
+                   + ") are different!");
   }
 
   int dim{};
@@ -1404,10 +1408,7 @@ int ExplicitTriangulation::readFromFile(std::ifstream &stream) {
   const auto read_guard = [&stream]() {
     char g{};
     readBin(stream, g);
-    if(g == 0) {
-      return true;
-    }
-    return false;
+    return g == 0;
   };
 
 #define READ_FIXED(ARRAY, N_ITEMS)               \

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -608,6 +608,10 @@ namespace ttk {
      */
     int writeToFile(std::ofstream &stream) const;
     /**
+     * @brief Write internal state to disk using an ASCII format
+     */
+    int writeToFileASCII(std::ofstream &stream) const;
+    /**
      * @brief Read from disk into internal state
      *
      * Use a custom binary format for fast loading

--- a/core/base/skeleton/OneSkeleton.cpp
+++ b/core/base/skeleton/OneSkeleton.cpp
@@ -125,6 +125,75 @@ int OneSkeleton::buildEdgeLinks(
   return 0;
 }
 
+using edgeType = std::array<SimplexId, 2>;
+
+template <std::size_t n>
+std::array<edgeType, n> getLocalEdges(const CellArray &ttkNotUsed(cellArray),
+                                      const SimplexId ttkNotUsed(cid)) {
+  return {};
+}
+
+template <>
+std::array<edgeType, 1> getLocalEdges(const CellArray &cellArray,
+                                      const SimplexId cid) {
+  return {
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))},
+  };
+}
+
+template <>
+std::array<edgeType, 3> getLocalEdges(const CellArray &cellArray,
+                                      const SimplexId cid) {
+  // triangle case: {0-1}, {0-2}, {1-2}
+  return {
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))},
+
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))},
+
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))},
+  };
+}
+
+template <>
+std::array<edgeType, 4> getLocalEdges(const CellArray &cellArray,
+                                      const SimplexId cid) {
+  // quad case: {0-1}, {1-2}, {2-3}, {3-0}
+  return {
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 2)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 3)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 0))},
+  };
+}
+
+template <>
+std::array<edgeType, 6> getLocalEdges(const CellArray &cellArray,
+                                      const SimplexId cid) {
+  // tet case: {0-1}, {0-2}, {0-3}, {1-2}, {1-3}, {2-3}
+  return {
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))},
+    edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 2)),
+             static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))},
+  };
+}
+
 template <std::size_t n>
 int OneSkeleton::buildEdgeList(
   const SimplexId &vertexNumber,
@@ -171,59 +240,7 @@ int OneSkeleton::buildEdgeList(
 
     // id of edge in cell
     SimplexId ecid{};
-
-    using edgeType = std::array<SimplexId, 2>;
-    std::array<edgeType, n> localEdges{};
-    if(n == 1) {
-      localEdges[0]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))};
-    } else if(n == 3) {
-      // triangle case: {0-1}, {0-2}, {1-2}
-      localEdges[0]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))};
-      localEdges[1]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))};
-      localEdges[2]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))};
-    } else if(n == 4) {
-      // quad case: {0-1}, {1-2}, {2-3}, {3-0}
-      localEdges[0]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))};
-      localEdges[1]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))};
-      localEdges[2]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 2)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))};
-      localEdges[3]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 3)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 0))};
-    } else if(n == 6) {
-      // tet case: {0-1}, {0-2}, {0-3}, {1-2}, {1-3}, {2-3}
-      localEdges[0]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 1))};
-      localEdges[1]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))};
-      localEdges[2]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 0)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))};
-      localEdges[3]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 2))};
-      localEdges[4]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 1)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))};
-      localEdges[5]
-        = edgeType{static_cast<SimplexId>(cellArray.getCellVertex(cid, 2)),
-                   static_cast<SimplexId>(cellArray.getCellVertex(cid, 3))};
-    }
+    const auto localEdges{getLocalEdges<n>(cellArray, cid)};
 
     for(const auto &le : localEdges) {
       // edge processing

--- a/core/vtk/ttkTriangulationWriter/ttkTriangulationWriter.cpp
+++ b/core/vtk/ttkTriangulationWriter/ttkTriangulationWriter.cpp
@@ -40,11 +40,6 @@ int ttkTriangulationWriter::OpenFile() {
   return 0;
 }
 
-template <typename T>
-void writeBin(std::ofstream &stream, const T var) {
-  stream.write(reinterpret_cast<const char *>(&var), sizeof(var));
-}
-
 int ttkTriangulationWriter::Write() {
 
   ttk::Timer tm{};
@@ -65,6 +60,12 @@ int ttkTriangulationWriter::Write() {
     return 1;
   }
 
+  // basic preconditions
+  triangulation->preconditionEdges();
+  if(triangulation->getDimensionality() > 2) {
+    triangulation->preconditionTriangles();
+  }
+
   const auto explTri
     = static_cast<ttk::ExplicitTriangulation *>(triangulation->getData());
 
@@ -73,7 +74,11 @@ int ttkTriangulationWriter::Write() {
     return 1;
   }
 
-  explTri->writeToFile(this->Stream);
+  if(this->UseASCIIFormat) {
+    explTri->writeToFileASCII(this->Stream);
+  } else {
+    explTri->writeToFile(this->Stream);
+  }
   this->Stream.flush();
 
   this->printMsg("Wrote triangulation to " + std::string{this->Filename}, 1.0,

--- a/core/vtk/ttkTriangulationWriter/ttkTriangulationWriter.h
+++ b/core/vtk/ttkTriangulationWriter/ttkTriangulationWriter.h
@@ -25,6 +25,9 @@ public:
   vtkSetStringMacro(Filename);
   vtkGetStringMacro(Filename);
 
+  vtkSetMacro(UseASCIIFormat, bool);
+  vtkGetMacro(UseASCIIFormat, bool);
+
   // expose vtkWriter methods (duck-typing)
   int Write();
   vtkDataObject *GetInput();
@@ -39,6 +42,7 @@ protected:
 
   char *Filename{};
   std::ofstream Stream{};
+  bool UseASCIIFormat{false};
 
 private:
   ttkTriangulationWriter(const ttkTriangulationWriter &) = delete;

--- a/paraview/xmls/TriangulationWriter.xml
+++ b/paraview/xmls/TriangulationWriter.xml
@@ -6,35 +6,56 @@
         name="ttkTriangulationWriter"
         class="ttkTriangulationWriter"
         label="TTK Triangulation File Writer">
-        <Documentation
+
+      <Documentation
           long_help="Write a TTK Triangulation into a file."
           short_help="Write TTK Triangulation to disk.">
-          Export a TTK (Explicit) Triangulation into a file.
-        </Documentation>
-        <InputProperty name="Input" command="SetInputConnection">
-          <ProxyGroupDomain name="groups">
-            <Group name="sources"/>
-            <Group name="filters"/>
-          </ProxyGroupDomain>
-          <DataTypeDomain name="input_type" composite_data_supported="0">
-            <DataType value="vtkUnstructuredGrid"/>
-          </DataTypeDomain>
-        </InputProperty>
-        <StringVectorProperty
+        Export a TTK (Explicit) Triangulation into a file.
+      </Documentation>
+
+      <InputProperty name="Input" command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type" composite_data_supported="0">
+          <DataType value="vtkUnstructuredGrid"/>
+        </DataTypeDomain>
+      </InputProperty>
+
+      <StringVectorProperty
           name="FileName"
           command="SetFilename"
           number_of_elements="1">
-          <FileListDomain name="files"/>
-          <Documentation>
-              This property specifies the file name for the Triangulation writer.
-          </Documentation>
-        </StringVectorProperty>
-        <Hints>
-          <Property name="Input" show="0"/>
-          <Property name="FileName" show="0"/>
-          <WriterFactory extensions="tpt"
-                         file_description="TTK Preconditioned Triangulation File Format" />
-        </Hints>
+        <FileListDomain name="files"/>
+        <Documentation>
+          This property specifies the file name for the Triangulation writer.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+          name="UseASCIIFormat"
+          label="Use ASCII format (no reader available)"
+          command="SetUseASCIIFormat"
+          number_of_elements="1"
+          default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Write Triangulation using ASCII format instead of binary.
+        </Documentation>
+      </IntVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Output">
+        <Property name="FileName" />
+        <Property name="UseASCIIFormat" />
+      </PropertyGroup>
+
+      <Hints>
+        <Property name="Input" show="0"/>
+        <Property name="FileName" show="0"/>
+        <WriterFactory extensions="tpt"
+                       file_description="TTK Preconditioned Triangulation File Format" />
+      </Hints>
     </WriterProxy>
     <!-- End Writer -->
   </ProxyGroup>


### PR DESCRIPTION
This PR complements https://github.com/topology-tool-kit/ttk/pull/598 with an ASCII backend for the `TriangulationWriter` module. Be aware that there is no corresponding reader in TTK for this file particular format. The format version of this particular writer is set to 2 (the binary writer is still at version 1).

The writer basically exports the internal state of the ExplicitTriangulation into a file (one value per line). Sections are prefixed by the name of the corresponding ExplicitTriangulation class member. The non-owned data structure `cellArray` (which decomposes VTK cells into vertices) is also included.

To better accommodate between `std::vector<std::array>>` and `FlatJaggedArray`, some methods of the latter have been slightly modified to return `size_t` instead of `SimplexId`.

Additionally, a MSVC warning in `OneSkeleton` has been fixed by using templated functions instead of if statements.

Enjoy,
Pierre