### PR TITLE
[MatrixToHeatMap] do not look for arrays not present anymore in the table

### DIFF
--- a/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
+++ b/core/vtk/ttkMatrixToHeatMap/ttkMatrixToHeatMap.cpp
@@ -58,6 +58,14 @@ int ttkMatrixToHeatMap::RequestData(vtkInformation * /*request*/,
         ScalarFields.emplace_back(name);
       }
     }
+  } else {
+    // Remove manually selected arrays that are not present in the input table
+    ScalarFields.erase(
+      std::remove_if(ScalarFields.begin(), ScalarFields.end(),
+                     [&input](const std::string &name) {
+                       return not input->GetColumnByName(name.data());
+                     }),
+      ScalarFields.end());
   }
 
   const auto nInputs = ScalarFields.size();


### PR DESCRIPTION
This PR fixes #835.

The problem was that if you first execute `TTKMatrixToHeatMap` by manually selecting the columns in the table, then you remove some columns in the input table (for example with a `TTKTableDataSelector` before), these columns that are not present anymore will still be selected by `TTKMatrixToHeatMap` and the filter will try to access these arrays (whereas they are not anymore in the table) therefore causing a segfault. 

Example of pipeline leading to a segfault:
- Open a csv in ttk-data or compute a distance matrix of some dataset
- Call `TTKTableDataSelector` and select some arrays
- Call `TTKMatrixToHeatMap` and select all arrays and click on apply
- Then remove one array in `TTKTableDataSelector`

The problem only occur when the columns are manually selected and not when the regexp is used because in the latter case only arrays present in the table and matching the regexp are processed.

The fix proposed here is to verify if the columns selected are still in the table, if not they are not processed.

