### PR TITLE
[MPI] MPI preconditioning will execute when using 1 process

### DIFF
--- a/core/base/common/BaseClass.cpp
+++ b/core/base/common/BaseClass.cpp
@@ -24,8 +24,7 @@ BaseClass::BaseClass() : lastObject_{false}, wrapper_{nullptr} {
     if(flag) {
       MPI_Comm_rank(MPI_COMM_WORLD, &ttk::MPIrank_);
       MPI_Comm_size(MPI_COMM_WORLD, &ttk::MPIsize_);
-      if(ttk::MPIsize_ > 1)
-        MPI_Comm_dup(MPI_COMM_WORLD, &ttk::MPIcomm_);
+      MPI_Comm_dup(MPI_COMM_WORLD, &ttk::MPIcomm_);
     } else {
       ttk::MPIrank_ = 0;
       ttk::MPIsize_ = 0;

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -67,6 +67,10 @@ namespace ttk {
     return ttk::MPIsize_ > 1;
   };
 
+  inline bool hasInitializedMPI() {
+    return ttk::MPIsize_ > 0;
+  };
+
   inline int startMPITimer(Timer &t, int rank, int size) {
     if(size > 0) {
       MPI_Barrier(ttk::MPIcomm_);

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -309,6 +309,7 @@ int ExplicitTriangulation::preconditionEdgesInternal() {
 
 #ifdef TTK_ENABLE_MPI
     if(this->getDimensionality() == 2 || this->getDimensionality() == 3) {
+      this->preconditionTriangleEdges();
       return this->preconditionDistributedEdges();
     }
 #endif // TTK_ENABLE_MPI

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -591,7 +591,9 @@ int ExplicitTriangulation::preconditionDistributedCells() {
   if(this->hasPreconditionedDistributedCells_) {
     return 0;
   }
-
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -907,7 +909,9 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
   if(this->hasPreconditionedDistributedEdges_) {
     return 0;
   }
-
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -1044,7 +1048,9 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
   if(this->hasPreconditionedDistributedTriangles_) {
     return 0;
   }
-
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -1175,7 +1181,9 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
   if(this->hasPreconditionedDistributedVertices_) {
     return 0;
   }
-
+  if(!hasInitializedMPI()) {
+    return -1;
+  }
   if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -591,9 +591,7 @@ int ExplicitTriangulation::preconditionDistributedCells() {
   if(this->hasPreconditionedDistributedCells_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
+
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -909,9 +907,7 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
   if(this->hasPreconditionedDistributedEdges_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
+
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -1048,9 +1044,7 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
   if(this->hasPreconditionedDistributedTriangles_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
+
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -1181,9 +1175,7 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
   if(this->hasPreconditionedDistributedVertices_) {
     return 0;
   }
-  if(!isRunningWithMPI()) {
-    return -1;
-  }
+
   if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");
     return -2;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -309,7 +309,6 @@ int ExplicitTriangulation::preconditionEdgesInternal() {
 
 #ifdef TTK_ENABLE_MPI
     if(this->getDimensionality() == 2 || this->getDimensionality() == 3) {
-      this->preconditionTriangleEdges();
       return this->preconditionDistributedEdges();
     }
 #endif // TTK_ENABLE_MPI
@@ -920,6 +919,10 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
 
   if(this->getDimensionality() != 2 && this->getDimensionality() != 3) {
     return -3;
+  }
+
+  if(this->getDimensionality() == 2) {
+    this->preconditionTriangleEdges();
   }
 
   Timer tm{};

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3067,6 +3067,9 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
   if(this->hasPreconditionedDistributedCells_) {
     return 0;
   }
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3399,6 +3402,9 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   if(this->hasPreconditionedDistributedEdges_) {
     return 0;
   }
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3545,6 +3551,9 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
   if(this->hasPreconditionedDistributedTriangles_) {
     return 0;
   }
+  if(!ttk::hasInitializedMPI()) {
+    return -1;
+  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3678,6 +3687,9 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
 int ImplicitTriangulation::preconditionDistributedVertices() {
   if(this->hasPreconditionedDistributedVertices_) {
     return 0;
+  }
+  if(!hasInitializedMPI()) {
+    return -1;
   }
   if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3067,9 +3067,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
   if(this->hasPreconditionedDistributedCells_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3402,9 +3399,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
   if(this->hasPreconditionedDistributedEdges_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3551,9 +3545,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
   if(this->hasPreconditionedDistributedTriangles_) {
     return 0;
   }
-  if(!ttk::isRunningWithMPI()) {
-    return -1;
-  }
   if(this->cellGid_ == nullptr) {
     this->printWrn("Missing global identifiers on cells");
     return -2;
@@ -3687,9 +3678,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
 int ImplicitTriangulation::preconditionDistributedVertices() {
   if(this->hasPreconditionedDistributedVertices_) {
     return 0;
-  }
-  if(!isRunningWithMPI()) {
-    return -1;
   }
   if(this->vertGid_ == nullptr) {
     this->printWrn("Missing global identifiers array!");

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3414,6 +3414,10 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
     return -3;
   }
 
+  if(this->getDimensionality() == 2) {
+    this->preconditionTriangleEdges();
+  }
+
   Timer tm{};
 
   this->preconditionDistributedCells();

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -41,17 +41,21 @@ ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
                    + std::string(dataSet->GetClassName()) + "'",
                  ttk::debug::Priority::DETAIL);
 #if TTK_ENABLE_MPI
-  if(!hasMPISupport_) {
-    printErr(
-      "MPI is not supported for this filter, the results will be incorrect");
+  if(ttk::hasInitializedMPI()) {
+    if(!hasMPISupport_) {
+      printErr(
+        "MPI is not supported for this filter, the results will be incorrect");
+    }
+    this->MPIPipelinePreconditioning(dataSet);
   }
-  this->MPIPipelinePreconditioning(dataSet);
 #endif
   auto triangulation = ttkTriangulationFactory::GetTriangulation(
     this->debugLevel_, this->CompactTriangulationCacheSize, dataSet);
 #if TTK_ENABLE_MPI
-  if(triangulation) {
-    this->MPITriangulationPreconditioning(triangulation, dataSet);
+  if(ttk::hasInitializedMPI()) {
+    if(triangulation) {
+      this->MPITriangulationPreconditioning(triangulation, dataSet);
+    }
   }
 #endif
   if(triangulation)
@@ -173,7 +177,7 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       newOrderArray->SetNumberOfComponents(1);
       newOrderArray->SetNumberOfTuples(nVertices);
 #if TTK_ENABLE_MPI
-      if(ttk::isRunningWithMPI()) {
+      if(ttk::hasInitializedMPI()) {
         this->MPIPipelinePreconditioning(inputData);
         auto vtkGlobalPointIds = inputData->GetPointData()->GetGlobalIds();
         auto rankArray = inputData->GetPointData()->GetArray("RankArray");

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -179,6 +179,8 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
 #if TTK_ENABLE_MPI
       if(ttk::hasInitializedMPI()) {
         this->MPIPipelinePreconditioning(inputData);
+      }
+      if(ttk::isRunningWithMPI()) {
         auto vtkGlobalPointIds = inputData->GetPointData()->GetGlobalIds();
         auto rankArray = inputData->GetPointData()->GetArray("RankArray");
         ttkTypeMacroA(
@@ -439,7 +441,7 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
   }
 
   vtkNew<vtkGhostCellsGenerator> generator;
-  if(!input->HasAnyGhostCells()) {
+  if(!input->HasAnyGhostCells() && ttk::isRunningWithMPI()) {
     generator->SetInputData(input);
     generator->BuildIfRequiredOff();
     generator->SetNumberOfGhostLayers(2);
@@ -455,14 +457,15 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
   if(input->GetPointData()->GetArray("RankArray") == nullptr) {
     int vertexNumber = input->GetNumberOfPoints();
     std::vector<int> rankArray(vertexNumber, 0);
-    double *boundingBox = input->GetBounds();
-    ttk::produceRankArray(rankArray,
-                          ttkUtils::GetPointer<ttk::LongSimplexId>(
-                            input->GetPointData()->GetGlobalIds()),
-                          ttkUtils::GetPointer<unsigned char>(
-                            input->GetPointData()->GetArray("vtkGhostType")),
-                          vertexNumber, boundingBox);
-
+    if(ttk::isRunningWithMPI()) {
+      double *boundingBox = input->GetBounds();
+      ttk::produceRankArray(rankArray,
+                            ttkUtils::GetPointer<ttk::LongSimplexId>(
+                              input->GetPointData()->GetGlobalIds()),
+                            ttkUtils::GetPointer<unsigned char>(
+                              input->GetPointData()->GetArray("vtkGhostType")),
+                            vertexNumber, boundingBox);
+    }
     vtkNew<vtkIntArray> vtkRankArray{};
     vtkRankArray->SetName("RankArray");
     vtkRankArray->SetNumberOfComponents(1);
@@ -479,14 +482,15 @@ void ttkAlgorithm::MPIPipelinePreconditioning(vtkDataSet *input) {
   if(input->GetCellData()->GetArray("RankArray") == nullptr) {
     int cellNumber = input->GetNumberOfCells();
     std::vector<int> cellsRankArray(cellNumber, 0);
-    double *boundingBox = input->GetBounds();
-    ttk::produceRankArray(cellsRankArray,
-                          ttkUtils::GetPointer<ttk::LongSimplexId>(
-                            input->GetCellData()->GetGlobalIds()),
-                          ttkUtils::GetPointer<unsigned char>(
-                            input->GetCellData()->GetArray("vtkGhostType")),
-                          cellNumber, boundingBox);
-
+    if(ttk::isRunningWithMPI()) {
+      double *boundingBox = input->GetBounds();
+      ttk::produceRankArray(cellsRankArray,
+                            ttkUtils::GetPointer<ttk::LongSimplexId>(
+                              input->GetCellData()->GetGlobalIds()),
+                            ttkUtils::GetPointer<unsigned char>(
+                              input->GetCellData()->GetArray("vtkGhostType")),
+                            cellNumber, boundingBox);
+    }
     vtkNew<vtkIntArray> vtkCellsRankArray{};
     vtkCellsRankArray->SetName("RankArray");
     vtkCellsRankArray->SetNumberOfComponents(1);

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -41,21 +41,17 @@ ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
                    + std::string(dataSet->GetClassName()) + "'",
                  ttk::debug::Priority::DETAIL);
 #if TTK_ENABLE_MPI
-  if(ttk::isRunningWithMPI()) {
-    if(!hasMPISupport_) {
-      printErr(
-        "MPI is not supported for this filter, the results will be incorrect");
-    }
-    this->MPIPipelinePreconditioning(dataSet);
+  if(!hasMPISupport_) {
+    printErr(
+      "MPI is not supported for this filter, the results will be incorrect");
   }
+  this->MPIPipelinePreconditioning(dataSet);
 #endif
   auto triangulation = ttkTriangulationFactory::GetTriangulation(
     this->debugLevel_, this->CompactTriangulationCacheSize, dataSet);
 #if TTK_ENABLE_MPI
-  if(ttk::isRunningWithMPI()) {
-    if(triangulation) {
-      this->MPITriangulationPreconditioning(triangulation, dataSet);
-    }
+  if(triangulation) {
+    this->MPITriangulationPreconditioning(triangulation, dataSet);
   }
 #endif
   if(triangulation)

--- a/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
+++ b/core/vtk/ttkGhostCellPreconditioning/ttkGhostCellPreconditioning.cpp
@@ -76,7 +76,7 @@ int ttkGhostCellPreconditioning::RequestData(
   if(verticesGlobalIds != nullptr && verticesGhostCells != nullptr
      && cellsGlobalIds != nullptr && cellsGhostCells != nullptr) {
 #ifdef TTK_ENABLE_MPI
-    if(ttk::isRunningWithMPI()) {
+    if(ttk::hasInitializedMPI()) {
       if(ttk::MPIrank_ == 0)
         this->printMsg(
           "Global Point Ids and Ghost Cells exist, therefore we can continue!");

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -157,11 +157,7 @@ int ttkScalarFieldCriticalPoints::RequestData(
 #endif
     for(size_t i = 0; i < criticalPoints_.size(); i++) {
 #if TTK_ENABLE_MPI
-      if(isRunningWithMPI()) {
-        vertexIds->SetTuple1(i, globalIds[criticalPoints_[i].first]);
-      } else {
-        vertexIds->SetTuple1(i, criticalPoints_[i].first);
-      }
+      vertexIds->SetTuple1(i, globalIds[criticalPoints_[i].first]);
 #else
       vertexIds->SetTuple1(i, criticalPoints_[i].first);
 #endif

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -157,7 +157,11 @@ int ttkScalarFieldCriticalPoints::RequestData(
 #endif
     for(size_t i = 0; i < criticalPoints_.size(); i++) {
 #if TTK_ENABLE_MPI
-      vertexIds->SetTuple1(i, globalIds[criticalPoints_[i].first]);
+      if(hasInitializedMPI()) {
+        vertexIds->SetTuple1(i, globalIds[criticalPoints_[i].first]);
+      } else {
+        vertexIds->SetTuple1(i, criticalPoints_[i].first);
+      }
 #else
       vertexIds->SetTuple1(i, criticalPoints_[i].first);
 #endif

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -57,7 +57,7 @@ void switchPeriodicity(ttk::Triangulation &triangulation,
   if(prevPeriodic != periodic) {
 
 #ifdef TTK_ENABLE_MPI
-    if(ttk::isRunningWithMPI() && periodic) {
+    if(ttk::hasInitializedMPI() && periodic) {
       dbg.printErr("Periodic implicit triangulation not (yet) supported in "
                    "an MPI context!");
       dbg.printErr("Keeping the Implicit triangulation.");
@@ -113,7 +113,7 @@ int ttkTriangulationManager::processExplicit(
   ttk::Timer tm{};
 
 #ifdef TTK_ENABLE_MPI
-  if(ttk::isRunningWithMPI()) {
+  if(ttk::hasInitializedMPI()) {
     this->printErr(
       "Compact triangulation not (yet) supported in an MPI context!");
     this->printErr("Keeping the Explicit triangulation.");


### PR DESCRIPTION
For now, the MPI preconditioning only executes when TTK is executed on more than one process. This means that when TTK is compiled with MPI, it won't execute correctly on one process, preventing the output for one and more than one process to be strictly identical.
In this pull request, we deleted the tests preventing the preconditioning, as well as modified the filter ScalarFieldCriticalPoints, to ensure that the output will always be identical, regardless of the number of processes. When TTK is used as standalone, instead of checking if the process is executed on more than one process, we check if MPI has been initialized. This will always be true when using TTK with Paraview.