### PR TITLE
CompactTriangulation: Fix segfault by resizing vectors

### DIFF
--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1493,6 +1493,8 @@ namespace ttk {
      */
     inline void initCache(const float ratio = 0.2) {
       cacheSize_ = nodeNumber_ * ratio + 1;
+      caches_.resize(threadNumber_);
+      cacheMaps_.resize(threadNumber_);
       for(int i = 0; i < threadNumber_; i++) {
         caches_[i].clear();
         cacheMaps_[i].clear();


### PR DESCRIPTION
The `CompactTriangulation::initCache` method is called when creating the compact triangulation using the `TriangulationManager` filter. The `caches_` and `cacheMaps_` member variables were not initialized (they were empty), causing a segfault when trying to request the compact triangulation, for instance with `ScalarFieldCriticalPoints` applied after `TriangulationManager`.

This PR fixes the segfault.

Enjoy,
Pierre