### PR TITLE
GitHub Actions: Fix macOS 12/OpenMP compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -268,6 +268,11 @@ jobs:
         cmake --build . --parallel
         sudo cmake --build . --target install
 
+    - name: Set PYTHONPATH for macOS pvpython
+      run: |
+        # pvpython does not embed the correct PYTHONPATH
+        echo "PYTHONPATH=/usr/local/lib/python3.10/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,13 +206,10 @@ jobs:
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew uninstall --ignore-dependencies python@3.10
-        brew install wget libomp ninja python@3.9 open-mpi
-        # force brew's Python 3.9 as default Python
-        echo "$(brew --prefix)/opt/python@3.9/libexec/bin" >> $GITHUB_PATH
+        brew install wget libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree ccache
-        python3.9 -m pip install scikit-learn packaging
+        python3 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp ninja python open-mpi
+        brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree ccache
         python3 -m pip install scikit-learn packaging
@@ -236,6 +236,11 @@ jobs:
       run: |
         tar xzf ttk-paraview-headless.tar.gz
         sudo cp -r ttk-paraview/* /usr/local
+
+    - name: Set compilers as environment variables
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
     - name: Create & configure TTK build directory
       run: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -410,6 +410,7 @@ jobs:
                      -DCMAKE_PREFIX_PATH=$(Build.ArtifactStagingDirectory)/pv-install/lib/cmake
                      -DTTK_BUILD_STANDALONE_APPS=ON
                      -DTTK_ENABLE_CPU_OPTIMIZATION=OFF
+                     -DTTK_ENABLE_OPENMP=OFF
                      $(TTK_MODULE_DISABLE)
                      $(TTK_MODULE_TEST)
                      -GNinja'


### PR DESCRIPTION
Following the LLVM 15 release, the brew-provided `libomp` became somewhat incompatible with Apple Clang (the default macOS compiler).
As a consequence, this PR switches the compiler to use directly Clang/LLVM 15 instead of Apple Clang.

Enjoy,
Pierre

