### PR TITLE
DiscreteMorseSandwich: Add parallelism with locks for saddle-saddle pairs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,17 @@ jobs:
         path: "ttk-data"
       name: Checkout ttk-data
 
+    - name: Resample large datasets
+      shell: python3 {0}
+      working-directory: ./ttk-data
+      run: |
+        from paraview import simple
+        for ds in ["ctBones.vti"]:
+            vti = simple.XMLImageDataReader(FileName=ds)
+            rsi = simple.ResampleToImage(Input=vti)
+            rsi.SamplingDimensions = [128, 128, 128]
+            simple.SaveData(ds, rsi)
+
     - name: Run ttk-data states [NOT ENFORCED]
       id: validate
       continue-on-error: true

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -424,6 +424,7 @@ int ttk::PersistentGenerators::computePersistentGenerators(
     this->edgeTrianglePartner_.resize(triangulation.getNumberOfEdges(), -1);
     this->onBoundary_.resize(triangulation.getNumberOfEdges(), false);
     this->s2Mapping_.resize(triangulation.getNumberOfTriangles(), -1);
+    this->s1Mapping_.resize(triangulation.getNumberOfEdges(), -1);
   }
 
   // get every critical cell sorted them by dimension


### PR DESCRIPTION
This PR updates the `DiscreteMorseSandwich::eliminateBoundariesSandwich` method to use the parallel algorithm described in the "Towards Lockfree Persistent Homology" article.

Due to their very late introduction in OpenMP, atomic compare-and-swap operations have been replaced by locks, without notable impact of performance.

There is no need for the first parallel pass any more. The 2-saddle boundaries now expand during the (only) parallel pass. The pairs are created once this pass is done.

Due to the slight increase in memory usage (a new vector of the size of the edges is used), the ctBones.vti data-set had to be resized for the CI to complete without errors on Ubuntu VMs.

Enjoy,
Pierre