### PR TITLE
FTMTree: Fix race condition

### DIFF
--- a/core/base/ftmTree/CMakeLists.txt
+++ b/core/base/ftmTree/CMakeLists.txt
@@ -37,8 +37,10 @@ if (TTK_ENABLE_FTM_TREE_PROCESS_SPEED)
   target_compile_definitions(ftmTree PUBLIC TTK_ENABLE_FTM_TREE_PROCESS_SPEED)
 endif()
 
+if (TTK_ENABLE_FTM_TREE_STATS_TIME)
+  target_compile_definitions(ftmTree PUBLIC TTK_ENABLE_FTM_TREE_STATS_TIME)
+endif()
+
 if (TTK_ENABLE_OPENMP AND TTK_ENABLE_OMP_PRIORITY)
   target_compile_definitions(ftmTree PUBLIC TTK_ENABLE_OMP_PRIORITY)
 endif()
-
-# target_compile_definitions(ftmTree PUBLIC TTK_ENABLE_FTM_TREE_STATS_TIME)

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -759,9 +759,7 @@ int FTMTree_MT::printTime(Timer &t,
     st << s;
 
 #ifdef TTK_ENABLE_FTM_TREE_PROCESS_SPEED
-    if(nbScalars == -1) {
-      nbScalars = scalars_->size;
-    }
+    const auto nbScalars = scalars_->size;
     int speed = nbScalars / t.getElapsedTime();
     st << " at " << speed << " vert/s";
 #endif

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -401,7 +401,16 @@ namespace ttk {
       trunkVerts.reserve(std::max(SimplexId{10}, nbScalars / 500));
       for(SimplexId v = 0; v < nbScalars; ++v) {
         if((*mt_data_.openedNodes)[v]) {
-          trunkVerts.emplace_back(v);
+          if(this->isCorrespondingNode(v)) {
+            // parallel leafGrowth can partially build the trunk,
+            // filter out the saddles with an upward arc
+            const auto node{this->getNode(this->getCorrespondingNodeId(v))};
+            if(node->getNumberOfUpSuperArcs() == 0) {
+              trunkVerts.emplace_back(v);
+            }
+          } else {
+            trunkVerts.emplace_back(v);
+          }
         }
       }
       sort(trunkVerts.begin(), trunkVerts.end(), comp_.vertLower);

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -62,6 +62,10 @@ namespace ttk {
       trunk(mesh, ct);
       printTime(bbTime, "trunk " + treeString, 3);
 
+      if(this->getNumberOfNodes() != this->getNumberOfSuperArcs() + 1) {
+        this->printErr(treeString + " not a tree!");
+      }
+
       // Segmentation
       if(ct && params_->segm) {
         Timer segmTime;

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -56,13 +56,6 @@ namespace ttk {
 
       Timer buildTime;
       leafGrowth(mesh);
-#ifdef TTK_ENABLE_FTM_TREE_PROCESS_SPEED
-      // count process
-      for(SimplexId i = 0; i < scalars_->size; i++) {
-        if((*mt_data_.vert2tree)[i] != nullCorresp)
-          ++nbProcessed;
-      }
-#endif
       printTime(buildTime, "leafGrowth " + treeString, 3);
 
       Timer bbTime;

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -602,6 +602,8 @@ int ttkFTMTree::getSkeletonNodes(vtkUnstructuredGrid *outputSkeletonNodes) {
 
 #ifdef TTK_ENABLE_FTM_TREE_STATS_TIME
 void ttkFTMTree::printCSVStats() {
+  using namespace ttk;
+
   for(auto &t : ftmTree_) {
     switch(GetTreeType()) {
       case ftm::TreeType::Join:
@@ -622,7 +624,9 @@ void ttkFTMTree::printCSVStats() {
   }
 }
 
-void ttkFTMTree::printCSVTree(const ftm::FTMTree_MT *const tree) const {
+void ttkFTMTree::printCSVTree(const ttk::ftm::FTMTree_MT *const tree) const {
+  using namespace ttk::ftm;
+
   const idSuperArc nbArc = tree->getNumberOfLeaves();
   cout << "begin; ";
   for(idSuperArc a = 0; a < nbArc; a++) {


### PR DESCRIPTION
This PR (hopefully) fixes the race condition in the FTMTree module that caused missing PersistenceDiagram pairs. The root cause is that in the `leafGrowth` method, in parallel, the task corresponding to the oldest leaf (a global extremum) sometimes advance along the trunk of the tree. Then, the `trunk` method generates additional arcs, losing the tree structure (we don't have #arcs == #nodes -1 anymore).

In this PR, a error is displayed if the output is not a tree and additional checks make sure that the `trunk` method only acts on non fully connected saddles.

Additionally, compiler errors when using the `TTK_ENABLE_FTM_TREE_STATS_TIME` and `TTK_ENABLE_FTM_TREE_PROCESS_SPEED` options were fixed.

Fixes #841.

Enjoy,
Pierre
