### PR TITLE
GitHub Actions: Update clang tools

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,6 +89,8 @@ jobs:
           - {tidy: true, sa: false, dox: false}
           - {tidy: false, sa: true, dox: false}
           - {tidy: false, sa: false, dox: true}
+    env:
+      CMAKE_EXPORT_COMPILE_COMMANDS: ON
 
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +128,6 @@ jobs:
         mkdir build
         cd build
         cmake \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
@@ -170,6 +171,9 @@ jobs:
         simplexId: [64BIT_IDS=TRUE, 64BIT_IDS=FALSE]
         opt: [Debug, Release]
         mpi: [MPI=TRUE, MPI=FALSE]
+    env:
+      CMAKE_EXPORT_COMPILE_COMMANDS: ON
+
     steps:
     - uses: actions/checkout@v2
 
@@ -206,7 +210,6 @@ jobs:
         mkdir build
         cd build
         cmake \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
           -DCMAKE_BUILD_TYPE=${{ matrix.opt }} \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,19 +30,17 @@ jobs:
   # ----------------------- #
   check-formatting:
     runs-on: ubuntu-22.04
-    env:
-      CLANG_FORMAT: clang-format-11
     steps:
     - uses: actions/checkout@v2
 
     - name: Install latest clang-format
       run: |
         sudo apt update
-        sudo apt install -y $CLANG_FORMAT
+        sudo apt install -y clang-format
 
     - name: Use clang-format to detect formatting issues
       run: |
-        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs $CLANG_FORMAT -n -Werror
+        git ls-files | grep -E "\.cpp$|\.cxx$|\.h$|\.hpp$" | xargs clang-format -n -Werror
 
     - name: Check line endings (Unix rather than DOS)
       run: |
@@ -85,8 +83,6 @@ jobs:
   # ------------- #
   lint-code:
     runs-on: ubuntu-22.04
-    env:
-      CLANG_TIDY: clang-tidy-12
     strategy:
       matrix:
         config:
@@ -111,7 +107,7 @@ jobs:
           python3-sklearn \
           zlib1g-dev \
           doxygen \
-          $CLANG_TIDY
+          clang-tidy
 
     - uses: dsaltares/fetch-gh-release-asset@master
       with:
@@ -145,7 +141,7 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 -P$(nproc) $CLANG_TIDY -p build --warnings-as-errors="*" 2> /dev/null
+        | xargs -n1 -P$(nproc) clang-tidy -p build --warnings-as-errors="*" 2> /dev/null
 
     - name: Use Clang static analyzer
       if: matrix.config.sa
@@ -153,7 +149,7 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 -P$(nproc) $CLANG_TIDY -p build --checks="-*,clang-analyzer-*" --warnings-as-errors="*" 2> /dev/null
+        | xargs -n1 -P$(nproc) clang-tidy -p build --checks="-*,clang-analyzer-*" --warnings-as-errors="*" 2> /dev/null
 
     - name: Check Doxygen documentation warnings
       if: matrix.config.dox
@@ -190,7 +186,8 @@ jobs:
           graphviz \
           python3-sklearn \
           zlib1g-dev \
-          clang-tools-11
+          clang-tools \
+          libomp-dev
 
     - uses: dsaltares/fetch-gh-release-asset@master
       with:
@@ -225,4 +222,4 @@ jobs:
         git ls-files \
         | grep core \
         | grep -E "\.cpp$|\.cxx$" \
-        | xargs -n1 -P$(nproc) clang-check-11 -p build --extra-arg=-Werror
+        | xargs -n1 -P$(nproc) clang-check -p build --extra-arg=-Werror

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
   # Test macOS build #
   # -----------------#
   test-build-macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       CCACHE_DIR: /Users/runner/work/ttk/.ccache
     steps:
@@ -220,9 +220,11 @@ jobs:
         brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree ccache
-        python3 -m pip install scikit-learn packaging
+        python3.10 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
+        # remove Python 3.11 installation
+        sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.11
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
@@ -261,7 +263,6 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DPython3_ROOT_DIR=$(brew --prefix python) \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
@@ -315,7 +316,7 @@ jobs:
     - name: Run ttk-data Python scripts
       run: |
         cd ttk-data
-        python3 -u python/run.py
+        python3.10 -u python/run.py
       env:
         PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
 

--- a/core/base/triangulation/Triangulation.cpp
+++ b/core/base/triangulation/Triangulation.cpp
@@ -19,14 +19,25 @@ Triangulation::Triangulation(const Triangulation &rhs)
   gridDimensions_ = rhs.gridDimensions_;
   hasPeriodicBoundaries_ = rhs.hasPeriodicBoundaries_;
 
-  if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
-    abstractTriangulation_ = &explicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
-    abstractTriangulation_ = &implicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.periodicImplicitTriangulation_) {
-    abstractTriangulation_ = &periodicImplicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.compactTriangulation_) {
-    abstractTriangulation_ = &compactTriangulation_;
+  switch(rhs.getType()) {
+    case Type::EXPLICIT:
+      this->abstractTriangulation_ = &this->explicitTriangulation_;
+      break;
+    case Type::COMPACT:
+      this->abstractTriangulation_ = &this->compactTriangulation_;
+      break;
+    case Type::IMPLICIT:
+      this->abstractTriangulation_ = &this->implicitTriangulation_;
+      break;
+    case Type::HYBRID_IMPLICIT:
+      this->abstractTriangulation_ = &this->implicitPreconditionsTriangulation_;
+      break;
+    case Type::PERIODIC:
+      this->abstractTriangulation_ = &this->periodicImplicitTriangulation_;
+      break;
+    case Type::HYBRID_PERIODIC:
+      this->abstractTriangulation_ = &this->periodicPreconditionsTriangulation_;
+      break;
   }
 }
 
@@ -43,15 +54,27 @@ Triangulation::Triangulation(Triangulation &&rhs) noexcept
   gridDimensions_ = rhs.gridDimensions_;
   hasPeriodicBoundaries_ = rhs.hasPeriodicBoundaries_;
 
-  if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
-    abstractTriangulation_ = &explicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
-    abstractTriangulation_ = &implicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.periodicImplicitTriangulation_) {
-    abstractTriangulation_ = &periodicImplicitTriangulation_;
-  } else if(rhs.abstractTriangulation_ == &rhs.compactTriangulation_) {
-    abstractTriangulation_ = &compactTriangulation_;
+  switch(rhs.getType()) {
+    case Type::EXPLICIT:
+      this->abstractTriangulation_ = &this->explicitTriangulation_;
+      break;
+    case Type::COMPACT:
+      this->abstractTriangulation_ = &this->compactTriangulation_;
+      break;
+    case Type::IMPLICIT:
+      this->abstractTriangulation_ = &this->implicitTriangulation_;
+      break;
+    case Type::HYBRID_IMPLICIT:
+      this->abstractTriangulation_ = &this->implicitPreconditionsTriangulation_;
+      break;
+    case Type::PERIODIC:
+      this->abstractTriangulation_ = &this->periodicImplicitTriangulation_;
+      break;
+    case Type::HYBRID_PERIODIC:
+      this->abstractTriangulation_ = &this->periodicPreconditionsTriangulation_;
+      break;
   }
+  rhs.abstractTriangulation_ = nullptr;
 }
 
 Triangulation &Triangulation::operator=(const Triangulation &rhs) {
@@ -65,15 +88,27 @@ Triangulation &Triangulation::operator=(const Triangulation &rhs) {
     compactTriangulation_ = rhs.compactTriangulation_;
     hasPeriodicBoundaries_ = rhs.hasPeriodicBoundaries_;
 
-    if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
-      abstractTriangulation_ = &explicitTriangulation_;
-    } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
-      abstractTriangulation_ = &implicitTriangulation_;
-    } else if(rhs.abstractTriangulation_
-              == &rhs.periodicImplicitTriangulation_) {
-      abstractTriangulation_ = &periodicImplicitTriangulation_;
-    } else if(rhs.abstractTriangulation_ == &rhs.compactTriangulation_) {
-      abstractTriangulation_ = &compactTriangulation_;
+    switch(rhs.getType()) {
+      case Type::EXPLICIT:
+        this->abstractTriangulation_ = &this->explicitTriangulation_;
+        break;
+      case Type::COMPACT:
+        this->abstractTriangulation_ = &this->compactTriangulation_;
+        break;
+      case Type::IMPLICIT:
+        this->abstractTriangulation_ = &this->implicitTriangulation_;
+        break;
+      case Type::HYBRID_IMPLICIT:
+        this->abstractTriangulation_
+          = &this->implicitPreconditionsTriangulation_;
+        break;
+      case Type::PERIODIC:
+        this->abstractTriangulation_ = &this->periodicImplicitTriangulation_;
+        break;
+      case Type::HYBRID_PERIODIC:
+        this->abstractTriangulation_
+          = &this->periodicPreconditionsTriangulation_;
+        break;
     }
   }
   return *this;
@@ -90,15 +125,27 @@ Triangulation &Triangulation::operator=(Triangulation &&rhs) noexcept {
     compactTriangulation_ = std::move(rhs.compactTriangulation_);
     hasPeriodicBoundaries_ = rhs.hasPeriodicBoundaries_;
 
-    if(rhs.abstractTriangulation_ == &rhs.explicitTriangulation_) {
-      abstractTriangulation_ = &explicitTriangulation_;
-    } else if(rhs.abstractTriangulation_ == &rhs.implicitTriangulation_) {
-      abstractTriangulation_ = &implicitTriangulation_;
-    } else if(rhs.abstractTriangulation_
-              == &rhs.periodicImplicitTriangulation_) {
-      abstractTriangulation_ = &periodicImplicitTriangulation_;
-    } else if(rhs.abstractTriangulation_ == &rhs.compactTriangulation_) {
-      abstractTriangulation_ = &compactTriangulation_;
+    switch(rhs.getType()) {
+      case Type::EXPLICIT:
+        this->abstractTriangulation_ = &this->explicitTriangulation_;
+        break;
+      case Type::COMPACT:
+        this->abstractTriangulation_ = &this->compactTriangulation_;
+        break;
+      case Type::IMPLICIT:
+        this->abstractTriangulation_ = &this->implicitTriangulation_;
+        break;
+      case Type::HYBRID_IMPLICIT:
+        this->abstractTriangulation_
+          = &this->implicitPreconditionsTriangulation_;
+        break;
+      case Type::PERIODIC:
+        this->abstractTriangulation_ = &this->periodicImplicitTriangulation_;
+        break;
+      case Type::HYBRID_PERIODIC:
+        this->abstractTriangulation_
+          = &this->periodicPreconditionsTriangulation_;
+        break;
     }
   }
   AbstractTriangulation::operator=(std::move(rhs));

--- a/core/base/triangulation/Triangulation.cpp
+++ b/core/base/triangulation/Triangulation.cpp
@@ -3,8 +3,7 @@
 using namespace std;
 using namespace ttk;
 
-Triangulation::Triangulation()
-  : AbstractTriangulation{}, abstractTriangulation_{nullptr} {
+Triangulation::Triangulation() : abstractTriangulation_{nullptr} {
   debugLevel_ = 0; // overrides the global debug level.
   gridDimensions_ = {-1, -1, -1};
   hasPeriodicBoundaries_ = false;
@@ -32,8 +31,10 @@ Triangulation::Triangulation(const Triangulation &rhs)
 }
 
 Triangulation::Triangulation(Triangulation &&rhs) noexcept
-  : AbstractTriangulation(std::move(rhs)), abstractTriangulation_{nullptr},
-    explicitTriangulation_{std::move(rhs.explicitTriangulation_)},
+  : AbstractTriangulation(
+    std::move(*static_cast<AbstractTriangulation *>(&rhs))),
+    abstractTriangulation_{nullptr}, explicitTriangulation_{std::move(
+                                       rhs.explicitTriangulation_)},
     implicitTriangulation_{std::move(rhs.implicitTriangulation_)},
     periodicImplicitTriangulation_{
       std::move(rhs.periodicImplicitTriangulation_)},


### PR DESCRIPTION
This PR updates the `check_code` workflow to use the latest Clang tools available in the Ubuntu 22.04 repositories (v14) instead of the pinned v11 packages. This also allows to use directly `clang-format`, `clang-check` and `clang-tidy` in the workflow instead of hiding them in environment variables, thus making it easier to copy-paste the commands into a terminal to use them locally.

Updating the tools revealed a new use-after-move warning in the move constructor of the Triangulation class (which does not seem to be used much in the TTK codebase). The PR fixes this warning and extends the constructors and operators= to use the implicit/periodic triangulations with preconditions. The if/else was replaced by a switch, as it emits a warning if an enumeration value is missing.

Enjoy,
Pierre