### PR TITLE
Reduce build times of PersistenceDiagram modules

### DIFF
--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.h
@@ -172,9 +172,6 @@ public:
   vtkSetMacro(ForceInputOffsetScalarField, bool);
   vtkGetMacro(ForceInputOffsetScalarField, bool);
 
-  vtkSetMacro(ComputeSaddleConnectors, bool);
-  vtkGetMacro(ComputeSaddleConnectors, bool);
-
   vtkSetMacro(ShowInsideDomain, bool);
   vtkGetMacro(ShowInsideDomain, bool);
 

--- a/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
+++ b/core/vtk/ttkPersistenceDiagramApproximation/ttkPersistenceDiagramApproximation.cpp
@@ -67,8 +67,24 @@ int ttkPersistenceDiagramApproximation::dispatch(
   this->setOutputOffsets(outputOffsets);
   this->setOutputMonotonyOffsets(outputMonotonyOffsets);
 
-  status = this->execute(CTDiagram, inputScalars, inputScalarsArray->GetMTime(),
-                         inputOrder, triangulation);
+  if(!std::is_same<ttk::ImplicitWithPreconditions, triangulationType>::value
+     && !std::is_same<ttk::ImplicitNoPreconditions, triangulationType>::value) {
+    this->printErr("Explicit, Compact or Periodic triangulation detected.");
+    this->printErr("Approximation only works on regular grids.");
+    return 0;
+  }
+
+  ttk::Timer tm{};
+
+  status
+    = this->executeApproximateTopology(CTDiagram, inputScalars, triangulation);
+
+  this->printMsg("Complete", 1.0, tm.getElapsedTime(), this->threadNumber_);
+
+  // finally sort the diagram
+  sortPersistenceDiagram(CTDiagram, inputOrder);
+
+  printMsg(ttk::debug::Separator::L1);
 
   // something wrong in baseCode
   if(status != 0) {

--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -339,24 +339,6 @@
       </DoubleVectorProperty>
 
       <IntVectorProperty
-         name="SaddleConnectors"
-         command="SetComputeSaddleConnectors"
-         label="Compute saddle-saddle pairs (SLOW!)"
-         number_of_elements="1"
-         default_values="0" panel_visibility="advanced">
-          <Hints>
-          <PropertyWidgetDecorator type="GenericDecorator"
-                                   mode="visibility"
-                                   property="BackEnd"
-                                   value="0" />
-        </Hints>
-        <BooleanDomain name="bool"/>
-        <Documentation>
-          Add saddle-saddle pairs in the diagram (SLOW!).
-        </Documentation>
-      </IntVectorProperty>
-
-      <IntVectorProperty
           name="Ignore Boundary"
           command="SetIgnoreBoundary"
           number_of_elements="1"
@@ -523,7 +505,6 @@
       </PropertyGroup>
 
       <PropertyGroup panel_widget="Line" label="Output options">
-        <Property name="SaddleConnectors" />
         <Property name="Ignore Boundary" />
         <Property name="DMSDimensions" />
         <Property name="ComputeMinSad" />

--- a/paraview/xmls/PersistenceDiagramApproximation.xml
+++ b/paraview/xmls/PersistenceDiagramApproximation.xml
@@ -43,15 +43,14 @@
           <Group name="filters"/>
         </ProxyGroupDomain>
         <DataTypeDomain name="input_type">
-          <DataType value="vtkDataSet"/>
+          <DataType value="vtkImageData"/>
         </DataTypeDomain>
         <InputArrayDomain name="input_scalars" number_of_components="1">
           <Property name="Input" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>
           Data-set to process.
-          Input should be a regular grid (.vti), otherwise FTM will be used
-          to compute the persistence diagram, and other fields will be empty.
+          Input should be a regular grid (.vti).
         </Documentation>
       </InputProperty>
 


### PR DESCRIPTION
This short PR reduces the build times of the `ttkPersistenceDiagram`, `ttkPersistenceDiagramApproximation` and `ttkTrackingFromFields` modules through these two optimizations:

- the computation of saddle-saddle pairs with the FTM backend has been deleted, since it is now superseded by the DiscreteMorseSandwich algorithm.
- `PersistenceDiagramApproximation` now calls only `executeApproximateTopology` in the base class instead of the way heavier `execute`. The filter has been made to be executed only on regular grids in order to get rid of its fallback to FTM.

The observed reduction in build times is as follow (on my computer with some template instantiations disabled):
* `ttkPersistenceDiagram`: from 180 to 110s,
* `ttkTrackingFromFields`: from 185 to 110s,
* `ttkPersistenceDiagramApproximation`: from 180 to 30s.

Enjoy,
Pierre