### PR TITLE
Update Github Actions

### DIFF
--- a/.github/actions/install-deps-unix/action.yml
+++ b/.github/actions/install-deps-unix/action.yml
@@ -7,20 +7,20 @@ runs:
     - name: Install Spectra dependency
       shell: bash
       run: |
-        wget https://github.com/yixuan/spectra/archive/v1.0.0.tar.gz
-        tar xvf v1.0.0.tar.gz
+        wget https://github.com/yixuan/spectra/archive/v1.0.1.tar.gz
+        tar xvf v1.0.1.tar.gz
         mkdir build_spectra && cd build_spectra
-        cmake ../spectra-1.0.0
+        cmake ../spectra-1.0.1
         sudo cmake --build . --target install --parallel
 
     - name: Install ZFP dependency
       shell: bash
       run: |
-        wget https://github.com/LLNL/zfp/archive/0.5.5.tar.gz
-        tar xvf 0.5.5.tar.gz
+        wget https://github.com/LLNL/zfp/archive/1.0.0.tar.gz
+        tar xvf 1.0.0.tar.gz
         mkdir build_zfp && cd build_zfp
         cmake \
           -DBUILD_SHARED_LIBS=OFF \
           -DBUILD_TESTING=OFF \
-          ../zfp-0.5.5
+          ../zfp-1.0.0
         sudo cmake --build . --target install --parallel

--- a/.github/actions/install-deps-unix/action.yml
+++ b/.github/actions/install-deps-unix/action.yml
@@ -24,12 +24,3 @@ runs:
           -DBUILD_TESTING=OFF \
           ../zfp-0.5.5
         sudo cmake --build . --target install --parallel
-
-    - name: Install WebSocket++ dependency
-      shell: bash
-      run: |
-        wget https://github.com/zaphoyd/websocketpp/archive/0.8.2.tar.gz
-        tar xvf 0.8.2.tar.gz
-        mkdir build_websocketpp && cd build_websocketpp
-        cmake ../websocketpp-0.8.2
-        sudo cmake --build . --target install --parallel

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -40,6 +40,7 @@ jobs:
           libosmesa-dev \
           libopenmpi-dev \
           libsqlite3-dev \
+          libwebsocketpp-dev \
           graphviz \
           ninja-build \
           zlib1g-dev \
@@ -115,7 +116,7 @@ jobs:
         brew install --cask xquartz
         brew install wget libomp ninja python open-mpi
         # TTK dependencies
-        brew install boost eigen graphviz numpy embree ccache
+        brew install boost eigen graphviz numpy embree websocketpp ccache
         python3 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
@@ -184,7 +185,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz ninja sccache
+          scikit-learn packaging openmp graphviz ninja websocketpp sccache
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -286,15 +286,19 @@ jobs:
           await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
 
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v6
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: true
+        script: |
+          const { owner, repo } = context.repo
+          await github.rest.repos.createRelease({
+            owner,
+            repo,
+            tag_name: "ccache",
+            name: "ccache archives",
+            body: "Holds ccache archives to speed up build jobs",
+            draft: false,
+            prerelease: true
+          })
 
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -25,7 +25,7 @@ jobs:
       CCACHE_DIR: /home/runner/.ccache
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Install Ubuntu dependencies
@@ -92,7 +92,7 @@ jobs:
         tar czf ttk-ccache.tar.gz .ccache
 
     - name: Upload ccache archive
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-ccache-${{ matrix.os }}
         path: /home/runner/ttk-ccache.tar.gz
@@ -106,7 +106,7 @@ jobs:
     env:
       CCACHE_DIR: /Users/runner/work/ttk/.ccache
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Remove hosted Python
@@ -166,7 +166,7 @@ jobs:
         tar czf ttk-ccache.tar.gz .ccache
 
     - name: Upload ccache archive
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-ccache-macOS
         path: /Users/runner/work/ttk/ttk-ccache.tar.gz
@@ -179,7 +179,7 @@ jobs:
     env:
       CONDA_ROOT: C:\Miniconda
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - uses: s-weigand/setup-conda@v1
@@ -261,7 +261,7 @@ jobs:
         tar czf ttk-sccache.tar.gz cache
 
     - name: Upload sccache archive
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-sccache-windows
         path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\ttk-sccache.tar.gz
@@ -300,7 +300,7 @@ jobs:
         prerelease: true
 
     - name: Fetch all uploaded artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Upload Ubuntu Bionic .deb as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -49,14 +49,10 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      name: Fetch TTK-ParaView headless Debian package
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-headless-${{ matrix.os }}.deb"
-        target: "ttk-paraview-headless.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview-headless.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-${{ matrix.os }}.deb
 
     - name: Install ParaView .deb
       run: |

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -23,8 +23,8 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     env:
       CCACHE_DIR: /home/runner/.ccache
-    steps:
 
+    steps:
     - uses: actions/checkout@v3
       name: Checkout TTK source code
 
@@ -75,6 +75,7 @@ jobs:
           -DTTK_ENABLE_MPI=TRUE \
           -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
           -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 \
           -GNinja \
           $GITHUB_WORKSPACE
 
@@ -106,20 +107,18 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout TTK source code
 
-    - name: Remove hosted Python
-      run: |
-        sudo rm -rf /usr/local/Frameworks/Python.framework
-
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp ninja python open-mpi
+        brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree websocketpp ccache
-        python3 -m pip install scikit-learn packaging
+        python3.10 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
+        # remove Python 3.11 installation
+        sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.11
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
@@ -133,6 +132,11 @@ jobs:
         tar xzf ttk-paraview-headless.tar.gz
         sudo cp -r ttk-paraview/* /usr/local
 
+    - name: Set compilers as environment variables
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
+
     - name: Create & configure TTK build directory
       run: |
         mkdir build
@@ -141,7 +145,6 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DPython3_ROOT_DIR=$(brew --prefix python) \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \
@@ -149,6 +152,7 @@ jobs:
           -DTTK_ENABLE_MPI=TRUE \
           -DTTK_ENABLE_CPU_OPTIMIZATION=FALSE \
           -DTTK_ENABLE_SHARED_BASE_LIBRARIES=TRUE \
+          -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 \
           -GNinja \
           $GITHUB_WORKSPACE
 

--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -299,6 +299,12 @@ jobs:
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3
 
+    - name: Delete ccache artifacts
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: |
+              ttk-*ccache*
+
     - name: Upload Ubuntu Bionic .deb as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -111,13 +111,10 @@ jobs:
           doxygen \
           clang-tidy
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-headless-ubuntu-22.04.deb"
-        target: "ttk-paraview-headless.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview-headless.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-ubuntu-22.04.deb
 
     - name: Install ParaView .deb
       run: |
@@ -193,13 +190,10 @@ jobs:
           clang-tools \
           libomp-dev
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-headless-ubuntu-22.04.deb"
-        target: "ttk-paraview-headless.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview-headless.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-ubuntu-22.04.deb
 
     - name: Install ParaView .deb
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
   check-formatting:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install latest clang-format
       run: |
@@ -93,7 +93,7 @@ jobs:
       CMAKE_EXPORT_COMPILE_COMMANDS: ON
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Ubuntu dependencies
       run: |
@@ -175,7 +175,7 @@ jobs:
       CMAKE_EXPORT_COMPILE_COMMANDS: ON
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Ubuntu dependencies
       run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Install Ubuntu dependencies
@@ -88,7 +88,7 @@ jobs:
         cpack -G DEB
 
     - name: Upload TTK .deb package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-${{ matrix.os }}.deb
         path: build/ttk.deb
@@ -103,7 +103,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - uses: dsaltares/fetch-gh-release-asset@master
@@ -116,7 +116,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Fetch TTK .deb artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ttk-${{ matrix.os }}.deb
 
@@ -135,7 +135,7 @@ jobs:
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"
@@ -159,7 +159,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Remove hosted Python
@@ -213,7 +213,7 @@ jobs:
         cpack -G productbuild
 
     - name: Upload .pkg package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk.pkg
         path: build/ttk.pkg
@@ -225,7 +225,7 @@ jobs:
     needs: build-macos
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Remove hosted Python
@@ -246,7 +246,7 @@ jobs:
         wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.pkg
 
     - name: Fetch TTK .pkg artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ttk.pkg
 
@@ -283,7 +283,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         ttkHelloWorldCmd -i examples/data/inputData.vtu
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"
@@ -311,7 +311,7 @@ jobs:
     env:
       CONDA_ROOT: C:\Miniconda
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - uses: s-weigand/setup-conda@v1
@@ -385,7 +385,7 @@ jobs:
         cpack -C Release -G NSIS64
 
     - name: Upload TTK .exe package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk.exe
         path: build/ttk.exe
@@ -401,7 +401,7 @@ jobs:
       TTK_DIR: C:\Program Files\TTK
       CONDA_ROOT: C:\Miniconda
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - uses: s-weigand/setup-conda@v1
@@ -424,7 +424,7 @@ jobs:
         -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
 
     - name: Fetch TTK .exe artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ttk.exe
 
@@ -483,7 +483,7 @@ jobs:
         cd %GITHUB_WORKSPACE%\examples\vtk-c++
         ttkHelloWorldCmd.exe -i %GITHUB_WORKSPACE%\examples\data\inputData.vtu
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"
@@ -524,7 +524,7 @@ jobs:
         prerelease: true
 
     - name: Fetch all uploaded artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Upload Ubuntu Focal .deb as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -518,15 +518,18 @@ jobs:
           await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
 
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v6
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: true
+        script: |
+          const { owner, repo } = context.repo
+          await github.rest.repos.createRelease({
+            owner,
+            repo,
+            tag_name: "${{ github.ref_name }}",
+            name: "Release ${{ github.ref_name }}",
+            draft: false,
+            prerelease: true
+          })
 
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,14 +47,10 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      name: Fetch TTK-ParaView package
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.deb"
-        target: "ttk-paraview.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.deb
 
     - name: Install ParaView .deb
       run: |
@@ -106,14 +102,10 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout TTK source code
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      name: Fetch TTK-ParaView package
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.deb"
-        target: "ttk-paraview.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.deb
 
     - name: Fetch TTK .deb artifact
       uses: actions/download-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,6 +39,7 @@ jobs:
           libgraphviz-dev \
           libsqlite3-dev \
           libgl1-mesa-dev \
+          libwebsocketpp-dev \
           graphviz \
           python3-sklearn \
           zlib1g-dev \
@@ -162,9 +163,9 @@ jobs:
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp mesa glew qt@5 ninja python
+        brew install wget llvm libomp mesa glew qt@5 ninja python
         # TTK dependencies
-        brew install boost eigen graphviz embree
+        brew install boost eigen graphviz embree websocketpp
         python3 -m pip install scikit-learn packaging
 
     - name: Install optional dependencies
@@ -174,6 +175,11 @@ jobs:
       run: |
         wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.pkg
         sudo installer -pkg ttk-paraview-${{ env.PV_TAG }}.pkg -target /
+
+    - name: Set compilers as environment variables
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
     - name: Create & configure TTK build directory
       run: |
@@ -228,7 +234,7 @@ jobs:
       run: |
         # ParaView dependencies
         brew install --cask xquartz
-        brew install wget libomp mesa glew qt@5 ninja python
+        brew install wget llvm libomp mesa glew qt@5 ninja python
         # TTK dependencies
         brew install boost eigen graphviz embree
         python3 -m pip install scikit-learn packaging
@@ -246,6 +252,11 @@ jobs:
       run: |
         sudo installer -pkg ttk-paraview-${{ env.PV_TAG }}.pkg -target /
         sudo installer -pkg ttk.pkg -target /
+
+    - name: Set compilers as environment variables
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
     - name: Test TTK examples
       run: |
@@ -312,7 +323,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz
+          scikit-learn packaging openmp graphviz websocketpp
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -504,6 +504,19 @@ jobs:
     needs: [test-linux, test-macos, test-windows]
     steps:
 
+    - name: Delete previous release
+      uses: actions/github-script@v6
+      continue-on-error: true
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          const { data: { id } } = await github.rest.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag: "${{ github.ref_name }}"
+          })
+          await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           libosmesa-dev \
           libopenmpi-dev \
           libsqlite3-dev \
+          libwebsocketpp-dev \
           graphviz \
           ninja-build \
           zlib1g-dev \
@@ -211,7 +212,7 @@ jobs:
         brew install --cask xquartz
         brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
-        brew install boost eigen graphviz numpy embree ccache
+        brew install boost eigen graphviz numpy embree websocketpp ccache
         python3.10 -m pip install scikit-learn packaging
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
@@ -339,7 +340,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz ninja sccache
+          scikit-learn packaging openmp graphviz ninja websocketpp sccache
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
         # add TTK & ParaView install folders to PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,15 +57,11 @@ jobs:
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - name: Fetch archived ccache
       continue-on-error: true
-      name: Fetch archived ccache
-      with:
-        repo: "topology-tool-kit/ttk"
-        version: "tags/ccache"
-        file: "ttk-ccache-${{ matrix.os }}.tar.gz"
-        target: "ttk-ccache.tar.gz"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        wget -O ttk-ccache.tar.gz \
+          https://github.com/${{ github.repository }}/releases/download/ccache/ttk-ccache-${{ matrix.os }}.tar.gz
 
     - name: Decompress ccache archive
       continue-on-error: true
@@ -73,14 +69,10 @@ jobs:
         tar xzf ttk-ccache.tar.gz
         mv .ccache /home/runner/
 
-    - uses: dsaltares/fetch-gh-release-asset@master
-      name: Fetch TTK-ParaView headless Debian package
-      with:
-        repo: "${{ env.PV_REPO }}"
-        version: "tags/${{ env.PV_TAG }}"
-        file: "ttk-paraview-headless-${{ matrix.os }}.deb"
-        target: "ttk-paraview-headless.deb"
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch TTK-ParaView headless Debian package
+      run: |
+        wget -O ttk-paraview-headless.deb \
+          https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-${{ matrix.os }}.deb
 
     - name: Install ParaView .deb
       run: |
@@ -232,7 +224,7 @@ jobs:
     - name: Fetch archived ccache
       continue-on-error: true
       run: |
-        wget https://github.com/topology-tool-kit/ttk/releases/download/ccache/ttk-ccache-macOS.tar.gz
+        wget https://github.com/${{ github.repository }}/releases/download/ccache/ttk-ccache-macOS.tar.gz
 
     - name: Decompress ccache archive
       continue-on-error: true
@@ -359,15 +351,12 @@ jobs:
       run: |
         rm -rf C:/hostedtoolcache/windows/Python
 
-    - uses: dsaltares/fetch-gh-release-asset@master
+    - name: Fetch archived ccache
       continue-on-error: true
-      name: Fetch archived ccache
-      with:
-        repo: "topology-tool-kit/ttk"
-        version: "tags/ccache"
-        file: "ttk-sccache-windows.tar.gz"
-        target: "ttk-sccache.tar.gz"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        Invoke-WebRequest `
+        -OutFile ttk-sccache.tar.gz `
+        -Uri https://github.com/${{ github.repository }}/releases/download/ccache/ttk-sccache-windows.tar.gz
 
     - name: Decompress ccache archive
       continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Install Ubuntu dependencies
@@ -121,7 +121,7 @@ jobs:
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"
@@ -184,7 +184,7 @@ jobs:
 
     - name: Upload result screenshots
       if: steps.validate.outcome == 'failure'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: screenshots-${{ matrix.os }}.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
@@ -210,7 +210,7 @@ jobs:
     env:
       CCACHE_DIR: /Users/runner/work/ttk/.ccache
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - name: Install macOS dependencies
@@ -288,7 +288,7 @@ jobs:
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"
@@ -308,7 +308,7 @@ jobs:
 
     - name: Upload result screenshots
       if: steps.validate.outcome == 'failure'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: screenshots-macOS.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
@@ -338,7 +338,7 @@ jobs:
       TTK_DIR: C:\Program Files (x86)\ttk
       CONDA_ROOT: C:\Miniconda
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK source code
 
     - uses: s-weigand/setup-conda@v1
@@ -483,7 +483,7 @@ jobs:
         cd %GITHUB_WORKSPACE%\examples\vtk-c++
         ttkHelloWorldCmd.exe -i %GITHUB_WORKSPACE%\examples\data\inputData.vtu
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: "topology-tool-kit/ttk-data"
         ref: "dev"

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -192,15 +192,18 @@ jobs:
           await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
 
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v6
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: true
+        script: |
+          const { owner, repo } = context.repo
+          await github.rest.repos.createRelease({
+            owner,
+            repo,
+            tag_name: "${{ github.ref_name }}",
+            name: "Release ${{ github.ref_name }}",
+            draft: false,
+            prerelease: true
+          })
 
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -177,6 +177,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-ubuntu, build-macos, build-windows]
     steps:
+
+    - name: Delete previous release
+      uses: actions/github-script@v6
+      continue-on-error: true
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          const { data: { id } } = await github.rest.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag: "${{ github.ref_name }}"
+          })
+          await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - name: Install Ubuntu dependencies
@@ -59,7 +59,7 @@ jobs:
         cpack -G DEB
 
     - name: Upload Debian package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-headless-${{ matrix.os }}
         path: build/ttk-paraview.deb
@@ -71,7 +71,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - name: Remove hosted Python
@@ -107,7 +107,7 @@ jobs:
         sudo cpack -G TGZ
 
     - name: Upload compressed binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-headless-macOS
         path: build/ttk-paraview.tar.gz
@@ -122,7 +122,7 @@ jobs:
       CONDA_ROOT: C:\Miniconda
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - uses: s-weigand/setup-conda@v1
@@ -164,7 +164,7 @@ jobs:
         mv ttk-paraview.exe $GITHUB_WORKSPACE
 
     - name: Upload install executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-headless-windows
         path: ttk-paraview.exe
@@ -189,7 +189,7 @@ jobs:
         prerelease: true
 
     - name: Fetch all uploaded artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Upload Ubuntu Bionic .deb as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/paraview/patch/main.yml
+++ b/paraview/patch/main.yml
@@ -67,7 +67,7 @@ jobs:
         mv ttk-paraview.deb.new ttk-paraview.deb
 
     - name: Upload .deb package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-${{ matrix.os }}.deb
         path: build/ttk-paraview.deb
@@ -102,7 +102,7 @@ jobs:
         cpack -G productbuild
 
     - name: Upload .pgk package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview.pkg
         path: build/ttk-paraview.pkg
@@ -130,7 +130,7 @@ jobs:
         cpack -G NSIS64
 
     - name: Upload .exe installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview.exe
         path: build/ttk-paraview.exe
@@ -151,7 +151,7 @@ jobs:
         prerelease: false
 
     - name: Fetch all uploaded artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Upload Ubuntu Bionic .deb as Release Asset
       uses: actions/upload-release-asset@v1

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - name: Install Ubuntu dependencies
@@ -62,7 +62,7 @@ jobs:
         cpack -G DEB
 
     - name: Upload Debian package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-${{ matrix.os }}
         path: build/ttk-paraview.deb
@@ -74,7 +74,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - name: Remove hosted Python
@@ -109,7 +109,7 @@ jobs:
         cpack -G productbuild
 
     - name: Upload .pgk package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-macOS
         path: build/ttk-paraview.pkg
@@ -124,7 +124,7 @@ jobs:
       CONDA_ROOT: C:\Miniconda
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout TTK-ParaView source code
 
     - uses: s-weigand/setup-conda@v1
@@ -166,7 +166,7 @@ jobs:
         mv ttk-paraview.exe $GITHUB_WORKSPACE
 
     - name: Upload install executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ttk-paraview-windows
         path: ttk-paraview.exe
@@ -191,7 +191,7 @@ jobs:
         prerelease: false
 
     - name: Fetch all uploaded artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Upload Ubuntu Focal .deb as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -194,15 +194,18 @@ jobs:
           await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
 
     - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v6
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
+        script: |
+          const { owner, repo } = context.repo
+          await github.rest.repos.createRelease({
+            owner,
+            repo,
+            tag_name: "${{ github.ref_name }}",
+            name: "Release ${{ github.ref_name }}",
+            draft: false,
+            prerelease: false
+          })
 
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -179,6 +179,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-ubuntu, build-macos, build-windows]
     steps:
+
+    - name: Delete previous release
+      uses: actions/github-script@v6
+      continue-on-error: true
+      with:
+        script: |
+          const { owner, repo } = context.repo
+          const { data: { id } } = await github.rest.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag: "${{ github.ref_name }}"
+          })
+          await github.rest.repos.deleteRelease({ owner, repo, release_id: id })
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1


### PR DESCRIPTION
This PR updates the GitHub Actions workflows:

* ZFP and Spectra have been updated to their latest release,
* the packaged version of Websocket++ is used on Ubuntu and macOS,
* the `actions/checkout`, `actions/download-artifact` and `actions/upload-artifact` were updated to their latest version (this should fix a NodeJS deprecation warning),
* the third-party action `dsaltares/fetch-gh-release-asset` has been replaced with a `wget` call,
* the deprecated `actions/create-release` has been replaced with some GitHub script,
* GitHub script is also used to delete existing releases before creating new ones with the same tag,
* the `ccache` workflow has been updated to reflect the last changes in the `test_build` workflow.

Enjoy,
Pierre