### PR TITLE
Use DiscreteMorseSandwich to return saddle connectors

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -669,6 +669,12 @@ in the gradient.
                             const triangulationType &triangulation);
 
       /**
+       * @brief Initialize/Allocate discrete gradient memory
+       */
+      void initMemory(const AbstractTriangulation &triangulation);
+
+    public:
+      /**
        * Compute the difference of function values of a pair of cells.
        */
       template <typename dataType, typename triangulationType>
@@ -880,33 +886,30 @@ gradient, false otherwise.
        */
       template <typename triangulationType>
       int reverseAscendingPath(const std::vector<Cell> &vpath,
-                               const triangulationType &triangulation);
+                               const triangulationType &triangulation) const;
 
       /**
        * Reverse the given descending VPath.
        */
       template <typename triangulationType>
       int reverseDescendingPath(const std::vector<Cell> &vpath,
-                                const triangulationType &triangulation);
+                                const triangulationType &triangulation) const;
 
       /**
        * Reverse the given ascending VPath restricted on a 2-separatrice.
        */
       template <typename triangulationType>
-      int reverseAscendingPathOnWall(const std::vector<Cell> &vpath,
-                                     const triangulationType &triangulation);
+      int reverseAscendingPathOnWall(
+        const std::vector<Cell> &vpath,
+        const triangulationType &triangulation) const;
 
       /**
        * Reverse the given descending VPath restricted on a 2-separatrice.
        */
       template <typename triangulationType>
-      int reverseDescendingPathOnWall(const std::vector<Cell> &vpath,
-                                      const triangulationType &triangulation);
-
-      /**
-       * @brief Initialize/Allocate discrete gradient memory
-       */
-      void initMemory(const AbstractTriangulation &triangulation);
+      int reverseDescendingPathOnWall(
+        const std::vector<Cell> &vpath,
+        const triangulationType &triangulation) const;
 
     protected:
       ftm::FTMTree contourTree_{};

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -398,7 +398,8 @@ according to them.
             data->preconditionTriangleStars();
             data->preconditionCellTriangles();
             // for filterSaddleConnectors
-            contourTree_.preconditionTriangulation(data);
+            contourTree_ = std::make_shared<ftm::FTMTree>();
+            contourTree_->preconditionTriangulation(data);
           }
         }
       }
@@ -406,6 +407,13 @@ according to them.
       static inline void
         clearCache(const AbstractTriangulation &triangulation) {
         triangulation.gradientCache_.clear();
+      }
+
+      /**
+       * @brief Use local storage instead of cache
+       */
+      inline void setLocalGradient() {
+        this->gradient_ = &this->localGradient_;
       }
 
       /**
@@ -912,7 +920,7 @@ gradient, false otherwise.
         const triangulationType &triangulation) const;
 
     protected:
-      ftm::FTMTree contourTree_{};
+      std::shared_ptr<ftm::FTMTree> contourTree_{};
 
       int IterationThreshold{-1};
       bool CollectPersistencePairs{false};

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -2756,7 +2756,8 @@ int DiscreteGradient::getAscendingWall(
 
 template <typename triangulationType>
 int DiscreteGradient::reverseAscendingPath(
-  const std::vector<Cell> &vpath, const triangulationType &triangulation) {
+  const std::vector<Cell> &vpath,
+  const triangulationType &triangulation) const {
 
   if(dimensionality_ == 2) {
     // assume that the first cell is an edge
@@ -2824,7 +2825,8 @@ int DiscreteGradient::reverseAscendingPath(
 
 template <typename triangulationType>
 int DiscreteGradient::reverseDescendingPath(
-  const std::vector<Cell> &vpath, const triangulationType &triangulation) {
+  const std::vector<Cell> &vpath,
+  const triangulationType &triangulation) const {
 
   // assume that the first cell is an edge
   for(size_t i = 0; i < vpath.size(); i += 2) {
@@ -2862,7 +2864,8 @@ int DiscreteGradient::reverseDescendingPath(
 
 template <typename triangulationType>
 int DiscreteGradient::reverseAscendingPathOnWall(
-  const std::vector<Cell> &vpath, const triangulationType &triangulation) {
+  const std::vector<Cell> &vpath,
+  const triangulationType &triangulation) const {
 
   if(dimensionality_ == 3) {
     // assume that the first cell is an edge
@@ -2901,7 +2904,8 @@ int DiscreteGradient::reverseAscendingPathOnWall(
 
 template <typename triangulationType>
 int DiscreteGradient::reverseDescendingPathOnWall(
-  const std::vector<Cell> &vpath, const triangulationType &triangulation) {
+  const std::vector<Cell> &vpath,
+  const triangulationType &triangulation) const {
 
   if(dimensionality_ == 3) {
     // assume that the first cell is a triangle

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1605,14 +1605,14 @@ int DiscreteGradient::filterSaddleConnectors(
     = static_cast<const dataType *>(inputScalarField_.first);
   const auto *const offsets = inputOffsets_;
 
-  contourTree_.setDebugLevel(debugLevel_);
-  contourTree_.setVertexScalars(scalars);
-  contourTree_.setTreeType(ftm::TreeType::Contour);
-  contourTree_.setVertexSoSoffsets(offsets);
-  contourTree_.setThreadNumber(threadNumber_);
-  contourTree_.setSegmentation(false);
-  contourTree_.build<dataType>(&triangulation);
-  ftm::FTMTree_MT *tree = contourTree_.getTree(ftm::TreeType::Contour);
+  contourTree_->setDebugLevel(debugLevel_);
+  contourTree_->setVertexScalars(scalars);
+  contourTree_->setTreeType(ftm::TreeType::Contour);
+  contourTree_->setVertexSoSoffsets(offsets);
+  contourTree_->setThreadNumber(threadNumber_);
+  contourTree_->setSegmentation(false);
+  contourTree_->build<dataType>(&triangulation);
+  ftm::FTMTree_MT *tree = contourTree_->getTree(ftm::TreeType::Contour);
 
   const SimplexId numberOfNodes = tree->getNumberOfNodes();
   for(SimplexId nodeId = 0; nodeId < numberOfNodes; ++nodeId) {

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -76,6 +76,26 @@ namespace ttk {
       return this->dg_.buildGradient(triangulation);
     }
 
+    /**
+     * @brief Ugly hack to avoid a call to buildGradient()
+     *
+     * An externally computed gradient can be retrofitted into this
+     * class using move semantics with setGradient().
+     * The internal gradient can be fetched back with getGradient()
+     * once the persistence pairs are computed .
+     * c.f. ttk::MorseSmaleComplex::returnSaddleConnectors
+     *
+     * @param[in] dg External gradient instance
+     */
+    inline void setGradient(ttk::dcg::DiscreteGradient &&dg) {
+      this->dg_ = std::move(dg);
+      // reset gradient pointer to local storage
+      this->dg_.setLocalGradient();
+    }
+    inline ttk::dcg::DiscreteGradient &&getGradient() {
+      return std::move(this->dg_);
+    }
+
     template <typename triangulationType>
     inline SimplexId
       getCellGreaterVertex(const dcg::Cell &c,

--- a/core/base/morseSmaleComplex/CMakeLists.txt
+++ b/core/base/morseSmaleComplex/CMakeLists.txt
@@ -5,4 +5,5 @@ ttk_add_base_library(morseSmaleComplex
     MorseSmaleComplex.h
   DEPENDS
     discreteGradient
+    discreteMorseSandwich
     )

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -78,6 +78,7 @@
 
 // base code includes
 #include <DiscreteGradient.h>
+#include <DiscreteMorseSandwich.h>
 #include <Triangulation.h>
 
 #include <queue>
@@ -213,9 +214,8 @@ namespace ttk {
      * Set the threshold for the iterative gradient reversal process.
      * Disable thresholding with -1 (default).
      */
-    int setIterationThreshold(const int iterationThreshold) {
+    inline void setIterationThreshold(const int iterationThreshold) {
       discreteGradient_.setIterationThreshold(iterationThreshold);
-      return 0;
     }
 
     /**
@@ -223,10 +223,9 @@ namespace ttk {
      * the (saddle,...,saddle) vpaths under a given persistence
      * threshold (disabled by default).
      */
-    int setReturnSaddleConnectors(const bool state) {
+    inline void setReturnSaddleConnectors(const bool state) {
       ReturnSaddleConnectors = state;
       discreteGradient_.setReturnSaddleConnectors(state);
-      return 0;
     }
 
     /**
@@ -234,10 +233,10 @@ namespace ttk {
      * (saddle,...,saddle) vpaths gradient reversal
      * (default value is 0.0).
      */
-    int setSaddleConnectorsPersistenceThreshold(const double threshold) {
+    inline void
+      setSaddleConnectorsPersistenceThreshold(const double threshold) {
       SaddleConnectorsPersistenceThreshold = threshold;
       discreteGradient_.setSaddleConnectorsPersistenceThreshold(threshold);
-      return 0;
     }
 
     /**
@@ -440,7 +439,13 @@ namespace ttk {
                              SimplexId *const morseSmaleManifold,
                              const triangulationType &triangulation) const;
 
-  protected:
+    template <typename dataType, typename triangulationType>
+    int returnSaddleConnectors(const double persistenceThreshold,
+                               const dataType *const scalars,
+                               const size_t scalarsMTime,
+                               const SimplexId *const offsets,
+                               const triangulationType &triangulation) const;
+
     dcg::DiscreteGradient discreteGradient_{};
 
     bool ComputeCriticalPoints{true};
@@ -496,8 +501,9 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   this->discreteGradient_.buildGradient(
     triangulation, this->ReturnSaddleConnectors);
 
-  if(dim == 3 && ReturnSaddleConnectors) {
-    discreteGradient_.reverseGradient<dataType>(triangulation);
+  if(this->ReturnSaddleConnectors) {
+    this->returnSaddleConnectors(this->SaddleConnectorsPersistenceThreshold,
+                                 scalars, scalarsMTime, offsets, triangulation);
   }
 
   std::vector<dcg::Cell> criticalPoints{};
@@ -1815,6 +1821,74 @@ int ttk::MorseSmaleComplex::setFinalSegmentation(
   this->printMsg("  Final segmentation computed", 1.0, tm.getElapsedTime(),
                  this->threadNumber_, debug::LineMode::NEW,
                  debug::Priority::DETAIL);
+
+  return 0;
+}
+
+template <typename dataType, typename triangulationType>
+int ttk::MorseSmaleComplex::returnSaddleConnectors(
+  const double persistenceThreshold,
+  const dataType *const scalars,
+  const size_t scalarsMTime,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) const {
+
+  Timer tm{};
+
+  const auto dim{triangulation.getDimensionality()};
+  if(dim != 3) {
+    this->printWrn("Can't return saddle connectors without a 3D dataset");
+    return 0;
+  }
+
+  // compute saddle-saddle Persistence Pairs from DiscreteMorseSandwich
+  ttk::DiscreteMorseSandwich dms{};
+  dms.setThreadNumber(this->threadNumber_);
+  dms.setDebugLevel(this->debugLevel_);
+  dms.buildGradient(scalars, scalarsMTime, offsets, triangulation);
+
+  using PersPairType = DiscreteMorseSandwich::PersistencePair;
+
+  std::vector<PersPairType> dms_pairs{};
+  dms.computePersistencePairs(dms_pairs, offsets, triangulation, false);
+
+  const auto getPersistence
+    = [this, &triangulation, scalars](const PersPairType &p) {
+        return this->discreteGradient_.getPersistence(
+          Cell{2, p.death}, Cell{1, p.birth}, scalars, triangulation);
+      };
+
+  // only keep saddle-saddle pairs below persistenceThreshold
+  decltype(dms_pairs) sadSadPairs{};
+  sadSadPairs.reserve(dms_pairs.size() / 2); // conservative allocation
+  for(const auto &pair : dms_pairs) {
+    if(pair.type == 1 && getPersistence(pair) <= persistenceThreshold) {
+      sadSadPairs.emplace_back(pair);
+    }
+  }
+
+  // DMS pairs output are already sorted by persistence
+
+  std::vector<bool> isVisited(triangulation.getNumberOfTriangles(), false);
+  std::vector<SimplexId> visitedTriangles{};
+
+  for(const auto &pair : sadSadPairs) {
+    const Cell birth{1, pair.birth};
+    const Cell death{2, pair.death};
+    // 1. get the 2-saddle wall
+    VisitedMask mask{isVisited, visitedTriangles};
+    this->discreteGradient_.getDescendingWall(death, mask, triangulation);
+    // 2. get the saddle connector
+    std::vector<Cell> vpath{};
+    this->discreteGradient_.getAscendingPathThroughWall(
+      birth, death, isVisited, &vpath, triangulation);
+    // 3. reverse the gradient on the saddle connector path
+    this->discreteGradient_.reverseAscendingPathOnWall(vpath, triangulation);
+  }
+
+  this->printMsg(
+    "Returned " + std::to_string(sadSadPairs.size()) + " saddle connectors",
+    1.0, tm.getElapsedTime(), this->threadNumber_);
 
   return 0;
 }

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -163,6 +163,9 @@ public:
   vtkSetMacro(SaddleConnectorsPersistenceThreshold, double);
   vtkGetMacro(SaddleConnectorsPersistenceThreshold, double);
 
+  vtkSetMacro(ThresholdIsAbsolute, bool);
+  vtkGetMacro(ThresholdIsAbsolute, bool);
+
 protected:
   template <typename scalarType, typename triangulationType>
   int dispatch(vtkDataArray *const inputScalars,

--- a/paraview/xmls/MorseSmaleComplex.xml
+++ b/paraview/xmls/MorseSmaleComplex.xml
@@ -1,4 +1,3 @@
-
 <ServerManagerConfiguration>
   <!-- This is the server manager configuration XML. It defines the interface to
        our new filter. As a rule of thumb, try to locate the configuration for
@@ -24,31 +23,31 @@
         Computer Graphics Forum, 2012.
 
         Online examples:
-        
+
         - https://topology-tool-kit.github.io/examples/1manifoldLearning/
-        
+
         - https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/
 
         - https://topology-tool-kit.github.io/examples/2manifoldLearning/
 
         - https://topology-tool-kit.github.io/examples/imageProcessing/
-        
+
         - https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/
-        
+
         - https://topology-tool-kit.github.io/examples/morseMolecule/
-        
+
         - https://topology-tool-kit.github.io/examples/morsePersistence/
-        
+
         - https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/
 
         - https://topology-tool-kit.github.io/examples/persistenceClustering0/
-        
+
         - https://topology-tool-kit.github.io/examples/persistenceClustering1/
-        
+
         - https://topology-tool-kit.github.io/examples/persistenceClustering2/
-        
+
         - https://topology-tool-kit.github.io/examples/persistenceClustering3/
-        
+
         - https://topology-tool-kit.github.io/examples/persistenceClustering4/
 
         - https://topology-tool-kit.github.io/examples/persistentGenerators_at/
@@ -56,9 +55,9 @@
         - https://topology-tool-kit.github.io/examples/persistentGenerators_darkSky/
 
         - https://topology-tool-kit.github.io/examples/tectonicPuzzle/
-        
+
         - https://topology-tool-kit.github.io/examples/tribute/
-        
+
       </Documentation>
       <InputProperty
         name="Input"
@@ -280,18 +279,23 @@
          </Documentation>
        </DoubleVectorProperty>
 
-      <!--
-      <IntVectorProperty name="IterationThreshold"
-        label="Iteration Threshold"
-        command="SetIterationThreshold"
-        number_of_elements="1"
-        default_values="-1"
-        panel_visibility="default">
-        <IntRangeDomain name="range" min="0" max="100" />
+       <IntVectorProperty name="ThresholdIsAbsolute"
+                          command="SetThresholdIsAbsolute"
+                          number_of_elements="1"
+                          default_values="1">
+        <BooleanDomain name="bool" />
+         <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+            mode="visibility"
+            property="ReturnSaddleConnectors"
+            value="1" />
+        </Hints>
         <Documentation>
-          Number of iterations in the gradient reversal pass.
+          This parameter determines if the saddle connectors
+          persistence threshold is an absolute scalar value, or a
+          fraction (0-1) of the function range.
         </Documentation>
-      </IntVectorProperty>-->
+      </IntVectorProperty>
 
       ${DEBUG_WIDGETS}
 
@@ -313,6 +317,7 @@
         <Property name="ComputeFinalSegmentation"/>
         <Property name="ReturnSaddleConnectors"/>
         <Property name="SaddleConnectorsPersistenceThreshold"/>
+        <Property name="ThresholdIsAbsolute" />
       </PropertyGroup>
 
       <OutputPort name="Critical Points" index="0" id="port0"/>


### PR DESCRIPTION
This PR updates the return saddle connectors algorithm in the MorseSmaleComplex module to use DiscreteMorseSandwich saddle-saddle pairs.

This new algorithm is very simple: since DiscreteMorseSandwich finds saddle-saddle pairs in ascending persistence order, the pairs are processed until the threshold is hit. For each pair, we find the saddle connector them reverse the v-path in the DiscreteGradient.

To avoid computing the DiscreteGradient twice (a first time for the MorseSmaleComplex and a second time for DiscreteMorseSandwich), move semantics is used to pass the DiscreteGradient instance in and out of the DiscreteMorseSandwich module. To allow it, the `contourTree_` member variable of the `DiscreteGradient` class has been made a (smart) pointer to provide an indirection since `FTMTree` instances cannot be copied or moved. This should have no impact on the rest of the code since after #853 and this PR, corresponding code should not be in use.

Enjoy,
Pierre