### PR TITLE
Switch to C++14

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -1,6 +1,6 @@
 # --- Prerequisites
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 # --- Global Options
 

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -196,8 +196,8 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
       idx_left[i] = idx[i];
     }
 
-    this->left_ = std::unique_ptr<KDTree>(
-      new KDTree(this, (coords_number_ + 1) % dimension, true));
+    this->left_
+      = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, true);
     this->left_->buildRecursive(data, idx_left, ptNumber, dimension, this,
                                 correspondance_map, weights, weight_number);
   }
@@ -208,8 +208,8 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
     for(int i = 0; i < ptNumber - median_loc - 1; i++) {
       idx_right[i] = idx[i + median_loc + 1];
     }
-    this->right_ = std::unique_ptr<KDTree>(
-      new KDTree(this, (coords_number_ + 1) % dimension, false));
+    this->right_
+      = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, false);
     this->right_->buildRecursive(data, idx_right, ptNumber, dimension, this,
                                  correspondance_map, weights, weight_number);
   }
@@ -285,8 +285,8 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
       idx_left[i] = idx_side[i];
     }
 
-    this->left_ = std::unique_ptr<KDTree>(
-      new KDTree(this, (coords_number_ + 1) % dimension, true));
+    this->left_
+      = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, true);
     this->left_->buildRecursive(data, idx_left, ptNumber, dimension, this,
                                 correspondance_map, weights, weight_number);
   }
@@ -297,8 +297,8 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
     for(unsigned int i = 0; i < idx_side.size() - median_loc - 1; i++) {
       idx_right[i] = idx_side[i + median_loc + 1];
     }
-    this->right_ = std::unique_ptr<KDTree>(
-      new KDTree(this, (coords_number_ + 1) % dimension, false));
+    this->right_
+      = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, false);
     this->right_->buildRecursive(data, idx_right, ptNumber, dimension, this,
                                  correspondance_map, weights, weight_number);
   }

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -535,7 +535,7 @@ void ttk::PDBarycenter::setInitialBarycenter(double min_persistence) {
 
 typename ttk::PDBarycenter::KDTreePair ttk::PDBarycenter::getKDTree() const {
   Timer tm;
-  auto kdt = std::unique_ptr<KDT>(new KDT{true, wasserstein_});
+  auto kdt = std::make_unique<KDT>(true, wasserstein_);
 
   const int dimension = geometrical_factor_ >= 1 ? 2 : 5;
 

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -158,7 +158,7 @@ RegistryTriangulation
   this->printMsg("Initializing Implicit Triangulation", 0, 0,
                  ttk::debug::LineMode::REPLACE, ttk::debug::Priority::DETAIL);
 
-  auto triangulation = RegistryTriangulation(new ttk::Triangulation());
+  auto triangulation = std::make_unique<ttk::Triangulation>();
 
   int extent[6];
   image->GetExtent(extent);
@@ -204,7 +204,7 @@ RegistryTriangulation
     return nullptr;
   }
 
-  auto triangulation = RegistryTriangulation(new ttk::Triangulation());
+  auto triangulation = std::make_unique<ttk::Triangulation>();
   int hasIndexArray
     = pointSet->GetPointData()->HasArray(ttk::compactTriangulationIndex);
 

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 # name of the project
 project(ttkExample-c++)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(TTKBase REQUIRED)
 

--- a/examples/vtk-c++/CMakeLists.txt
+++ b/examples/vtk-c++/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.8)
 # name of the project
 project(ttkExample-vtk-c++ LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(TTKVTK REQUIRED)
 


### PR DESCRIPTION
This PR switches the TTK codebase to use the C++14 standard rather than C++11. This is partly due to Boost requiring C++14 in a few releases.

In this PR, I also used one shiny new feature of the new standard: the function `std::make_unique` that replaces the call to the `std::unique_ptr` constructor (and avoids an explicit `new`).

@CharlesGueunet do you think this can impact the ParaView superbuild?
We are also thinking of switching to C++17. What's your though?

Enjoy,
Pierre