### PR TITLE
Examples: Remove the Threshold compatibility layer

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -45,7 +45,7 @@ jobs:
           ninja-build \
           zlib1g-dev \
           dpkg-dev
-        sudo python3 -m pip install scikit-learn packaging
+        sudo python3 -m pip install scikit-learn
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
@@ -114,7 +114,7 @@ jobs:
         brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree websocketpp ccache
-        python3.10 -m pip install scikit-learn packaging
+        python3.10 -m pip install scikit-learn
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
         # remove Python 3.11 installation
@@ -189,7 +189,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz ninja websocketpp sccache
+          scikit-learn openmp graphviz ninja websocketpp sccache
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -166,7 +166,7 @@ jobs:
         brew install wget llvm libomp mesa glew qt@5 ninja python
         # TTK dependencies
         brew install boost eigen graphviz embree websocketpp
-        python3 -m pip install scikit-learn packaging
+        python3 -m pip install scikit-learn
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
@@ -237,7 +237,7 @@ jobs:
         brew install wget llvm libomp mesa glew qt@5 ninja python
         # TTK dependencies
         brew install boost eigen graphviz embree
-        python3 -m pip install scikit-learn packaging
+        python3 -m pip install scikit-learn
 
     - name: Fetch TTK-ParaView
       run: |
@@ -323,7 +323,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz websocketpp
+          scikit-learn openmp graphviz websocketpp
 
     - name: Remove hosted Python
       shell: bash
@@ -413,7 +413,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz
+          scikit-learn openmp graphviz
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           ninja-build \
           zlib1g-dev \
           dpkg-dev
-        sudo python3 -m pip install scikit-learn packaging
+        sudo python3 -m pip install scikit-learn
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix
@@ -213,7 +213,7 @@ jobs:
         brew install wget llvm libomp ninja python open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy embree websocketpp ccache
-        python3.10 -m pip install scikit-learn packaging
+        python3.10 -m pip install scikit-learn
         # prepend ccache to system path
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
         # remove Python 3.11 installation
@@ -340,7 +340,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn packaging openmp graphviz ninja websocketpp sccache
+          scikit-learn openmp graphviz ninja websocketpp sccache
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
         # add TTK & ParaView install folders to PATH

--- a/examples/pvpython/example.py
+++ b/examples/pvpython/example.py
@@ -17,21 +17,9 @@
 # /// Michaux., IEEE Transactions on Visualization and Computer Graphics, Proc.
 # /// of IEEE VIS 2017.
 
+import sys
+
 from paraview.simple import *
-
-# paraview 5.9 VS 5.10 compatibility ===========================================
-def ThresholdBetween(threshold, lower, upper):
-    try:
-        # paraview 5.9
-        threshold.ThresholdRange = [lower, upper]
-    except:
-        # paraview 5.10
-        threshold.ThresholdMethod = "Between"
-        threshold.LowerThreshold = lower
-        threshold.UpperThreshold = upper
-
-
-# end of comphatibility ========================================================
 
 if len(sys.argv) == 2:
     inputFilePath = sys.argv[1]
@@ -54,12 +42,16 @@ persistenceCurve = TTKPersistenceCurve(persistenceDiagram)
 # 4. selecting the critical point pairs
 criticalPointPairs = Threshold(persistenceDiagram)
 criticalPointPairs.Scalars = ["CELLS", "PairIdentifier"]
-ThresholdBetween(criticalPointPairs, -0.1, 999999999)
+criticalPointPairs.ThresholdMethod = "Between"
+criticalPointPairs.LowerThreshold = -0.1
+criticalPointPairs.UpperThreshold = 999999999
 
 # 5. selecting the most persistent pairs
 persistentPairs = Threshold(criticalPointPairs)
 persistentPairs.Scalars = ["CELLS", "Persistence"]
-ThresholdBetween(persistentPairs, 0.05, 999999999)
+persistentPairs.ThresholdMethod = "Between"
+persistentPairs.LowerThreshold = 0.05
+persistentPairs.UpperThreshold = 999999999
 
 # 6. simplifying the input data to remove non-persistent pairs
 topologicalSimplification = TTKTopologicalSimplification(

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -18,13 +18,11 @@
 # /// of IEEE VIS 2017.
 
 import sys
-from packaging import version
 
 from vtk import (
     vtkDataObject,
     vtkTableWriter,
     vtkThreshold,
-    vtkVersion,
     vtkXMLPolyDataWriter,
     vtkXMLUnstructuredGridReader,
     vtkXMLUnstructuredGridWriter,
@@ -64,12 +62,9 @@ criticalPairs.SetInputConnection(diagram.GetOutputPort())
 criticalPairs.SetInputArrayToProcess(
     0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "PairIdentifier"
 )
-if version.parse(vtkVersion.GetVTKVersion()) < version.parse("9.2.0"):
-    criticalPairs.ThresholdBetween(-0.1, 999999)
-else:
-    criticalPairs.SetThresholdFunction(vtkThreshold.THRESHOLD_BETWEEN)
-    criticalPairs.SetLowerThreshold(-0.1)
-    criticalPairs.SetUpperThreshold(999999)
+criticalPairs.SetThresholdFunction(vtkThreshold.THRESHOLD_BETWEEN)
+criticalPairs.SetLowerThreshold(-0.1)
+criticalPairs.SetUpperThreshold(999999)
 
 # 5. selecting the most persistent pairs
 persistentPairs = vtkThreshold()
@@ -77,12 +72,9 @@ persistentPairs.SetInputConnection(criticalPairs.GetOutputPort())
 persistentPairs.SetInputArrayToProcess(
     0, 0, 0, vtkDataObject.FIELD_ASSOCIATION_CELLS, "Persistence"
 )
-if version.parse(vtkVersion.GetVTKVersion()) < version.parse("9.2.0"):
-    persistentPairs.ThresholdBetween(0.05, 999999)
-else:
-    persistentPairs.SetThresholdFunction(vtkThreshold.THRESHOLD_BETWEEN)
-    persistentPairs.SetLowerThreshold(0.05)
-    persistentPairs.SetUpperThreshold(999999)
+persistentPairs.SetThresholdFunction(vtkThreshold.THRESHOLD_BETWEEN)
+persistentPairs.SetLowerThreshold(0.05)
+persistentPairs.SetUpperThreshold(999999)
 
 # 6. simplifying the input data to remove non-persistent pairs
 topologicalSimplification = ttkTopologicalSimplification()

--- a/examples/vtk-c++/main.cpp
+++ b/examples/vtk-c++/main.cpp
@@ -27,7 +27,6 @@
 #include <vtkNew.h>
 #include <vtkTableWriter.h>
 #include <vtkThreshold.h>
-#include <vtkVersion.h>
 #include <vtkXMLPolyDataWriter.h>
 #include <vtkXMLUnstructuredGridReader.h>
 #include <vtkXMLUnstructuredGridWriter.h>
@@ -61,27 +60,18 @@ int main(int argc, char **argv) {
   criticalPairs->SetInputConnection(diagram->GetOutputPort());
   criticalPairs->SetInputArrayToProcess(
     0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_CELLS, "PairIdentifier");
-
-#if VTK_VERSION_NUMBER < VTK_VERSION_CHECK(9, 2, 0)
-  criticalPairs->ThresholdBetween(-0.1, 999999);
-#else
   criticalPairs->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
   criticalPairs->SetLowerThreshold(-0.1);
   criticalPairs->SetUpperThreshold(999999);
-#endif
 
   // 5. selecting the most persistent pairs
   vtkNew<vtkThreshold> persistentPairs{};
   persistentPairs->SetInputConnection(criticalPairs->GetOutputPort());
   persistentPairs->SetInputArrayToProcess(
     0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_CELLS, "Persistence");
-#if VTK_VERSION_NUMBER < VTK_VERSION_CHECK(9, 2, 0)
-  persistentPairs->ThresholdBetween(0.05, 999999);
-#else
   persistentPairs->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
   persistentPairs->SetLowerThreshold(0.05);
   persistentPairs->SetUpperThreshold(999999);
-#endif
 
   // 6. simplifying the input data to remove non-persistent pairs
   vtkNew<ttkTopologicalSimplification> topologicalSimplification{};


### PR DESCRIPTION
This PR removes the ParaView 5.9 vs. 5.10 Threshold compatibility layer in the TTK examples. The latest is preferred over the oldest.

This also allows us to remove the now unused Python `packaging` dependency in the CI pipelines. It was used in the examples to compare the VTK versions.

Enjoy,
Pierre