### PR TITLE
GitHub Actions: Display code warnings, delete artifacts, add missing dependencies

### DIFF
--- a/.github/workflows/ccache.yml
+++ b/.github/workflows/ccache.yml
@@ -307,12 +307,6 @@ jobs:
     - name: Fetch all uploaded artifacts
       uses: actions/download-artifact@v3
 
-    - name: Delete ccache artifacts
-      uses: geekyeggo/delete-artifact@v2
-      with:
-          name: |
-              ttk-*ccache*
-
     - name: Upload Ubuntu Bionic .deb as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
@@ -352,3 +346,9 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk-sccache-windows/ttk-sccache.tar.gz
         asset_name: ttk-sccache-windows.tar.gz
+
+    - name: Delete ccache artifacts
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: |
+              ttk-*ccache*

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -129,6 +129,7 @@ jobs:
         mkdir build
         cd build
         cmake \
+          -DCMAKE_BUILD_TYPE=Debug \
           -DTTK_BUILD_PARAVIEW_PLUGINS=TRUE \
           -DTTK_BUILD_VTK_WRAPPERS=TRUE \
           -DTTK_BUILD_STANDALONE_APPS=TRUE \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -105,6 +105,7 @@ jobs:
           libgraphviz-dev \
           libosmesa-dev \
           libsqlite3-dev \
+          libwebsocketpp-dev \
           graphviz \
           python3-sklearn \
           zlib1g-dev \
@@ -184,6 +185,7 @@ jobs:
           libgraphviz-dev \
           libosmesa-dev \
           libsqlite3-dev \
+          libwebsocketpp-dev \
           graphviz \
           python3-sklearn \
           zlib1g-dev \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -112,6 +112,9 @@ jobs:
           doxygen \
           clang-tidy
 
+    - name: Install optional dependencies
+      uses: ./.github/actions/install-deps-unix
+
     - name: Fetch TTK-ParaView headless Debian package
       run: |
         wget -O ttk-paraview-headless.deb \
@@ -191,6 +194,9 @@ jobs:
           zlib1g-dev \
           clang-tools \
           libomp-dev
+
+    - name: Install optional dependencies
+      uses: ./.github/actions/install-deps-unix
 
     - name: Fetch TTK-ParaView headless Debian package
       run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -576,3 +576,9 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk.exe/ttk.exe
         asset_name: ttk-$tag.exe
+
+    - name: Delete package artifacts
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: |
+              ttk*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,7 @@ jobs:
       with:
         name: screenshots-${{ matrix.os }}.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
+        retention-days: 10
 
     - name: Run ttk-data Python scripts
       run: |
@@ -307,6 +308,7 @@ jobs:
       with:
         name: screenshots-macOS.tar.gz
         path: ttk-data/tests/screenshots.tar.gz
+        retention-days: 10
 
     - name: Run ttk-data Python scripts
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,6 @@ jobs:
         if [[ "$VERS" == *"22.04"* ]]; then
           rm ttk-data/states/mergeTreeClustering.pvsm
           rm ttk-data/states/mergeTreeTemporalReduction.pvsm
-          rm ttk-data/states/persistentGenerators_darkSky.pvsm
         fi
 
         cd ttk-data/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
           -GNinja \
           $GITHUB_WORKSPACE
 
+    - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build & install TTK
       run: |
         cd build
@@ -267,6 +268,7 @@ jobs:
           -GNinja \
           $GITHUB_WORKSPACE
 
+    - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build & install TTK
       run: |
         cd build

--- a/core/base/ftrGraph/FTRSuperArc.h
+++ b/core/base/ftrGraph/FTRSuperArc.h
@@ -157,7 +157,7 @@ namespace ttk {
         fromUp_ = up;
       }
 
-      bool getFromUp(void) const {
+      bool getFromUp() const {
         return fromUp_;
       }
 #endif

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -247,3 +247,9 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk-paraview-headless-windows/ttk-paraview.exe
         asset_name: ttk-paraview-headless.exe
+
+    - name: Delete package artifacts
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: |
+              ttk-paraview-headless*

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -241,3 +241,9 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk-paraview-windows/ttk-paraview.exe
         asset_name: ttk-paraview-$tag.exe
+
+    - name: Delete package artifacts
+      uses: geekyeggo/delete-artifact@v2
+      with:
+          name: |
+              ttk-paraview*


### PR DESCRIPTION
This PR provides small improvements to the GitHub Actions workflows:

* workflow artifacts which are uploaded as release assets are deleted at the end of the workflow
* other workflow artifacts (screenshot archives) have their retention period reduced to 10 days (from 90 days by default),
* the missing `websocketpp`, `ZFP` and `Spectra` dependencies were added to the `check_code` workflow,
* after #857, `persistentGenerators_darkSky.pvsm` no longer OOM segfaults on Ubuntu 22
* static analysis is performed with Debug flags enabled (according to the [documentation](https://clang-analyzer.llvm.org/scan-build.html#recommended_debug))
* the `ammaraskar/gcc-problem-matcher` action is used to highlight GCC warnings in the GitHub Actions Summary page (with links to the corresponding lines/files). This is a first step to eliminate residual compiler warnings and enabling `-Werror` when building TTK.


Enjoy,
Pierre