### PR TITLE
[MPI] Boundary preconditioning

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2564,6 +2564,15 @@ namespace ttk {
       return this->cellRankArray_;
     }
 
+    inline void setLocalBound(double bound[6]) {
+      this->localBound_[0] = bound[0];
+      this->localBound_[1] = bound[1];
+      this->localBound_[2] = bound[2];
+      this->localBound_[3] = bound[3];
+      this->localBound_[4] = bound[4];
+      this->localBound_[5] = bound[5];
+    };
+
     // public precondition method (used in Triangulation/ttkAlgorithm)
     virtual int preconditionDistributedVertices() {
       return 0;
@@ -3651,6 +3660,9 @@ namespace ttk {
     std::unordered_map<SimplexId, SimplexId> edgeGidToLid_{};
     std::vector<SimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
+
+    double localBound_[6];
+    double globalBound_[6];
 
     bool hasPreconditionedDistributedCells_{false};
     bool hasPreconditionedDistributedEdges_{false};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2548,11 +2548,11 @@ namespace ttk {
       return this->vertGid_;
     }
 
-    inline const ttk::LongSimplexId *getEdgesGlobalIds() const {
+    inline const ttk::SimplexId *getEdgesGlobalIds() const {
       return this->edgeLidToGid_.data();
     }
 
-    inline const ttk::LongSimplexId *getTrianglesGlobalIds() const {
+    inline const ttk::SimplexId *getTrianglesGlobalIds() const {
       return this->triangleLidToGid_.data();
     }
 
@@ -2572,13 +2572,8 @@ namespace ttk {
       return this->cellRankArray_;
     }
 
-    inline void setLocalBound(double bound[6]) {
-      this->localBounds_[0] = bound[0];
-      this->localBounds_[1] = bound[1];
-      this->localBounds_[2] = bound[2];
-      this->localBounds_[3] = bound[3];
-      this->localBounds_[4] = bound[4];
-      this->localBounds_[5] = bound[5];
+    inline void setLocalBound(std::array<double, 6> &bound) {
+      this->localBounds_ = bound;
     };
 
     /// Pre-process the global boundaries when using MPI. Local bounds should
@@ -2808,38 +2803,6 @@ namespace ttk {
       return &(this->vertexGidToLid_);
     }
 
-    virtual inline const std::unordered_map<SimplexId, SimplexId> &
-      getEdgeGlobalIdMap() const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
-         && this->getDimensionality() != 3) {
-        this->printErr("Only 1D, 2D and 3D datasets are supported");
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("VertexGlobalMap query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedEdges() in a pre-process.");
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->edgeGidToLid_;
-    }
-
-    virtual inline const std::unordered_map<SimplexId, SimplexId> &
-      getTriangleGlobalIdMap() const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
-         && this->getDimensionality() != 3) {
-        this->printErr("Only 1D, 2D and 3D datasets are supported");
-      }
-      if(!this->hasPreconditionedDistributedEdges_) {
-        this->printErr("VertexGlobalMap query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedTriangles() in a pre-process.");
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->triangleGidToLid_;
-    }
-
     virtual inline std::vector<int> *getNeighborRanksWriteMode() {
       return &(this->neighborRanks_);
     }
@@ -2885,7 +2848,7 @@ namespace ttk {
       return it->second;
     }
 
-    inline LongSimplexId getEdgeGlobalIdInternal(const SimplexId leid) const {
+    inline SimplexId getEdgeGlobalIdInternal(const SimplexId leid) const {
       return this->edgeLidToGid_[leid];
     }
 
@@ -2899,8 +2862,7 @@ namespace ttk {
       return it->second;
     }
 
-    inline LongSimplexId
-      getTriangleGlobalIdInternal(const SimplexId ltid) const {
+    inline SimplexId getTriangleGlobalIdInternal(const SimplexId ltid) const {
       return this->triangleLidToGid_[ltid];
     }
 
@@ -3730,13 +3692,13 @@ namespace ttk {
     // (neighboring) ranks (per MPI rank)
     std::vector<std::vector<SimplexId>> remoteGhostCells_{};
 
-    std::vector<ttk::LongSimplexId> edgeLidToGid_{};
+    std::vector<ttk::SimplexId> edgeLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> edgeGidToLid_{};
-    std::vector<ttk::LongSimplexId> triangleLidToGid_{};
+    std::vector<ttk::SimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
 
-    double localBounds_[6]{0, 0, 0, 0, 0, 0};
-    double globalBounds_[6]{0, 0, 0, 0, 0, 0};
+    std::array<double, 6> localBounds_;
+    std::array<double, 6> globalBounds_;
 
     bool hasPreconditionedDistributedCells_{false};
     bool hasPreconditionedDistributedEdges_{false};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -3735,8 +3735,8 @@ namespace ttk {
     std::vector<ttk::LongSimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
 
-    double localBounds_[6];
-    double globalBounds_[6];
+    double localBounds_[6]{0, 0, 0, 0, 0, 0};
+    double globalBounds_[6]{0, 0, 0, 0, 0, 0};
 
     bool hasPreconditionedDistributedCells_{false};
     bool hasPreconditionedDistributedEdges_{false};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2548,6 +2548,14 @@ namespace ttk {
       return this->vertGid_;
     }
 
+    inline const ttk::LongSimplexId *getEdgesGlobalIds() const {
+      return this->edgeLidToGid_.data();
+    }
+
+    inline const ttk::LongSimplexId *getTrianglesGlobalIds() const {
+      return this->triangleLidToGid_.data();
+    }
+
     // RankArray on points & cells
 
     inline void setVertRankArray(const int *const rankArray) {
@@ -2565,16 +2573,47 @@ namespace ttk {
     }
 
     inline void setLocalBound(double bound[6]) {
-      this->localBound_[0] = bound[0];
-      this->localBound_[1] = bound[1];
-      this->localBound_[2] = bound[2];
-      this->localBound_[3] = bound[3];
-      this->localBound_[4] = bound[4];
-      this->localBound_[5] = bound[5];
+      this->localBounds_[0] = bound[0];
+      this->localBounds_[1] = bound[1];
+      this->localBounds_[2] = bound[2];
+      this->localBounds_[3] = bound[3];
+      this->localBounds_[4] = bound[4];
+      this->localBounds_[5] = bound[5];
     };
+
+    /// Pre-process the global boundaries when using MPI. Local bounds should
+    /// be set prior to using this function.
+    ///
+    /// \pre This function should be called prior to any traversal, in a
+    /// clearly distinct pre-processing step that involves no traversal at
+    /// all. An error will be returned otherwise.
+    /// \note It is recommended to exclude this preconditioning function from
+    /// any time performance measurement.
+    /// \return Returns 0 upon success, negative values otherwise.
+    /// \sa globalBounds_
+    virtual int preconditionGlobalBoundary() {
+
+      if(!hasPreconditionedGlobalBoundary_) {
+        preconditionGlobalBoundaryInternal();
+        hasPreconditionedGlobalBoundary_ = true;
+      }
+      return 0;
+    }
+
+    virtual inline int preconditionGlobalBoundaryInternal() {
+      return 0;
+    }
 
     // public precondition method (used in Triangulation/ttkAlgorithm)
     virtual int preconditionDistributedVertices() {
+      return 0;
+    }
+
+    virtual int preconditionEdgeRankArray() {
+      return 0;
+    }
+
+    virtual int preconditionTriangleRankArray() {
       return 0;
     }
 
@@ -2769,6 +2808,38 @@ namespace ttk {
       return &(this->vertexGidToLid_);
     }
 
+    virtual inline const std::unordered_map<SimplexId, SimplexId> &
+      getEdgeGlobalIdMap() const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("VertexGlobalMap query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedEdges() in a pre-process.");
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->edgeGidToLid_;
+    }
+
+    virtual inline const std::unordered_map<SimplexId, SimplexId> &
+      getTriangleGlobalIdMap() const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+      }
+      if(!this->hasPreconditionedDistributedEdges_) {
+        this->printErr("VertexGlobalMap query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedTriangles() in a pre-process.");
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->triangleGidToLid_;
+    }
+
     virtual inline std::vector<int> *getNeighborRanksWriteMode() {
       return &(this->neighborRanks_);
     }
@@ -2814,7 +2885,7 @@ namespace ttk {
       return it->second;
     }
 
-    inline SimplexId getEdgeGlobalIdInternal(const SimplexId leid) const {
+    inline LongSimplexId getEdgeGlobalIdInternal(const SimplexId leid) const {
       return this->edgeLidToGid_[leid];
     }
 
@@ -2828,7 +2899,8 @@ namespace ttk {
       return it->second;
     }
 
-    inline SimplexId getTriangleGlobalIdInternal(const SimplexId ltid) const {
+    inline LongSimplexId
+      getTriangleGlobalIdInternal(const SimplexId ltid) const {
       return this->triangleLidToGid_[ltid];
     }
 
@@ -3612,6 +3684,8 @@ namespace ttk {
     const LongSimplexId *vertGid_{};
     // PointData "RankArray" from "TTKGhostCellPreconditioning"
     const int *vertRankArray_{};
+    std::vector<int> edgeRankArray_{};
+    std::vector<int> triangleRankArray_{};
     // CellData "RankArray" from "TTKGhostCellPreconditioning"
     // (warning: for Implicit/Periodic triangulations, concerns
     // "squares"/"cubes" and not "triangles"/"tetrahedron")
@@ -3656,18 +3730,19 @@ namespace ttk {
     // (neighboring) ranks (per MPI rank)
     std::vector<std::vector<SimplexId>> remoteGhostCells_{};
 
-    std::vector<SimplexId> edgeLidToGid_{};
+    std::vector<ttk::LongSimplexId> edgeLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> edgeGidToLid_{};
-    std::vector<SimplexId> triangleLidToGid_{};
+    std::vector<ttk::LongSimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
 
-    double localBound_[6];
-    double globalBound_[6];
+    double localBounds_[6];
+    double globalBounds_[6];
 
     bool hasPreconditionedDistributedCells_{false};
     bool hasPreconditionedDistributedEdges_{false};
     bool hasPreconditionedDistributedTriangles_{false};
     bool hasPreconditionedDistributedVertices_{false};
+    bool hasPreconditionedGlobalBoundary_{false};
 
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -114,10 +114,10 @@ namespace ttk {
    * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
-  template <typename DT, typename IT>
+  template <typename DT, typename IT, typename globalIdType>
   int getGhostCellScalars(DT *scalarArray,
                           const int *const rankArray,
-                          const LongSimplexId *const globalIds,
+                          const globalIdType *const globalIds,
                           const std::unordered_map<IT, IT> &gidToLidMap,
                           const std::vector<int> *neighbors,
                           const int rankToSend,
@@ -133,6 +133,7 @@ namespace ttk {
     }
     MPI_Datatype MPI_DT = getMPIType(static_cast<DT>(0));
     MPI_Datatype MPI_IT = getMPIType(static_cast<IT>(0));
+    MPI_Datatype MPI_GIT = getMPIType(static_cast<globalIdType>(0));
     // we need unique tags for each rankToSend, otherwise messages might become
     // entangled
     int tagMultiplier = rankToSend + 1;
@@ -141,8 +142,8 @@ namespace ttk {
     int valuesTag = 103 * tagMultiplier;
     if(rankToSend == ttk::MPIrank_) {
       // initialize the inner vectors with size 0
-      std::vector<std::vector<IT>> rankVectors(
-        ttk::MPIsize_, std::vector<IT>(0));
+      std::vector<std::vector<globalIdType>> rankVectors(
+        ttk::MPIsize_, std::vector<globalIdType>(0));
       // aggregate the needed ids
 
       for(IT i = 0; i < nVerts; i++) {
@@ -156,7 +157,7 @@ namespace ttk {
         MPI_Send(
           &nValues, 1, MPI_IT, neighbors->at(r), amountTag, communicator);
         if(nValues > 0) {
-          MPI_Send(rankVectors[neighbors->at(r)].data(), nValues, MPI_IT,
+          MPI_Send(rankVectors[neighbors->at(r)].data(), nValues, MPI_GIT,
                    neighbors->at(r), idsTag, communicator);
         }
       }
@@ -171,7 +172,7 @@ namespace ttk {
           for(IT i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
-              IT globalId = rankVectors[neighbors->at(r)][i];
+              globalIdType globalId = rankVectors[neighbors->at(r)][i];
               IT localId = gidToLidMap.at(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
@@ -190,8 +191,8 @@ namespace ttk {
                  MPI_STATUS_IGNORE);
 
         if(nValues > 0) {
-          std::vector<IT> receivedIds(nValues);
-          MPI_Recv(receivedIds.data(), nValues, MPI_IT, rankToSend, idsTag,
+          std::vector<globalIdType> receivedIds(nValues);
+          MPI_Recv(receivedIds.data(), nValues, MPI_GIT, rankToSend, idsTag,
                    communicator, MPI_STATUS_IGNORE);
 
           // assemble the scalar values
@@ -338,10 +339,10 @@ namespace ttk {
    * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
-  template <typename DT, typename IT>
+  template <typename DT, typename IT, typename globalIdType>
   int exchangeGhostCells(DT *scalarArray,
                          const int *const rankArray,
-                         const LongSimplexId *const globalIds,
+                         const globalIdType *const globalIds,
                          const std::unordered_map<IT, IT> &gidToLidMap,
                          const IT nVerts,
                          MPI_Comm communicator,
@@ -354,9 +355,9 @@ namespace ttk {
       return -1;
     }
     for(int r = 0; r < ttk::MPIsize_; r++) {
-      getGhostCellScalars<DT, IT>(scalarArray, rankArray, globalIds,
-                                  gidToLidMap, neighbors, r, nVerts,
-                                  communicator, dimensionNumber);
+      getGhostCellScalars<DT, IT, globalIdType>(
+        scalarArray, rankArray, globalIds, gidToLidMap, neighbors, r, nVerts,
+        communicator, dimensionNumber);
       MPI_Barrier(communicator);
     }
     return 0;
@@ -835,9 +836,9 @@ namespace ttk {
 
     // we receive the values at the ghostcells through the abstract
     // exchangeGhostCells method
-    ttk::exchangeGhostCells<ttk::SimplexId, IT>(orderArray, rankArray,
-                                                globalIds, gidToLidMap, nVerts,
-                                                ttk::MPIcomm_, neighbors);
+    ttk::exchangeGhostCells<ttk::SimplexId, IT, ttk::LongSimplexId>(
+      orderArray, rankArray, globalIds, gidToLidMap, nVerts, ttk::MPIcomm_,
+      neighbors);
   }
 
   /**

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -53,6 +53,9 @@ namespace ttk {
   inline MPI_Datatype getMPIType(const unsigned long long ttkNotUsed(val)) {
     return MPI_UNSIGNED_LONG_LONG;
   };
+  inline MPI_Datatype getMPIType(const unsigned char ttkNotUsed(val)) {
+    return MPI_UNSIGNED_CHAR;
+  };
 
   template <typename DT, typename IT>
   struct value {
@@ -412,8 +415,8 @@ namespace ttk {
    * @param[in] neighbors vector of neighboring ranks
    */
   void inline produceRankArray(std::vector<int> &rankArray,
-                               LongSimplexId *globalIds,
-                               unsigned char *ghostCells,
+                               const LongSimplexId *globalIds,
+                               const unsigned char *ghostCells,
                                int nVertices,
                                double *boundingBox,
                                std::vector<int> *neighbors) {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -95,11 +95,77 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     return -1;
   }
 
+#if TTK_ENABLE_MPI
+  this->preconditionEdgeRankArray();
+  if(ttk::isRunningWithMPI()) {
+    ttk::SimplexId edgeNumber = edgeList_.size();
+    std::vector<unsigned char> charBoundary(edgeNumber, false);
+    for(int i = 0; i < edgeNumber; ++i) {
+      charBoundary[i] = boundaryEdges_[i] ? '1' : '0';
+    }
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+      charBoundary.data(), this->edgeRankArray_.data(),
+      this->getEdgesGlobalIds(), this->getEdgeGlobalIdMap(), edgeNumber,
+      ttk::MPIcomm_, this->getNeighborRanks());
+    for(int i = 0; i < edgeNumber; ++i) {
+      boundaryEdges_[i] = (charBoundary[i] == '1');
+    }
+  }
+#endif
+
   this->printMsg("Extracted boundary edges", 1.0, tm.getElapsedTime(), 1);
 
   return 0;
 }
 
+#if TTK_ENABLE_MPI
+int ExplicitTriangulation::preconditionEdgeRankArray() {
+  ttk::SimplexId edgeNumber = this->getNumberOfEdgesInternal();
+  edgeRankArray_.resize(edgeNumber, 0);
+  if(ttk::isRunningWithMPI()) {
+    ttk::SimplexId min_id;
+    for(ttk::SimplexId id = 0; id < edgeNumber; id++) {
+      this->TTK_TRIANGULATION_INTERNAL(getEdgeStar)(id, 0, min_id);
+      const auto nStar{this->TTK_TRIANGULATION_INTERNAL(getEdgeStarNumber)(id)};
+      for(SimplexId i = 1; i < nStar; ++i) {
+        SimplexId sid{-1};
+        this->TTK_TRIANGULATION_INTERNAL(getEdgeStar)(id, i, sid);
+        // rule: an edge is owned by the cell in its star with the
+        // lowest global id
+        if(this->cellGid_[sid] < this->cellGid_[min_id]) {
+          min_id = sid;
+        }
+      }
+      edgeRankArray_[id] = cellRankArray_[min_id];
+    }
+  }
+  return 0;
+}
+
+int ExplicitTriangulation::preconditionTriangleRankArray() {
+  ttk::SimplexId triangleNumber = this->getNumberOfTrianglesInternal();
+  triangleRankArray_.resize(triangleNumber, 0);
+  if(ttk::isRunningWithMPI()) {
+    ttk::SimplexId min_id;
+    for(ttk::SimplexId id = 0; id < triangleNumber; id++) {
+      this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(id, 0, min_id);
+      const auto nStar{
+        this->TTK_TRIANGULATION_INTERNAL(getTriangleStarNumber)(id)};
+      for(SimplexId i = 1; i < nStar; ++i) {
+        SimplexId sid{-1};
+        this->TTK_TRIANGULATION_INTERNAL(getTriangleStar)(id, i, sid);
+        // rule: an triangle is owned by the cell in its star with the
+        // lowest global id
+        if(this->cellGid_[sid] < this->cellGid_[min_id]) {
+          min_id = sid;
+        }
+      }
+      triangleRankArray_[id] = cellRankArray_[min_id];
+    }
+  }
+  return 0;
+}
+#endif
 int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
 
   if(this->cellArray_ == nullptr || this->vertexNumber_ == 0) {
@@ -134,6 +200,23 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     return -1;
   }
 
+#if TTK_ENABLE_MPI
+  this->preconditionTriangleRankArray();
+  if(ttk::isRunningWithMPI()) {
+    ttk::SimplexId triangleNumber = triangleList_.size();
+    std::vector<unsigned char> charBoundary(triangleNumber, false);
+    for(int i = 0; i < triangleNumber; ++i) {
+      charBoundary[i] = boundaryTriangles_[i] ? '1' : '0';
+    }
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+      charBoundary.data(), this->triangleRankArray_.data(),
+      this->getTrianglesGlobalIds(), this->getTriangleGlobalIdMap(),
+      triangleNumber, ttk::MPIcomm_, this->getNeighborRanks());
+    for(int i = 0; i < triangleNumber; ++i) {
+      boundaryTriangles_[i] = (charBoundary[i] == '1');
+    }
+  }
+#endif
   this->printMsg("Extracted boundary triangles", 1.0, tm.getElapsedTime(), 1);
 
   return 0;
@@ -190,7 +273,24 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     printErr("Unsupported dimension for vertex boundary precondition");
     return -1;
   }
+#if TTK_ENABLE_MPI
 
+  if(ttk::isRunningWithMPI()) {
+    std::vector<unsigned char> charBoundary(vertexNumber_, false);
+    for(int i = 0; i < vertexNumber_; ++i) {
+      charBoundary[i] = boundaryVertices_[i] ? '1' : '0';
+    }
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+      charBoundary.data(), this->vertRankArray_, this->getVertsGlobalIds(),
+      this->getVertexGlobalIdMap(), vertexNumber_, ttk::MPIcomm_,
+      this->getNeighborRanks());
+    for(int i = 0; i < vertexNumber_; ++i) {
+      if(vertRankArray_[i] != ttk::MPIrank_) {
+        boundaryVertices_[i] = (charBoundary[i] == '1');
+      }
+    }
+  }
+#endif
   this->printMsg("Extracted boundary vertices", 1.0, tm.getElapsedTime(), 1);
 
   return 0;
@@ -952,7 +1052,7 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
 
   const auto countCellEdges
     = [this, &edgeAlreadyProcessed](const SimplexId lcid,
-                                    std::vector<SimplexId> &edgeGid,
+                                    std::vector<LongSimplexId> &edgeGid,
                                     std::vector<SimplexId> &edgeRangeId,
                                     const size_t rangeId, size_t &edgeCount) {
         SimplexId nEdges{};
@@ -1093,7 +1193,7 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
 
   const auto countCellTriangles
     = [this, &triangleAlreadyProcessed](
-        const SimplexId lcid, std::vector<SimplexId> &triangleGid,
+        const SimplexId lcid, std::vector<LongSimplexId> &triangleGid,
         std::vector<SimplexId> &triangleRangeId, const size_t rangeId,
         size_t &triangleCount) {
         const auto nTriangles{this->getCellTriangleNumberInternal(lcid)};

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -103,10 +103,10 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     for(int i = 0; i < edgeNumber; ++i) {
       charBoundary[i] = boundaryEdges_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId, ttk::SimplexId>(
       charBoundary.data(), this->edgeRankArray_.data(),
-      this->getEdgesGlobalIds(), this->getEdgeGlobalIdMap(), edgeNumber,
-      ttk::MPIcomm_, this->getNeighborRanks());
+      this->getEdgesGlobalIds(), this->edgeGidToLid_, edgeNumber, ttk::MPIcomm_,
+      this->getNeighborRanks());
     for(int i = 0; i < edgeNumber; ++i) {
       boundaryEdges_[i] = (charBoundary[i] == '1');
     }
@@ -208,10 +208,10 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     for(int i = 0; i < triangleNumber; ++i) {
       charBoundary[i] = boundaryTriangles_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId, ttk::SimplexId>(
       charBoundary.data(), this->triangleRankArray_.data(),
-      this->getTrianglesGlobalIds(), this->getTriangleGlobalIdMap(),
-      triangleNumber, ttk::MPIcomm_, this->getNeighborRanks());
+      this->getTrianglesGlobalIds(), this->triangleGidToLid_, triangleNumber,
+      ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < triangleNumber; ++i) {
       boundaryTriangles_[i] = (charBoundary[i] == '1');
     }
@@ -280,7 +280,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     for(int i = 0; i < vertexNumber_; ++i) {
       charBoundary[i] = boundaryVertices_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId>(
+    ttk::exchangeGhostCells<unsigned char, ttk::SimplexId, ttk::LongSimplexId>(
       charBoundary.data(), this->vertRankArray_, this->getVertsGlobalIds(),
       this->getVertexGlobalIdMap(), vertexNumber_, ttk::MPIcomm_,
       this->getNeighborRanks());
@@ -1052,7 +1052,7 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
 
   const auto countCellEdges
     = [this, &edgeAlreadyProcessed](const SimplexId lcid,
-                                    std::vector<LongSimplexId> &edgeGid,
+                                    std::vector<SimplexId> &edgeGid,
                                     std::vector<SimplexId> &edgeRangeId,
                                     const size_t rangeId, size_t &edgeCount) {
         SimplexId nEdges{};
@@ -1193,7 +1193,7 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
 
   const auto countCellTriangles
     = [this, &triangleAlreadyProcessed](
-        const SimplexId lcid, std::vector<LongSimplexId> &triangleGid,
+        const SimplexId lcid, std::vector<SimplexId> &triangleGid,
         std::vector<SimplexId> &triangleRangeId, const size_t rangeId,
         size_t &triangleCount) {
         const auto nTriangles{this->getCellTriangleNumberInternal(lcid)};

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -635,6 +635,8 @@ namespace ttk {
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
+    int preconditionEdgeRankArray() override;
+    int preconditionTriangleRankArray() override;
 
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -290,9 +290,116 @@ bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
     case VertexPosition::CENTER_1D:
       return false;
     default:
+#if TTK_ENABLE_MPI
+      if(this->vertRankArray_[vertexId] == ttk::MPIrank_) {
+        return true;
+      } else {
+        return this->isVertexOnGlobalBoundary(vertexId);
+      }
+#else
       return true;
+#endif
   }
 }
+
+#if TTK_ENABLE_MPI
+template <typename Derived>
+bool ImplicitTriangulationCRTP<Derived>::isVertexOnGlobalBoundary(
+  const SimplexId &vertexId) const {
+
+  switch(this->underlying().getVertexPosition(vertexId)) {
+    // 1D cases
+    case VertexPosition::LEFT_CORNER_1D: // a
+      return isOnGlobalBoundary_[0];
+    case VertexPosition::RIGHT_CORNER_1D: // b
+      return isOnGlobalBoundary_[1];
+    // 2D corners
+    case VertexPosition::TOP_LEFT_CORNER_2D: // a
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[2];
+    case VertexPosition::TOP_RIGHT_CORNER_2D: // b
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[2];
+    case VertexPosition::BOTTOM_LEFT_CORNER_2D: // c
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[3];
+    case VertexPosition::BOTTOM_RIGHT_CORNER_2D: // d
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[3];
+    // 2D edges
+    case VertexPosition::TOP_EDGE_2D: // ab
+      return isOnGlobalBoundary_[2];
+    case VertexPosition::BOTTOM_EDGE_2D: // cd
+      return isOnGlobalBoundary_[3];
+    case VertexPosition::LEFT_EDGE_2D: // ac
+      return isOnGlobalBoundary_[0];
+    case VertexPosition::RIGHT_EDGE_2D: // bd
+      return isOnGlobalBoundary_[1];
+    // 3D Corners
+    case VertexPosition::TOP_LEFT_FRONT_CORNER_3D: // a
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[2]
+             || isOnGlobalBoundary_[4];
+    case VertexPosition::TOP_RIGHT_FRONT_CORNER_3D: // b
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[2]
+             || isOnGlobalBoundary_[4];
+    case VertexPosition::BOTTOM_LEFT_FRONT_CORNER_3D: // c
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[3]
+             || isOnGlobalBoundary_[4];
+    case VertexPosition::BOTTOM_RIGHT_FRONT_CORNER_3D: // d
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[3]
+             || isOnGlobalBoundary_[4];
+    case VertexPosition::TOP_LEFT_BACK_CORNER_3D: // e
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[2]
+             || isOnGlobalBoundary_[5];
+    case VertexPosition::TOP_RIGHT_BACK_CORNER_3D: // f
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[2]
+             || isOnGlobalBoundary_[5];
+    case VertexPosition::BOTTOM_LEFT_BACK_CORNER_3D: // g
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[3]
+             || isOnGlobalBoundary_[5];
+    case VertexPosition::BOTTOM_RIGHT_BACK_CORNER_3D: // h
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[3]
+             || isOnGlobalBoundary_[5];
+    // 3D edges
+    case VertexPosition::TOP_FRONT_EDGE_3D: // ab
+      return isOnGlobalBoundary_[2] || isOnGlobalBoundary_[4];
+    case VertexPosition::BOTTOM_FRONT_EDGE_3D: // cd
+      return isOnGlobalBoundary_[3] || isOnGlobalBoundary_[4];
+    case VertexPosition::LEFT_FRONT_EDGE_3D: // ac
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[4];
+    case VertexPosition::RIGHT_FRONT_EDGE_3D: // bd
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[4];
+    case VertexPosition::TOP_BACK_EDGE_3D: // ef
+      return isOnGlobalBoundary_[2] || isOnGlobalBoundary_[5];
+    case VertexPosition::BOTTOM_BACK_EDGE_3D: // gh
+      return isOnGlobalBoundary_[3] || isOnGlobalBoundary_[5];
+    case VertexPosition::LEFT_BACK_EDGE_3D: // eg
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[5];
+    case VertexPosition::RIGHT_BACK_EDGE_3D: // fh
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[5];
+    case VertexPosition::TOP_LEFT_EDGE_3D: // ae
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[2];
+    case VertexPosition::TOP_RIGHT_EDGE_3D: // bf
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[2];
+    case VertexPosition::BOTTOM_LEFT_EDGE_3D: // cg
+      return isOnGlobalBoundary_[0] || isOnGlobalBoundary_[3];
+    case VertexPosition::BOTTOM_RIGHT_EDGE_3D: // dh
+      return isOnGlobalBoundary_[1] || isOnGlobalBoundary_[3];
+    // 3D faces
+    case VertexPosition::FRONT_FACE_3D: // abcd
+      return isOnGlobalBoundary_[4];
+    case VertexPosition::BACK_FACE_3D: // efgh
+      return isOnGlobalBoundary_[5];
+    case VertexPosition::TOP_FACE_3D: // abef
+      return isOnGlobalBoundary_[2];
+    case VertexPosition::BOTTOM_FACE_3D: // cdgh
+      return isOnGlobalBoundary_[3];
+    case VertexPosition::LEFT_FACE_3D: // aceg
+      return isOnGlobalBoundary_[0];
+    case VertexPosition::RIGHT_FACE_3D: // bdfh
+      return isOnGlobalBoundary_[1];
+    // 3D central part
+    default:
+      return false;
+  }
+}
+#endif
 
 template <typename Derived>
 bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
@@ -3701,6 +3808,52 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   }
 
   this->hasPreconditionedDistributedVertices_ = true;
+
+  return 0;
+}
+
+int ImplicitTriangulation::preconditionBoundaryVerticesInternal() {
+  if(this->vertexNumber_ == 0) {
+    this->printErr("Empty dataset, precondition skipped");
+    return 1;
+  }
+  // Reorganize bounds to only execute Allreduce twice
+  double tempBounds[6] = {localBound_[0], localBound_[2], localBound_[4],
+                          localBound_[1], localBound_[3], localBound_[5]};
+  double tempGlobalBounds[6];
+  // Compute and send to all processes the lower bounds of the data set
+  MPI_Allreduce(
+    tempBounds, tempGlobalBounds, 3, MPI_DOUBLE, MPI_MIN, ttk::MPIcomm_);
+
+  // Compute and send to all processes the higher bounds of the data set
+  MPI_Allreduce(tempBounds + 3, tempGlobalBounds + 3, 3, MPI_DOUBLE, MPI_MAX,
+                ttk::MPIcomm_);
+
+  globalBound_[0] = tempGlobalBounds[0];
+  globalBound_[1] = tempGlobalBounds[3];
+  globalBound_[2] = tempGlobalBounds[1];
+  globalBound_[3] = tempGlobalBounds[4];
+  globalBound_[4] = tempGlobalBounds[2];
+  globalBound_[5] = tempGlobalBounds[5];
+
+  isOnGlobalBoundary_[0] = (static_cast<int>(std::round(
+                              (localBound_[0] - globalBound_[0]) / spacing_[0]))
+                            == 0);
+  isOnGlobalBoundary_[1] = (static_cast<int>(std::round(
+                              (localBound_[1] - globalBound_[1]) / spacing_[0]))
+                            == 0);
+  isOnGlobalBoundary_[2] = (static_cast<int>(std::round(
+                              (localBound_[2] - globalBound_[2]) / spacing_[1]))
+                            == 0);
+  isOnGlobalBoundary_[3] = (static_cast<int>(std::round(
+                              (localBound_[3] - globalBound_[3]) / spacing_[1]))
+                            == 0);
+  isOnGlobalBoundary_[4] = (static_cast<int>(std::round(
+                              (localBound_[4] - globalBound_[4]) / spacing_[2]))
+                            == 0);
+  isOnGlobalBoundary_[5] = (static_cast<int>(std::round(
+                              (localBound_[5] - globalBound_[5]) / spacing_[2]))
+                            == 0);
 
   return 0;
 }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3585,7 +3585,7 @@ int ttk::ImplicitTriangulation::preconditionDistributedEdges() {
 
   const auto countCellEdges
     = [this, &edgeAlreadyProcessed](const SimplexId lcid,
-                                    std::vector<LongSimplexId> &edgeGid,
+                                    std::vector<SimplexId> &edgeGid,
                                     std::vector<SimplexId> &edgeRangeId,
                                     const size_t rangeId, size_t &edgeCount) {
         SimplexId nEdges{};
@@ -3732,7 +3732,7 @@ int ttk::ImplicitTriangulation::preconditionDistributedTriangles() {
 
   const auto countCellTriangles
     = [this, &triangleAlreadyProcessed](
-        const SimplexId lcid, std::vector<LongSimplexId> &triangleGid,
+        const SimplexId lcid, std::vector<SimplexId> &triangleGid,
         std::vector<SimplexId> &triangleRangeId, const size_t rangeId,
         size_t &triangleCount) {
         const auto nTriangles{this->getCellTriangleNumberInternal(lcid)};

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -291,11 +291,14 @@ bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
       return false;
     default:
 #if TTK_ENABLE_MPI
-      if(this->vertRankArray_[vertexId] == ttk::MPIrank_) {
-        return true;
-      } else {
-        return this->isVertexOnGlobalBoundary(vertexId);
+      if(ttk::isRunningWithMPI()) {
+        if(this->vertRankArray_[vertexId] == ttk::MPIrank_) {
+          return true;
+        } else {
+          return this->isVertexOnGlobalBoundary(vertexId);
+        }
       }
+      return true;
 #else
       return true;
 #endif

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3835,24 +3835,27 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   return 0;
 }
 int ImplicitTriangulation::preconditionGlobalBoundaryInternal() {
-  // Reorganize bounds to only execute Allreduce twice
-  double tempBounds[6] = {localBounds_[0], localBounds_[2], localBounds_[4],
-                          localBounds_[1], localBounds_[3], localBounds_[5]};
-  double tempGlobalBounds[6];
-  // Compute and send to all processes the lower bounds of the data set
-  MPI_Allreduce(
-    tempBounds, tempGlobalBounds, 3, MPI_DOUBLE, MPI_MIN, ttk::MPIcomm_);
+  if(isRunningWithMPI()) {
+    // Reorganize bounds to only execute Allreduce twice
+    double tempBounds[6] = {localBounds_[0], localBounds_[2], localBounds_[4],
+                            localBounds_[1], localBounds_[3], localBounds_[5]};
+    double tempGlobalBounds[6];
+    // Compute and send to all processes the lower bounds of the data set
+    MPI_Allreduce(
+      tempBounds, tempGlobalBounds, 3, MPI_DOUBLE, MPI_MIN, ttk::MPIcomm_);
 
-  // Compute and send to all processes the higher bounds of the data set
-  MPI_Allreduce(tempBounds + 3, tempGlobalBounds + 3, 3, MPI_DOUBLE, MPI_MAX,
-                ttk::MPIcomm_);
+    // Compute and send to all processes the higher bounds of the data set
+    MPI_Allreduce(tempBounds + 3, tempGlobalBounds + 3, 3, MPI_DOUBLE, MPI_MAX,
+                  ttk::MPIcomm_);
 
-  globalBounds_[0] = tempGlobalBounds[0];
-  globalBounds_[1] = tempGlobalBounds[3];
-  globalBounds_[2] = tempGlobalBounds[1];
-  globalBounds_[3] = tempGlobalBounds[4];
-  globalBounds_[4] = tempGlobalBounds[2];
-  globalBounds_[5] = tempGlobalBounds[5];
+    globalBounds_[0] = tempGlobalBounds[0];
+    globalBounds_[1] = tempGlobalBounds[3];
+    globalBounds_[2] = tempGlobalBounds[1];
+    globalBounds_[3] = tempGlobalBounds[4];
+    globalBounds_[4] = tempGlobalBounds[2];
+    globalBounds_[5] = tempGlobalBounds[5];
+  }
+
   return 0;
 }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -279,7 +279,7 @@ namespace ttk {
     // the cellGid_ array only applies on cubic cells, not on
     // simplicial ones...
     std::vector<SimplexId> cellLidToGid_{};
-    bool isOnGlobalBoundary_[6];
+    std::array<bool, 6> isOnGlobalBoundary_;
 
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -257,6 +257,9 @@ namespace ttk {
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
     int preconditionBoundaryVerticesInternal() override;
+    int preconditionBoundaryEdgesInternal() override;
+    int preconditionBoundaryTrianglesInternal() override;
+    int preconditionGlobalBoundaryInternal() override;
 
   public:
     inline SimplexId

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -256,6 +256,7 @@ namespace ttk {
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
+    int preconditionBoundaryVerticesInternal() override;
 
   public:
     inline SimplexId
@@ -275,6 +276,8 @@ namespace ttk {
     // the cellGid_ array only applies on cubic cells, not on
     // simplicial ones...
     std::vector<SimplexId> cellLidToGid_{};
+    bool isOnGlobalBoundary_[6];
+
 #endif // TTK_ENABLE_MPI
 
     enum class VertexPosition : char {
@@ -923,6 +926,10 @@ namespace ttk {
 
     bool TTK_TRIANGULATION_INTERNAL(isVertexOnBoundary)(
       const SimplexId &vertexId) const override;
+
+#if TTK_ENABLE_MPI
+    bool isVertexOnGlobalBoundary(const SimplexId &) const;
+#endif
 
     bool TTK_TRIANGULATION_INTERNAL(isEdgeOnBoundary)(
       const SimplexId &edgeId) const override;

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -169,7 +169,7 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      exchangeGhostCells<dataType, SimplexId>(
+      exchangeGhostCells<dataType, SimplexId, ttk::LongSimplexId>(
         outputData, triangulation->getVertRankArray(),
         triangulation->getVertsGlobalIds(),
         triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1418,6 +1418,15 @@ namespace ttk {
       return abstractTriangulation_->getVertexGlobalIdMapWriteMode();
     }
 
+    inline const std::unordered_map<SimplexId, SimplexId> &
+      getEdgeGlobalIdMap() const override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return this->getEdgeGlobalIdMap();
+#endif
+      return abstractTriangulation_->getEdgeGlobalIdMap();
+    }
+
     /// Set the flag for precondtioning of distributed vertices of the
     /// triangulation.
     inline void setHasPreconditionedDistributedVertices(bool flag) override {
@@ -1436,6 +1445,13 @@ namespace ttk {
       return abstractTriangulation_->setLocalBound(bound);
     }
 
+    inline const ttk::LongSimplexId *getEdgesGlobalIds() {
+      return abstractTriangulation_->getEdgesGlobalIds();
+    }
+
+    inline const ttk::LongSimplexId *getTrianglesGlobalIds() {
+      return abstractTriangulation_->getTrianglesGlobalIds();
+    }
     /// Get the corresponding local id for a given global id of a vertex.
     ///
     /// \pre For this function to behave correctly,
@@ -2353,6 +2369,44 @@ namespace ttk {
 #endif
       return abstractTriangulation_->preconditionDistributedVertices();
     }
+
+    inline int preconditionEdgeRankArray() override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->preconditionEdgeRankArray();
+    }
+
+    inline int preconditionTriangleRankArray() override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->preconditionTriangleRankArray();
+    }
+
+    /// Pre-process the global boundaries when using MPI. Local bounds should
+    /// be set prior to using this function.
+    ///
+    /// \pre This function should be called prior to any traversal, in a
+    /// clearly distinct pre-processing step that involves no traversal at
+    /// all. An error will be returned otherwise.
+    /// \note It is recommended to exclude this preconditioning function from
+    /// any time performance measurement.
+    /// \return Returns 0 upon success, negative values otherwise.
+    /// \sa globalBounds_
+
+    inline int preconditionGlobalBoundary() override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->preconditionGlobalBoundary();
+    }
+
 #endif // TTK_ENABLE_MPI
 
     /// Pre-process the vertex links.

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1418,15 +1418,6 @@ namespace ttk {
       return abstractTriangulation_->getVertexGlobalIdMapWriteMode();
     }
 
-    inline const std::unordered_map<SimplexId, SimplexId> &
-      getEdgeGlobalIdMap() const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(isEmptyCheck())
-        return this->getEdgeGlobalIdMap();
-#endif
-      return abstractTriangulation_->getEdgeGlobalIdMap();
-    }
-
     /// Set the flag for precondtioning of distributed vertices of the
     /// triangulation.
     inline void setHasPreconditionedDistributedVertices(bool flag) override {
@@ -1441,15 +1432,15 @@ namespace ttk {
       return abstractTriangulation_->getNeighborRanks();
     }
 
-    inline void setLocalBound(double bound[6]) {
+    inline void setLocalBound(std::array<double, 6> &bound) {
       return abstractTriangulation_->setLocalBound(bound);
     }
 
-    inline const ttk::LongSimplexId *getEdgesGlobalIds() {
+    inline const ttk::SimplexId *getEdgesGlobalIds() {
       return abstractTriangulation_->getEdgesGlobalIds();
     }
 
-    inline const ttk::LongSimplexId *getTrianglesGlobalIds() {
+    inline const ttk::SimplexId *getTrianglesGlobalIds() {
       return abstractTriangulation_->getTrianglesGlobalIds();
     }
     /// Get the corresponding local id for a given global id of a vertex.

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1432,6 +1432,10 @@ namespace ttk {
       return abstractTriangulation_->getNeighborRanks();
     }
 
+    inline void setLocalBound(double bound[6]) {
+      return abstractTriangulation_->setLocalBound(bound);
+    }
+
     /// Get the corresponding local id for a given global id of a vertex.
     ///
     /// \pre For this function to behave correctly,

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -638,7 +638,7 @@ void ttkAlgorithm::MPIGhostPipelinePreconditioning(vtkDataSet *input) {
   if(!input->HasAnyGhostCells() && ttk::isRunningWithMPI()) {
     generator->SetInputData(input);
     generator->BuildIfRequiredOff();
-    generator->SetNumberOfGhostLayers(2);
+    generator->SetNumberOfGhostLayers(1);
     generator->Update();
     input->ShallowCopy(generator->GetOutputDataObject(0));
     input->GetPointData()->AddArray(
@@ -818,6 +818,9 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
     triangulation->setCellRankArray(
       ttkUtils::GetPointer<int>(cd->GetArray("RankArray")));
   }
+  double bounds[6];
+  input->GetBounds(bounds);
+  triangulation->setLocalBound(bounds);
 }
 #endif
 //==============================================================================

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -818,8 +818,8 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
     triangulation->setCellRankArray(
       ttkUtils::GetPointer<int>(cd->GetArray("RankArray")));
   }
-  double bounds[6];
-  input->GetBounds(bounds);
+  std::array<double, 6> bounds;
+  input->GetBounds(bounds.data());
   triangulation->setLocalBound(bounds);
 }
 #endif


### PR DESCRIPTION
Hi all,

Up until now, the MPI preconditioning would automatically compute 2 layers of ghost cells. This was due to the fact that numerous filters required not only information on neighbor simplices but also whether those simplices were on the global boundary. 
The global boundary is the real boundary of the data set if it had been executed sequentially. A local boundary is a boundary created by the distribution of the data set over multiple computing nodes. 

Having two layers of ghosts allowed each process to know whether the first layer of ghosts are on the boundary or not. However, this is memory consuming, it may increase communication costs when the exchange of ghost value is needed and it created problems on other filters that are being implemented using MPI. Therefore, a new solution has been implemented in this Pull Request.
Now, there is only one layer of ghost instead of two, and MPI support has been added to the boundary preconditioning to ensure that boundary preconditioning only refers to the global boundary.

For Explicit Triangulations, in sequential, the boundary preconditioning is stored in a boolean vector, with each element indicating whether the associated simplex is on the boundary or not. The MPI implementation builds on top of that: the boundary preconditioning is computed as it would be in sequential and then the values of ghost simplices for the boundary vector are exchanged between processes. The value of the owner of the simplex is the correct value of the boundary preconditioning.  This is done for vertices, edges and triangles.
The exchange of ghosts requires a RankArray for the corresponding simplices. For vertices and cells, those arrays are already automatically computed. For edges and triangles, those arrays can be computed using `preconditionEdgeRankArray` and `preconditionTriangleRankArray`. An edge or a triangle has the same RankArray value than the simplex of highest dimension of its star with the lowest global id.

For Implicit Triangulations, the computation of boundary in sequential is done on the fly. To compute the global boundary using MPI, we add a preconditioning step: the computation of `isOnGlobalBoundary_`. This is an array of size 6 of booleans. Each element stores the information of whether the face of the data set associated is on the global boundary or not. The array is organized as follows: LEFT, RIGHT, TOP, BOTTOM, FRONT, BACK. A face is considered on the global boundary if the distance between the global boundary and the local boundary is smaller than the spacing of one cell for that direction. 
When evaluating if a vertex is on the boundary or not, if the vertex is on the local boundary and is a ghost, the appropriate elements of `isOnGlobalBoundary_` are evaluated. For edges and triangle, an element is considered on the  global boundary using MPI if each of its vertices are on the global boundary.

Global Edge Ids and Global Triangle Ids have been changed of SimplexId to LongSimplexId for coherency (Global Vertex Ids and Global Cell Ids are LongSimplexId).