### PR TITLE
Support i386  for LongSimplexId

### DIFF
--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -25,3 +25,9 @@ if(TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
   # in the base layer, only this module is affected
   target_compile_definitions(common PRIVATE TTK_REDUCE_TEMPLATE_INSTANTIATIONS)
 endif()
+
+if(CMAKE_SIZEOF_VOID_P LESS_EQUAL 4)
+  # provides compatibility between LongSimplexId and vtkIdType on i386
+  # c.f. VTK_USE_64BIT_IDS in $PARAVIEW_SOURCE_DIR/VTK/Common/Core/CMakeLists.txt
+  target_compile_definitions(common PUBLIC TTK_HW_IS_32BITS)
+endif()

--- a/core/base/common/DataTypes.h
+++ b/core/base/common/DataTypes.h
@@ -9,7 +9,11 @@
 
 namespace ttk {
   /// \brief Identifier type for simplices of any dimension.
+#ifdef TTK_HW_IS_32BITS // i386
+  using LongSimplexId = int;
+#else // amd64
   using LongSimplexId = long long int;
+#endif // TTK_HW_IS_32BITS
 
   /// \brief Identifier type for simplices of any dimension.
 #ifdef TTK_ENABLE_64BIT_IDS


### PR DESCRIPTION
This PR uses a similar mechanism that of VTK to set the `LongSimplexId` type to `int` in i386 hardware. This way, `LongSimplexId` and `vtkIdType` should be the same.

This should hopefully fix #852. I quickly tested it on an i386 Debian virtual machine (I'm not familiar enough with FreeBSD).

Enjoy,
Pierre