### PR TITLE
GitHub Actions: Enable -Werror when building TTK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,8 @@ jobs:
           -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 \
           -GNinja \
           $GITHUB_WORKSPACE
+      env:
+        CXXFLAGS: -Werror
 
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build & install TTK
@@ -267,6 +269,8 @@ jobs:
           -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 \
           -GNinja \
           $GITHUB_WORKSPACE
+      env:
+        CXXFLAGS: -Werror
 
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: Build & install TTK
@@ -414,6 +418,8 @@ jobs:
           -DTTK_IMPLICIT_PRECONDITIONS_THRESHOLD=64*64*64 ^
           -GNinja ^
           ..
+      env:
+        CXXFLAGS: -Werror
 
     - name: Fix clang-cl OpenMP flags in build.ninja
       shell: bash

--- a/core/base/approximateTopology/ApproximateTopology.h
+++ b/core/base/approximateTopology/ApproximateTopology.h
@@ -561,7 +561,6 @@ void ttk::ApproximateTopology::tripletsToPersistencePairs(
   Timer tm;
   if(triplets.empty())
     return;
-  size_t numberOfPairs = 0;
 
   // // accelerate getRep lookup?
   // std::vector<SimplexId> firstRep(vertexRepresentatives.size());
@@ -597,7 +596,6 @@ void ttk::ApproximateTopology::tripletsToPersistencePairs(
     SimplexId r2 = getRep(std::get<2>(t));
     if(r1 != r2) {
       SimplexId s = std::get<0>(t);
-      numberOfPairs++;
 
       // Add pair
       if(splitTree) {

--- a/core/base/common/CMakeLists.txt
+++ b/core/base/common/CMakeLists.txt
@@ -31,3 +31,9 @@ if(CMAKE_SIZEOF_VOID_P LESS_EQUAL 4)
   # c.f. VTK_USE_64BIT_IDS in $PARAVIEW_SOURCE_DIR/VTK/Common/Core/CMakeLists.txt
   target_compile_definitions(common PUBLIC TTK_HW_IS_32BITS)
 endif()
+
+if(WIN32)
+  # disable Windows warnings on some POSIX calls being insecure
+  # (Windows provides secure but non-portable alternatives)
+  target_compile_definitions(common PUBLIC _CRT_SECURE_NO_WARNINGS)
+endif()

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -1649,14 +1649,6 @@ bool SubLevelSetTree::buildPlanarLayout(const double &scaleX,
 
   } while(!nodeQueue.empty());
 
-  // scale a bit
-  int maintainedArcNumber = 0;
-  for(int i = 0; i < (int)superArcList_.size(); i++) {
-    if(!superArcList_[i].pruned_) {
-      maintainedArcNumber++;
-    }
-  }
-
   // test
   //   for(int i = 0; i < (int) superArcList_.size(); i++){
   //     if(!superArcList_[i].pruned_){
@@ -2438,7 +2430,6 @@ int ContourTree::combineTrees() {
 
   queue<const Node *> nodeQueue;
   const Node *mergeNode = nullptr, *splitNode = nullptr;
-  int initNumber = 0;
 
   do {
 
@@ -2566,8 +2557,6 @@ int ContourTree::combineTrees() {
       }
     } while(nodeQueue.size());
 
-    initNumber++;
-
     if((int)nodeList_.size() == vertexNumber_)
       break;
 
@@ -2587,23 +2576,6 @@ int ContourTree::combineTrees() {
 }
 
 int ContourTree::finalize() {
-
-  int minCount = 0, mergeCount = 0, splitCount = 0, maxCount = 0, regCount = 0;
-
-  for(int i = 0; i < (int)nodeList_.size(); i++) {
-    if(!nodeList_[i].getNumberOfDownArcs()) {
-      minCount++;
-    } else if(!nodeList_[i].getNumberOfUpArcs()) {
-      maxCount++;
-    } else if((nodeList_[i].getNumberOfDownArcs() == 1)
-              && (nodeList_[i].getNumberOfUpArcs() == 1)) {
-      regCount++;
-    } else if(nodeList_[i].getNumberOfDownArcs() > 1) {
-      mergeCount++;
-    } else if(nodeList_[i].getNumberOfUpArcs() > 1) {
-      splitCount++;
-    }
-  }
 
   vector<bool> inQueue(nodeList_.size(), false);
   queue<int> nodeIdQueue;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -415,14 +415,9 @@ bool ttk::ContourTreeAlignment::alignTree(
   std::vector<std::shared_ptr<ttk::cta::AlignmentNode>> nodes1 = nodes;
   std::vector<std::shared_ptr<ttk::cta::CTNode>> nodes2 = ct->getGraph().first;
 
-  int i = 0;
-  int j = 0;
-
   for(const auto &node1 : nodes1) {
 
     t1 = this->rootAtNode(node1);
-
-    j = 0;
 
     for(const auto &node2 : nodes2) {
 
@@ -442,11 +437,7 @@ bool ttk::ContourTreeAlignment::alignTree(
           res = match.second;
         }
       }
-
-      j++;
     }
-
-    i++;
   }
 
   if(res)
@@ -477,8 +468,6 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
 
   std::vector<std::shared_ptr<ttk::cta::CTNode>> nodes2 = ct->getGraph().first;
 
-  int i = 0;
-
   t1 = this->rootAtNode(alignmentRoot);
 
   for(const auto &node2 : nodes2) {
@@ -500,8 +489,6 @@ bool ttk::ContourTreeAlignment::alignTree_consistentRoot(
         res = match.second;
       }
     }
-
-    i++;
   }
 
   if(res)

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -518,9 +518,15 @@ int ttk::ContourTreeAlignment::execute(
   for(size_t i = 0; i < nTrees; i++) {
     permutation.push_back(i);
   }
-  std::srand(seed);
-  if(alignmenttreeType != ttk::cta::lastMatchedValue)
-    std::random_shuffle(permutation.begin(), permutation.end());
+
+  // initialize random engine using user-provided seed
+  std::mt19937 random_engine{};
+  random_engine.seed(seed);
+
+  if(alignmenttreeType != ttk::cta::lastMatchedValue) {
+    // shuffle using the random engine
+    std::shuffle(permutation.begin(), permutation.end(), random_engine);
+  }
 
   this->printMsg(
     "Shuffling input trees. Used seed: " + std::to_string(seed), 1);

--- a/core/base/ftrGraph/Graph_Template.h
+++ b/core/base/ftrGraph/Graph_Template.h
@@ -21,7 +21,6 @@ namespace ttk {
       std::map<std::pair<idVertex, idVertex>, idSuperArc> masterArcs;
 
       // int totalArc = getNumberOfArcs();
-      int merged = 0;
 
       // Arc created by increasing and decreasing tasks are reversed in
       // terms of up/down node. We use this property to merge such arcs. in
@@ -70,8 +69,6 @@ namespace ttk {
         }
 
         if(arc.merged()) {
-          ++merged;
-          // std::cout << "arc merged: " << printArc(arcId) << std::endl;
           const idSuperArc target = arc.mergedIn();
           if(mapArcs.count(target) == 0) {
             mapArcs[arcId] = target;
@@ -79,8 +76,6 @@ namespace ttk {
           }
         }
       }
-
-      // std::cout << "Merged: " << merged << " / " << totalArc << std::endl;
 
       if(!mapArcs.size())
         return;

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -97,8 +97,8 @@ namespace ttk {
                               const PowerFunc &power);
 
     template <typename PowerFunc>
-    inline dataType cost(const Container &coordinates,
-                         const PowerFunc &power) const {
+    inline dataType getCost(const Container &coordinates,
+                            const PowerFunc &power) const {
       dataType cost = 0;
       for(size_t i = 0; i < coordinates.size(); i++) {
         cost += power(std::abs(coordinates[i] - coordinates_[i]));
@@ -346,7 +346,7 @@ void ttk::KDTree<dataType, Container>::getKClosest(const unsigned int k,
   /// will need to sort them according to their cost.
   if(this->isLeaf()) {
     dataType cost{};
-    TTK_POW_LAMBDA(cost = this->cost, dataType, p, coordinates);
+    TTK_POW_LAMBDA(cost = this->getCost, dataType, p, coordinates);
     cost += weight_[weight_index];
     neighbours.push_back(this);
     costs.push_back(cost);
@@ -370,7 +370,7 @@ void ttk::KDTree<dataType, Container>::recursiveGetKClosest(
   const PowerFunc &power) {
   // 1- Look wether or not to include the current point in the nearest
   // neighbours
-  dataType cost = this->cost(coordinates, power);
+  dataType cost = this->getCost(coordinates, power);
   cost += weight_[weight_index];
 
   if(costs.size() < k) {

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -548,7 +548,6 @@ namespace ttk {
 
       // Compute projection
       double tempBirth = 0, tempDeath = 0;
-      int offDiagonal = 0;
       double alphaSum = 0;
       for(unsigned int i = 0; i < trees.size(); ++i)
         if((int)nodes[i] != -1)
@@ -568,7 +567,6 @@ namespace ttk {
           }
           tempBirth += tTempBirth * alphas[i] / alphaSum;
           tempDeath += tTempDeath * alphas[i] / alphaSum;
-          ++offDiagonal;
         }
       }
       double projec = (tempBirth + tempDeath) / 2;

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
@@ -750,8 +750,8 @@ namespace ttk {
       for(unsigned int j = 0; j < matchings.size(); ++j) {
         auto match0 = std::get<0>(matchings[j]);
         auto match1 = std::get<1>(matchings[j]);
-        if(match0 < barycenter.tree.getNumberOfNodes() and match0 >= 0
-           and match1 < tree.tree.getNumberOfNodes() and match1 >= 0)
+        if(match0 < barycenter.tree.getNumberOfNodes()
+           and match1 < tree.tree.getNumberOfNodes())
           matchingVector[match0] = match1;
       }
     }
@@ -768,8 +768,8 @@ namespace ttk {
       for(unsigned int j = 0; j < matchings.size(); ++j) {
         auto match0 = std::get<0>(matchings[j]);
         auto match1 = std::get<1>(matchings[j]);
-        if(match0 < barycenter.tree.getNumberOfNodes() and match0 >= 0
-           and match1 < tree.tree.getNumberOfNodes() and match1 >= 0)
+        if(match0 < barycenter.tree.getNumberOfNodes()
+           and match1 < tree.tree.getNumberOfNodes())
           matchingVector[match1] = match0;
       }
     }

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsUtils.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <MergeTreePrincipalGeodesics.h>
+
 namespace ttk {
   template <class dataType>
   dataType MergeTreePrincipalGeodesics::computeVarianceFromDistances(
@@ -17,10 +19,11 @@ namespace ttk {
     std::vector<std::vector<double>> &v,
     std::vector<std::vector<double>> &v2,
     std::vector<double> &ts,
-    bool computeGlobalVariance) {
+    bool globalVariance) {
+
     std::vector<ftm::MergeTree<dataType>> allInterpolated(trees.size());
     ftm::MergeTree<dataType> barycenterInterpolated;
-    if(not computeGlobalVariance) {
+    if(not globalVariance) {
       for(unsigned int i = 0; i < trees.size(); ++i)
         getInterpolation<dataType>(
           barycenter, v, v2, ts[i], allInterpolated[i]);
@@ -33,7 +36,7 @@ namespace ttk {
   num_threads(this->threadNumber_) if(parallelize_)
 #endif
     for(unsigned int i = 0; i < trees.size(); ++i) {
-      if(computeGlobalVariance) {
+      if(globalVariance) {
         computeOneDistance(barycenter, trees[i], distances[i], true);
       } else {
         computeOneDistance(

--- a/core/base/progressiveTopology/ProgressiveTopology.cpp
+++ b/core/base/progressiveTopology/ProgressiveTopology.cpp
@@ -395,7 +395,6 @@ void ttk::ProgressiveTopology::tripletsToPersistencePairs(
   Timer tm;
   if(triplets.empty())
     return;
-  size_t numberOfPairs = 0;
 
   const auto lt = [=](const SimplexId a, const SimplexId b) -> bool {
     return offsets[a] < offsets[b];
@@ -415,7 +414,6 @@ void ttk::ProgressiveTopology::tripletsToPersistencePairs(
     SimplexId r2 = getRep(std::get<2>(t));
     if(r1 != r2) {
       SimplexId s = std::get<0>(t);
-      numberOfPairs++;
 
       // Add pair
       if(splitTree) {

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -363,7 +363,6 @@ int ttk::TopologicalSimplification::execute(
   SweepCmp cmp;
 
   // processing
-  int iteration{};
   for(SimplexId i = 0; i < vertexNumber_; ++i) {
 
     this->printMsg("Starting simplifying iteration #" + std::to_string(i),
@@ -482,7 +481,6 @@ int ttk::TopologicalSimplification::execute(
     if(addPerturbation_)
       addPerturbation<dataType>(outputScalars, offsets);
 
-    ++iteration;
     if(!needForMoreIterations)
       break;
   }

--- a/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
+++ b/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
@@ -220,8 +220,8 @@ public:
     return persistenceThreshold_;
   }
 
-  void SetDeleteMultiPersPairs(bool deleteMultiPersPairs) {
-    deleteMultiPersPairs_ = deleteMultiPersPairs;
+  void SetDeleteMultiPersPairs(bool delMultiPersPairs) {
+    deleteMultiPersPairs_ = delMultiPersPairs;
     Modified();
     resetDataVisualization();
   }

--- a/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
+++ b/core/vtk/ttkWRLExporter/ttkWRLExporter.cpp
@@ -33,7 +33,8 @@
 TTKWRLEXPORTER_EXPORT vtkPolyData *ttkWRLExporterPolyData_ = nullptr;
 
 // Over-ride the appropriate functions of the vtkVRMLExporter class.
-void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
+TTKWRLEXPORTER_EXPORT void vtkVRMLExporter::WriteAnActor(vtkActor *anActor,
+                                                         FILE *fp) {
 
   ttk::Debug debugInfo;
   debugInfo.setDebugMsgPrefix("WRLExporter");
@@ -314,7 +315,7 @@ void vtkVRMLExporter::WriteAnActor(vtkActor *anActor, FILE *fp) {
   pm->Delete();
 }
 
-void vtkVRMLExporter::WriteData() {
+TTKWRLEXPORTER_EXPORT void vtkVRMLExporter::WriteData() {
 
   vtkRenderer *ren;
   vtkActorCollection *ac;
@@ -434,11 +435,12 @@ void vtkVRMLExporter::WriteData() {
   }
 }
 
-void vtkVRMLExporter::WritePointData(vtkPoints *points,
-                                     vtkDataArray *normals,
-                                     vtkDataArray *tcoords,
-                                     vtkUnsignedCharArray *colors,
-                                     FILE *fp) {
+TTKWRLEXPORTER_EXPORT void
+  vtkVRMLExporter::WritePointData(vtkPoints *points,
+                                  vtkDataArray *normals,
+                                  vtkDataArray *tcoords,
+                                  vtkUnsignedCharArray *colors,
+                                  FILE *fp) {
 
   double *p;
   unsigned char *c;


### PR DESCRIPTION
This PR enables the `-Werror` compiler flag when building TTK in the `test_build` workflow.
All warnings are fixed:
- on Ubuntu 18.04, variable renaming fixed -Wshadow,
- on Ubuntu 22.04, tautological comparisons  were removed,
- on macOS, unused variables (written but never read) were removed,
- also on macOS, the `std::random_shuffle` method was replaced by `std::shuffle` in `ContourTreeAlignment` (a updated seed is needed in the corresponding state file & Python script),
- on Windows, a missing attribute has been added to the `WRLExporter` module,
- also on Windows, the `_CRT_SECURE_NO_WARNINGS` definition is used to silence warnings on purportedly more secure alternatives to standard POSIX functions (`fopen`).

Enjoy,
Pierre
