### PR TITLE
[MPI] Get GhostCells from Triangulation

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2818,10 +2818,23 @@ namespace ttk {
       return &(this->remoteGhostCells_);
     }
 
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getGhostVerticesPerOwner() const {
+      return &(this->ghostVerticesPerOwner_);
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostVertices() const {
+      return &(this->remoteGhostVertices_);
+    }
+
     virtual inline void setHasPreconditionedDistributedVertices(bool flag) {
       this->hasPreconditionedDistributedVertices_ = flag;
     }
 
+    virtual inline bool hasPreconditionedDistributedVertices() const {
+      return this->hasPreconditionedDistributedVertices_;
+    }
     virtual inline bool hasPreconditionedDistributedCells() const {
       return this->hasPreconditionedDistributedCells_;
     }
@@ -3665,6 +3678,11 @@ namespace ttk {
     // global ids of local (owned) cells that are ghost cells of other
     // (neighboring) ranks (per MPI rank)
     std::vector<std::vector<SimplexId>> remoteGhostCells_{};
+    // global ids of (local) ghost vertices per each MPI (neighboring) rank
+    std::vector<std::vector<SimplexId>> ghostVerticesPerOwner_{};
+    // global ids of local (owned) vertices that are ghost cells of other
+    // (neighboring) ranks (per MPI rank)
+    std::vector<std::vector<SimplexId>> remoteGhostVertices_{};
 
     std::array<double, 6> localBounds_;
     std::array<double, 6> globalBounds_;

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2787,7 +2787,7 @@ namespace ttk {
       this->hasPreconditionedDistributedVertices_ = flag;
     }
 
-    virtual inline bool getHasPreconditionedDistributedCells() const {
+    virtual inline bool hasPreconditionedDistributedCells() const {
       return this->hasPreconditionedDistributedCells_;
     }
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2607,7 +2607,6 @@ namespace ttk {
       return 0;
     }
 
-
     // global <-> local id mappings
 
     virtual inline SimplexId getVertexGlobalId(const SimplexId lvid) const {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2775,7 +2775,7 @@ namespace ttk {
 
     virtual inline const std::vector<std::vector<SimplexId>> *
       getGhostCellsPerOwner() const {
-      return &(this->ghostCellPerOwner_);
+      return &(this->ghostCellsPerOwner_);
     }
 
     virtual inline const std::vector<std::vector<SimplexId>> *
@@ -3658,7 +3658,7 @@ namespace ttk {
     // list of neighboring ranks (sharing ghost cells to current rank)
     std::vector<int> neighborRanks_{};
     // global ids of (local) ghost cells per each MPI (neighboring) rank
-    std::vector<std::vector<SimplexId>> ghostCellPerOwner_{};
+    std::vector<std::vector<SimplexId>> ghostCellsPerOwner_{};
     // global ids of local (owned) cells that are ghost cells of other
     // (neighboring) ranks (per MPI rank)
     std::vector<std::vector<SimplexId>> remoteGhostCells_{};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2569,6 +2569,11 @@ namespace ttk {
       return 0;
     }
 
+    // public precondition method (used in Triangulation/ttkAlgorithm)
+    virtual int preconditionDistributedCells() {
+      return 0;
+    }
+
     // global <-> local id mappings
 
     virtual inline SimplexId getVertexGlobalId(const SimplexId lvid) const {
@@ -2768,8 +2773,22 @@ namespace ttk {
       return &(this->neighborRanks_);
     }
 
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getGhostCellsPerOwner() const {
+      return &(this->ghostCellPerOwner_);
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostCells() const {
+      return &(this->remoteGhostCells_);
+    }
+
     virtual inline void setHasPreconditionedDistributedVertices(bool flag) {
       this->hasPreconditionedDistributedVertices_ = flag;
+    }
+
+    virtual inline bool getHasPreconditionedDistributedCells() const {
+      return this->hasPreconditionedDistributedCells_;
     }
 
   protected:
@@ -3585,9 +3604,6 @@ namespace ttk {
 
     // precondition methods for distributed meshes
 
-    virtual int preconditionDistributedCells() {
-      return 0;
-    }
     virtual int preconditionDistributedEdges() {
       return 0;
     }

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -271,7 +271,7 @@ namespace ttk {
    * @return 0 in case of success
    */
   template <typename DT, typename IT, typename globalIdType>
-  int getGhostCellScalarsWithoutTriangulation(
+  int getGhostDataScalarsWithoutTriangulation(
     DT *scalarArray,
     const int *const rankArray,
     const globalIdType *const globalIds,
@@ -541,7 +541,7 @@ namespace ttk {
      * @return 0 in case of success
      */
   template <typename DT, typename IT, typename globalIdType>
-  int exchangeGhostCellsWithoutTriangulation(
+  int exchangeGhostDataWithoutTriangulation(
     DT *scalarArray,
     const int *const rankArray,
     const globalIdType *const globalIds,
@@ -554,7 +554,7 @@ namespace ttk {
       return -1;
     }
     for(int r = 0; r < ttk::MPIsize_; r++) {
-      getGhostCellScalarsWithoutTriangulation<DT, IT, globalIdType>(
+      getGhostDataScalarsWithoutTriangulation<DT, IT, globalIdType>(
         scalarArray, rankArray, globalIds, gidToLidMap, neighbors, r, nVerts,
         communicator, dimensionNumber);
       MPI_Barrier(communicator);
@@ -1033,7 +1033,7 @@ namespace ttk {
 
     // we receive the values at the ghostcells through the abstract
     // exchangeGhostCells method
-    ttk::exchangeGhostCellsWithoutTriangulation<ttk::SimplexId, IT>(
+    ttk::exchangeGhostDataWithoutTriangulation<ttk::SimplexId, IT>(
       orderArray, rankArray, globalIds, gidToLidMap, nVerts, ttk::MPIcomm_,
       neighbors);
   }

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -422,7 +422,7 @@ namespace ttk {
     if(!ttk::isRunningWithMPI()) {
       return -1;
     }
-    if(!triangulation->getHasPreconditionedDistributedCells()) {
+    if(!triangulation->hasPreconditionedDistributedCells()) {
       return -1;
     }
     for(int r = 0; r < ttk::MPIsize_; r++) {

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -130,12 +130,11 @@ namespace ttk {
         = triangulation->getGhostCellsPerOwner();
       // receive the scalar values
       for(int r = 0; r < neighborNumber; r++) {
-        ttk::SimplexId nValues
-          = ghostCellsPerOwner->at(neighbors.at(r)).size();
+        ttk::SimplexId nValues = ghostCellsPerOwner->at(neighbors.at(r)).size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
-          MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT, neighbors.at(r),
-                   valuesTag, communicator, MPI_STATUS_IGNORE);
+          MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT,
+                   neighbors.at(r), valuesTag, communicator, MPI_STATUS_IGNORE);
 
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
@@ -179,13 +178,12 @@ namespace ttk {
     return 0;
   }
 
-
   template <typename DT, typename triangulationType>
   int getGhostVertexScalars(DT *scalarArray,
-                          const triangulationType *triangulation,
-                          const int rankToSend,
-                          MPI_Comm communicator,
-                          const int dimensionNumber) {
+                            const triangulationType *triangulation,
+                            const int rankToSend,
+                            MPI_Comm communicator,
+                            const int dimensionNumber) {
     const std::vector<int> &neighbors = triangulation->getNeighborRanks();
     if(!ttk::isRunningWithMPI()) {
       return -1;
@@ -205,14 +203,15 @@ namespace ttk {
           = ghostVerticesPerOwner->at(neighbors.at(r)).size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
-          MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT, neighbors.at(r),
-                   valuesTag, communicator, MPI_STATUS_IGNORE);
+          MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT,
+                   neighbors.at(r), valuesTag, communicator, MPI_STATUS_IGNORE);
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
               ttk::SimplexId globalId
                 = ghostVerticesPerOwner->at(neighbors.at(r))[i];
-              ttk::SimplexId localId = triangulation->getVertexLocalId(globalId);
+              ttk::SimplexId localId
+                = triangulation->getVertexLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
           }
@@ -233,7 +232,8 @@ namespace ttk {
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               ttk::SimplexId globalId = ghostVerticesForThisRank[i];
-              ttk::SimplexId localId = triangulation->getVertexLocalId(globalId);
+              ttk::SimplexId localId
+                = triangulation->getVertexLocalId(globalId);
               valuesToSend[i * dimensionNumber + j]
                 = scalarArray[localId * dimensionNumber + j];
             }
@@ -502,9 +502,9 @@ namespace ttk {
 
   template <typename DT, typename triangulationType>
   int exchangeGhostVertices(DT *scalarArray,
-                         const triangulationType *triangulation,
-                         MPI_Comm communicator,
-                         const int dimensionNumber = 1) {
+                            const triangulationType *triangulation,
+                            MPI_Comm communicator,
+                            const int dimensionNumber = 1) {
     if(!ttk::isRunningWithMPI()) {
       return -1;
     }

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -122,11 +122,11 @@ namespace ttk {
     int valuesTag = 103 * tagMultiplier;
     if(rankToSend == ttk::MPIrank_) {
       int neighborNumber = neighbors->size();
-      const std::vector<std::vector<ttk::SimplexId>> *ghostCellPerOwner
+      const std::vector<std::vector<ttk::SimplexId>> *ghostCellsPerOwner
         = triangulation->getGhostCellsPerOwner();
       // receive the scalar values
       for(int r = 0; r < neighborNumber; r++) {
-        ttk::SimplexId nValues = ghostCellPerOwner->at(neighbors->at(r)).size();
+        ttk::SimplexId nValues = ghostCellsPerOwner->at(neighbors->at(r)).size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
           MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT, r,
@@ -136,9 +136,9 @@ namespace ttk {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
               ttk::SimplexId globalId
-                = ghostCellPerOwner->at(neighbors->at(r))[i];
+                = ghostCellsPerOwner->at(neighbors->at(r))[i];
               ttk::SimplexId localId
-                = triangulation->getVertexLocalId(globalId);
+                = triangulation->getCellLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
           }
@@ -160,7 +160,7 @@ namespace ttk {
             for(int j = 0; j < dimensionNumber; j++) {
               ttk::SimplexId globalId = ghostCellsForThisRank[i];
               ttk::SimplexId localId
-                = triangulation->getVertexLocalId(globalId);
+                = triangulation->getCellLocalId(globalId);
               valuesToSend[i * dimensionNumber + j]
                 = scalarArray[localId * dimensionNumber + j];
             }
@@ -438,7 +438,7 @@ namespace ttk {
      * for every rank
      * this method is for usage without a triangulation, if a triangulation is
      available,
-     * use exchangeGhostCellScalars(), it is more performant when used multiple
+     * use exchangeGhostCells(), it is more performant when used multiple
      times
 
      * @param[out] scalarArray the scalar array which we want to fill and which

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -126,7 +126,8 @@ namespace ttk {
         = triangulation->getGhostCellsPerOwner();
       // receive the scalar values
       for(int r = 0; r < neighborNumber; r++) {
-        ttk::SimplexId nValues = ghostCellsPerOwner->at(neighbors->at(r)).size();
+        ttk::SimplexId nValues
+          = ghostCellsPerOwner->at(neighbors->at(r)).size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
           MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT, r,
@@ -137,8 +138,7 @@ namespace ttk {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
               ttk::SimplexId globalId
                 = ghostCellsPerOwner->at(neighbors->at(r))[i];
-              ttk::SimplexId localId
-                = triangulation->getCellLocalId(globalId);
+              ttk::SimplexId localId = triangulation->getCellLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
           }
@@ -159,8 +159,7 @@ namespace ttk {
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               ttk::SimplexId globalId = ghostCellsForThisRank[i];
-              ttk::SimplexId localId
-                = triangulation->getCellLocalId(globalId);
+              ttk::SimplexId localId = triangulation->getCellLocalId(globalId);
               valuesToSend[i * dimensionNumber + j]
                 = scalarArray[localId * dimensionNumber + j];
             }

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -99,6 +99,92 @@ namespace ttk {
    *
    * @param[out] scalarArray the scalar array which we want to fill and which is
    * filled on the other ranks
+   * @param[in] triangulation the triangulation for the data
+   * @param[in] rankToSend Destination process identifier
+   * @param[in] communicator the communicator over which the ranks are connected
+   * (most likely ttk::MPIcomm_)
+   * @return 0 in case of success
+   */
+  template <typename DT, typename triangulationType>
+  int getGhostCellScalars(DT *scalarArray,
+                          const triangulationType *triangulation,
+                          const int rankToSend,
+                          MPI_Comm communicator,
+                          const int dimensionNumber) {
+    const std::vector<int> *neighbors = triangulation->getNeighborRanks();
+    if(!ttk::isRunningWithMPI()) {
+      return -1;
+    }
+    MPI_Datatype MPI_DT = getMPIType(static_cast<DT>(0));
+    // we need unique tags for each rankToSend, otherwise messages might become
+    // entangled
+    int tagMultiplier = rankToSend + 1;
+    int valuesTag = 103 * tagMultiplier;
+    if(rankToSend == ttk::MPIrank_) {
+      int neighborNumber = neighbors->size();
+      const std::vector<std::vector<ttk::SimplexId>> *ghostCellPerOwner
+        = triangulation->getGhostCellsPerOwner();
+      // receive the scalar values
+      for(int r = 0; r < neighborNumber; r++) {
+        ttk::SimplexId nValues = ghostCellPerOwner->at(neighbors->at(r)).size();
+        std::vector<DT> receivedValues(nValues * dimensionNumber);
+        if(nValues > 0) {
+          MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT, r,
+                   valuesTag, communicator, MPI_STATUS_IGNORE);
+
+          for(ttk::SimplexId i = 0; i < nValues; i++) {
+            for(int j = 0; j < dimensionNumber; j++) {
+              DT receivedVal = receivedValues[i * dimensionNumber + j];
+              ttk::SimplexId globalId
+                = ghostCellPerOwner->at(neighbors->at(r))[i];
+              ttk::SimplexId localId
+                = triangulation->getVertexLocalId(globalId);
+              scalarArray[localId * dimensionNumber + j] = receivedVal;
+            }
+          }
+        }
+      }
+    } else { // owner ranks
+      // if rankToSend is not the neighbor of the current rank, we do not need
+      // to do anything
+      if(std::find(neighbors->begin(), neighbors->end(), rankToSend)
+         != neighbors->end()) {
+        // get the needed globalids from the triangulation
+        std::vector<ttk::SimplexId> ghostCellsForThisRank
+          = triangulation->getRemoteGhostCells()->at(rankToSend);
+        ttk::SimplexId nValues = ghostCellsForThisRank.size();
+        if(nValues > 0) {
+          // assemble the scalar values
+          std::vector<DT> valuesToSend(nValues * dimensionNumber);
+          for(ttk::SimplexId i = 0; i < nValues; i++) {
+            for(int j = 0; j < dimensionNumber; j++) {
+              ttk::SimplexId globalId = ghostCellsForThisRank[i];
+              ttk::SimplexId localId
+                = triangulation->getVertexLocalId(globalId);
+              valuesToSend[i * dimensionNumber + j]
+                = scalarArray[localId * dimensionNumber + j];
+            }
+          }
+
+          // send the scalar values
+          MPI_Send(valuesToSend.data(), nValues * dimensionNumber, MPI_DT,
+                   rankToSend, valuesTag, communicator);
+        }
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * @brief Request all ghost cell scalar data from one rank from their owning
+   * ranks and get the data
+   * this method is for usage without a triangulation, if a triangulation is
+   * available, use getGhostCellScalars(), it is more performant when used
+   * multiple times
+   *
+   * @param[out] scalarArray the scalar array which we want to fill and which is
+   * filled on the other ranks
    * @param[in] rankArray the owner array for the scalar data
    * @param[in] globalIds the global id array for the scalar data
    * @param[in] gidToLidMap a map which translates global ids to local,
@@ -112,15 +198,16 @@ namespace ttk {
    * @return 0 in case of success
    */
   template <typename DT, typename IT>
-  int getGhostCellScalars(DT *scalarArray,
-                          const int *const rankArray,
-                          const LongSimplexId *const globalIds,
-                          const std::unordered_map<IT, IT> &gidToLidMap,
-                          const std::vector<int> *neighbors,
-                          const int rankToSend,
-                          const IT nVerts,
-                          MPI_Comm communicator,
-                          const int dimensionNumber) {
+  int getGhostCellScalarsWithoutTriangulation(
+    DT *scalarArray,
+    const int *const rankArray,
+    const LongSimplexId *const globalIds,
+    const std::unordered_map<IT, IT> &gidToLidMap,
+    const std::vector<int> *neighbors,
+    const int rankToSend,
+    const IT nVerts,
+    MPI_Comm communicator,
+    const int dimensionNumber) {
     if(neighbors == nullptr) {
       return -1;
     }
@@ -211,7 +298,6 @@ namespace ttk {
 
     return 0;
   }
-
   /**
    * @brief get the neighbors of a rank by traversing the rankArray
    *
@@ -269,9 +355,6 @@ namespace ttk {
         std::unordered_set<int> s(begin, end);
         setsFromRanks[i] = s;
         begin = end;
-        // std::cout << "R" << std::to_string(i) << " nr needs something from "
-        // << std::to_string(setsFromRanks[i].size()) << " neighborSet." <<
-        // std::endl;
       }
       // now we need to check for each rank if they are a neighbor of any other
       // rank. If so, we need to add those to the neighbors
@@ -326,24 +409,61 @@ namespace ttk {
    *
    * @param[out] scalarArray the scalar array which we want to fill and which is
    * filled on the other ranks
-   * @param[in] rankArray the owner array for the scalar data
-   * @param[in] globalIds the global id array for the scalar data
-   * @param[in] gidToLidMap a map which translates global ids to local,
-   * rank-based ids
-   * @param[in] nVerts number of vertices in the arrays
+   * @param[in] triangulation the triangulation for the data
    * @param[in] communicator the communicator over which the ranks are connected
    * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
-  template <typename DT, typename IT>
+  template <typename DT, typename triangulationType>
   int exchangeGhostCells(DT *scalarArray,
-                         const int *const rankArray,
-                         const LongSimplexId *const globalIds,
-                         const std::unordered_map<IT, IT> &gidToLidMap,
-                         const IT nVerts,
+                         const triangulationType *triangulation,
                          MPI_Comm communicator,
-                         const std::vector<int> *neighbors,
                          const int dimensionNumber = 1) {
+    if(!ttk::isRunningWithMPI()) {
+      return -1;
+    }
+    if(!triangulation->getHasPreconditionedDistributedCells()) {
+      return -1;
+    }
+    for(int r = 0; r < ttk::MPIsize_; r++) {
+      getGhostCellScalars<DT, triangulationType>(
+        scalarArray, triangulation, r, communicator, dimensionNumber);
+      MPI_Barrier(communicator);
+    }
+    return 0;
+  }
+
+  /**
+     * @brief exchange all ghost cell information by calling getGhostCellScalars
+     * for every rank
+     * this method is for usage without a triangulation, if a triangulation is
+     available,
+     * use exchangeGhostCellScalars(), it is more performant when used multiple
+     times
+
+     * @param[out] scalarArray the scalar array which we want to fill and which
+     is
+     * filled on the other ranks
+     * @param[in] rankArray the owner array for the scalar data
+     * @param[in] globalIds the global id array for the scalar data
+     * @param[in] gidToLidMap a map which translates global ids to local,
+     * rank-based ids
+     * @param[in] nVerts number of vertices in the arrays
+     * @param[in] communicator the communicator over which the ranks are
+     connected
+     * (most likely ttk::MPIcomm_)
+     * @return 0 in case of success
+     */
+  template <typename DT, typename IT>
+  int exchangeGhostCellsWithoutTriangulation(
+    DT *scalarArray,
+    const int *const rankArray,
+    const LongSimplexId *const globalIds,
+    const std::unordered_map<IT, IT> &gidToLidMap,
+    const IT nVerts,
+    MPI_Comm communicator,
+    const std::vector<int> *neighbors,
+    const int dimensionNumber = 1) {
     if(!ttk::isRunningWithMPI()) {
       return -1;
     }
@@ -351,9 +471,9 @@ namespace ttk {
       return -1;
     }
     for(int r = 0; r < ttk::MPIsize_; r++) {
-      getGhostCellScalars<DT, IT>(scalarArray, rankArray, globalIds,
-                                  gidToLidMap, neighbors, r, nVerts,
-                                  communicator, dimensionNumber);
+      getGhostCellScalarsWithoutTriangulation<DT, IT>(
+        scalarArray, rankArray, globalIds, gidToLidMap, neighbors, r, nVerts,
+        communicator, dimensionNumber);
       MPI_Barrier(communicator);
     }
     return 0;
@@ -832,9 +952,9 @@ namespace ttk {
 
     // we receive the values at the ghostcells through the abstract
     // exchangeGhostCells method
-    ttk::exchangeGhostCells<ttk::SimplexId, IT>(orderArray, rankArray,
-                                                globalIds, gidToLidMap, nVerts,
-                                                ttk::MPIcomm_, neighbors);
+    ttk::exchangeGhostCellsWithoutTriangulation<ttk::SimplexId, IT>(
+      orderArray, rankArray, globalIds, gidToLidMap, nVerts, ttk::MPIcomm_,
+      neighbors);
   }
 
   /**

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -103,8 +103,8 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     for(int i = 0; i < edgeNumber; ++i) {
       charBoundary[i] = boundaryEdges_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
-                                                ttk::SimplexId>(
+    ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
+                                               ttk::SimplexId>(
       charBoundary.data(), this->edgeRankArray_.data(),
       this->edgeLidToGid_.data(), this->edgeGidToLid_, edgeNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
@@ -209,8 +209,8 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     for(int i = 0; i < triangleNumber; ++i) {
       charBoundary[i] = boundaryTriangles_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
-                                                ttk::SimplexId>(
+    ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
+                                               ttk::SimplexId>(
       charBoundary.data(), this->triangleRankArray_.data(),
       this->triangleLidToGid_.data(), this->triangleGidToLid_, triangleNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
@@ -278,15 +278,14 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
 #if TTK_ENABLE_MPI
 
   if(ttk::isRunningWithMPI()) {
+    this->preconditionDistributedVertices();
     std::vector<unsigned char> charBoundary(vertexNumber_, false);
     for(int i = 0; i < vertexNumber_; ++i) {
       charBoundary[i] = boundaryVertices_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
-                                                ttk::LongSimplexId>(
-      charBoundary.data(), this->vertRankArray_, this->getVertsGlobalIds(),
-      this->getVertexGlobalIdMap(), vertexNumber_, ttk::MPIcomm_,
-      this->getNeighborRanks());
+    ttk::exchangeGhostVertices<unsigned char, ExplicitTriangulation>(
+      charBoundary.data(), this, ttk::MPIcomm_);
+
     for(int i = 0; i < vertexNumber_; ++i) {
       if(vertRankArray_[i] != ttk::MPIrank_) {
         boundaryVertices_[i] = (charBoundary[i] == '1');

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -1285,13 +1285,52 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
     this->printErr("Missing global vertex identifiers array!");
     return -2;
   }
-
-  // allocate memory
-  this->vertexGidToLid_.reserve(this->vertexNumber_);
-
-  for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexGidToLid_[this->vertGid_[i]] = i;
+  if(this->vertRankArray_ == nullptr) {
+    this->printErr("Missing vertex RankArray!");
+    return -3;
   }
+
+  // number of local vertices (with ghost vertices...)
+  const auto nLocVertices{this->getNumberOfVertices()};
+
+  // global vertex id -> local vertex id (reverse of this->vertGid_)
+  this->vertexGidToLid_.reserve(nLocVertices);
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    this->vertexGidToLid_[this->vertGid_[lvid]] = lvid;
+  }
+  this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
+
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    if(this->vertRankArray_[lvid] != ttk::MPIrank_) {
+      // store ghost cell global ids (per rank)
+      this->ghostVerticesPerOwner_[this->vertRankArray_[lvid]].emplace_back(
+        this->vertGid_[lvid]);
+    }
+  }
+
+  // for each rank, store the global id of local cells that are ghost cells of
+  // other ranks.
+  const auto MIT{ttk::getMPIType(ttk::SimplexId{})};
+  this->remoteGhostVertices_.resize(ttk::MPIsize_);
+  // number of owned cells that are ghost cells of other ranks
+  std::vector<size_t> nOwnedGhostVerticesPerRank(ttk::MPIsize_);
+
+  for(const auto neigh : this->neighborRanks_) {
+    // 1. send to neigh number of ghost cells owned by neigh
+    const auto nVerts{this->ghostVerticesPerOwner_[neigh].size()};
+    MPI_Sendrecv(&nVerts, 1, ttk::getMPIType(nVerts), neigh, ttk::MPIrank_,
+                 &nOwnedGhostVerticesPerRank[neigh], 1, ttk::getMPIType(nVerts),
+                 neigh, neigh, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    this->remoteGhostVertices_[neigh].resize(nOwnedGhostVerticesPerRank[neigh]);
+
+    // 2. send to neigh list of ghost cells owned by neigh
+    MPI_Sendrecv(this->ghostVerticesPerOwner_[neigh].data(),
+                 this->ghostVerticesPerOwner_[neigh].size(), MIT, neigh,
+                 ttk::MPIrank_, this->remoteGhostVertices_[neigh].data(),
+                 this->remoteGhostVertices_[neigh].size(), MIT, neigh, neigh,
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
+  }
+
 
   this->hasPreconditionedDistributedVertices_ = true;
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -103,7 +103,8 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     for(int i = 0; i < edgeNumber; ++i) {
       charBoundary[i] = boundaryEdges_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId, ttk::SimplexId>(
+    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
+                                                ttk::SimplexId>(
       charBoundary.data(), this->edgeRankArray_.data(),
       this->edgeLidToGid_.data(), this->edgeGidToLid_, edgeNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
@@ -208,7 +209,8 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     for(int i = 0; i < triangleNumber; ++i) {
       charBoundary[i] = boundaryTriangles_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId, ttk::SimplexId>(
+    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
+                                                ttk::SimplexId>(
       charBoundary.data(), this->triangleRankArray_.data(),
       this->triangleLidToGid_.data(), this->triangleGidToLid_, triangleNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
@@ -280,7 +282,8 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
     for(int i = 0; i < vertexNumber_; ++i) {
       charBoundary[i] = boundaryVertices_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId, ttk::LongSimplexId>(
+    ttk::exchangeGhostCellsWithoutTriangulation<unsigned char, ttk::SimplexId,
+                                                ttk::LongSimplexId>(
       charBoundary.data(), this->vertRankArray_, this->getVertsGlobalIds(),
       this->getVertexGlobalIdMap(), vertexNumber_, ttk::MPIcomm_,
       this->getNeighborRanks());
@@ -1330,7 +1333,6 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
                  this->remoteGhostVertices_[neigh].size(), MIT, neigh, neigh,
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
-
 
   this->hasPreconditionedDistributedVertices_ = true;
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3320,7 +3320,6 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
 
-
   this->hasPreconditionedDistributedVertices_ = true;
 
   return 0;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3274,13 +3274,52 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
     this->printErr("Missing global vertex identifiers array!");
     return -2;
   }
-
-  // allocate memory
-  this->vertexGidToLid_.reserve(this->vertexNumber_);
-
-  for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexGidToLid_[this->vertGid_[i]] = i;
+  if(this->vertRankArray_ == nullptr) {
+    this->printErr("Missing vertex RankArray!");
+    return -3;
   }
+
+  // number of local vertices (with ghost vertices...)
+  const auto nLocVertices{this->getNumberOfVertices()};
+
+  // global vertex id -> local vertex id (reverse of this->vertGid_)
+  this->vertexGidToLid_.reserve(nLocVertices);
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    this->vertexGidToLid_[this->vertGid_[lvid]] = lvid;
+  }
+  this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
+
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    if(this->vertRankArray_[lvid] != ttk::MPIrank_) {
+      // store ghost cell global ids (per rank)
+      this->ghostVerticesPerOwner_[this->vertRankArray_[lvid]].emplace_back(
+        this->vertGid_[lvid]);
+    }
+  }
+
+  // for each rank, store the global id of local cells that are ghost cells of
+  // other ranks.
+  const auto MIT{ttk::getMPIType(ttk::SimplexId{})};
+  this->remoteGhostVertices_.resize(ttk::MPIsize_);
+  // number of owned cells that are ghost cells of other ranks
+  std::vector<size_t> nOwnedGhostVerticesPerRank(ttk::MPIsize_);
+
+  for(const auto neigh : this->neighborRanks_) {
+    // 1. send to neigh number of ghost cells owned by neigh
+    const auto nVerts{this->ghostVerticesPerOwner_[neigh].size()};
+    MPI_Sendrecv(&nVerts, 1, ttk::getMPIType(nVerts), neigh, ttk::MPIrank_,
+                 &nOwnedGhostVerticesPerRank[neigh], 1, ttk::getMPIType(nVerts),
+                 neigh, neigh, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    this->remoteGhostVertices_[neigh].resize(nOwnedGhostVerticesPerRank[neigh]);
+
+    // 2. send to neigh list of ghost cells owned by neigh
+    MPI_Sendrecv(this->ghostVerticesPerOwner_[neigh].data(),
+                 this->ghostVerticesPerOwner_[neigh].size(), MIT, neigh,
+                 ttk::MPIrank_, this->remoteGhostVertices_[neigh].data(),
+                 this->remoteGhostVertices_[neigh].size(), MIT, neigh, neigh,
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
+  }
+
 
   this->hasPreconditionedDistributedVertices_ = true;
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -169,11 +169,16 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
+      exchangeGhostVertices<dataType, triangulationType>(
+        outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
+      /*
+       * old method
       exchangeGhostCellsWithoutTriangulation<dataType, SimplexId, ttk::LongSimplexId>(
         outputData, triangulation->getVertRankArray(),
         triangulation->getVertsGlobalIds(),
         triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
         triangulation->getNeighborRanks(), dimensionNumber_);
+      */
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -169,11 +169,8 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      exchangeGhostCells<dataType, SimplexId>(
-        outputData, triangulation->getVertRankArray(),
-        triangulation->getVertsGlobalIds(),
-        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
-        triangulation->getNeighborRanks(), dimensionNumber_);
+      exchangeGhostCells<dataType, triangulationType>(
+        outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -169,8 +169,11 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      exchangeGhostCells<dataType, triangulationType>(
-        outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
+      exchangeGhostCellsWithoutTriangulation<dataType, SimplexId>(
+        outputData, triangulation->getVertRankArray(),
+         triangulation->getVertsGlobalIds(),
+         triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
+         triangulation->getNeighborRanks(), dimensionNumber_);
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -171,9 +171,9 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
       // neighbors
       exchangeGhostCellsWithoutTriangulation<dataType, SimplexId>(
         outputData, triangulation->getVertRankArray(),
-         triangulation->getVertsGlobalIds(),
-         triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
-         triangulation->getNeighborRanks(), dimensionNumber_);
+        triangulation->getVertsGlobalIds(),
+        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
+        triangulation->getNeighborRanks(), dimensionNumber_);
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -173,8 +173,8 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
         outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
       /*
        * old method
-      exchangeGhostCellsWithoutTriangulation<dataType, SimplexId, ttk::LongSimplexId>(
-        outputData, triangulation->getVertRankArray(),
+      exchangeGhostCellsWithoutTriangulation<dataType, SimplexId,
+      ttk::LongSimplexId>( outputData, triangulation->getVertRankArray(),
         triangulation->getVertsGlobalIds(),
         triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
         triangulation->getNeighborRanks(), dimensionNumber_);

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -171,14 +171,6 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
       // neighbors
       exchangeGhostVertices<dataType, triangulationType>(
         outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
-      /*
-       * old method
-      exchangeGhostCellsWithoutTriangulation<dataType, SimplexId,
-      ttk::LongSimplexId>( outputData, triangulation->getVertRankArray(),
-        triangulation->getVertsGlobalIds(),
-        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
-        triangulation->getNeighborRanks(), dimensionNumber_);
-      */
     }
 #endif
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1441,7 +1441,7 @@ namespace ttk {
       return abstractTriangulation_->getGhostCellsPerOwner();
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    inline const std::vector<std::vector<SimplexId>> *
       getRemoteGhostCells() const override {
       return abstractTriangulation_->getRemoteGhostCells();
     }

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1424,8 +1424,8 @@ namespace ttk {
       abstractTriangulation_->setHasPreconditionedDistributedVertices(flag);
     }
 
-    inline bool getHasPreconditionedDistributedCells() const override {
-      return abstractTriangulation_->getHasPreconditionedDistributedCells();
+    inline bool hasPreconditionedDistributedCells() const override {
+      return abstractTriangulation_->hasPreconditionedDistributedCells();
     }
 
     inline std::vector<int> *getNeighborRanksWriteMode() override {

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1424,12 +1424,26 @@ namespace ttk {
       abstractTriangulation_->setHasPreconditionedDistributedVertices(flag);
     }
 
+    inline bool getHasPreconditionedDistributedCells() const override {
+      return abstractTriangulation_->getHasPreconditionedDistributedCells();
+    }
+
     inline std::vector<int> *getNeighborRanksWriteMode() override {
       return abstractTriangulation_->getNeighborRanksWriteMode();
     }
 
     inline const std::vector<int> *getNeighborRanks() const override {
       return abstractTriangulation_->getNeighborRanks();
+    }
+
+    inline const std::vector<std::vector<SimplexId>> *
+      getGhostCellsPerOwner() const override {
+      return abstractTriangulation_->getGhostCellsPerOwner();
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostCells() const override {
+      return abstractTriangulation_->getRemoteGhostCells();
     }
 
     /// Get the corresponding local id for a given global id of a vertex.
@@ -2348,6 +2362,32 @@ namespace ttk {
         return -1;
 #endif
       return abstractTriangulation_->preconditionDistributedVertices();
+    }
+#endif // TTK_ENABLE_MPI
+
+#if TTK_ENABLE_MPI
+    /// Pre-process the distributed ghost cells .
+    ///
+    /// This function should ONLY be called as a pre-condition to the
+    /// following functions:
+    ///   - getGhostCellsPerOwner()
+    ///   - getRemoteGhostCells()
+    ///
+    /// \pre This function should be called prior to any traversal, in a
+    /// clearly distinct pre-processing step that involves no traversal at
+    /// all. An error will be returned otherwise.
+    /// \note It is recommended to exclude this preconditioning function from
+    /// any time performance measurement.
+    /// \return Returns 0 upon success, negative values otherwise.
+    /// \sa getGhostCellsPerOwner()
+    /// \sa getRemoteGhostCells()
+    inline int preconditionDistributedCells() override {
+
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return abstractTriangulation_->preconditionDistributedCells();
     }
 #endif // TTK_ENABLE_MPI
 

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1427,6 +1427,9 @@ namespace ttk {
     inline bool hasPreconditionedDistributedCells() const override {
       return abstractTriangulation_->hasPreconditionedDistributedCells();
     }
+    inline bool hasPreconditionedDistributedVertices() const override {
+      return abstractTriangulation_->hasPreconditionedDistributedVertices();
+    }
 
     inline const std::vector<int> &getNeighborRanks() const override {
       return abstractTriangulation_->getNeighborRanks();

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -817,6 +817,7 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
       ttkUtils::GetPointer<ttk::LongSimplexId>(cd->GetGlobalIds()));
     triangulation->setCellRankArray(
       ttkUtils::GetPointer<int>(cd->GetArray("RankArray")));
+    triangulation->preconditionDistributedCells();
   }
 }
 #endif


### PR DESCRIPTION
Hi all,

similarly to #860 , the `AbstractTriangulation` already has the attributes `ghostCellPerOwner_` and `remoteGhostCells_`, which are however not used after getting computed.

This PR adapts `getGhostCellScalars(..)` to get the ghostCell information from the triangulation and to use the triangulation-methods to e.g. get the local id for global ids. For this to work correctly, the triangulation needs to precondition the cells beforehand, this is done in `MPITriangulationPreconditioning()`where similar methods already reside.

However, not all classes actually have a triangulation when they try to exchange ghost cell information (for example, when creating an order array for an existing scalar array), therefore the old functionality still exists in the `getGhostCellScalarsWithoutTriangulation(..)` method. 

Any feedback is welcome.
