### PR TITLE
Reduce build times of mergeTree filters

### DIFF
--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -4,7 +4,6 @@
 #include <MergeTreeUtils.h>
 #include <MergeTreeVisualization.h>
 #include <ttkFTMTreeUtils.h>
-#include <ttkMacros.h>
 #include <ttkMergeTreeClustering.h>
 #include <ttkMergeTreeVisualization.h>
 
@@ -142,21 +141,12 @@ int ttkMergeTreeClustering::RequestData(vtkInformation *ttkNotUsed(request),
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees, inputTrees2;
   loadBlocks(inputTrees, blocks);
   loadBlocks(inputTrees2, blocks2);
-  auto *block0 = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0));
-  auto arrayToGet = block0->GetPointData()->GetArray("Scalar");
-  if(arrayToGet == nullptr)
-    arrayToGet = block0->GetCellData()->GetArray(PersistenceBirthName);
-  int dataTypeInt = arrayToGet->GetDataType();
 
   // If we have already computed once but the input has changed
   if(treesNodes.size() != 0 and inputTrees[0]->GetBlock(0) != treesNodes[0])
     resetDataVisualization();
 
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees, inputTrees2););
-  }
-  return res;
+  return run<float>(outputVector, inputTrees, inputTrees2);
 }
 
 template <class dataType>

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.cpp
@@ -1,5 +1,4 @@
 #include <ttkFTMTreeUtils.h>
-#include <ttkMacros.h>
 #include <ttkMergeTreeDistanceMatrix.h>
 #include <ttkUtils.h>
 
@@ -285,16 +284,6 @@ int ttkMergeTreeDistanceMatrix::RequestData(
   loadBlocks(inputTrees, blocks);
   loadBlocks(inputTrees2, blocks2);
 
-  auto arrayToGet
-    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
-        ->GetPointData()
-        ->GetArray("Scalar");
-  if(arrayToGet == nullptr)
-    arrayToGet = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
-                   ->GetCellData()
-                   ->GetArray(PersistenceBirthName);
-  int dataTypeInt = arrayToGet->GetDataType();
-
   // --- Load field data parameters
   if(UseFieldDataParameters) {
     printMsg("Load parameters from field data.");
@@ -311,10 +300,5 @@ int ttkMergeTreeDistanceMatrix::RequestData(
     }
   }
 
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees, inputTrees2));
-  }
-
-  return res;
+  return run<float>(outputVector, inputTrees, inputTrees2);
 }

--- a/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.cpp
+++ b/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.cpp
@@ -11,7 +11,6 @@
 #include <vtkSmartPointer.h>
 #include <vtkTable.h>
 
-#include <ttkMacros.h>
 #include <ttkUtils.h>
 
 // A VTK macro that enables the instantiation of this class via ::New()
@@ -110,11 +109,6 @@ int ttkMergeTreePrincipalGeodesics::RequestData(
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees, inputTrees2;
   ttk::ftm::loadBlocks(inputTrees, blocks);
   ttk::ftm::loadBlocks(inputTrees2, blocks2);
-  auto *block0 = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0));
-  auto arrayToGet = block0->GetPointData()->GetArray("Scalar");
-  if(arrayToGet == nullptr)
-    arrayToGet = block0->GetCellData()->GetArray("Birth");
-  int dataTypeInt = arrayToGet->GetDataType();
 
   // ------------------------------------------------------------------------------------
   // If we have already computed once but the input has changed
@@ -134,11 +128,7 @@ int ttkMergeTreePrincipalGeodesics::RequestData(
   else
     printMsg("Computation without normalized Wasserstein.");
 
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees, inputTrees2););
-  }
-  return res;
+  return run<float>(outputVector, inputTrees, inputTrees2);
 }
 
 template <class dataType>

--- a/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
+++ b/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
@@ -10,7 +10,6 @@
 #include <vtkSmartPointer.h>
 #include <vtkVariantArray.h>
 
-#include <ttkMacros.h>
 #include <ttkUtils.h>
 
 // A VTK macro that enables the instantiation of this class via ::New()
@@ -114,14 +113,6 @@ int ttkMergeTreePrincipalGeodesicsDecoding::RequestData(
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputBary, inputTrees;
   ttk::ftm::loadBlocks(inputBary, blockBary);
   ttk::ftm::loadBlocks(inputTrees, blockInputTrees);
-  auto arrayToGet = vtkUnstructuredGrid::SafeDownCast(inputBary[0]->GetBlock(0))
-                      ->GetPointData()
-                      ->GetArray("Scalar");
-  if(arrayToGet == nullptr)
-    arrayToGet = vtkUnstructuredGrid::SafeDownCast(inputBary[0]->GetBlock(0))
-                   ->GetPointData()
-                   ->GetArray("Birth");
-  int dataTypeInt = arrayToGet->GetDataType();
 
   // If we have already computed once but the input has changed
   if((baryTreeNodes.size() != 0
@@ -289,11 +280,7 @@ int ttkMergeTreePrincipalGeodesicsDecoding::RequestData(
 
   // ------------------------------------------------------------------------------------
 
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputBary, inputTrees););
-  }
-  return res;
+  return run<float>(outputVector, inputBary, inputTrees);
 }
 
 template <class dataType>

--- a/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionDecoding/ttkMergeTreeTemporalReductionDecoding.cpp
@@ -11,7 +11,6 @@
 #include <vtkPointData.h>
 #include <vtkTable.h>
 
-#include <ttkMacros.h>
 #include <ttkUtils.h>
 
 using namespace ttk;
@@ -114,11 +113,6 @@ int ttkMergeTreeTemporalReductionDecoding::RequestData(
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees;
   loadBlocks(inputTrees, blocks);
   printMsg("Load Blocks done.", debug::Priority::VERBOSE);
-  int dataTypeInt
-    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
-        ->GetPointData()
-        ->GetArray("Scalar")
-        ->GetDataType();
   auto assignmentSolverArray
     = blocks->GetFieldData()->GetArray("AssignmentSolver");
   if(assignmentSolverArray)
@@ -148,12 +142,7 @@ int ttkMergeTreeTemporalReductionDecoding::RequestData(
       interpolatedTrees[j] = true;
   }
 
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(
-      res = run<VTK_TT>(outputVector, inputTrees, coefs, interpolatedTrees););
-  }
-  return res;
+  return run<float>(outputVector, inputTrees, coefs, interpolatedTrees);
 }
 
 template <class dataType>

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -13,7 +13,6 @@
 #include <vtkResampleToImage.h>
 #include <vtkTable.h>
 
-#include <ttkMacros.h>
 #include <ttkUtils.h>
 
 using namespace ttk;
@@ -107,22 +106,13 @@ int ttkMergeTreeTemporalReductionEncoding::RequestData(
   std::vector<vtkSmartPointer<vtkMultiBlockDataSet>> inputTrees;
   loadBlocks(inputTrees, blocks);
   printMsg("Load blocks done.", debug::Priority::VERBOSE);
-  int dataTypeInt
-    = vtkUnstructuredGrid::SafeDownCast(inputTrees[0]->GetBlock(0))
-        ->GetPointData()
-        ->GetArray("Scalar")
-        ->GetDataType();
 
   // If we have already computed once but the input has changed
   if(treesNodes.size() != 0 and inputTrees[0]->GetBlock(0) != treesNodes[0])
     resetDataVisualization();
 
   // Run
-  int res = 0;
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = run<VTK_TT>(outputVector, inputTrees););
-  }
-  return res;
+  return run<float>(outputVector, inputTrees);
 }
 
 template <class dataType>

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.cpp
@@ -169,17 +169,8 @@ int ttkPlanarGraphLayout::mergeTreePlanarLayoutCall(
   vtkUnstructuredGrid *treeArcs
     = vtkUnstructuredGrid::GetData(inputVector[0], 1);
   auto output = vtkUnstructuredGrid::GetData(outputVector);
-  int dataTypeInt
-    = treeNodes->GetPointData()->GetArray("Scalar")->GetDataType();
 
-  int res = 0;
-
-  switch(dataTypeInt) {
-    vtkTemplateMacro(res = mergeTreePlanarLayoutCallTemplate<VTK_TT>(
-                       treeNodes, treeArcs, output););
-  }
-
-  return res;
+  return mergeTreePlanarLayoutCallTemplate<float>(treeNodes, treeArcs, output);
 }
 
 int ttkPlanarGraphLayout::RequestData(vtkInformation *request,


### PR DESCRIPTION
This PR removes the template instantiations in the `mergeTree` modules, thus reducing their compilation time. The concerned modules are:

- `ttkMergeTreeClustering` (from 130s to 25s),
- `ttkMergeTreeDistanceMatrix` (from 70s to 15s),
- `ttkMergeTreePrincipalGeodesics` (from 130s to 25s),
- `ttkMergeTreePrincipalGeodesicsDecoding` (from 110s to 25s),
- `ttkMergeTreeTemporalDecoding` (from 110s to 25s),
- `ttkMergeTreeTemporalEncoding` (from 120s to 25s) and
- `ttkPlanarGraphLayout` (from 65s to 30s).

All of these modules converts merge trees in VTK format (as outputted by `ttkFTMTree`) to the internal merge tree representation used in the base layer and defined in the `ftmTree` module.

Using `vtkTemplateMacro` in these filters was not necessary since:

1. the data are copied from the VTK arrays to the internal structure (c.f. `ttk::ftm::makeTree` in ttkFTMTreeUtils.h) using `vtkDataArray::GetTuple` that casts the data in `double` (no `ttkUtils::GetPointer` or `ttkUtils::GetVoidPointer` used),
https://github.com/topology-tool-kit/ttk/blob/2a1f2b72cfdbfbd802e05f5c7db33f71685041b9/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h#L38
2. the `vtkDataArray` on which the templating is performed, the `Scalar` Point Data array on `ttkFTMTree`'s `Ouput Nodes` is defined to be a `vtkFloatArray`. https://github.com/topology-tool-kit/ttk/blob/2a1f2b72cfdbfbd802e05f5c7db33f71685041b9/core/vtk/ttkFTMTree/ttkFTMStructures.h#L117

To keep the compatibility with the previous implementation, the `float` variant is explicitly chosen in the filters.

This is quite similar to what has been done to the `ttkPersistenceDiagramClustering` module several years ago.

Aggressive de-templating of base modules could lead to additional improvements in the build times but a lot more work is needed.

Enjoy,
Pierre
