### PR TITLE
GitHub Actions: Execute test_build workflow on pushes on "dev" branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@ name: test_build
 
 on:
   push:
+    # triggered on commit pushes on the "dev" branch
+    branches:
+      - 'dev'
     # triggered on tag pushes with tags beginning with either "v" or "dev"
-    branch-ignore:
-      - '*'
     tags:
       - 'v*'
       - 'dev*'
@@ -12,10 +13,9 @@ on:
       - 'build*'
       - 'test*'
   pull_request:
-    # also triggered by pull requests on the "dev" & "mpi" branches
+    # also triggered by pull requests on the "dev" branch
     branches:
       - 'dev'
-      - 'mpi'
 
 env:
   PV_TAG: v5.10.1-headless
@@ -29,6 +29,10 @@ jobs:
   # ------------------#
   test-build-ubuntu:
     runs-on: ${{ matrix.os }}
+    # trigger job when push event on a branch (not on a tag) only for
+    # the "topology-tool-kit/ttk" repository
+    # (pull-requests and tag pushes not affected)
+    if: ${{ github.repository_owner == 'topology-tool-kit' || !contains(github.ref, 'heads') }}
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
@@ -203,6 +207,7 @@ jobs:
   # -----------------#
   test-build-macos:
     runs-on: macos-12
+    if: ${{ github.repository_owner == 'topology-tool-kit' || !contains(github.ref, 'heads') }}
     env:
       CCACHE_DIR: /Users/runner/work/ttk/.ccache
     steps:
@@ -333,6 +338,7 @@ jobs:
   # ------------------ #
   test-build-windows:
     runs-on: windows-2022
+    if: ${{ github.repository_owner == 'topology-tool-kit' || !contains(github.ref, 'heads') }}
     env:
       PV_DIR: C:\Program Files\TTK-ParaView
       TTK_DIR: C:\Program Files (x86)\ttk


### PR DESCRIPTION
This PR extends the `test_build` workflow to be executed also on pushes on the "dev" branch, but only on the `topology-tool-kit/ttk` repository (forked repositories that have enabled actions will skip the execution of the workflow).

Now, there should be 3 ways to execute this workflow:
* by pushing a tag matching the specifications,
* on a pull request on the "dev" branch and
* on a push on the "dev" branch iff the repository is `topology-tool-kit/ttk`.

This should also enable the badge in the README.

Enjoy,
Pierre