### PR TITLE
GitHub Actions: More aggressive deletion of Python 3.11 on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,6 +226,7 @@ jobs:
         echo "$(brew --prefix)/opt/ccache/libexec" >> $GITHUB_PATH
         # remove Python 3.11 installation
         sudo rm -rf /Library/Frameworks/Python.framework/Versions/3.11
+        sudo rm -rf /usr/local/Frameworks/Python.framework/Versions/3.11
 
     - name: Install optional dependencies
       uses: ./.github/actions/install-deps-unix


### PR DESCRIPTION
This PR deletes another directory in which an installation of Python 3.11 in the macOS VM can be found. This is to ensure that the correct Python (3.10) is selected by CMake to be linked by TTK. We already use Python 3.10 for the ParaView headless binaries and the `scikit-learn` package. Mixing Python versions can lead to errors in the `DimensionReduction` module.

Enjoy,
Pierre