### PR TITLE
MorseSmaleComplex: Support non-manifold datasets

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -251,7 +251,8 @@ in the gradient.
                             VisitedMask &mask,
                             const triangulationType &triangulation,
                             std::vector<Cell> *const wall = nullptr,
-                            std::set<SimplexId> *const saddles = nullptr) const;
+                            std::vector<SimplexId> *const saddles
+                            = nullptr) const;
 
       /**
        * Return the 2-separatrice coming from the given 1-saddle.
@@ -261,7 +262,8 @@ in the gradient.
                            VisitedMask &mask,
                            const triangulationType &triangulation,
                            std::vector<Cell> *const wall = nullptr,
-                           std::set<SimplexId> *const saddles = nullptr) const;
+                           std::vector<SimplexId> *const saddles
+                           = nullptr) const;
 
       /**
        * Get the vertex id of with the maximum scalar field value on

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1079,7 +1079,11 @@ int DiscreteGradient::getDescendingWall(
   VisitedMask &mask,
   const triangulationType &triangulation,
   std::vector<Cell> *const wall,
-  std::set<SimplexId> *const saddles) const {
+  std::vector<SimplexId> *const saddles) const {
+
+  if(saddles != nullptr) {
+    saddles->clear();
+  }
 
   if(dimensionality_ == 3) {
     if(cell.dim_ == 2) {
@@ -1108,7 +1112,7 @@ int DiscreteGradient::getDescendingWall(
             triangulation.getTriangleEdge(triangleId, j, edgeId);
 
             if((saddles != nullptr) and isSaddle1(Cell(1, edgeId))) {
-              saddles->insert(edgeId);
+              saddles->emplace_back(edgeId);
             }
 
             const SimplexId pairedCellId
@@ -1119,6 +1123,12 @@ int DiscreteGradient::getDescendingWall(
             }
           }
         }
+      }
+
+      if(saddles != nullptr && saddles->size() > 1) {
+        std::sort(saddles->begin(), saddles->end());
+        const auto last = std::unique(saddles->begin(), saddles->end());
+        saddles->erase(last, saddles->end());
       }
     }
   }
@@ -1132,7 +1142,11 @@ int DiscreteGradient::getAscendingWall(
   VisitedMask &mask,
   const triangulationType &triangulation,
   std::vector<Cell> *const wall,
-  std::set<SimplexId> *const saddles) const {
+  std::vector<SimplexId> *const saddles) const {
+
+  if(saddles != nullptr) {
+    saddles->clear();
+  }
 
   if(dimensionality_ == 3) {
     if(cell.dim_ == 1) {
@@ -1163,7 +1177,7 @@ int DiscreteGradient::getAscendingWall(
             triangulation.getEdgeTriangle(edgeId, j, triangleId);
 
             if((saddles != nullptr) and isSaddle2(Cell(2, triangleId))) {
-              saddles->insert(triangleId);
+              saddles->emplace_back(triangleId);
             }
 
             const SimplexId pairedCellId
@@ -1174,6 +1188,12 @@ int DiscreteGradient::getAscendingWall(
             }
           }
         }
+      }
+
+      if(saddles != nullptr && saddles->size() > 1) {
+        std::sort(saddles->begin(), saddles->end());
+        const auto last = std::unique(saddles->begin(), saddles->end());
+        saddles->erase(last, saddles->end());
       }
     }
   }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
@@ -5,30 +5,24 @@ ttk::MorseSmaleComplex::MorseSmaleComplex() {
 }
 
 void ttk::MorseSmaleComplex::flattenSeparatricesVectors(
-  std::vector<std::vector<Separatrix>> &separatrices,
-  std::vector<std::vector<std::vector<ttk::dcg::Cell>>> &separatricesGeometry)
-  const {
+  std::vector<std::vector<Separatrix>> &separatrices) const {
 
   std::vector<size_t> partialSizes{0};
   for(const auto &sep : separatrices) {
     partialSizes.emplace_back(partialSizes.back() + sep.size());
   }
   separatrices[0].resize(partialSizes.back());
-  separatricesGeometry[0].resize(partialSizes.back());
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 1; i < separatrices.size(); ++i) {
-    const auto offset = partialSizes[i];
-
     for(size_t j = 0; j < separatrices[i].size(); ++j) {
-      // shift separatrices geometry_
-      separatrices[i][j].geometry_ = offset + j;
+      const auto o = partialSizes[i] + j;
       // flatten separatrices1 and separatricesGeometry1
-      separatrices[0][offset + j] = separatrices[i][j];
-      separatricesGeometry[0][offset + j]
-        = std::move(separatricesGeometry[i][j]);
+      separatrices[0][o].source_ = separatrices[i][j].source_;
+      separatrices[0][o].destination_ = separatrices[i][j].destination_;
+      separatrices[0][o].geometry_ = std::move(separatrices[i][j].geometry_);
     }
   }
 }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
@@ -16,12 +16,12 @@ void ttk::MorseSmaleComplex::flattenSeparatricesVectors(
   separatrices[0].resize(partialSizes.back());
   separatricesGeometry[0].resize(partialSizes.back());
 
-  for(size_t i = 1; i < separatrices.size(); ++i) {
-    const auto offset = partialSizes[i];
-
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
+  for(size_t i = 1; i < separatrices.size(); ++i) {
+    const auto offset = partialSizes[i];
+
     for(size_t j = 0; j < separatrices[i].size(); ++j) {
       // shift separatrices geometry_
       for(size_t k = 0; k < separatrices[i][j].geometry_.size(); ++k) {

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
@@ -25,7 +25,7 @@ void ttk::MorseSmaleComplex::flattenSeparatricesVectors(
     for(size_t j = 0; j < separatrices[i].size(); ++j) {
       // shift separatrices geometry_
       for(size_t k = 0; k < separatrices[i][j].geometry_.size(); ++k) {
-        separatrices[i][j].geometry_[k] += offset;
+        separatrices[i][j].geometry_[k] = offset + j;
       }
       // flatten separatrices1 and separatricesGeometry1
       separatrices[0][offset + j] = std::move(separatrices[i][j]);

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.cpp
@@ -24,11 +24,9 @@ void ttk::MorseSmaleComplex::flattenSeparatricesVectors(
 
     for(size_t j = 0; j < separatrices[i].size(); ++j) {
       // shift separatrices geometry_
-      for(size_t k = 0; k < separatrices[i][j].geometry_.size(); ++k) {
-        separatrices[i][j].geometry_[k] = offset + j;
-      }
+      separatrices[i][j].geometry_ = offset + j;
       // flatten separatrices1 and separatricesGeometry1
-      separatrices[0][offset + j] = std::move(separatrices[i][j]);
+      separatrices[0][offset + j] = separatrices[i][j];
       separatricesGeometry[0][offset + j]
         = std::move(separatricesGeometry[i][j]);
     }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -684,9 +684,8 @@ int ttk::MorseSmaleComplex::getDescendingSeparatrices1(
   }
   const SimplexId numberOfSaddles = saddleIndexes.size();
 
-  // estimation of the number of separatrices, apriori :
-  // numberOfAscendingPaths=2, numberOfDescendingPaths=2
-  const SimplexId numberOfSeparatrices = 4 * numberOfSaddles;
+  // only 2 descending separatrices per 1-saddle
+  const SimplexId numberOfSeparatrices = 2 * numberOfSaddles;
   separatrices.resize(numberOfSeparatrices);
   separatricesGeometry.resize(numberOfSeparatrices);
 
@@ -703,8 +702,6 @@ int ttk::MorseSmaleComplex::getDescendingSeparatrices1(
       const Cell &saddle1 = saddle;
 
       for(int j = 0; j < 2; ++j) {
-        const int shift = j + 2;
-
         SimplexId vertexId;
         triangulation.getEdgeVertex(saddle1.id_, j, vertexId);
 
@@ -715,7 +712,7 @@ int ttk::MorseSmaleComplex::getDescendingSeparatrices1(
 
         const Cell &lastCell = vpath.back();
         if(lastCell.dim_ == 0 and discreteGradient_.isCellCritical(lastCell)) {
-          const SimplexId separatrixIndex = 4 * i + shift;
+          const SimplexId separatrixIndex = 2 * i + j;
 
           separatricesGeometry[separatrixIndex] = std::move(vpath);
           separatrices[separatrixIndex]

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -302,7 +302,7 @@ namespace ttk {
     int getDescendingSeparatrices2(
       const std::vector<dcg::Cell> &criticalPoints,
       std::vector<Separatrix> &separatrices,
-      std::vector<std::set<SimplexId>> &separatricesSaddles,
+      std::vector<std::vector<SimplexId>> &separatricesSaddles,
       const triangulationType &triangulation) const;
 
     /**
@@ -313,7 +313,7 @@ namespace ttk {
     int setDescendingSeparatrices2(
       Output2Separatrices &outSeps2,
       const std::vector<Separatrix> &separatrices,
-      const std::vector<std::set<SimplexId>> &separatricesSaddles,
+      const std::vector<std::vector<SimplexId>> &separatricesSaddles,
       const SimplexId *const offsets,
       const triangulationType &triangulation) const;
 
@@ -344,7 +344,7 @@ namespace ttk {
     int getAscendingSeparatrices2(
       const std::vector<dcg::Cell> &criticalPoints,
       std::vector<Separatrix> &separatrices,
-      std::vector<std::set<SimplexId>> &separatricesSaddles,
+      std::vector<std::vector<SimplexId>> &separatricesSaddles,
       const triangulationType &triangulation) const;
 
     /**
@@ -355,7 +355,7 @@ namespace ttk {
     int setAscendingSeparatrices2(
       Output2Separatrices &outSeps2,
       const std::vector<Separatrix> &separatrices,
-      const std::vector<std::set<SimplexId>> &separatricesSaddles,
+      const std::vector<std::vector<SimplexId>> &separatricesSaddles,
       const SimplexId *const offsets,
       const triangulationType &triangulation) const;
 
@@ -544,7 +544,7 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   if(dim == 3 && ComputeDescendingSeparatrices2) {
     Timer tmp;
     std::vector<Separatrix> separatrices;
-    std::vector<std::set<SimplexId>> separatricesSaddles;
+    std::vector<std::vector<SimplexId>> separatricesSaddles;
     getDescendingSeparatrices2(
       criticalPoints, separatrices, separatricesSaddles, triangulation);
     setDescendingSeparatrices2(
@@ -558,7 +558,7 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   if(dim == 3 && ComputeAscendingSeparatrices2) {
     Timer tmp;
     std::vector<Separatrix> separatrices;
-    std::vector<std::set<SimplexId>> separatricesSaddles;
+    std::vector<std::vector<SimplexId>> separatricesSaddles;
     getAscendingSeparatrices2(
       criticalPoints, separatrices, separatricesSaddles, triangulation);
     setAscendingSeparatrices2(
@@ -763,15 +763,15 @@ int ttk::MorseSmaleComplex::getSaddleConnectors(
   using Vpath = std::vector<Cell>;
 
   std::vector<std::vector<Separatrix>> sepsByThread(saddles2.size());
+  std::vector<SimplexId> saddles1{};
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_) schedule(dynamic) \
-  firstprivate(isVisited, visitedTriangles)
+  firstprivate(isVisited, visitedTriangles, saddles1)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < saddles2.size(); ++i) {
     const auto &s2{saddles2[i]};
 
-    std::set<SimplexId> saddles1{};
     VisitedMask mask{isVisited, visitedTriangles};
     discreteGradient_.getDescendingWall(
       s2, mask, triangulation, nullptr, &saddles1);
@@ -946,7 +946,7 @@ template <typename triangulationType>
 int ttk::MorseSmaleComplex::getAscendingSeparatrices2(
   const std::vector<Cell> &criticalPoints,
   std::vector<Separatrix> &separatrices,
-  std::vector<std::set<SimplexId>> &separatricesSaddles,
+  std::vector<std::vector<SimplexId>> &separatricesSaddles,
   const triangulationType &triangulation) const {
   const Cell emptyCell;
 
@@ -996,7 +996,7 @@ template <typename triangulationType>
 int ttk::MorseSmaleComplex::getDescendingSeparatrices2(
   const std::vector<Cell> &criticalPoints,
   std::vector<Separatrix> &separatrices,
-  std::vector<std::set<SimplexId>> &separatricesSaddles,
+  std::vector<std::vector<SimplexId>> &separatricesSaddles,
   const triangulationType &triangulation) const {
   const Cell emptyCell;
 
@@ -1097,7 +1097,7 @@ template <typename triangulationType>
 int ttk::MorseSmaleComplex::setAscendingSeparatrices2(
   Output2Separatrices &outSeps2,
   const std::vector<Separatrix> &separatrices,
-  const std::vector<std::set<SimplexId>> &separatricesSaddles,
+  const std::vector<std::vector<SimplexId>> &separatricesSaddles,
   const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 
@@ -1317,7 +1317,7 @@ template <typename triangulationType>
 int ttk::MorseSmaleComplex::setDescendingSeparatrices2(
   Output2Separatrices &outSeps2,
   const std::vector<Separatrix> &separatrices,
-  const std::vector<std::set<SimplexId>> &separatricesSaddles,
+  const std::vector<std::vector<SimplexId>> &separatricesSaddles,
   const SimplexId *const offsets,
   const triangulationType &triangulation) const {
 


### PR DESCRIPTION
This PR reworks how the ascending 1-separatrices are computed, in order to fix a segfault happening on non-manifold datasets.

Old assumptions in the code that counted 2 ascending separatrices per saddle are invalid for non-manifold datasets. For instance, in a 2D Rips Complex, an edge is often shared by more than two triangles. This PR relaxes these assumptions, the code doesn't expect an arbitrary number of ascending 1-separatrices per saddle any more.

Since this change may degrade the performance of the filter, I performed some code cleaning, especially around the `Separatrix` data-structure, which possessed unused or ill-used class members. `std::set`s were also replaced with `std::vector`s in `DiscreteGradient` for storing a de-duplicated list of saddles on walls.

Finally, the computation of `separatrixFunctionMin`, `separatrixFunctionMax` and `numberOfCriticalPointsOnBoundary` has been modified to take into account that there may be no saddles on the boundary on a wall.

Enjoy,
Pierre
