### PR TITLE
[MPI] Add MPI support to the discrete gradient filter

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2858,6 +2858,30 @@ namespace ttk {
       return this->hasPreconditionedDistributedCells_;
     }
 
+    ttk::SimplexId inline getDistributedGlobalCellId(ttk::SimplexId localCellId,
+                                                     int cellDim) const {
+      if(ttk::hasInitializedMPI()) {
+        switch(cellDim) {
+          case 0:
+            return this->getVertexGlobalIdInternal(localCellId);
+          case 1:
+            return this->getEdgeGlobalIdInternal(localCellId);
+          case 2:
+            if(getDimensionality() == 2) {
+              return this->getCellGlobalIdInternal(localCellId);
+            } else {
+              return this->getTriangleGlobalIdInternal(localCellId);
+            }
+          case 3: {
+            return this->getCellGlobalIdInternal(localCellId);
+          }
+        }
+        return -1;
+      } else {
+        return localCellId;
+      }
+    }
+
   protected:
     inline SimplexId getVertexGlobalIdInternal(const SimplexId lvid) const {
       return this->vertGid_[lvid];

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2550,11 +2550,11 @@ namespace ttk {
 
     // RankArray on points & cells
 
-    inline void setVertRankArray(const int *const rankArray) {
-      this->vertRankArray_ = rankArray;
+    inline void setVertexRankArray(const int *const rankArray) {
+      this->vertexRankArray_ = rankArray;
     }
-    inline const int *getVertRankArray() const {
-      return this->vertRankArray_;
+    inline const int *getVertexRankArray() const {
+      return this->vertexRankArray_;
     }
 
     inline void setCellRankArray(const int *const rankArray) {
@@ -3692,7 +3692,7 @@ namespace ttk {
     // "GlobalPointIds" from "Generate Global Ids"
     const LongSimplexId *vertGid_{};
     // PointData "RankArray" from "TTKGhostCellPreconditioning"
-    const int *vertRankArray_{};
+    const int *vertexRankArray_{};
     // CellData "RankArray" from "TTKGhostCellPreconditioning"
     // (warning: for Implicit/Periodic triangulations, concerns
     // "squares"/"cubes" and not "triangles"/"tetrahedron")

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2807,8 +2807,35 @@ namespace ttk {
       return this->neighborRanks_;
     }
 
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getGhostCellsPerOwner() const {
+      return &(this->ghostCellsPerOwner_);
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostCells() const {
+      return &(this->remoteGhostCells_);
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getGhostVerticesPerOwner() const {
+      return &(this->ghostVerticesPerOwner_);
+    }
+
+    virtual inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostVertices() const {
+      return &(this->remoteGhostVertices_);
+    }
+
     virtual inline void setHasPreconditionedDistributedVertices(bool flag) {
       this->hasPreconditionedDistributedVertices_ = flag;
+    }
+
+    virtual inline bool hasPreconditionedDistributedVertices() const {
+      return this->hasPreconditionedDistributedVertices_;
+    }
+    virtual inline bool hasPreconditionedDistributedCells() const {
+      return this->hasPreconditionedDistributedCells_;
     }
 
   protected:
@@ -3646,10 +3673,15 @@ namespace ttk {
     // list of neighboring ranks (sharing ghost cells to current rank)
     std::vector<int> neighborRanks_{};
     // global ids of (local) ghost cells per each MPI (neighboring) rank
-    std::vector<std::vector<SimplexId>> ghostCellPerOwner_{};
+    std::vector<std::vector<SimplexId>> ghostCellsPerOwner_{};
     // global ids of local (owned) cells that are ghost cells of other
     // (neighboring) ranks (per MPI rank)
     std::vector<std::vector<SimplexId>> remoteGhostCells_{};
+    // global ids of (local) ghost vertices per each MPI (neighboring) rank
+    std::vector<std::vector<SimplexId>> ghostVerticesPerOwner_{};
+    // global ids of local (owned) vertices that are ghost cells of other
+    // (neighboring) ranks (per MPI rank)
+    std::vector<std::vector<SimplexId>> remoteGhostVertices_{};
 
     std::array<double, 6> localBounds_;
     std::array<double, 6> globalBounds_;

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2858,28 +2858,35 @@ namespace ttk {
       return this->hasPreconditionedDistributedCells_;
     }
 
-    ttk::SimplexId inline getDistributedGlobalCellId(ttk::SimplexId localCellId,
-                                                     int cellDim) const {
+    inline int getDistributedGlobalCellId(const SimplexId &localCellId,
+                                          const int &cellDim,
+                                          SimplexId &globalCellId) const {
       if(ttk::hasInitializedMPI()) {
         switch(cellDim) {
           case 0:
-            return this->getVertexGlobalIdInternal(localCellId);
+            globalCellId = this->getVertexGlobalIdInternal(localCellId);
+            break;
           case 1:
-            return this->getEdgeGlobalIdInternal(localCellId);
+            globalCellId = this->getEdgeGlobalIdInternal(localCellId);
+            break;
           case 2:
             if(getDimensionality() == 2) {
-              return this->getCellGlobalIdInternal(localCellId);
+              globalCellId = this->getCellGlobalIdInternal(localCellId);
+              break;
             } else {
-              return this->getTriangleGlobalIdInternal(localCellId);
+              globalCellId = this->getTriangleGlobalIdInternal(localCellId);
+              break;
             }
           case 3: {
-            return this->getCellGlobalIdInternal(localCellId);
+            globalCellId = this->getCellGlobalIdInternal(localCellId);
+            break;
           }
         }
-        return -1;
+        globalCellId = -1;
       } else {
-        return localCellId;
+        globalCellId = localCellId;
       }
+      return 0;
     }
 
   protected:

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2881,8 +2881,10 @@ namespace ttk {
             globalCellId = this->getCellGlobalIdInternal(localCellId);
             break;
           }
+          default:
+            globalCellId = -1;
+            break;
         }
-        globalCellId = -1;
       } else {
         globalCellId = localCellId;
       }

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -164,27 +164,22 @@ bool DiscreteGradient::isCellCritical(const int cellDim,
   }
 
   if(cellDim == 0) {
-    return ((*gradient_)[0][cellId] != GHOST_GRADIENT)
-           && ((*gradient_)[0][cellId] == NULL_GRADIENT);
+    return ((*gradient_)[0][cellId] == NULL_GRADIENT);
   }
 
   if(cellDim == 1) {
-    return ((*gradient_)[1][cellId] != GHOST_GRADIENT)
-           && ((*gradient_)[1][cellId] == NULL_GRADIENT
-               && (dimensionality_ == 1
-                   || (*gradient_)[2][cellId] == NULL_GRADIENT));
+    return (
+      (*gradient_)[1][cellId] == NULL_GRADIENT
+      && (dimensionality_ == 1 || (*gradient_)[2][cellId] == NULL_GRADIENT));
   }
 
   if(cellDim == 2) {
-    return ((*gradient_)[3][cellId] != GHOST_GRADIENT)
-           && ((*gradient_)[3][cellId] == NULL_GRADIENT
-               && (dimensionality_ == 2
-                   || (*gradient_)[4][cellId] == NULL_GRADIENT));
+    return ((*gradient_)[3][cellId] == -1
+            && (dimensionality_ == 2 || (*gradient_)[4][cellId] == -1));
   }
 
   if(cellDim == 3) {
-    return ((*gradient_)[5][cellId] != GHOST_GRADIENT)
-           && ((*gradient_)[5][cellId] == NULL_GRADIENT);
+    return ((*gradient_)[5][cellId] == NULL_GRADIENT);
   }
 
   return false;
@@ -249,10 +244,12 @@ void DiscreteGradient::setCellToGhost(const int cellDim,
 
   if(cellDim == 1) {
     (*gradient_)[1][cellId] = GHOST_GRADIENT;
+    (*gradient_)[2][cellId] = GHOST_GRADIENT;
   }
 
   if(cellDim == 2) {
     (*gradient_)[3][cellId] = GHOST_GRADIENT;
+    (*gradient_)[4][cellId] = GHOST_GRADIENT;
   }
 
   if(cellDim == 3) {

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -164,21 +164,27 @@ bool DiscreteGradient::isCellCritical(const int cellDim,
   }
 
   if(cellDim == 0) {
-    return ((*gradient_)[0][cellId] == -1);
+    return ((*gradient_)[0][cellId] != GHOST_GRADIENT)
+           && ((*gradient_)[0][cellId] == NULL_GRADIENT);
   }
 
   if(cellDim == 1) {
-    return ((*gradient_)[1][cellId] == -1
-            && (dimensionality_ == 1 || (*gradient_)[2][cellId] == -1));
+    return ((*gradient_)[1][cellId] != GHOST_GRADIENT)
+           && ((*gradient_)[1][cellId] == NULL_GRADIENT
+               && (dimensionality_ == 1
+                   || (*gradient_)[2][cellId] == NULL_GRADIENT));
   }
 
   if(cellDim == 2) {
-    return ((*gradient_)[3][cellId] == -1
-            && (dimensionality_ == 2 || (*gradient_)[4][cellId] == -1));
+    return ((*gradient_)[3][cellId] != GHOST_GRADIENT)
+           && ((*gradient_)[3][cellId] == NULL_GRADIENT
+               && (dimensionality_ == 2
+                   || (*gradient_)[4][cellId] == NULL_GRADIENT));
   }
 
   if(cellDim == 3) {
-    return ((*gradient_)[5][cellId] == -1);
+    return ((*gradient_)[5][cellId] != GHOST_GRADIENT)
+           && ((*gradient_)[5][cellId] == NULL_GRADIENT);
   }
 
   return false;
@@ -233,3 +239,24 @@ int DiscreteGradient::setManifoldSize(
 
   return 0;
 }
+
+#if TTK_ENABLE_MPI
+void DiscreteGradient::setCellToGhost(const int cellDim,
+                                      const SimplexId cellId) {
+  if(cellDim == 0) {
+    (*gradient_)[0][cellId] = GHOST_GRADIENT;
+  }
+
+  if(cellDim == 1) {
+    (*gradient_)[1][cellId] = GHOST_GRADIENT;
+  }
+
+  if(cellDim == 2) {
+    (*gradient_)[3][cellId] = GHOST_GRADIENT;
+  }
+
+  if(cellDim == 3) {
+    (*gradient_)[5][cellId] = GHOST_GRADIENT;
+  }
+}
+#endif

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -174,8 +174,9 @@ bool DiscreteGradient::isCellCritical(const int cellDim,
   }
 
   if(cellDim == 2) {
-    return ((*gradient_)[3][cellId] == -1
-            && (dimensionality_ == 2 || (*gradient_)[4][cellId] == -1));
+    return (
+      (*gradient_)[3][cellId] == NULL_GRADIENT
+      && (dimensionality_ == 2 || (*gradient_)[4][cellId] == NULL_GRADIENT));
   }
 
   if(cellDim == 3) {

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -240,7 +240,7 @@ int DiscreteGradient::setManifoldSize(
   return 0;
 }
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
 void DiscreteGradient::setCellToGhost(const int cellDim,
                                       const SimplexId cellId) {
   if(cellDim == 0) {

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -325,12 +325,22 @@ in the gradient.
       int getCriticalPoints(std::vector<Cell> &criticalPoints,
                             const triangulationType &triangulation) const;
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
+      /**
+       * Get the Global Id of the simplex by calling the appropriate global id
+       * retrieval function based on the simplex dimension cellDim
+       */
       template <typename triangulationType>
       int getDistributedGlobalCellId(
         int localCellId,
         int cellDim,
         const triangulationType &triangulation) const;
+
+      /**
+       * Set the Cell Gradient to GHOST_GRADIENT
+       */
+      void setCellToGhost(const int cellDim, const SimplexId cellId);
+
 #endif
       /**
        * Compute manifold size for critical extrema
@@ -486,9 +496,6 @@ gradient, false otherwise.
         const std::vector<Cell> &vpath,
         const triangulationType &triangulation) const;
 
-#if TTK_ENABLE_MPI
-      void setCellToGhost(const int cellDim, const SimplexId cellId);
-#endif
     protected:
       int dimensionality_{-1};
       SimplexId numberOfVertices_{};

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -327,16 +327,6 @@ in the gradient.
 
 #ifdef TTK_ENABLE_MPI
       /**
-       * Get the Global Id of the simplex by calling the appropriate global id
-       * retrieval function based on the simplex dimension cellDim
-       */
-      template <typename triangulationType>
-      int getDistributedGlobalCellId(
-        int localCellId,
-        int cellDim,
-        const triangulationType &triangulation) const;
-
-      /**
        * Set the Cell Gradient to GHOST_GRADIENT
        */
       void setCellToGhost(const int cellDim, const SimplexId cellId);

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -44,6 +44,8 @@ namespace ttk {
       SimplexId id_{-1};
     };
 
+    enum gradientValue { NULL_GRADIENT = -1, GHOST_GRADIENT = -2 };
+
     /**
      * @brief Extended Cell structure for processLowerStars
      */
@@ -78,6 +80,9 @@ namespace ttk {
     public:
       DiscreteGradient() {
         this->setDebugMsgPrefix("DiscreteGradient");
+#ifdef TTK_ENABLE_MPI
+        hasMPISupport_ = true;
+#endif
       }
 
       /**
@@ -320,6 +325,13 @@ in the gradient.
       int getCriticalPoints(std::vector<Cell> &criticalPoints,
                             const triangulationType &triangulation) const;
 
+#if TTK_ENABLE_MPI
+      template <typename triangulationType>
+      int getDistributedGlobalCellId(
+        int localCellId,
+        int cellDim,
+        const triangulationType &triangulation) const;
+#endif
       /**
        * Compute manifold size for critical extrema
        */
@@ -474,6 +486,9 @@ gradient, false otherwise.
         const std::vector<Cell> &vpath,
         const triangulationType &triangulation) const;
 
+#if TTK_ENABLE_MPI
+      void setCellToGhost(const int cellDim, const SimplexId cellId);
+#endif
     protected:
       int dimensionality_{-1};
       SimplexId numberOfVertices_{};

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -468,7 +468,7 @@ int DiscreteGradient::processLowerStars(
 
   // store lower star structure
   lowerStarType Lx;
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
   const int *vertRankArray = triangulation.getVertRankArray();
 #endif
 #ifdef TTK_ENABLE_OPENMP
@@ -516,7 +516,7 @@ int DiscreteGradient::processLowerStars(
     lowerStar(Lx, x, offsets, triangulation);
     // In case the vertex is a ghost, the gradient of the
     // simplices of its star is set to GHOST_GRADIENT
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
     if(vertRankArray[x] != ttk::MPIrank_) {
       int sizeDim = Lx.size();
       for(int i = 0; i < sizeDim; i++) {
@@ -596,7 +596,7 @@ int DiscreteGradient::processLowerStars(
           }
         }
       }
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
     }
 #endif
   }
@@ -1537,7 +1537,7 @@ ttk::SimplexId DiscreteGradient::getCellLowerVertex(
   return vertexId;
 }
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
 template <typename triangulationType>
 int DiscreteGradient::getDistributedGlobalCellId(
   int localCellId, int cellDim, const triangulationType &triangulation) const {

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -122,8 +122,7 @@ int DiscreteGradient::setCriticalPoints(
     triangulation.getCellIncenter(cell.id_, cell.dim_, points[i].data());
     cellDimensions[i] = cellDim;
 #ifdef TTK_ENABLE_MPI
-    cellIds[i]
-      = this->getDistributedGlobalCellId(cellId, cellDim, triangulation);
+    cellIds[i] = triangulation.getDistributedGlobalCellId(cellId, cellDim);
 #else
     cellIds[i] = cellId;
 #endif
@@ -1537,33 +1536,6 @@ ttk::SimplexId DiscreteGradient::getCellLowerVertex(
   return vertexId;
 }
 
-#ifdef TTK_ENABLE_MPI
-template <typename triangulationType>
-int DiscreteGradient::getDistributedGlobalCellId(
-  int localCellId, int cellDim, const triangulationType &triangulation) const {
-  if(ttk::hasInitializedMPI()) {
-    switch(cellDim) {
-      case 0:
-        return triangulation.getVertexGlobalId(localCellId);
-      case 1:
-        return triangulation.getEdgeGlobalId(localCellId);
-      case 2:
-        if(getDimensionality() == 2) {
-          return triangulation.getCellGlobalId(localCellId);
-        } else {
-          return triangulation.getTriangleGlobalId(localCellId);
-        }
-      case 3: {
-        return triangulation.getCellGlobalId(localCellId);
-      }
-    }
-    return -1;
-  } else {
-    return localCellId;
-  }
-}
-#endif
-
 template <typename triangulationType>
 int DiscreteGradient::setGradientGlyphs(
   std::vector<std::array<float, 3>> &points,
@@ -1626,9 +1598,9 @@ int DiscreteGradient::setGradientGlyphs(
         cells_pairTypes[nProcessedGlyphs] = i;
 #ifdef TTK_ENABLE_MPI
         cellIds[2 * nProcessedGlyphs + 0]
-          = this->getDistributedGlobalCellId(j, i, triangulation);
+          = triangulation.getDistributedGlobalCellId(j, i);
         cellIds[2 * nProcessedGlyphs + 1]
-          = this->getDistributedGlobalCellId(pcid, i + 1, triangulation);
+          = triangulation.getDistributedGlobalCellId(pcid, i + 1);
 #else
         cellIds[2 * nProcessedGlyphs + 0] = j;
         cellIds[2 * nProcessedGlyphs + 1] = pcid;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -112,7 +112,7 @@ int DiscreteGradient::setCriticalPoints(
   ttk::SimplexId globalId{-1};
   // for all critical cells
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp parallel for num_threads(threadNumber_) private(globalId)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nCritPoints; ++i) {
     const Cell &cell = criticalPoints[i];
@@ -1580,7 +1580,7 @@ int DiscreteGradient::setGradientGlyphs(
   cellDimensions.resize(2 * nGlyphs);
   ttk::SimplexId globalId{-1};
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp parallel for num_threads(threadNumber_) private(globalId)
 #endif // TTK_ENABLE_OPENMP
   for(int i = 0; i < nDims - 1; ++i) {
     const SimplexId nCells = getNumberOfCells(i, triangulation);

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -109,7 +109,9 @@ int DiscreteGradient::setCriticalPoints(
   cellIds.resize(nCritPoints);
   isOnBoundary.resize(nCritPoints);
   PLVertexIdentifiers.resize(nCritPoints);
+#ifdef TTK_ENABLE_MPI
   ttk::SimplexId globalId{-1};
+#endif
   // for all critical cells
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_) private(globalId)
@@ -1578,7 +1580,9 @@ int DiscreteGradient::setGradientGlyphs(
   cells_pairTypes.resize(nGlyphs);
   cellIds.resize(2 * nGlyphs);
   cellDimensions.resize(2 * nGlyphs);
+#ifdef TTK_ENABLE_MPI
   ttk::SimplexId globalId{-1};
+#endif
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_) private(globalId)
 #endif // TTK_ENABLE_OPENMP

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -114,7 +114,11 @@ int DiscreteGradient::setCriticalPoints(
 #endif
   // for all critical cells
 #ifdef TTK_ENABLE_OPENMP
+#if TTK_ENABLE_MPI
 #pragma omp parallel for num_threads(threadNumber_) private(globalId)
+#else
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nCritPoints; ++i) {
     const Cell &cell = criticalPoints[i];
@@ -1584,7 +1588,11 @@ int DiscreteGradient::setGradientGlyphs(
   ttk::SimplexId globalId{-1};
 #endif
 #ifdef TTK_ENABLE_OPENMP
+#if TTK_ENABLE_MPI
 #pragma omp parallel for num_threads(threadNumber_) private(globalId)
+#else
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
 #endif // TTK_ENABLE_OPENMP
   for(int i = 0; i < nDims - 1; ++i) {
     const SimplexId nCells = getNumberOfCells(i, triangulation);

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -469,7 +469,7 @@ int DiscreteGradient::processLowerStars(
   // store lower star structure
   lowerStarType Lx;
 #ifdef TTK_ENABLE_MPI
-  const int *vertRankArray = triangulation.getVertRankArray();
+  const int *vertexRankArray = triangulation.getVertexRankArray();
 #endif
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_) \
@@ -517,7 +517,7 @@ int DiscreteGradient::processLowerStars(
     // In case the vertex is a ghost, the gradient of the
     // simplices of its star is set to GHOST_GRADIENT
 #ifdef TTK_ENABLE_MPI
-    if(vertRankArray != nullptr && vertRankArray[x] != ttk::MPIrank_) {
+    if(vertexRankArray != nullptr && vertexRankArray[x] != ttk::MPIrank_) {
       int sizeDim = Lx.size();
       for(int i = 0; i < sizeDim; i++) {
         int nCells = Lx[i].size();

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -109,7 +109,7 @@ int DiscreteGradient::setCriticalPoints(
   cellIds.resize(nCritPoints);
   isOnBoundary.resize(nCritPoints);
   PLVertexIdentifiers.resize(nCritPoints);
-
+  ttk::SimplexId globalId{-1};
   // for all critical cells
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
@@ -122,7 +122,8 @@ int DiscreteGradient::setCriticalPoints(
     triangulation.getCellIncenter(cell.id_, cell.dim_, points[i].data());
     cellDimensions[i] = cellDim;
 #ifdef TTK_ENABLE_MPI
-    cellIds[i] = triangulation.getDistributedGlobalCellId(cellId, cellDim);
+    triangulation.getDistributedGlobalCellId(cellId, cellDim, globalId);
+    cellIds[i] = globalId;
 #else
     cellIds[i] = cellId;
 #endif
@@ -1577,7 +1578,7 @@ int DiscreteGradient::setGradientGlyphs(
   cells_pairTypes.resize(nGlyphs);
   cellIds.resize(2 * nGlyphs);
   cellDimensions.resize(2 * nGlyphs);
-
+  ttk::SimplexId globalId{-1};
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
@@ -1597,10 +1598,10 @@ int DiscreteGradient::setGradientGlyphs(
         points_pairOrigins[2 * nProcessedGlyphs + 1] = 1;
         cells_pairTypes[nProcessedGlyphs] = i;
 #ifdef TTK_ENABLE_MPI
-        cellIds[2 * nProcessedGlyphs + 0]
-          = triangulation.getDistributedGlobalCellId(j, i);
-        cellIds[2 * nProcessedGlyphs + 1]
-          = triangulation.getDistributedGlobalCellId(pcid, i + 1);
+        triangulation.getDistributedGlobalCellId(j, i, globalId);
+        cellIds[2 * nProcessedGlyphs + 0] = globalId;
+        triangulation.getDistributedGlobalCellId(pcid, i + 1, globalId);
+        cellIds[2 * nProcessedGlyphs + 1] = globalId;
 #else
         cellIds[2 * nProcessedGlyphs + 0] = j;
         cellIds[2 * nProcessedGlyphs + 1] = pcid;

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -517,7 +517,7 @@ int DiscreteGradient::processLowerStars(
     // In case the vertex is a ghost, the gradient of the
     // simplices of its star is set to GHOST_GRADIENT
 #ifdef TTK_ENABLE_MPI
-    if(vertRankArray[x] != ttk::MPIrank_) {
+    if(vertRankArray != nullptr && vertRankArray[x] != ttk::MPIrank_) {
       int sizeDim = Lx.size();
       for(int i = 0; i < sizeDim; i++) {
         int nCells = Lx[i].size();
@@ -1541,22 +1541,26 @@ ttk::SimplexId DiscreteGradient::getCellLowerVertex(
 template <typename triangulationType>
 int DiscreteGradient::getDistributedGlobalCellId(
   int localCellId, int cellDim, const triangulationType &triangulation) const {
-  switch(cellDim) {
-    case 0:
-      return triangulation.getVertexGlobalId(localCellId);
-    case 1:
-      return triangulation.getEdgeGlobalId(localCellId);
-    case 2:
-      if(getDimensionality() == 2) {
+  if(ttk::hasInitializedMPI()) {
+    switch(cellDim) {
+      case 0:
+        return triangulation.getVertexGlobalId(localCellId);
+      case 1:
+        return triangulation.getEdgeGlobalId(localCellId);
+      case 2:
+        if(getDimensionality() == 2) {
+          return triangulation.getCellGlobalId(localCellId);
+        } else {
+          return triangulation.getTriangleGlobalId(localCellId);
+        }
+      case 3: {
         return triangulation.getCellGlobalId(localCellId);
-      } else {
-        return triangulation.getTriangleGlobalId(localCellId);
       }
-    case 3: {
-      return triangulation.getCellGlobalId(localCellId);
     }
+    return -1;
+  } else {
+    return localCellId;
   }
-  return -1;
 }
 #endif
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -296,7 +296,7 @@ int ExplicitTriangulation::preconditionBoundaryVerticesInternal() {
       charBoundary.data(), this, ttk::MPIcomm_);
 
     for(int i = 0; i < vertexNumber_; ++i) {
-      if(vertRankArray_[i] != ttk::MPIrank_) {
+      if(vertexRankArray_[i] != ttk::MPIrank_) {
         boundaryVertices_[i] = (charBoundary[i] == '1');
       }
     }
@@ -1298,7 +1298,7 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
     this->printErr("Missing global vertex identifiers array!");
     return -2;
   }
-  if(this->vertRankArray_ == nullptr) {
+  if(this->vertexRankArray_ == nullptr) {
     this->printErr("Missing vertex RankArray!");
     return -3;
   }
@@ -1314,9 +1314,9 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
   this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
-    if(this->vertRankArray_[lvid] != ttk::MPIrank_) {
+    if(this->vertexRankArray_[lvid] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
-      this->ghostVerticesPerOwner_[this->vertRankArray_[lvid]].emplace_back(
+      this->ghostVerticesPerOwner_[this->vertexRankArray_[lvid]].emplace_back(
         this->vertGid_[lvid]);
     }
   }

--- a/core/base/identifiers/Identifiers.h
+++ b/core/base/identifiers/Identifiers.h
@@ -67,7 +67,7 @@ namespace ttk {
     MPI_Datatype mpiPointType_;
     int dimension_{};
     int hasSentData_{0};
-    ttk::SimplexId *vertRankArray_{nullptr};
+    ttk::SimplexId *vertexRankArray_{nullptr};
     ttk::SimplexId *cellRankArray_{nullptr};
     unsigned char *vertGhost_{nullptr};
     unsigned char *cellGhost_{nullptr};
@@ -109,8 +109,8 @@ namespace ttk {
       pointsToCells_ = pointsToCells;
     }
 
-    void setVertRankArray(ttk::SimplexId *vertRankArray) {
-      this->vertRankArray_ = vertRankArray;
+    void setVertexRankArray(ttk::SimplexId *vertexRankArray) {
+      this->vertexRankArray_ = vertexRankArray;
     }
 
     void setCellRankArray(ttk::SimplexId *cellRankArray) {
@@ -249,8 +249,8 @@ namespace ttk {
           this->findPoint(
             id, receivedPoints[n].x, receivedPoints[n].y, receivedPoints[n].z);
           if((vertGhost_ != nullptr && vertGhost_[id] == 0)
-             || (vertRankArray_ != nullptr
-                 && vertRankArray_[id] == ttk::MPIrank_)) {
+             || (vertexRankArray_ != nullptr
+                 && vertexRankArray_[id] == ttk::MPIrank_)) {
             globalId = vertexIdentifiers_[id];
             if(globalId >= 0) {
 #ifdef TTK_ENABLE_OPENMP
@@ -511,18 +511,18 @@ namespace ttk {
       // If the vertex is not owned, it will be added to the vector of
       // ghosts.
 
-      if(vertRankArray_ != nullptr) {
+      if(vertexRankArray_ != nullptr) {
         for(ttk::SimplexId i = 0; i < vertexNumber_; i++) {
-          if(vertRankArray_[i] != ttk::MPIrank_) {
+          if(vertexRankArray_[i] != ttk::MPIrank_) {
             realVertexNumber--;
             if(outdatedGlobalPointIds_ == nullptr) {
               p[0] = pointSet_[i * 3];
               p[1] = pointSet_[i * 3 + 1];
               p[2] = pointSet_[i * 3 + 2];
-              vertGhostCoordinatesPerRank[neighborToId_[vertRankArray_[i]]]
+              vertGhostCoordinatesPerRank[neighborToId_[vertexRankArray_[i]]]
                 .push_back(Point{p[0], p[1], p[2], i});
             } else {
-              vertGhostGlobalIdsPerRank[neighborToId_[vertRankArray_[i]]]
+              vertGhostGlobalIdsPerRank[neighborToId_[vertexRankArray_[i]]]
                 .push_back(
                   static_cast<ttk::SimplexId>(outdatedGlobalPointIds_[i]));
             }
@@ -579,9 +579,9 @@ namespace ttk {
       }
 
       // Generate global ids for vertices
-      if(vertRankArray_ != nullptr) {
+      if(vertexRankArray_ != nullptr) {
         for(ttk::SimplexId i = 0; i < vertexNumber_; i++) {
-          if(vertRankArray_[i] == ttk::MPIrank_) {
+          if(vertexRankArray_[i] == ttk::MPIrank_) {
             vertexIdentifiers_[i] = vertIndex;
             (*vertGtoL_)[vertIndex] = i;
             vertIndex++;
@@ -649,7 +649,7 @@ namespace ttk {
       // store the outdated global ids of ghost points and their local id.
       // Otherwise, vertGhostCoordinatesPerRank needs to be resized. This vector
       // will store the coordinates of a ghost point and its local id.
-      if(vertRankArray_ != nullptr) {
+      if(vertexRankArray_ != nullptr) {
         if(outdatedGlobalPointIds_ == nullptr) {
           vertGhostCoordinatesPerRank.resize(neighborNumber_);
         } else {
@@ -686,14 +686,14 @@ namespace ttk {
            || (!hasSentData_ && ttk::MPIrank_ < neighbors_->at(i))) {
           // it is the turn of the current process to send its ghosts
           if(outdatedGlobalPointIds_ == nullptr) {
-            if(vertRankArray_ == nullptr) {
+            if(vertexRankArray_ == nullptr) {
               sendToAllNeighbors<Point>(vertGhostCoordinates, mpiPointType_);
             } else {
               sendToAllNeighborsUsingRankArray<Point>(
                 vertGhostCoordinatesPerRank, mpiPointType_);
             }
           } else {
-            if(vertRankArray_ == nullptr) {
+            if(vertexRankArray_ == nullptr) {
               sendToAllNeighbors<ttk::SimplexId>(
                 vertGhostGlobalIds, mpiIdType_);
             } else {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3159,7 +3159,7 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
     this->printErr("Missing global vertex identifiers array!");
     return -2;
   }
-  if(this->vertRankArray_ == nullptr) {
+  if(this->vertexRankArray_ == nullptr) {
     this->printErr("Missing vertex RankArray!");
     return -3;
   }
@@ -3175,9 +3175,9 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
-    if(this->vertRankArray_[lvid] != ttk::MPIrank_) {
+    if(this->vertexRankArray_[lvid] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
-      this->ghostVerticesPerOwner_[this->vertRankArray_[lvid]].emplace_back(
+      this->ghostVerticesPerOwner_[this->vertexRankArray_[lvid]].emplace_back(
         this->vertGid_[lvid]);
     }
   }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3224,13 +3224,13 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
     this->cellLidToGid_[lcid] = globCellId;
   }
 
-  this->ghostCellPerOwner_.resize(ttk::MPIsize_);
+  this->ghostCellsPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
     const auto locCubeId{lcid / nTetraPerCube};
     if(this->cellRankArray_[locCubeId] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
-      this->ghostCellPerOwner_[this->cellRankArray_[locCubeId]].emplace_back(
+      this->ghostCellsPerOwner_[this->cellRankArray_[locCubeId]].emplace_back(
         this->cellLidToGid_[lcid]);
     }
   }
@@ -3244,15 +3244,15 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
 
   for(const auto neigh : this->neighborRanks_) {
     // 1. send to neigh number of ghost cells owned by neigh
-    const auto nCells{this->ghostCellPerOwner_[neigh].size()};
+    const auto nCells{this->ghostCellsPerOwner_[neigh].size()};
     MPI_Sendrecv(&nCells, 1, ttk::getMPIType(nCells), neigh, ttk::MPIrank_,
                  &nOwnedGhostCellsPerRank[neigh], 1, ttk::getMPIType(nCells),
                  neigh, neigh, ttk::MPIcomm_, MPI_STATUS_IGNORE);
     this->remoteGhostCells_[neigh].resize(nOwnedGhostCellsPerRank[neigh]);
 
     // 2. send to neigh list of ghost cells owned by neigh
-    MPI_Sendrecv(this->ghostCellPerOwner_[neigh].data(),
-                 this->ghostCellPerOwner_[neigh].size(), MIT, neigh,
+    MPI_Sendrecv(this->ghostCellsPerOwner_[neigh].data(),
+                 this->ghostCellsPerOwner_[neigh].size(), MIT, neigh,
                  ttk::MPIrank_, this->remoteGhostCells_[neigh].data(),
                  this->remoteGhostCells_[neigh].size(), MIT, neigh, neigh,
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
@@ -3274,12 +3274,50 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
     this->printErr("Missing global vertex identifiers array!");
     return -2;
   }
+  if(this->vertRankArray_ == nullptr) {
+    this->printErr("Missing vertex RankArray!");
+    return -3;
+  }
 
-  // allocate memory
-  this->vertexGidToLid_.reserve(this->vertexNumber_);
+  // number of local vertices (with ghost vertices...)
+  const auto nLocVertices{this->getNumberOfVertices()};
 
-  for(SimplexId i = 0; i < this->vertexNumber_; ++i) {
-    this->vertexGidToLid_[this->vertGid_[i]] = i;
+  // global vertex id -> local vertex id (reverse of this->vertGid_)
+  this->vertexGidToLid_.reserve(nLocVertices);
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    this->vertexGidToLid_[this->vertGid_[lvid]] = lvid;
+  }
+  this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
+
+  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
+    if(this->vertRankArray_[lvid] != ttk::MPIrank_) {
+      // store ghost cell global ids (per rank)
+      this->ghostVerticesPerOwner_[this->vertRankArray_[lvid]].emplace_back(
+        this->vertGid_[lvid]);
+    }
+  }
+
+  // for each rank, store the global id of local cells that are ghost cells of
+  // other ranks.
+  const auto MIT{ttk::getMPIType(ttk::SimplexId{})};
+  this->remoteGhostVertices_.resize(ttk::MPIsize_);
+  // number of owned cells that are ghost cells of other ranks
+  std::vector<size_t> nOwnedGhostVerticesPerRank(ttk::MPIsize_);
+
+  for(const auto neigh : this->neighborRanks_) {
+    // 1. send to neigh number of ghost cells owned by neigh
+    const auto nVerts{this->ghostVerticesPerOwner_[neigh].size()};
+    MPI_Sendrecv(&nVerts, 1, ttk::getMPIType(nVerts), neigh, ttk::MPIrank_,
+                 &nOwnedGhostVerticesPerRank[neigh], 1, ttk::getMPIType(nVerts),
+                 neigh, neigh, ttk::MPIcomm_, MPI_STATUS_IGNORE);
+    this->remoteGhostVertices_[neigh].resize(nOwnedGhostVerticesPerRank[neigh]);
+
+    // 2. send to neigh list of ghost cells owned by neigh
+    MPI_Sendrecv(this->ghostVerticesPerOwner_[neigh].data(),
+                 this->ghostVerticesPerOwner_[neigh].size(), MIT, neigh,
+                 ttk::MPIrank_, this->remoteGhostVertices_[neigh].data(),
+                 this->remoteGhostVertices_[neigh].size(), MIT, neigh, neigh,
+                 ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
 
   this->hasPreconditionedDistributedVertices_ = true;
@@ -3429,6 +3467,11 @@ SimplexId
 
 SimplexId ttk::ImplicitTriangulation::getEdgeGlobalIdInternal(
   const SimplexId leid) const {
+
+  if(!ttk::isRunningWithMPI()) {
+    return leid;
+  }
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(leid > this->getNumberOfEdgesInternal() - 1 || leid < 0) {
     return -1;
@@ -3437,10 +3480,6 @@ SimplexId ttk::ImplicitTriangulation::getEdgeGlobalIdInternal(
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE
-
-  if(!ttk::isRunningWithMPI()) {
-    return leid;
-  }
 
   if(this->dimensionality_ == 1) {
     return this->getCellGlobalIdInternal(leid);
@@ -3464,6 +3503,10 @@ SimplexId ttk::ImplicitTriangulation::getEdgeGlobalIdInternal(
 SimplexId ttk::ImplicitTriangulation::getEdgeLocalIdInternal(
   const SimplexId geid) const {
 
+  if(!ttk::isRunningWithMPI()) {
+    return geid;
+  }
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(geid > this->metaGrid_->getNumberOfEdgesInternal() - 1 || geid < 0) {
     return -1;
@@ -3472,10 +3515,6 @@ SimplexId ttk::ImplicitTriangulation::getEdgeLocalIdInternal(
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE
-
-  if(!ttk::isRunningWithMPI()) {
-    return geid;
-  }
 
   if(this->dimensionality_ == 1) {
     return this->getCellLocalIdInternal(geid);
@@ -3521,6 +3560,11 @@ SimplexId ttk::ImplicitTriangulation::findTriangleFromVertices(
 
 SimplexId ttk::ImplicitTriangulation::getTriangleGlobalIdInternal(
   const SimplexId ltid) const {
+
+  if(!ttk::isRunningWithMPI()) {
+    return ltid;
+  }
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(ltid > this->getNumberOfTrianglesInternal() - 1 || ltid < 0) {
     return -1;
@@ -3529,10 +3573,6 @@ SimplexId ttk::ImplicitTriangulation::getTriangleGlobalIdInternal(
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE
-
-  if(!ttk::isRunningWithMPI()) {
-    return ltid;
-  }
 
   if(this->dimensionality_ == 2) {
     return this->getCellGlobalIdInternal(ltid);
@@ -3561,6 +3601,11 @@ SimplexId ttk::ImplicitTriangulation::getTriangleGlobalIdInternal(
 
 SimplexId ttk::ImplicitTriangulation::getTriangleLocalIdInternal(
   const SimplexId gtid) const {
+
+  if(!ttk::isRunningWithMPI()) {
+    return gtid;
+  }
+
 #ifndef TTK_ENABLE_KAMIKAZE
   if(gtid > this->metaGrid_->getNumberOfTrianglesInternal() - 1 || gtid < 0) {
     return -1;
@@ -3569,10 +3614,6 @@ SimplexId ttk::ImplicitTriangulation::getTriangleLocalIdInternal(
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE
-
-  if(!ttk::isRunningWithMPI()) {
-    return gtid;
-  }
 
   if(this->dimensionality_ == 2) {
     return this->getCellGlobalIdInternal(gtid);

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -245,7 +245,7 @@ int ttk::ScalarFieldCriticalPoints::executeLegacy(
   if(triangulation) {
 
 #if TTK_ENABLE_MPI
-    const auto rankArray{triangulation->getVertRankArray()};
+    const auto rankArray{triangulation->getVertexRankArray()};
     if(ttk::isRunningWithMPI() && rankArray == nullptr) {
       this->printErr("Missing vertex rank array");
       return -6;

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -169,11 +169,8 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     if(useMPI) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
-      exchangeGhostCells<dataType, SimplexId, ttk::LongSimplexId>(
-        outputData, triangulation->getVertRankArray(),
-        triangulation->getVertsGlobalIds(),
-        triangulation->getVertexGlobalIdMap(), vertexNumber, ttk::MPIcomm_,
-        triangulation->getNeighborRanks(), dimensionNumber_);
+      exchangeGhostVertices<dataType, triangulationType>(
+        outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
     }
 #endif
 

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -104,7 +104,7 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
 
 #if TTK_ENABLE_MPI
   bool useMPI{false};
-  if(ttk::isRunningWithMPI() && triangulation->getVertRankArray() != nullptr
+  if(ttk::isRunningWithMPI() && triangulation->getVertexRankArray() != nullptr
      && triangulation->getVertsGlobalIds() != nullptr)
     useMPI = true;
 #endif

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1488,16 +1488,18 @@ namespace ttk {
      *
      * @param localCellId: local id of the simplex
      * @param cellDim: dimension of the simplex
-     * @return ttk::SimplexId global id of the simplex
+     * @param globalCellId global id of the simplex
      */
-    inline ttk::SimplexId getDistributedGlobalCellId(ttk::SimplexId localCellId,
-                                                     int cellDim) const {
+    inline int getDistributedGlobalCellId(const ttk::SimplexId &localCellId,
+                                          const int &cellDim,
+                                          ttk::SimplexId &globalCellId) const {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
 #endif
       return this->abstractTriangulation_->getDistributedGlobalCellId(
-        localCellId, cellDim);
+        localCellId, cellDim, globalCellId);
+      ;
     }
 
 #endif // TTK_ENABLE_MPI

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2847,7 +2847,7 @@ namespace ttk {
 
     // RankArray on points & cells
 
-    TTK_GET_SET_ARRAYS(VertRankArray, int);
+    TTK_GET_SET_ARRAYS(VertexRankArray, int);
     TTK_GET_SET_ARRAYS(CellRankArray, int);
 
 #undef TTK_GET_SET_ARRAYS

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1482,6 +1482,24 @@ namespace ttk {
       this->implicitTriangulation_.createMetaGrid(bounds);
     }
 
+    /**
+     * @brief  Get the Global Id of the simplex by calling the appropriate
+     * global id retrieval function based on the simplex dimension cellDim
+     *
+     * @param localCellId: local id of the simplex
+     * @param cellDim: dimension of the simplex
+     * @return ttk::SimplexId global id of the simplex
+     */
+    inline ttk::SimplexId getDistributedGlobalCellId(ttk::SimplexId localCellId,
+                                                     int cellDim) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(isEmptyCheck())
+        return -1;
+#endif
+      return this->abstractTriangulation_->getDistributedGlobalCellId(
+        localCellId, cellDim);
+    }
+
 #endif // TTK_ENABLE_MPI
 
     /// Get the \p localLinkId-th simplex of the link of the \p vertexId-th

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1424,6 +1424,13 @@ namespace ttk {
       abstractTriangulation_->setHasPreconditionedDistributedVertices(flag);
     }
 
+    inline bool hasPreconditionedDistributedCells() const override {
+      return abstractTriangulation_->hasPreconditionedDistributedCells();
+    }
+    inline bool hasPreconditionedDistributedVertices() const override {
+      return abstractTriangulation_->hasPreconditionedDistributedVertices();
+    }
+
     inline const std::vector<int> &getNeighborRanks() const override {
       return abstractTriangulation_->getNeighborRanks();
     }
@@ -1433,6 +1440,16 @@ namespace ttk {
 
     inline void setLocalBound(std::array<double, 6> &bound) {
       return abstractTriangulation_->setLocalBound(bound);
+    }
+
+    inline const std::vector<std::vector<SimplexId>> *
+      getGhostCellsPerOwner() const override {
+      return abstractTriangulation_->getGhostCellsPerOwner();
+    }
+
+    inline const std::vector<std::vector<SimplexId>> *
+      getRemoteGhostCells() const override {
+      return abstractTriangulation_->getRemoteGhostCells();
     }
 
     /// Get the corresponding local id for a given global id of a vertex.
@@ -2404,7 +2421,24 @@ namespace ttk {
 #endif
       return abstractTriangulation_->preconditionGlobalBoundary();
     }
+#endif // TTK_ENABLE_MPI
 
+#if TTK_ENABLE_MPI
+    /// Pre-process the distributed ghost cells .
+    ///
+    /// This function should ONLY be called as a pre-condition to the
+    /// following functions:
+    ///   - getGhostCellsPerOwner()
+    ///   - getRemoteGhostCells()
+    ///
+    /// \pre This function should be called prior to any traversal, in a
+    /// clearly distinct pre-processing step that involves no traversal at
+    /// all. An error will be returned otherwise.
+    /// \note It is recommended to exclude this preconditioning function from
+    /// any time performance measurement.
+    /// \return Returns 0 upon success, negative values otherwise.
+    /// \sa getGhostCellsPerOwner()
+    /// \sa getRemoteGhostCells()
     inline int preconditionDistributedCells() override {
 
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -526,7 +526,7 @@ bool ttkAlgorithm::GenerateGlobalIds(
         identifiers.setOutdatedGlobalCellIds(
           ttkUtils::GetPointer<ttk::LongSimplexId>(
             input->GetCellData()->GetGlobalIds()));
-        identifiers.setVertRankArray(ttkUtils::GetPointer<ttk::SimplexId>(
+        identifiers.setVertexRankArray(ttkUtils::GetPointer<ttk::SimplexId>(
           input->GetPointData()->GetArray("RankArray")));
         identifiers.setCellRankArray(ttkUtils::GetPointer<ttk::SimplexId>(
           input->GetCellData()->GetArray("RankArray")));
@@ -679,7 +679,7 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
     }
   }
 
-  int *vertRankArray
+  int *vertexRankArray
     = ttkUtils::GetPointer<int>(input->GetPointData()->GetArray("RankArray"));
 
   // Get the neighbor ranks
@@ -693,11 +693,11 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
   }
 
   if(neighborRanks.empty()) {
-    if(vertRankArray == nullptr) {
+    if(vertexRankArray == nullptr) {
       ttk::preconditionNeighborsUsingBoundingBox(boundingBox, neighborRanks);
     } else {
       ttk::preconditionNeighborsUsingRankArray(
-        neighborRanks, vertRankArray, vertexNumber, ttk::MPIcomm_);
+        neighborRanks, vertexRankArray, vertexNumber, ttk::MPIcomm_);
       preciseNeighborComputation = true;
     }
   }
@@ -714,7 +714,7 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
     unsigned char *ghostPoints = ttkUtils::GetPointer<unsigned char>(
       input->GetPointData()->GetArray("vtkGhostType"));
     pointValidity = checkGlobalIdValidity(
-      globalPointIds, vertexNumber, ghostPoints, vertRankArray);
+      globalPointIds, vertexNumber, ghostPoints, vertexRankArray);
   }
   if(pointValidity && globalCellIds != nullptr) {
 
@@ -802,7 +802,7 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
     // to the triangulation
     triangulation->setVertsGlobalIds(
       ttkUtils::GetPointer<ttk::LongSimplexId>(pd->GetGlobalIds()));
-    triangulation->setVertRankArray(
+    triangulation->setVertexRankArray(
       ttkUtils::GetPointer<int>(pd->GetArray("RankArray")));
     triangulation->preconditionDistributedVertices();
   }

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -102,8 +102,12 @@ int ttkDiscreteGradient::fillCriticalPoints(
     cellScalars->SetTuple1(i, scalars[critPoints_PLVertexIdentifiers[i]]);
     isOnBoundary->SetTuple1(i, critPoints_isOnBoundary[i]);
 #ifdef TTK_ENABLE_MPI
-    PLVertexIdentifiers->SetTuple1(
-      i, triangulation.getVertexGlobalId(critPoints_PLVertexIdentifiers[i]));
+    if(ttk::hasInitializedMPI()) {
+      PLVertexIdentifiers->SetTuple1(
+        i, triangulation.getVertexGlobalId(critPoints_PLVertexIdentifiers[i]));
+    } else {
+      PLVertexIdentifiers->SetTuple1(i, critPoints_PLVertexIdentifiers[i]);
+    }
 #else
     PLVertexIdentifiers->SetTuple1(i, critPoints_PLVertexIdentifiers[i]);
 #endif

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -101,7 +101,12 @@ int ttkDiscreteGradient::fillCriticalPoints(
     cellIds->SetTuple1(i, critPoints_cellIds[i]);
     cellScalars->SetTuple1(i, scalars[critPoints_PLVertexIdentifiers[i]]);
     isOnBoundary->SetTuple1(i, critPoints_isOnBoundary[i]);
+#if TTK_ENABLE_MPI
+    PLVertexIdentifiers->SetTuple1(
+      i, triangulation.getVertexGlobalId(critPoints_PLVertexIdentifiers[i]));
+#else
     PLVertexIdentifiers->SetTuple1(i, critPoints_PLVertexIdentifiers[i]);
+#endif
   }
 
   ttkUtils::CellVertexFromPoints(outputCriticalPoints, points);
@@ -279,11 +284,20 @@ int ttkDiscreteGradient::RequestData(vtkInformation *ttkNotUsed(request),
     ttkUtils::GetVoidPointer(inputScalars), inputScalars->GetMTime());
   this->setInputOffsets(
     static_cast<SimplexId *>(ttkUtils::GetVoidPointer(inputOffsets)));
-
+#ifdef TTK_ENABLE_MPI_TIME
+  ttk::Timer t_mpi;
+  ttk::startMPITimer(t_mpi, ttk::MPIrank_, ttk::MPIsize_);
+#endif
   ttkTemplateMacro(triangulation->getType(),
                    (ret = this->buildGradient<TTK_TT>(
-                      *static_cast<TTK_TT *>(triangulation->getData()))));
-
+                      *static_cast<TTK_TT *>(triangulation->getData()), true)));
+#ifdef TTK_ENABLE_MPI_TIME
+  double elapsedTime = ttk::endMPITimer(t_mpi, ttk::MPIrank_, ttk::MPIsize_);
+  if(ttk::MPIrank_ == 0) {
+    printMsg("Computation performed using " + std::to_string(ttk::MPIsize_)
+             + " MPI processes lasted :" + std::to_string(elapsedTime));
+  }
+#endif
   if(ret != 0) {
     this->printErr("DiscreteGradient.buildGradient() error code: "
                    + std::to_string(ret));
@@ -298,7 +312,10 @@ int ttkDiscreteGradient::RequestData(vtkInformation *ttkNotUsed(request),
 
   // gradient glyphs
   if(ComputeGradientGlyphs) {
-    fillGradientGlyphs(outputGradientGlyphs, *triangulation);
+    ttkTemplateMacro(triangulation->getType(),
+                     (fillGradientGlyphs<TTK_TT>(
+                       outputGradientGlyphs,
+                       *static_cast<TTK_TT *>(triangulation->getData()))));
   }
 
   return 1;

--- a/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
+++ b/core/vtk/ttkDiscreteGradient/ttkDiscreteGradient.cpp
@@ -101,7 +101,7 @@ int ttkDiscreteGradient::fillCriticalPoints(
     cellIds->SetTuple1(i, critPoints_cellIds[i]);
     cellScalars->SetTuple1(i, scalars[critPoints_PLVertexIdentifiers[i]]);
     isOnBoundary->SetTuple1(i, critPoints_isOnBoundary[i]);
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
     PLVertexIdentifiers->SetTuple1(
       i, triangulation.getVertexGlobalId(critPoints_PLVertexIdentifiers[i]));
 #else


### PR DESCRIPTION
Hi all,

This PR adds MPI support to the discrete gradient filter.

The gradient is computed by iterating on each vertex of a data set. When the vertex is a ghost vertex, all simplices of its lower star are set to ghosts by setting their gradient to the value GHOST_GRADIENT (-2).

The data array CellId and ttkVertexScalarField are field using global ids when using MPI.

Changes to `ImplicitTriangulation` were also made to fix a bug introduced in #871, that would result in all global ids of intermediary simplices being equal to 1 when executed on one process.

Any feedback is welcome.
