### PR TITLE
FTMTree: Sort produced nodes and arcs

### DIFF
--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -551,8 +551,10 @@ void FTMTree_MT::move(FTMTree_MT *mt) {
 void FTMTree_MT::normalizeIds() {
   Timer normTime;
   sortLeaves(true);
-  sortNodes();
-  sortArcs();
+  if(this->params_->treeType != TreeType::Contour) {
+    sortNodes();
+    sortArcs();
+  }
 
   auto getNodeParentArcNb
     = [&](const idNode curNode, const bool goUp) -> idSuperArc {

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -527,6 +527,15 @@ namespace ttk {
        */
       void sortNodes();
 
+      /**
+       * @brief Sort tree arcs
+       *
+       * Arcs are sorted according to the lexicographic order (down
+       * node order, up node order). The node order is the one used in
+       * @ref sortNodes.
+       */
+      void sortArcs();
+
       idNode makeNode(SimplexId vertexId, SimplexId linked = nullVertex);
 
       idNode makeNode(const Node *const n, SimplexId linked = nullVertex);

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -519,6 +519,14 @@ namespace ttk {
 
       void sortLeaves(const bool parallel = false);
 
+      /**
+       * @brief Sort tree nodes according to vertex order
+       *
+       * The vertex order is the same for Join Trees and Split Trees:
+       * minima first, maxima last.
+       */
+      void sortNodes();
+
       idNode makeNode(SimplexId vertexId, SimplexId linked = nullVertex);
 
       idNode makeNode(const Node *const n, SimplexId linked = nullVertex);


### PR DESCRIPTION
This PR extends the `FTMTree_MT::normalizeIds` method by sorting produced nodes and arcs according to the vertex order field.

This should make the FTMTree filter output deterministic when used in parallel (previously, the nodes and arcs order was depending on the parallel scheduling).

Enjoy,
Pierre