### PR TITLE
Add mailmap file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
         if [[ "$VERS" == *"22.04"* ]]; then
           rm ttk-data/states/mergeTreeClustering.pvsm
           rm ttk-data/states/mergeTreeTemporalReduction.pvsm
+          rm ttk-data/states/persistentGenerators_darkSky.pvsm
         fi
 
         cd ttk-data/tests

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,42 @@
+Julien Tierny <julien.tierny@gmail.com> Julien J Tierny <julien.tierny@gmail.com>
+Julien Tierny <julien.tierny@gmail.com> Julien Tierny <julien@richard.nation>
+Julien Tierny <julien.tierny@gmail.com> Julien J Tierny <julien@vger.lip6.fr>
+Julien Tierny <julien.tierny@gmail.com> Julien Tierny <julien.tiernygmail.com>
+Julien Tierny <julien.tierny@gmail.com> julien.tierny@sorbonne-universite.fr <julien.tierny@gmail.com>
+
+Pierre Guillou <pierre.guillou@lip6.fr> Pierre Guillou <guillou@cri.ensmp.fr>
+Pierre Guillou <pierre.guillou@lip6.fr> pierre-guillou <47317188+pierre-guillou@users.noreply.github.com>
+
+Mathieu Pont <matthieu.pont@hotmail.fr> MatPont <matthieu.pont@hotmail.fr>
+
+Guillaume Favelier <guillaume.favelier@lip6.fr> GuillaumeFavelier <guillaume.favelier@lip6.fr>
+Guillaume Favelier <guillaume.favelier@lip6.fr> GuillaumeFavelier <guillaume.favelier@gmail.com>
+Guillaume Favelier <guillaume.favelier@lip6.fr> Guillaume Favelier <guillaume.favelier@gmail.com>
+Guillaume Favelier <guillaume.favelier@lip6.fr> GuillaumeFavelier <GuillaumeFavelier@gmail.com>
+
+Maxime Soler <mxe.slr@gmail.com> M. S <mxe.slr@gmail.com>
+Maxime Soler <mxe.slr@gmail.com> madblade <j0433035@frep-x128782.main.glb.corp.local>
+Maxime Soler <mxe.slr@gmail.com> madblade <mxe.slr@gmail.com>
+Maxime Soler <mxe.slr@gmail.com> madblade <j0433035@taiwan036.(none)>
+Maxime Soler <mxe.slr@gmail.com> madblade <j0433035@taiwan055.(none)>
+Maxime Soler <mxe.slr@gmail.com> madblade <j0433035@xrai-frpau-053.main.glb.corp.local>
+Maxime Soler <mxe.slr@gmail.com> madblade <j0433035@xrai-frpau-083.main.glb.corp.local>
+Maxime Soler <mxe.slr@gmail.com> madblade <>
+
+Jules Vidal <jules.vidal@lip6.fr> julesvidal <jules.vidal@lip6.fr>
+Jules Vidal <jules.vidal@lip6.fr> julesvidal <julius@machvidal.localdomain>
+Jules Vidal <jules.vidal@lip6.fr> jules <juliusvidalus@orange.fr>
+
+Florian Wetzels <f_wetzels13@cs.uni-kl.de> floWetzels <f_wetzels13@cs.uni-kl.de>
+
+Lutz Hofmann <lutz.hofmann@iwr.uni-heidelberg.de> lhofmann <lhofmann@users.noreply.github.com>
+Lutz Hofmann <lutz.hofmann@iwr.uni-heidelberg.de> lhofmann <lhofmann@google.com>
+Lutz Hofmann <lutz.hofmann@iwr.uni-heidelberg.de> Lutz Hofmann <lhofmann@users.noreply.github.com>
+
+Eve Le Guillou <eve.leguillou@protonmail.com> eve-le-guillou <eve.leguillou@protonmail.com>
+Eve Le Guillou <eve.leguillou@protonmail.com> Le Guillou Eve <eve.le-guillou@centrale.centralelille.fr>
+
+Charles Gueunet <charles.gueunet@gmail.com> Charles Gueunet <charles.gueunet@lip6.fr>
+Charles Gueunet <charles.gueunet@gmail.com> Charles Gueunet <charles.gueunet@kitware.com>
+Charles Gueunet <charles.gueunet@gmail.com> Gueunet Charles <charles.gueunet@gmail.com>
+Charles Gueunet <charles.gueunet@gmail.com> charles gueunet <charles.gueunet@gmail.com>


### PR DESCRIPTION
This PR adds a simple `.mailmap` file at the root of the git repository. This file registers links between git identities referring to the same person. This file is used by `git` (c.f. https://git-scm.com/docs/gitmailmap) to show the relevant identity if a commit has been done under a deprecated one (for instance, if the e-mail address is no longer valid).

This helps shorten the list of git commit authors as displayed by `git shortlog -sne`. This is also helpful to get better repository insights with tools such as `git-of-theseus` (https://github.com/erikbern/git-of-theseus).

The completeness of the provided mailmap file is left as an exercise...

Enjoy,
Pierre