### PR TITLE
GitHub Actions: Reduce workflows concurrency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,10 @@ on:
       - 'mpi'
 
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PV_TAG: v5.10.1-headless
   PV_REPO: topology-tool-kit/ttk-paraview

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ on:
     branches:
       - 'dev'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PV_TAG: v5.10.1-headless
   PV_REPO: topology-tool-kit/ttk-paraview


### PR DESCRIPTION
This PR uses [concurrency groups](https://docs.github.com/en/actions/using-jobs/using-concurrency) to reduce the number of workflows running in parallel. Pushing a new commit to an open PR (or to the `dev` branch of `topology-tool-kit/ttk` repository) will cancel already running workflows for this PR rather than letting older workflows run in parallel with newer workflows.

This should reduce the computational impact on GitHub's infrastructure and avoid concurrency issues with ccache when several pushes in the `dev` branch happen in a short time span.

Enjoy,
Pierre
