### PR TITLE
ImplicitTriangulation: Support on-the-fly global/local vertex identifiers

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2881,11 +2881,13 @@ namespace ttk {
     }
 
   protected:
-    inline SimplexId getVertexGlobalIdInternal(const SimplexId lvid) const {
+    virtual inline SimplexId
+      getVertexGlobalIdInternal(const SimplexId lvid) const {
       return this->vertGid_[lvid];
     }
 
-    inline SimplexId getVertexLocalIdInternal(const SimplexId gvid) const {
+    virtual inline SimplexId
+      getVertexLocalIdInternal(const SimplexId gvid) const {
       const auto it{this->vertexGidToLid_.find(gvid)};
 #ifndef TTK_ENABLE_KAMIKAZE
       if(it == this->vertexGidToLid_.end()) {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -827,19 +827,8 @@ namespace ttk {
     /// third: z).
     /// \return Returns 0 upon success, negative values otherwise (for
     /// instance, if the object is not representing a regular grid).
-    virtual inline int getGridDimensions(std::vector<int> &dimensions) {
-
-      if((gridDimensions_[0] == -1) && (gridDimensions_[1] == -1)
-         && (gridDimensions_[2] == -1)) {
-        return -1;
-      }
-
-      dimensions.resize(3);
-      dimensions[0] = gridDimensions_[0];
-      dimensions[1] = gridDimensions_[1];
-      dimensions[2] = gridDimensions_[2];
-
-      return 0;
+    virtual inline const std::array<SimplexId, 3> &getGridDimensions() const {
+      return this->gridDimensions_;
     }
 
     /// Get the number of cells in the triangulation.
@@ -3681,7 +3670,7 @@ namespace ttk {
       hasPreconditionedVertexLinks_, hasPreconditionedVertexNeighbors_,
       hasPreconditionedVertexStars_, hasPreconditionedVertexTriangles_;
 
-    std::array<int, 3> gridDimensions_;
+    std::array<SimplexId, 3> gridDimensions_;
 
     std::vector<bool> boundaryEdges_, boundaryTriangles_, boundaryVertices_;
     std::vector<std::array<SimplexId, 6>> tetraEdgeList_;

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2883,18 +2883,12 @@ namespace ttk {
   protected:
     virtual inline SimplexId
       getVertexGlobalIdInternal(const SimplexId lvid) const {
-      return this->vertGid_[lvid];
+      return lvid;
     }
 
     virtual inline SimplexId
       getVertexLocalIdInternal(const SimplexId gvid) const {
-      const auto it{this->vertexGidToLid_.find(gvid)};
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->vertexGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
+      return gvid;
     }
 
     // overriden in ImplicitTriangulation &

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -621,6 +621,22 @@ namespace ttk {
 #ifdef TTK_ENABLE_MPI
 
     inline SimplexId
+      getVertexGlobalIdInternal(const SimplexId lvid) const override {
+      return this->vertGid_[lvid];
+    }
+
+    inline SimplexId
+      getVertexLocalIdInternal(const SimplexId gvid) const override {
+      const auto it{this->vertexGidToLid_.find(gvid)};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(it == this->vertexGidToLid_.end()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return it->second;
+    }
+
+    inline SimplexId
       getEdgeGlobalIdInternal(const SimplexId leid) const override {
       return this->edgeLidToGid_[leid];
     }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3246,8 +3246,10 @@ void ttk::ImplicitTriangulation::createMetaGrid(const double *const bounds) {
   };
 
   this->metaGrid_ = std::make_shared<ImplicitNoPreconditions>();
-  this->metaGrid_->setInputGrid(
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, dimensions[0], dimensions[1], dimensions[2]);
+  this->metaGrid_->setInputGrid(globalBounds[0], globalBounds[1],
+                                globalBounds[2], this->spacing_[0],
+                                this->spacing_[1], this->spacing_[2],
+                                dimensions[0], dimensions[1], dimensions[2]);
   this->metaGrid_->preconditionBoundaryVertices();
   this->metaGrid_->preconditionBoundaryEdges();
   this->metaGrid_->preconditionBoundaryTriangles();

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3316,10 +3316,10 @@ SimplexId ttk::ImplicitTriangulation::getEdgeLocalIdInternal(
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(geid > this->metaGrid_->getNumberOfEdgesInternal() - 1 || geid < 0) {
+  if(this->metaGrid_ == nullptr) {
     return -1;
   }
-  if(this->metaGrid_ == nullptr) {
+  if(geid > this->metaGrid_->getNumberOfEdgesInternal() - 1 || geid < 0) {
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE
@@ -3415,10 +3415,10 @@ SimplexId ttk::ImplicitTriangulation::getTriangleLocalIdInternal(
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(gtid > this->metaGrid_->getNumberOfTrianglesInternal() - 1 || gtid < 0) {
+  if(this->metaGrid_ == nullptr) {
     return -1;
   }
-  if(this->metaGrid_ == nullptr) {
+  if(gtid > this->metaGrid_->getNumberOfTrianglesInternal() - 1 || gtid < 0) {
     return -1;
   }
 #endif // TTK_ENABLE_KAMIKAZE

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3245,6 +3245,14 @@ void ttk::ImplicitTriangulation::createMetaGrid(const double *const bounds) {
       + 1,
   };
 
+  this->localGridOffset_ = {
+    static_cast<SimplexId>((this->origin_[0] - globalBounds[0])
+                           / this->spacing_[0]),
+    static_cast<SimplexId>((this->origin_[1] - globalBounds[2])
+                           / this->spacing_[1]),
+    static_cast<SimplexId>((this->origin_[2] - globalBounds[4])
+                           / this->spacing_[2]),
+  };
   this->metaGrid_ = std::make_shared<ImplicitNoPreconditions>();
   this->metaGrid_->setInputGrid(globalBounds[0], globalBounds[1],
                                 globalBounds[2], this->spacing_[0],

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3155,10 +3155,6 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   if(!hasInitializedMPI()) {
     return -1;
   }
-  if(this->vertGid_ == nullptr) {
-    this->printErr("Missing global vertex identifiers array!");
-    return -2;
-  }
   if(this->vertexRankArray_ == nullptr) {
     this->printErr("Missing vertex RankArray!");
     return -3;
@@ -3167,18 +3163,13 @@ int ImplicitTriangulation::preconditionDistributedVertices() {
   // number of local vertices (with ghost vertices...)
   const auto nLocVertices{this->getNumberOfVertices()};
 
-  // global vertex id -> local vertex id (reverse of this->vertGid_)
-  this->vertexGidToLid_.reserve(nLocVertices);
-  for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
-    this->vertexGidToLid_[this->vertGid_[lvid]] = lvid;
-  }
   this->ghostVerticesPerOwner_.resize(ttk::MPIsize_);
 
   for(LongSimplexId lvid = 0; lvid < nLocVertices; ++lvid) {
     if(this->vertexRankArray_[lvid] != ttk::MPIrank_) {
       // store ghost cell global ids (per rank)
       this->ghostVerticesPerOwner_[this->vertexRankArray_[lvid]].emplace_back(
-        this->vertGid_[lvid]);
+        this->getVertexGlobalIdInternal(lvid));
     }
   }
 
@@ -3548,7 +3539,7 @@ bool ImplicitTriangulation::isVertexOnGlobalBoundaryInternal(
   }
 #endif // TTK_ENABLE_KAMIKAZE
 
-  const auto gvid{this->vertGid_[lvid]};
+  const auto gvid{this->getVertexGlobalIdInternal(lvid)};
   if(gvid == -1) {
     return false;
   }

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3554,8 +3554,7 @@ bool ImplicitTriangulation::isEdgeOnGlobalBoundaryInternal(
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(leid > this->TTK_TRIANGULATION_INTERNAL(getNumberOfEdges)() - 1
-     || leid < 0) {
+  if(leid > this->getNumberOfEdgesInternal() - 1 || leid < 0) {
     return false;
   }
   if(this->metaGrid_ == nullptr) {
@@ -3578,8 +3577,7 @@ bool ImplicitTriangulation::isTriangleOnGlobalBoundaryInternal(
   }
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(ltid > this->TTK_TRIANGULATION_INTERNAL(getNumberOfTriangles)() - 1
-     || ltid < 0) {
+  if(ltid > this->getNumberOfTrianglesInternal() - 1 || ltid < 0) {
     return false;
   }
   if(this->metaGrid_ == nullptr) {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -297,6 +297,8 @@ namespace ttk {
     // simplicial ones...
     std::vector<SimplexId> cellLidToGid_{};
     std::shared_ptr<ImplicitTriangulation> metaGrid_{};
+    // offset coordinates of the local grid inside the metaGrid_
+    std::array<SimplexId, 3> localGridOffset_{};
 #endif // TTK_ENABLE_MPI
 
     enum class VertexPosition : char {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -32,14 +32,8 @@ namespace ttk {
     ImplicitTriangulation &operator=(const ImplicitTriangulation &) = default;
     ImplicitTriangulation &operator=(ImplicitTriangulation &&) = default;
 
-    int getGridDimensions(std::vector<int> &dimensions) override {
-
-      dimensions.resize(3);
-      dimensions[0] = dimensions_[0];
-      dimensions[1] = dimensions_[1];
-      dimensions[2] = dimensions_[2];
-
-      return 0;
+    inline const std::array<SimplexId, 3> &getGridDimensions() const override {
+      return this->dimensions_;
     }
 
     int getCellEdgeInternal(const SimplexId &cellId,
@@ -513,7 +507,7 @@ namespace ttk {
     int dimensionality_; //
     float origin_[3]; //
     float spacing_[3]; //
-    SimplexId dimensions_[3]; // dimensions
+    std::array<SimplexId, 3> dimensions_; // dimensions
     SimplexId nbvoxels_[3]; // nombre de voxels par axe
 
     // Vertex helper //

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -266,6 +266,9 @@ namespace ttk {
 
     void createMetaGrid(const double *const bounds);
 
+    SimplexId getVertexGlobalIdInternal(const SimplexId lvid) const override;
+    SimplexId getVertexLocalIdInternal(const SimplexId gvid) const override;
+
     SimplexId getEdgeGlobalIdInternal(const SimplexId leid) const override;
     SimplexId getEdgeLocalIdInternal(const SimplexId geid) const override;
 

--- a/core/base/multiresTriangulation/MultiresTriangulation.h
+++ b/core/base/multiresTriangulation/MultiresTriangulation.h
@@ -810,8 +810,7 @@ namespace ttk {
       triangulation_ = triangulation;
       if(triangulation_) {
         dimensionality_ = triangulation_->getDimensionality();
-        std::vector<int> gridDim(3);
-        triangulation_->getGridDimensions(gridDim);
+        const auto &gridDim{triangulation_->getGridDimensions()};
         for(int i = 0; i < 3; i++) {
           gridDimensions_[i] = gridDim[i];
           nbvoxels_[i] = gridDimensions_[i] - 1;


### PR DESCRIPTION
This PR implements the `getVertexGlobalIdInternal` and `getVertexLocalIdInternal` methods for `ImplicitTriangulation`, using an on-the-fly computation scheme based on the meta grid introduced in #871: the offset of the local grid inside the meta grid is computed from the bounding box and stored inside `ImplicitTriangulation`.

The `getGridDimensions` method has been reworked on the occasion.

Uses of `vertGid_` and `vertexGidToLid_` were removed from `ImplicitTriangulation`. We still need `preconditionDistributedVertices` as it fills other class members (`ghostVerticesPerOwner_`, `remoteGhostVertices_`) that may be used somewhere else (?)

I have not touched `ttkAlgorithm` to remove the call to `Identifiers` as it also computes the vertex rank array (and other cell-related arrays).

Enjoy,
Pierre
