### PR TITLE
ImplicitTriangulation: Support on-the-fly global/local cell identifiers

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2891,22 +2891,14 @@ namespace ttk {
       return gvid;
     }
 
-    // overriden in ImplicitTriangulation &
-    // PeriodicImplicitTriangulation (where cellGid_ refers to
-    // squares/cubes and not triangles/tetrahedron)
     virtual inline SimplexId
       getCellGlobalIdInternal(const SimplexId lcid) const {
-      return this->cellGid_[lcid];
+      return lcid;
     }
 
-    virtual inline SimplexId getCellLocalIdInternal(const SimplexId gcid) const {
-      const auto it{this->cellGidToLid_.find(gcid)};
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(it == this->cellGidToLid_.end()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return it->second;
+    virtual inline SimplexId
+      getCellLocalIdInternal(const SimplexId gcid) const {
+      return gcid;
     }
 
     virtual inline SimplexId
@@ -3716,8 +3708,6 @@ namespace ttk {
     // "squares"/"cubes" and not "triangles"/"tetrahedron")
     const int *cellRankArray_{};
 
-    // inverse of cellGid_
-    std::unordered_map<SimplexId, SimplexId> cellGidToLid_{};
     // inverse of vertGid_
     std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2899,7 +2899,7 @@ namespace ttk {
       return this->cellGid_[lcid];
     }
 
-    inline SimplexId getCellLocalIdInternal(const SimplexId gcid) const {
+    virtual inline SimplexId getCellLocalIdInternal(const SimplexId gcid) const {
       const auto it{this->cellGidToLid_.find(gcid)};
 #ifndef TTK_ENABLE_KAMIKAZE
       if(it == this->cellGidToLid_.end()) {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2882,23 +2882,23 @@ namespace ttk {
 
   protected:
     virtual inline SimplexId
-      getVertexGlobalIdInternal(const SimplexId lvid) const {
-      return lvid;
+      getVertexGlobalIdInternal(const SimplexId ttkNotUsed(lvid)) const {
+      return -1;
     }
 
     virtual inline SimplexId
-      getVertexLocalIdInternal(const SimplexId gvid) const {
-      return gvid;
+      getVertexLocalIdInternal(const SimplexId ttkNotUsed(gvid)) const {
+      return -1;
     }
 
     virtual inline SimplexId
-      getCellGlobalIdInternal(const SimplexId lcid) const {
-      return lcid;
+      getCellGlobalIdInternal(const SimplexId ttkNotUsed(lcid)) const {
+      return -1;
     }
 
     virtual inline SimplexId
-      getCellLocalIdInternal(const SimplexId gcid) const {
-      return gcid;
+      getCellLocalIdInternal(const SimplexId ttkNotUsed(gcid)) const {
+      return -1;
     }
 
     virtual inline SimplexId

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -637,6 +637,22 @@ namespace ttk {
     }
 
     inline SimplexId
+      getCellGlobalIdInternal(const SimplexId lcid) const override {
+      return this->cellGid_[lcid];
+    }
+
+    inline SimplexId
+      getCellLocalIdInternal(const SimplexId gcid) const override {
+      const auto it{this->cellGidToLid_.find(gcid)};
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(it == this->cellGidToLid_.end()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return it->second;
+    }
+
+    inline SimplexId
       getEdgeGlobalIdInternal(const SimplexId leid) const override {
       return this->edgeLidToGid_[leid];
     }
@@ -711,6 +727,9 @@ namespace ttk {
     std::vector<CellRange> gatheredCellRanges_{};
     // number of CellRanges per rank
     std::vector<int> nRangesPerRank_{};
+
+    // inverse of cellGid_
+    std::unordered_map<SimplexId, SimplexId> cellGidToLid_{};
 
     std::vector<SimplexId> edgeLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> edgeGidToLid_{};

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -254,20 +254,13 @@ namespace ttk {
     int preconditionDistributedVertices() override;
 
   public:
-    inline SimplexId
-      getCellGlobalIdInternal(const SimplexId lcid) const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(lcid < 0 || lcid >= this->getNumberOfCellsInternal()) {
-        return -1;
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->cellLidToGid_[lcid];
-    }
-
     void createMetaGrid(const double *const bounds);
 
     SimplexId getVertexGlobalIdInternal(const SimplexId lvid) const override;
     SimplexId getVertexLocalIdInternal(const SimplexId gvid) const override;
+
+    SimplexId getCellGlobalIdInternal(const SimplexId lcid) const override;
+    SimplexId getCellLocalIdInternal(const SimplexId gcid) const override;
 
     SimplexId getEdgeGlobalIdInternal(const SimplexId leid) const override;
     SimplexId getEdgeLocalIdInternal(const SimplexId geid) const override;
@@ -292,6 +285,7 @@ namespace ttk {
 #ifdef TTK_ENABLE_MPI
     // the cellGid_ array only applies on cubic cells, not on
     // simplicial ones...
+    // TODO remove
     std::vector<SimplexId> cellLidToGid_{};
     std::shared_ptr<ImplicitTriangulation> metaGrid_{};
     // offset coordinates of the local grid inside the metaGrid_

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -283,10 +283,6 @@ namespace ttk {
 
   protected:
 #ifdef TTK_ENABLE_MPI
-    // the cellGid_ array only applies on cubic cells, not on
-    // simplicial ones...
-    // TODO remove
-    std::vector<SimplexId> cellLidToGid_{};
     std::shared_ptr<ImplicitTriangulation> metaGrid_{};
     // offset coordinates of the local grid inside the metaGrid_
     std::array<SimplexId, 3> localGridOffset_{};


### PR DESCRIPTION
Following #878, this PR implements `getCellGlobalIdInternal` and `getCellLocalIdInternal` for `ImplicitTriangulation`.

The `preconditionDistributedCells` method has been reduced to avoid computing what we can get with these new methods. The class member `cellGidToLid_` has been moved from `AbstractTriangulation` to `ExplicitTriangulation`.

Enjoy,
Pierre