### PR TITLE
MorseSmaleComplex: Use relationship between pairs to skip saddle connectors returning

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -40,6 +40,16 @@ namespace ttk {
       explicit Cell(const int dim, const SimplexId id) : dim_{dim}, id_{id} {
       }
 
+      inline bool operator==(const Cell &other) const {
+        return std::tie(this->dim_, this->id_)
+               == std::tie(other.dim_, other.id_);
+      }
+
+      inline std::string to_string() const {
+        return '{' + std::to_string(this->dim_) + ' '
+               + std::to_string(this->id_) + '}';
+      }
+
       int dim_{-1};
       SimplexId id_{-1};
     };

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1039,6 +1039,10 @@ bool DiscreteGradient::getAscendingPathThroughWall(
       }
     }
 
+    if(currentId == -1) {
+      return true;
+    }
+
     SimplexId oldId;
     do {
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1809,6 +1809,8 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
   std::vector<bool> isVisited(triangulation.getNumberOfTriangles(), false);
   std::vector<SimplexId> visitedTriangles{};
 
+  size_t nReturned{};
+
   for(const auto &pair : sadSadPairs) {
     const Cell birth{1, pair.birth};
     const Cell death{2, pair.death};
@@ -1818,14 +1820,20 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
     // 2. get the saddle connector
     std::vector<Cell> vpath{};
     this->discreteGradient_.getAscendingPathThroughWall(
-      birth, death, isVisited, &vpath, triangulation);
+      birth, death, isVisited, &vpath, triangulation, true);
     // 3. reverse the gradient on the saddle connector path
-    this->discreteGradient_.reverseAscendingPathOnWall(vpath, triangulation);
+    if(vpath.back() == death) {
+      this->discreteGradient_.reverseAscendingPathOnWall(vpath, triangulation);
+      nReturned++;
+    } else {
+      this->printMsg("Could not return saddle connector " + birth.to_string()
+                       + " -> " + death.to_string(),
+                     debug::Priority::DETAIL);
+    }
   }
 
-  this->printMsg(
-    "Returned " + std::to_string(sadSadPairs.size()) + " saddle connectors",
-    1.0, tm.getElapsedTime(), this->threadNumber_);
+  this->printMsg("Returned " + std::to_string(nReturned) + " saddle connectors",
+                 1.0, tm.getElapsedTime(), this->threadNumber_);
 
   return 0;
 }

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -783,6 +783,11 @@ int ttk::MorseSmaleComplex::getSaddleConnectors(
       const bool isMultiConnected
         = discreteGradient_.getAscendingPathThroughWall(
           s1, s2, isVisited, &vpath, triangulation);
+
+      if(vpath.empty()) {
+        // safety, should be unreachable
+        continue;
+      }
       const auto &last = vpath.back();
 
       if(!isMultiConnected && last.dim_ == s2.dim_ && last.id_ == s2.id_) {


### PR DESCRIPTION
This PR fixes issues with the algorithm introduced in #857 to return saddle connectors. First, invalid saddle connectors are detected and skipped to avoid infinite loops or segfauls. Secondly, `DiscreteMorseSandwich` now optionally exports the parent relationship between 2-saddles (a 2-saddle points to its children, meaning the 2-saddles whose boundary has been merged into its one). This relationship is then used to avoid computing the 2-separatrix wall if the connector of one or more children has been skipped, leading to improved performance.

Enjoy,
Pierre