### PR TITLE
Replace manual memory management

### DIFF
--- a/core/base/contourAroundPoint/CMakeLists.txt
+++ b/core/base/contourAroundPoint/CMakeLists.txt
@@ -1,7 +1,4 @@
-# ttk_add_baseCode_package(unionFind)
 ttk_add_base_library(contourAroundPoint
   SOURCES ContourAroundPoint.cpp
   HEADERS ContourAroundPoint.hpp
   DEPENDS triangulation)
-
-# set_property(TARGET contourAroundPoint PROPERTY CXX_STANDARD 14)

--- a/core/base/contourAroundPoint/ContourAroundPoint.cpp
+++ b/core/base/contourAroundPoint/ContourAroundPoint.cpp
@@ -1,11 +1,8 @@
 #include "ContourAroundPoint.hpp"
 
-using module = ttk::ContourAroundPoint;
-using ttkIdx = ttk::SimplexId; // for Windows
-
 //----------------------------------------------------------------------------//
 
-int module::setInputPoints(
+int ttk::ContourAroundPoint::setInputPoints(
   float *coords, float *scalars, float *isovals, int *flags, std::size_t np) {
   _inpPtsCoords = coords;
   _inpPtsScalars = scalars;
@@ -21,45 +18,4 @@ int module::setInputPoints(
   if(!flags)
     return -4;
   return 0;
-}
-
-//----------------------------------------------------------------------------//
-
-void module::getOutputContours(ttkIdx *&cinfos,
-                               ttkIdx &nc,
-                               float *&coords,
-                               float *&scalars,
-                               int *&flags,
-                               ttkIdx &nv) const {
-
-  nc = _outContoursNc;
-
-  cinfos = new ttkIdx[_outContoursCinfos.size()];
-  std::copy(_outContoursCinfos.begin(), _outContoursCinfos.end(), cinfos);
-
-  nv = _outContoursScalars.size();
-
-  coords = new float[nv * 3];
-  std::copy(_outContoursCoords.begin(), _outContoursCoords.end(), coords);
-  scalars = new float[nv];
-  std::copy(_outContoursScalars.begin(), _outContoursScalars.end(), scalars);
-  flags = new int[nv];
-  std::copy(_outContoursFlags.begin(), _outContoursFlags.end(), flags);
-}
-
-//----------------------------------------------------------------------------//
-
-void module::getOutputCentroids(float *&coords,
-                                float *&scalars,
-                                int *&flags,
-                                ttkIdx &nv) const {
-
-  nv = _outCentroidsScalars.size();
-
-  coords = new float[nv * 3];
-  std::copy(_outCentroidsCoords.begin(), _outCentroidsCoords.end(), coords);
-  scalars = new float[nv];
-  std::copy(_outCentroidsScalars.begin(), _outCentroidsScalars.end(), scalars);
-  flags = new int[nv];
-  std::copy(_outCentroidsFlags.begin(), _outCentroidsFlags.end(), flags);
 }

--- a/core/base/contourAroundPoint/ContourAroundPoint.hpp
+++ b/core/base/contourAroundPoint/ContourAroundPoint.hpp
@@ -85,38 +85,6 @@ namespace ttk {
     template <class scalarT>
     int execute() const;
 
-    /**
-     * Get the output field data (e.g. for the wrapped algorithm).
-     * To be called after a successful `execute`.
-     * The ownership of the pointers moves to the caller.
-     * @param cinfos Sequence of cell infos like `n v0 ... vn-1`.
-     * @param nc Number of cells.
-     * @param coords 3D Vertex coordinates as interleaved array.
-     * @param flags isMax-flag for each vertex.
-     * @param scalars Scalar value for each vertex.
-     * @param nv Number of vertices.
-     */
-    void getOutputContours(SimplexId *&cinfos,
-                           SimplexId &nc,
-                           float *&coords,
-                           float *&scalars,
-                           int *&flags,
-                           SimplexId &nv) const;
-
-    /**
-     * Get the output point data (e.g. for the wrapped algorithm).
-     * To be called after a successful `execute`.
-     * The ownership of the pointers moves to the caller.
-     * @param coords 3D point coordinates as interleaved array.
-     * @param scalars Scalar value for each point.
-     * @param flags isMax-flag for each point.
-     * @param nv Number of vertices.
-     */
-    void getOutputCentroids(float *&coords,
-                            float *&scalars,
-                            int *&flags,
-                            SimplexId &nv) const;
-
   protected:
     /// Given one of the input points, find the nearest vertex in the input
     /// field. N.B.: Typically, the points are actually vertices of the input
@@ -188,7 +156,7 @@ namespace ttk {
 
     /* Output data (contours and centroids) */
 
-    mutable std::vector<SimplexId> _outContoursCinfos;
+    mutable std::vector<LongSimplexId> _outContoursCinfos;
     mutable SimplexId _outContoursNc = 0;
     mutable std::vector<float> _outContoursCoords;
     mutable std::vector<float> _outContoursScalars;

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -527,9 +527,9 @@ void ContourForests::unifyTree(const char treetype) {
 
   // could use swap, more efficient
   if(treetype == 0) {
-    jt_->clone(&tmpTree);
+    jt_.clone(&tmpTree);
   } else if(treetype == 1) {
-    st_->clone(&tmpTree);
+    st_.clone(&tmpTree);
   } else if(treetype == 2) {
     clone(&tmpTree);
   }

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -20,8 +20,8 @@ Interface::Interface(const SimplexId &seed) : seed_(seed) {
 // ------------------------- ContourForests
 
 ContourForests::ContourForests()
-  : ContourForestsTree(new Params(), new Scalars()), parallelParams_(),
-    parallelData_() {
+  : ContourForestsTree(std::make_shared<Params>(), std::make_shared<Scalars>()),
+    parallelParams_(), parallelData_() {
   this->setDebugMsgPrefix("ContourForests");
   this->printWrn(
     "DEPRECATED This module will be removed in a future release, please use "
@@ -30,8 +30,8 @@ ContourForests::ContourForests()
 }
 
 ContourForests::~ContourForests() {
-  delete params_;
-  delete scalars_;
+  params_.reset();
+  scalars_.reset();
 }
 
 // Get

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -485,7 +485,8 @@ void ContourForests::unifyTree(const char treetype) {
 
       // Finish the current Arc (segmentation + close)
       if(totalSize) {
-        newArc_tt->appendVertLists(listVertList, listVertSize, totalSize);
+        newArc_tt->appendVertLists(
+          listVertList, listVertSize, this->storage_, totalSize);
       }
       const idNode &closingNode_tt = tmpTree.makeNode(currentNode);
       tmpTree.closeSuperArc(newArcId_tt, closingNode_tt, false, false);

--- a/core/base/contourForests/ContourForests.h
+++ b/core/base/contourForests/ContourForests.h
@@ -122,6 +122,9 @@ namespace ttk {
       // local
       ParallelData parallelData_;
 
+      // storage
+      std::list<std::vector<std::pair<SimplexId, bool>>> storage_;
+
     public:
       ContourForests();
 

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -115,10 +115,10 @@ namespace ttk {
         vect_baseUF_ST[tree].resize(scalars_->size);
 
         // Statistical reserve
-        parallelData_.trees[tree].jt_->treeData_.nodes.reserve(resSize);
-        parallelData_.trees[tree].jt_->treeData_.superArcs.reserve(resSize);
-        parallelData_.trees[tree].st_->treeData_.nodes.reserve(resSize);
-        parallelData_.trees[tree].st_->treeData_.superArcs.reserve(resSize);
+        parallelData_.trees[tree].jt_.treeData_.nodes.reserve(resSize);
+        parallelData_.trees[tree].jt_.treeData_.superArcs.reserve(resSize);
+        parallelData_.trees[tree].st_.treeData_.nodes.reserve(resSize);
+        parallelData_.trees[tree].st_.treeData_.superArcs.reserve(resSize);
       }
       printDebug(timerAllocPara, "Parallel allocations             ");
 
@@ -139,9 +139,9 @@ namespace ttk {
         } else {
           for(idPartition i = 0; i < parallelParams_.nbPartitions; i++) {
             std::cout << i << " jt:" << std::endl;
-            parallelData_.trees[i].jt_->printTree2();
+            parallelData_.trees[i].jt_.printTree2();
             std::cout << i << " st:" << std::endl;
-            parallelData_.trees[i].st_->printTree2();
+            parallelData_.trees[i].st_.printTree2();
             std::cout << "-----" << std::endl;
           }
         }
@@ -192,19 +192,19 @@ namespace ttk {
       } else {
         if(parallelParams_.partitionNum >= 0) {
           if(parallelParams_.partitionNum > parallelParams_.nbInterfaces) {
-            jt_->clone(parallelData_.trees[parallelParams_.nbInterfaces].jt_);
-            st_->clone(parallelData_.trees[parallelParams_.nbInterfaces].st_);
+            jt_.clone(&parallelData_.trees[parallelParams_.nbInterfaces].jt_);
+            st_.clone(&parallelData_.trees[parallelParams_.nbInterfaces].st_);
           } else {
-            jt_->clone(parallelData_.trees[parallelParams_.partitionNum].jt_);
-            st_->clone(parallelData_.trees[parallelParams_.partitionNum].st_);
+            jt_.clone(&parallelData_.trees[parallelParams_.partitionNum].jt_);
+            st_.clone(&parallelData_.trees[parallelParams_.partitionNum].st_);
           }
         } else if(parallelParams_.nbPartitions == 1) {
-          jt_->clone(parallelData_.trees[0].jt_);
-          st_->clone(parallelData_.trees[0].st_);
+          jt_.clone(&parallelData_.trees[0].jt_);
+          st_.clone(&parallelData_.trees[0].st_);
         } else {
           unify();
-          jt_->parallelInitNodeValence(parallelParams_.nbThreads);
-          st_->parallelInitNodeValence(parallelParams_.nbThreads);
+          jt_.parallelInitNodeValence(parallelParams_.nbThreads);
+          st_.parallelInitNodeValence(parallelParams_.nbThreads);
         }
       }
 
@@ -235,17 +235,17 @@ namespace ttk {
           printTree2();
         else {
           std::cout << "JT :" << std::endl;
-          jt_->printTree2();
+          jt_.printTree2();
           std::cout << "ST :" << std::endl;
-          st_->printTree2();
+          st_.printTree2();
         }
       } else if(params_->debugLevel > 2) {
         std::stringstream msg;
         if(params_->treeType == TreeType::Contour)
           msg << "max node : " << getNumberOfNodes();
         else {
-          msg << "JT max node : " << jt_->getNumberOfNodes();
-          msg << "ST max node : " << st_->getNumberOfNodes();
+          msg << "JT max node : " << jt_.getNumberOfNodes();
+          msg << "ST max node : " << st_.getNumberOfNodes();
         }
         this->printMsg(msg.str());
       }
@@ -253,17 +253,17 @@ namespace ttk {
       if(params_->treeType == TreeType::Contour) {
         updateSegmentation();
       } else {
-        jt_->updateSegmentation();
-        st_->updateSegmentation();
+        jt_.updateSegmentation();
+        st_.updateSegmentation();
       }
 
       // reclaim memory
       {
         for(idPartition tree = 0; tree < parallelParams_.nbPartitions; ++tree) {
-          parallelData_.trees[tree].jt_->treeData_.nodes.shrink_to_fit();
-          parallelData_.trees[tree].jt_->treeData_.superArcs.shrink_to_fit();
-          parallelData_.trees[tree].st_->treeData_.nodes.shrink_to_fit();
-          parallelData_.trees[tree].st_->treeData_.superArcs.shrink_to_fit();
+          parallelData_.trees[tree].jt_.treeData_.nodes.shrink_to_fit();
+          parallelData_.trees[tree].jt_.treeData_.superArcs.shrink_to_fit();
+          parallelData_.trees[tree].st_.treeData_.nodes.shrink_to_fit();
+          parallelData_.trees[tree].st_.treeData_.superArcs.shrink_to_fit();
         }
         // Not while arc segmentation depends on std::vector in partitions
         // parallelData_.interfaces.clear();

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -217,7 +217,8 @@ namespace ttk {
       if(params_->treeType == TreeType::Contour
          && parallelParams_.partitionNum == -1 && params_->simplifyThreshold) {
         DebugTimer timerGlobalSimplify;
-        SimplexId simplifed = globalSimplify<scalarType>(-1, nullVertex, mesh);
+        SimplexId simplifed
+          = globalSimplify<scalarType>(-1, nullVertex, this->storage_, mesh);
         if(params_->debugLevel >= 1) {
           printDebug(timerGlobalSimplify, "Simplify Contour tree            ");
           std::cout << " ( " << simplifed << " pairs merged )" << std::endl;
@@ -455,7 +456,7 @@ namespace ttk {
 
           // Combine, destroy JT and ST to compute CT
           parallelData_.trees[i].combine(
-            std::get<0>(seedsPos), std::get<1>(seedsPos));
+            std::get<0>(seedsPos), std::get<1>(seedsPos), this->storage_);
           parallelData_.trees[i].updateSegmentation();
 
           if(params_->debugLevel > 2) {

--- a/core/base/contourForestsTree/ContourForestsTree.cpp
+++ b/core/base/contourForestsTree/ContourForestsTree.cpp
@@ -27,8 +27,11 @@ ContourForestsTree::~ContourForestsTree() = default;
 // Process
 // {
 
-int ContourForestsTree::combine(const SimplexId &seed0,
-                                const SimplexId &seed1) {
+int ContourForestsTree::combine(
+  const SimplexId &seed0,
+  const SimplexId &seed1,
+  std::list<std::vector<std::pair<SimplexId, bool>>> &storage) {
+
   queue<pair<bool, idNode>> growingNodes;
   pair<bool, idNode> head;
 
@@ -264,7 +267,7 @@ int ContourForestsTree::combine(const SimplexId &seed0,
              << ") node :" << xt->getNode(head.second)->getVertexId() << endl;
       }
 
-      xt->delNode(head.second);
+      xt->delNode(head.second, storage);
     }
 
     // DelNode(YT, i)
@@ -283,7 +286,7 @@ int ContourForestsTree::combine(const SimplexId &seed0,
                << " up" << endl;
         }
 
-        yt->delNode(correspondingNodeId, arcVertList, arcVertSize);
+        yt->delNode(correspondingNodeId, storage, arcVertList, arcVertSize);
       }
     }
 

--- a/core/base/contourForestsTree/ContourForestsTree.cpp
+++ b/core/base/contourForestsTree/ContourForestsTree.cpp
@@ -14,8 +14,8 @@ using namespace std;
 using namespace ttk;
 using namespace cf;
 
-ContourForestsTree::ContourForestsTree(Params *const params,
-                                       Scalars *const scalars,
+ContourForestsTree::ContourForestsTree(const std::shared_ptr<Params> &params,
+                                       const std::shared_ptr<Scalars> &scalars,
                                        idPartition part)
   : MergeTree(params, scalars, TreeType::Contour, part),
     jt_(params, scalars, TreeType::Join, part),

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -46,8 +46,8 @@ namespace ttk {
       // -----------------
       // {
 
-      ContourForestsTree(Params *const params,
-                         Scalars *const scalars,
+      ContourForestsTree(const std::shared_ptr<Params> &params,
+                         const std::shared_ptr<Scalars> &scalars,
                          idPartition part = nullPartition);
       ~ContourForestsTree() override;
 

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -100,7 +100,9 @@ namespace ttk {
       // {
 
       /// \brief Combine tree with Natarajan's algorithm
-      int combine(const SimplexId &seed0, const SimplexId &seed1);
+      int combine(const SimplexId &seed0,
+                  const SimplexId &seed1,
+                  std::list<std::vector<std::pair<SimplexId, bool>>> &storage);
 
     private:
       // -----------------

--- a/core/base/contourForestsTree/ContourForestsTree.h
+++ b/core/base/contourForestsTree/ContourForestsTree.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <memory>
 #include <queue>
 #include <set>
 
@@ -37,7 +38,7 @@ namespace ttk {
       friend class ContourForests;
 
     protected:
-      MergeTree *jt_, *st_;
+      MergeTree jt_, st_;
 
     public:
       // -----------------
@@ -58,8 +59,8 @@ namespace ttk {
 
       void flush() {
         MergeTree::flush();
-        jt_->flush();
-        st_->flush();
+        jt_.flush();
+        st_.flush();
       }
 
       // }
@@ -68,12 +69,12 @@ namespace ttk {
       // -----------------
       // {
 
-      inline MergeTree *getJoinTree() const {
-        return jt_;
+      inline MergeTree *getJoinTree() {
+        return &jt_;
       }
 
-      inline MergeTree *getSplitTree() const {
-        return st_;
+      inline MergeTree *getSplitTree() {
+        return &st_;
       }
 
       inline MergeTree *getTree(const TreeType &tt) {

--- a/core/base/contourForestsTree/ExtendedUF.h
+++ b/core/base/contourForestsTree/ExtendedUF.h
@@ -47,6 +47,16 @@ namespace ttk {
         origin_ = other.origin_;
       }
 
+      inline ExtendedUnionFind &operator=(const ExtendedUnionFind &other) {
+        if(&other != this) {
+          rank_ = other.rank_;
+          parent_ = this;
+          data_ = other.data_;
+          origin_ = other.origin_;
+        }
+        return *this;
+      }
+
       inline void setData(const ufDataType &d) {
         data_ = d;
       }

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -537,9 +537,11 @@ idNode MergeTree::makeNode(const Node *const n, const SimplexId &term) {
   return makeNode(n->getVertexId(), term);
 }
 
-void MergeTree::delNode(const idNode &node,
-                        const pair<SimplexId, bool> *markVertices,
-                        const SimplexId &nbMark) {
+void MergeTree::delNode(
+  const idNode &node,
+  std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
+  const pair<SimplexId, bool> *markVertices,
+  const SimplexId &nbMark) {
   Node *mainNode = getNode(node);
 
   if(mainNode->getNumberOfUpSuperArcs() == 0) {
@@ -629,8 +631,8 @@ void MergeTree::delNode(const idNode &node,
           const auto *upSegm = treeData_.superArcs[upArc].getVertList();
           const auto *downSegm = treeData_.superArcs[downArc].getVertList();
 
-          pair<SimplexId, bool> *newSegmentation
-            = new pair<SimplexId, bool>[upSize + downSize];
+          storage.emplace_back(upSize + downSize);
+          pair<SimplexId, bool> *newSegmentation = storage.back().data();
 
           for(SimplexId i = 0; i < downSize; i++) {
             newSegmentation[i] = downSegm[i];
@@ -638,23 +640,6 @@ void MergeTree::delNode(const idNode &node,
 
           for(SimplexId i = 0; i < upSize; i++) {
             newSegmentation[i + downSize] = upSegm[i];
-          }
-
-          // avoid some memory leaks
-          if(treeData_.superArcs[downArc].getSegmentation().size()) {
-            const auto &downVect
-              = treeData_.superArcs[downArc].getSegmentation().data();
-            if(downSegm < downVect || downSegm >= downVect + downSize) {
-              delete[] downSegm;
-            }
-          }
-
-          if(treeData_.superArcs[upArc].getSegmentation().size()) {
-            const auto &upVect
-              = treeData_.superArcs[upArc].getSegmentation().data();
-            if(upSegm < upVect || upSegm >= upVect + upSize) {
-              delete[] upSegm;
-            }
           }
 
           treeData_.superArcs[downArc].setVertList(newSegmentation);

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -13,11 +13,11 @@ using namespace cf;
 
 // Constructors & destructors
 
-MergeTree::MergeTree(Params *const params,
-                     Scalars *const scalars,
+MergeTree::MergeTree(std::shared_ptr<Params> params,
+                     std::shared_ptr<Scalars> scalars,
                      TreeType type,
                      idPartition part)
-  : params_(params), scalars_(scalars) {
+  : params_(std::move(params)), scalars_(std::move(scalars)) {
   if(type == TreeType::Join) {
     this->setDebugMsgPrefix("JoinTree");
   } else if(type == TreeType::Split) {

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -1018,9 +1018,9 @@ void MergeTree::printTree2() {
 }
 
 // Clone
-MergeTree *MergeTree::clone() const {
-  MergeTree *newMT
-    = new MergeTree(params_, scalars_, treeData_.treeType, treeData_.partition);
+std::shared_ptr<MergeTree> MergeTree::clone() const {
+  auto newMT = std::make_shared<MergeTree>(
+    params_, scalars_, treeData_.treeType, treeData_.partition);
 
   newMT->treeData_.superArcs = treeData_.superArcs;
   newMT->treeData_.nodes = treeData_.nodes;

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -401,14 +401,18 @@ namespace ttk {
 
       // BFS simplification for local CT
       template <typename scalarType>
-      SimplexId localSimplify(const SimplexId &podSeed0,
-                              const SimplexId &podSeed1);
+      SimplexId localSimplify(
+        const SimplexId &podSeed0,
+        const SimplexId &podSeed1,
+        std::list<std::vector<std::pair<SimplexId, bool>>> &storage);
 
       // BFS simpliciation for global CT
       template <typename scalarType, typename triangulationType>
-      SimplexId globalSimplify(const SimplexId posSeed0,
-                               const SimplexId posSeed1,
-                               const triangulationType &mesh);
+      SimplexId globalSimplify(
+        const SimplexId posSeed0,
+        const SimplexId posSeed1,
+        std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
+        const triangulationType &mesh);
 
       // Having sorted std::pairs, simplify the current tree
       // in accordance with threashol, between the two seeds.
@@ -416,6 +420,7 @@ namespace ttk {
       SimplexId simplifyTree(
         const SimplexId &posSeed0,
         const SimplexId &posSeed1,
+        std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
         const std::vector<std::tuple<SimplexId, SimplexId, scalarType, bool>>
           &sortedPairs);
 
@@ -527,6 +532,7 @@ namespace ttk {
       idNode getParent(const idNode &n);
 
       void delNode(const idNode &node,
+                   std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
                    const std::pair<SimplexId, bool> *mv = nullptr,
                    const SimplexId &nbm = 0);
 

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -46,6 +46,9 @@ namespace ttk {
       // local
       TreeData treeData_;
 
+      // storage
+      std::list<ExtendedUnionFind> storageEUF_;
+
     public:
       // CONSTRUCT
       // -----------

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -620,7 +620,7 @@ namespace ttk {
       }
 
       // Clone
-      MergeTree *clone() const;
+      std::shared_ptr<MergeTree> clone() const;
 
       void clone(const MergeTree *mt);
 

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -40,8 +40,8 @@ namespace ttk {
 
     protected:
       // global
-      Params *const params_;
-      Scalars *const scalars_;
+      std::shared_ptr<Params> params_;
+      std::shared_ptr<Scalars> scalars_;
 
       // local
       TreeData treeData_;
@@ -55,8 +55,8 @@ namespace ttk {
       // {
 
       // Tree with global data and partition number
-      MergeTree(Params *const params,
-                Scalars *const scalars,
+      MergeTree(std::shared_ptr<Params> params,
+                std::shared_ptr<Scalars> scalars,
                 TreeType type,
                 idPartition part = nullPartition);
 

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -50,8 +50,10 @@ namespace ttk {
     // Simplify
 
     template <typename scalarType>
-    SimplexId MergeTree::localSimplify(const SimplexId &posSeed0,
-                                       const SimplexId &posSeed1) {
+    SimplexId MergeTree::localSimplify(
+      const SimplexId &posSeed0,
+      const SimplexId &posSeed1,
+      std::list<std::vector<std::pair<SimplexId, bool>>> &storage) {
 
       // if null threshold, leave
       if(!params_->simplifyThreshold) {
@@ -89,15 +91,17 @@ namespace ttk {
       // --------------
       // {
 
-      return simplifyTree<scalarType>(posSeed0, posSeed1, pairs);
+      return simplifyTree<scalarType>(posSeed0, posSeed1, storage, pairs);
 
       // }
     }
 
     template <typename scalarType, typename triangulationType>
-    SimplexId MergeTree::globalSimplify(const SimplexId posSeed0,
-                                        const SimplexId posSeed1,
-                                        const triangulationType &mesh) {
+    SimplexId MergeTree::globalSimplify(
+      const SimplexId posSeed0,
+      const SimplexId posSeed1,
+      std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
+      const triangulationType &mesh) {
 
       // if null threshold, leave
       if(!params_->simplifyThreshold) {
@@ -173,7 +177,7 @@ namespace ttk {
       //{
 
       // identify subtrees and merge them in recept'arcs
-      return simplifyTree<scalarType>(posSeed0, posSeed1, sortedPairs);
+      return simplifyTree<scalarType>(posSeed0, posSeed1, storage, sortedPairs);
       //}
     }
 
@@ -181,6 +185,7 @@ namespace ttk {
     SimplexId MergeTree::simplifyTree(
       const SimplexId &posSeed0,
       const SimplexId &posSeed1,
+      std::list<std::vector<std::pair<SimplexId, bool>>> &storage,
       const std::vector<std::tuple<SimplexId, SimplexId, scalarType, bool>>
         &sortedPairs) {
       const auto nbNode = getNumberOfNodes();
@@ -365,7 +370,8 @@ namespace ttk {
             }
 
             subtreeUF[thisOriginId]->find()->setData(receptArcId);
-            getSuperArc(receptArcId)->makeAllocGlobal(std::get<2>(receptArc));
+            getSuperArc(receptArcId)
+              ->makeAllocGlobal(std::get<2>(receptArc), storage);
 
             if(DEBUG) {
               std::cout << "create arc : " << printArc(receptArcId)

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -2327,9 +2327,11 @@ int ContourTree::build() {
   mergeTree_.setDebugLevel(debugLevel_);
   splitTree_.setDebugLevel(debugLevel_);
 
+  std::vector<int> localVertSoSoffsets{};
+
   // 0) init data structures
-  if(!vertexSoSoffsets_) {
-    vertexSoSoffsets_ = new vector<int>;
+  if(!externalOffets_) {
+    vertexSoSoffsets_ = &localVertSoSoffsets;
     vertexSoSoffsets_->resize(vertexNumber_);
     for(int i = 0; i < (int)vertexSoSoffsets_->size(); i++)
       (*vertexSoSoffsets_)[i] = i;
@@ -2337,8 +2339,9 @@ int ContourTree::build() {
 
   // build the actual extrema list
 
-  minimumList_ = new vector<int>;
-  maximumList_ = new vector<int>;
+  std::vector<int> minimumVec, maximumVec;
+  minimumList_ = &minimumVec;
+  maximumList_ = &maximumVec;
 
   for(int i = 0; i < vertexNumber_; i++) {
 

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -529,6 +529,7 @@ namespace ttk {
 
     inline void setVertexSoSoffsets(std::vector<int> *vertexSoSoffsets) {
       vertexSoSoffsets_ = vertexSoSoffsets;
+      externalOffets_ = true;
     }
 
     virtual int simplify(const double &simplificationThreshold,
@@ -576,6 +577,7 @@ namespace ttk {
     double minScalar_{}, maxScalar_{};
     const std::vector<real> *vertexScalars_{};
     std::vector<int> *vertexSoSoffsets_{};
+    bool externalOffets_{false};
     const AbstractTriangulation *triangulation_{};
     std::vector<int> *minimumList_{}, *maximumList_{};
     std::vector<Node> nodeList_{}, originalNodeList_{};

--- a/core/base/contourTreeAlignment/CTA_contourtree.cpp
+++ b/core/base/contourTreeAlignment/CTA_contourtree.cpp
@@ -20,7 +20,7 @@ ContourTree::ContourTree(float *scalars,
   float maxVal = -FLT_MAX;
 
   for(size_t i = 0; i < nVertices; i++) {
-    std::shared_ptr<ttk::cta::CTNode> node(new ttk::cta::CTNode);
+    auto node = std::make_shared<ttk::cta::CTNode>();
     node->scalarValue = scalars[i];
     node->edgeList = std::vector<int>();
     node->branchID = -1;
@@ -32,7 +32,7 @@ ContourTree::ContourTree(float *scalars,
   }
   int j = 0;
   for(size_t i = 0; i < nEdges; i++) {
-    std::shared_ptr<ttk::cta::CTEdge> edge(new ttk::cta::CTEdge);
+    auto edge = std::make_shared<ttk::cta::CTEdge>();
     edge->area = regionSizes[i];
     edge->segId = segmentationIds[i];
     if(!regions.empty())
@@ -83,7 +83,7 @@ std::shared_ptr<ttk::cta::Tree> ContourTree::computeRootedTree(
   int &id) {
 
   // initialize tree
-  std::shared_ptr<Tree> t(new Tree);
+  auto t = std::make_shared<Tree>();
 
   // set id and increment for later calls
   t->id = id;
@@ -147,7 +147,7 @@ std::shared_ptr<ttk::cta::BinaryTree> ContourTree::computeRootedTree_binary(
   int &id) {
 
   // initialize tree
-  std::shared_ptr<BinaryTree> t(new BinaryTree);
+  auto t = std::make_shared<BinaryTree>();
 
   // set id and increment for later calls
   t->id = id;

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -196,8 +196,7 @@ bool ttk::ContourTreeAlignment::initialize(
                        std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<ttk::cta::AlignmentNode> currNode(
-    new ttk::cta::AlignmentNode());
+  auto currNode = std::make_shared<ttk::cta::AlignmentNode>();
   std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
@@ -220,8 +219,7 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -230,8 +228,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
       childNode->nodeRefs.emplace_back(0, currTree->child1->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -249,8 +246,7 @@ bool ttk::ContourTreeAlignment::initialize(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -259,8 +255,7 @@ bool ttk::ContourTreeAlignment::initialize(
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
       childNode->nodeRefs.emplace_back(0, currTree->child2->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -297,8 +292,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
                        std::shared_ptr<ttk::cta::AlignmentNode>>>
     q;
 
-  std::shared_ptr<ttk::cta::AlignmentNode> currNode(
-    new ttk::cta::AlignmentNode());
+  auto currNode = std::make_shared<ttk::cta::AlignmentNode>();
   std::shared_ptr<ttk::cta::BinaryTree> currTree;
 
   currNode->freq = 1;
@@ -321,8 +315,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child1 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
       childNode->freq = 1;
       childNode->type = currTree->child1->type;
       childNode->branchID = -1;
@@ -331,8 +324,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
       childNode->nodeRefs.emplace_back(0, currTree->child1->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
       childEdge->area = currTree->child1->area;
       childEdge->scalardistance = currTree->child1->scalardistanceParent;
       childEdge->volume = currTree->child1->volume;
@@ -354,8 +346,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
 
     if(currTree->child2 != nullptr) {
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
       childNode->freq = 1;
       childNode->type = currTree->child2->type;
       childNode->branchID = -1;
@@ -364,8 +355,7 @@ bool ttk::ContourTreeAlignment::initialize_consistentRoot(
       childNode->nodeRefs = std::vector<std::pair<int, int>>();
       childNode->nodeRefs.emplace_back(0, currTree->child2->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
       childEdge->area = currTree->child2->area;
       childEdge->scalardistance = currTree->child2->scalardistanceParent;
       childEdge->volume = currTree->child2->volume;
@@ -520,8 +510,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
   std::shared_ptr<ttk::cta::AlignmentNode> currNode;
   std::shared_ptr<ttk::cta::AlignmentTree> currTree;
 
-  currNode
-    = std::shared_ptr<ttk::cta::AlignmentNode>(new ttk::cta::AlignmentNode());
+  currNode = std::make_shared<ttk::cta::AlignmentNode>();
 
   if(res->node1 == nullptr && res->node2 == nullptr) {
     return;
@@ -608,8 +597,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
 
       childNode->freq
         = (currTree->child1->node1 == nullptr ? 0
@@ -669,8 +657,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           (int)contourtrees.size() - 1,
           currTree->child1->node2->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
 
       if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
@@ -788,8 +775,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
         continue;
       }
 
-      std::shared_ptr<ttk::cta::AlignmentNode> childNode(
-        new ttk::cta::AlignmentNode());
+      auto childNode = std::make_shared<ttk::cta::AlignmentNode>();
 
       childNode->freq
         = (currTree->child2->node1 == nullptr ? 0
@@ -849,8 +835,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
           (int)contourtrees.size() - 1,
           currTree->child2->node2->nodeRefs[0].second);
 
-      std::shared_ptr<ttk::cta::AlignmentEdge> childEdge(
-        new ttk::cta::AlignmentEdge());
+      auto childEdge = std::make_shared<ttk::cta::AlignmentEdge>();
 
       if(alignmenttreeType == ttk::cta::lastMatchedValue) {
 
@@ -1210,11 +1195,11 @@ float ttk::ContourTreeAlignment::editCost(
   const std::shared_ptr<ttk::cta::BinaryTree> &t2) {
 
   float v1 = 0, v2 = 0;
-  if(t1.get() != nullptr)
+  if(t1 != nullptr)
     v1 = arcMatchMode == ttk::cta::persistence ? t1->scalardistanceParent
          : arcMatchMode == ttk::cta::area      ? t1->area
                                                : t1->volume;
-  if(t2.get() != nullptr)
+  if(t2 != nullptr)
     v2 = arcMatchMode == ttk::cta::persistence ? t2->scalardistanceParent
          : arcMatchMode == ttk::cta::area      ? t2->area
                                                : t2->volume;
@@ -1309,8 +1294,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
 
   if(memT[t1->id][t2->id] == editCost(t1, t2) + memF[t1->id][t2->id]) {
 
-    std::shared_ptr<ttk::cta::AlignmentTree> resNode(
-      new ttk::cta::AlignmentTree);
+    auto resNode = std::make_shared<ttk::cta::AlignmentTree>();
 
     resNode->node1 = t1;
     resNode->node2 = t2;
@@ -1347,7 +1331,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
       = traceAlignmentTree(t1->child1, t2, memT, memF);
     std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t1->child2, true);
-    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
+    auto res = std::make_shared<ttk::cta::AlignmentTree>();
     res->node1 = t1;
     res->node2 = nullptr;
     res->height = 0;
@@ -1372,7 +1356,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
       = traceAlignmentTree(t1->child2, t2, memT, memF);
     std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t1->child1, true);
-    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
+    auto res = std::make_shared<ttk::cta::AlignmentTree>();
     res->node1 = t1;
     res->node2 = nullptr;
     res->height = 0;
@@ -1397,7 +1381,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
       = traceAlignmentTree(t1, t2->child1, memT, memF);
     std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t2->child2, false);
-    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
+    auto res = std::make_shared<ttk::cta::AlignmentTree>();
     res->node1 = nullptr;
     res->node2 = t2;
     res->height = 0;
@@ -1422,7 +1406,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
       = traceAlignmentTree(t1, t2->child2, memT, memF);
     std::shared_ptr<ttk::cta::AlignmentTree> resChild2
       = traceNullAlignment(t2->child1, false);
-    std::shared_ptr<ttk::cta::AlignmentTree> res(new ttk::cta::AlignmentTree());
+    auto res = std::make_shared<ttk::cta::AlignmentTree>();
     res->node1 = nullptr;
     res->node2 = t2;
     res->height = 0;
@@ -1440,8 +1424,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
 
   printErr("Alignment computation failed. Traceback of memoization table not "
            "possible.");
-  return std::shared_ptr<ttk::cta::AlignmentTree>(
-    new ttk::cta::AlignmentTree());
+  return std::make_shared<ttk::cta::AlignmentTree>();
 }
 
 std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
@@ -1514,7 +1497,7 @@ std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
 
       std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
+      auto t = std::make_shared<ttk::cta::AlignmentTree>();
       t->node1 = t1->child1;
       t->node2 = nullptr;
 
@@ -1554,7 +1537,7 @@ std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
 
       std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
+      auto t = std::make_shared<ttk::cta::AlignmentTree>();
       t->node1 = t1->child2;
       t->node2 = nullptr;
 
@@ -1594,7 +1577,7 @@ std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
 
       std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
+      auto t = std::make_shared<ttk::cta::AlignmentTree>();
       t->node1 = nullptr;
       t->node2 = t2->child1;
 
@@ -1634,7 +1617,7 @@ std::vector<std::shared_ptr<ttk::cta::AlignmentTree>>
 
       std::vector<std::shared_ptr<ttk::cta::AlignmentTree>> res;
 
-      std::shared_ptr<ttk::cta::AlignmentTree> t(new ttk::cta::AlignmentTree);
+      auto t = std::make_shared<ttk::cta::AlignmentTree>();
       t->node1 = nullptr;
       t->node2 = t2->child2;
 
@@ -1677,7 +1660,7 @@ std::shared_ptr<ttk::cta::AlignmentTree>
 
   if(t == nullptr)
     return nullptr;
-  std::shared_ptr<ttk::cta::AlignmentTree> at(new ttk::cta::AlignmentTree());
+  auto at = std::make_shared<ttk::cta::AlignmentTree>();
   at->node1 = first ? t : nullptr;
   at->node2 = first ? nullptr : t;
   at->height = t->height;
@@ -1722,7 +1705,7 @@ std::shared_ptr<ttk::cta::BinaryTree>
     const std::shared_ptr<ttk::cta::AlignmentEdge> &parent,
     int &id) {
 
-  std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
+  auto t = std::make_shared<ttk::cta::BinaryTree>();
 
   if(parent == nullptr) {
     t->scalardistanceParent = 10000;
@@ -1781,7 +1764,7 @@ std::shared_ptr<ttk::cta::BinaryTree>
     bool parent1,
     int &id) {
 
-  std::shared_ptr<ttk::cta::BinaryTree> t(new ttk::cta::BinaryTree);
+  auto t = std::make_shared<ttk::cta::BinaryTree>();
 
   t->scalardistanceParent = arc->scalardistance;
   t->area = arc->area;
@@ -1813,8 +1796,8 @@ std::shared_ptr<ttk::cta::BinaryTree>
 
     if(edge != arc) {
 
-      std::shared_ptr<ttk::cta::BinaryTree> child = computeRootedDualTree(
-        edge, edge->node1.lock() == node ? true : false, id);
+      std::shared_ptr<ttk::cta::BinaryTree> child
+        = computeRootedDualTree(edge, edge->node1.lock() == node, id);
       children.push_back(child);
       t->size += child->size;
       if(t->height < child->height + 1)

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -555,11 +555,11 @@ int ttk::ContourTreeAlignment::execute(
 
   std::vector<std::shared_ptr<ContourTree>> contourtreesToAlign;
   for(size_t i = 0; i < nTrees; i++) {
-    std::shared_ptr<ContourTree> ct(new ContourTree(
+    auto ct = std::make_shared<ContourTree>(
       scalars[permutation[i]], regionSizes[permutation[i]],
       segmentationIds[permutation[i]], topologies[permutation[i]],
       nVertices[permutation[i]], nEdges[permutation[i]],
-      segRegions.empty() ? std::vector<std::vector<int>>() : segRegions[i]));
+      segRegions.empty() ? std::vector<std::vector<int>>() : segRegions[i]);
     if(ct->isBinary()) {
       contourtreesToAlign.push_back(ct);
     } else {

--- a/core/base/ftmTree/FTMSuperArc.h
+++ b/core/base/ftmTree/FTMSuperArc.h
@@ -48,7 +48,7 @@ namespace ttk {
       // This arc will needs to receive both ends before being printed
       SuperArc()
         : downNodeId_(nullNodes), upNodeId_(nullNodes),
-          state_(ComponentState::Visible), lastVisited_(nullVertex), region_(),
+          state_(ComponentState::Visible), lastVisited_(nullVertex),
           verticesSeen_(0), normalizedId_(nullSuperArc) {
       }
 
@@ -56,7 +56,7 @@ namespace ttk {
                idNode u,
                const ComponentState &state = ComponentState::Visible)
         : downNodeId_(d), upNodeId_(u), state_(state), lastVisited_(nullVertex),
-          region_(), verticesSeen_(0), normalizedId_(nullSuperArc) {
+          verticesSeen_(0), normalizedId_(nullSuperArc) {
       }
 
       // ------------------

--- a/core/base/ftmTree/FTMTree.cpp
+++ b/core/base/ftmTree/FTMTree.cpp
@@ -17,11 +17,7 @@ using namespace std;
 using namespace ttk;
 using namespace ftm;
 
-FTMTree::FTMTree() : FTMTree_CT(new Params, new Scalars) {
+FTMTree::FTMTree()
+  : FTMTree_CT(std::make_shared<Params>(), std::make_shared<Scalars>()) {
   this->setDebugMsgPrefix("FTMTree");
-}
-
-FTMTree::~FTMTree() {
-  delete params_;
-  delete scalars_;
 }

--- a/core/base/ftmTree/FTMTree.h
+++ b/core/base/ftmTree/FTMTree.h
@@ -54,7 +54,7 @@ namespace ttk {
       // -----------------
 
       FTMTree();
-      ~FTMTree() override;
+      ~FTMTree() override = default;
 
       // -------
       // PROCESS

--- a/core/base/ftmTree/FTMTreeUtils.h
+++ b/core/base/ftmTree/FTMTreeUtils.h
@@ -44,9 +44,9 @@ namespace ttk {
     template <class dataType>
     void mergeTreeTemplateToDouble(MergeTree<dataType> &mt,
                                    MergeTree<double> &newMt) {
-      std::vector<double> newScalarsValues;
-      for(auto val : mt.scalarsValues)
-        newScalarsValues.push_back(static_cast<double>(val));
+      auto newScalarsValues = std::make_shared<std::vector<double>>();
+      for(auto val : *mt.scalarsValues)
+        newScalarsValues->push_back(static_cast<double>(val));
       newMt = MergeTree<double>(mt.scalars, newScalarsValues, mt.params);
       newMt.tree.copyMergeTreeStructure(&(mt.tree));
     }
@@ -78,9 +78,9 @@ namespace ttk {
     template <class dataType>
     void mergeTreeDoubleToTemplate(MergeTree<double> &mt,
                                    MergeTree<dataType> &newMt) {
-      std::vector<dataType> newScalarsValues;
-      for(auto val : mt.scalarsValues)
-        newScalarsValues.push_back(static_cast<dataType>(val));
+      auto newScalarsValues = std::make_shared<std::vector<dataType>>();
+      for(auto val : *mt.scalarsValues)
+        newScalarsValues->push_back(static_cast<dataType>(val));
       newMt = MergeTree<dataType>(mt.scalars, newScalarsValues, mt.params);
       newMt.tree.copyMergeTreeStructure(&(mt.tree));
     }
@@ -122,14 +122,13 @@ namespace ttk {
     template <class dataType>
     MergeTree<dataType> createEmptyMergeTree(int scalarSize) {
       // Init Scalars
-      ftm::Scalars scalars;
-      scalars.size = scalarSize;
-      dataType *scalarsValues = nullptr;
-      scalars.values = (void *)scalarsValues;
+      auto scalars = std::make_shared<ftm::Scalars>();
+      scalars->size = scalarSize;
+      scalars->values = (void *)nullptr;
 
       // Init Params
-      ftm::Params params;
-      params.treeType = ftm::Join_Split;
+      auto params = std::make_shared<ftm::Params>();
+      params->treeType = ftm::Join_Split;
 
       // Init tree
       MergeTree<dataType> mergeTree(scalars, params);
@@ -140,9 +139,10 @@ namespace ttk {
     template <class dataType>
     void setTreeScalars(MergeTree<dataType> &mergeTree,
                         std::vector<dataType> &scalarsVector) {
-      mergeTree.scalarsValues = scalarsVector;
-      mergeTree.scalars.values = (void *)(mergeTree.scalarsValues.data());
-      mergeTree.scalars.size = mergeTree.scalarsValues.size();
+      mergeTree.scalarsValues
+        = std::make_shared<std::vector<dataType>>(scalarsVector);
+      mergeTree.scalars->values = (void *)(mergeTree.scalarsValues->data());
+      mergeTree.scalars->size = mergeTree.scalarsValues->size();
     }
 
     template <class dataType>

--- a/core/base/ftmTree/FTMTreeUtils_Template.h
+++ b/core/base/ftmTree/FTMTreeUtils_Template.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <FTMTree_MT.h>
+
 namespace ttk {
   namespace ftm {
 

--- a/core/base/ftmTree/FTMTree_CT.cpp
+++ b/core/base/ftmTree/FTMTree_CT.cpp
@@ -38,7 +38,7 @@ int FTMTree_CT::combine() {
   // Reserve
   mt_data_.nodes->reserve(jt_.getNumberOfNodes());
   mt_data_.superArcs->reserve(jt_.getNumberOfSuperArcs() + 2);
-  mt_data_.leaves->reserve(jt_.getNumberOfLeaves() + st_.getNumberOfLeaves());
+  mt_data_.leaves.reserve(jt_.getNumberOfLeaves() + st_.getNumberOfLeaves());
 
   // Add JT & ST Leaves to growingNodes
 
@@ -70,7 +70,7 @@ int FTMTree_CT::combine() {
 
   // Warning, have a reserve here, can't make it at the begnining, need build
   // output
-  mt_data_.leaves->reserve(jt_.getLeaves().size() + st_.getLeaves().size());
+  mt_data_.leaves.reserve(jt_.getLeaves().size() + st_.getLeaves().size());
   mt_data_.superArcs->reserve(jt_.getNumberOfSuperArcs());
   mt_data_.nodes->reserve(jt_.getNumberOfNodes());
 
@@ -171,7 +171,7 @@ int FTMTree_CT::combine() {
         // check if leaf
         if(!currentNode->getNumberOfDownSuperArcs()
            || !currentNode->getNumberOfUpSuperArcs())
-          mt_data_.leaves->emplace_back(node1);
+          mt_data_.leaves.emplace_back(node1);
       }
 
       // j <- GetAdj(XT, i)
@@ -192,7 +192,7 @@ int FTMTree_CT::combine() {
         // create a new node
         node2 = makeNode(parentNode);
         if(!parentNode->getNumberOfUpSuperArcs())
-          mt_data_.leaves->emplace_back(node2);
+          mt_data_.leaves.emplace_back(node2);
       }
 
       // CREATE ARC

--- a/core/base/ftmTree/FTMTree_CT.cpp
+++ b/core/base/ftmTree/FTMTree_CT.cpp
@@ -21,9 +21,8 @@ using namespace ttk;
 
 using namespace ftm;
 
-FTMTree_CT::FTMTree_CT(Params *const params,
-
-                       Scalars *const scalars)
+FTMTree_CT::FTMTree_CT(const std::shared_ptr<Params> &params,
+                       const std::shared_ptr<Scalars> &scalars)
   : FTMTree_MT(params, scalars, TreeType::Contour),
     jt_(new FTMTree_MT(params, scalars, TreeType::Join)),
     st_(new FTMTree_MT(params, scalars, TreeType::Split)) {
@@ -318,7 +317,7 @@ void FTMTree_CT::finalizeSegmentation() {
 #pragma omp parallel for schedule(dynamic)
 #endif
   for(idSuperArc i = 0; i < nbArc; i++) {
-    getSuperArc(i)->createSegmentation(scalars_);
+    getSuperArc(i)->createSegmentation(scalars_.get());
   }
 
   printTime(finSegmTime, "post-process segm", 4);

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -36,7 +36,8 @@ namespace ttk {
       // Constructors
       // -----------------
 
-      FTMTree_CT(Params *const params, Scalars *const scalars);
+      FTMTree_CT(const std::shared_ptr<Params> &params,
+                 const std::shared_ptr<Scalars> &scalars);
       ~FTMTree_CT() override;
 
       // -----------------

--- a/core/base/ftmTree/FTMTree_CT.h
+++ b/core/base/ftmTree/FTMTree_CT.h
@@ -29,7 +29,7 @@ namespace ttk {
 
     class FTMTree_CT : public FTMTree_MT {
     protected:
-      FTMTree_MT *jt_, *st_;
+      FTMTree_MT jt_, st_;
 
     public:
       // -----------------
@@ -38,18 +38,18 @@ namespace ttk {
 
       FTMTree_CT(const std::shared_ptr<Params> &params,
                  const std::shared_ptr<Scalars> &scalars);
-      ~FTMTree_CT() override;
+      ~FTMTree_CT() override = default;
 
       // -----------------
       // ACCESSOR
       // -----------------
 
-      inline FTMTree_MT *getJoinTree() const {
-        return jt_;
+      inline FTMTree_MT *getJoinTree() {
+        return &jt_;
       }
 
-      inline FTMTree_MT *getSplitTree() const {
-        return st_;
+      inline FTMTree_MT *getSplitTree() {
+        return &st_;
       }
 
       inline FTMTree_MT *getTree(const TreeType tt) {
@@ -72,21 +72,21 @@ namespace ttk {
       inline void preconditionTriangulation(AbstractTriangulation *tri,
                                             const bool preproc = true) {
         FTMTree_MT::preconditionTriangulation(tri, preproc);
-        jt_->preconditionTriangulation(tri, false);
-        st_->preconditionTriangulation(tri, false);
+        jt_.preconditionTriangulation(tri, false);
+        st_.preconditionTriangulation(tri, false);
       }
 
       inline int setDebugLevel(const int &d) override {
         Debug::setDebugLevel(d);
-        jt_->setDebugLevel(d);
-        st_->setDebugLevel(d);
+        jt_.setDebugLevel(d);
+        st_.setDebugLevel(d);
         return 0;
       }
 
       inline int setThreadNumber(const int n) override {
         Debug::setThreadNumber(n);
-        jt_->setThreadNumber(n);
-        st_->setThreadNumber(n);
+        jt_.setThreadNumber(n);
+        st_.setThreadNumber(n);
         return 0;
       }
 

--- a/core/base/ftmTree/FTMTree_CT_Template.h
+++ b/core/base/ftmTree/FTMTree_CT_Template.h
@@ -32,10 +32,10 @@ namespace ttk {
 #ifdef TTK_ENABLE_OMP_PRIORITY
       {
         // Set priority
-        if(st_->getNumberOfLeaves() < jt_->getNumberOfLeaves())
-          st_->setPrior();
+        if(st_.getNumberOfLeaves() < jt_.getNumberOfLeaves())
+          st_.setPrior();
         else
-          jt_->setPrior();
+          jt_.setPrior();
       }
 #endif
 
@@ -53,13 +53,13 @@ namespace ttk {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task UNTIED() if(threadNumber_ > 1)
 #endif
-            jt_->build(mesh, tt == TreeType::Contour);
+            jt_.build(mesh, tt == TreeType::Contour);
           }
           if(tt == TreeType::Split || bothMT) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task UNTIED() if(threadNumber_ > 1)
 #endif
-            st_->build(mesh, tt == TreeType::Contour);
+            st_.build(mesh, tt == TreeType::Contour);
           }
         }
 #ifdef TTK_ENABLE_OPENMP
@@ -85,14 +85,14 @@ namespace ttk {
         std::string nbNodes;
         switch(tt) {
           case TreeType::Join:
-            nbNodes = std::to_string(jt_->getNumberOfNodes());
+            nbNodes = std::to_string(jt_.getNumberOfNodes());
             break;
           case TreeType::Split:
-            nbNodes = std::to_string(st_->getNumberOfNodes());
+            nbNodes = std::to_string(st_.getNumberOfNodes());
             break;
           case TreeType::Join_Split:
             nbNodes
-              = std::to_string(jt_->getNumberOfNodes() + st_->getNumberOfNodes());
+              = std::to_string(jt_.getNumberOfNodes() + st_.getNumberOfNodes());
             break;
           default:
             nbNodes = std::to_string(getNumberOfNodes());
@@ -136,15 +136,15 @@ int FTMTree_CT::leafSearch(const triangulationType *mesh) {
           }
         }
 
-        jt_->setValence(v, downval);
-        st_->setValence(v, upval);
+        jt_.setValence(v, downval);
+        st_.setValence(v, upval);
 
         if(!downval) {
-          jt_->makeNode(v);
+          jt_.makeNode(v);
         }
 
         if(!upval) {
-          st_->makeNode(v);
+          st_.makeNode(v);
         }
       }
     }

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -57,9 +57,6 @@ void FTMTree_MT::clear() {
     sort(mt_data_.ufs.begin(), mt_data_.ufs.end());
     auto it = unique(mt_data_.ufs.begin(), mt_data_.ufs.end());
     mt_data_.ufs.resize(std::distance(mt_data_.ufs.begin(), it));
-    for(auto *addr : *mt_data_.ufs)
-      if(addr)
-        delete addr;
   }
 
   // if (mt_data_.propagation) {

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -542,18 +542,18 @@ idSuperArc FTMTree_MT::makeSuperArc(idNode downNodeId, idNode upNodeId)
   return newSuperArcId;
 }
 
-void FTMTree_MT::move(std::shared_ptr<FTMTree_MT> &mt) {
+void FTMTree_MT::move(FTMTree_MT &mt) {
   // we already have common data
-  mt_data_.superArcs = mt->mt_data_.superArcs;
-  mt->mt_data_.superArcs = nullptr;
-  mt_data_.nodes = mt->mt_data_.nodes;
-  mt->mt_data_.nodes = nullptr;
-  mt_data_.leaves = mt->mt_data_.leaves;
-  mt->mt_data_.leaves = nullptr;
-  mt_data_.roots = mt->mt_data_.roots;
-  mt->mt_data_.roots = nullptr;
-  mt_data_.vert2tree = mt->mt_data_.vert2tree;
-  mt->mt_data_.vert2tree = nullptr;
+  mt_data_.superArcs = mt.mt_data_.superArcs;
+  mt.mt_data_.superArcs = nullptr;
+  mt_data_.nodes = mt.mt_data_.nodes;
+  mt.mt_data_.nodes = nullptr;
+  mt_data_.leaves = mt.mt_data_.leaves;
+  mt.mt_data_.leaves = nullptr;
+  mt_data_.roots = mt.mt_data_.roots;
+  mt.mt_data_.roots = nullptr;
+  mt_data_.vert2tree = mt.mt_data_.vert2tree;
+  mt.mt_data_.vert2tree = nullptr;
 }
 
 void FTMTree_MT::normalizeIds() {

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -579,7 +579,7 @@ namespace ttk {
 
       std::shared_ptr<FTMTree_MT> clone() const;
 
-      void move(std::shared_ptr<FTMTree_MT> &mt);
+      void move(FTMTree_MT &mt);
 
       // Print
       std::string printArc(idSuperArc a);

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -54,6 +54,7 @@ namespace ttk {
       std::vector<std::list<std::vector<SimplexId>>> trunkSegments;
 
       // Track informations
+      std::vector<AtomicUF> storage;
       std::vector<UF> ufs;
       std::vector<UF> propagation;
       std::shared_ptr<FTMAtomicVector<CurrentState>> states;

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -154,11 +154,13 @@ namespace ttk {
       if(nbLeaves == 1) {
         const SimplexId v = (*mt_data_.nodes)[0].getVertexId();
         mt_data_.openedNodes[v] = 1;
-        mt_data_.ufs[v] = new AtomicUF(v);
+        mt_data_.storage.emplace_back(v);
+        mt_data_.ufs[v] = &mt_data_.storage[0];
         return;
       }
 
       mt_data_.activeTasks = nbLeaves;
+      mt_data_.storage.resize(nbLeaves);
 
       auto comp = [this](const idNode a, const idNode b) {
 #ifdef HIGHER
@@ -176,7 +178,7 @@ namespace ttk {
         SimplexId v = getNode(l)->getVertexId();
         // for each node: get vert, create uf and lauch
         mt_data_.storage[n] = AtomicUF{v};
-        mt_data_.ufs[v] = new AtomicUF(v);
+        mt_data_.ufs[v] = &mt_data_.storage[n];
 
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task UNTIED() OPTIONAL_PRIORITY(isPrior())

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -184,14 +184,14 @@ void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
   if(debugLevel_ > 4) {
     switch(params_->treeType) {
       case TreeType::Join:
-        jt_->printTree2();
+        jt_.printTree2();
         break;
       case TreeType::Split:
-        st_->printTree2();
+        st_.printTree2();
         break;
       case TreeType::Join_Split:
-        jt_->printTree2();
-        st_->printTree2();
+        jt_.printTree2();
+        st_.printTree2();
         break;
       default:
         printTree2();

--- a/core/base/mergeTreeClustering/MergeTreeUtils.h
+++ b/core/base/mergeTreeClustering/MergeTreeUtils.h
@@ -192,21 +192,19 @@ namespace ttk {
   // Testing
   // --------------------
   template <class dataType>
-  ftm::FTMTree_MT *
+  std::shared_ptr<ftm::FTMTree_MT>
     makeFakeTree(dataType *nodesScalar,
                  std::vector<SimplexId> &nodes,
                  std::vector<std::tuple<ftm::idNode, ftm::idNode>> &arcs) {
     // Init Scalars
-    ftm::Scalars *scalars = new ftm::Scalars();
+    auto scalars = std::make_shared<ftm::Scalars>();
     scalars->size = nodes.size();
     scalars->values = (void *)nodesScalar;
 
     // Init Tree
-    ftm::Params *params = new ftm::Params();
-    // ftm::FTMTree_MT *tree = new ftm::FTMTree_MT(params, nullptr, scalars,
-    // ftm::Join_Split);
-    ftm::FTMTree_MT *tree
-      = new ftm::FTMTree_MT(params, scalars, ftm::Join_Split);
+    auto params = std::make_shared<ftm::Params>();
+    auto tree
+      = std::make_shared<ftm::FTMTree_MT>(params, scalars, ftm::Join_Split);
     tree->makeAlloc();
 
     // Add Nodes

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -122,8 +122,7 @@ int ttk::TopologicalCompression::PerformSimplification(
   std::vector<int> inputOffsets(vertexNumber);
   std::vector<SimplexId> critConstraints(nbConstraints);
   std::vector<double> inArray(vertexNumber);
-  // std::vector<int> *oo = new std::vector<int>(vertexNumber);
-  decompressedOffsets_.resize(vertexNumber); // oo->data();
+  decompressedOffsets_.resize(vertexNumber);
   int status = 0;
 
   // Offsets
@@ -131,15 +130,11 @@ int ttk::TopologicalCompression::PerformSimplification(
     inputOffsets[i] = i;
 
   // Preprocess simplification.
-  // std::vector<int>* authorizedSaddles = new std::vector<int>();
   for(int i = 0; i < nbConstraints; ++i) {
     std::tuple<int, double, int> t = constraints[i];
     int id = std::get<0>(t);
     double val = std::get<1>(t);
     int type = std::get<2>(t);
-
-    // if (type == 0)
-    // authorizedSaddles->push_back(id);
 
     array[id] = val;
 
@@ -347,8 +342,6 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     int nbJ = JTPairs.size();
     int nbS = STPairs.size();
     std::vector<int> critConstraints(2 * nbJ + 2 * nbS);
-
-    // auto* authorizedSaddles = new std::vector<int>();
 
     dataType maxEpsilon = 0;
     dataType epsilonSum2 = 0;

--- a/core/base/webSocketIO/WebSocketIO.cpp
+++ b/core/base/webSocketIO/WebSocketIO.cpp
@@ -61,7 +61,7 @@ int ttk::WebSocketIO::startServer(int PortNumber) {
   this->server.start_accept();
 
   // Start the Asio io_service run loop
-  this->serverThread = new thread([this]() {
+  this->serverThread = thread([this]() {
     try {
       {
         std::lock_guard<std::mutex> guard(this->mutex);
@@ -76,7 +76,7 @@ int ttk::WebSocketIO::startServer(int PortNumber) {
       this->printErr("Unable to start server: " + std::string(e.what()));
     }
   });
-  this->serverThread->detach();
+  this->serverThread.detach();
 
   this->printMsg("Starting Server at Port: " + std::to_string(this->portNumber),
                  1, t.getElapsedTime());
@@ -140,8 +140,6 @@ int ttk::WebSocketIO::stopServer() {
         std::lock_guard<std::mutex> guard(this->mutex);
         con = this->serverThreadRunning;
       }
-      delete this->serverThread;
-      this->serverThread = nullptr;
 
       this->printMsg("Terminating Server Thread", 1, 0,
                      ttk::debug::LineMode::NEW, ttk::debug::Priority::DETAIL);

--- a/core/base/webSocketIO/WebSocketIO.h
+++ b/core/base/webSocketIO/WebSocketIO.h
@@ -98,7 +98,7 @@ namespace ttk {
     ttk::Timer msgTimer;
     size_t nMessages;
 
-    std::thread *serverThread = nullptr;
+    std::thread serverThread{};
     con_list connections;
     std::mutex mutex;
     websocketpp::lib::error_code ec;

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -646,7 +646,7 @@ void ttkFTMTree::printCSVTree(const ttk::ftm::FTMTree_MT *const tree) const {
 
 int ttkFTMTree::preconditionTriangulation() {
   triangulation_.resize(nbCC_);
-  ftmTree_.resize(nbCC_);
+  ftmTree_ = std::vector<ttk::ftm::LocalFTM>(nbCC_);
 
   for(int cc = 0; cc < nbCC_; cc++) {
     triangulation_[cc]

--- a/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTreeUtils.h
@@ -28,20 +28,21 @@ namespace ttk {
       auto treeNodeIdArray = treeNodes->GetPointData()->GetArray("TreeNodeId");
 
       // Init Scalars
-      Scalars scalars;
+      auto scalars = std::make_shared<Scalars>();
       vtkSmartPointer<vtkDataArray> nodesScalar
         = treeNodes->GetPointData()->GetArray("Scalar"); // 1: Scalar
-      scalars.size = nodesScalar->GetNumberOfTuples();
-      std::vector<dataType> scalarsValues(nodesScalar->GetNumberOfTuples());
+      scalars->size = nodesScalar->GetNumberOfTuples();
+      auto scalarsValues = std::make_shared<std::vector<dataType>>(
+        nodesScalar->GetNumberOfTuples());
       for(int i = 0; i < nodesScalar->GetNumberOfTuples(); ++i) {
         int index = (treeNodeIdArray ? treeNodeIdArray->GetTuple1(i) : i);
-        scalarsValues[index] = nodesScalar->GetTuple1(i);
+        (*scalarsValues)[index] = nodesScalar->GetTuple1(i);
       }
-      scalars.values = (void *)(scalarsValues.data());
+      scalars->values = (void *)(scalarsValues->data());
 
       // Init Tree
-      Params params;
-      params.treeType = Join_Split;
+      auto params = std::make_shared<Params>();
+      params->treeType = Join_Split;
       MergeTree<dataType> mergeTree(scalars, scalarsValues, params);
 
       // Add Nodes


### PR DESCRIPTION
This PR reworks the following modules: `webSocketIO`, `ftrGraph`, `boundingVolumeHierarchy`, `contourAroundPoint`, `contourTree`, `contourTreeAlignment`, `contourForests` and `ftmTree` to replace manual memory management (`new` & `delete`) with modern C++ alternatives (allocate on stack, `std::shared_ptr`, `std::unique_ptr`, storage with a large enough scope).

This might remove some memory leaks but also might improve the performance when indirections are removed. At least, the `ftmTree` performance seems to be the same.

Enjoy,
Pierre