### PR TITLE
MorseSmaleComplex: Improve segmentation performance

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -191,21 +191,19 @@ bool DiscreteGradient::isCellCritical(const Cell &cell) const {
 }
 
 int DiscreteGradient::setManifoldSize(
-  const size_t nCritPoints,
-  const std::vector<size_t> &nCriticalPointsByDim,
+  const std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
   const SimplexId *const ascendingManifold,
   const SimplexId *const descendingManifold,
   std::vector<SimplexId> &manifoldSize) const {
 
-  // in the manifoldSize vector, critical points are sorted first by
-  // dim then by index
+  const auto nCritPoints{
+    criticalCellsByDim[0].size() + criticalCellsByDim[1].size()
+    + criticalCellsByDim[2].size() + criticalCellsByDim[3].size()};
 
-  // ascendingManifold (resp. descendingManifold) region indices are
-  // numbered from 0 to #maxima == nCriticalPointsByDim.back()
-  // (resp. #minina == nCriticalPointsByDim[0])
+  const auto dim{this->dimensionality_};
 
   if(nCritPoints == 0
-     || (nCriticalPointsByDim[0] == 0 && nCriticalPointsByDim.back() == 0)) {
+     || (criticalCellsByDim[0].empty() && criticalCellsByDim[dim].empty())) {
     // no critical points || no extrema
     return 0;
   }
@@ -213,7 +211,7 @@ int DiscreteGradient::setManifoldSize(
   manifoldSize.resize(nCritPoints, 0);
 
   // descending manifold cells size
-  if(nCriticalPointsByDim[0] > 0) {
+  if(!criticalCellsByDim[0].empty()) {
     for(SimplexId i = 0; i < numberOfVertices_; ++i) {
       if(descendingManifold[i] != -1) {
         manifoldSize[descendingManifold[i]]++;
@@ -221,9 +219,9 @@ int DiscreteGradient::setManifoldSize(
     }
   }
 
-  if(nCriticalPointsByDim.back() > 0) {
+  if(!criticalCellsByDim[dim].empty()) {
     // index of first maximum in critical points array
-    const auto nFirstMaximum{nCritPoints - nCriticalPointsByDim.back()};
+    const auto nFirstMaximum{nCritPoints - criticalCellsByDim[dim].size()};
 
     // ascending manifold cells size
     for(SimplexId i = 0; i < numberOfVertices_; ++i) {

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -307,14 +307,14 @@ in the gradient.
        * inputScalarField_
        */
       template <typename triangulationType>
-      int setCriticalPoints(const std::vector<Cell> &criticalPoints,
-                            std::vector<size_t> &nCriticalPointsByDim,
-                            std::vector<std::array<float, 3>> &points,
-                            std::vector<char> &cellDimensions,
-                            std::vector<SimplexId> &cellIds,
-                            std::vector<char> &isOnBoundary,
-                            std::vector<SimplexId> &PLVertexIdentifiers,
-                            const triangulationType &triangulation) const;
+      int setCriticalPoints(
+        const std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+        std::vector<std::array<float, 3>> &points,
+        std::vector<char> &cellDimensions,
+        std::vector<SimplexId> &cellIds,
+        std::vector<char> &isOnBoundary,
+        std::vector<SimplexId> &PLVertexIdentifiers,
+        const triangulationType &triangulation) const;
 
       /**
        * Detect the critical points and build their geometric embedding.
@@ -332,8 +332,9 @@ in the gradient.
        * Get the output critical points as a STL vector of cells.
        */
       template <typename triangulationType>
-      int getCriticalPoints(std::vector<Cell> &criticalPoints,
-                            const triangulationType &triangulation) const;
+      int getCriticalPoints(
+        std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+        const triangulationType &triangulation) const;
 
 #ifdef TTK_ENABLE_MPI
       /**
@@ -345,11 +346,11 @@ in the gradient.
       /**
        * Compute manifold size for critical extrema
        */
-      int setManifoldSize(const size_t nCritPoints,
-                          const std::vector<size_t> &nCriticalPointsByDim,
-                          const SimplexId *const ascendingManifold,
-                          const SimplexId *const descendingManifold,
-                          std::vector<SimplexId> &manifoldSize) const;
+      int setManifoldSize(
+        const std::array<std::vector<SimplexId>, 4> &criticalCellsByDim,
+        const SimplexId *const ascendingManifold,
+        const SimplexId *const descendingManifold,
+        std::vector<SimplexId> &manifoldSize) const;
 
       /**
        * Build the glyphs representing the discrete gradient vector field.

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -390,7 +390,6 @@ namespace ttk {
      */
     template <typename triangulationType>
     int setFinalSegmentation(const SimplexId numberOfMaxima,
-                             const SimplexId numberOfMinima,
                              const SimplexId *const ascendingManifold,
                              const SimplexId *const descendingManifold,
                              SimplexId *const morseSmaleManifold,
@@ -598,9 +597,9 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
     }
     if(ComputeAscendingSegmentation && ComputeDescendingSegmentation
        && ComputeFinalSegmentation) {
-      setFinalSegmentation(numberOfMaxima, numberOfMinima,
-                           outManifold.ascending_, outManifold.descending_,
-                           outManifold.morseSmale_, triangulation);
+      setFinalSegmentation(numberOfMaxima, outManifold.ascending_,
+                           outManifold.descending_, outManifold.morseSmale_,
+                           triangulation);
     }
 
     this->printMsg(
@@ -1705,7 +1704,6 @@ int ttk::MorseSmaleComplex::setDescendingSegmentation(
 template <typename triangulationType>
 int ttk::MorseSmaleComplex::setFinalSegmentation(
   const SimplexId numberOfMaxima,
-  const SimplexId ttkNotUsed(numberOfMinima),
   const SimplexId *const ascendingManifold,
   const SimplexId *const descendingManifold,
   SimplexId *const morseSmaleManifold,

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -479,7 +479,13 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
   }
 
   std::vector<dcg::Cell> criticalPoints{};
-  discreteGradient_.getCriticalPoints(criticalPoints, triangulation);
+  {
+    Timer tm{};
+    discreteGradient_.getCriticalPoints(criticalPoints, triangulation);
+    this->printMsg("  Critical points extracted", 1.0, tm.getElapsedTime(),
+                   this->threadNumber_, debug::LineMode::NEW,
+                   debug::Priority::DETAIL);
+  }
 
   std::vector<std::vector<Separatrix>> separatrices1{};
 
@@ -569,8 +575,11 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
                    debug::LineMode::NEW, debug::Priority::DETAIL);
   }
 
-  this->printMsg("2-separatrices computed", 1.0, tm2sep.getElapsedTime(),
-                 this->threadNumber_);
+  if(this->ComputeAscendingSeparatrices2
+     || this->ComputeDescendingSeparatrices2) {
+    this->printMsg("2-separatrices computed", 1.0, tm2sep.getElapsedTime(),
+                   this->threadNumber_);
+  }
 
   if(ComputeAscendingSegmentation || ComputeDescendingSegmentation) {
     Timer tmp;


### PR DESCRIPTION
This PR focuses on improving the performance of the Morse-Smale complex ascending and descending segmentations.

The main idea is to follow integral lines for every vertex or tetrahedron towards the corresponding local minimum or maximum. The previous approach used a BFS from the extrema to extract their basins.

For instance, here are some speedups on `ctBones.vti` (8 threads):
* critical points extraction: from 1.55s to 0.21s
* ascending manifold: from 2.68s to 1.13s
* descending manifold: from 5.33s to 0.18s

While the new approach is way more efficient for the descending manifold, the speedup observed on the ascending manifold is less consequent. This is in part due to the number of tetrahedron being around 6 times the number of vertices on a regular grid and the need to handle non-manifold datasets.

I tried another faster propagation scheme for the ascending segmentation, with no real success. It consisted in following integral lines on vertices by their greatest neighbor. This was two or three times slower than the computation of the descending manifold (mostly due to the extraction of the greatest neighbor) but failed to stop at some separatrices.

Another improvement is the rewrite of the `DiscreteGradient::getCriticalPoints` method using an optimized version that has been moved from `DiscreteMorseSandwich`. Previously, the critical cells were stored in a flat manner as `Cell`s. Now, only the simplex ids are stored, in separate vectors per dimension. This remove the need to extract back cells of specific dimensions inside `MorseSmaleComplex`. Additionally, the extraction process has been parallelized using a map-reduce scheme (at it was in `DiscreteMorseSandwich`).

Enjoy,
Pierre
