### PR TITLE
[MergeTree*] avoid casting unsigned int max value to int

### DIFF
--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
@@ -107,7 +107,7 @@ namespace ttk {
         auto birthDeathBary
           = getParametrizedBirthDeath<dataType>(barycenterTree, j);
         std::tuple<dataType, dataType> birthDeath;
-        if((int)matchingVector[j] != -1) {
+        if(matchingVector[j] != std::numeric_limits<ftm::idNode>::max()) {
           birthDeath
             = getParametrizedBirthDeath<dataType>(treeTree, matchingVector[j]);
         } else {
@@ -376,7 +376,8 @@ namespace ttk {
                            useDoubleInput, isFirstInput);
         getMatchingVector(barycenter, extremity, matching, matchingVector);
       } else
-        matchingVector.resize(barycenterTree->getNumberOfNodes(), -1);
+        matchingVector.resize(barycenterTree->getNumberOfNodes(),
+                              std::numeric_limits<ftm::idNode>::max());
 
       std::vector<std::vector<double>> oriV = v;
       for(unsigned int i = 0; i < barycenter.tree.getNumberOfNodes(); ++i) {
@@ -388,7 +389,7 @@ namespace ttk {
         dataType birthBary = std::get<0>(birthDeathBary);
         dataType deathBary = std::get<1>(birthDeathBary);
         std::vector<double> newV{0.0, 0.0};
-        if((int)matched != -1) {
+        if(matched != std::numeric_limits<ftm::idNode>::max()) {
           auto birthDeathMatched
             = getParametrizedBirthDeath<dataType>(extremityTree, matched);
           newV[0] = std::get<0>(birthDeathMatched);
@@ -786,7 +787,7 @@ namespace ttk {
         for(unsigned int j = 0; j < trees.size(); ++j) {
           dataType birth = allProjec[j];
           dataType death = allProjec[j];
-          if((int)matchingMatrix[i][j] != -1) {
+          if(matchingMatrix[i][j] != std::numeric_limits<ftm::idNode>::max()) {
             auto birthDeath = getParametrizedBirthDeath<dataType>(
               ftmTrees[j], matchingMatrix[i][j]);
             birth = std::get<0>(birthDeath);
@@ -1408,7 +1409,7 @@ namespace ttk {
         for(unsigned int i = 0; i < trees.size(); ++i) {
           auto matched = matchingMatrix[node][i];
           std::tuple<dataType, dataType> birthDeath;
-          if((int)matched == -1) {
+          if(matched == std::numeric_limits<ftm::idNode>::max()) {
             birthDeath = barycenter.tree.template getBirthDeath<dataType>(node);
             auto projec
               = (std::get<0>(birthDeath) + std::get<1>(birthDeath)) / 2.0;

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
@@ -746,7 +746,8 @@ namespace ttk {
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings,
       std::vector<ftm::idNode> &matchingVector) {
       matchingVector.clear();
-      matchingVector.resize(barycenter.tree.getNumberOfNodes(), -1);
+      matchingVector.resize(barycenter.tree.getNumberOfNodes(),
+                            std::numeric_limits<ftm::idNode>::max());
       for(unsigned int j = 0; j < matchings.size(); ++j) {
         auto match0 = std::get<0>(matchings[j]);
         auto match1 = std::get<1>(matchings[j]);
@@ -764,7 +765,8 @@ namespace ttk {
       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings,
       std::vector<ftm::idNode> &matchingVector) {
       matchingVector.clear();
-      matchingVector.resize(tree.tree.getNumberOfNodes(), -1);
+      matchingVector.resize(
+        tree.tree.getNumberOfNodes(), std::numeric_limits<ftm::idNode>::max());
       for(unsigned int j = 0; j < matchings.size(); ++j) {
         auto match0 = std::get<0>(matchings[j]);
         auto match1 = std::get<1>(matchings[j]);
@@ -784,8 +786,10 @@ namespace ttk {
         &matchings,
       std::vector<std::vector<ftm::idNode>> &matchingMatrix) {
       matchingMatrix.clear();
-      matchingMatrix.resize(barycenter.tree.getNumberOfNodes(),
-                            std::vector<ftm::idNode>(trees.size(), -1));
+      matchingMatrix.resize(
+        barycenter.tree.getNumberOfNodes(),
+        std::vector<ftm::idNode>(
+          trees.size(), std::numeric_limits<ftm::idNode>::max()));
       for(unsigned int i = 0; i < trees.size(); ++i) {
         std::vector<ftm::idNode> matchingVector;
         getMatchingVector<dataType>(

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -949,7 +949,9 @@ public:
         // _ m[i][j] contains the node in treesOri[j] matched to the node i in
         // the barycenter
         std::vector<std::vector<idNode>> baryMatching(
-          trees[i]->getNumberOfNodes(), std::vector<idNode>(numInputsOri, -1));
+          trees[i]->getNumberOfNodes(),
+          std::vector<idNode>(
+            numInputsOri, std::numeric_limits<idNode>::max()));
         if(ShiftMode == 1) {
           for(size_t j = 0; j < outputMatchingBarycenter[c].size(); ++j)
             for(auto match : outputMatchingBarycenter[c][j])
@@ -1003,7 +1005,7 @@ public:
           double point[3] = {0, 0, 0};
           if(ShiftMode == 1) { // Star barycenter
             for(int j = 0; j < numInputsOri; ++j) {
-              if((int)baryMatching[node][j] != -1) {
+              if(baryMatching[node][j] != std::numeric_limits<idNode>::max()) {
                 nodeMesh = treesNodeCorrMesh[j][baryMatching[node][j]];
                 getPoint(treesNodes[j], nodeMesh, point);
                 noMatched += 1;


### PR DESCRIPTION
This PR removes all casting of unsigned int max value to int in the merge tree related filters.

Instead of initializing some unsigned int to -1 it uses the `std` function `std::numeric_limits<ftm::idNode>::max()` and to test equality it now avoids casting to int and then comparing to -1 by comparing directly to this value.