### PR TITLE
[MergeTreeDistance] rename misleading distanceSquared parameter name and fix display

### DIFF
--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -840,7 +840,7 @@ namespace ttk {
       mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
       mergeTreeDistance.setIsCalled(true);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
-      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDistanceSquaredRoot(true); // squared root
       mergeTreeDistance.setNodePerTask(nodePerTask_);
       if(useDoubleInput) {
         double weight = mixDistancesMinMaxPairWeight(isFirstInput);

--- a/core/base/mergeTreeClustering/MergeTreeBase.h
+++ b/core/base/mergeTreeClustering/MergeTreeBase.h
@@ -41,7 +41,7 @@ namespace ttk {
     bool normalizedWasserstein_ = true;
     bool keepSubtree_ = false;
 
-    bool distanceSquared_ = true; // squared root
+    bool distanceSquaredRoot_ = true; // squared root
     bool useFullMerge_ = false;
 
     bool isPersistenceDiagram_ = false;
@@ -142,8 +142,8 @@ namespace ttk {
       barycenterMergeTree_ = imt;
     }
 
-    void setDistanceSquared(bool distanceSquared) {
-      distanceSquared_ = distanceSquared;
+    void setDistanceSquaredRoot(bool distanceSquaredRoot) {
+      distanceSquaredRoot_ = distanceSquaredRoot;
     }
 
     void setUseMinMaxPair(bool useMinMaxPair) {

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -626,7 +626,7 @@ namespace ttk {
       mergeTreeBary.setAssignmentSolver(assignmentSolverID_);
       mergeTreeBary.setIsCalled(true);
       mergeTreeBary.setThreadNumber(this->threadNumber_);
-      mergeTreeBary.setDistanceSquared(true); // squared root
+      mergeTreeBary.setDistanceSquaredRoot(true); // squared root
       mergeTreeBary.setProgressiveBarycenter(progressiveBarycenter_);
       mergeTreeBary.setDeterministic(deterministic_);
       mergeTreeBary.setTol(tol_);

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -511,7 +511,7 @@ namespace ttk {
           }
         }
       }
-      if(distanceSquared_)
+      if(distanceSquaredRoot_)
         distance = std::sqrt(distance);
 
       // ---------------------
@@ -601,10 +601,12 @@ namespace ttk {
                debug::LineMode::NEW, debug::Priority::INFO);
       printMsg(debug::Separator::L2);
       std::stringstream ss2;
-      ss2 << "DISTANCE²       = " << distance;
+      ss2 << "DISTANCE²       = "
+          << (distanceSquaredRoot_ ? distance * distance : distance);
       printMsg(ss2.str());
       std::stringstream ss3;
-      ss3 << "DISTANCE        = " << std::sqrt(distance);
+      ss3 << "DISTANCE        = "
+          << (distanceSquaredRoot_ ? distance : std::sqrt(distance));
       printMsg(ss3.str());
       printMsg(debug::Separator::L2);
       std::stringstream ss4;

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -87,11 +87,11 @@ namespace ttk {
         BranchMappingDistance branchDist;
         branchDist.setBaseMetric(branchMetric_);
         branchDist.setAssignmentSolver(assignmentSolverID_);
-        branchDist.setSquared(distanceSquared_);
+        branchDist.setSquared(not distanceSquaredRoot_);
         PathMappingDistance pathDist;
         pathDist.setBaseMetric(pathMetric_);
         pathDist.setAssignmentSolver(assignmentSolverID_);
-        pathDist.setSquared(distanceSquared_);
+        pathDist.setSquared(not distanceSquaredRoot_);
         pathDist.setComputeMapping(true);
 
         distanceMatrix[i][i] = 0.0;
@@ -171,7 +171,7 @@ namespace ttk {
               mergeTreeDistance.setNormalizedWassersteinReg(
                 normalizedWassersteinReg_);
               mergeTreeDistance.setKeepSubtree(keepSubtree_);
-              mergeTreeDistance.setDistanceSquared(distanceSquared_);
+              mergeTreeDistance.setDistanceSquaredRoot(distanceSquaredRoot_);
               mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
               mergeTreeDistance.setSaveTree(true);
               mergeTreeDistance.setCleanTree(true);
@@ -181,7 +181,7 @@ namespace ttk {
               if(useDoubleInput_) {
                 double weight = mixDistancesMinMaxPairWeight(isFirstInput);
                 mergeTreeDistance.setMinMaxPairWeight(weight);
-                mergeTreeDistance.setDistanceSquared(true);
+                mergeTreeDistance.setDistanceSquaredRoot(true);
               }
               std::vector<std::tuple<ftm::idNode, ftm::idNode>> outputMatching;
               distanceMatrix[i][j] = mergeTreeDistance.execute<dataType>(

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsBase.h
@@ -62,7 +62,7 @@ namespace ttk {
       mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
       mergeTreeDistance.setIsCalled(isCalled);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
-      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDistanceSquaredRoot(true); // squared root
       mergeTreeDistance.setNodePerTask(nodePerTask_);
       if(useDoubleInput) {
         double weight = mixDistancesMinMaxPairWeight(isFirstInput);

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -63,7 +63,7 @@ namespace ttk {
       mergeTreeDistance.setKeepSubtree(keepSubtree_);
       mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
-      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDistanceSquaredRoot(true); // squared root
       mergeTreeDistance.setDebugLevel(2);
       mergeTreeDistance.setPreprocess(false);
       mergeTreeDistance.setPostprocess(false);

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -109,7 +109,7 @@ namespace ttk {
       mergeTreeDistance.setKeepSubtree(keepSubtree_);
       mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
-      mergeTreeDistance.setDistanceSquared(true); // squared root
+      mergeTreeDistance.setDistanceSquaredRoot(true); // squared root
       mergeTreeDistance.setDebugLevel(2);
       mergeTreeDistance.setPreprocess(false);
       mergeTreeDistance.setPostprocess(false);

--- a/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
+++ b/core/vtk/ttkMergeTreeDistanceMatrix/ttkMergeTreeDistanceMatrix.h
@@ -170,12 +170,12 @@ public:
     return keepSubtree_;
   }
 
-  void SetDistanceSquared(bool distanceSquared) {
-    distanceSquared_ = distanceSquared;
+  void SetDistanceSquaredRoot(bool distanceSquaredRoot) {
+    distanceSquaredRoot_ = distanceSquaredRoot;
     Modified();
   }
-  int GetDistanceSquared() {
-    return distanceSquared_;
+  int GetDistanceSquaredRoot() {
+    return distanceSquaredRoot_;
   }
 
   vtkSetMacro(UseFieldDataParameters, bool);

--- a/paraview/xmls/MergeTreeDistanceMatrix.xml
+++ b/paraview/xmls/MergeTreeDistanceMatrix.xml
@@ -82,8 +82,8 @@ Online examples:
                 ${MERGE_TREE_INPUT_WIDGETS}
 
                 <IntVectorProperty
-                name="DistanceSquared"
-                command="SetDistanceSquared"
+                name="DistanceSquaredRoot"
+                command="SetDistanceSquaredRoot"
                 label="Distance Square Root"
                 number_of_elements="1"
                 default_values="1"
@@ -97,7 +97,7 @@ Online examples:
             <PropertyGroup panel_widget="Line" label="Input options">
               <Property name="UseFieldDataParameters"/>
               <Property name="MixtureCoefficient"/>
-              <Property name="DistanceSquared"/>
+              <Property name="DistanceSquaredRoot"/>
             </PropertyGroup>
             ${MERGE_TREE_PREPROCESS_WIDGETS}
 


### PR DESCRIPTION
This PR renames the misleading `distanceSquared` parameter of merge tree related filters to `distanceSquaredRoot` since setting this parameter to true will returns the squared root of the sum the costs (the real distance) and not the distance squared.

It also fixes the display of the distance computation to take into account this parameter.