### PR TITLE
[MergeTreeClustering] fix barycenter parameters xml logical expression

### DIFF
--- a/paraview/xmls/MergeTreeClustering.xml
+++ b/paraview/xmls/MergeTreeClustering.xml
@@ -142,8 +142,8 @@ Online examples:
                   <Hints>
                   <PropertyWidgetDecorator type="CompositeDecorator">
                     <Expression type="and">
-                      <Expression type="and">
-                        <Expression type="or">
+                      <Expression type="or">
+                        <Expression type="and">
                           <Expression type="and">
                             <PropertyWidgetDecorator type="GenericDecorator"
                                                     mode="visibility"
@@ -156,12 +156,12 @@ Online examples:
                           </Expression>
                           <PropertyWidgetDecorator type="GenericDecorator"
                                                   mode="visibility"
-                                                  property="Backend"
+                                                  property="KeepSubtree"
                                                   value="0" />
                         </Expression>
                         <PropertyWidgetDecorator type="GenericDecorator"
                                                 mode="visibility"
-                                                property="KeepSubtree"
+                                                property="Backend"
                                                 value="0" />
                       </Expression>
                       <PropertyWidgetDecorator type="GenericDecorator"
@@ -186,8 +186,8 @@ Online examples:
                   <Hints>
                   <PropertyWidgetDecorator type="CompositeDecorator">
                     <Expression type="and">
-                      <Expression type="and">
-                        <Expression type="or">
+                      <Expression type="or">
+                        <Expression type="and">
                           <Expression type="and">
                             <PropertyWidgetDecorator type="GenericDecorator"
                                                     mode="visibility"
@@ -200,12 +200,12 @@ Online examples:
                           </Expression>
                           <PropertyWidgetDecorator type="GenericDecorator"
                                                   mode="visibility"
-                                                  property="Backend"
+                                                  property="KeepSubtree"
                                                   value="0" />
                         </Expression>
                         <PropertyWidgetDecorator type="GenericDecorator"
                                                 mode="visibility"
-                                                property="KeepSubtree"
+                                                property="Backend"
                                                 value="0" />
                       </Expression>
                       <PropertyWidgetDecorator type="GenericDecorator"
@@ -230,8 +230,8 @@ Online examples:
                   <Hints>
                   <PropertyWidgetDecorator type="CompositeDecorator">
                     <Expression type="and">
-                      <Expression type="and">
-                        <Expression type="or">
+                      <Expression type="or">
+                        <Expression type="and">
                           <Expression type="and">
                             <PropertyWidgetDecorator type="GenericDecorator"
                                                     mode="visibility"
@@ -244,12 +244,12 @@ Online examples:
                           </Expression>
                           <PropertyWidgetDecorator type="GenericDecorator"
                                                   mode="visibility"
-                                                  property="Backend"
+                                                  property="KeepSubtree"
                                                   value="0" />
                         </Expression>
                         <PropertyWidgetDecorator type="GenericDecorator"
                                                 mode="visibility"
-                                                property="KeepSubtree"
+                                                property="Backend"
                                                 value="0" />
                       </Expression>
                       <PropertyWidgetDecorator type="GenericDecorator"


### PR DESCRIPTION
This PR fixes the logical expressions in the xml file of the `MergeTreeClustering` filter of some parameters related to the barycenter/clustering computation.

The problem was that the logical gates was not in the right order allowing for some parameters to not show after some very specific manipulation.

Example: select the custom backend, check the keep subtrees option, then select the Wasserstein backend, check the compute barycenter option, then the number of clusters option will not show.