### PR TITLE
MPI: On-the-fly computation of rank for vertices & cells of Implicit triangulations

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2816,24 +2816,24 @@ namespace ttk {
       return this->neighborRanks_;
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    virtual inline const std::vector<std::vector<SimplexId>> &
       getGhostCellsPerOwner() const {
-      return &(this->ghostCellsPerOwner_);
+      return this->ghostCellsPerOwner_;
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    virtual inline const std::vector<std::vector<SimplexId>> &
       getRemoteGhostCells() const {
-      return &(this->remoteGhostCells_);
+      return this->remoteGhostCells_;
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    virtual inline const std::vector<std::vector<SimplexId>> &
       getGhostVerticesPerOwner() const {
-      return &(this->ghostVerticesPerOwner_);
+      return this->ghostVerticesPerOwner_;
     }
 
-    virtual inline const std::vector<std::vector<SimplexId>> *
+    virtual inline const std::vector<std::vector<SimplexId>> &
       getRemoteGhostVertices() const {
-      return &(this->remoteGhostVertices_);
+      return this->remoteGhostVertices_;
     }
 
     virtual inline void setHasPreconditionedDistributedVertices(bool flag) {

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2839,6 +2839,29 @@ namespace ttk {
       return this->getVertexRankInternal(lvid);
     }
 
+    virtual inline int getCellRank(const SimplexId lcid) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedCells_) {
+        this->printErr("CellRankId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedCells() in a pre-process.");
+        return -1;
+      }
+      if(lcid < 0 || lcid >= this->getNumberOfCells()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(!ttk::isRunningWithMPI()) {
+        return lcid;
+      }
+      return this->getCellRankInternal(lcid);
+    }
+
     virtual inline const std::vector<int> &getNeighborRanks() const {
       return this->neighborRanks_;
     }
@@ -2953,6 +2976,11 @@ namespace ttk {
 
     virtual inline int
       getVertexRankInternal(const SimplexId ttkNotUsed(lvid)) const {
+      return -1;
+    }
+
+    virtual inline int
+      getCellRankInternal(const SimplexId ttkNotUsed(lcid)) const {
       return -1;
     }
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2542,8 +2542,15 @@ namespace ttk {
     inline void setVertexRankArray(const int *const rankArray) {
       this->vertexRankArray_ = rankArray;
     }
+    inline void setVertexGhostArray(const unsigned char *const data) {
+      this->vertexGhost_ = data;
+    }
     inline const int *getVertexRankArray() const {
       return this->vertexRankArray_;
+    }
+
+    inline void setCellGhostArray(const unsigned char *const data) {
+      this->cellGhost_ = data;
     }
 
     inline void setCellRankArray(const int *const rankArray) {
@@ -3710,6 +3717,11 @@ namespace ttk {
 
     // inverse of vertGid_
     std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
+
+    // "vtkGhostType" PointData array
+    const unsigned char *vertexGhost_{};
+    // "vtkGhostType" CellData array
+    const unsigned char *cellGhost_{};
 
     // list of neighboring ranks (sharing ghost cells to current rank)
     std::vector<int> neighborRanks_{};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2521,22 +2521,6 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_MPI
 
-    // GlobalPointIds, GlobalCellIds
-
-    inline void setCellsGlobalIds(const LongSimplexId *const cellGid) {
-      this->cellGid_ = cellGid;
-    }
-    inline const LongSimplexId *getCellsGlobalIds() const {
-      return this->cellGid_;
-    }
-
-    inline void setVertsGlobalIds(const LongSimplexId *array) {
-      this->vertGid_ = array;
-    }
-    inline const LongSimplexId *getVertsGlobalIds() const {
-      return this->vertGid_;
-    }
-
     // "vtkGhostType" on points & cells
 
     inline void setVertexGhostArray(const unsigned char *const data) {
@@ -2774,33 +2758,6 @@ namespace ttk {
         return this->getCellLocalIdInternal(gtid);
       }
       return -1;
-    }
-
-    virtual inline const std::unordered_map<SimplexId, SimplexId> &
-      getVertexGlobalIdMap() const {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
-         && this->getDimensionality() != 3) {
-        this->printErr("Only 1D, 2D and 3D datasets are supported");
-      }
-      if(!this->hasPreconditionedDistributedVertices_) {
-        this->printErr("VertexGlobalMap query without pre-process!");
-        this->printErr(
-          "Please call preconditionDistributedVertices() in a pre-process.");
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_;
-    }
-
-    virtual inline std::unordered_map<SimplexId, SimplexId> &
-      getVertexGlobalIdMap() {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
-         && this->getDimensionality() != 3) {
-        this->printErr("Only 1D, 2D and 3D datasets are supported");
-      }
-#endif // TTK_ENABLE_KAMIKAZE
-      return this->vertexGidToLid_;
     }
 
     virtual inline int getVertexRank(const SimplexId lvid) const {
@@ -3744,16 +3701,6 @@ namespace ttk {
     virtual int preconditionDistributedTriangles() {
       return 0;
     }
-
-    // "GlobalCellIds" from "Generate Global Ids"
-    // (warning: for Implicit/Periodic triangulations, concerns
-    // "squares"/"cubes" and not "triangles"/"tetrahedron")
-    const LongSimplexId *cellGid_{};
-    // "GlobalPointIds" from "Generate Global Ids"
-    const LongSimplexId *vertGid_{};
-
-    // inverse of vertGid_
-    std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
 
     // "vtkGhostType" PointData array
     const unsigned char *vertexGhost_{};

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2816,6 +2816,29 @@ namespace ttk {
       return this->vertexGidToLid_;
     }
 
+    virtual inline int getVertexRank(const SimplexId lvid) const {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->getDimensionality() != 1 && this->getDimensionality() != 2
+         && this->getDimensionality() != 3) {
+        this->printErr("Only 1D, 2D and 3D datasets are supported");
+        return -1;
+      }
+      if(!this->hasPreconditionedDistributedVertices_) {
+        this->printErr("VertexRankId query without pre-process!");
+        this->printErr(
+          "Please call preconditionDistributedVertices() in a pre-process.");
+        return -1;
+      }
+      if(lvid < 0 || lvid >= this->getNumberOfVertices()) {
+        return -1;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      if(!ttk::isRunningWithMPI()) {
+        return lvid;
+      }
+      return this->getVertexRankInternal(lvid);
+    }
+
     virtual inline const std::vector<int> &getNeighborRanks() const {
       return this->neighborRanks_;
     }
@@ -2925,6 +2948,11 @@ namespace ttk {
 
     virtual inline SimplexId
       getTriangleLocalIdInternal(const SimplexId ttkNotUsed(gtid)) const {
+      return -1;
+    }
+
+    virtual inline int
+      getVertexRankInternal(const SimplexId ttkNotUsed(lvid)) const {
       return -1;
     }
 

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -2537,27 +2537,14 @@ namespace ttk {
       return this->vertGid_;
     }
 
-    // RankArray on points & cells
+    // "vtkGhostType" on points & cells
 
-    inline void setVertexRankArray(const int *const rankArray) {
-      this->vertexRankArray_ = rankArray;
-    }
     inline void setVertexGhostArray(const unsigned char *const data) {
       this->vertexGhost_ = data;
-    }
-    inline const int *getVertexRankArray() const {
-      return this->vertexRankArray_;
     }
 
     inline void setCellGhostArray(const unsigned char *const data) {
       this->cellGhost_ = data;
-    }
-
-    inline void setCellRankArray(const int *const rankArray) {
-      this->cellRankArray_ = rankArray;
-    }
-    inline const int *getCellRankArray() const {
-      return this->cellRankArray_;
     }
 
     /// Pre-process the global boundaries when using MPI. Local bounds should
@@ -3764,12 +3751,6 @@ namespace ttk {
     const LongSimplexId *cellGid_{};
     // "GlobalPointIds" from "Generate Global Ids"
     const LongSimplexId *vertGid_{};
-    // PointData "RankArray" from "TTKGhostCellPreconditioning"
-    const int *vertexRankArray_{};
-    // CellData "RankArray" from "TTKGhostCellPreconditioning"
-    // (warning: for Implicit/Periodic triangulations, concerns
-    // "squares"/"cubes" and not "triangles"/"tetrahedron")
-    const int *cellRankArray_{};
 
     // inverse of vertGid_
     std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};

--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -24,11 +24,11 @@ namespace ttk {
   public:
     ArrayPreconditioning();
 
-    template <typename DT, typename IT>
+    template <typename DT, typename IT, typename GVR>
     int processScalarArray(ttk::SimplexId *orderArray,
                            const DT *scalarArray,
                            const IT *globalIds,
-                           const int *rankArray,
+                           const GVR &getVertexRank,
                            const size_t nVerts,
                            const int burstSize) const { // start global timer
       ttk::Timer globalTimer;
@@ -49,14 +49,15 @@ namespace ttk {
       if(ttk::isRunningWithMPI()) {
         std::vector<int> neighbors{};
         ttk::produceOrdering<DT, IT>(orderArray, scalarArray, globalIds,
-                                     rankArray, nVerts, burstSize, neighbors);
+                                     getVertexRank, nVerts, burstSize,
+                                     neighbors);
       }
 #else
       this->printMsg("MPI not enabled!");
       TTK_FORCE_USE(orderArray);
       TTK_FORCE_USE(scalarArray);
       TTK_FORCE_USE(globalIds);
-      TTK_FORCE_USE(rankArray);
+      TTK_FORCE_USE(getVertexRank);
       TTK_FORCE_USE(burstSize);
       return 0;
 #endif

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -126,11 +126,10 @@ namespace ttk {
     int valuesTag = 103 * tagMultiplier;
     if(rankToSend == ttk::MPIrank_) {
       int neighborNumber = neighbors.size();
-      const std::vector<std::vector<ttk::SimplexId>> *ghostCellsPerOwner
-        = triangulation->getGhostCellsPerOwner();
+      const auto &ghostCellsPerOwner = triangulation->getGhostCellsPerOwner();
       // receive the scalar values
       for(int r = 0; r < neighborNumber; r++) {
-        ttk::SimplexId nValues = ghostCellsPerOwner->at(neighbors.at(r)).size();
+        ttk::SimplexId nValues = ghostCellsPerOwner[neighbors[r]].size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
           MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT,
@@ -139,8 +138,7 @@ namespace ttk {
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
-              ttk::SimplexId globalId
-                = ghostCellsPerOwner->at(neighbors.at(r))[i];
+              ttk::SimplexId globalId = ghostCellsPerOwner[neighbors[r]][i];
               ttk::SimplexId localId = triangulation->getCellLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
@@ -153,8 +151,8 @@ namespace ttk {
       if(std::find(neighbors.begin(), neighbors.end(), rankToSend)
          != neighbors.end()) {
         // get the needed globalids from the triangulation
-        std::vector<ttk::SimplexId> ghostCellsForThisRank
-          = triangulation->getRemoteGhostCells()->at(rankToSend);
+        const auto &ghostCellsForThisRank
+          = triangulation->getRemoteGhostCells()[rankToSend];
         ttk::SimplexId nValues = ghostCellsForThisRank.size();
         if(nValues > 0) {
           // assemble the scalar values
@@ -195,12 +193,11 @@ namespace ttk {
     int valuesTag = 103 * tagMultiplier;
     if(rankToSend == ttk::MPIrank_) {
       int neighborNumber = neighbors.size();
-      const std::vector<std::vector<ttk::SimplexId>> *ghostVerticesPerOwner
+      const auto &ghostVerticesPerOwner
         = triangulation->getGhostVerticesPerOwner();
       // receive the scalar values
       for(int r = 0; r < neighborNumber; r++) {
-        ttk::SimplexId nValues
-          = ghostVerticesPerOwner->at(neighbors.at(r)).size();
+        ttk::SimplexId nValues = ghostVerticesPerOwner[neighbors[r]].size();
         std::vector<DT> receivedValues(nValues * dimensionNumber);
         if(nValues > 0) {
           MPI_Recv(receivedValues.data(), nValues * dimensionNumber, MPI_DT,
@@ -208,8 +205,7 @@ namespace ttk {
           for(ttk::SimplexId i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
-              ttk::SimplexId globalId
-                = ghostVerticesPerOwner->at(neighbors.at(r))[i];
+              ttk::SimplexId globalId = ghostVerticesPerOwner[neighbors[r]][i];
               ttk::SimplexId localId
                 = triangulation->getVertexLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
@@ -223,8 +219,8 @@ namespace ttk {
       if(std::find(neighbors.begin(), neighbors.end(), rankToSend)
          != neighbors.end()) {
         // get the needed globalids from the triangulation
-        std::vector<ttk::SimplexId> ghostVerticesForThisRank
-          = triangulation->getRemoteGhostVertices()->at(rankToSend);
+        const auto &ghostVerticesForThisRank
+          = triangulation->getRemoteGhostVertices()[rankToSend];
         ttk::SimplexId nValues = ghostVerticesForThisRank.size();
         if(nValues > 0) {
           // assemble the scalar values

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -486,9 +486,6 @@ int DiscreteGradient::processLowerStars(
   // store lower star structure
   lowerStarType Lx;
 
-#ifdef TTK_ENABLE_MPI
-  const int *vertexRankArray = triangulation.getVertexRankArray();
-#endif
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_) \
   firstprivate(Lx, pqZero, pqOne)
@@ -535,7 +532,8 @@ int DiscreteGradient::processLowerStars(
     // In case the vertex is a ghost, the gradient of the
     // simplices of its star is set to GHOST_GRADIENT
 #ifdef TTK_ENABLE_MPI
-    if(vertexRankArray != nullptr && vertexRankArray[x] != ttk::MPIrank_) {
+    if(ttk::isRunningWithMPI()
+       && triangulation.getVertexRank(x) != ttk::MPIrank_) {
       int sizeDim = Lx.size();
       for(int i = 0; i < sizeDim; i++) {
         int nCells = Lx[i].size();

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -106,7 +106,8 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     }
     ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
                                                ttk::SimplexId>(
-      charBoundary.data(), this->edgeRankArray_.data(),
+      charBoundary.data(),
+      [this](const SimplexId a) { return this->edgeRankArray_[a]; },
       this->edgeLidToGid_.data(), this->edgeGidToLid_, edgeNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < edgeNumber; ++i) {
@@ -237,7 +238,8 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     }
     ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
                                                ttk::SimplexId>(
-      charBoundary.data(), this->triangleRankArray_.data(),
+      charBoundary.data(),
+      [this](const SimplexId a) { return this->triangleRankArray_[a]; },
       this->triangleLidToGid_.data(), this->triangleGidToLid_, triangleNumber,
       ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < triangleNumber; ++i) {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -620,6 +620,13 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_MPI
 
+    inline void setCellsGlobalIds(const LongSimplexId *const cellGid) {
+      this->cellGid_ = cellGid;
+    }
+    inline void setVertsGlobalIds(const LongSimplexId *array) {
+      this->vertGid_ = array;
+    }
+
     inline SimplexId
       getVertexGlobalIdInternal(const SimplexId lvid) const override {
       return this->vertGid_[lvid];
@@ -688,6 +695,10 @@ namespace ttk {
       return this->vertexRankArray_[lvid];
     }
 
+    inline std::unordered_map<SimplexId, SimplexId> &getVertexGlobalIdMap() {
+      return this->vertexGidToLid_;
+    }
+
     inline void setBoundingBox(const double *const bBox) {
       this->boundingBox_
         = {bBox[0], bBox[1], bBox[2], bBox[3], bBox[4], bBox[5]};
@@ -739,6 +750,13 @@ namespace ttk {
     // number of CellRanges per rank
     std::vector<int> nRangesPerRank_{};
 
+    // "GlobalCellIds" from "Generate Global Ids"
+    const LongSimplexId *cellGid_{};
+    // "GlobalPointIds" from "Generate Global Ids"
+    const LongSimplexId *vertGid_{};
+
+    // inverse of vertGid_
+    std::unordered_map<SimplexId, SimplexId> vertexGidToLid_{};
     // inverse of cellGid_
     std::unordered_map<SimplexId, SimplexId> cellGidToLid_{};
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -688,6 +688,11 @@ namespace ttk {
       return this->vertexRankArray_[lvid];
     }
 
+    inline void setBoundingBox(const double *const bBox) {
+      this->boundingBox_
+        = {bBox[0], bBox[1], bBox[2], bBox[3], bBox[4], bBox[5]};
+    }
+
   protected:
     template <typename Func0, typename Func1, typename Func2>
     int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,
@@ -703,6 +708,8 @@ namespace ttk {
     int preconditionDistributedEdges() override;
     int preconditionDistributedVertices() override;
     int preconditionDistributedTriangles() override;
+    int preconditionVertexRankArray();
+    int preconditionCellRankArray();
     int preconditionEdgeRankArray() override;
     int preconditionTriangleRankArray() override;
 
@@ -740,6 +747,10 @@ namespace ttk {
     std::vector<SimplexId> triangleLidToGid_{};
     std::unordered_map<SimplexId, SimplexId> triangleGidToLid_{};
 
+    std::array<double, 6> boundingBox_{};
+
+    std::vector<int> vertexRankArray_{};
+    std::vector<int> cellRankArray_{};
     std::vector<int> edgeRankArray_{};
     std::vector<int> triangleRankArray_{};
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -684,6 +684,10 @@ namespace ttk {
       return it->second;
     }
 
+    inline int getVertexRankInternal(const SimplexId lvid) const override {
+      return this->vertexRankArray_[lvid];
+    }
+
   protected:
     template <typename Func0, typename Func1, typename Func2>
     int exchangeDistributedInternal(const Func0 &getGlobalSimplexId,

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3191,6 +3191,11 @@ void ttk::ImplicitTriangulation::createMetaGrid(const double *const bounds) {
     return;
   }
 
+  // no need to create it anew?
+  if(this->metaGrid_ != nullptr) {
+    return;
+  }
+
   // Reorganize bounds to only execute Allreduce twice
   std::array<double, 6> tempBounds = {
     bounds[0], bounds[2], bounds[4], bounds[1], bounds[3], bounds[5],

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3077,10 +3077,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
   if(!ttk::hasInitializedMPI()) {
     return -1;
   }
-  if(this->cellRankArray_ == nullptr) {
-    this->printErr("Missing cell RankArray!");
-    return -3;
-  }
   if(this->cellGhost_ == nullptr) {
     this->printErr("Missing cell ghost array!");
     return -3;

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3242,6 +3242,44 @@ void ttk::ImplicitTriangulation::createMetaGrid(const double *const bounds) {
   this->metaGrid_->preconditionBoundaryTriangles();
 }
 
+std::array<SimplexId, 3>
+  ttk::ImplicitTriangulation::getVertGlobalCoords(const SimplexId lvid) const {
+
+  // local vertex coordinates
+  std::array<SimplexId, 3> p{};
+  if(this->dimensionality_ == 3) {
+    this->vertexToPosition(lvid, p.data());
+  } else if(this->dimensionality_ == 2) {
+    this->vertexToPosition2d(lvid, p.data());
+  }
+
+  // global vertex coordinates
+  p[0] += this->localGridOffset_[0];
+  p[1] += this->localGridOffset_[1];
+  p[2] += this->localGridOffset_[2];
+
+  return p;
+}
+
+std::array<SimplexId, 3>
+  ttk::ImplicitTriangulation::getVertLocalCoords(const SimplexId gvid) const {
+
+  // global vertex coordinates
+  std::array<SimplexId, 3> p{};
+  if(this->dimensionality_ == 3) {
+    this->metaGrid_->vertexToPosition(gvid, p.data());
+  } else if(this->dimensionality_ == 2) {
+    this->metaGrid_->vertexToPosition2d(gvid, p.data());
+  }
+
+  // local vertex coordinates
+  p[0] -= this->localGridOffset_[0];
+  p[1] -= this->localGridOffset_[1];
+  p[2] -= this->localGridOffset_[2];
+
+  return p;
+}
+
 SimplexId ttk::ImplicitTriangulation::getVertexGlobalIdInternal(
   const SimplexId lvid) const {
 
@@ -3259,19 +3297,7 @@ SimplexId ttk::ImplicitTriangulation::getVertexGlobalIdInternal(
   }
 #endif // TTK_ENABLE_KAMIKAZE
 
-  // local vertex coordinates
-  std::array<SimplexId, 3> p{};
-  if(this->dimensionality_ == 3) {
-    this->vertexToPosition(lvid, p.data());
-  } else if(this->dimensionality_ == 2) {
-    this->vertexToPosition2d(lvid, p.data());
-  }
-
-  // global vertex coordinates
-  p[0] += this->localGridOffset_[0];
-  p[1] += this->localGridOffset_[1];
-  p[2] += this->localGridOffset_[2];
-
+  const auto p{this->getVertGlobalCoords(lvid)};
   const auto &dims{this->metaGrid_->getGridDimensions()};
 
   // global coordinates to identifier (inverse of vertexToPosition)
@@ -3296,19 +3322,7 @@ SimplexId ttk::ImplicitTriangulation::getVertexLocalIdInternal(
   }
 #endif // TTK_ENABLE_KAMIKAZE
 
-  // global vertex coordinates
-  std::array<SimplexId, 3> p{};
-  if(this->dimensionality_ == 3) {
-    this->metaGrid_->vertexToPosition(gvid, p.data());
-  } else if(this->dimensionality_ == 2) {
-    this->metaGrid_->vertexToPosition2d(gvid, p.data());
-  }
-
-  // local vertex coordinates
-  p[0] -= this->localGridOffset_[0];
-  p[1] -= this->localGridOffset_[1];
-  p[2] -= this->localGridOffset_[2];
-
+  const auto p{this->getVertLocalCoords(gvid)};
   const auto &dims{this->getGridDimensions()};
 
   // local coordinates to identifier (inverse of vertexToPosition)

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -269,6 +269,7 @@ namespace ttk {
     SimplexId getTriangleLocalIdInternal(const SimplexId gtid) const override;
 
     int getVertexRankInternal(const SimplexId lvid) const override;
+    int getCellRankInternal(const SimplexId lcid) const override;
 
   protected:
     bool isVertexOnGlobalBoundaryInternal(const SimplexId lvid) const override;
@@ -293,6 +294,8 @@ namespace ttk {
     std::array<SimplexId, 3> localGridOffset_{};
     // hold the neighboring ranks vertex bounding boxes (metaGrid_ coordinates)
     std::vector<std::array<SimplexId, 6>> neighborVertexBBoxes_{};
+    // hold the neighboring ranks cells bounding boxes (metaGrid_ coordinates)
+    std::vector<std::array<SimplexId, 6>> neighborCellBBoxes_{};
 #endif // TTK_ENABLE_MPI
 
     enum class VertexPosition : char {

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -279,6 +279,9 @@ namespace ttk {
                                    const SimplexId v1) const;
     SimplexId findTriangleFromVertices(std::array<SimplexId, 3> &verts) const;
 
+    std::array<SimplexId, 3> getVertGlobalCoords(const SimplexId lvid) const;
+    std::array<SimplexId, 3> getVertLocalCoords(const SimplexId gvid) const;
+
 #endif // TTK_ENABLE_MPI
 
   protected:

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -268,6 +268,8 @@ namespace ttk {
     SimplexId getTriangleGlobalIdInternal(const SimplexId ltid) const override;
     SimplexId getTriangleLocalIdInternal(const SimplexId gtid) const override;
 
+    int getVertexRankInternal(const SimplexId lvid) const override;
+
   protected:
     bool isVertexOnGlobalBoundaryInternal(const SimplexId lvid) const override;
     bool isEdgeOnGlobalBoundaryInternal(const SimplexId leid) const override;
@@ -289,6 +291,8 @@ namespace ttk {
     std::shared_ptr<ImplicitTriangulation> metaGrid_{};
     // offset coordinates of the local grid inside the metaGrid_
     std::array<SimplexId, 3> localGridOffset_{};
+    // hold the neighboring ranks vertex bounding boxes (metaGrid_ coordinates)
+    std::vector<std::array<SimplexId, 6>> neighborVertexBBoxes_{};
 #endif // TTK_ENABLE_MPI
 
     enum class VertexPosition : char {

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -244,21 +244,14 @@ int ttk::ScalarFieldCriticalPoints::executeLegacy(
 
   if(triangulation) {
 
-#if TTK_ENABLE_MPI
-    const auto rankArray{triangulation->getVertexRankArray()};
-    if(ttk::isRunningWithMPI() && rankArray == nullptr) {
-      this->printErr("Missing vertex rank array");
-      return -6;
-    }
-#endif // TTK_ENABLE_MPI
-
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic, chunkSize) num_threads(threadNumber_)
 #endif
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
 #if TTK_ENABLE_MPI
       if(!isRunningWithMPI()
-         || (isRunningWithMPI() && (rankArray[i] == ttk::MPIrank_))) {
+         || (isRunningWithMPI()
+             && (triangulation->getVertexRank(i) == ttk::MPIrank_))) {
 #endif
         vertexTypes[i] = getCriticalType(i, offsets, triangulation);
 #if TTK_ENABLE_MPI

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -104,8 +104,7 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
 
 #if TTK_ENABLE_MPI
   bool useMPI{false};
-  if(ttk::isRunningWithMPI() && triangulation->getVertexRankArray() != nullptr
-     && triangulation->getVertsGlobalIds() != nullptr)
+  if(ttk::isRunningWithMPI() && triangulation->getVertsGlobalIds() != nullptr)
     useMPI = true;
 #endif
   SimplexId vertexNumber = triangulation->getNumberOfVertices();

--- a/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
+++ b/core/base/scalarFieldSmoother/ScalarFieldSmoother.h
@@ -102,11 +102,6 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
     return -4;
 #endif
 
-#if TTK_ENABLE_MPI
-  bool useMPI{false};
-  if(ttk::isRunningWithMPI() && triangulation->getVertsGlobalIds() != nullptr)
-    useMPI = true;
-#endif
   SimplexId vertexNumber = triangulation->getNumberOfVertices();
 
   std::vector<dataType> tmpData(vertexNumber * dimensionNumber_, 0);
@@ -164,14 +159,14 @@ int ttk::ScalarFieldSmoother::smooth(const triangulationType *triangulation,
         }
       }
     }
-#if TTK_ENABLE_MPI
-    if(useMPI) {
+#ifdef TTK_ENABLE_MPI
+    if(ttk::isRunningWithMPI()) {
       // after each iteration we need to exchange the ghostcell values with our
       // neighbors
       exchangeGhostVertices<dataType, triangulationType>(
         outputData, triangulation, ttk::MPIcomm_, dimensionNumber_);
     }
-#endif
+#endif // TTK_ENABLE_MPI
 
     if(debugLevel_ >= (int)(debug::Priority::INFO)) {
       if(!(it % ((numberOfIterations) / timeBuckets))) {

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1380,12 +1380,12 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param leid Input local vertex identifier.
     /// \return vertexId Input global vertex identifier.
-    inline SimplexId getVertexGlobalId(const SimplexId leid) const override {
+    inline SimplexId getVertexGlobalId(const SimplexId lvid) const override {
 #ifndef TTK_ENABLE_KAMIKAZE
       if(isEmptyCheck())
         return -1;
 #endif
-      return abstractTriangulation_->getVertexGlobalId(leid);
+      return abstractTriangulation_->getVertexGlobalId(lvid);
     }
 
     /// Get the global id to local id map for the triangulation.
@@ -1399,23 +1399,8 @@ namespace ttk {
     /// from any time performance measurement.
     /// \param map the std::unordered_map<SimplexId, SimplexId> in which we want
     /// our GidToLidMap. \return 0 if succesful, -1 else.
-    inline const std::unordered_map<SimplexId, SimplexId> &
-      getVertexGlobalIdMap() const override {
-#ifndef TTK_ENABLE_KAMIKAZE
-      if(isEmptyCheck())
-        return this->getVertexGlobalIdMap();
-#endif
-      return abstractTriangulation_->getVertexGlobalIdMap();
-    }
-
-    /// Get the pointer of global id to local id map for the triangulation.
-    ///
-    /// \note This method is similar to getVertexGlobalIdMap() except it is not
-    /// const and allows for modification of the triangulation and the map.
-
-    inline std::unordered_map<SimplexId, SimplexId> &
-      getVertexGlobalIdMap() override {
-      return abstractTriangulation_->getVertexGlobalIdMap();
+    inline std::unordered_map<SimplexId, SimplexId> &getVertexGlobalIdMap() {
+      return this->explicitTriangulation_.getVertexGlobalIdMap();
     }
 
     /// Set the flag for precondtioning of distributed vertices of the
@@ -2844,39 +2829,20 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_MPI
 
-    // support TriangulationManager by setting "RankArray" & "Global
-    // Ids" arrays in all triangulation instances
+    // GlobalPointIds, GlobalCellIds (only for ExplicitTriangulation)
 
-#define TTK_GET_SET_ARRAYS(FNAME, TYPE)                         \
-  inline void set##FNAME(const TYPE *const data) {              \
-    if(data == nullptr) {                                       \
-      return;                                                   \
-    }                                                           \
-    this->explicitTriangulation_.set##FNAME(data);              \
-    this->compactTriangulation_.set##FNAME(data);               \
-    this->implicitTriangulation_.set##FNAME(data);              \
-    this->implicitPreconditionsTriangulation_.set##FNAME(data); \
-    this->periodicImplicitTriangulation_.set##FNAME(data);      \
-    this->periodicPreconditionsTriangulation_.set##FNAME(data); \
-  }                                                             \
-  inline const TYPE *get##FNAME() const {                       \
-    if(this->abstractTriangulation_ != nullptr) {               \
-      return this->abstractTriangulation_->get##FNAME();        \
-    }                                                           \
-    return {};                                                  \
-  }
+    inline void setVertsGlobalIds(const LongSimplexId *data) {
+      this->explicitTriangulation_.setVertsGlobalIds(data);
+    }
+    inline void setCellsGlobalIds(const LongSimplexId *const data) {
+      this->explicitTriangulation_.setCellsGlobalIds(data);
+    }
 
-    // GlobalPointIds, GlobalCellIds
-
-    TTK_GET_SET_ARRAYS(VertsGlobalIds, LongSimplexId);
-    TTK_GET_SET_ARRAYS(CellsGlobalIds, LongSimplexId);
-
-#undef TTK_GET_SET_ARRAYS
+    // "vtkGhostType" on vertices & cells
 
     inline void setVertexGhostArray(const unsigned char *data) {
       this->abstractTriangulation_->setVertexGhostArray(data);
     }
-
     inline void setCellGhostArray(const unsigned char *data) {
       this->abstractTriangulation_->setCellGhostArray(data);
     }

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1448,6 +1448,10 @@ namespace ttk {
       return abstractTriangulation_->getRemoteGhostCells();
     }
 
+    inline int getVertexRank(const SimplexId lvid) const override {
+      return this->abstractTriangulation_->getVertexRank(lvid);
+    }
+
     /// Get the corresponding local id for a given global id of a vertex.
     ///
     /// \pre For this function to behave correctly,

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1438,12 +1438,12 @@ namespace ttk {
       return abstractTriangulation_->getNeighborRanks();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *
+    inline const std::vector<std::vector<SimplexId>> &
       getGhostCellsPerOwner() const override {
       return abstractTriangulation_->getGhostCellsPerOwner();
     }
 
-    inline const std::vector<std::vector<SimplexId>> *
+    inline const std::vector<std::vector<SimplexId>> &
       getRemoteGhostCells() const override {
       return abstractTriangulation_->getRemoteGhostCells();
     }

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2867,11 +2867,6 @@ namespace ttk {
     TTK_GET_SET_ARRAYS(VertsGlobalIds, LongSimplexId);
     TTK_GET_SET_ARRAYS(CellsGlobalIds, LongSimplexId);
 
-    // RankArray on points & cells
-
-    TTK_GET_SET_ARRAYS(VertexRankArray, int);
-    TTK_GET_SET_ARRAYS(CellRankArray, int);
-
 #undef TTK_GET_SET_ARRAYS
 
     inline void setVertexGhostArray(const unsigned char *data) {

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -2872,6 +2872,14 @@ namespace ttk {
 
 #undef TTK_GET_SET_ARRAYS
 
+    inline void setVertexGhostArray(const unsigned char *data) {
+      this->abstractTriangulation_->setVertexGhostArray(data);
+    }
+
+    inline void setCellGhostArray(const unsigned char *data) {
+      this->abstractTriangulation_->setCellGhostArray(data);
+    }
+
 #endif // TTK_ENABLE_MPI
 
   protected:

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1480,6 +1480,8 @@ namespace ttk {
     inline void createMetaGrid(const double *const bounds) {
       this->implicitPreconditionsTriangulation_.createMetaGrid(bounds);
       this->implicitTriangulation_.createMetaGrid(bounds);
+      // also pass bounding box to ExplicitTriangulation...
+      this->explicitTriangulation_.setBoundingBox(bounds);
     }
 
     /**

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -189,14 +189,17 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       }
       if(ttk::isRunningWithMPI()) {
         auto vtkGlobalPointIds = inputData->GetPointData()->GetGlobalIds();
-        auto rankArray = inputData->GetPointData()->GetArray("RankArray");
+        const auto triangulation{this->GetTriangulation(inputData)};
         ttkTypeMacroA(
           scalarArray->GetDataType(),
           (ttk::produceOrdering<T0>(
             ttkUtils::GetPointer<ttk::SimplexId>(newOrderArray),
             ttkUtils::GetPointer<T0>(scalarArray),
             ttkUtils::GetPointer<ttk::LongSimplexId>(vtkGlobalPointIds),
-            ttkUtils::GetPointer<int>(rankArray), nVertices, 500, neighbors)));
+            [triangulation](const ttk::SimplexId a) {
+              return triangulation->getVertexRank(a);
+            },
+            nVertices, 500, neighbors)));
       } else
 #endif // TTK_ENABLE_MPI
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -698,7 +698,8 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
   // If the global ids are not valid, they are computed again
   if(!pointValidity || !cellValidity) {
     bool flag{false};
-    if(triangulation) {
+    if(triangulation != nullptr
+       && triangulation->getType() == ttk::Triangulation::Type::EXPLICIT) {
       flag = this->GenerateGlobalIds(
         input, triangulation->getVertexGlobalIdMap(), neighborRanks);
     } else {

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -433,8 +433,7 @@ int ttkAlgorithm::RequestDataObject(vtkInformation *ttkNotUsed(request),
 
 bool ttkAlgorithm::checkGlobalIdValidity(ttk::LongSimplexId *globalIds,
                                          ttk::SimplexId simplexNumber,
-                                         unsigned char *ghost,
-                                         int *rankArray) {
+                                         unsigned char *ghost) {
   ttk::SimplexId ghostNumber = 0;
   if(ghost != nullptr) {
 #ifdef TTK_ENABLE_OPENMP
@@ -443,17 +442,6 @@ bool ttkAlgorithm::checkGlobalIdValidity(ttk::LongSimplexId *globalIds,
     for(ttk::SimplexId i = 0; i < simplexNumber; i++) {
       if(ghost[i] == 1) {
         ghostNumber++;
-      }
-    }
-  } else {
-    if(rankArray != nullptr) {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for reduction(+ : ghostNumber)
-#endif // TTK_ENABLE_OPENMP
-      for(ttk::SimplexId i = 0; i < simplexNumber; i++) {
-        if(rankArray[i] != ttk::MPIrank_) {
-          ghostNumber++;
-        }
       }
     }
   }
@@ -674,11 +662,7 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
     }
   }
 
-  int *vertexRankArray
-    = ttkUtils::GetPointer<int>(input->GetPointData()->GetArray("RankArray"));
-
   // Get the neighbor ranks
-  bool preciseNeighborComputation{false};
   std::vector<int> &neighborRanks{
     triangulation != nullptr ? triangulation->getNeighborRanks() : neighbors};
 
@@ -688,13 +672,7 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
   }
 
   if(neighborRanks.empty()) {
-    if(vertexRankArray == nullptr) {
-      ttk::preconditionNeighborsUsingBoundingBox(boundingBox, neighborRanks);
-    } else {
-      ttk::preconditionNeighborsUsingRankArray(
-        neighborRanks, vertexRankArray, vertexNumber, ttk::MPIcomm_);
-      preciseNeighborComputation = true;
-    }
+    ttk::preconditionNeighborsUsingBoundingBox(boundingBox, neighborRanks);
   }
 
   // Checks if global ids are valid
@@ -708,17 +686,14 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
   if(globalPointIds != nullptr) {
     unsigned char *ghostPoints = ttkUtils::GetPointer<unsigned char>(
       input->GetPointData()->GetArray("vtkGhostType"));
-    pointValidity = checkGlobalIdValidity(
-      globalPointIds, vertexNumber, ghostPoints, vertexRankArray);
+    pointValidity
+      = checkGlobalIdValidity(globalPointIds, vertexNumber, ghostPoints);
   }
   if(pointValidity && globalCellIds != nullptr) {
 
-    int *cellRankArray
-      = ttkUtils::GetPointer<int>(input->GetCellData()->GetArray("RankArray"));
     unsigned char *ghostCells = ttkUtils::GetPointer<unsigned char>(
       input->GetCellData()->GetArray("vtkGhostType"));
-    cellValidity = checkGlobalIdValidity(
-      globalCellIds, cellNumber, ghostCells, cellRankArray);
+    cellValidity = checkGlobalIdValidity(globalCellIds, cellNumber, ghostCells);
   }
   // If the global ids are not valid, they are computed again
   if(!pointValidity || !cellValidity) {
@@ -734,55 +709,6 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
     if(triangulation) {
       triangulation->setHasPreconditionedDistributedVertices(flag);
     }
-  }
-  // If the RankArray array doesn't exist for pointdata, it is created
-  if(input->GetPointData()->GetArray("RankArray") == nullptr) {
-    std::vector<int> rankArray(vertexNumber, 0);
-    if(ttk::isRunningWithMPI()) {
-      ttk::produceRankArray(rankArray,
-                            ttkUtils::GetPointer<ttk::LongSimplexId>(
-                              input->GetPointData()->GetGlobalIds()),
-                            ttkUtils::GetPointer<unsigned char>(
-                              input->GetPointData()->GetArray("vtkGhostType")),
-                            vertexNumber, boundingBox, neighborRanks);
-    }
-    if(!preciseNeighborComputation) {
-      ttk::preconditionNeighborsUsingRankArray<int>(
-        neighborRanks, rankArray.data(), vertexNumber, ttk::MPIcomm_);
-    }
-    vtkNew<vtkIntArray> vtkRankArray{};
-    vtkRankArray->SetName("RankArray");
-    vtkRankArray->SetNumberOfComponents(1);
-    vtkRankArray->SetNumberOfTuples(vertexNumber);
-
-    for(int i = 0; i < vertexNumber; i++) {
-      vtkRankArray->SetComponent(i, 0, rankArray[i]);
-    }
-
-    input->GetPointData()->AddArray(vtkRankArray);
-  }
-
-  // If the RankArray array doesn't exist for celldata, it is created
-  if(input->GetCellData()->GetArray("RankArray") == nullptr) {
-    std::vector<int> cellsRankArray(cellNumber, 0);
-    if(ttk::isRunningWithMPI()) {
-      ttk::produceRankArray(cellsRankArray,
-                            ttkUtils::GetPointer<ttk::LongSimplexId>(
-                              input->GetCellData()->GetGlobalIds()),
-                            ttkUtils::GetPointer<unsigned char>(
-                              input->GetCellData()->GetArray("vtkGhostType")),
-                            cellNumber, boundingBox, neighborRanks);
-    }
-    vtkNew<vtkIntArray> vtkCellsRankArray{};
-    vtkCellsRankArray->SetName("RankArray");
-    vtkCellsRankArray->SetNumberOfComponents(1);
-    vtkCellsRankArray->SetNumberOfTuples(cellNumber);
-
-    for(int i = 0; i < cellNumber; i++) {
-      vtkCellsRankArray->SetComponent(i, 0, cellsRankArray[i]);
-    }
-
-    input->GetCellData()->AddArray(vtkCellsRankArray);
   }
 }
 

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -790,12 +790,14 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
   if(pd == nullptr) {
     triangulation->printWrn("No point data on input object");
   } else {
-    // provide "GlobalPointIds" & "RankArray" point data arrays
+    // provide "GlobalPointIds" & "vtkGhostType" point data arrays
     // to the triangulation
     triangulation->setVertsGlobalIds(
       ttkUtils::GetPointer<ttk::LongSimplexId>(pd->GetGlobalIds()));
     triangulation->setVertexRankArray(
       ttkUtils::GetPointer<int>(pd->GetArray("RankArray")));
+    triangulation->setVertexGhostArray(
+      ttkUtils::GetPointer<unsigned char>(pd->GetArray("vtkGhostType")));
     triangulation->preconditionDistributedVertices();
   }
 
@@ -803,12 +805,14 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
   if(cd == nullptr) {
     triangulation->printWrn("No cell data on input object");
   } else {
-    // provide "GlobalCellIds" & "RankArray" cell data arrays to
+    // provide "GlobalCellIds" & "vtkGhostType" cell data arrays to
     // the triangulation
     triangulation->setCellsGlobalIds(
       ttkUtils::GetPointer<ttk::LongSimplexId>(cd->GetGlobalIds()));
     triangulation->setCellRankArray(
       ttkUtils::GetPointer<int>(cd->GetArray("RankArray")));
+    triangulation->setCellGhostArray(
+      ttkUtils::GetPointer<unsigned char>(cd->GetArray("vtkGhostType")));
     triangulation->preconditionDistributedCells();
   }
 }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -197,7 +197,10 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
             ttkUtils::GetPointer<T0>(scalarArray),
             ttkUtils::GetPointer<ttk::LongSimplexId>(vtkGlobalPointIds),
             ttkUtils::GetPointer<int>(rankArray), nVertices, 500, neighbors)));
-      } else {
+      } else
+#endif // TTK_ENABLE_MPI
+
+      {
         switch(scalarArray->GetDataType()) {
           vtkTemplateMacro(ttk::preconditionOrderArray(
             nVertices,
@@ -207,17 +210,6 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
             this->threadNumber_));
         }
       }
-
-#else
-      switch(scalarArray->GetDataType()) {
-        vtkTemplateMacro(ttk::preconditionOrderArray(
-          nVertices,
-          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(scalarArray)),
-          static_cast<ttk::SimplexId *>(
-            ttkUtils::GetVoidPointer(newOrderArray)),
-          this->threadNumber_));
-      }
-#endif // TTK_ENABLE_MPI
 
       // append order array temporarily to input
       inputData

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -794,8 +794,6 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
     // to the triangulation
     triangulation->setVertsGlobalIds(
       ttkUtils::GetPointer<ttk::LongSimplexId>(pd->GetGlobalIds()));
-    triangulation->setVertexRankArray(
-      ttkUtils::GetPointer<int>(pd->GetArray("RankArray")));
     triangulation->setVertexGhostArray(
       ttkUtils::GetPointer<unsigned char>(pd->GetArray("vtkGhostType")));
     triangulation->preconditionDistributedVertices();
@@ -809,8 +807,6 @@ void ttkAlgorithm::MPITriangulationPreconditioning(
     // the triangulation
     triangulation->setCellsGlobalIds(
       ttkUtils::GetPointer<ttk::LongSimplexId>(cd->GetGlobalIds()));
-    triangulation->setCellRankArray(
-      ttkUtils::GetPointer<int>(cd->GetArray("RankArray")));
     triangulation->setCellGhostArray(
       ttkUtils::GetPointer<unsigned char>(cd->GetArray("vtkGhostType")));
     triangulation->preconditionDistributedCells();

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -236,8 +236,7 @@ protected:
 
   bool checkGlobalIdValidity(ttk::LongSimplexId *globalIds,
                              ttk::SimplexId simplexNumber,
-                             unsigned char *ghost,
-                             int *rankArray);
+                             unsigned char *ghost);
   /**
    * This methods generates global ids and is called during the MPI
    * preconditioning. It behaves differently for PolyData and ImageData

--- a/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
+++ b/core/vtk/ttkScalarFieldCriticalPoints/ttkScalarFieldCriticalPoints.cpp
@@ -152,19 +152,16 @@ int ttkScalarFieldCriticalPoints::RequestData(
     vertexIds->SetNumberOfComponents(1);
     vertexIds->SetNumberOfTuples(criticalPoints_.size());
     vertexIds->SetName(ttk::VertexScalarFieldName);
-#if TTK_ENABLE_MPI
-    const auto *globalIds = triangulation->getVertsGlobalIds();
-#endif
     for(size_t i = 0; i < criticalPoints_.size(); i++) {
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
       if(hasInitializedMPI()) {
-        vertexIds->SetTuple1(i, globalIds[criticalPoints_[i].first]);
-      } else {
+        vertexIds->SetTuple1(
+          i, triangulation->getVertexGlobalId(criticalPoints_[i].first));
+      } else
+#endif // TTK_ENABLE_MPI
+      {
         vertexIds->SetTuple1(i, criticalPoints_[i].first);
       }
-#else
-      vertexIds->SetTuple1(i, criticalPoints_[i].first);
-#endif
     }
 
     output->GetPointData()->AddArray(vertexIds);


### PR DESCRIPTION
This PR adds the support of on-the-fly computation of vertex and cell rank for Implicit triangulations, thus alleviating the need of storing them in memory. The buffers that previously held them were moved from `AbstractTriangulation` to `ExplicitTriangulation`. In `ttkAlgorithm`, "RankArray" PointData or CellData arrays are not needed anymore and code has been reworked to get rid of them. In particular, `MPIUtils` functions that required a pointer to a "RankArray" buffer were altered to take a Callable instead.

The on-the-fly computation of ranks relies on pre-computing bounding boxes of non-ghost vertices & cells. These bounding boxes are exchanged & stored as integer coordinates in the meta-grid. Then, a query quickly compares the global coordinates to the bounding boxes of the neighbors, to get the rank it fits in. The result should be identical to what was provided through the "RankArray" data arrays.

Other now less useful `AbstractTriangulation` members were moved to `ExplicitTriangulation`, such as the pointers to vertex and cell global identifiers or the map global to local vertex identifier.

Enjoy,
Pierre
