### PR TITLE
DimensionReduction: Clean API

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -171,7 +171,7 @@ int DimensionReduction::execute() const {
 #endif
   gc.push_back(pNumberOfNeighbors);
 
-  pMethod = PyLong_FromLong(method_);
+  pMethod = PyLong_FromLong(static_cast<long>(this->Method));
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!pMethod) {
     this->printErr("Python: cannot convert pMethod.");
@@ -180,7 +180,7 @@ int DimensionReduction::execute() const {
 #endif
   gc.push_back(pMethod);
 
-  if(threadNumber_ > 1 && method_ == 2) { // MDS
+  if(threadNumber_ > 1 && this->Method == METHOD::MDS) { // MDS
     this->printWrn(
       "MDS is known to be instable when used with multiple threads");
   }
@@ -353,8 +353,8 @@ int DimensionReduction::execute() const {
   for(auto i : gc)
     Py_DECREF(i);
 
-  this->printMsg("Computed " + methodToString[this->method_], 1.0,
-                 t.getElapsedTime(), this->threadNumber_);
+  this->printMsg("Computed " + methodToString[static_cast<int>(this->Method)],
+                 1.0, t.getElapsedTime(), this->threadNumber_);
 
   return 0;
 

--- a/core/base/dimensionReduction/DimensionReduction.cpp
+++ b/core/base/dimensionReduction/DimensionReduction.cpp
@@ -66,8 +66,8 @@ int DimensionReduction::execute() const {
 
   Timer t;
 
-  const int numberOfComponents = std::max(2, numberOfComponents_);
-  const int numberOfNeighbors = std::max(1, numberOfNeighbors_);
+  const int numberOfComponents = std::max(2, this->NumberOfComponents);
+  const int numberOfNeighbors = std::max(1, this->NumberOfNeighbors);
 
   // declared here to avoid crossing initialization with goto
   vector<PyObject *> gc;
@@ -192,7 +192,7 @@ int DimensionReduction::execute() const {
   }
 #endif
 
-  pIsDeterministic = PyLong_FromLong(randomState_);
+  pIsDeterministic = PyLong_FromLong(static_cast<long>(this->IsDeterministic));
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!pIsDeterministic) {
     this->printErr("Python: cannot convert pIsDeterministic.");

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -171,16 +171,6 @@ namespace ttk {
       FunctionName = functionName;
     }
 
-    inline void setInputMatrixDimensions(SimplexId numberOfRows,
-                                         SimplexId numberOfColumns) {
-      numberOfRows_ = numberOfRows;
-      numberOfColumns_ = numberOfColumns;
-    }
-
-    inline void setInputMatrix(void *data) {
-      matrix_ = data;
-    }
-
     inline void setInputMethod(METHOD method) {
       this->Method = method;
     }
@@ -197,13 +187,12 @@ namespace ttk {
       this->IsDeterministic = isDeterm;
     }
 
-    inline void setOutputComponents(std::vector<std::vector<double>> *data) {
-      embedding_ = data;
-    }
-
     bool isPythonFound() const;
 
-    int execute() const;
+    int execute(std::vector<std::vector<double>> &outputEmbedding,
+                const std::vector<double> &inputMatrix,
+                const int nRows,
+                const int nColumns) const;
 
   protected:
     // se
@@ -258,18 +247,14 @@ namespace ttk {
     std::string pca_MaxIteration{"auto"};
 
     // testing
-    std::string ModulePath{};
-    std::string ModuleName{};
-    std::string FunctionName{};
+    std::string ModulePath{"default"};
+    std::string ModuleName{"dimensionReduction"};
+    std::string FunctionName{"doIt"};
 
-    SimplexId numberOfRows_{0};
-    SimplexId numberOfColumns_{0};
     METHOD Method{METHOD::MDS};
     int NumberOfComponents{2};
     int NumberOfNeighbors{5};
     int IsDeterministic{true};
-    void *matrix_{};
-    std::vector<std::vector<double>> *embedding_{};
     char majorVersion_{'0'};
   };
 } // namespace ttk

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -187,6 +187,20 @@ namespace ttk {
       this->IsDeterministic = isDeterm;
     }
 
+    inline void setIsInputDistanceMatrix(const bool data) {
+      if(data) {
+        this->se_Affinity = "precomputed";
+        this->mds_Dissimilarity = "precomputed";
+        this->tsne_Metric = "precomputed";
+        this->iso_Metric = "precomputed";
+      } else {
+        this->se_Affinity = "nearest_neighbors";
+        this->mds_Dissimilarity = "euclidean";
+        this->tsne_Metric = "euclidean";
+        this->iso_Metric = "euclidean";
+      }
+    }
+
     bool isPythonFound() const;
 
     int execute(std::vector<std::vector<double>> &outputEmbedding,

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -46,6 +46,22 @@ namespace ttk {
   public:
     DimensionReduction();
 
+    /** Scikit-Learn Dimension Reduction algorithms */
+    enum class METHOD {
+      /** Spectral Embedding */
+      SE = 0,
+      /** Locally Linear Embedding */
+      LLE = 1,
+      /** Multi-Dimensional Scaling */
+      MDS = 2,
+      /** t-distributed Stochastic Neighbor Embedding */
+      T_SNE = 3,
+      /** IsoMap Embedding */
+      ISOMAP = 4,
+      /** Principal Component Analysis */
+      PCA = 5,
+    };
+
     inline int setSEParameters(std::string &Affinity,
                                float Gamma,
                                std::string &EigenSolver,
@@ -64,7 +80,7 @@ namespace ttk {
                                 std::string &EigenSolver,
                                 float Tolerance,
                                 int MaxIteration,
-                                std::string &Method,
+                                std::string &Method_s,
                                 float HessianTolerance,
                                 float ModifiedTolerance,
                                 std::string &NeighborsAlgorithm) {
@@ -72,7 +88,7 @@ namespace ttk {
       lle_EigenSolver = EigenSolver;
       lle_Tolerance = Tolerance;
       lle_MaxIteration = MaxIteration;
-      lle_Method = Method;
+      lle_Method = Method_s;
       lle_HessianTolerance = HessianTolerance;
       lle_ModifiedTolerance = ModifiedTolerance;
       lle_NeighborsAlgorithm = NeighborsAlgorithm;
@@ -107,7 +123,7 @@ namespace ttk {
                                  std::string &Metric,
                                  std::string &Init,
                                  int Verbose,
-                                 std::string &Method,
+                                 std::string &Method_s,
                                  float Angle) {
       tsne_Perplexity = Perplexity;
       tsne_Exaggeration = Exaggeration;
@@ -118,7 +134,7 @@ namespace ttk {
       tsne_Metric = Metric;
       tsne_Init = Init;
       tsne_Verbose = Verbose;
-      tsne_Method = Method;
+      tsne_Method = Method_s;
       tsne_Angle = Angle;
       return 0;
     }
@@ -176,8 +192,8 @@ namespace ttk {
       return 0;
     }
 
-    inline int setInputMethod(int method) {
-      method_ = method;
+    inline int setInputMethod(METHOD method) {
+      this->Method = method;
       return 0;
     }
 
@@ -264,7 +280,7 @@ namespace ttk {
 
     SimplexId numberOfRows_{0};
     SimplexId numberOfColumns_{0};
-    int method_{};
+    METHOD Method{METHOD::MDS};
     int numberOfComponents_{0};
     int numberOfNeighbors_{0};
     int randomState_{0};

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -197,19 +197,16 @@ namespace ttk {
       return 0;
     }
 
-    inline int setInputNumberOfComponents(int numberOfComponents) {
-      numberOfComponents_ = numberOfComponents;
-      return 0;
+    inline void setInputNumberOfComponents(const int numberOfComponents) {
+      this->NumberOfComponents = numberOfComponents;
     }
 
-    inline int setInputNumberOfNeighbors(int numberOfNeighbors) {
-      numberOfNeighbors_ = numberOfNeighbors;
-      return 0;
+    inline void setInputNumberOfNeighbors(const int numberOfNeighbors) {
+      this->NumberOfNeighbors = numberOfNeighbors;
     }
 
-    inline int setInputIsDeterministic(int randomState) {
-      randomState_ = randomState;
-      return 0;
+    inline void setInputIsDeterministic(const int isDeterm) {
+      this->IsDeterministic = isDeterm;
     }
 
     inline int setOutputComponents(std::vector<std::vector<double>> *data) {
@@ -281,9 +278,9 @@ namespace ttk {
     SimplexId numberOfRows_{0};
     SimplexId numberOfColumns_{0};
     METHOD Method{METHOD::MDS};
-    int numberOfComponents_{0};
-    int numberOfNeighbors_{0};
-    int randomState_{0};
+    int NumberOfComponents{2};
+    int NumberOfNeighbors{5};
+    int IsDeterministic{true};
     void *matrix_{};
     std::vector<std::vector<double>> *embedding_{};
     char majorVersion_{'0'};

--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -62,10 +62,10 @@ namespace ttk {
       PCA = 5,
     };
 
-    inline int setSEParameters(std::string &Affinity,
-                               float Gamma,
-                               std::string &EigenSolver,
-                               bool InputIsADistanceMatrix) {
+    inline void setSEParameters(const std::string &Affinity,
+                                const float Gamma,
+                                const std::string &EigenSolver,
+                                const bool InputIsADistanceMatrix) {
       if(InputIsADistanceMatrix) {
         se_Affinity = "precomputed";
       } else {
@@ -73,17 +73,16 @@ namespace ttk {
       }
       se_Gamma = Gamma;
       se_EigenSolver = EigenSolver;
-      return 0;
     }
 
-    inline int setLLEParameters(float Regularization,
-                                std::string &EigenSolver,
-                                float Tolerance,
-                                int MaxIteration,
-                                std::string &Method_s,
-                                float HessianTolerance,
-                                float ModifiedTolerance,
-                                std::string &NeighborsAlgorithm) {
+    inline void setLLEParameters(const float Regularization,
+                                 const std::string &EigenSolver,
+                                 const float Tolerance,
+                                 const int MaxIteration,
+                                 const std::string &Method_s,
+                                 const float HessianTolerance,
+                                 const float ModifiedTolerance,
+                                 const std::string &NeighborsAlgorithm) {
       lle_Regularization = Regularization;
       lle_EigenSolver = EigenSolver;
       lle_Tolerance = Tolerance;
@@ -92,15 +91,14 @@ namespace ttk {
       lle_HessianTolerance = HessianTolerance;
       lle_ModifiedTolerance = ModifiedTolerance;
       lle_NeighborsAlgorithm = NeighborsAlgorithm;
-      return 0;
     }
 
-    inline int setMDSParameters(bool Metric,
-                                int Init,
-                                int MaxIteration,
-                                int Verbose,
-                                float Epsilon,
-                                bool Dissimilarity) {
+    inline void setMDSParameters(const bool Metric,
+                                 const int Init,
+                                 const int MaxIteration,
+                                 const int Verbose,
+                                 const float Epsilon,
+                                 const bool Dissimilarity) {
       mds_Metric = Metric;
       mds_Init = Init;
       mds_MaxIteration = MaxIteration;
@@ -111,20 +109,19 @@ namespace ttk {
       } else {
         mds_Dissimilarity = "euclidean";
       }
-      return 0;
     }
 
-    inline int setTSNEParameters(float Perplexity,
-                                 float Exaggeration,
-                                 float LearningRate,
-                                 int MaxIteration,
-                                 int MaxIterationProgress,
-                                 float GradientThreshold,
-                                 std::string &Metric,
-                                 std::string &Init,
-                                 int Verbose,
-                                 std::string &Method_s,
-                                 float Angle) {
+    inline void setTSNEParameters(const float Perplexity,
+                                  const float Exaggeration,
+                                  const float LearningRate,
+                                  const int MaxIteration,
+                                  const int MaxIterationProgress,
+                                  const float GradientThreshold,
+                                  const std::string &Metric,
+                                  const std::string &Init,
+                                  const int Verbose,
+                                  const std::string &Method_s,
+                                  const float Angle) {
       tsne_Perplexity = Perplexity;
       tsne_Exaggeration = Exaggeration;
       tsne_LearningRate = LearningRate;
@@ -136,65 +133,56 @@ namespace ttk {
       tsne_Verbose = Verbose;
       tsne_Method = Method_s;
       tsne_Angle = Angle;
-      return 0;
     }
 
-    inline int setISOParameters(std::string &EigenSolver,
-                                float Tolerance,
-                                int MaxIteration,
-                                std::string &PathMethod,
-                                std::string &NeighborsAlgorithm) {
+    inline void setISOParameters(const std::string &EigenSolver,
+                                 const float Tolerance,
+                                 const int MaxIteration,
+                                 const std::string &PathMethod,
+                                 const std::string &NeighborsAlgorithm) {
       iso_EigenSolver = EigenSolver;
       iso_Tolerance = Tolerance;
       iso_MaxIteration = MaxIteration;
       iso_PathMethod = PathMethod;
       iso_NeighborsAlgorithm = NeighborsAlgorithm;
-      return 0;
     }
 
-    inline int setPCAParameters(bool Copy,
-                                bool Whiten,
-                                std::string &SVDSolver,
-                                float Tolerance,
-                                std::string &MaxIteration) {
+    inline void setPCAParameters(const bool Copy,
+                                 const bool Whiten,
+                                 const std::string &SVDSolver,
+                                 const float Tolerance,
+                                 const std::string &MaxIteration) {
       pca_Copy = Copy;
       pca_Whiten = Whiten;
       pca_SVDSolver = SVDSolver;
       pca_Tolerance = Tolerance;
       pca_MaxIteration = MaxIteration;
-      return 0;
     }
 
-    inline int setInputModulePath(const std::string &modulePath) {
+    inline void setInputModulePath(const std::string &modulePath) {
       ModulePath = modulePath;
-      return 0;
     }
 
-    inline int setInputModuleName(const std::string &moduleName) {
+    inline void setInputModuleName(const std::string &moduleName) {
       ModuleName = moduleName;
-      return 0;
     }
 
-    inline int setInputFunctionName(const std::string &functionName) {
+    inline void setInputFunctionName(const std::string &functionName) {
       FunctionName = functionName;
-      return 0;
     }
 
-    inline int setInputMatrixDimensions(SimplexId numberOfRows,
-                                        SimplexId numberOfColumns) {
+    inline void setInputMatrixDimensions(SimplexId numberOfRows,
+                                         SimplexId numberOfColumns) {
       numberOfRows_ = numberOfRows;
       numberOfColumns_ = numberOfColumns;
-      return 0;
     }
 
-    inline int setInputMatrix(void *data) {
+    inline void setInputMatrix(void *data) {
       matrix_ = data;
-      return 0;
     }
 
-    inline int setInputMethod(METHOD method) {
+    inline void setInputMethod(METHOD method) {
       this->Method = method;
-      return 0;
     }
 
     inline void setInputNumberOfComponents(const int numberOfComponents) {
@@ -209,9 +197,8 @@ namespace ttk {
       this->IsDeterministic = isDeterm;
     }
 
-    inline int setOutputComponents(std::vector<std::vector<double>> *data) {
+    inline void setOutputComponents(std::vector<std::vector<double>> *data) {
       embedding_ = data;
-      return 0;
     }
 
     bool isPythonFound() const;

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -79,7 +79,6 @@ int ttkDimensionReduction::RequestData(vtkInformation *ttkNotUsed(request),
 
     this->setInputMatrixDimensions(numberOfRows, numberOfColumns);
     this->setInputMatrix(inputData.data());
-    this->setInputMethod(Method);
     this->setInputNumberOfComponents(NumberOfComponents);
     this->setInputNumberOfNeighbors(NumberOfNeighbors);
     this->setInputIsDeterministic(IsDeterministic);

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -77,10 +77,8 @@ int ttkDimensionReduction::RequestData(vtkInformation *ttkNotUsed(request),
 
     outputData_.clear();
 
-    this->setInputMatrixDimensions(numberOfRows, numberOfColumns);
-    this->setInputMatrix(inputData.data());
-    this->setOutputComponents(&outputData_);
-    const int errorCode = this->execute();
+    const int errorCode = this->execute(
+      this->outputData_, inputData, numberOfRows, numberOfColumns);
 
     if(!errorCode) {
       if(KeepAllDataArrays)

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.cpp
@@ -79,9 +79,6 @@ int ttkDimensionReduction::RequestData(vtkInformation *ttkNotUsed(request),
 
     this->setInputMatrixDimensions(numberOfRows, numberOfColumns);
     this->setInputMatrix(inputData.data());
-    this->setInputNumberOfComponents(NumberOfComponents);
-    this->setInputNumberOfNeighbors(NumberOfNeighbors);
-    this->setInputIsDeterministic(IsDeterministic);
     this->setOutputComponents(&outputData_);
     const int errorCode = this->execute();
 

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -93,12 +93,7 @@ public:
   // SE && MDS
   void SetInputIsADistanceMatrix(const bool b) {
     this->InputIsADistanceMatrix = b;
-    if(b) {
-      this->mds_Dissimilarity = "precomputed";
-      this->se_Affinity = "precomputed";
-      this->tsne_Metric = "precomputed";
-      this->iso_Metric = "precomputed";
-    }
+    this->setIsInputDistanceMatrix(b);
     Modified();
   }
   vtkGetMacro(InputIsADistanceMatrix, bool);

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -48,6 +48,7 @@
 // TTK includes
 #include <DimensionReduction.h>
 #include <ttkAlgorithm.h>
+#include <ttkMacros.h>
 
 class TTKDIMENSIONREDUCTION_EXPORT ttkDimensionReduction
   : public ttkAlgorithm,
@@ -83,8 +84,8 @@ public:
   vtkSetMacro(IsDeterministic, int);
   vtkGetMacro(IsDeterministic, int);
 
-  vtkSetMacro(Method, int);
-  vtkGetMacro(Method, int);
+  ttkSetEnumMacro(Method, METHOD);
+  vtkGetEnumMacro(Method, METHOD);
 
   vtkSetMacro(KeepAllDataArrays, bool);
   vtkGetMacro(KeepAllDataArrays, bool);
@@ -249,7 +250,6 @@ private:
 
   int NumberOfComponents{2};
   int NumberOfNeighbors{5};
-  int Method{2}; // MDS
   int IsDeterministic{true};
   bool KeepAllDataArrays{true};
 

--- a/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
+++ b/core/vtk/ttkDimensionReduction/ttkDimensionReduction.h
@@ -248,9 +248,6 @@ private:
   std::string RegexpString{".*"};
   std::vector<std::string> ScalarFields{};
 
-  int NumberOfComponents{2};
-  int NumberOfNeighbors{5};
-  int IsDeterministic{true};
   bool KeepAllDataArrays{true};
 
   // mds && se


### PR DESCRIPTION
This PR reworks the API of the `DimensionReduction` base module. It introduces a new enum class to improve the method selection, compact the setters and removes duplicate class members between the base and VTK layers.

This should make the base module easier to be called from another base module.

Enjoy,
Pierre

