### PR TITLE
[FTMTree] fix scalars and params copy

### DIFF
--- a/core/base/ftmTree/FTMTreeUtils.h
+++ b/core/base/ftmTree/FTMTreeUtils.h
@@ -47,7 +47,8 @@ namespace ttk {
       auto newScalarsValues = std::make_shared<std::vector<double>>();
       for(auto val : *mt.scalarsValues)
         newScalarsValues->push_back(static_cast<double>(val));
-      newMt = MergeTree<double>(mt.scalars, newScalarsValues, mt.params);
+      auto newScalars = std::make_shared<ftm::Scalars>(*mt.scalars);
+      newMt = MergeTree<double>(newScalars, newScalarsValues, mt.params);
       newMt.tree.copyMergeTreeStructure(&(mt.tree));
     }
 
@@ -81,7 +82,8 @@ namespace ttk {
       auto newScalarsValues = std::make_shared<std::vector<dataType>>();
       for(auto val : *mt.scalarsValues)
         newScalarsValues->push_back(static_cast<dataType>(val));
-      newMt = MergeTree<dataType>(mt.scalars, newScalarsValues, mt.params);
+      auto newScalars = std::make_shared<ftm::Scalars>(*mt.scalars);
+      newMt = MergeTree<dataType>(newScalars, newScalarsValues, mt.params);
       newMt.tree.copyMergeTreeStructure(&(mt.tree));
     }
 

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -938,11 +938,13 @@ namespace ttk {
 
       void copy(const MergeTree<dataType> &mt) {
         // Copy scalars
+        scalars = std::make_shared<ftm::Scalars>();
         scalars->size = mt.scalars->size;
         scalarsValues = mt.scalarsValues;
         scalars->values = (void *)(scalarsValues->data());
 
         // Copy params
+        params = std::make_shared<ftm::Params>();
         params->treeType = mt.params->treeType;
 
         // Copy tree


### PR DESCRIPTION
This PR fixes the use of shared pointers of #883 in `ftmTree`. 

Indeed, during a copy of a `MergeTree` the now-used pointers were shared between the old and the new tree resulting in problem if scalars of the first tree were modified (the scalars of the copied tree would also be modified).

Especially with the `mergeTreeTemplateToDouble` function that changes the type of the scalars, giving weird results when trying to access the scalars of the template tree since they were casted in double.

This PR fixes that by creating a new pointer and copying the information.

Done with the agreement of @pierre-guillou.