### PR TITLE
Fix English typos inside TTK codebase

### DIFF
--- a/.github/actions/install-deps-unix/action.yml
+++ b/.github/actions/install-deps-unix/action.yml
@@ -1,5 +1,5 @@
 name: 'Install dependencies for Unix'
-description: 'Install TTK optionall dependencies on Ubuntu & macOS'
+description: 'Install TTK optional dependencies on Ubuntu & macOS'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -216,7 +216,7 @@ can also be triggered by Git tags matching regular expressions:
 * `check*` for the TTK *check_code* workflow,
 * `test*` for the TTK *test_build* workflow.
 
-The last two might be of interest for TTK developpers that want to
+The last two might be of interest for TTK developers that want to
 test their code before writing a Pull Request.
 
 ### ParaView Headless Packages
@@ -409,7 +409,7 @@ reference database.
 Since these tests and the reference database don't belong to the same
 Git repository, an error in any of these two steps won't make the
 whole workflow fail. However, there will be annotations in the
-*Summary* page of the workflow. It is up to TTK developpers to
+*Summary* page of the workflow. It is up to TTK developers to
 maintain the reference databases in sync with the TTK code.
 
 Composite Actions

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,7 +79,7 @@ jobs:
         # not enough RAM to build in parallel (or with ninja)
         cmake --build .
 
-    - name: Package TTK & update package informations
+    - name: Package TTK & update package information
       run: |
         cd build
         cpack -G DEB

--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -117,9 +117,9 @@ function(ttk_add_base_template_library library)
   install(FILES ${ARG_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ttk/base")
 endfunction()
 
-# Add compile flags and defintions to the target
+# Add compile flags and definitions to the target
 # according to the options selected by the user.
-# Only options and defintions common to all modules
+# Only options and definitions common to all modules
 # should be here.
 #
 # Usage:

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD 14)
 option(TTK_BUILD_VTK_WRAPPERS "Build the TTK VTK Wrappers" ON)
 cmake_dependent_option(TTK_BUILD_PARAVIEW_PLUGINS "Build the TTK ParaView Plugins" ON "TTK_BUILD_VTK_WRAPPERS" OFF)
 option(TTK_BUILD_STANDALONE_APPS "Build the TTK Standalone Applications" ON)
-option(TTK_WHITELIST_MODE "Explicitely enable each filter" OFF)
+option(TTK_WHITELIST_MODE "Explicitly enable each filter" OFF)
 mark_as_advanced(TTK_WHITELIST_MODE BUILD_SHARED_LIBS)
 
 # This option allows library to be built dynamic
@@ -32,7 +32,7 @@ endif ()
 # This variable has two possible values "SingleArray" and "OffsetAndConnectiviy".
 # * "SingleArray" use a layout compatible with VTK < 9 were the cell array store the
 #   cells and their connectivity in a flat array
-# * "OffsetAndConnectivity" use a layout comatible with VTK >= 9, having two arrays
+# * "OffsetAndConnectivity" use a layout compatible with VTK >= 9, having two arrays
 #   (see https://vtk.org/doc/nightly/html/classvtkCellArray.html#details for more info)
 set(TTK_CELL_ARRAY_LAYOUT "SingleArray" CACHE STRING "Layout for the cell array.")
 set_property(CACHE TTK_CELL_ARRAY_LAYOUT PROPERTY STRINGS "SingleArray" "OffsetAndConnectivity")
@@ -49,7 +49,7 @@ if(TTK_BUILD_PARAVIEW_PLUGINS OR TTK_BUILD_VTK_WRAPPERS)
   # Find ParaView, otherwise VTK
   find_package(ParaView)
   if(ParaView_FOUND)
-    # hande version manually so we do not have to include
+    # handle version manually so we do not have to include
     # files from VTK / ParaView in the code.
     # this is necessary to work with build folder directly (MacOS)
     add_definitions(-DPARAVIEW_VERSION_MAJOR=${ParaView_VERSION_MAJOR})
@@ -64,7 +64,7 @@ if(TTK_BUILD_PARAVIEW_PLUGINS OR TTK_BUILD_VTK_WRAPPERS)
   else()
     find_package(VTK)
     if(VTK_FOUND)
-      # hande version manually so we do not have to include
+      # handle version manually so we do not have to include
       # files from VTK / ParaView in the code.
       # this is necessary to work with build folder directly (MacOS)
       add_definitions(-DVTK_VERSION_MAJOR=${VTK_VERSION_MAJOR})
@@ -149,7 +149,7 @@ if(Boost_FOUND)
   message(STATUS "Found Boost ${Boost_VERSION} (${Boost_INCLUDE_DIR})")
 endif()
 
-# optional pakages
+# optional packages
 
 find_package(ZLIB QUIET)
 if(ZLIB_FOUND)

--- a/CMake/merge_tree_input.xml
+++ b/CMake/merge_tree_input.xml
@@ -12,7 +12,7 @@ default_values="0">
     <Entry value="2" text="Custom"/>
 </EnumerationDomain>
   <Documentation>
-    Backend for the computation of the distance between merge trees. The Edit Distance, the Branch Mapping Distance and the Path Mapping Distance do not allow to compute geodesics, barycenters and clusters contrary to the Wasserstein Distance. One can choose Custom to configure manually the three parameters controling the distance.
+    Backend for the computation of the distance between merge trees. The Edit Distance, the Branch Mapping Distance and the Path Mapping Distance do not allow to compute geodesics, barycenters and clusters contrary to the Wasserstein Distance. One can choose Custom to configure manually the three parameters controlling the distance.
   </Documentation>
 </IntVectorProperty>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Please find below a few guidelines that we invite you to consider before making 
 Please find below generic recommendations for setting up your fork of TTK's main repository.
   - Setting up your Github account:
     - Create an account on [Github](https://github.com/).
-    - If applicable, we recommand to upgrade (for free) this account to a Github Pro account, through the [Github education program](https://docs.github.com/en/education/explore-the-benefits-of-teaching-and-learning-with-github-education/use-github-in-your-classroom-and-research/apply-for-an-educator-or-researcher-discount).
+    - If applicable, we recommend to upgrade (for free) this account to a Github Pro account, through the [Github education program](https://docs.github.com/en/education/explore-the-benefits-of-teaching-and-learning-with-github-education/use-github-in-your-classroom-and-research/apply-for-an-educator-or-researcher-discount).
   - Forking TTK's main repository:
     - Go to [TTK's main source code repository](https://github.com/topology-tool-kit/ttk) and click on the "Fork" button (top right corner).
     - In the remainder, let us designate by `@PUBLIC` the URL of [TTK's main source code repository](https://github.com/topology-tool-kit/ttk) (i.e. `@PUBLIC = https://github.com/topology-tool-kit/ttk`)
     - Similarly, let us designate by `@FORK` the URL of your public fork of TTK's public repository.
   - Creating your private TTK repository:
-    - We recommand to use a private repository for the development of unpublished features.
+    - We recommend to use a private repository for the development of unpublished features.
     - For this, create and setup a *private* repository (e.g. `ttk-yourusername`). Let us call it `@PRIVATE`.
     - Clone your `@PRIVATE` repository locally and enter the following commands:
     ```
@@ -26,11 +26,11 @@ Please find below generic recommendations for setting up your fork of TTK's main
     ```
     $ git pull ttk-public dev
     ```
-    - When developing a new unpublished feature, we recommand to create a new branch on your `@PRIVATE` repository.
+    - When developing a new unpublished feature, we recommend to create a new branch on your `@PRIVATE` repository.
     - When this feature is ready to be made public (e.g. after publication of the corresponding research), push the corresponding branch to your `@FORK`. This will enable you to open a pull-request (PR) to the [main TTK repository](https://github.com/topology-tool-kit/ttk).
   - Setting up [ttk-data](https://github.com/topology-tool-kit/ttk-data)
     - The repository [ttk-data](https://github.com/topology-tool-kit/ttk-data) hosts data sets and examples.
-    - We recommand that you re-iterate the above procedure (with a public fork and a private repository) for this repository as well.
+    - We recommend that you re-iterate the above procedure (with a public fork and a private repository) for this repository as well.
     - Note that only the features which are covered by examples in [ttk-data](https://github.com/topology-tool-kit/ttk-data) are tested by the continuous integration.
 
 # 1. Authorship

--- a/core/base/abstractTriangulation/AbstractTriangulation.h
+++ b/core/base/abstractTriangulation/AbstractTriangulation.h
@@ -409,7 +409,7 @@ namespace ttk {
     /// \param cellId Input global cell identifier.
     /// \param localVertexId Input local vertex identifier,
     /// in [0, getCellVertexNumber()].
-    /// \param vertexId Ouput global vertex identifier.
+    /// \param vertexId Output global vertex identifier.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa getCellVertexNumber()
     virtual inline int getCellVertex(const SimplexId &cellId,

--- a/core/base/approximateTopology/ApproximateTopology.h
+++ b/core/base/approximateTopology/ApproximateTopology.h
@@ -70,8 +70,8 @@ namespace ttk {
 
     template <typename scalarType, typename offsetType>
     void updatePropagation(
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
       std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -115,8 +115,8 @@ namespace ttk {
     void computeCriticalPoints(
       std::vector<std::vector<std::pair<polarity, polarity>>>
         &vertexLinkPolarity,
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<polarity> &toProcess,
       std::vector<DynamicTree> &link,
       std::vector<uint8_t> &vertexLink,
@@ -128,10 +128,10 @@ namespace ttk {
       int *monotonyOffsets);
 
     template <typename scalarType, typename offsetType>
-    ttk::SimplexId propageFromSaddles(
+    ttk::SimplexId propagateFromSaddles(
       const SimplexId vertexId,
       std::vector<Lock> &vertLock,
-      std::vector<polarity> &toPropage,
+      std::vector<polarity> &toPropagate,
       std::vector<std::vector<SimplexId>> &vertexRepresentatives,
       std::vector<std::vector<SimplexId>> &saddleCC,
       std::vector<polarity> &isUpdated,
@@ -149,8 +149,8 @@ namespace ttk {
       const int *const monotonyOffsets,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-      const std::vector<polarity> &toPropageMin,
-      const std::vector<polarity> &toPropageMax) const;
+      const std::vector<polarity> &toPropagateMin,
+      const std::vector<polarity> &toPropagateMax) const;
 
     template <typename scalarType, typename offsetType>
     void sortVertices(const SimplexId vertexNumber,
@@ -186,8 +186,8 @@ namespace ttk {
     void initSaddleSeeds(std::vector<polarity> &isNew,
                          std::vector<std::vector<std::pair<polarity, polarity>>>
                            &vertexLinkPolarity,
-                         std::vector<polarity> &toPropageMin,
-                         std::vector<polarity> &toPropageMax,
+                         std::vector<polarity> &toPropagateMin,
+                         std::vector<polarity> &toPropagateMax,
                          std::vector<polarity> &toProcess,
                          std::vector<DynamicTree> &link,
                          std::vector<uint8_t> &vertexLink,
@@ -198,8 +198,8 @@ namespace ttk {
 
     template <typename scalarType, typename offsetType>
     void updatePropagation(
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
       std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -261,10 +261,10 @@ namespace ttk {
       const offsetType *const offsets,
       int *monotonyOffsets) const;
 
-    ttk::SimplexId propageFromSaddles(
+    ttk::SimplexId propagateFromSaddles(
       const SimplexId vertexId,
       std::vector<Lock> &vertLock,
-      std::vector<polarity> &toPropage,
+      std::vector<polarity> &toPropagate,
       std::vector<std::vector<SimplexId>> &vertexRepresentatives,
       std::vector<std::vector<SimplexId>> &saddleCC,
       std::vector<polarity> &isUpdated,
@@ -277,8 +277,8 @@ namespace ttk {
       const SimplexId *const offsets,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-      const std::vector<polarity> &toPropageMin,
-      const std::vector<polarity> &toPropageMax) const;
+      const std::vector<polarity> &toPropagateMin,
+      const std::vector<polarity> &toPropagateMax) const;
 
     template <typename scalarType, typename offsetType>
     bool printPolarity(std::vector<polarity> &isNew,
@@ -334,8 +334,8 @@ int ttk::ApproximateTopology::executeApproximateTopology(
     vertexNumber);
 
   std::vector<polarity> isNew(vertexNumber, 255);
-  std::vector<polarity> toPropageMin(vertexNumber, 0),
-    toPropageMax(vertexNumber, 0);
+  std::vector<polarity> toPropagateMin(vertexNumber, 0),
+    toPropagateMax(vertexNumber, 0);
   std::vector<polarity> isUpToDateMin(vertexNumber, 0),
     isUpToDateMax(vertexNumber, 0);
 
@@ -421,19 +421,19 @@ int ttk::ApproximateTopology::executeApproximateTopology(
     }
   } // end while
 
-  computeCriticalPoints(vertexLinkPolarity, toPropageMin, toPropageMax,
+  computeCriticalPoints(vertexLinkPolarity, toPropagateMin, toPropagateMax,
                         toProcess, link, vertexLink, vertexLinkByBoundaryType,
                         saddleCCMin, saddleCCMax, fakeScalars, offsets,
                         monotonyOffsets);
 
-  updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
+  updatePropagation(toPropagateMin, toPropagateMax, vertexRepresentativesMin,
                     vertexRepresentativesMax, saddleCCMin, saddleCCMax,
                     vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
                     fakeScalars, offsets, monotonyOffsets);
 
   computePersistencePairsFromSaddles(
     CTDiagram_, fakeScalars, offsets, monotonyOffsets, vertexRepresentativesMin,
-    vertexRepresentativesMax, toPropageMin, toPropageMax);
+    vertexRepresentativesMax, toPropagateMin, toPropagateMax);
   // ADD GLOBAL MIN-MAX PAIR
   CTDiagram_.emplace_back(this->globalMin_, this->globalMax_, -1);
   // fakeScalars[this->globalMax_] - fakeScalars[this->globalMin_], -1);
@@ -465,8 +465,8 @@ void ttk::ApproximateTopology::computePersistencePairsFromSaddles(
   const int *const monotonyOffsets,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-  const std::vector<polarity> &toPropageMin,
-  const std::vector<polarity> &toPropageMax) const {
+  const std::vector<polarity> &toPropagateMin,
+  const std::vector<polarity> &toPropagateMax) const {
 
   Timer timer{};
   // CTDiagram.clear();
@@ -475,10 +475,10 @@ void ttk::ApproximateTopology::computePersistencePairsFromSaddles(
 
   for(SimplexId localId = 0; localId < nbDecVert; localId++) {
     SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
-    if(toPropageMin[globalId]) {
+    if(toPropagateMin[globalId]) {
       getTripletsFromSaddles(globalId, tripletsMin, vertexRepresentativesMin);
     }
-    if(toPropageMax[globalId]) {
+    if(toPropagateMax[globalId]) {
       getTripletsFromSaddles(globalId, tripletsMax, vertexRepresentativesMax);
     }
   }
@@ -791,10 +791,10 @@ int ttk::ApproximateTopology::getMonotonyChangeByOldPointCPApproximate(
 }
 
 template <typename scalarType, typename offsetType>
-ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
+ttk::SimplexId ttk::ApproximateTopology::propagateFromSaddles(
   const SimplexId vertexId,
   std::vector<Lock> &vertLock,
-  std::vector<polarity> &toPropage,
+  std::vector<polarity> &toPropagate,
   std::vector<std::vector<SimplexId>> &vertexRepresentatives,
   std::vector<std::vector<SimplexId>> &saddleCC,
   std::vector<polarity> &isUpdated,
@@ -804,7 +804,7 @@ ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
   const offsetType *const offsets,
   const int *const monotonyOffsets) const {
 
-  auto &toProp = toPropage[vertexId];
+  auto &toProp = toPropagate[vertexId];
   auto &reps = vertexRepresentatives[vertexId];
   auto &updated = isUpdated[vertexId];
 
@@ -831,7 +831,7 @@ ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
     vertLock[vertexId].lock();
   }
   if(saddleCC[vertexId].size()
-     and !toProp) { // tis a saddle point, should have to propage on it
+     and !toProp) { // tis a saddle point, should have to propagate on it
     printErr("ERRRROR");
   }
   if(toProp) { // SADDLE POINT
@@ -855,10 +855,10 @@ ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
       //          + std::to_string(neighborId) + " ("
       //          + std::to_string(fakeScalars[neighborId]) + " , "
       //          + std::to_string(offsets[neighborId]) + ")");
-      SimplexId ret = propageFromSaddles(neighborId, vertLock, toPropage,
-                                         vertexRepresentatives, saddleCC,
-                                         isUpdated, globalExtremum, splitTree,
-                                         fakeScalars, offsets, monotonyOffsets);
+      SimplexId ret = propagateFromSaddles(
+        neighborId, vertLock, toPropagate, vertexRepresentatives, saddleCC,
+        isUpdated, globalExtremum, splitTree, fakeScalars, offsets,
+        monotonyOffsets);
       reps.emplace_back(ret);
     }
 
@@ -894,10 +894,10 @@ ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
       }
     }
     if(maxNeighbor != vertexId) { // not an extremum
-      ret = propageFromSaddles(maxNeighbor, vertLock, toPropage,
-                               vertexRepresentatives, saddleCC, isUpdated,
-                               globalExtremum, splitTree, fakeScalars, offsets,
-                               monotonyOffsets);
+      ret = propagateFromSaddles(maxNeighbor, vertLock, toPropagate,
+                                 vertexRepresentatives, saddleCC, isUpdated,
+                                 globalExtremum, splitTree, fakeScalars,
+                                 offsets, monotonyOffsets);
 
     } else { // needed to find the globalExtremum per thread
 #ifdef TTK_ENABLE_OPENMP
@@ -925,8 +925,8 @@ ttk::SimplexId ttk::ApproximateTopology::propageFromSaddles(
 
 template <typename scalarType, typename offsetType>
 void ttk::ApproximateTopology::updatePropagation(
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
   std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -944,14 +944,14 @@ void ttk::ApproximateTopology::updatePropagation(
 
   if(debugLevel_ > 5) {
     const auto pred = [](const polarity a) { return a > 0; };
-    const auto numberOfCandidatesToPropageMax
-      = std::count_if(toPropageMax.begin(), toPropageMax.end(), pred);
-    std::cout << " sad-max we have " << numberOfCandidatesToPropageMax
-              << " vertices to propage from outta " << nDecVerts << std::endl;
-    const auto numberOfCandidatesToPropageMin
-      = std::count_if(toPropageMin.begin(), toPropageMin.end(), pred);
-    std::cout << " min-sad we have " << numberOfCandidatesToPropageMin
-              << " vertices to propage from outta " << nDecVerts << std::endl;
+    const auto numberOfCandidatesToPropagateMax
+      = std::count_if(toPropagateMax.begin(), toPropagateMax.end(), pred);
+    std::cout << " sad-max we have " << numberOfCandidatesToPropagateMax
+              << " vertices to propagate from outta " << nDecVerts << std::endl;
+    const auto numberOfCandidatesToPropagateMin
+      = std::count_if(toPropagateMin.begin(), toPropagateMin.end(), pred);
+    std::cout << " min-sad we have " << numberOfCandidatesToPropagateMin
+              << " vertices to propagate from outta " << nDecVerts << std::endl;
   }
 
   std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
@@ -967,21 +967,23 @@ void ttk::ApproximateTopology::updatePropagation(
     isUpdatedMax[v] = 0;
   }
 
-  // propage along split tree
+  // propagate along split tree
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nDecVerts; i++) {
     SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
-    if(toPropageMin[v]) {
-      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
-                         saddleCCMin, isUpdatedMin, globalMinThr, false,
-                         fakeScalars, offsets, monotonyOffsets);
+    if(toPropagateMin[v]) {
+      propagateFromSaddles(v, vertLockMin, toPropagateMin,
+                           vertexRepresentativesMin, saddleCCMin, isUpdatedMin,
+                           globalMinThr, false, fakeScalars, offsets,
+                           monotonyOffsets);
     }
-    if(toPropageMax[v]) {
-      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
-                         saddleCCMax, isUpdatedMax, globalMaxThr, true,
-                         fakeScalars, offsets, monotonyOffsets);
+    if(toPropagateMax[v]) {
+      propagateFromSaddles(v, vertLockMax, toPropagateMax,
+                           vertexRepresentativesMax, saddleCCMax, isUpdatedMax,
+                           globalMaxThr, true, fakeScalars, offsets,
+                           monotonyOffsets);
     }
   }
 
@@ -1020,7 +1022,7 @@ void ttk::ApproximateTopology::updatePropagation(
       = *std::min_element(globalMinThr.begin(), globalMinThr.end(), lt);
     globalMax_
       = *std::max_element(globalMaxThr.begin(), globalMaxThr.end(), lt);
-    // printMsg("Explicitely found global extremas");
+    // printMsg("Explicitly found global extremas");
   }
   if(debugLevel_ > 3) {
     printMsg("Propagation Update", 1, tm.getElapsedTime(), threadNumber_);
@@ -1253,8 +1255,8 @@ int ttk::ApproximateTopology::updateGlobalPolarity(
 template <typename ScalarType, typename offsetType>
 void ttk::ApproximateTopology::computeCriticalPoints(
   std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<polarity> &toProcess,
   std::vector<DynamicTree> &link,
   std::vector<uint8_t> &vertexLink,
@@ -1280,7 +1282,7 @@ void ttk::ApproximateTopology::computeCriticalPoints(
                                  vertexLinkByBoundaryType, fakeScalars, offsets,
                                  monotonyOffsets);
       getValencesFromLink(globalId, vertexLinkPolarity[globalId],
-                          link[globalId], toPropageMin, toPropageMax,
+                          link[globalId], toPropagateMin, toPropagateMax,
                           saddleCCMin, saddleCCMax);
     }
   } // end for openmp

--- a/core/base/assignmentSolver/AssignmentAuction.h
+++ b/core/base/assignmentSolver/AssignmentAuction.h
@@ -2,7 +2,7 @@
 /// \class ttk::AssignmentAuction
 /// \author Mathieu Pont (mathieu.pont@lip6.fr)
 ///
-/// Auction algorithm for Balanced and Unbalanced Assignement Problem
+/// Auction algorithm for Balanced and Unbalanced Assignment Problem
 ///
 /// For the unbalanced problem:
 ///   The cost matrix in input has a size of (n + 1) x (m + 1)

--- a/core/base/assignmentSolver/AssignmentExhaustive.h
+++ b/core/base/assignmentSolver/AssignmentExhaustive.h
@@ -2,7 +2,7 @@
 /// \class ttk::AssignmentExhaustive
 /// \author Mathieu Pont (mathieu.pont@lip6.fr)
 ///
-/// Exhaustive Search for Unbalanced Assignement Problem
+/// Exhaustive Search for Unbalanced Assignment Problem
 ///   (TODO manage balanced problem)
 ///
 /// The cost matrix in input has a size of (n + 1) x (m + 1)
@@ -12,7 +12,7 @@
 /// - the last cell (costMatrix[n][m]) is not used
 ///
 /// An exhaustive search for the assignment problem has an exponential
-/// complexity Use this algorithm only for small assigment problem
+/// complexity Use this algorithm only for small assignment problem
 
 #pragma once
 
@@ -80,7 +80,7 @@ namespace ttk {
             continue;
 
           if(ind == max_dim - 1) {
-            // A new assignement without unassigned costs is made here
+            // A new assignment without unassigned costs is made here
             // allAsgn.push_back(new_asgn);
 
             // Construct assignments with unassigned costs
@@ -172,7 +172,7 @@ namespace ttk {
 
             unsigned int new_ind = new_asgn.size();
             if(new_ind == max_dim) {
-              // A new assignement is made here
+              // A new assignment is made here
               for(auto new_unasgn_elem : new_unasgn)
                 new_asgn.push_back(new_unasgn_elem);
               // std::sort(new_asgn.begin()+min_dim, new_asgn.end());
@@ -239,7 +239,7 @@ namespace ttk {
 
             unsigned int new_ind = new_asgn.size();
             if(new_ind == max_dim) {
-              // A new assignement is made here
+              // A new assignment is made here
               for(auto new_unasgn_elem : new_unasgn)
                 new_asgn.push_back(new_unasgn_elem);
               // std::sort(new_asgn.begin()+min_dim, new_asgn.end());

--- a/core/base/assignmentSolver/AssignmentMunkresImpl.h
+++ b/core/base/assignmentSolver/AssignmentMunkresImpl.h
@@ -187,7 +187,7 @@ int ttk::AssignmentMunkres<dataType>::stepOne(int &step) // ~ 0% perf
     }
   }
 
-  // Substract minimum value in every column except the last.
+  // Subtract minimum value in every column except the last.
   for(int c = 0; c < this->colSize - 1; ++c) {
     minInCol = (*C)[0][c];
 

--- a/core/base/assignmentSolver/AssignmentSolver.h
+++ b/core/base/assignmentSolver/AssignmentSolver.h
@@ -2,7 +2,7 @@
 /// \class ttk::AssignmentSolver
 /// \author Mathieu Pont (mathieu.pont@lip6.fr)
 ///
-/// Assignement Problem Solver abstract class
+/// Assignment Problem Solver abstract class
 ///
 /// For the unbalanced problem:
 ///   The cost matrix in input has a size of (n + 1) x (m + 1)

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -284,7 +284,7 @@ namespace ttk {
       if(nCols < 1)
         return 0;
 
-      std::vector<std::string> formatedRows(nRows);
+      std::vector<std::string> formattedRows(nRows);
       std::vector<size_t> colSizes(nCols, 0);
       for(int i = 0; i < nRows; i++)
         for(int j = 0; j < nCols; j++)
@@ -302,7 +302,7 @@ namespace ttk {
       // Values
       int resultIndex = 0;
       for(int i = 0; i < nRows; i++) {
-        auto &row = formatedRows[resultIndex++];
+        auto &row = formattedRows[resultIndex++];
         row
           = formatCell(rows[i][0], colSizes[0], " ") + (hasHeader ? ": " : "");
         if(nCols > 1)
@@ -311,7 +311,7 @@ namespace ttk {
           row += "," + formatCell(rows[i][j], colSizes[j], " ");
       }
 
-      return this->printMsg(formatedRows, priority, lineMode, stream);
+      return this->printMsg(formattedRows, priority, lineMode, stream);
     }
 
     /**

--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -30,7 +30,7 @@ namespace ttk {
     }
 
     /**
-     * @brief Clear the underlaying vectors
+     * @brief Clear the underlying vectors
      */
     inline void clear() {
       this->data_.clear();

--- a/core/base/common/ProgramBase.h
+++ b/core/base/common/ProgramBase.h
@@ -4,7 +4,7 @@
 /// \date February 2017.
 ///
 /// \brief Base editor class for standalone programs. This class parses the
-/// the comamnd line, execute the TTK module and takes care of the IO.
+/// the command line, execute the TTK module and takes care of the IO.
 
 #pragma once
 

--- a/core/base/common/Shuffle.h
+++ b/core/base/common/Shuffle.h
@@ -3,7 +3,7 @@
 
 namespace ttk {
   /**
-   * @brief Platform-independant alternative to std::shuffle
+   * @brief Platform-independent alternative to std::shuffle
    * implementing the Fisher-Yates shuffle algorithm
    *
    * @param[in,out] toShuffle Vector of elements to be shuffled

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1469,7 +1469,7 @@ namespace ttk {
       } else if(getDimensionality() == 3) {
         preconditionTriangles();
       } else {
-        this->printErr("Unsupported dimension for vertex link precondtion");
+        this->printErr("Unsupported dimension for vertex link precondition");
         return -1;
       }
       return 0;

--- a/core/base/connectedComponents/ConnectedComponents.h
+++ b/core/base/connectedComponents/ConnectedComponents.h
@@ -7,7 +7,7 @@
 ///
 /// This filter consumes a scalar field with a feature mask and computes for
 /// each edge connected group of vertices with a non-background mask value a
-/// so-called connected component via flood-filling, where the backgroud is
+/// so-called connected component via flood-filling, where the background is
 /// masked with values smaller-equal zero. The computed components store the
 /// size, seed, and center of mass of each component. The flag
 /// UseSeedIdAsComponentId controls if the resulting segmentation is either

--- a/core/base/contourAroundPoint/ContourAroundPoint.hpp
+++ b/core/base/contourAroundPoint/ContourAroundPoint.hpp
@@ -50,7 +50,7 @@ namespace ttk {
      * \param triangulation Pointer to a valid triangulation.
      * \param scalars Scalar for each vertex.
      * \param sizeFilter 0 --> all pass, 10000 none pass.
-     * \param radius If all vertices lie on a shpere and the output is supposed
+     * \param radius If all vertices lie on a sphere and the output is supposed
      *        to do so as well, pass the radius of the sphere here or -1 to have
      *        it computed. The default 0 signals that the data is not spherical.
      * \return 0 upon success, negative values otherwise.
@@ -103,7 +103,7 @@ namespace ttk {
                         int flag,
                         float scalar) const;
 
-    /// Exctract the contour from the input edges that intersect it.
+    /// Extract the contour from the input edges that intersect it.
     /// `inpEdges` may be empty.
     template <typename scalarT, class triangulationType = AbstractTriangulation>
     void extendOutFld(const std::set<SimplexId> &inpEdges,

--- a/core/base/contourForests/ContourForests.cpp
+++ b/core/base/contourForests/ContourForests.cpp
@@ -105,8 +105,8 @@ void ContourForests::initNbPartitions() {
 // {
 
 void ContourForests::stitch() {
-  // We need goods informations here befor starting
-  // Get the arc/NODE correspoding to the seed + crossingEdges
+  // We need goods information here before starting
+  // Get the arc/NODE corresponding to the seed + crossingEdges
 
   if(params_->treeType == TreeType::Contour) {
     stitchTree(2);
@@ -221,7 +221,7 @@ void ContourForests::stitchTree(const char treetype) {
       curTreeStitchNode->clearUpSuperArcs();
 
       // for the other tree we need to replace arc (hide the one that is
-      // replaced) Exeption : the seed may contain noise directly above: we
+      // replaced) Exception : the seed may contain noise directly above: we
       // clear its down arcs if it is the stitch node.
       if(stitchVertex == seedPair.first) {
         if(DEBUG) {
@@ -332,7 +332,7 @@ void ContourForests::unifyTree(const char treetype) {
   tmpTree.treeData_.nodes.reserve(scalars_->size / 50);
   tmpTree.treeData_.superArcs.reserve(scalars_->size / 50);
 
-  // partition, node in partion, is a leaf
+  // partition, node in partition, is a leaf
   queue<tuple<idInterface, idNode>> leavesNodes;
   vector<unsigned> nbVisit(scalars_->size, 0);
 

--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -39,7 +39,7 @@ namespace ttk {
       DebugTimer timerTOTAL;
 
       // -----------
-      // Paramemters
+      // Parameters
       // -----------
       initTreeType();
       initNbScalars(mesh);
@@ -217,11 +217,11 @@ namespace ttk {
       if(params_->treeType == TreeType::Contour
          && parallelParams_.partitionNum == -1 && params_->simplifyThreshold) {
         DebugTimer timerGlobalSimplify;
-        SimplexId simplifed
+        SimplexId simplified
           = globalSimplify<scalarType>(-1, nullVertex, this->storage_, mesh);
         if(params_->debugLevel >= 1) {
           printDebug(timerGlobalSimplify, "Simplify Contour tree            ");
-          std::cout << " ( " << simplifed << " pairs merged )" << std::endl;
+          std::cout << " ( " << simplified << " pairs merged )" << std::endl;
         }
       }
 
@@ -423,7 +423,7 @@ namespace ttk {
         if(params_->treeType == TreeType::Contour) {
           DebugTimer timerCombine;
 
-          // clone here if we do not want to destry original merge trees!
+          // clone here if we do not want to destroy original merge trees!
           auto *jt = parallelData_.trees[i].getJoinTree();
           auto *st = parallelData_.trees[i].getSplitTree();
 

--- a/core/base/contourForestsTree/ContourForestsTree.cpp
+++ b/core/base/contourForestsTree/ContourForestsTree.cpp
@@ -108,7 +108,7 @@ int ContourForestsTree::combine(
     head = growingNodes.front();
 
     if(head.first) {
-      // node come frome jt
+      // node come from jt
       xt = &jt_;
       yt = &st_;
     } else {

--- a/core/base/contourForestsTree/DeprecatedNode.h
+++ b/core/base/contourForestsTree/DeprecatedNode.h
@@ -31,8 +31,8 @@ namespace ttk {
     private:
       // mesh vertex where this node is
       SimplexId vertexId_;
-      // For leaves, linkedNode is the saddle ending the persistance pair
-      // For saddle, linked is the leaf starting the persistance pair in which
+      // For leaves, linkedNode is the saddle ending the persistence pair
+      // For saddle, linked is the leaf starting the persistence pair in which
       // they are
       SimplexId linkedNode_;
       // link with superArc above and below
@@ -77,7 +77,7 @@ namespace ttk {
         return linkedNode_;
       }
 
-      inline const SimplexId &getTerminaison() const {
+      inline const SimplexId &getTermination() const {
         return linkedNode_;
       }
 
@@ -85,7 +85,7 @@ namespace ttk {
         linkedNode_ = linked;
       }
 
-      inline void setTerminaison(const SimplexId &linked) {
+      inline void setTermination(const SimplexId &linked) {
         linkedNode_ = linked;
       }
 

--- a/core/base/contourForestsTree/DeprecatedSegmentation.h
+++ b/core/base/contourForestsTree/DeprecatedSegmentation.h
@@ -69,7 +69,7 @@ namespace ttk {
       // create a new arc region with the associated Segment in Segments
       ArcRegion(const segmentIterator &s);
 
-      // During combinaison: concat some segmentations
+      // During combinations: concat some segmentations
       void addSegment(const segmentIterator &begin, const segmentIterator &end);
 
       // Put all segments in one std::vector in the arc

--- a/core/base/contourForestsTree/DeprecatedStructures.h
+++ b/core/base/contourForestsTree/DeprecatedStructures.h
@@ -44,7 +44,7 @@ namespace ttk {
       }
     };
 
-    // Tree datas ( 1 per tree )
+    // Tree data ( 1 per tree )
     struct TreeData {
       TreeType treeType;
       idPartition partition;
@@ -61,7 +61,7 @@ namespace ttk {
       std::vector<idCorresp> vert2tree;
     };
 
-    // info on one vertex and CT arc in wich it is
+    // info on one vertex and CT arc in which it is
     struct vertex {
       SimplexId id;
       idSuperArc ctArc;
@@ -71,7 +71,7 @@ namespace ttk {
     using segmentRevIterator = std::vector<vertex>::reverse_iterator;
 
     // If we want to cross a Segment in the sorted order,
-    // wich is form the end to the beginning in the case of Split Tree,
+    // which is form the end to the beginning in the case of Split Tree,
     // we can do so by using sbegin and send which use this class
     class sorted_iterator : public segmentIterator {
     public:

--- a/core/base/contourForestsTree/DeprecatedSuperArc.h
+++ b/core/base/contourForestsTree/DeprecatedSuperArc.h
@@ -4,7 +4,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date June 2016.
 ///
-///\brief TTK classe representing a SuperArc of a tree,
+///\brief TTK class representing a SuperArc of a tree,
 /// containing regular vertices.
 ///
 ///\param dataType Data type of the input scalar field (char, float,
@@ -44,13 +44,13 @@ namespace ttk {
       SimplexId lastVisited_;
       // Stat of this arc, if replaced...
       ComponentState state_;
-      // ... use this field to know by wich other arc.
+      // ... use this field to know by which other arc.
       // Caution, we do not want chained replacant !
       idSuperArc replacantId_;
 
       // Regular nodes in this arc
       // Vector for initialisation only (mergetree::build & simplify)
-      // Use vertList and sizeVertList_ to acces Arc's vertices after combine
+      // Use vertList and sizeVertList_ to access Arc's vertices after combine
       std::vector<std::pair<SimplexId, bool>> vertices_;
       // initialized with vertices_.data() and vertices_.size()
       // these two variable allow to split the segmentation when
@@ -324,7 +324,7 @@ namespace ttk {
         sizeVertList_ = newSize;
       }
 
-      // From array : alloc should be already done (chck boundary no kamikaze
+      // From array : alloc should be already done (check boundary no kamikaze
       // only)
       inline int addSegmentationGlobal(const std::pair<SimplexId, bool> *arr,
                                        const SimplexId &size) {

--- a/core/base/contourForestsTree/MergeTree.cpp
+++ b/core/base/contourForestsTree/MergeTree.cpp
@@ -327,7 +327,7 @@ SimplexId MergeTree::insertNodeAboveSeed(const idSuperArc &arc,
       // need to insert node
       const idNode &newNodeId = makeNode(stitchVert);
       Node *newNode = getNode(newNodeId);
-      // for the instert node to works
+      // for the insert node to works
       updateCorrespondingArc(stitchVert, arc);
       insertNode(newNode, false);
       newNode->setUpValence(1);
@@ -596,7 +596,7 @@ void MergeTree::delNode(
       if(markVertices != nullptr) {
         // In case the two segmenation are already contiguous,
         // it means we are removing a regular node that was inserted in the
-        // tree only for the combinaison.
+        // tree only for the combinations.
         if((treeData_.superArcs[downArc].getVertList()
             + treeData_.superArcs[downArc].getVertSize())
            == treeData_.superArcs[upArc].getVertList()) {
@@ -1240,7 +1240,7 @@ tuple<idNode, idNode, SimplexId> MergeTree::createReceptArc(
   }
 
   // if upNode == downNode, take one none merging arc randomly
-  // (this case is possbile if several degenerate node are following)
+  // (this case is possible if several degenerate node are following)
   if(upNode == downNode) {
     // several degen. nodes adjacent
     // Prefer down for JT / ST

--- a/core/base/contourForestsTree/MergeTree.h
+++ b/core/base/contourForestsTree/MergeTree.h
@@ -73,7 +73,7 @@ namespace ttk {
         scalars_->size = tri->getNumberOfVertices();
       }
 
-      /// \brief init the type of the current tree froms params
+      /// \brief init the type of the current tree from params
       void initTreeType() {
         treeData_.treeType = params_->treeType;
       }
@@ -168,7 +168,7 @@ namespace ttk {
        * @pre For this function to behave correctly in the absence of
        * the VTK wrapper, ttk::preconditionOrderArray() needs to be
        * called to fill the @p offsets buffer prior to any
-       * computation (the VTK wrapper already includes a mecanism to
+       * computation (the VTK wrapper already includes a mechanism to
        * automatically generate such a preconditioned buffer).
        * @see examples/c++/main.cpp for an example use.
        */
@@ -330,7 +330,7 @@ namespace ttk {
       }
 
       // }
-      // Get vertex correponding object
+      // Get vertex corresponding object
       // ................................{
 
       inline SuperArc *vertex2SuperArc(const SimplexId &vert) {
@@ -538,7 +538,7 @@ namespace ttk {
 
       void hideNode(const idNode &node);
 
-      // For persistance std::pair on CT
+      // For persistence std::pair on CT
       // these function allow to make a JT / ST od the CT
       std::vector<idNode> getNodeNeighbors(const idNode &node);
 
@@ -556,14 +556,14 @@ namespace ttk {
                                        const SimplexId &v);
 
       // }
-      // Update informations
+      // Update information
       // ...........................{
 
       void updateSegmentation();
 
       void parallelUpdateSegmentation(const bool ct = false);
 
-      // will disapear
+      // will disappear
       void parallelInitNodeValence(const int nbThreadValence);
 
       // }

--- a/core/base/contourForestsTree/MergeTreeTemplate.h
+++ b/core/base/contourForestsTree/MergeTreeTemplate.h
@@ -63,7 +63,7 @@ namespace ttk {
       const bool DEBUG = false;
 
       // -----------------
-      // Persistance pairs
+      // Persistence pairs
       // -----------------
       // {
 
@@ -133,7 +133,7 @@ namespace ttk {
       //---------------------
       //{
 
-      // origin, end, persistance, needToGoUp
+      // origin, end, persistence, needToGoUp
       std::vector<std::tuple<SimplexId, SimplexId, scalarType, bool>> pairsJT;
       std::vector<std::tuple<SimplexId, SimplexId, scalarType, bool>> pairsST;
 
@@ -203,7 +203,7 @@ namespace ttk {
       const bool DEBUG = false;
 
       if(DEBUG) {
-        std::cout << "Imapct simplify on tree btwn : " << posSeed0 << " and "
+        std::cout << "Impact simplify on tree btwn : " << posSeed0 << " and "
                   << posSeed1 << std::endl;
       }
 
@@ -280,7 +280,7 @@ namespace ttk {
 
         // if we have processed all but one arc of this node, we nee to continue
         // traversall
-        // throug it
+        // through it
         if(valenceOffset[parentNodeId].first
              + valenceOffset[parentNodeId].second + 1
            == getNode(parentNodeId)->getValence()) {
@@ -497,7 +497,7 @@ namespace ttk {
       for(const idNode &leave : treeData_.leaves) {
         Node *curNode = getNode(leave);
         SimplexId curVert = curNode->getVertexId();
-        SimplexId termVert = getNode(curNode->getTerminaison())->getVertexId();
+        SimplexId termVert = getNode(curNode->getTermination())->getVertexId();
 
         addPair<scalarType>(pairs, curVert, termVert, mesh);
       }
@@ -535,7 +535,7 @@ namespace ttk {
       for(const idNode &leave : treeData_.leaves) {
         Node *curNode = getNode(leave);
         SimplexId curVert = curNode->getVertexId();
-        SimplexId termVert = getNode(curNode->getTerminaison())->getVertexId();
+        SimplexId termVert = getNode(curNode->getTermination())->getVertexId();
 
         addPair<scalarType>(
           pairs, curVert, termVert, mesh, treeData_.treeType == TreeType::Join);
@@ -601,7 +601,7 @@ namespace ttk {
               SimplexId further = merge->getOrigin();
               idSuperArc furtherI = 0;
 
-              // Find the most persistant way
+              // Find the most persistent way
               for(idSuperArc ni = 1; ni < nbDown; ++ni) {
                 const idSuperArc curSaId = getNode(n)->getDownSuperArcId(ni);
                 const SuperArc *curSA = getSuperArc(curSaId);
@@ -632,7 +632,7 @@ namespace ttk {
 
                   ExtendedUnionFind *neighUF = vect_JoinUF[neigh]->find();
 
-                  if(ni != furtherI) { // keep the more persitent pair
+                  if(ni != furtherI) { // keep the more persistent pair
                     addPair<scalarType>(
                       pairsJT, neighUF->getOrigin(), v, mesh, true);
                     pendingMinMax.erase(neighUF->getOrigin());
@@ -703,7 +703,7 @@ namespace ttk {
               idSuperArc furtherI = 0;
 
               for(idSuperArc ni = 1; ni < nbUp; ++ni) {
-                // find the more persistant way
+                // find the more persistent way
                 const idSuperArc curSaId = getNode(n)->getUpSuperArcId(ni);
                 const SuperArc *curSA = getSuperArc(curSaId);
                 // Ignore hidden / simplified arc
@@ -727,7 +727,7 @@ namespace ttk {
               }
 
               if(nbUp > 1) {
-                // close finsh pair and make union
+                // close finish pair and make union
                 for(idSuperArc ni = 0; ni < nbUp; ++ni) {
                   const idSuperArc curSaId = getNode(n)->getUpSuperArcId(ni);
                   const SuperArc *curSA = getSuperArc(curSaId);
@@ -753,7 +753,7 @@ namespace ttk {
 
                   ExtendedUnionFind::makeUnion(merge, neighUF)
                     ->setOrigin(further);
-                  // Re-visit after merge lead to add the most persistant
+                  // Re-visit after merge lead to add the most persistent
                   // pair....
                 }
               }
@@ -831,7 +831,7 @@ namespace ttk {
                          const SimplexId &posSeed0,
                          const SimplexId &posSeed1,
                          const triangulationType &mesh) {
-      // idea, work on the neighbohood instead of working on the node itsef.
+      // idea, work on the neighborhood instead of working on the node itself.
       // Need lower / higher star construction.
       //
       // at this time, ST have no root except in Adjacency list. These root are
@@ -962,7 +962,7 @@ namespace ttk {
             = makeNode(treeData_.superArcs[tmp_sa].getLastVisited(), origin);
           Node *originNode = getNode(
             getNode(getSuperArc(tmp_sa)->getDownNodeId())->getOrigin());
-          originNode->setTerminaison(rootNode);
+          originNode->setTermination(rootNode);
 
           const bool overlapB
             = scalars_->sosOffsets[getNode(rootNode)->getVertexId()]
@@ -974,7 +974,7 @@ namespace ttk {
           closeSuperArc(tmp_sa, rootNode, overlapB, overlapA);
 
           // in the case we have 1 vertex domain,
-          // hide the close SuperArc wich is point1 <>> point1
+          // hide the close SuperArc which is point1 <>> point1
           if(getSuperArc(tmp_sa)->getDownNodeId()
              == getSuperArc(tmp_sa)->getUpNodeId()) {
             hideArc(tmp_sa);
@@ -1088,9 +1088,9 @@ namespace ttk {
         for(auto *neigh : vect_neighUF) {
           closeSuperArc((idSuperArc)neigh->find()->getData(), closingNode,
                         overlapB, overlapA);
-          // persistance pair closing here.
-          // For the one who will continue, it will be overide later
-          vertex2Node(neigh->find()->getOrigin())->setTerminaison(closingNode);
+          // persistence pair closing here.
+          // For the one who will continue, it will be override later
+          vertex2Node(neigh->find()->getOrigin())->setTermination(closingNode);
 
           // cout <<
           // getNode(getCorrespondingNode(neigh->find()->getOrigin()))->getVertexId()
@@ -1099,7 +1099,7 @@ namespace ttk {
           if((isJT && isLower(neigh->find()->getOrigin(), farOrigin))
              || (!isJT && isHigher(neigh->find()->getOrigin(), farOrigin))) {
             // here we keep the continuing the most persitant pair.
-            // It means a pair end when a parent have another origin thant the
+            // It means a pair end when a parent have another origin than the
             // current leaf (or is the root) It might be not intuitive but it is
             // more convenient for degenerate cases
             farOrigin = neigh->find()->getOrigin();
@@ -1155,15 +1155,15 @@ namespace ttk {
         std::cout << "nbNode initial : " << nbNodes << std::endl;
         std::cout << "nbArcs initial : " << nbArcs << std::endl;
 
-        idSuperArc nbArcsVisibles = 0;
-        idSuperArc nbNodesVisibles = 0;
+        idSuperArc nbArcsVisible = 0;
+        idSuperArc nbNodesVisible = 0;
 
         // for each visible arc, verify he is in the node
 
         for(idSuperArc aid = 0; aid < nbArcs; aid++) {
           const SuperArc &arc = treeData_.superArcs[aid];
           if(arc.isVisible()) {
-            ++nbArcsVisibles;
+            ++nbArcsVisible;
             const idNode &up = arc.getUpNodeId();
             const idNode &down = arc.getDownNodeId();
             if(up == nullNodes || down == nullNodes) {
@@ -1216,7 +1216,7 @@ namespace ttk {
         for(idNode nid = 0; nid < nbNodes; nid++) {
           const Node &node = treeData_.nodes[nid];
           if(!node.isHidden()) {
-            ++nbNodesVisibles;
+            ++nbNodesVisible;
 
             // Verify up arcs
             const auto &nbup = node.getNumberOfUpSuperArcs();
@@ -1284,7 +1284,7 @@ namespace ttk {
 
           if(segmSize && !segmVect) {
             res = false;
-            std::cout << "[Verif] Inconsistant segmentation for arc : ";
+            std::cout << "[Verif] Inconsistent segmentation for arc : ";
             std::cout << printArc(aid);
             std::cout << " have size of " << segmSize;
             std::cout << " and a null list" << std::endl;
@@ -1315,8 +1315,8 @@ namespace ttk {
         }
         std::cout << std::endl;
 
-        std::cout << "Nb visible Node : " << nbNodesVisibles << std::endl;
-        std::cout << "Nb visible Arcs : " << nbArcsVisibles << std::endl;
+        std::cout << "Nb visible Node : " << nbNodesVisible << std::endl;
+        std::cout << "Nb visible Arcs : " << nbArcsVisible << std::endl;
       }
       return res;
     }

--- a/core/base/contourTree/ContourTree.cpp
+++ b/core/base/contourTree/ContourTree.cpp
@@ -2330,7 +2330,7 @@ int ContourTree::build() {
   std::vector<int> localVertSoSoffsets{};
 
   // 0) init data structures
-  if(!externalOffets_) {
+  if(!externalOffsets_) {
     vertexSoSoffsets_ = &localVertSoSoffsets;
     vertexSoSoffsets_->resize(vertexNumber_);
     for(int i = 0; i < (int)vertexSoSoffsets_->size(); i++)
@@ -2405,7 +2405,7 @@ int ContourTree::build() {
     }
   }
 
-  // note: at this point, the split tree is layed out upside down.
+  // note: at this point, the split tree is laid out upside down.
 
   // 3) merge the two trees into the contour tree
   combineTrees();

--- a/core/base/contourTree/ContourTree.h
+++ b/core/base/contourTree/ContourTree.h
@@ -529,7 +529,7 @@ namespace ttk {
 
     inline void setVertexSoSoffsets(std::vector<int> *vertexSoSoffsets) {
       vertexSoSoffsets_ = vertexSoSoffsets;
-      externalOffets_ = true;
+      externalOffsets_ = true;
     }
 
     virtual int simplify(const double &simplificationThreshold,
@@ -577,7 +577,7 @@ namespace ttk {
     double minScalar_{}, maxScalar_{};
     const std::vector<real> *vertexScalars_{};
     std::vector<int> *vertexSoSoffsets_{};
-    bool externalOffets_{false};
+    bool externalOffsets_{false};
     const AbstractTriangulation *triangulation_{};
     std::vector<int> *minimumList_{}, *maximumList_{};
     std::vector<Node> nodeList_{}, originalNodeList_{};

--- a/core/base/contourTreeAlignment/CTA_contourtree.h
+++ b/core/base/contourTreeAlignment/CTA_contourtree.h
@@ -206,7 +206,7 @@ namespace ttk {
       /// segmentationIds Segmentation ids of the contour tree edges.
       /// segmentationIds[i] is an identifier of the segment associated with the
       /// edge of index i. \param topology Connectivity information describing
-      /// the graph stucture. topology[i][0] and topology[i][1] are the indices
+      /// the graph structure. topology[i][0] and topology[i][1] are the indices
       /// of the two nodes incident to the edge of index i. \param nVertices The
       /// number of vertices in the graph and the length of scalar array. \param
       /// nEdges The number of edges in the graph and the length of regionSizes,
@@ -250,7 +250,7 @@ namespace ttk {
       /// branch information to the node objects.
       void computeBranches();
 
-      /// Returns a graph representaiton of the contour tree as node list and
+      /// Returns a graph representation of the contour tree as node list and
       /// edge list.
       ///
       /// \returns Pair consisting of the node list and the edge list.

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.cpp
@@ -588,7 +588,7 @@ void ttk::ContourTreeAlignment::computeNewAlignmenttree(
     auto openEdgesNew2 = std::get<3>(q.front());
     q.pop();
 
-    // type 'rootNode' not possible, otherwise has to be catched
+    // type 'rootNode' not possible, otherwise has to be caught
 
     if(currTree->child1 != nullptr) {
 

--- a/core/base/contourTreeAlignment/ContourTreeAlignment.h
+++ b/core/base/contourTreeAlignment/ContourTreeAlignment.h
@@ -9,7 +9,7 @@
 /// for n contour trees. To compute the alignment, use the execute function.
 /// Each contour tree is represented by an integer array for the topology,  an
 /// integer array for each of the edge scalars `regionSize` and
-/// `segementationId`, a `<scalarType>` array for the vertex scalars and two
+/// `segmentationId`, a `<scalarType>` array for the vertex scalars and two
 /// integers for the number of edges and vertices. These properties are passed
 /// as vectors of arrays, where the i-th array in a vector represents the
 /// corresponding array for the i-th tree. The alignment tree is written to the
@@ -99,7 +99,7 @@ namespace ttk {
      *
      * It stores the following alignment information:
      * - frequency
-     * - references to the ids of the represented nodes of the origial contour
+     * - references to the ids of the represented nodes of the original contour
      * trees
      *
      * \sa ttk::ContourTreeAlignment
@@ -134,7 +134,7 @@ namespace ttk {
      *
      * It stores the following alignment information:
      * - frequency
-     * - references to the ids of the represented arcs of the origial contour
+     * - references to the ids of the represented arcs of the original contour
      * trees
      *
      * \sa ttk::ContourTreeAlignment
@@ -245,7 +245,7 @@ namespace ttk {
     /// will be filled by this algorithm. outputSegmentationIds[i*n+j] should be
     /// the id of the segment from the jth input field associated the ith node
     /// of the alignment tree. \param outputArcIds Vector for the alignment edge
-    /// maching that will be filled by this algorithm. outputArcIds[i*n+j]
+    /// matching that will be filled by this algorithm. outputArcIds[i*n+j]
     /// should be the id of the arc from the jth input tree associated the ith
     /// node of the alignment tree. \param outputEdges Vector for the alignment
     /// graph connectivity. The ith edge of the alignment connects the nodes of

--- a/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
+++ b/core/base/depthImageBasedGeometryApproximation/DepthImageBasedGeometryApproximation.h
@@ -165,7 +165,7 @@ int ttk::DepthImageBasedGeometryApproximation::execute(
                                     camPos[2] - camRight[2] * camWidthWorldHalf
                                       - camUpTrue[2] * camHeightWorldHalf};
 
-// Compute vertex coordinates while parallizing over rows
+// Compute vertex coordinates while parallelizing over rows
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif

--- a/core/base/dijkstra/Dijkstra.h
+++ b/core/base/dijkstra/Dijkstra.h
@@ -16,7 +16,7 @@ namespace ttk {
      * @param[in] source Source vertex for the Dijkstra algorithm
      * @param[in] triangulation Access to neighbor vertices
      * @param[out] outputDists Distances to source for every mesh vertex
-     * @param[in] bounds Stop the algorithim if all vertices are reached
+     * @param[in] bounds Stop the algorithm if all vertices are reached
      * @param[in] mask Vector masking the triangulation
      *
      * @return 0 in case of success

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -164,7 +164,7 @@ triangulation.
        * @pre For this function to behave correctly in the absence of
        * the VTK wrapper, ttk::preconditionOrderArray() needs to be
        * called to fill the @p data buffer prior to any
-       * computation (the VTK wrapper already includes a mecanism to
+       * computation (the VTK wrapper already includes a mechanism to
        * automatically generate such a preconditioned buffer).
        * @see examples/c++/main.cpp for an example use.
        */

--- a/core/base/dynamicTree/DynamicTree.h
+++ b/core/base/dynamicTree/DynamicTree.h
@@ -47,7 +47,7 @@ namespace ttk {
     /// operation
     bool insertEdge(DynTreeNode *const n);
 
-    /// Remove the link between this node and its parent, thus makeing a new
+    /// Remove the link between this node and its parent, thus making a new
     /// root
     inline void removeEdge() {
 #ifndef TTK_ENABLE_KAMIKAZE

--- a/core/base/fiberSurface/FiberSurface.cpp
+++ b/core/base/fiberSurface/FiberSurface.cpp
@@ -388,7 +388,7 @@ int FiberSurface::computeTriangleIntersection(
   std::array<double, 3> baryA = barypA, baryB = barypB;
   if(fabs(barypB[(pivotVertexId + 1) % 3])
      < fabs(barypA[(pivotVertexId + 1) % 3])) {
-    // let's swith the two
+    // let's switch the two
     A = pB;
     B = pA;
     baryA = barypB;

--- a/core/base/ftmTree/FTMAtomicVector.h
+++ b/core/base/ftmTree/FTMAtomicVector.h
@@ -3,7 +3,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date 2017-02-09
 ///
-///\brief TTK processing package that manage a paralle vecrion of vector
+///\brief TTK processing package that manage a parallel vecrion of vector
 
 #pragma once
 

--- a/core/base/ftmTree/FTMNode.h
+++ b/core/base/ftmTree/FTMNode.h
@@ -25,8 +25,8 @@ namespace ttk {
     private:
       // mesh vertex where this node is
       SimplexId vertexId_;
-      // For leaves, linkedNode is the saddle ending the persistance pair
-      // For saddle, linked is the leaf starting the persistance pair in which
+      // For leaves, linkedNode is the saddle ending the persistence pair
+      // For saddle, linked is the leaf starting the persistence pair in which
       // they are
       SimplexId linkedNode_;
       // link with superArc above and below
@@ -65,7 +65,7 @@ namespace ttk {
         return linkedNode_;
       }
 
-      inline SimplexId getTerminaison() const {
+      inline SimplexId getTermination() const {
         return linkedNode_;
       }
 
@@ -73,7 +73,7 @@ namespace ttk {
         linkedNode_ = linked;
       }
 
-      inline void setTerminaison(SimplexId linked) {
+      inline void setTermination(SimplexId linked) {
         linkedNode_ = linked;
       }
 

--- a/core/base/ftmTree/FTMSegmentation.cpp
+++ b/core/base/ftmTree/FTMSegmentation.cpp
@@ -390,7 +390,7 @@ tuple<SimplexId, ArcRegion> ArcRegion::splitFront(SimplexId v,
       remainingRegion.concat(reg.segmentBegin, reg.segmentEnd);
       willErase.emplace_back(it);
       if(splitVert == nullVertex || s->isLower(*reg.segmentBegin, splitVert)) {
-        // we ignore vertices that does not come frome this arc
+        // we ignore vertices that does not come from this arc
         splitVert = *reg.segmentBegin;
       }
     }

--- a/core/base/ftmTree/FTMSegmentation.h
+++ b/core/base/ftmTree/FTMSegmentation.h
@@ -139,8 +139,8 @@ namespace ttk {
       // Put all segments in one vector in the arc
       // Suppose that all segment are already sorted
       // see Segments::sortAll
-      // For Contour Tree segmentaion, you have to precise the current arc since
-      // a segment can contain vertices for several arcs
+      // For Contour Tree segmentation, you have to precise the current arc
+      // since a segment can contain vertices for several arcs
       void createSegmentation(const Scalars *s);
 
       inline SimplexId count() const {

--- a/core/base/ftmTree/FTMSuperArc.h
+++ b/core/base/ftmTree/FTMSuperArc.h
@@ -4,7 +4,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date June 2016.
 ///
-///\brief TTK classe representing a SuperArc of a tree,
+///\brief TTK class representing a SuperArc of a tree,
 /// containing regular vertices.
 ///
 ///\param dataType Data type of the input scalar field (char, float,
@@ -133,7 +133,7 @@ namespace ttk {
       // Segmentation
       // ------------
 
-      // Fonction using ArcRegion
+      // Function using ArcRegion
 
       inline void concat(const segm_it &begin, const segm_it &end) {
         region_.concat(begin, end);

--- a/core/base/ftmTree/FTMTree_CT.cpp
+++ b/core/base/ftmTree/FTMTree_CT.cpp
@@ -88,7 +88,7 @@ int FTMTree_CT::combine() {
       tie(isJT, currentNodeId) = remainingNodes.front();
       remainingNodes.pop();
       if(isJT) {
-        // node come frome jt
+        // node come from jt
         xt = &jt_;
       } else {
         // node come from st
@@ -268,7 +268,7 @@ void FTMTree_CT::createCTArcSegmentation(idSuperArc ctArc,
                                          idSuperArc xtArc) {
   const FTMTree_MT *xt = (isJT) ? &jt_ : &st_;
 
-  /*Here we prefere to create lots of small region, each arc having its own
+  /*Here we prefer to create lots of small region, each arc having its own
    * segmentation with no overlap instead of having a same vertice in several
    * arc and using vert2tree to decide because we do not want to maintain
    * vert2tree information during the whole computation*/

--- a/core/base/ftmTree/FTMTree_MT.cpp
+++ b/core/base/ftmTree/FTMTree_MT.cpp
@@ -142,7 +142,7 @@ void FTMTree_MT::buildSegmentation() {
   // current status of the segmentation of this arc
   vector<SimplexId> posSegm(nbArcs, 0);
 
-  // Segments are connex region of geometrie forming
+  // Segments are connex region of geometry forming
   // the segmentation (sorted in ascending order)
   const SimplexId nbVert = scalars_->size;
   const SimplexId chunkSize = getChunkSize();
@@ -224,7 +224,7 @@ void FTMTree_MT::buildSegmentation() {
 
   // Update SuperArc region
 
-  // ST have a segmentation wich is in the reverse-order of its build
+  // ST have a segmentation which is in the reverse-order of its build
   // ST have a segmentation sorted in ascending order as JT
   for(idSuperArc arcChunkId = 0; arcChunkId < arcChunkNb; ++arcChunkId) {
 #ifdef TTK_ENABLE_OPENMP
@@ -294,7 +294,7 @@ void FTMTree_MT::delNode(idNode node) {
     // Root: No Superarc
 #ifndef TTK_ENABLE_KAMIKAZE
     if(mainNode->getNumberOfDownSuperArcs() != 1) {
-      // Root with several childs: impossible /\ .
+      // Root with several children: impossible /\ .
       cout << endl << "[FTMTree_MT]:delNode won't delete ";
       cout << mainNode->getVertexId() << " (root) with ";
       cout << static_cast<unsigned>(mainNode->getNumberOfDownSuperArcs())
@@ -486,7 +486,7 @@ idNode FTMTree_MT::makeNode(SimplexId vertexId, SimplexId term) {
 
   idNode newNodeId = mt_data_.nodes->getNext();
   (*mt_data_.nodes)[newNodeId].setVertexId(vertexId);
-  (*mt_data_.nodes)[newNodeId].setTerminaison(term);
+  (*mt_data_.nodes)[newNodeId].setTermination(term);
   updateCorrespondingNode(vertexId, newNodeId);
 
   return newNodeId;
@@ -615,7 +615,7 @@ void FTMTree_MT::normalizeIds() {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(std::abs((long)nIdMax - (long)nIdMin) > 1) {
-    this->printMsg({"error during normalize, tree compromized: ",
+    this->printMsg({"error during normalize, tree compromised: ",
                     std::to_string(nIdMin), " ", std::to_string(nIdMax)},
                    debug::Priority::ERROR);
   }

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -38,7 +38,7 @@ namespace ttk {
   namespace ftm {
     using UF = AtomicUF *;
 
-    // Tree datas ( 1 per tree )
+    // Tree data ( 1 per tree )
     struct TreeData {
       TreeType treeType;
 
@@ -53,7 +53,7 @@ namespace ttk {
       std::vector<SimplexId> visitOrder;
       std::vector<std::list<std::vector<SimplexId>>> trunkSegments;
 
-      // Track informations
+      // Track information
       std::vector<AtomicUF> storage;
       std::vector<UF> ufs;
       std::vector<UF> propagation;
@@ -232,9 +232,9 @@ namespace ttk {
                      const SimplexId orig);
 
       template <class triangulationType>
-      std::tuple<bool, bool> propage(const triangulationType *mesh,
-                                     CurrentState &currentState,
-                                     UF curUF);
+      std::tuple<bool, bool> propagate(const triangulationType *mesh,
+                                       CurrentState &currentState,
+                                       UF curUF);
 
       template <class triangulationType>
       void closeAndMergeOnSaddle(const triangulationType *mesh,
@@ -261,7 +261,7 @@ namespace ttk {
 
       // segmentation
 
-      /// \brief use vert2tree to compute the segmentation of the fresh builded
+      /// \brief use vert2tree to compute the segmentation of the fresh built
       /// merge tree.
       void buildSegmentation();
 
@@ -302,7 +302,7 @@ namespace ttk {
       inline void preconditionTriangulation(AbstractTriangulation *tri,
                                             const bool preproc = true) {
         if(tri && preproc) {
-          // propage through vertices (build)
+          // propagate through vertices (build)
           tri->preconditionVertexNeighbors();
         }
       }
@@ -350,7 +350,7 @@ namespace ttk {
        * @pre For this function to behave correctly in the absence of
        * the VTK wrapper, ttk::preconditionOrderArray() needs to be
        * called to fill the @p sos buffer prior to any
-       * computation (the VTK wrapper already includes a mecanism to
+       * computation (the VTK wrapper already includes a mechanism to
        * automatically generate such a preconditioned buffer).
        * @see examples/c++/main.cpp for an example use.
        */
@@ -478,7 +478,7 @@ namespace ttk {
         return mt_data_.vert2tree[val];
       }
 
-      // Get corresponding elemnt
+      // Get corresponding element
 
       inline SuperArc *vertex2SuperArc(const SimplexId vert) {
         return &((*mt_data_.superArcs)[getCorrespondingSuperArcId(vert)]);

--- a/core/base/ftmTree/FTMTree_MT_Template.h
+++ b/core/base/ftmTree/FTMTree_MT_Template.h
@@ -176,7 +176,7 @@ namespace ttk {
       for(idNode n = 0; n < nbLeaves; ++n) {
         const idNode l = mt_data_.leaves[n];
         SimplexId v = getNode(l)->getVertexId();
-        // for each node: get vert, create uf and lauch
+        // for each node: get vert, create uf and launch
         mt_data_.storage[n] = AtomicUF{v};
         mt_data_.ufs[v] = &mt_data_.storage[n];
 
@@ -254,7 +254,7 @@ namespace ttk {
 
         // Saddle & Last detection + propagation
         bool isSaddle, isLast;
-        std::tie(isSaddle, isLast) = propage(mesh, *currentState, startUF);
+        std::tie(isSaddle, isLast) = propagate(mesh, *currentState, startUF);
 
         // regular propagation
 #ifdef TTK_ENABLE_OPENMP
@@ -340,9 +340,9 @@ namespace ttk {
     // ------------------------------------------------------------------------
 
     template <class triangulationType>
-    std::tuple<bool, bool> FTMTree_MT::propage(const triangulationType *mesh,
-                                               CurrentState &currentState,
-                                               UF curUF) {
+    std::tuple<bool, bool> FTMTree_MT::propagate(const triangulationType *mesh,
+                                                 CurrentState &currentState,
+                                                 UF curUF) {
       bool becameSaddle = false, isLast = false;
       const auto nbNeigh = mesh->getVertexNeighborNumber(currentState.vertex);
       valence decr = 0;

--- a/core/base/ftmTreePP/FTMTreePP.cpp
+++ b/core/base/ftmTreePP/FTMTreePP.cpp
@@ -3,7 +3,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date 2017-08-03
 ///
-///\brief TTK processing package that add persistance pairs features
+///\brief TTK processing package that add persistence pairs features
 // to the contour tree package.
 ///
 ///\param dataType Data type of the input scalar field (char, float,

--- a/core/base/ftmTreePP/FTMTreePP.h
+++ b/core/base/ftmTreePP/FTMTreePP.h
@@ -3,7 +3,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date 2017-08-03
 ///
-///\brief TTK processing package that add persistance pairs features
+///\brief TTK processing package that add persistence pairs features
 // to the contour tree package.
 ///
 ///\param dataType Data type of the input scalar field (char, float,

--- a/core/base/ftrGraph/CMakeLists.txt
+++ b/core/base/ftrGraph/CMakeLists.txt
@@ -8,7 +8,7 @@ if(ENABLE_PROFILING)
   set(profiler_lib profiler)
 endif()
 
-# option (TTK_DISABLE_FTR_LAZY "Disable the lazyness optimization" OFF)
+# option (TTK_DISABLE_FTR_LAZY "Disable the laziness optimization" OFF)
 # mark_as_advanced(TTK_DISABLE_FTR_LAZY)
 
 option (TTK_ENABLE_FTR_TASK_STATS "print propagations death time (min only)" OFF)

--- a/core/base/ftrGraph/DynamicGraph.h
+++ b/core/base/ftrGraph/DynamicGraph.h
@@ -83,12 +83,12 @@ namespace ttk {
         return getNode(nid)->getCorArc();
       }
 
-      // check wether or not this node is connected to others
+      // check whether or not this node is connected to others
       bool isDisconnected(const DynGraphNode<Type> *const node) const {
         return !node->hasParent();
       }
 
-      // check wether or not this node is connected to others
+      // check whether or not this node is connected to others
       bool isDisconnected(const std::size_t nid) {
         return !getNode(nid)->hasParent();
       }
@@ -194,8 +194,8 @@ namespace ttk {
     };
 
     // Same as dynamic graph but keep the number of subtrees at any time
-    // CAREFULL: this number is not protected for parallel modification, and
-    // this class is not made for parallel acess.
+    // CAREFUL: this number is not protected for parallel modification, and
+    // this class is not made for parallel access.
     template <typename Type>
     class LocalForest : public DynamicGraph<Type> {
       std::size_t nbCC_;
@@ -360,7 +360,7 @@ namespace ttk {
                       const Type weight,
                       const idSuperArc corArc);
 
-      /// Remove the link between this node and its parent, thus makeing a new
+      /// Remove the link between this node and its parent, thus making a new
       /// root
       void removeEdge();
     };

--- a/core/base/ftrGraph/FTRAtomicVector.h
+++ b/core/base/ftrGraph/FTRAtomicVector.h
@@ -3,7 +3,7 @@
 /// \author Charles Gueunet <charles.gueunet@lip6.fr>
 /// \date 2018-01-22
 ///
-///\brief TTK processing package that manage a paralle version of vector *Same
+///\brief TTK processing package that manage a parallel version of vector *Same
 /// as in FTM: Common ?*
 
 #pragma once

--- a/core/base/ftrGraph/FTRDataTypes.h
+++ b/core/base/ftrGraph/FTRDataTypes.h
@@ -12,7 +12,7 @@
 // core includes
 #include <DataTypes.h>
 
-// c++ incldues
+// c++ includes
 #include <functional>
 #include <limits>
 
@@ -45,7 +45,7 @@ namespace ttk {
     /// Edges are sorted by their starting vertex (see orderedEdge)
     using orderedTriangle = std::tuple<idEdge, idEdge, idEdge>;
 
-    /// \brief position of a vertex in a trianlge
+    /// \brief position of a vertex in a triangle
     enum class vertPosInTriangle : char { Start = 0, Middle, End };
 
     // For tasks:

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -75,7 +75,7 @@ namespace ttk {
 
     template <typename ScalarType, typename triangulationType>
     class FTRGraph : public Allocable {
-      // Exernal fields
+      // External fields
       Params params_{};
       Scalars<ScalarType> scalars_{};
 
@@ -164,7 +164,7 @@ namespace ttk {
       // Parameters
       // ----------
 
-      /// The nuber of threads to be used during the computation
+      /// The number of threads to be used during the computation
       /// of the reeb graph
       int setThreadNumber(const int nb) override {
         params_.threadNumber = nb;
@@ -190,7 +190,7 @@ namespace ttk {
       }
 
       /// When several points have the same scalar value,
-      /// we use simulation of simplicity to distingish between
+      /// we use simulation of simplicity to distinguish between
       /// them in a morse discret geometry compliant way.
       /// This is explained in the TTK report.
       /// Set the array to use here
@@ -266,7 +266,7 @@ namespace ttk {
       /// has been completely visited and then continue. When a 1 Saddle is met,
       /// we split the local propagation with a BFS to continue locally. if arc
       /// is supplied, this arc will be used for the growth NOTE: use an
-      /// insertion/deletion list to add lazyness on DynGraph
+      /// insertion/deletion list to add laziness on DynGraph
       void growthFromSeed(const idVertex seed,
                           Propagation *localProp,
                           idSuperArc currentArc = nullSuperArc);
@@ -286,7 +286,7 @@ namespace ttk {
         lowerComps(const std::vector<idEdge> &finishingEdges,
                    const Propagation *const localProp);
 
-      /// Symetric to lowerComps
+      /// Symmetric to lowerComps
       /// \ref lowerComps
       std::set<DynGraphNode<idVertex> *>
         upperComps(const std::vector<idEdge> &startingEdges,
@@ -381,7 +381,7 @@ namespace ttk {
 
       /// local growth replacing the global sort
       /// Add vertices above the current one in the propagation,
-      /// return true if vertices aboves the current one have been found.
+      /// return true if vertices above the current one have been found.
       /// Note, these vertices may not have been added if already marked as in
       /// the propagation.
       void localGrowth(Propagation *const localProp,
@@ -415,7 +415,7 @@ namespace ttk {
                          const std::set<DynGraphNode<idVertex> *> &upperComp,
                          const bool hidden = false);
 
-      // Retrun one triangle by upper CC of the vertex v
+      // Return one triangle by upper CC of the vertex v
       std::set<idCell> upCCtriangleSeeds(const idVertex v,
                                          const Propagation *const localProp);
 
@@ -428,7 +428,7 @@ namespace ttk {
                    const Propagation *const localProp);
 
       // bfs on triangles/edges crossing the level set at saddle, starting
-      // at seed. upper vertices encountred are added to newLocalProp
+      // at seed. upper vertices encountered are added to newLocalProp
       // : saddle is the starting saddle,
       // : seed is at first call the first triangle of this bfs (will change
       // during recursive call)
@@ -441,7 +441,7 @@ namespace ttk {
                           Propagation *const newLocalProp,
                           const idSuperArc arc);
 
-      // visit a vertex in terms of segmantation and history,
+      // visit a vertex in terms of segmentation and history,
       // also check if the current arc is merging through an opposite one.
       idSuperArc visit(Propagation *const localProp, const idSuperArc curArc);
 
@@ -450,7 +450,7 @@ namespace ttk {
       // Create a new propagation starting at leaf
       Propagation *newPropagation(const idVertex leaf, const bool fromMax);
 
-      // Compute the wieght of the edge in the dyngraph between e1 and e2.
+      // Compute the weight of the edge in the dyngraph between e1 and e2.
       // This weight is the min value of the two endpoints, we use the mirror
       // array (int)
       idVertex getWeight(const orderedEdge &e1,

--- a/core/base/ftrGraph/FTRGraphPrivate_Template.h
+++ b/core/base/ftrGraph/FTRGraphPrivate_Template.h
@@ -5,7 +5,7 @@
 #include "FTRGraph_Template.h"
 #include "FTRTasks.h"
 
-// c++ incldues
+// c++ includes
 #include <unordered_map>
 
 // trick to print a full line in an atomic operation, avoid mixed up redulsts in
@@ -226,7 +226,7 @@ void ttk::ftr::FTRGraph<ScalarType, triangulationType>::growthFromSeed(
     localGrowth(localProp, star.upper);
   } // end propagation while
 
-  // get the corresponging critical point on which
+  // get the corresponding critical point on which
   // the propagation has stopped (join, split, max)
   const idVertex upVert = localProp->getCurVertex();
 
@@ -253,7 +253,7 @@ void ttk::ftr::FTRGraph<ScalarType, triangulationType>::growthFromSeed(
 
   PRINT(upVert << " active " << localProp->getNbArcs());
 
-  // reached node id and wether it has been created by this task or already
+  // reached node id and whether it has been created by this task or already
   // existed
   idNode saddleNode;
   idSuperArc joinParentArc{};
@@ -412,8 +412,8 @@ void ttk::ftr::FTRGraph<ScalarType, triangulationType>::growthSequential(
 #ifndef TTK_DISABLE_FTR_LAZY
     if(valences_.lower[curVert] < 2 && valences_.upper[curVert] < 2) {
 
-      // simple reeb regular, lazyness
-      if(star.lower.size()) {
+      // simple reeb regular, laziness
+      if(!star.lower.empty()) {
         // not a min nor a saddle: 1 CC below (need findSubtree)
         currentArc = dynGraph(localProp).getSubtreeArc(star.lower[0]);
         if(valences_.upper[curVert] && valences_.lower[curVert]) {
@@ -682,7 +682,7 @@ void ttk::ftr::FTRGraph<ScalarType, triangulationType>::
                            const Propagation *const localProp,
                            const idSuperArc curArc) {
   // Check if exist ?
-  // If not, the triangle will be visited again once a merge have occured.
+  // If not, the triangle will be visited again once a merge have occurred.
   // So we do not add the edge now
   dynGraph(localProp).removeEdge(
     std::get<0>(oTriangle), std::get<1>(oTriangle));

--- a/core/base/ftrGraph/FTRLazy.h
+++ b/core/base/ftrGraph/FTRLazy.h
@@ -4,10 +4,10 @@
 /// \author Gueunet Charles <charles.gueunet+ttk@gmail.com>
 /// \date 2018-07-31
 ///
-/// \brief TTK %DynamicGraph lazyness
+/// \brief TTK %DynamicGraph laziness
 ///
 /// This class maintain the information per arc
-/// for the lazy evalutaion of each DG component.
+/// for the lazy evaluation of each DG component.
 ///
 /// \sa ttk::FTRGraph
 

--- a/core/base/ftrGraph/FTRPropagation.h
+++ b/core/base/ftrGraph/FTRPropagation.h
@@ -59,7 +59,7 @@ namespace ttk {
         return curVert_;
       }
 
-      // used to avoid thhe fibonacci heaps the local propagation is only
+      // used to avoid the fibonacci heaps the local propagation is only
       // used to store comp and current vert during a sequential pass using
       // the reference alforithm and so it's a mock propagation used for
       // compliance with the rest of the code

--- a/core/base/ftrGraph/FTRScalars.h
+++ b/core/base/ftrGraph/FTRScalars.h
@@ -69,7 +69,7 @@ namespace ttk {
        * @pre For this function to behave correctly in the absence of
        * the VTK wrapper, ttk::preconditionOrderArray() needs to be
        * called to fill the @p sos buffer prior to any
-       * computation (the VTK wrapper already includes a mecanism to
+       * computation (the VTK wrapper already includes a mechanism to
        * automatically generate such a preconditioned buffer).
        * @see examples/c++/main.cpp for an example use.
        */

--- a/core/base/ftrGraph/FTRTasks.h
+++ b/core/base/ftrGraph/FTRTasks.h
@@ -79,7 +79,7 @@ namespace ttk {
       }
     };
 
-    // Explain priority explicitely
+    // Explain priority explicitly
     enum PriorityLevel { Min = 0, Low, Average, High, Higher, Max };
   } // namespace ftr
 } // namespace ttk

--- a/core/base/ftrGraph/Graph.cpp
+++ b/core/base/ftrGraph/Graph.cpp
@@ -21,7 +21,7 @@ std::string Graph::print(const int verbosity) const {
   }
 
   if(verbosity >= 2) {
-    res << "visibles arcs: " << getNumberOfVisibleArcs() << endl;
+    res << "visible arcs: " << getNumberOfVisibleArcs() << endl;
   }
 
   if(verbosity >= 3) {

--- a/core/base/ftrGraph/Graph.h
+++ b/core/base/ftrGraph/Graph.h
@@ -357,7 +357,7 @@ namespace ttk {
       // tools
 
       // ensure that main arc have valid up/down node even if the merge of
-      // the two arc occured during the computation, leaving some unfinished
+      // the two arc occurred during the computation, leaving some unfinished
       // arcs.
       template <typename ScalarType>
       void consolidateArc(const idSuperArc mainArc,

--- a/core/base/ftrGraph/Graph_Template.h
+++ b/core/base/ftrGraph/Graph_Template.h
@@ -25,7 +25,7 @@ namespace ttk {
       // Arc created by increasing and decreasing tasks are reversed in
       // terms of up/down node. We use this property to merge such arcs. in
       // order to distinguish between arcs around a loop, and arc is
-      // described by the fisrt and last vertex of its segmentation if any.
+      // described by the first and last vertex of its segmentation if any.
       // Otherwise by its up / last node.
 
       const idSuperArc nbArcs = arcs_.size();

--- a/core/base/ftrGraph/Mesh.h
+++ b/core/base/ftrGraph/Mesh.h
@@ -51,7 +51,7 @@ namespace ttk {
       triScheme(const char u) : scheme(u) {
       }
 
-      // direct acess to data
+      // direct access to data
       operator char() const {
         return scheme;
       }

--- a/core/base/helloWorld/HelloWorld.h
+++ b/core/base/helloWorld/HelloWorld.h
@@ -46,7 +46,7 @@ namespace ttk {
     }
 
     /**
-     * TODO 3: Implmentation of the algorithm.
+     * TODO 3: Implementation of the algorithm.
      *
      *         Note: If the algorithm requires a triangulation then this
      *               method must be called after the triangulation has been
@@ -100,7 +100,7 @@ namespace ttk {
             outputData[i] += inputData[neighborId];
           }
 
-          // devide by neighbor number
+          // divide by neighbor number
           outputData[i] /= (nNeighbors + 1);
         }
 

--- a/core/base/icosphere/Icosphere.h
+++ b/core/base/icosphere/Icosphere.h
@@ -254,7 +254,7 @@ int ttk::Icosphere::computeIcosphere(
         = s % 2 == 0 ? connectivityList : connectivityListTemp.data();
       IT *newList = s % 2 != 0 ? connectivityList : connectivityListTemp.data();
 
-      // reset indicies
+      // reset indices
       const size_t nOldTriangles = triangleIndex;
       triangleIndex = 0;
 

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -85,7 +85,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p data buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/jacobiSet/JacobiSet.h
+++ b/core/base/jacobiSet/JacobiSet.h
@@ -54,11 +54,10 @@ namespace ttk {
                          const triangulationType &triangulation);
 
     template <class dataTypeU, class dataTypeV>
-    int perturbate(const dataTypeU *const uField,
-                   const dataTypeV *const vField,
-                   const dataTypeU uEpsilon = Geometry::powIntTen(-DBL_DIG),
-                   const dataTypeV vEpsilon
-                   = Geometry::powIntTen(-DBL_DIG)) const;
+    int perturb(const dataTypeU *const uField,
+                const dataTypeV *const vField,
+                const dataTypeU uEpsilon = Geometry::powIntTen(-DBL_DIG),
+                const dataTypeV vEpsilon = Geometry::powIntTen(-DBL_DIG)) const;
 
     inline void
       setEdgeFans(const std::vector<std::vector<SimplexId>> *edgeFans) {
@@ -85,7 +84,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p sosOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */
@@ -97,7 +96,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p sosOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/jacobiSet/JacobiSet_Template.h
+++ b/core/base/jacobiSet/JacobiSet_Template.h
@@ -555,10 +555,10 @@ char ttk::JacobiSet::getCriticalType(const SimplexId &edgeId,
 }
 
 template <class dataTypeU, class dataTypeV>
-int ttk::JacobiSet::perturbate(const dataTypeU *const uField,
-                               const dataTypeV *const vField,
-                               const dataTypeU uEpsilon,
-                               const dataTypeV vEpsilon) const {
+int ttk::JacobiSet::perturb(const dataTypeU *const uField,
+                            const dataTypeV *const vField,
+                            const dataTypeU uEpsilon,
+                            const dataTypeV vEpsilon) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(!uField)

--- a/core/base/kdTree/KDTree.h
+++ b/core/base/kdTree/KDTree.h
@@ -28,7 +28,7 @@ namespace ttk {
     // Power used for the computation of distances. p=2 yields euclidean
     // distance
     int p_{2};
-    // Wether or not the KDTree should include weights that add up to distance
+    // Whether or not the KDTree should include weights that add up to distance
     // for the computation of nearest neighbours
     bool include_weights_{false};
 
@@ -71,7 +71,7 @@ namespace ttk {
                         const int &ptNumber,
                         const int &dimension,
                         KDTree<dataType, Container> *parent,
-                        KDTreeMap &correspondance_map,
+                        KDTreeMap &correspondence_map,
                         const std::vector<std::vector<dataType>> &weights = {},
                         const int weight_number = 1);
 
@@ -148,7 +148,7 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
     const std::vector<std::vector<dataType>> &weights,
     const int weight_number) {
 
-  KDTreeMap correspondance_map(ptNumber);
+  KDTreeMap correspondence_map(ptNumber);
   // First, perform a argsort on the data
   // initialize original index locations
   for(int axis = 0; axis < dimension; axis++) {
@@ -166,7 +166,7 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
   });
   int median_loc = (int)(ptNumber - 1) / 2;
   int median_idx = idx[median_loc];
-  correspondance_map[median_idx] = this;
+  correspondence_map[median_idx] = this;
 
   for(int axis = 0; axis < dimension; axis++) {
     coordinates_[axis] = data[dimension * median_idx + axis];
@@ -199,7 +199,7 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
     this->left_
       = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, true);
     this->left_->buildRecursive(data, idx_left, ptNumber, dimension, this,
-                                correspondance_map, weights, weight_number);
+                                correspondence_map, weights, weight_number);
   }
 
   if(idx.size() > 1) {
@@ -211,10 +211,10 @@ typename ttk::KDTree<dataType, Container>::KDTreeMap
     this->right_
       = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, false);
     this->right_->buildRecursive(data, idx_right, ptNumber, dimension, this,
-                                 correspondance_map, weights, weight_number);
+                                 correspondence_map, weights, weight_number);
   }
 
-  return correspondance_map;
+  return correspondence_map;
 }
 
 template <typename dataType, typename Container>
@@ -224,7 +224,7 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
   const int &ptNumber,
   const int &dimension,
   KDTree<dataType, Container> *parent,
-  KDTreeMap &correspondance_map,
+  KDTreeMap &correspondence_map,
   const std::vector<std::vector<dataType>> &weights,
   const int weight_number) {
 
@@ -235,7 +235,7 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
   });
   int median_loc = (int)(idx_side.size() - 1) / 2;
   int median_idx = idx_side[median_loc];
-  correspondance_map[median_idx] = this;
+  correspondence_map[median_idx] = this;
 
   for(int axis = 0; axis < dimension; axis++) {
     coordinates_[axis] = data[dimension * median_idx + axis];
@@ -288,7 +288,7 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
     this->left_
       = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, true);
     this->left_->buildRecursive(data, idx_left, ptNumber, dimension, this,
-                                correspondance_map, weights, weight_number);
+                                correspondence_map, weights, weight_number);
   }
 
   if(idx_side.size() > 1) {
@@ -300,7 +300,7 @@ void ttk::KDTree<dataType, Container>::buildRecursive(
     this->right_
       = std::make_unique<KDTree>(this, (coords_number_ + 1) % dimension, false);
     this->right_->buildRecursive(data, idx_right, ptNumber, dimension, this,
-                                 correspondance_map, weights, weight_number);
+                                 correspondence_map, weights, weight_number);
   }
 }
 
@@ -368,7 +368,7 @@ void ttk::KDTree<dataType, Container>::recursiveGetKClosest(
   std::vector<dataType> &costs,
   const int weight_index,
   const PowerFunc &power) {
-  // 1- Look wether or not to include the current point in the nearest
+  // 1- Look whether or not to include the current point in the nearest
   // neighbours
   dataType cost = this->getCost(coordinates, power);
   cost += weight_[weight_index];

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -149,7 +149,7 @@ namespace ttk {
           authorizationMask[authorizedExtremaIndices[i]] = -2;
 
         IT writeIndex = 0;
-// find discareded maxima
+// find discarded maxima
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
@@ -783,12 +783,12 @@ namespace ttk {
         }
 
         if(performSuperlevelSetPropagation) {
-          // skip first idx as it correponds to saddle
+          // skip first idx as it corresponds to saddle
           for(IT i = 1; i <= nSegmentVertices; i++)
             localOrder[localVertexSequence[i]] = -i;
         } else {
           IT order = -nSegmentVertices;
-          // skip last idx as it correponds to saddle
+          // skip last idx as it corresponds to saddle
           for(IT i = 0; i < nSegmentVertices; i++)
             localOrder[localVertexSequence[i]] = order++;
         }
@@ -803,7 +803,7 @@ namespace ttk {
                                      const TT *triangulation,
                                      const IT *segmentation,
                                      const IT *inputOrder) const {
-        // quick espace for small segments
+        // quick escape for small segments
         if(propagation->segmentSize == 1) {
           localOrder[propagation->segment[0]] = -2;
           return 1;
@@ -1139,9 +1139,9 @@ namespace ttk {
         // init propagations
         status = this->initializePropagations<IT, TT>(
           propagations,
-          queueMask, // use as authorization mask (will be overriden by
+          queueMask, // use as authorization mask (will be overridden by
                      // subsequent procedures)
-          localOrder, // use as maxima buffer (will be overriden by subsequent
+          localOrder, // use as maxima buffer (will be overridden by subsequent
                       // procedures)
 
           authorizedExtremaIndices, nAuthorizedExtremaIndices, order,
@@ -1224,7 +1224,7 @@ namespace ttk {
         status = this->initializePropagations<IT, TT>(
           propagations,
           queueMask, // will be ignored since there are no authorized maxima
-          localOrder, // use as maxima buffer (will be overriden by subsequent
+          localOrder, // use as maxima buffer (will be overridden by subsequent
                       // procedures)
 
           nullptr, 0, order, triangulation);

--- a/core/base/lowestCommonAncestor/LowestCommonAncestor.cpp
+++ b/core/base/lowestCommonAncestor/LowestCommonAncestor.cpp
@@ -196,8 +196,8 @@ int ttk::LowestCommonAncestor::eulerianTransverse() {
   nodeOrder_.reserve(2 * getNumberOfNodes() + 1);
   nodeDepth_.clear();
   nodeDepth_.reserve(2 * getNumberOfNodes() + 1);
-  nodeFirstAppearence_.clear();
-  nodeFirstAppearence_.resize(getNumberOfNodes(), -1);
+  nodeFirstAppearance_.clear();
+  nodeFirstAppearance_.resize(getNumberOfNodes(), -1);
   // Transverse starting from the root
   std::stack<int> nodeStack;
   int depth = 0;
@@ -219,7 +219,7 @@ int ttk::LowestCommonAncestor::eulerianTransverse() {
       for(int i = 0; i < numberOfSuccessors; i++) {
         nodeStack.push(node_[nodeId].getSuccessorId(i));
       }
-      nodeFirstAppearence_[nodeId] = iteration;
+      nodeFirstAppearance_[nodeId] = iteration;
       isVisited[nodeId] = true;
     }
     // Next depth

--- a/core/base/lowestCommonAncestor/LowestCommonAncestor.h
+++ b/core/base/lowestCommonAncestor/LowestCommonAncestor.h
@@ -82,11 +82,11 @@ namespace ttk {
     /// \pre preprocess() must have been called after the last change in the
     /// tree.
     inline int query(int i, int j) const {
-      if(nodeFirstAppearence_[i] > nodeFirstAppearence_[j]) {
+      if(nodeFirstAppearance_[i] > nodeFirstAppearance_[j]) {
         std::swap(i, j);
       }
       return nodeOrder_[RMQuery(
-        nodeFirstAppearence_[i], nodeFirstAppearence_[j])];
+        nodeFirstAppearance_[i], nodeFirstAppearance_[j])];
     }
 
   protected:
@@ -116,7 +116,7 @@ namespace ttk {
     /* Eulerian Transverse */
     std::vector<int> nodeOrder_{};
     std::vector<int> nodeDepth_{};
-    std::vector<int> nodeFirstAppearence_{};
+    std::vector<int> nodeFirstAppearance_{};
 
     /* Range Minimum Query */
     int blocSize_{};

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.cpp
@@ -307,9 +307,8 @@ int MandatoryCriticalPoints::buildPairs(
     }
   }
   // Sort pair by increasing value of d(S,M) (.second)
-  criticalPointPairComparaison pairComparaison;
-  std::sort(
-    extremaSaddlePair.begin(), extremaSaddlePair.end(), pairComparaison);
+  criticalPointPairComparison pairComparison;
+  std::sort(extremaSaddlePair.begin(), extremaSaddlePair.end(), pairComparison);
 
   const std::string treeName = treeType == TreeType::JoinTree
                                  ? "minimum - join saddle"
@@ -336,7 +335,7 @@ int MandatoryCriticalPoints::computePlanarLayout(
   std::vector<double> &xCoord,
   std::vector<double> &yCoord) const {
 
-  /* Informations */
+  /* Information */
   const int numberOfPoints = mdtTree.getNumberOfVertices();
   const double rangeMin = getGlobalMinimum();
   const double rangeMax = getGlobalMaximum();
@@ -447,7 +446,7 @@ int MandatoryCriticalPoints::computePlanarLayout(
 
   /* X coordinates */
   // Sorting
-  pairComparaison xCoordCmp;
+  pairComparison xCoordCmp;
   std::sort(xOrder.begin(), xOrder.end(), xCoordCmp);
   // X coordinates for all points except root (global extremum)
   int pointCount = 0;
@@ -496,7 +495,7 @@ int MandatoryCriticalPoints::computeExtremumComponent(
   // Get the list of the sub tree super arc ids
   std::vector<int> subTreeSuperArcId;
   getSubTreeSuperArcIds(&tree, rootSuperArcId, subTreeSuperArcId);
-  // Comparaison
+  // Comparison
   int sign = (pointType == PointType::Minimum) ? 1 : -1;
   // Compute each super arc
   for(int i = 0; i < (int)subTreeSuperArcId.size(); i++) {
@@ -1225,7 +1224,7 @@ int MandatoryCriticalPoints::enumerateMandatorySaddles(
     order.emplace_back(i, mandatoryMergedExtrema_tmp[i].size());
   }
   // Sort by number of merged extrema
-  mandatorySaddleComparaison cmp;
+  mandatorySaddleComparison cmp;
   std::sort(order.begin(), order.end(), cmp);
   // Reorder for output
   mandatoryMergedExtrema.clear();
@@ -1461,7 +1460,7 @@ int MandatoryCriticalPoints::simplify(
               lastSaddleId = rootSaddleId;
               rootSaddleId = saddleParentSaddle[rootSaddleId];
             }
-            // Link the root to the proccessed saddle
+            // Link the root to the processed saddle
             saddleParentSaddle[rootSaddleId] = i;
           }
         }

--- a/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
+++ b/core/base/mandatoryCriticalPoints/MandatoryCriticalPoints.h
@@ -120,7 +120,7 @@ namespace ttk {
   };
 
   /// Comparison between critical point pairs ( (Extremum,Saddle), dist(M,S) )
-  struct criticalPointPairComparaison {
+  struct criticalPointPairComparison {
     bool operator()(const std::pair<std::pair<int, int>, double> &left,
                     const std::pair<std::pair<int, int>, double> &right) const {
       return (left.second < right.second);
@@ -128,7 +128,7 @@ namespace ttk {
   };
 
   /// Comparison between mandatory saddles (Saddle id, Number of merged extrema)
-  struct mandatorySaddleComparaison {
+  struct mandatorySaddleComparison {
     bool operator()(const std::pair<int, int> &left,
                     const std::pair<int, int> &right) const {
       return (left.second < right.second);
@@ -137,7 +137,7 @@ namespace ttk {
 
   // TODO : template
   /// Comparison of the second member of a std::pair<int,double>
-  struct pairComparaison {
+  struct pairComparison {
     bool operator()(const std::pair<int, double> &left,
                     const std::pair<int, double> &right) const {
       return (left.second < right.second);

--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -249,7 +249,7 @@ namespace ttk {
     }
 
     // ------------------------------------------------------------------------
-    // Assignement
+    // Assignment
     // ------------------------------------------------------------------------
     template <class dataType>
     void assignmentCentroidsAccelerated(

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -280,7 +280,7 @@ namespace ttk {
     // Edit Distance Dynamic Programming Equations
     // ------------------------------------------------------------------------
     template <class dataType>
-    void computeForestToEmpyDistance(
+    void computeForestToEmptyDistance(
       ftm::FTMTree_MT *tree1,
       ftm::idNode nodeI,
       int i,
@@ -458,7 +458,7 @@ namespace ttk {
                       std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>
                         &outputMatching) {
       // ---------------------
-      // ----- Init dynamic progamming tables
+      // ----- Init dynamic programming tables
       // --------------------
       size_t nRows = tree1->getNumberOfNodes() + 1;
       size_t nCols = tree2->getNumberOfNodes() + 1;
@@ -596,7 +596,7 @@ namespace ttk {
             tree1, tree2, outputMatching);
       }
 
-      // std::cout << "TIME COMP.MATC. = " << t_match_time << std::endl;
+      // std::cout << "TIME COMP.MATCH. = " << t_match_time << std::endl;
       printMsg("Total", 1, t_total.getElapsedTime(), this->threadNumber_,
                debug::LineMode::NEW, debug::Priority::INFO);
       printMsg(debug::Separator::L2);
@@ -707,8 +707,8 @@ namespace ttk {
       if(processTree1) {
         if(computeEmptyTree) {
           int i = nodeI + 1;
-          // --- Forst to empty tree distance
-          computeForestToEmpyDistance(tree1, nodeI, i, treeTable, forestTable);
+          // --- Forest to empty tree distance
+          computeForestToEmptyDistance(tree1, nodeI, i, treeTable, forestTable);
 
           // --- Subtree to empty tree distance
           computeSubtreeToEmptyDistance(
@@ -1072,7 +1072,7 @@ namespace ttk {
             if(isTree1) {
               int i = nodeT + 1;
               // --- Forest to empty tree distance
-              computeForestToEmpyDistance(
+              computeForestToEmptyDistance(
                 tree, nodeT, i, treeTable, forestTable);
 
               // --- Subtree to empty tree distance

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
@@ -5,7 +5,7 @@
 ///
 /// This module defines the %MergeTreePrincipalGeodesics class that computes
 /// Principal Geodesic Analysis on the space of merge trees or persistence
-/// diagrams, that is, a set of orthognal geodesic axes defining a basis with
+/// diagrams, that is, a set of orthogonal geodesic axes defining a basis with
 /// the barycenter as origin.
 ///
 /// \b Related \b publication: \n
@@ -28,7 +28,7 @@ namespace ttk {
   /**
    * The MergeTreePrincipalGeodesics class provides methods to compute
    * Principal Geodesic Analysis on the space of merge trees or persistence
-   * diagrams, that is, a set of orthognal geodesic axes defining a basis with
+   * diagrams, that is, a set of orthogonal geodesic axes defining a basis with
    * the barycenter as origin.
    */
   class MergeTreePrincipalGeodesics : virtual public Debug,
@@ -211,12 +211,12 @@ namespace ttk {
                     return (std::get<0>(a) > std::get<0>(b));
                   });
 
-      // Init vectors according farest input
-      // (repeat with the ith farest until projection gives non null vector)
+      // Init vectors according fairest input
+      // (repeat with the ith fairest until projection gives non null vector)
       unsigned int i = 0;
       bool foundGoodIndex = false;
       while(not foundGoodIndex) {
-        // Get matching of the ith farest input
+        // Get matching of the ith fairest input
         if(bestIndex >= 0 and bestIndex < (int)trees.size()) {
           if(geodesicNumber != 0) {
             dataType distance;

--- a/core/base/mergeTreePrincipalGeodesicsDecoding/MergeTreePrincipalGeodesicsDecoding.h
+++ b/core/base/mergeTreePrincipalGeodesicsDecoding/MergeTreePrincipalGeodesicsDecoding.h
@@ -30,8 +30,8 @@ namespace ttk {
 
   protected:
     bool computeReconstructionError_ = false;
-    bool transferInputTreesInformations_ = false;
-    bool transferBarycenterInformations_ = false;
+    bool transferInputTreesInformation_ = false;
+    bool transferBarycenterInformation_ = false;
 
     std::vector<std::vector<double *>> pVS_, pV2s_, pTrees2Vs_, pTrees2V2s_;
     size_t vSize_, vSize2_;
@@ -174,7 +174,7 @@ namespace ttk {
 
       // Reconstruction
       reconstructedTrees.resize(allTreesTs_.size());
-      if(transferBarycenterInformations_)
+      if(transferBarycenterInformation_)
         recBaryMatchings.resize(reconstructedTrees.size());
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
@@ -183,7 +183,7 @@ namespace ttk {
         getMultiInterpolation<dataType>(barycenter, vSToUse, v2sToUse,
                                         vSizeToUse, allTreesTs_[i],
                                         reconstructedTrees[i]);
-        if(transferBarycenterInformations_) {
+        if(transferBarycenterInformation_) {
           dataType distance;
           computeOneDistance<dataType>(reconstructedTrees[i], barycenter,
                                        recBaryMatchings[i], distance, true);
@@ -192,7 +192,7 @@ namespace ttk {
 
       // Compute reconstruction error (if input trees are provided)
       if(inputTrees.size() != 0
-         and (computeReconstructionError_ or transferInputTreesInformations_)) {
+         and (computeReconstructionError_ or transferInputTreesInformation_)) {
         auto reconstructionError = computeReconstructionError(
           barycenter, inputTrees, vSToUse, v2sToUse, vSizeToUse, allTreesTs_,
           reconstructionErrors, recInputMatchings);
@@ -216,13 +216,13 @@ namespace ttk {
       for(unsigned int i = 0; i < inputTrees.size(); ++i)
         postprocessingPipeline<dataType>(&(inputTrees[i].tree));
 
-      if(inputTrees.size() != 0 and transferInputTreesInformations_) {
+      if(inputTrees.size() != 0 and transferInputTreesInformation_) {
         for(unsigned int i = 0; i < inputTrees.size(); ++i)
           convertBranchDecompositionMatching<dataType>(
             &(reconstructedTrees[i].tree), &(inputTrees[i].tree),
             recInputMatchings[i]);
       }
-      if(transferBarycenterInformations_)
+      if(transferBarycenterInformation_)
         for(unsigned int i = 0; i < reconstructedTrees.size(); ++i)
           convertBranchDecompositionMatching<dataType>(
             &(reconstructedTrees[i].tree), &(barycenter.tree),

--- a/core/base/meshGraph/MeshGraph.h
+++ b/core/base/meshGraph/MeshGraph.h
@@ -317,7 +317,7 @@ int ttk::MeshGraph::execute(
       IT aInputIndex = inputConnectivityArray[temp++];
       IT bInputIndex = inputConnectivityArray[temp];
 
-      // get point indicies
+      // get point indices
       IT a = aInputIndex * 3;
       IT a0 = a + 1;
       IT a1 = a + 2;

--- a/core/base/metricDistortion/MetricDistortion.h
+++ b/core/base/metricDistortion/MetricDistortion.h
@@ -4,7 +4,7 @@
 /// \date 2022.
 ///
 /// This module defines the %MetricDistortion class that computes distance,
-/// area and curvature information about a surface and an optionnal distance
+/// area and curvature information about a surface and an optional distance
 /// matrix (giving the distance between the points of the surface in a metric
 /// space).
 ///
@@ -20,7 +20,7 @@ namespace ttk {
 
   /**
    * The MetricDistortion class provides methods to compute distance,
-   * area and curvature information about a surface and an optionnal distance
+   * area and curvature information about a surface and an optional distance
    * matrix (giving the distance between the points of the surface in a metric
    * space).
    */

--- a/core/base/multiresTopology/MultiresTopology.cpp
+++ b/core/base/multiresTopology/MultiresTopology.cpp
@@ -4,8 +4,8 @@ void ttk::MultiresTopology::getValencesFromLink(
   const SimplexId vertexId,
   const std::vector<std::pair<polarity, polarity>> &vlp,
   DynamicTree &link,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<std::vector<SimplexId>> &saddleCCMin,
   std::vector<std::vector<SimplexId>> &saddleCCMax) const {
 
@@ -32,21 +32,21 @@ void ttk::MultiresTopology::getValencesFromLink(
     }
 
     if(downValence > 1) {
-      toPropageMin[vertexId] = 255;
+      toPropagateMin[vertexId] = 255;
     } else {
       saddleCCMin[vertexId].clear();
-      toPropageMin[vertexId] = 0;
+      toPropagateMin[vertexId] = 0;
     }
     if(upValence > 1) {
-      toPropageMax[vertexId] = 255;
+      toPropagateMax[vertexId] = 255;
     } else {
       saddleCCMax[vertexId].clear();
-      toPropageMax[vertexId] = 0;
+      toPropagateMax[vertexId] = 0;
     }
 
   } else { // not a saddle
-    toPropageMax[vertexId] = 0;
-    toPropageMin[vertexId] = 0;
+    toPropagateMax[vertexId] = 0;
+    toPropagateMin[vertexId] = 0;
   }
 }
 

--- a/core/base/multiresTopology/MultiresTopology.h
+++ b/core/base/multiresTopology/MultiresTopology.h
@@ -114,8 +114,8 @@ namespace ttk {
       const SimplexId vertexId,
       const std::vector<std::pair<polarity, polarity>> &vlp,
       DynamicTree &link,
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<std::vector<SimplexId>> &saddleCCMin,
       std::vector<std::vector<SimplexId>> &saddleCCMax) const;
 

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -201,7 +201,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p inputOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
@@ -22,7 +22,7 @@ void ttk::PersistenceDiagramAuction::runAuctionRound(int &n_biddings,
       if(use_kdt_) {
         idx_reassigned = b.runDiagonalKDTBidding(
           &all_goods, twin_good, wasserstein_, epsilon, geometricalFactor_,
-          correspondance_kdt_map_, diagonal_queue_, kdt_index);
+          correspondence_kdt_map_, diagonal_queue_, kdt_index);
       } else {
         idx_reassigned
           = b.runDiagonalBidding(&all_goods, twin_good, wasserstein_, epsilon,
@@ -327,7 +327,7 @@ int ttk::Bidder::runDiagonalKDTBidding(
   int wasserstein,
   double epsilon,
   double geometricalFactor,
-  std::vector<KDT *> &correspondance_kdt_map,
+  std::vector<KDT *> &correspondence_kdt_map,
   std::priority_queue<std::pair<int, double>,
                       std::vector<std::pair<int, double>>,
                       Compare> &diagonal_queue,
@@ -429,7 +429,7 @@ int ttk::Bidder::runDiagonalKDTBidding(
   best_good->assign(this->position_in_auction_, new_price);
   if(is_twin) {
     // Update weight in KDTree if the closest good is in it
-    correspondance_kdt_map[best_good->id_]->updateWeight(new_price, kdt_index);
+    correspondence_kdt_map[best_good->id_]->updateWeight(new_price, kdt_index);
     if(non_empty_goods) {
       diagonal_queue.push(best_pair);
     }

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
@@ -16,9 +16,9 @@ namespace ttk {
 
     KDT default_kdt_{};
     KDT &kdt_{default_kdt_};
-    std::vector<KDT *> default_correspondance_kdt_map_{};
-    std::vector<KDT *> &correspondance_kdt_map_{
-      default_correspondance_kdt_map_};
+    std::vector<KDT *> default_correspondence_kdt_map_{};
+    std::vector<KDT *> &correspondence_kdt_map_{
+      default_correspondence_kdt_map_};
 
     PersistenceDiagramAuction(int wasserstein,
                               double geometricalFactor,
@@ -36,11 +36,11 @@ namespace ttk {
                               double lambda,
                               double delta_lim,
                               KDT &kdt,
-                              std::vector<KDT *> &correspondance_kdt_map,
+                              std::vector<KDT *> &correspondence_kdt_map,
                               double epsilon = {},
                               double initial_diag_price = {},
                               bool use_kdTree = true)
-      : kdt_{kdt}, correspondance_kdt_map_{correspondance_kdt_map},
+      : kdt_{kdt}, correspondence_kdt_map_{correspondence_kdt_map},
         bidders_{bidders}, goods_{goods} {
 
       n_bidders_ = bidders.size();
@@ -188,7 +188,7 @@ namespace ttk {
           coordinates.push_back((1 - geometricalFactor_) * g.coords_[2]);
         }
       }
-      correspondance_kdt_map_
+      correspondence_kdt_map_
         = kdt_.build(coordinates.data(), goods_.size(), dimension);
     }
 

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
@@ -260,7 +260,7 @@ namespace ttk {
       int wasserstein,
       double epsilon,
       double geometricalFactor,
-      std::vector<KDT *> &correspondance_kdt_map,
+      std::vector<KDT *> &correspondence_kdt_map,
       std::priority_queue<std::pair<int, double>,
                           std::vector<std::pair<int, double>>,
                           Compare> &diagonal_queue,

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -28,7 +28,7 @@ void ttk::PDBarycenter::runMatching(
   double epsilon,
   std::vector<int> &sizes,
   KDT &kdt,
-  std::vector<KDT *> &correspondance_kdt_map,
+  std::vector<KDT *> &correspondence_kdt_map,
   std::vector<double> *min_diag_price,
   std::vector<double> *min_price,
   std::vector<std::vector<MatchingType>> *all_matchings,
@@ -42,7 +42,7 @@ void ttk::PDBarycenter::runMatching(
   for(int i = 0; i < numberOfInputs_; i++) {
     PersistenceDiagramAuction auction(
       current_bidder_diagrams_[i], barycenter_goods_[i], wasserstein_,
-      geometrical_factor_, lambda_, 0.01, kdt, correspondance_kdt_map, epsilon,
+      geometrical_factor_, lambda_, 0.01, kdt, correspondence_kdt_map, epsilon,
       min_diag_price->at(i), use_kdt);
     int n_biddings = 0;
     auction.buildUnassignedBidders();
@@ -73,7 +73,7 @@ void ttk::PDBarycenter::runMatchingAuction(
   double *total_cost,
   std::vector<int> &sizes,
   KDT &kdt,
-  std::vector<KDT *> &correspondance_kdt_map,
+  std::vector<KDT *> &correspondence_kdt_map,
   std::vector<double> *min_diag_price,
   std::vector<std::vector<MatchingType>> *all_matchings,
   bool use_kdt) {
@@ -83,7 +83,7 @@ void ttk::PDBarycenter::runMatchingAuction(
   for(int i = 0; i < numberOfInputs_; i++) {
     PersistenceDiagramAuction auction(
       current_bidder_diagrams_[i], barycenter_goods_[i], wasserstein_,
-      geometrical_factor_, lambda_, 0.01, kdt, correspondance_kdt_map,
+      geometrical_factor_, lambda_, 0.01, kdt, correspondence_kdt_map,
       (*min_diag_price)[i], use_kdt);
     std::vector<MatchingType> matchings;
     double cost = auction.run(matchings);
@@ -561,14 +561,14 @@ typename ttk::PDBarycenter::KDTreePair ttk::PDBarycenter::getKDTree() const {
       weights[idx].push_back(g.getPrice());
     }
   }
-  // Correspondance map : position in barycenter_goods_ --> KDT node
+  // Correspondence map : position in barycenter_goods_ --> KDT node
 
-  auto correspondance_kdt_map
+  auto correspondence_kdt_map
     = kdt->build(coordinates.data(), barycenter_goods_[0].size(), dimension,
                  weights, barycenter_goods_.size());
   this->printMsg(" Building KDTree", 1, tm.getElapsedTime(),
                  debug::LineMode::NEW, debug::Priority::VERBOSE);
-  return std::make_pair(std::move(kdt), correspondance_kdt_map);
+  return std::make_pair(std::move(kdt), correspondence_kdt_map);
 }
 
 std::vector<std::vector<ttk::MatchingType>>

--- a/core/base/persistenceDiagramClustering/PDBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.h
@@ -62,7 +62,7 @@ namespace ttk {
                      double epsilon,
                      std::vector<int> &sizes,
                      KDT &kdt,
-                     std::vector<KDT *> &correspondance_kdt_map,
+                     std::vector<KDT *> &correspondence_kdt_map,
                      std::vector<double> *min_diag_price,
                      std::vector<double> *min_price,
                      std::vector<std::vector<MatchingType>> *all_matchings,
@@ -73,7 +73,7 @@ namespace ttk {
       runMatchingAuction(double *total_cost,
                          std::vector<int> &sizes,
                          KDT &kdt,
-                         std::vector<KDT *> &correspondance_kdt_map,
+                         std::vector<KDT *> &correspondence_kdt_map,
                          std::vector<double> *min_diag_price,
                          std::vector<std::vector<MatchingType>> *all_matchings,
                          bool use_kdt);

--- a/core/base/persistenceDiagramClustering/PDClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PDClustering.cpp
@@ -449,7 +449,7 @@ std::vector<int> ttk::PDClustering::execute(
           CriticalVertex{0, CriticalType::Local_minimum, g.x_, critCoords},
           CriticalVertex{0, CriticalType::Saddle1, g.y_, critCoords}, 0, true});
         if(g.getPersistence() > 1000) {
-          this->printMsg("Found a anormally high persistence in min diagram",
+          this->printMsg("Found a abnormally high persistence in min diagram",
                          debug::Priority::WARNING);
         }
       }
@@ -463,7 +463,7 @@ std::vector<int> ttk::PDClustering::execute(
           CriticalVertex{0, CriticalType::Saddle1, g.x_, critCoords},
           CriticalVertex{0, CriticalType::Saddle2, g.y_, critCoords}, 1, true});
         if(g.getPersistence() > 1000) {
-          this->printMsg("Found a anormally high persistence in sad diagram",
+          this->printMsg("Found a abnormally high persistence in sad diagram",
                          debug::Priority::WARNING);
         }
       }
@@ -485,7 +485,7 @@ std::vector<int> ttk::PDClustering::execute(
           true});
 
         if(g.getPersistence() > 1000) {
-          this->printMsg("Found a anormally high persistence in min diagram",
+          this->printMsg("Found a abnormally high persistence in min diagram",
                          debug::Priority::WARNING);
         }
       }
@@ -1009,7 +1009,7 @@ void ttk::PDClustering::initializeCentroidsKMeanspp() {
       probabilities[i] = square(min_distance_to_centroid[i]);
 
       // The following block is useful in case of need for a deterministic
-      // algoritm
+      // algorithm
       if(deterministic_ && min_distance_to_centroid[i] > maximal_distance) {
         maximal_distance = min_distance_to_centroid[i];
         candidate_centroid = i;
@@ -1240,7 +1240,7 @@ void ttk::PDClustering::updateClusters() {
 
 void ttk::PDClustering::invertClusters() {
   /// Converts the clustering (vector of vector of diagram's id) into
-  /// a vector of size numberOfInputs_ containg the cluster of each input
+  /// a vector of size numberOfInputs_ containing the cluster of each input
   /// diagram.
 
   // Initializes clusters with -1

--- a/core/base/persistentGenerators/PersistentGenerators.h
+++ b/core/base/persistentGenerators/PersistentGenerators.h
@@ -230,13 +230,13 @@ void ttk::PersistentGenerators::findHandlesGenerators(
     std::vector<SimplexId> generator{};
     std::set<SimplexId> visited1Sads{};
 
-    std::queue<SimplexId> toPropage{};
-    toPropage.push(s1);
+    std::queue<SimplexId> toPropagate{};
+    toPropagate.push(s1);
 
-    while(!toPropage.empty()) {
+    while(!toPropagate.empty()) {
       // current 1-saddle
-      const auto curr{toPropage.front()};
-      toPropage.pop();
+      const auto curr{toPropagate.front()};
+      toPropagate.pop();
       visited1Sads.emplace(curr);
 
       if(curr != s1) {
@@ -273,7 +273,7 @@ void ttk::PersistentGenerators::findHandlesGenerators(
 
         const auto next{min2sad[min]};
         if(visited1Sads.find(next) == visited1Sads.end()) {
-          toPropage.push(next);
+          toPropagate.push(next);
         }
       }
     }

--- a/core/base/planarGraphLayout/MergeTreeVisualization.h
+++ b/core/base/planarGraphLayout/MergeTreeVisualization.h
@@ -501,7 +501,7 @@ namespace ttk {
       printMsg(ss5.str(), debug::Priority::VERBOSE);
 
       // ----------------------------------------------------
-      // Branches positionning and avoid edges crossing
+      // Branches positioning and avoid edges crossing
       // ----------------------------------------------------
       Timer t_avoid;
       printMsg("Avoid edges crossing", debug::Priority::VERBOSE);
@@ -970,12 +970,12 @@ namespace ttk {
     // ==========================================================================
     // Utils
     // ==========================================================================
-    void parseExcludeImportantPairsString(std::string &exludeString,
+    void parseExcludeImportantPairsString(std::string &excludeString,
                                           std::vector<double> &excludeVector) {
       excludeVector.clear();
-      if(exludeString == "")
+      if(excludeString.empty())
         return;
-      std::string s{exludeString};
+      std::string s{excludeString};
       std::string delimiter = ",";
 
       size_t pos = 0;

--- a/core/base/planarGraphLayout/PlanarGraphLayout.cpp
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.cpp
@@ -16,7 +16,7 @@ int ttk::PlanarGraphLayout::computeDotLayout(
   float *layout,
 
   // Input
-  const std::vector<size_t> &nodeIndicies,
+  const std::vector<size_t> &nodeIndices,
   const std::string &dotString) const {
 #ifdef TTK_ENABLE_GRAPHVIZ
   Timer t;
@@ -33,7 +33,7 @@ int ttk::PlanarGraphLayout::computeDotLayout(
   // ---------------------------------------------------------
   // Get layout data from GraphViz
   // ---------------------------------------------------------
-  for(auto i : nodeIndicies) {
+  for(auto i : nodeIndices) {
     Agnode_t *n = agnode(G, const_cast<char *>(std::to_string(i).data()), 0);
     if(n != nullptr) {
       auto &coord = ND_coord(n);
@@ -55,7 +55,7 @@ int ttk::PlanarGraphLayout::computeDotLayout(
   return 1;
 #else
   TTK_FORCE_USE(layout);
-  TTK_FORCE_USE(nodeIndicies);
+  TTK_FORCE_USE(nodeIndices);
   TTK_FORCE_USE(dotString);
 
   this->printErr("This filter requires GraphViz to compute a layout.");

--- a/core/base/planarGraphLayout/PlanarGraphLayout.h
+++ b/core/base/planarGraphLayout/PlanarGraphLayout.h
@@ -9,7 +9,7 @@
 /// layout of a \b vtkUnstructuredGrid. To improve the quality of the layout it
 /// is possible to pass additional field data to the algorithm:\n \b 1) \b
 /// Sequences: Points are positioned along the x-axis based on a sequence (e.g.,
-/// time indicies or scalar values). \b 1) \b Sizes: Points cover space on the
+/// time indices or scalar values). \b 1) \b Sizes: Points cover space on the
 /// y-axis based on their size. \b 1) \b Branches: Points with the same branch
 /// label are positioned on straight lines. \b 1) \b Levels: The layout of
 /// points with the same level label are computed individually and afterwards
@@ -63,8 +63,8 @@ namespace ttk {
     template <typename IT, typename CT>
     int extractLevel(
       // Output
-      std::vector<size_t> &nodeIndicies,
-      std::vector<size_t> &edgeIndicies,
+      std::vector<size_t> &nodeIndices,
+      std::vector<size_t> &edgeIndices,
 
       // Input
       const CT *connectivityList,
@@ -83,8 +83,8 @@ namespace ttk {
       const ST *pointSequences,
       const float *sizes,
       const IT *branches,
-      const std::vector<size_t> &nodeIndicies,
-      const std::vector<size_t> &edgeIndicies,
+      const std::vector<size_t> &nodeIndices,
+      const std::vector<size_t> &edgeIndices,
       const std::map<ST, size_t> &sequenceValueToIndexMap) const;
 
     template <typename IT, typename CT>
@@ -106,7 +106,7 @@ namespace ttk {
       float *layout,
 
       // Input
-      const std::vector<size_t> &nodeIndicies,
+      const std::vector<size_t> &nodeIndices,
       const std::string &dotString) const;
   };
 } // namespace ttk
@@ -117,8 +117,8 @@ namespace ttk {
 template <typename IT, typename CT>
 int ttk::PlanarGraphLayout::extractLevel(
   // Output
-  std::vector<size_t> &nodeIndicies,
-  std::vector<size_t> &edgeIndicies,
+  std::vector<size_t> &nodeIndices,
+  std::vector<size_t> &edgeIndices,
 
   // Input
   const CT *connectivityList,
@@ -129,13 +129,13 @@ int ttk::PlanarGraphLayout::extractLevel(
 
   // If levels==nullptr then return all points and edges
   if(levels == nullptr) {
-    nodeIndicies.resize(nPoints);
+    nodeIndices.resize(nPoints);
     for(size_t i = 0; i < nPoints; i++)
-      nodeIndicies[i] = i;
+      nodeIndices[i] = i;
 
-    edgeIndicies.resize(nEdges);
+    edgeIndices.resize(nEdges);
     for(size_t i = 0; i < nEdges; i++)
-      edgeIndicies[i] = i;
+      edgeIndices[i] = i;
 
     return 1;
   }
@@ -143,7 +143,7 @@ int ttk::PlanarGraphLayout::extractLevel(
   // Get nodes at level
   for(size_t i = 0; i < nPoints; i++)
     if(levels[i] == level)
-      nodeIndicies.push_back(i);
+      nodeIndices.push_back(i);
 
   // Get edges at level
   size_t nEdges2 = nEdges * 2;
@@ -151,7 +151,7 @@ int ttk::PlanarGraphLayout::extractLevel(
     auto n0l = levels[connectivityList[i + 0]];
     auto n1l = levels[connectivityList[i + 1]];
     if(n0l == level && n0l == n1l)
-      edgeIndicies.push_back(i / 2);
+      edgeIndices.push_back(i / 2);
   }
 
   return 1;
@@ -170,8 +170,8 @@ int ttk::PlanarGraphLayout::computeDotString(
   const ST *pointSequences,
   const float *sizes,
   const IT *branches,
-  const std::vector<size_t> &nodeIndicies,
-  const std::vector<size_t> &edgeIndicies,
+  const std::vector<size_t> &nodeIndices,
+  const std::vector<size_t> &edgeIndices,
   const std::map<ST, size_t> &sequenceValueToIndexMap) const {
 
   Timer t;
@@ -200,7 +200,7 @@ int ttk::PlanarGraphLayout::computeDotString(
 
     // If useSizes then map size to node height
     if(useSizes)
-      for(auto &i : nodeIndicies)
+      for(auto &i : nodeIndices)
         nodeString += nl(i) + "[height=" + std::to_string(sizes[i]) + "];";
   }
 
@@ -221,7 +221,7 @@ int ttk::PlanarGraphLayout::computeDotString(
     // Collect nodes with the same sequence index
     std::vector<std::vector<size_t>> sequenceIndexToPointIndexMap(
       nSequenceValues);
-    for(auto &i : nodeIndicies)
+    for(auto &i : nodeIndices)
       sequenceIndexToPointIndexMap
         [sequenceValueToIndexMap.find(pointSequences[i])->second]
           .push_back(i);
@@ -242,7 +242,7 @@ int ttk::PlanarGraphLayout::computeDotString(
   // Edges
   // ---------------------------------------------------------------------------
   {
-    for(auto &edgeIndex : edgeIndicies) {
+    for(auto &edgeIndex : edgeIndices) {
       size_t temp = edgeIndex * 2;
       auto &i0 = connectivityList[temp + 0];
       auto &i1 = connectivityList[temp + 1];
@@ -326,19 +326,19 @@ int ttk::PlanarGraphLayout::computeSlots(
   // Adjust positions from bottom to top (skip last level)
   // ---------------------------------------------------------------------------
   for(IT l = 0; l < nLevels - 1; l++) {
-    std::vector<size_t> nodeIndicies;
-    std::vector<size_t> edgeIndicies;
+    std::vector<size_t> nodeIndices;
+    std::vector<size_t> edgeIndices;
 
     // get nodes at current level (parents)
     this->extractLevel<IT, CT>(
       // Output
-      nodeIndicies, edgeIndicies,
+      nodeIndices, edgeIndices,
 
       // Input
       connectivityList, nPoints, nEdges, l, levels);
 
     // for each parent adjust position of children
-    for(auto &parent : nodeIndicies) {
+    for(auto &parent : nodeIndices) {
       auto &children = nodeIndexChildrenIndexMap[parent];
       size_t nChildren = children.size();
       if(nChildren < 1)
@@ -445,14 +445,14 @@ int ttk::PlanarGraphLayout::computeLayout(
   // Compute initial layout for each level
   // ---------------------------------------------------------------------------
   for(IT l = 0; l < nLevels; l++) {
-    std::vector<size_t> nodeIndicies;
-    std::vector<size_t> edgeIndicies;
+    std::vector<size_t> nodeIndices;
+    std::vector<size_t> edgeIndices;
 
     // Extract nodes and edges at certain level
     {
       int status = this->extractLevel<IT, CT>(
         // Output
-        nodeIndicies, edgeIndicies,
+        nodeIndices, edgeIndices,
 
         // Input
         connectivityList, nPoints, nEdges, l, levels);
@@ -468,15 +468,15 @@ int ttk::PlanarGraphLayout::computeLayout(
         dotString,
 
         // Input
-        connectivityList, pointSequences, sizes, branches, nodeIndicies,
-        edgeIndicies, sequenceValueToIndexMap);
+        connectivityList, pointSequences, sizes, branches, nodeIndices,
+        edgeIndices, sequenceValueToIndexMap);
       if(status != 1)
         return 0;
     }
 
     // Compute Dot Layout
     {
-      int status = this->computeDotLayout(layout, nodeIndicies, dotString);
+      int status = this->computeDotLayout(layout, nodeIndices, dotString);
       if(status != 1)
         return 0;
     }

--- a/core/base/progressiveTopology/ProgressiveTopology.cpp
+++ b/core/base/progressiveTopology/ProgressiveTopology.cpp
@@ -48,7 +48,7 @@ int ttk::ProgressiveTopology::executeCPProgressive(
   std::vector<std::vector<SimplexId>> vertexRepresentativesMin{},
     vertexRepresentativesMax{};
   std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
-  std::vector<polarity> toPropageMin{}, toPropageMax{};
+  std::vector<polarity> toPropagateMin{}, toPropagateMax{};
   std::vector<char> vertexTypes{};
 
   if(computePersistenceDiagram) {
@@ -56,8 +56,8 @@ int ttk::ProgressiveTopology::executeCPProgressive(
     saddleCCMax.resize(vertexNumber);
     vertexRepresentativesMin.resize(vertexNumber);
     vertexRepresentativesMax.resize(vertexNumber);
-    toPropageMin.resize(vertexNumber, 0);
-    toPropageMax.resize(vertexNumber, 0);
+    toPropagateMin.resize(vertexNumber, 0);
+    toPropagateMax.resize(vertexNumber, 0);
     isUpToDateMin.resize(vertexNumber, 0);
     isUpToDateMax.resize(vertexNumber, 0);
   } else {
@@ -79,7 +79,7 @@ int ttk::ProgressiveTopology::executeCPProgressive(
     toReprocess.resize(vertexNumber, 0);
   }
 
-  // lock vertex thread access for firstPropage
+  // lock vertex thread access for firstPropagate
   std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
 
   // pre-allocate memory
@@ -117,10 +117,10 @@ int ttk::ProgressiveTopology::executeCPProgressive(
   multiresTriangulation_.setDecimationLevel(decimationLevel_);
 
   if(computePersistenceDiagram) {
-    initSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
+    initSaddleSeeds(isNew, vertexLinkPolarity, toPropagateMin, toPropagateMax,
                     toProcess, link, vertexLink, vertexLinkByBoundaryType,
                     saddleCCMin, saddleCCMax, offsets);
-    initPropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
+    initPropagation(toPropagateMin, toPropagateMax, vertexRepresentativesMin,
                     vertexRepresentativesMax, saddleCCMin, saddleCCMax,
                     vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
                     offsets);
@@ -128,7 +128,7 @@ int ttk::ProgressiveTopology::executeCPProgressive(
     // compute pairs in non-progressive mode
     computePersistencePairsFromSaddles(
       CTDiagram_, offsets, vertexRepresentativesMin, vertexRepresentativesMax,
-      toPropageMin, toPropageMax);
+      toPropagateMin, toPropagateMax);
   } else {
     initCriticalPoints(isNew, vertexLinkPolarity, toProcess, toReprocess, link,
                        vertexLink, vertexLinkByBoundaryType, vertexTypes,
@@ -152,17 +152,17 @@ int ttk::ProgressiveTopology::executeCPProgressive(
              ttk::debug::LineMode::REPLACE);
 
     if(computePersistenceDiagram) {
-      updateSaddleSeeds(isNew, vertexLinkPolarity, toPropageMin, toPropageMax,
-                        toProcess, toReprocess, link, vertexLink,
-                        vertexLinkByBoundaryType, saddleCCMin, saddleCCMax,
+      updateSaddleSeeds(isNew, vertexLinkPolarity, toPropagateMin,
+                        toPropagateMax, toProcess, toReprocess, link,
+                        vertexLink, vertexLinkByBoundaryType, saddleCCMin,
+                        saddleCCMax, isUpToDateMin, isUpToDateMax, offsets);
+      updatePropagation(toPropagateMin, toPropagateMax,
+                        vertexRepresentativesMin, vertexRepresentativesMax,
+                        saddleCCMin, saddleCCMax, vertLockMin, vertLockMax,
                         isUpToDateMin, isUpToDateMax, offsets);
-      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin,
-                        vertexRepresentativesMax, saddleCCMin, saddleCCMax,
-                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
-                        offsets);
       computePersistencePairsFromSaddles(
         CTDiagram_, offsets, vertexRepresentativesMin, vertexRepresentativesMax,
-        toPropageMin, toPropageMax);
+        toPropagateMin, toPropagateMax);
     } else {
       updateCriticalPoints(isNew, vertexLinkPolarity, toProcess, toReprocess,
                            link, vertexLink, vertexLinkByBoundaryType,
@@ -232,15 +232,15 @@ int ttk::ProgressiveTopology::resumeProgressive(int computePersistenceDiagram,
     + std::to_string(
       multiresTriangulation_.DL_to_RL(stoppingDecimationLevel_)));
 
-  // lock vertex thread access for firstPropage
+  // lock vertex thread access for firstPropagate
   std::vector<Lock> vertLockMin(vertexNumber), vertLockMax(vertexNumber);
   // propagation markers
-  std::vector<polarity> toPropageMin{}, toPropageMax{};
+  std::vector<polarity> toPropagateMin{}, toPropagateMax{};
   std::vector<polarity> isUpToDateMin{}, isUpToDateMax{};
 
   if(computePersistenceDiagram) {
-    toPropageMin.resize(vertexNumber, 0);
-    toPropageMax.resize(vertexNumber, 0);
+    toPropagateMin.resize(vertexNumber, 0);
+    toPropagateMax.resize(vertexNumber, 0);
     isUpToDateMin.resize(vertexNumber, 0);
     isUpToDateMax.resize(vertexNumber, 0);
   }
@@ -254,17 +254,17 @@ int ttk::ProgressiveTopology::resumeProgressive(int computePersistenceDiagram,
     printMsg(this->resolutionInfoString(), 0, timer.getElapsedTime(),
              this->threadNumber_, ttk::debug::LineMode::REPLACE);
     if(computePersistenceDiagram) {
-      updateSaddleSeeds(isNew_, vertexLinkPolarity_, toPropageMin, toPropageMax,
-                        toProcess_, toReprocess_, link_, vertexLink_,
-                        vertexLinkByBoundaryType_, saddleCCMin_, saddleCCMax_,
+      updateSaddleSeeds(isNew_, vertexLinkPolarity_, toPropagateMin,
+                        toPropagateMax, toProcess_, toReprocess_, link_,
+                        vertexLink_, vertexLinkByBoundaryType_, saddleCCMin_,
+                        saddleCCMax_, isUpToDateMin, isUpToDateMax, offsets);
+      updatePropagation(toPropagateMin, toPropagateMax,
+                        vertexRepresentativesMin_, vertexRepresentativesMax_,
+                        saddleCCMin_, saddleCCMax_, vertLockMin, vertLockMax,
                         isUpToDateMin, isUpToDateMax, offsets);
-      updatePropagation(toPropageMin, toPropageMax, vertexRepresentativesMin_,
-                        vertexRepresentativesMax_, saddleCCMin_, saddleCCMax_,
-                        vertLockMin, vertLockMax, isUpToDateMin, isUpToDateMax,
-                        offsets);
       computePersistencePairsFromSaddles(
         CTDiagram_, offsets, vertexRepresentativesMin_,
-        vertexRepresentativesMax_, toPropageMin, toPropageMax);
+        vertexRepresentativesMax_, toPropagateMin, toPropagateMax);
     } else {
       updateCriticalPoints(isNew_, vertexLinkPolarity_, toProcess_,
                            toReprocess_, link_, vertexLink_,
@@ -305,8 +305,8 @@ void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
   const SimplexId *const offsets,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-  const std::vector<polarity> &toPropageMin,
-  const std::vector<polarity> &toPropageMax) const {
+  const std::vector<polarity> &toPropagateMin,
+  const std::vector<polarity> &toPropagateMax) const {
 
   Timer timer{};
   std::vector<triplet> tripletsMax{}, tripletsMin{};
@@ -314,10 +314,10 @@ void ttk::ProgressiveTopology::computePersistencePairsFromSaddles(
 
   for(SimplexId localId = 0; localId < nbDecVert; localId++) {
     SimplexId globalId = multiresTriangulation_.localToGlobalVertexId(localId);
-    if(toPropageMin[globalId]) {
+    if(toPropagateMin[globalId]) {
       getTripletsFromSaddles(globalId, tripletsMin, vertexRepresentativesMin);
     }
-    if(toPropageMax[globalId]) {
+    if(toPropagateMax[globalId]) {
       getTripletsFromSaddles(globalId, tripletsMax, vertexRepresentativesMax);
     }
   }
@@ -575,8 +575,8 @@ void ttk::ProgressiveTopology::updateCriticalPoints(
 void ttk::ProgressiveTopology::updateSaddleSeeds(
   std::vector<polarity> &isNew,
   std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<polarity> &toProcess,
   std::vector<polarity> &toReprocess,
   std::vector<DynamicTree> &link,
@@ -625,7 +625,7 @@ void ttk::ProgressiveTopology::updateSaddleSeeds(
                         vertexLink[globalId], link[globalId],
                         vertexLinkByBoundaryType, offsets);
         getValencesFromLink(globalId, vertexLinkPolarity[globalId],
-                            link[globalId], toPropageMin, toPropageMax,
+                            link[globalId], toPropagateMin, toPropagateMax,
                             saddleCCMin, saddleCCMax);
       }
       isNew[globalId] = false;
@@ -643,7 +643,7 @@ void ttk::ProgressiveTopology::updateSaddleSeeds(
           toProcess[globalId] = 255; // mark as processed
         }
         getValencesFromLink(globalId, vertexLinkPolarity[globalId],
-                            link[globalId], toPropageMin, toPropageMax,
+                            link[globalId], toPropagateMin, toPropagateMax,
                             saddleCCMin, saddleCCMax);
         toReprocess[globalId] = 0;
       }
@@ -699,10 +699,10 @@ bool ttk::ProgressiveTopology::getMonotonyChangeByOldPointCP(
   return hasMonotonyChanged;
 }
 
-ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
+ttk::SimplexId ttk::ProgressiveTopology::propagateFromSaddles(
   const SimplexId vertexId,
   std::vector<Lock> &vertLock,
-  std::vector<polarity> &toPropage,
+  std::vector<polarity> &toPropagate,
   std::vector<std::vector<SimplexId>> &vertexRepresentatives,
   std::vector<std::vector<SimplexId>> &saddleCC,
   std::vector<polarity> &isUpdated,
@@ -710,7 +710,7 @@ ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
   const SimplexId *const offsets,
   const bool splitTree) const {
 
-  auto &toProp = toPropage[vertexId];
+  auto &toProp = toPropagate[vertexId];
   auto &reps = vertexRepresentatives[vertexId];
   auto &updated = isUpdated[vertexId];
 
@@ -734,8 +734,8 @@ ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
       SimplexId neighborId = -1;
       SimplexId localId = CC[r];
       multiresTriangulation_.getVertexNeighbor(vertexId, localId, neighborId);
-      SimplexId ret = propageFromSaddles(
-        neighborId, vertLock, toPropage, vertexRepresentatives, saddleCC,
+      SimplexId ret = propagateFromSaddles(
+        neighborId, vertLock, toPropagate, vertexRepresentatives, saddleCC,
         isUpdated, globalExtremum, offsets, splitTree);
       reps.emplace_back(ret);
     }
@@ -768,9 +768,9 @@ ttk::SimplexId ttk::ProgressiveTopology::propageFromSaddles(
       }
     }
     if(maxNeighbor != vertexId) { // not an extremum
-      ret = propageFromSaddles(maxNeighbor, vertLock, toPropage,
-                               vertexRepresentatives, saddleCC, isUpdated,
-                               globalExtremum, offsets, splitTree);
+      ret = propagateFromSaddles(maxNeighbor, vertLock, toPropagate,
+                                 vertexRepresentatives, saddleCC, isUpdated,
+                                 globalExtremum, offsets, splitTree);
     } else {
 #ifdef TTK_ENABLE_OPENMP
       const auto tid = omp_get_thread_num();
@@ -830,8 +830,8 @@ void ttk::ProgressiveTopology::initCriticalPoints(
 void ttk::ProgressiveTopology::initSaddleSeeds(
   std::vector<polarity> &isNew,
   std::vector<std::vector<std::pair<polarity, polarity>>> &vertexLinkPolarity,
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<polarity> &toProcess,
   std::vector<DynamicTree> &link,
   std::vector<uint8_t> &vertexLink,
@@ -854,7 +854,8 @@ void ttk::ProgressiveTopology::initSaddleSeeds(
                     vertexLink[globalId], link[globalId],
                     vertexLinkByBoundaryType, offsets);
     getValencesFromLink(globalId, vertexLinkPolarity[globalId], link[globalId],
-                        toPropageMin, toPropageMax, saddleCCMin, saddleCCMax);
+                        toPropagateMin, toPropagateMax, saddleCCMin,
+                        saddleCCMax);
     toProcess[globalId] = 255;
     isNew[globalId] = 0;
   }
@@ -865,8 +866,8 @@ void ttk::ProgressiveTopology::initSaddleSeeds(
 }
 
 void ttk::ProgressiveTopology::initPropagation(
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
   std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -888,15 +889,15 @@ void ttk::ProgressiveTopology::initPropagation(
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nDecVerts; i++) {
     SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
-    if(toPropageMin[v]) {
-      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
-                         saddleCCMin, isUpdatedMin, globalMinThr, offsets,
-                         false);
+    if(toPropagateMin[v]) {
+      propagateFromSaddles(v, vertLockMin, toPropagateMin,
+                           vertexRepresentativesMin, saddleCCMin, isUpdatedMin,
+                           globalMinThr, offsets, false);
     }
-    if(toPropageMax[v]) {
-      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
-                         saddleCCMax, isUpdatedMax, globalMaxThr, offsets,
-                         true);
+    if(toPropagateMax[v]) {
+      propagateFromSaddles(v, vertLockMax, toPropagateMax,
+                           vertexRepresentativesMax, saddleCCMax, isUpdatedMax,
+                           globalMaxThr, offsets, true);
     }
   }
 
@@ -913,8 +914,8 @@ void ttk::ProgressiveTopology::initPropagation(
 }
 
 void ttk::ProgressiveTopology::updatePropagation(
-  std::vector<polarity> &toPropageMin,
-  std::vector<polarity> &toPropageMax,
+  std::vector<polarity> &toPropagateMin,
+  std::vector<polarity> &toPropagateMax,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
   std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
   std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -931,21 +932,21 @@ void ttk::ProgressiveTopology::updatePropagation(
   std::vector<SimplexId> globalMaxThr(threadNumber_, 0);
   std::vector<SimplexId> globalMinThr(threadNumber_, 0);
 
-  // propage along split tree
+  // propagate along split tree
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
   for(size_t i = 0; i < nDecVerts; i++) {
     SimplexId v = multiresTriangulation_.localToGlobalVertexId(i);
-    if(toPropageMin[v]) {
-      propageFromSaddles(v, vertLockMin, toPropageMin, vertexRepresentativesMin,
-                         saddleCCMin, isUpdatedMin, globalMinThr, offsets,
-                         false);
+    if(toPropagateMin[v]) {
+      propagateFromSaddles(v, vertLockMin, toPropagateMin,
+                           vertexRepresentativesMin, saddleCCMin, isUpdatedMin,
+                           globalMinThr, offsets, false);
     }
-    if(toPropageMax[v]) {
-      propageFromSaddles(v, vertLockMax, toPropageMax, vertexRepresentativesMax,
-                         saddleCCMax, isUpdatedMax, globalMaxThr, offsets,
-                         true);
+    if(toPropagateMax[v]) {
+      propagateFromSaddles(v, vertLockMax, toPropagateMax,
+                           vertexRepresentativesMax, saddleCCMax, isUpdatedMax,
+                           globalMaxThr, offsets, true);
     }
   }
 

--- a/core/base/progressiveTopology/ProgressiveTopology.h
+++ b/core/base/progressiveTopology/ProgressiveTopology.h
@@ -135,8 +135,8 @@ namespace ttk {
     void initSaddleSeeds(std::vector<polarity> &isNew,
                          std::vector<std::vector<std::pair<polarity, polarity>>>
                            &vertexLinkPolarity,
-                         std::vector<polarity> &toPropageMin,
-                         std::vector<polarity> &toPropageMax,
+                         std::vector<polarity> &toPropagateMin,
+                         std::vector<polarity> &toPropagateMax,
                          std::vector<polarity> &toProcess,
                          std::vector<DynamicTree> &link,
                          std::vector<uint8_t> &vertexLink,
@@ -146,8 +146,8 @@ namespace ttk {
                          const SimplexId *const offsets) const;
 
     void initPropagation(
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
       std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -159,8 +159,8 @@ namespace ttk {
       const SimplexId *const offsets) const;
 
     void updatePropagation(
-      std::vector<polarity> &toPropageMin,
-      std::vector<polarity> &toPropageMax,
+      std::vector<polarity> &toPropagateMin,
+      std::vector<polarity> &toPropagateMax,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
       std::vector<std::vector<SimplexId>> &saddleCCMin,
@@ -221,8 +221,8 @@ namespace ttk {
       updateSaddleSeeds(std::vector<polarity> &isNew,
                         std::vector<std::vector<std::pair<polarity, polarity>>>
                           &vertexLinkPolarity,
-                        std::vector<polarity> &toPropageMin,
-                        std::vector<polarity> &toPropageMax,
+                        std::vector<polarity> &toPropagateMin,
+                        std::vector<polarity> &toPropagateMax,
                         std::vector<polarity> &toProcess,
                         std::vector<polarity> &toReprocess,
                         std::vector<DynamicTree> &link,
@@ -246,10 +246,10 @@ namespace ttk {
                             std::vector<std::pair<polarity, polarity>> &vlp,
                             const SimplexId *const offsets) const;
 
-    ttk::SimplexId propageFromSaddles(
+    ttk::SimplexId propagateFromSaddles(
       const SimplexId vertexId,
       std::vector<Lock> &vertLock,
-      std::vector<polarity> &toPropage,
+      std::vector<polarity> &toPropagate,
       std::vector<std::vector<SimplexId>> &vertexRepresentatives,
       std::vector<std::vector<SimplexId>> &saddleCC,
       std::vector<polarity> &isUpdated,
@@ -262,8 +262,8 @@ namespace ttk {
       const SimplexId *const offsets,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMin,
       std::vector<std::vector<SimplexId>> &vertexRepresentativesMax,
-      const std::vector<polarity> &toPropageMin,
-      const std::vector<polarity> &toPropageMax) const;
+      const std::vector<polarity> &toPropagateMin,
+      const std::vector<polarity> &toPropagateMax) const;
 
     double predictNextIterationDuration(const double currItDuration,
                                         const size_t nCurrPairs) const;

--- a/core/base/quadrangulationSubdivision/Quadrangulation.cpp
+++ b/core/base/quadrangulationSubdivision/Quadrangulation.cpp
@@ -26,7 +26,7 @@ int ttk::Quadrangulation::preconditionVertexStars() {
   zsk.setThreadNumber(this->threadNumber_);
 
   return zsk.buildVertexStars(
-    this->nVerts_, this->buildQuadOffets(), this->vertexStars_);
+    this->nVerts_, this->buildQuadOffsets(), this->vertexStars_);
 }
 
 int ttk::Quadrangulation::preconditionEdges() {
@@ -35,11 +35,11 @@ int ttk::Quadrangulation::preconditionEdges() {
   osk.setDebugLevel(this->debugLevel_);
   osk.setThreadNumber(this->threadNumber_);
 
-  return osk.buildEdgeList(this->nVerts_, this->buildQuadOffets(), this->edges_,
-                           this->edgeStars_, this->quadEdges_);
+  return osk.buildEdgeList(this->nVerts_, this->buildQuadOffsets(),
+                           this->edges_, this->edgeStars_, this->quadEdges_);
 }
 
-ttk::CellArray ttk::Quadrangulation::buildQuadOffets() {
+ttk::CellArray ttk::Quadrangulation::buildQuadOffsets() {
 
   if(static_cast<SimplexId>(this->quadOffsets_.size()) != this->nCells_ + 1) {
     this->quadOffsets_.resize(this->nCells_ + 1);

--- a/core/base/quadrangulationSubdivision/Quadrangulation.h
+++ b/core/base/quadrangulationSubdivision/Quadrangulation.h
@@ -128,7 +128,7 @@ namespace ttk {
     using Point = ttk::SurfaceGeometrySmoother::Point;
 
   private:
-    CellArray buildQuadOffets();
+    CellArray buildQuadOffsets();
 
     const Point *vertCoords_{};
     const Quad *cells_{};

--- a/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
+++ b/core/base/quadrangulationSubdivision/QuadrangulationSubdivision.h
@@ -217,7 +217,7 @@ ttk::SimplexId ttk::QuadrangulationSubdivision::findEdgeMiddle(
   SimplexId midId{};
   float minValue{std::numeric_limits<float>::infinity()};
 
-  // euclidian barycenter of a and b
+  // euclidean barycenter of a and b
   Point edgeEuclBary = (outputPoints_[e[0]] + outputPoints_[e[1]]) * 0.5F;
 
   for(size_t i = 0; i < vertexDistance_[e[0]].size(); ++i) {
@@ -237,10 +237,10 @@ ttk::SimplexId ttk::QuadrangulationSubdivision::findEdgeMiddle(
       sum += std::abs(m - n);
     }
 
-    // get the euclidian distance to AB
+    // get the euclidean distance to AB
     Point curr{};
     triangulation.getVertexPoint(i, curr[0], curr[1], curr[2]);
-    // try to minimize the euclidian distance to AB too
+    // try to minimize the euclidean distance to AB too
     sum += Geometry::distance(curr.data(), edgeEuclBary.data());
 
     // search for the minimizing index

--- a/core/base/reebSpace/ReebSpace.h
+++ b/core/base/reebSpace/ReebSpace.h
@@ -62,7 +62,7 @@ namespace ttk {
       // of 2-sheets attached to it?)
       std::vector<SimplexId> sheet0List_{};
       // NB: the corresponding 2-sheet should have the same global
-      // indentifier.
+      // identifier.
       std::vector<SimplexId> sheet3List_{};
     };
 
@@ -190,10 +190,10 @@ namespace ttk {
 
     template <class dataTypeU, class dataTypeV>
     inline int
-      perturbate(const dataTypeU *const uField,
-                 const dataTypeV *const vField,
-                 const dataTypeU &uEpsilon = Geometry::powIntTen(-DBL_DIG),
-                 const dataTypeV &vEpsilon = Geometry::powIntTen(-DBL_DIG));
+      perturb(const dataTypeU *const uField,
+              const dataTypeV *const vField,
+              const dataTypeU &uEpsilon = Geometry::powIntTen(-DBL_DIG),
+              const dataTypeV &vEpsilon = Geometry::powIntTen(-DBL_DIG));
 
     inline void setExpand3Sheets(const bool &onOff) {
       expand3sheets_ = onOff;
@@ -213,7 +213,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p sosOffsetsU buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */
@@ -225,7 +225,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p sosOffsetsV buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */
@@ -792,13 +792,13 @@ inline int ttk::ReebSpace::computeGeometricalMeasures(
 }
 
 template <class dataTypeU, class dataTypeV>
-inline int ttk::ReebSpace::perturbate(const dataTypeU *const uField,
-                                      const dataTypeV *const vField,
-                                      const dataTypeU &uEpsilon,
-                                      const dataTypeV &vEpsilon) {
+inline int ttk::ReebSpace::perturb(const dataTypeU *const uField,
+                                   const dataTypeV *const vField,
+                                   const dataTypeU &uEpsilon,
+                                   const dataTypeV &vEpsilon) {
 
   jacobiSet_.setVertexNumber(vertexNumber_);
-  jacobiSet_.perturbate(uField, vField, uEpsilon, vEpsilon);
+  jacobiSet_.perturb(uField, vField, uEpsilon, vEpsilon);
 
   return 0;
 }
@@ -1672,7 +1672,7 @@ int ttk::ReebSpace::disconnect3sheetFrom1sheet(
 
   if((data.sheet1List_[sheet1Id].hasSaddleEdges_)
      && (data.sheet1List_[sheet1Id].sheet3List_.size() == 1)) {
-    // this guy is no longer separting any body.
+    // this guy is no longer separating any body.
     data.sheet1List_[sheet1Id].pruned_ = true;
     data.sheet2List_[sheet1Id].pruned_ = true;
 

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -68,7 +68,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p offsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
+++ b/core/base/surfaceGeometrySmoother/SurfaceGeometrySmoother.h
@@ -170,7 +170,7 @@ namespace ttk {
     }
 
     /**
-     * @brief Compute euclidian projection in a triangle plane
+     * @brief Compute euclidean projection in a triangle plane
      *
      * @param[in] p Point to be projected
      * @param[in] a Triangle vertex coordinates
@@ -185,7 +185,7 @@ namespace ttk {
     }
 
     /**
-     * @brief Compute euclidian projection on a 3D segment
+     * @brief Compute euclidean projection on a 3D segment
      *
      * @param[in] p Point to be projected
      * @param[in] a First segment vertex coordinates
@@ -703,7 +703,7 @@ int ttk::SurfaceGeometrySmoother::execute(
     }
   } else {
     // generate a ttkVertexScalarField-like point data array using raw
-    // euclidian distance between the points to smooth and every
+    // euclidean distance between the points to smooth and every
     // vertex of the surface
     Timer tm_nv{};
     this->printMsg("Computing nearest vertices...", debug::Priority::INFO,

--- a/core/base/topologicalCompression/PersistenceDiagramCompression.h
+++ b/core/base/topologicalCompression/PersistenceDiagramCompression.h
@@ -572,7 +572,8 @@ int ttk::TopologicalCompression::compressForPersistenceDiagram(
     else if(seg >= 0)
       affectedSegments[seg] = true;
     else {
-      this->printErr("Negative segment encoutered (" + std::to_string(i) + ")");
+      this->printErr("Negative segment encountered (" + std::to_string(i)
+                     + ")");
     }
   }
   std::vector<int> empty;

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -37,7 +37,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p inputOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -157,7 +157,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill the @p inputOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/trackingFromFields/TrackingFromFields.h
+++ b/core/base/trackingFromFields/TrackingFromFields.h
@@ -71,7 +71,7 @@ namespace ttk {
      * @pre For this function to behave correctly in the absence of
      * the VTK wrapper, ttk::preconditionOrderArray() needs to be
      * called to fill every buffer in the @p io vector prior to any
-     * computation (the VTK wrapper already includes a mecanism to
+     * computation (the VTK wrapper already includes a mechanism to
      * automatically generate such a preconditioned buffer).
      * @see examples/c++/main.cpp for an example use.
      */

--- a/core/base/trackingFromOverlap/TrackingFromOverlap.h
+++ b/core/base/trackingFromOverlap/TrackingFromOverlap.h
@@ -3,13 +3,13 @@
 /// \author Jonas Lukasczyk <jl@jluk.de>
 /// \date 01.09.2018
 ///
-/// \brief TTK %trackingFromOverlap processing package that tracks labled point
+/// \brief TTK %trackingFromOverlap processing package that tracks labeled point
 /// sets.
 ///
 /// %TrackingFromOverlap is a TTK processing package that provides algorithms to
-/// track labled point sets across time (and optionally levels) based on spatial
-/// overlap, where two points overlap iff their corresponding coordinates are
-/// equal.
+/// track labeled point sets across time (and optionally levels) based on
+/// spatial overlap, where two points overlap iff their corresponding
+/// coordinates are equal.
 ///
 /// \b Related \b publication: \n
 /// 'Nested Tracking Graphs'
@@ -94,15 +94,15 @@ namespace ttk {
     // This function sorts points based on their x, y, and then z coordinate
     int sortCoordinates(const float *pointCoordinates,
                         const size_t nPoints,
-                        std::vector<size_t> &sortedIndicies) const {
+                        std::vector<size_t> &sortedIndices) const {
       printMsg("Sorting coordinates ... ", debug::Priority::PERFORMANCE);
       Timer t;
 
-      sortedIndicies.resize(nPoints);
+      sortedIndices.resize(nPoints);
       for(size_t i = 0; i < nPoints; i++)
-        sortedIndicies[i] = i;
+        sortedIndices[i] = i;
       CoordinateComparator c = CoordinateComparator(pointCoordinates);
-      sort(sortedIndicies.begin(), sortedIndicies.end(), c);
+      sort(sortedIndices.begin(), sortedIndices.end(), c);
 
       std::stringstream msg;
       msg << "done (" << t.getElapsedTime() << " s).";
@@ -208,8 +208,8 @@ namespace ttk {
       return 1;
     }
 
-    // This function sorts all unique lables of a point set and then maps these
-    // lables to their respective index in the sorted list
+    // This function sorts all unique labels of a point set and then maps these
+    // labels to their respective index in the sorted list
     template <typename labelType>
     int computeLabelIndexMap(const labelType *pointLabels,
                              const size_t nPoints,
@@ -323,10 +323,10 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   // -------------------------------------------------------------------------
   // Sort coordinates
   // -------------------------------------------------------------------------
-  std::vector<size_t> sortedIndicies0;
-  std::vector<size_t> sortedIndicies1;
-  this->sortCoordinates(pointCoordinates0, nPoints0, sortedIndicies0);
-  this->sortCoordinates(pointCoordinates1, nPoints1, sortedIndicies1);
+  std::vector<size_t> sortedIndices0;
+  std::vector<size_t> sortedIndices1;
+  this->sortCoordinates(pointCoordinates0, nPoints0, sortedIndices0);
+  this->sortCoordinates(pointCoordinates1, nPoints1, sortedIndices1);
 
   // -------------------------------------------------------------------------
   // Track Nodes
@@ -367,8 +367,8 @@ int ttk::TrackingFromOverlap::computeOverlap(const float *pointCoordinates0,
   std::unordered_map<size_t, std::unordered_map<size_t, size_t>> edgesMap;
   // Iterate over both point sets synchronously using comparison function
   while(i < nPoints0 && j < nPoints1) {
-    size_t pointIndex0 = sortedIndicies0[i];
-    size_t pointIndex1 = sortedIndicies1[j];
+    size_t pointIndex0 = sortedIndices0[i];
+    size_t pointIndex1 = sortedIndices1[j];
 
     // Determine point configuration
     int c = compare(pointIndex0, pointIndex1);

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -407,7 +407,7 @@ namespace ttk {
     /// \param cellId Input global cell identifier.
     /// \param localVertexId Input local vertex identifier,
     /// in [0, getCellVertexNumber()].
-    /// \param vertexId Ouput global vertex identifier.
+    /// \param vertexId Output global vertex identifier.
     /// \return Returns 0 upon success, negative values otherwise.
     /// \sa getCellVertexNumber()
     inline int getCellVertex(const SimplexId &cellId,
@@ -1398,7 +1398,7 @@ namespace ttk {
     /// \note It is recommended to exclude such a preconditioning step
     /// from any time performance measurement.
     /// \param map the std::unordered_map<SimplexId, SimplexId> in which we want
-    /// our GidToLidMap. \return 0 if succesful, -1 else.
+    /// our GidToLidMap. \return 0 if successful, -1 else.
     inline std::unordered_map<SimplexId, SimplexId> &getVertexGlobalIdMap() {
       return this->explicitTriangulation_.getVertexGlobalIdMap();
     }

--- a/core/base/uncertainDataEstimator/UncertainDataEstimator.h
+++ b/core/base/uncertainDataEstimator/UncertainDataEstimator.h
@@ -133,7 +133,7 @@ namespace ttk {
           binValue_[i] = rangeMin_ + (dx / 2.0) + (static_cast<double>(i) * dx);
         }
       }
-      /* Add input datas */
+      /* Add input data */
       for(SimplexId i = 0; i < numberOfVertices_; i++) {
         int bin
           = static_cast<int>(floor((inputData[i] - rangeMin_) * numberOfBins_

--- a/core/ttk.doxygen
+++ b/core/ttk.doxygen
@@ -1377,7 +1377,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #
@@ -2010,7 +2010,7 @@ PREDEFINED  = "vtkSetMacro(name,type)= \
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.h
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.h
@@ -9,7 +9,7 @@
 /// \brief Baseclass of all VTK filters that wrap ttk modules.
 ///
 /// This is an abstract vtkAlgorithm that provides standardized input/output
-/// managment for VTK wrappers of ttk filters. The class also provides a static
+/// management for VTK wrappers of ttk filters. The class also provides a static
 /// method to retrieve a ttk::Triangulation of a vtkDataSet.
 
 #pragma once
@@ -54,7 +54,7 @@ public:
 
   /**
    * Explicitly sets the maximum number of threads for the base code
-   * (overriden by UseAllCores member).
+   * (overridden by UseAllCores member).
    */
   void SetThreadNumber(int threadNumber) {
     this->ThreadNumber = threadNumber;
@@ -123,7 +123,7 @@ public:
 
   /**
    * Retrieve an identifier field and provides a ttk::SimplexId
-   * pointer to the underlaying buffer.
+   * pointer to the underlying buffer.
    *
    * Use the same parameters as GetOptionalArray to fetch the VTK data
    * array.
@@ -260,7 +260,7 @@ protected:
   /**
    * This method is called during the first pipeline pass in
    * ProcessRequest() to create empty output data objects. The data type of
-   * the generated outputs is specified in FillOutputPortInfomration().
+   * the generated outputs is specified in FillOutputPortInformation().
    *
    * In general it should not be necessary to override this method.
    */

--- a/core/vtk/ttkAlgorithm/ttkUtils.h
+++ b/core/vtk/ttkAlgorithm/ttkUtils.h
@@ -72,7 +72,7 @@ public:
     SetVoidArray(vtkDataArray *array, void *data, vtkIdType size, int save);
 
   // Fill Cell array using a pointer with the old memory layout
-  // DEPRECTAED
+  // DEPRECATED
   static void FillCellArrayFromSingle(vtkIdType const *cells,
                                       vtkIdType ncells,
                                       vtkCellArray *cellArray);

--- a/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.h
+++ b/core/vtk/ttkCinemaDarkroom/ttkCinemaDarkroomShader.h
@@ -110,7 +110,7 @@ protected:
   int FillInputPortInformation(int port, vtkInformation *info) override;
   int FillOutputPortInformation(int port, vtkInformation *info) override;
 
-  /// Replaces all palceholder strings of the input string based on previously
+  /// Replaces all placeholder strings of the input string based on previously
   /// added replacements.
   std::string PerformReplacements(const std::string &input);
 

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.cpp
@@ -268,7 +268,7 @@ vtkCellArray *ttkCinemaImaging::GetCells(vtkPointSet *pointSet) {
 
 int ttkCinemaImaging::AddFieldDataArray(vtkFieldData *fd,
                                         vtkDataArray *array,
-                                        int tupelIdx,
+                                        int tupleIdx,
                                         const std::string &name) {
   if(!array)
     return 0;
@@ -281,11 +281,11 @@ int ttkCinemaImaging::AddFieldDataArray(vtkFieldData *fd,
   newArray->SetNumberOfTuples(1);
 
   if(newArray->GetDataType() == array->GetDataType()) {
-    newArray->SetTuple(0, tupelIdx, array);
+    newArray->SetTuple(0, tupleIdx, array);
   } else {
     for(size_t i = 0; i < nComponents; i++)
       newArray->SetValue(
-        i, array->GetVariantValue(tupelIdx * nComponents + i).ToDouble());
+        i, array->GetVariantValue(tupleIdx * nComponents + i).ToDouble());
   }
 
   fd->AddArray(newArray);
@@ -295,17 +295,17 @@ int ttkCinemaImaging::AddFieldDataArray(vtkFieldData *fd,
 
 int ttkCinemaImaging::AddAllFieldDataArrays(vtkPointSet *inputGrid,
                                             vtkImageData *image,
-                                            int tupelIdx) {
+                                            int tupleIdx) {
   auto imageFD = image->GetFieldData();
 
   auto inputGridPD = inputGrid->GetPointData();
   for(int i = 0; i < inputGridPD->GetNumberOfArrays(); i++) {
     ttkCinemaImaging::AddFieldDataArray(
-      imageFD, inputGridPD->GetArray(i), tupelIdx);
+      imageFD, inputGridPD->GetArray(i), tupleIdx);
   }
 
   ttkCinemaImaging::AddFieldDataArray(
-    imageFD, inputGrid->GetPoints()->GetData(), tupelIdx, "CamPosition");
+    imageFD, inputGrid->GetPoints()->GetData(), tupleIdx, "CamPosition");
 
   return 1;
 };

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImaging.h
@@ -101,12 +101,12 @@ public:
 
   static int AddFieldDataArray(vtkFieldData *fd,
                                vtkDataArray *array,
-                               int tupelIdx,
+                               int tupleIdx,
                                const std::string &name = "");
 
   static int AddAllFieldDataArrays(vtkPointSet *inputGrid,
                                    vtkImageData *image,
-                                   int tupelIdx);
+                                   int tupleIdx);
 
   static int ComputeDirFromFocalPoint(vtkPointSet *inputGrid);
 

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -231,7 +231,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
   // Update database
   // ===========================================================================
   {
-    // Initilize file lock for remaining operations
+    // Initialize file lock for remaining operations
     std::string lockFilePath;
     if(!this->GetLockFilePath(lockFilePath))
       return 0;
@@ -247,7 +247,7 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
     struct stat info;
 
     // -------------------------------------------------------------------------
-    // If data.csv file does not exsist create it
+    // If data.csv file does not exist create it
     // -------------------------------------------------------------------------
     if(stat(csvPath.data(), &info) != 0) {
       ttk::Timer t;
@@ -328,12 +328,12 @@ int ttkCinemaWriter::ProcessDataProduct(vtkDataObject *input) {
         if(columnName.compare("FILE") == 0)
           continue;
 
-        bool exsist = false;
+        bool exist = false;
         for(size_t j = 0; j < nFields; j++) {
           if(fields[j].compare(columnName) == 0)
-            exsist = true;
+            exist = true;
         }
-        if(!exsist) {
+        if(!exist) {
           this->printErr("'data.csv' file contains column '" + columnName
                          + "' not present in field data.");
           this->printErr("Unable to insert data product into cinema database.");
@@ -557,7 +557,7 @@ int ttkCinemaWriter::RequestData(vtkInformation *ttkNotUsed(request),
   // Prepare Database
   // -------------------------------------------------------------------------
   {
-    // Initilize file lock for remaining operations
+    // Initialize file lock for remaining operations
     std::string lockFilePath;
     if(!this->GetLockFilePath(lockFilePath))
       return 0;

--- a/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
+++ b/core/vtk/ttkConnectedComponents/ttkConnectedComponents.h
@@ -10,7 +10,7 @@
 ///
 /// This filter consumes a scalar field with a feature mask and computes for
 /// each edge connected group of vertices with a non-background mask value a
-/// so-called connected component via flood-filling, where the backgroud is
+/// so-called connected component via flood-filling, where the background is
 /// masked with values smaller-equal zero. The computed components store the
 /// size, seed, and center of mass of each component. The flag
 /// UseSeedIdAsComponentId controls if the resulting segmentation is either

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.cpp
@@ -67,7 +67,7 @@ int ttkDepthImageBasedGeometryApproximation::RequestData(
     // Get depth array
     auto depthArray = this->GetInputArrayToProcess(0, inputImage);
 
-    // Get camera paramters from field data
+    // Get camera parameters from field data
     auto inputFD = inputImage->GetFieldData();
 
     auto camHeight

--- a/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
+++ b/core/vtk/ttkDepthImageBasedGeometryApproximation/ttkDepthImageBasedGeometryApproximation.h
@@ -3,7 +3,7 @@
 /// \author Jonas Lukasczyk (jl@jluk.de)
 /// \date 01.07.2018
 ///
-/// \brief TTK VTK-filter that approximates the geomerty that is depicted by a
+/// \brief TTK VTK-filter that approximates the geometry that is depicted by a
 /// set of depth images.
 ///
 /// VTK wrapping code for the ttk::DepthImageBasedGeometryApproximation package.

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -129,7 +129,7 @@ int ttkExtract::ExtractBlocks(vtkDataObject *output,
     this->printMsg({{"Extraction Mode",
                      "Block" + std::string(extractTuples ? " Tuples" : "")},
                     {"Output Type", outputDataTypeName + extentString},
-                    {"Indicies", "[" + indicesString + "]"}});
+                    {"Indices", "[" + indicesString + "]"}});
     this->printMsg(ttk::debug::Separator::L2);
   }
 
@@ -241,7 +241,7 @@ int ttkExtract::ExtractRows(vtkDataObject *output,
   {
     this->printMsg(ttk::debug::Separator::L1);
     this->printMsg(
-      {{"Extraction Mode", "Rows"}, {"Indicies", "[" + indicesString + "]"}});
+      {{"Extraction Mode", "Rows"}, {"Indices", "[" + indicesString + "]"}});
     this->printMsg(ttk::debug::Separator::L2);
   }
 
@@ -427,18 +427,18 @@ int ttkExtract::AddMaskArray(vtkDataObject *output,
   // initialize mask array
   const size_t nInPoints = inputAsDS->GetNumberOfPoints();
   const size_t nInCells = inputAsDS->GetNumberOfCells();
-  const size_t nOutValus = isPointDataArray ? nInPoints : nInCells;
+  const size_t nOutValues = isPointDataArray ? nInPoints : nInCells;
 
   auto maskArray = vtkSmartPointer<vtkSignedCharArray>::New();
   maskArray->SetName("Mask");
-  maskArray->SetNumberOfTuples(nOutValus);
+  maskArray->SetNumberOfTuples(nOutValues);
   auto maskArrayData = ttkUtils::GetPointer<signed char>(maskArray);
 
   // compute mask
   int status = 0;
   switch(inputArray->GetDataType()) {
     vtkTemplateMacro((
-      status = computeMask<VTK_TT>(maskArrayData, expressionValues, nOutValus,
+      status = computeMask<VTK_TT>(maskArrayData, expressionValues, nOutValues,
                                    ttkUtils::GetPointer<VTK_TT>(inputArray),
                                    this->ValidationMode, this->threadNumber_)));
   }

--- a/core/vtk/ttkFTMTree/ttkFTMStructures.h
+++ b/core/vtk/ttkFTMTree/ttkFTMStructures.h
@@ -188,7 +188,7 @@ namespace ttk {
 
       inline void addArray(vtkUnstructuredGrid *skeletonArcs, Params params) {
         // Some arcs might have been less sampled than the desired value, if
-        // they have not enought regular vertices. Here we ensur that we will no
+        // they have not enough regular vertices. Here we ensur that we will no
         // keep noise in these arrays.
         const size_t nbPoints = skeletonArcs->GetNumberOfPoints();
         const size_t nbCells = skeletonArcs->GetNumberOfCells();

--- a/core/vtk/ttkFTMTree/ttkFTMTree.cpp
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.cpp
@@ -2,7 +2,7 @@
 #include <ttkMacros.h>
 #include <ttkUtils.h>
 
-// VTK inclues
+// VTK includes
 #include <vtkConnectivityFilter.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
@@ -76,7 +76,7 @@ int ttkFTMTree::RequestData(vtkInformation *ttkNotUsed(request),
   if(input->IsA("vtkUnstructuredGrid")) {
     // This data set may have several connected components,
     // we need to apply the FTM Tree for each one of these components
-    // We then reconstruct the global tree using an offest mecanism
+    // We then reconstruct the global tree using an offset mechanism
     auto inputWithId = vtkSmartPointer<vtkUnstructuredGrid>::New();
     inputWithId->ShallowCopy(input);
     identify(inputWithId);

--- a/core/vtk/ttkFTMTree/ttkFTMTree.h
+++ b/core/vtk/ttkFTMTree/ttkFTMTree.h
@@ -8,7 +8,7 @@
 /// \brief TTK VTK-filter for the computation of merge and contour trees.
 ///
 /// The computation of the Merge / Contour tree done by this package is done in
-/// parallel if TTK_ENABLE_OPENMP is set to ON, using a task based approch
+/// parallel if TTK_ENABLE_OPENMP is set to ON, using a task based approach
 /// described in the article mention below.
 /// The VTK wrapper will first call a connectivity filter, and then call
 /// a contour / merge tree computation for each connected components. The final
@@ -30,7 +30,7 @@
 /// 1. The nodes of the tree
 /// 2. The arcs of the tree
 /// 3. The semgentation of the initial dataset
-/// The structure of the tree (Nodes+Arcs) have a concept of nodeId, wich is
+/// The structure of the tree (Nodes+Arcs) have a concept of nodeId, which is
 /// an id that is consistent between execution if SetWithNormalize is set to
 /// True. The downNodeId of an arc is its starting node (directed towards the
 /// leaves as the computation starts here) and the upNodeId it the ending node,

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.cpp
@@ -214,7 +214,7 @@ int ttkFTRGraph::addSampledSkeletonArc(const Graph &graph,
         sum[1] /= chunk;
         sum[2] /= chunk;
 
-        // do not use memorized points as even if a point already exisit it is
+        // do not use memorized points as even if a point already exist it is
         // from another vertex and should not be used
         pointIds[1] = points->InsertNextPoint(sum);
         arcData.points.emplace(regV, pointIds[1]);

--- a/core/vtk/ttkFTRGraph/ttkFTRGraph.h
+++ b/core/vtk/ttkFTRGraph/ttkFTRGraph.h
@@ -8,17 +8,16 @@
 /// \brief TTK VTK-filter for the computation of Reeb Graphs
 ///
 /// The computation of the Reeb graph done by this package is done in
-/// parallel if TTK_ENABLE_OPENMP is set to ON, using a task based approch
+/// parallel if TTK_ENABLE_OPENMP is set to ON, using a task based approach
 /// described in the article mention below.
 ///
 /// \param Input Input scalar field, either 2D or 3D, regular
 /// grid or triangulation (vtkDataSet)
 /// \param SingleSweep control if the computation should start from both minima
-/// and maxima simultaneously. If you encouter troubled with FTR, you should try
-/// to use the single sweep. It is slower but may be more robust.
-/// \param Segmentation control wethear or not the output should be augmented
-/// with the segmentation.
-/// \param SuperArcSamplingLevel control the number of subdivision
+/// and maxima simultaneously. If you encounter troubled with FTR, you should
+/// try to use the single sweep. It is slower but may be more robust. \param
+/// Segmentation control wethear or not the output should be augmented with the
+/// segmentation. \param SuperArcSamplingLevel control the number of subdivision
 /// of each superarc. Intermediate point will be located on the barycenter of
 /// the corresponding portion of vertex.
 /// \param Output the output of this filter
@@ -26,7 +25,7 @@
 /// 1. The nodes of the tree
 /// 2. The arcs of the tree
 /// 3. The semgentation of the initial dataset
-/// The structure of the tree (Nodes+Arcs) have a concept of nodeId, wich is
+/// The structure of the tree (Nodes+Arcs) have a concept of nodeId, which is
 /// an id that is consistent between execution if SetWithNormalize is set to
 /// True. The downNodeId of an arc is its starting node (directed towards the
 /// leaves as the computation starts here) and the upNodeId it the ending node,
@@ -94,7 +93,7 @@ public:
   /// @}
 
   /// @brief if set to true, a post processing pass will be used to enforce
-  /// consistend node ids between executions
+  /// consistent node ids between executions
   /// @{
   void SetWithNormalize(const bool norm) {
     params_.normalize = norm;

--- a/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
+++ b/core/vtk/ttkHelloWorld/ttkHelloWorld.cpp
@@ -110,7 +110,7 @@ int ttkHelloWorld::RequestData(vtkInformation *ttkNotUsed(request),
   //               const char *name
   //            )
   //
-  //       The parameter 'idx' is often missunderstood: lets say the filter
+  //       The parameter 'idx' is often misunderstood: lets say the filter
   //       requires n arrays, then idx enumerates them from 0 to n-1.
   //
   //       The 'port' is the input port index at which the object is connected

--- a/core/vtk/ttkIcosphere/ttkIcosphere.h
+++ b/core/vtk/ttkIcosphere/ttkIcosphere.h
@@ -32,7 +32,7 @@ private:
   // single ico sphere
   double Center[3]{0, 0, 0};
 
-  // alternatvely create a sphere at each point
+  // alternately create a sphere at each point
   vtkDataArray *Centers{nullptr};
 
 public:

--- a/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
+++ b/core/vtk/ttkIdentifierRandomizer/ttkIdentifierRandomizer.cpp
@@ -74,7 +74,7 @@ int shuffleScalarFieldValues(const T *const inputField,
   // results are platform-dependent
   ttk::shuffle(shuffledValues, random_engine);
 
-  // link original value to shuffled value correspondance
+  // link original value to shuffled value correspondence
   std::map<T, T> originalToShuffledValues{};
   for(size_t i = 0; i < inputValues.size(); ++i) {
     originalToShuffledValues[inputValues[i]] = shuffledValues[i];

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.h
@@ -9,7 +9,7 @@
 /// distance between two merge trees.
 ///
 /// \param Input vtkMultiBlockDataSet Input trees
-/// \param Input (optionnal) vtkMultiBlockDataSet Input trees
+/// \param Input (optional) vtkMultiBlockDataSet Input trees
 /// \param Output vtkMultiBlockDataSet Input trees (processed)
 /// \param Output vtkMultiBlockDataSet Centroids trees
 /// \param Output vtkMultiBlockDataSet Matchings

--- a/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
+++ b/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
@@ -8,11 +8,11 @@
 ///
 /// This VTK filter uses the ttk::MergeTreePrincipalGeodesics module to compute
 /// Principal Geodesic Analysis on the space of merge trees or persistence
-/// diagrams, that is, a set of orthognal geodesic axes defining a basis with
+/// diagrams, that is, a set of orthogonal geodesic axes defining a basis with
 /// the barycenter as origin.
 ///
 /// \param Input vtkMultiBlockDataSet Input trees
-/// \param Input (optionnal) vtkMultiBlockDataSet Input trees
+/// \param Input (optional) vtkMultiBlockDataSet Input trees
 /// \param Output vtkMultiBlockDataSet Barycenter
 /// \param Output vtkTable Coefficients
 /// \param Output vtkTable Geodesics Vectors

--- a/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
+++ b/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
@@ -319,8 +319,7 @@ int ttkMergeTreePrincipalGeodesicsDecoding::runCompute(
 
   if(OutputInputTrees
      or (ReconstructInputTrees
-         and (computeReconstructionError_
-              or transferInputTreesInformations_))) {
+         and (computeReconstructionError_ or transferInputTreesInformation_))) {
     bool useSadMaxPairs
       = (useDoubleInput_ and not processFirstInput) or mixtureCoefficient_ == 0;
     bool isInputPD = ttk::ftm::constructTrees<dataType>(
@@ -485,7 +484,7 @@ int ttkMergeTreePrincipalGeodesicsDecoding::runOutput(
     getMatchingMatrix<double>(
       baryMTree[0], inputMTrees, baryMatchings_, matchingMatrix);
   // TODO compute matching to barycenter if correlation matrix is not provided
-  if(transferInputTreesInformations_
+  if(transferInputTreesInformation_
      and (inputMTrees.empty() or baryMatchings_.empty()))
     printWrn("Please provide input trees and correlation matrix to transfer "
              "input trees information.");
@@ -614,9 +613,9 @@ int ttkMergeTreePrincipalGeodesicsDecoding::runOutput(
     } else
       visuMaker.setShiftMode(2); // Line
 
-    // TODO transfer other informations?
+    // TODO transfer other information?
     if(isReconstructedTree) {
-      if(transferBarycenterInformations_) {
+      if(transferBarycenterInformation_) {
         ttk::ftm::MergeTree<dataType> baryMT;
         ttk::ftm::mergeTreeDoubleToTemplate<dataType>(baryMTree[0], baryMT);
         std::vector<ttk::ftm::idNode> matchingVector;
@@ -631,7 +630,7 @@ int ttkMergeTreePrincipalGeodesicsDecoding::runOutput(
         std::string nameBaryNodeId{"BaryNodeId"};
         visuMaker.addCustomIntArray(nameBaryNodeId, baryNodeID);
       }
-      if(transferInputTreesInformations_ and !inputMTrees.empty()
+      if(transferInputTreesInformation_ and !inputMTrees.empty()
          and !baryMatchings_.empty()) {
         ttk::ftm::MergeTree<dataType> inputMT;
         ttk::ftm::mergeTreeDoubleToTemplate<dataType>(

--- a/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.h
+++ b/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.h
@@ -159,19 +159,19 @@ public:
   }
   vtkGetMacro(computeReconstructionError_, bool);
 
-  void SettransferInputTreesInformations_(bool b) {
-    transferInputTreesInformations_ = b;
+  void SettransferInputTreesInformation_(bool b) {
+    transferInputTreesInformation_ = b;
     Modified();
     resetDataVisualization();
   }
-  vtkGetMacro(transferInputTreesInformations_, bool);
+  vtkGetMacro(transferInputTreesInformation_, bool);
 
-  void SettransferBarycenterInformations_(bool b) {
-    transferBarycenterInformations_ = b;
+  void SettransferBarycenterInformation_(bool b) {
+    transferBarycenterInformation_ = b;
     Modified();
     resetDataVisualization();
   }
-  vtkGetMacro(transferBarycenterInformations_, bool);
+  vtkGetMacro(transferBarycenterInformation_, bool);
 
   vtkSetMacro(ConstructGeodesicsTrees, bool);
   vtkGetMacro(ConstructGeodesicsTrees, bool);

--- a/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
+++ b/core/vtk/ttkMetricDistortion/ttkMetricDistortion.h
@@ -6,12 +6,12 @@
 /// \brief TTK VTK-filter that wraps the ttk::MetricDistortion module.
 ///
 /// This VTK filter uses the ttk::MetricDistortion module to compute distance,
-/// area and curvature information about a surface and an optionnal distance
+/// area and curvature information about a surface and an optional distance
 /// matrix (giving the distance between the points of the surface in a metric
 /// space).
 ///
 /// \param Input vtkPolyData.
-/// \param Input vtkTable (optionnal)
+/// \param Input vtkTable (optional)
 /// \param Output vtkDataSet.
 ///
 /// This filter can be used as any other VTK filter (for instance, by using the

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -62,7 +62,7 @@ private:
   // Used for critical type and for point coordinates
   std::vector<vtkUnstructuredGrid *> treesNodes;
   std::vector<std::vector<int>>
-    treesNodeCorrMesh; // used to acces treesNodes given input trees
+    treesNodeCorrMesh; // used to access treesNodes given input trees
 
   // Segmentation
   std::vector<vtkDataSet *> treesSegmentation;

--- a/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkPlanarGraphLayout.h
@@ -10,7 +10,7 @@
 /// This filter computes a planar graph layout of a \b vtkUnstructuredGrid. To
 /// improve the quality of the layout it is possible to pass additional field
 /// data to the algorithm:\n \b 1) \b Sequences: Points are positioned along the
-/// x-axis based on a sequence (e.g., time indicies or scalar values). \b 1) \b
+/// x-axis based on a sequence (e.g., time indices or scalar values). \b 1) \b
 /// Sizes: Points cover space on the y-axis based on their size. \b 1) \b
 /// Branches: Points with the same branch label are positioned on straight
 /// lines. \b 1) \b Levels: The layout of points with the same level label are

--- a/core/vtk/ttkProgramBase/ttkProgramBase.cpp
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.cpp
@@ -36,7 +36,7 @@ int ttkProgramBase::load(const std::vector<std::string> &inputPaths) {
         inputPaths[i], unstructuredGridReaders_);
     } else {
       stringstream msg;
-      msg << "[ttkProgramBase] Unkown input extension `" << extension << "' :("
+      msg << "[ttkProgramBase] Unknown input extension `" << extension << "' :("
           << endl;
       printErr(msg.str());
       return -1;

--- a/core/vtk/ttkProgramBase/ttkProgramBase.h
+++ b/core/vtk/ttkProgramBase/ttkProgramBase.h
@@ -4,7 +4,7 @@
 /// \date February 2017.
 ///
 /// \brief Base VTK editor class for standalone programs. This class parses the
-/// the comamnd line, execute the TTK module and takes care of the IO.
+/// the command line, execute the TTK module and takes care of the IO.
 
 #pragma once
 

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.h
@@ -8,7 +8,7 @@
 ///
 /// VTK wrapping code for the ttk::TrackingFromOverlap package.
 ///
-/// This filter identifies and tracks labled vtkPointSets across time (and
+/// This filter identifies and tracks labeled vtkPointSets across time (and
 /// optionally levels) based on spatial overlap, where two points overlap iff
 /// their corresponding coordinates are equal. This filter can be executed
 /// iteratively and can generate nested tracking graphs.

--- a/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
+++ b/core/vtk/ttkUncertainDataEstimator/ttkUncertainDataEstimator.cpp
@@ -52,7 +52,7 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *ttkNotUsed(request),
   this->printMsg(std::vector<std::vector<std::string>>{
     {"#Inputs", std::to_string(numInputs)}});
 
-  // Get input datas
+  // Get input data
   std::vector<vtkDataSet *> input(numInputs);
   for(int i = 0; i < numInputs; i++) {
     input[i] = vtkDataSet::GetData(inputVector[0], i);
@@ -66,7 +66,7 @@ int ttkUncertainDataEstimator::RequestData(vtkInformation *ttkNotUsed(request),
   int numFields = 0;
   int numArrays = 0;
 
-  // Get arrays from input datas
+  // Get arrays from input data
   std::vector<vtkDataArray *> inputScalarField;
 
   for(int i = 0; i < numInputs; i++) {

--- a/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
+++ b/core/vtk/ttkUserInterfaceBase/ttkUserInterfaceBase.cpp
@@ -189,7 +189,7 @@ int ttkUserInterfaceBase::run() {
 
   {
     stringstream msg;
-    msg << "[UserInterace] Initializing user interface..." << endl;
+    msg << "[UserInterface] Initializing user interface..." << endl;
     printMsg(msg.str());
   }
 

--- a/paraview/xmls/ConnectedComponents.xml
+++ b/paraview/xmls/ConnectedComponents.xml
@@ -3,7 +3,7 @@
   <ProxyGroup name="filters">
     <SourceProxy name="ConnectedComponents" class="ttkConnectedComponents" label="TTK ConnectedComponents">
       <Documentation long_help="TTK connectedComponents" short_help="TTK connectedComponents">
-        This filter consumes a scalar field with a feature mask and computes for each edge connected group of vertices with a non-background mask value a so-called connected component via flood-filling, where the backgroud is masked with values smaller-equal zero. The computed components store the size, seed, and center of mass of each component. The flag UseSeedIdAsComponentId controls if the resulting segmentation is either labeled by the index of the component, or by its seed location (which can be used as a deterministic component label).
+        This filter consumes a scalar field with a feature mask and computes for each edge connected group of vertices with a non-background mask value a so-called connected component via flood-filling, where the background is masked with values smaller-equal zero. The computed components store the size, seed, and center of mass of each component. The flag UseSeedIdAsComponentId controls if the resulting segmentation is either labeled by the index of the component, or by its seed location (which can be used as a deterministic component label).
       </Documentation>
 
       <InputProperty name="Segmentation" command="SetInputConnection">
@@ -14,7 +14,7 @@
         <DataTypeDomain name="input_type">
           <DataType value="vtkDataSet" />
         </DataTypeDomain>
-        <InputArrayDomain attribute_type="point" name="segmantation_point_arrays" number_of_components="1" optional="1" />
+        <InputArrayDomain attribute_type="point" name="segmentation_point_arrays" number_of_components="1" optional="1" />
         <Documentation>A vtkDataSet.</Documentation>
       </InputProperty>
 
@@ -22,7 +22,7 @@
       <OutputPort index="1" id="port1" name="Components" />
 
       <StringVectorProperty name="FeatureMask" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5" default_values="None">
-        <ArrayListDomain name="array_list" input_domain_name="segmantation_point_arrays" none_string="None">
+        <ArrayListDomain name="array_list" input_domain_name="segmentation_point_arrays" none_string="None">
           <RequiredProperties>
             <Property function="Input" name="Segmentation" />
           </RequiredProperties>

--- a/paraview/xmls/ContourForests.xml
+++ b/paraview/xmls/ContourForests.xml
@@ -225,7 +225,7 @@
         </Documentation>
       </IntVectorProperty>-->
 
-      <IntVectorProperty name="Independant Merge Trees"
+      <IntVectorProperty name="Independent Merge Trees"
         command="SetLessPartition"
         label="Parallel Join/Split tree computation"
         number_of_elements="1"
@@ -255,7 +255,7 @@
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Parallelism">
-        <Property name="Independant Merge Trees"/>
+        <Property name="Independent Merge Trees"/>
         <Property name="Partition Number"/>
       </PropertyGroup>
 

--- a/paraview/xmls/Extract.xml
+++ b/paraview/xmls/Extract.xml
@@ -120,7 +120,7 @@ Auto: Extracted blocks (of any type) are appended to a new 'vtkMultiBlockDataSet
                 <Hints>
                     <PropertyWidgetDecorator type="GenericDecorator" mode="visibility" property="ExtractionMode" value="2" />
                 </Hints>
-                <Documentation>Determines how vertex values are compared agains each value of the expression.</Documentation>
+                <Documentation>Determines how vertex values are compared against each value of the expression.</Documentation>
             </IntVectorProperty>
 
             <StringVectorProperty name="InputArray" label="Input Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5">

--- a/paraview/xmls/MandatoryCriticalPoints.xml
+++ b/paraview/xmls/MandatoryCriticalPoints.xml
@@ -125,7 +125,7 @@ Online Examples:
       </IntVectorProperty>
 
       <IntVectorProperty
-         name="OutputMinmumComponentId"
+         name="OutputMinimumComponentId"
          label="Only display minimum with Id"
          command="SetOutputMinimumComponentId"
          number_of_elements="1"
@@ -216,7 +216,7 @@ specify in the text box below which maximum to display.
         <Property name="OutputAllJoinSaddleComponents" />
         <Property name="OutputAllSplitSaddleComponents" />
         <Property name="OutputAllMaximumComponents" />
-        <Property name="OutputMinmumComponentId" />
+        <Property name="OutputMinimumComponentId" />
         <Property name="OutputJoinSaddleComponentId" />
         <Property name="OutputSplitSaddleComponentId" />
         <Property name="OutputMaxmumComponentId" />

--- a/paraview/xmls/MergeTreeClustering.xml
+++ b/paraview/xmls/MergeTreeClustering.xml
@@ -41,9 +41,9 @@ These backends are different through 3 parameters:
 
 These parameters can be configured manually by selecting the Custom backend.
 
-The input of this filter is a vtkMultiBlockDataset. Each block is itself a vtkMultiBlockDataset containing the outputs of the FTMTree filter (the segmentation output is optionnal).
+The input of this filter is a vtkMultiBlockDataset. Each block is itself a vtkMultiBlockDataset containing the outputs of the FTMTree filter (the segmentation output is optional).
 
-When using the clustering algorithm, this filter allows to use the join tree and the split tree at the same time (each input data and each centroid is considered to be two objects: its join and split tree, the distance between data is the sum of the distance between their join tree and the ditance between their split tree). The first input should containing all the join or split tree and the second input should contains all the trees of the other type.
+When using the clustering algorithm, this filter allows to use the join tree and the split tree at the same time (each input data and each centroid is considered to be two objects: its join and split tree, the distance between data is the sum of the distance between their join tree and the distance between their split tree). The first input should containing all the join or split tree and the second input should contains all the trees of the other type.
 
 Online examples:
 
@@ -282,7 +282,7 @@ Online examples:
                                            value="1" />
                   </Hints>
                   <Documentation>
-                    Set the alpha coefficent of the first tree. Use to work when there is only 2 input trees, the alpha of the second input will be (1-alpha).
+                    Set the alpha coefficient of the first tree. Use to work when there is only 2 input trees, the alpha of the second input will be (1-alpha).
                   </Documentation>
                   <DoubleRangeDomain name="range" min="0" max="1" />
                 </DoubleVectorProperty> 

--- a/paraview/xmls/MergeTreePrincipalGeodesicsDecoding.xml
+++ b/paraview/xmls/MergeTreePrincipalGeodesicsDecoding.xml
@@ -67,7 +67,7 @@
       </InputProperty>
       
       <InputProperty
-        name="Correlation Matrix (optionnal)"
+        name="Correlation Matrix (optional)"
         port_index="3"
         command="SetInputConnection">
         <ProxyGroupDomain name="groups">
@@ -86,7 +86,7 @@
       </InputProperty>
       
       <InputProperty
-        name="Input Trees (optionnal)"
+        name="Input Trees (optional)"
         port_index="4"
         command="SetInputConnection">
         <ProxyGroupDomain name="groups">
@@ -182,9 +182,9 @@
       </IntVectorProperty>
       
       <IntVectorProperty
-      name="TransferInputTreesInformations"
-      command="SettransferInputTreesInformations_"
-      label="Transfer Input Trees Informations"
+      name="TransferInputTreesInformation"
+      command="SettransferInputTreesInformation_"
+      label="Transfer Input Trees Information"
       number_of_elements="1"
       default_values="0"
       panel_visibility="advanced">
@@ -201,9 +201,9 @@
       </IntVectorProperty>
       
       <IntVectorProperty
-      name="TransferBarycenterInformations"
-      command="SettransferBarycenterInformations_"
-      label="Transfer Barycenter Informations"
+      name="TransferBarycenterInformation"
+      command="SettransferBarycenterInformation_"
+      label="Transfer Barycenter Information"
       number_of_elements="1"
       default_values="0"
       panel_visibility="advanced">
@@ -339,8 +339,8 @@
         <Property name="OutputBarycenter"/>
         <Property name="ReconstructInputTrees"/>
         <Property name="ComputeReconstructionError"/>
-        <Property name="TransferInputTreesInformations"/>
-        <Property name="TransferBarycenterInformations"/>
+        <Property name="TransferInputTreesInformation"/>
+        <Property name="TransferBarycenterInformation"/>
         <Property name="ConstructGeodesicsTrees"/>
         <Property name="ConstructEllipses"/>
         <Property name="ConstructRectangle"/>

--- a/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
+++ b/paraview/xmls/MergeTreeTemporalReductionEncoding.xml
@@ -11,7 +11,7 @@ This filter allows to compute a temporal reduction of a sequence of merge trees.
 
 It greedily removes trees in the sequence that can be accurately reconstructed with the geodesic computation. This iterated removal reveals key frames in the sequence (the trees that are not removed and used to reconstruct the removed trees). 
 
-The input of this filter is a vtkMultiBlockDataset. Each block is itself a vtkMultiBlockDataset containing the outputs of the FTMTree filter (the segmentation output is optionnal).
+The input of this filter is a vtkMultiBlockDataset. Each block is itself a vtkMultiBlockDataset containing the outputs of the FTMTree filter (the segmentation output is optional).
 
 The output of this filter contains the key frames and the reduction coefficients needed to reconstructs the removed trees. To reconstruct the sequence, call the MergeTreeTemporalReductionDecoding filter.
 

--- a/paraview/xmls/MetricDistortion.xml
+++ b/paraview/xmls/MetricDistortion.xml
@@ -6,7 +6,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy name="ttkMetricDistortion" class="ttkMetricDistortion" label="TTK MetricDistortion">
-      <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter computes distance, area and curvature information about a surface and an optionnal distance matrix (giving the distance between the points of the surface in a metric space).</Documentation>
+      <Documentation long_help="MetricDistortion Long" short_help="MetricDistortion Short">This filter computes distance, area and curvature information about a surface and an optional distance matrix (giving the distance between the points of the surface in a metric space).</Documentation>
 
       <!-- INPUT DATA OBJECTS -->      
       <InputProperty

--- a/paraview/xmls/PersistenceDiagramClustering.xml
+++ b/paraview/xmls/PersistenceDiagramClustering.xml
@@ -94,7 +94,7 @@
       <Documentation>
         When there are only two input diagrams and one cluster, the progressive approach is not used by default to compute the barycenter.
           Instead, the Auction Algorithm is used to compute the Wasserstein distance between the two diagrams, and the barycenter is deduced from
-          the corresponding assignments without additional computationnal cost.
+          the corresponding assignments without additional computational cost.
           This option forces the use of the progressive approach to compute the barycenter.
       </Documentation>
 
@@ -308,7 +308,7 @@
                            </PropertyWidgetDecorator>
         </Hints>
         <Documentation>
-            Ajust the spacing for the display of diagrams.
+            Adjust the spacing for the display of diagrams.
         </Documentation>
       </DoubleVectorProperty>
 
@@ -337,7 +337,7 @@
         <BooleanDomain name="bool"/>
          <Documentation>
           If activated, the clustering is initialized cleverly. The option may avoid local minima at the cost
-          of some initial computations proportionnal to the product of the number of clusters and the number of diagrams.
+          of some initial computations proportional to the product of the number of clusters and the number of diagrams.
          </Documentation>
       </IntVectorProperty>
 

--- a/paraview/xmls/PlanarGraphLayout.xml
+++ b/paraview/xmls/PlanarGraphLayout.xml
@@ -5,7 +5,7 @@
             <Documentation long_help="TTK PlanarGraphLayout" short_help="TTK PlanarGraphLayout">
 This filter computes a planar graph layout of a 'vtkUnstructuredGrid'. To improve the quality of the layout it is possible to pass additional field data to the algorithm:
 
-1) Sequences: Points are positioned along the x-axis based on a sequence (e.g., time indicies or scalar values).
+1) Sequences: Points are positioned along the x-axis based on a sequence (e.g., time indices or scalar values).
 
 2) Sizes: Points cover space on the y-axis based on their size.
 
@@ -73,7 +73,7 @@ IEEE Transactions on Visualization and Computer Graphics, 2021
                                              value="0" />
                 </Hints>
                 <BooleanDomain name="bool" />
-                <Documentation>Points are positioned along the x-axis based on a sequence (e.g., time indicies or scalar values).</Documentation>
+                <Documentation>Points are positioned along the x-axis based on a sequence (e.g., time indices or scalar values).</Documentation>
             </IntVectorProperty>
 
             <StringVectorProperty name="SequenceArray" label="Sequence Array" command="SetInputArrayToProcess" element_types="0 0 0 0 2" number_of_elements="5">

--- a/paraview/xmls/StringArrayConverter.xml
+++ b/paraview/xmls/StringArrayConverter.xml
@@ -9,7 +9,7 @@
           short_help="Converts string arrays into int arrays.">
         This filter converts an input vtkStringArray into an
         vtkIntArray to make it easier to apply Threshold on the data
-        set. The correspondance between a string value and an int is
+        set. The correspondence between a string value and an int is
         to be stored in the output Field Data.
       </Documentation>
 

--- a/paraview/xmls/TrackingFromOverlap.xml
+++ b/paraview/xmls/TrackingFromOverlap.xml
@@ -3,7 +3,7 @@
     <ProxyGroup name="filters">
         <SourceProxy name="ttkTrackingFromOverlap" class="ttkTrackingFromOverlap" label="TTK TrackingFromOverlap">
             <Documentation long_help="TTK TrackingFromOverlap" short_help="TTK TrackingFromOverlap">
-This filter identifies and tracks labled vtkPointSets across time (and optionally levels) based on spatial overlap, where two points overlap iff their corresponding coordinates are equal. This filter can be executed iteratively and can generate nested tracking graphs.
+This filter identifies and tracks labeled vtkPointSets across time (and optionally levels) based on spatial overlap, where two points overlap iff their corresponding coordinates are equal. This filter can be executed iteratively and can generate nested tracking graphs.
 
 Related publication:
 

--- a/scripts/docker/pkg/mesa.sh
+++ b/scripts/docker/pkg/mesa.sh
@@ -1,6 +1,6 @@
 MESA_VERSION=20.3.5
 
-# install packges required for build
+# install packages required for build
 require-pkgs \
     pkg-config      \
 	python3-dev		\

--- a/standalone/WebSocketIO/receivingVtkDataObjects.html
+++ b/standalone/WebSocketIO/receivingVtkDataObjects.html
@@ -38,7 +38,7 @@
       <h3>Overview</h3>
       <ul>
         <li>The <code>ttkWebSocketIO</code> library enables bidirectional data transfer between VTK (ParaView) and the browser by serializing <code>vtkDataObjects</code> and sending them through a websocket connection.</li>
-        <li>The libary consits of the two endpoints necessary for such a connection:
+        <li>The library consists of the two endpoints necessary for such a connection:
           <ol>
             <li>Server: A <code>ttkWebSocketIO</code> VTK filter (e.g., at the end of a pipeline in ParaView).</li>
             <li>Client: A webpage that uses the <code>ttkWebSocketIO.js</code> library (e.g., a visual analytics interface).</li>

--- a/standalone/WebSocketIO/sendingVtkDataObjects.html
+++ b/standalone/WebSocketIO/sendingVtkDataObjects.html
@@ -38,7 +38,7 @@
       <h3>Overview</h3>
       <ul>
         <li>The <code>ttkWebSocketIO</code> library enables bidirectional data transfer between VTK (ParaView) and the browser by serializing <code>vtkDataObjects</code> and sending them through a websocket connection.</li>
-        <li>The libary consits of the two endpoints necessary for such a connection:
+        <li>The library consists of the two endpoints necessary for such a connection:
           <ol>
             <li>Server: A <code>ttkWebSocketIO</code> VTK filter (e.g., at the end of a pipeline in ParaView).</li>
             <li>Client: A webpage that uses the <code>ttkWebSocketIO.js</code> library (e.g., a visual analytics interface).</li>


### PR DESCRIPTION
This PR fixes the most glaring typos inside the TTK codebase, mostly in commented text but sometimes in variable names too.

I spent the last two weeks reading carefully all TTK code and fixing typos (just kidding, I used https://github.com/crate-ci/typos). 

Enjoy,
Pierre