### PR TITLE
Forbid use of Variable-Length Arrays

### DIFF
--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -8,6 +8,7 @@ if (NOT MSVC) # GCC and Clang
     -Wextra
     -Wtype-limits
     -Wshadow
+    -Wvla
     )
 
   # performance and debug flags


### PR DESCRIPTION
This PR adds the `-Wvla` compiler flag to detect the use of Variable-Length Arrays inside TTK. VLAs are a controversial C feature introduced in C99 but made optional in C11. They don't seem to be part of the C++ standard (but are supported anyway). A `std::vector` (although heap-allocated) is a natural replacement.

This PR removes the last VLA occurrence inside `MPIUtils.h`. With the compiler flag (and the CI), no new VLA should be introduced anymore in TTK.

Enjoy,
Pierre