### PR TITLE
GaussianPointCloud: Avoid parallel random

### DIFF
--- a/core/base/gaussianPointCloud/GaussianPointCloud.h
+++ b/core/base/gaussianPointCloud/GaussianPointCloud.h
@@ -71,26 +71,18 @@ int ttk::GaussianPointCloud::generate(const int &dimension,
 
   Timer t;
 
-  std::vector<std::mt19937> genVector(threadNumber_);
-  for(auto i = 0; i < threadNumber_; i++)
-    genVector[i].seed(seed + i * threadNumber_);
+  std::mt19937 gen{};
+  gen.seed(seed);
 
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
   for(int i = 0; i < numberOfSamples; i++) {
-    int tId = 0;
-#ifdef TTK_ENABLE_OPENMP
-    tId = omp_get_thread_num();
-#endif
-    castSample<dataType>(dimension, genVector[tId], outputData[3 * i],
-                         outputData[3 * i + 1], outputData[3 * i + 2]);
+    this->castSample(dimension, gen, outputData[3 * i], outputData[3 * i + 1],
+                     outputData[3 * i + 2]);
   }
 
   this->printMsg(std::vector<std::vector<std::string>>{
     {"#Samples", std::to_string(numberOfSamples)}});
   this->printMsg("Samples generated in " + std::to_string(dimension) + "D", 1.0,
-                 t.getElapsedTime(), this->threadNumber_);
+                 t.getElapsedTime(), 1);
 
   return 0;
 }


### PR DESCRIPTION
This PR removes the OpenMP parallel generation of Gaussian point cloud, as it interferes with the determinism introduced in https://github.com/topology-tool-kit/ttk/commit/a6c7c013aafbeb7772a47e4e1f3c95257e7644d0. 

Indeed, the previous pseudo-random determinist scheme was dependent on the number of threads on which the filter is run (one pseudo-random generator with a distinct seed per thread). To keep the determinism, the OpenMP support has been removed (the filter is fast anyway).

Enjoy,
Pierre