### PR TITLE
PersistenceDiagram: Force PersistenceSimplexPairs on non-manifold datasets

### DIFF
--- a/core/base/abstractTriangulation/AbstractTriangulation.cpp
+++ b/core/base/abstractTriangulation/AbstractTriangulation.cpp
@@ -33,6 +33,7 @@ int AbstractTriangulation::clear() {
   hasPreconditionedVertexNeighbors_ = false;
   hasPreconditionedVertexStars_ = false;
   hasPreconditionedVertexTriangles_ = false;
+  hasPreconditionedManifold_ = false;
 
   boundaryEdges_.clear();
   boundaryTriangles_.clear();

--- a/core/base/common/FlatJaggedArray.h
+++ b/core/base/common/FlatJaggedArray.h
@@ -70,7 +70,7 @@ namespace ttk {
       const SimplexId *const ptr;
       inline SimplexId operator[](const size_t id) const {
 #ifndef TTK_ENABLE_KAMIKAZE
-        if(id >= this->len) {
+        if(id >= this->len || ptr == nullptr) {
           return -1;
         }
 #endif
@@ -244,7 +244,7 @@ namespace ttk {
      */
     inline void writeToFile(const std::string &fName) const {
       std::ofstream out(fName);
-      for(const auto &slice : *this) {
+      for(const auto slice : *this) {
         for(const auto el : slice) {
           out << el << " ";
         }

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -129,10 +129,8 @@ int DiscreteGradient::setCriticalPoints(
     }
   }
 
-  const auto nDims{
-    criticalCellsByDim[3].empty() ? criticalCellsByDim[2].empty() ? 1 : 2 : 3};
-  std::vector<std::vector<std::string>> rows(nDims);
-  for(int i = 0; i < nDims; ++i) {
+  std::vector<std::vector<std::string>> rows(this->dimensionality_ + 1);
+  for(int i = 0; i < this->dimensionality_ + 1; ++i) {
     rows[i]
       = std::vector<std::string>{"#" + std::to_string(i) + "-cell(s)",
                                  std::to_string(criticalCellsByDim[i].size())};

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -1249,13 +1249,16 @@ int ttk::DiscreteMorseSandwich::computePersistencePairs(
       }
     }
 
+    int nBoundComp
+      = (dim == 3 ? nCavities : nHandles) + nConnComp - nNonPairedMax;
+    nBoundComp = std::max(nBoundComp, 0);
+
     // print Betti numbers
     std::vector<std::vector<std::string>> rows{
       {" #Connected components", std::to_string(nConnComp)},
       {" #Topological handles", std::to_string(nHandles)},
       {" #Cavities", std::to_string(nCavities)},
-      {" #Boundary components", std::to_string((dim == 3 ? nCavities : nHandles)
-                                               + nConnComp - nNonPairedMax)},
+      {" #Boundary components", std::to_string(nBoundComp)},
     };
 
     this->printMsg(rows, debug::Priority::DETAIL);

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -1064,21 +1064,6 @@ void ttk::DiscreteMorseSandwich::extractCriticalCells(
   TTK_PSORT(this->threadNumber_, critTriangles.begin(), critTriangles.end());
   TTK_PSORT(this->threadNumber_, critTetras.begin(), critTetras.end());
 
-  if(sortEdges) {
-    TTK_PSORT(this->threadNumber_, criticalCellsByDim[1].begin(),
-              criticalCellsByDim[1].end(),
-              [&critCellsOrder](const SimplexId a, const SimplexId b) {
-                return critCellsOrder[1][a] < critCellsOrder[1][b];
-              });
-  } else {
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif // TTK_ENABLE_OPENMP
-    for(size_t i = 0; i < critEdges.size(); ++i) {
-      criticalCellsByDim[1][i] = critEdges[i].id_;
-    }
-  }
-
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
@@ -1104,6 +1089,21 @@ void ttk::DiscreteMorseSandwich::extractCriticalCells(
     for(size_t i = 0; i < critTetras.size(); ++i) {
       criticalCellsByDim[3][i] = critTetras[i].id_;
       critCellsOrder[3][critTetras[i].id_] = i;
+    }
+  }
+
+  if(sortEdges) {
+    TTK_PSORT(this->threadNumber_, criticalCellsByDim[1].begin(),
+              criticalCellsByDim[1].end(),
+              [&critCellsOrder](const SimplexId a, const SimplexId b) {
+                return critCellsOrder[1][a] < critCellsOrder[1][b];
+              });
+  } else {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif // TTK_ENABLE_OPENMP
+    for(size_t i = 0; i < critEdges.size(); ++i) {
+      criticalCellsByDim[1][i] = critEdges[i].id_;
     }
   }
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -720,6 +720,37 @@ int ExplicitTriangulation::preconditionVertexTrianglesInternal() {
   return 0;
 }
 
+int ttk::ExplicitTriangulation::preconditionManifoldInternal() {
+
+  // quick check by numbering (d-1)-simplices star
+  FlatJaggedArray *simplexStar{};
+
+  if(this->getDimensionality() == 3) {
+    this->preconditionTriangleStarsInternal();
+    simplexStar = &this->triangleStarData_;
+  } else if(this->getDimensionality() == 2) {
+    this->preconditionEdgeStarsInternal();
+    simplexStar = &this->edgeStarData_;
+  } else if(this->getDimensionality() == 1) {
+    this->preconditionVertexStarsInternal();
+    simplexStar = &this->vertexStarData_;
+  }
+
+  if(simplexStar == nullptr) {
+    return 0;
+  }
+
+  for(const auto star : *simplexStar) {
+    if(star.size() < 1 || star.size() > 2) {
+      this->isManifold_ = false;
+      this->printWrn("Non manifold data-set detected");
+      break;
+    }
+  }
+
+  return 0;
+}
+
 #ifdef TTK_ENABLE_MPI
 
 int ExplicitTriangulation::preconditionDistributedCells() {

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -515,6 +515,8 @@ namespace ttk {
     int preconditionVertexStarsInternal() override;
     int preconditionVertexTrianglesInternal() override;
 
+    int preconditionManifoldInternal() override;
+
 #ifdef TTK_CELL_ARRAY_NEW
     // Layout with connectivity + offset array (new)
     inline int setInputCells(const SimplexId &cellNumber,

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -242,6 +242,9 @@ namespace ttk {
     template <class triangulationType>
     void checkProgressivityRequirement(const triangulationType *triangulation);
 
+    template <class triangulationType>
+    void checkManifold(const triangulationType *const triangulation);
+
     inline void
       preconditionTriangulation(AbstractTriangulation *triangulation) {
       if(triangulation) {
@@ -257,8 +260,10 @@ namespace ttk {
           dms_.setDebugLevel(debugLevel_);
           dms_.setThreadNumber(threadNumber_);
           dms_.preconditionTriangulation(triangulation);
+          triangulation->preconditionManifold();
         }
-        if(this->BackEnd == BACKEND::PERSISTENT_SIMPLEX) {
+        if(this->BackEnd == BACKEND::PERSISTENT_SIMPLEX
+           || this->BackEnd == BACKEND::DISCRETE_MORSE_SANDWICH) {
           psp_.preconditionTriangulation(triangulation);
         }
       }
@@ -375,6 +380,7 @@ int ttk::PersistenceDiagram::execute(std::vector<PersistencePair> &CTDiagram,
   printMsg(ttk::debug::Separator::L1);
 
   checkProgressivityRequirement(triangulation);
+  checkManifold(triangulation);
 
   Timer tm{};
 
@@ -714,5 +720,21 @@ void ttk::PersistenceDiagram::checkProgressivityRequirement(
     printWrn("Defaulting to the FTM backend.");
 
     BackEnd = BACKEND::FTM;
+  }
+}
+
+template <class triangulationType>
+void ttk::PersistenceDiagram::checkManifold(
+  const triangulationType *const triangulation) {
+
+  if(this->BackEnd != BACKEND::DISCRETE_MORSE_SANDWICH) {
+    return;
+  }
+
+  if(!triangulation->isManifold()) {
+    this->printWrn("Non-manifold data-set detected.");
+    this->printWrn("Defaulting to the Persistence Simplex backend.");
+
+    this->BackEnd = BACKEND::PERSISTENT_SIMPLEX;
   }
 }

--- a/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
+++ b/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
@@ -226,9 +226,9 @@ int ttk::PersistentSimplexPairs::computePersistencePairs(
 
   this->pairCells(pairs, boundaries, filtration, filtOrder);
 
-  this->printMsg(
-    "Computed " + std::to_string(pairs.size()) + " persistence pairs", 1.0,
-    tm.getElapsedTime(), 1);
+  this->printMsg("Computed " + std::to_string(pairs.size())
+                   + " persistence pair" + (pairs.size() > 1 ? "s" : ""),
+                 1.0, tm.getElapsedTime(), 1);
 
   return 0;
 }
@@ -245,34 +245,39 @@ std::vector<ttk::PersistentSimplexPairs::Simplex>
                            + this->nTetra_);
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp parallel num_threads(threadNumber_)
 #endif // TTK_ENABLE_OPENMP
-  for(SimplexId i = 0; i < this->nVerts_; ++i) {
-    res[i].fillVert(i, offset);
-  }
+  {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp for nowait
+#endif // TTK_ENABLE_OPENMP
+    for(SimplexId i = 0; i < this->nVerts_; ++i) {
+      res[i].fillVert(i, offset);
+    }
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp for nowait
 #endif // TTK_ENABLE_OPENMP
-  for(SimplexId i = 0; i < this->nEdges_; ++i) {
-    const auto o = this->nVerts_ + i;
-    res[o].fillEdge(i, o, offset, triangulation);
-  }
+    for(SimplexId i = 0; i < this->nEdges_; ++i) {
+      const auto o = this->nVerts_ + i;
+      res[o].fillEdge(i, o, offset, triangulation);
+    }
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp for nowait
 #endif // TTK_ENABLE_OPENMP
-  for(SimplexId i = 0; i < this->nTri_; ++i) {
-    const auto o = this->nVerts_ + this->nEdges_ + i;
-    res[o].fillTriangle(i, o, offset, triangulation);
-  }
+    for(SimplexId i = 0; i < this->nTri_; ++i) {
+      const auto o = this->nVerts_ + this->nEdges_ + i;
+      res[o].fillTriangle(i, o, offset, triangulation);
+    }
 
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
+#pragma omp for
 #endif // TTK_ENABLE_OPENMP
-  for(SimplexId i = 0; i < this->nTetra_; ++i) {
-    const auto o = this->nVerts_ + this->nEdges_ + this->nTri_ + i;
-    res[o].fillTetra(i, o, offset, triangulation);
+    for(SimplexId i = 0; i < this->nTetra_; ++i) {
+      const auto o = this->nVerts_ + this->nEdges_ + this->nTri_ + i;
+      res[o].fillTetra(i, o, offset, triangulation);
+    }
   }
 
   TTK_PSORT(this->threadNumber_, res.begin(), res.end());

--- a/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
+++ b/core/base/persistentSimplexPairs/PersistentSimplexPairs.h
@@ -31,9 +31,9 @@ namespace ttk {
       /** second (higher) vertex id */
       SimplexId death;
       /** pair type (min-saddle: 0, saddle-saddle: 1, saddle-max: 2) */
-      SimplexId type;
+      int type;
 
-      PersistencePair(SimplexId b, SimplexId d, SimplexId t)
+      PersistencePair(SimplexId b, SimplexId d, int t)
         : birth{b}, death{d}, type{t} {
       }
     };

--- a/core/base/triangulation/Triangulation.h
+++ b/core/base/triangulation/Triangulation.h
@@ -1913,6 +1913,46 @@ namespace ttk {
       return !abstractTriangulation_;
     }
 
+    /// Check if the triangulation is manifold or not (Rips Complexes
+    /// are not manifold)
+    /// \return True if the triangulation is manifold
+    inline bool isManifold() const override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->isEmptyCheck()) {
+        return true;
+      }
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->abstractTriangulation_->isManifold();
+    }
+
+    /// Check if the triangulation is manifold or not.
+    ///
+    /// \ref ttk::ExplicitTriangulation (and maybe \ref
+    /// ttk::CompactTriangulation too) can be generated from
+    /// non-manifold datasets (such as a Rips Complex). Some TTK
+    /// modules may be valid only for manifold triangulations, other
+    /// may have alternatives for non-manifold data-sets (\see
+    /// ttk::PersistenceDiagram::checkManifold).
+    ///
+    /// This function should ONLY be called as a pre-condition to the
+    /// following function(s):
+    ///   - isManifold()
+    ///
+    /// \pre This function should be called prior to any traversal, in a
+    /// clearly distinct pre-processing step that involves no traversal at
+    /// all. An error will be returned otherwise.
+    /// \note It is recommended to exclude this preconditioning function from
+    /// any time performance measurement.
+    /// \return Returns 0 upon success, negative values otherwise.
+    /// \sa isManifold()
+    inline int preconditionManifold() override {
+#ifndef TTK_ENABLE_KAMIKAZE
+      if(this->isEmptyCheck())
+        return false;
+#endif // TTK_ENABLE_KAMIKAZE
+      return this->abstractTriangulation_->preconditionManifold();
+    }
+
     /// Check if the triangle with global identifier \p triangleId is on the
     /// boundary of the domain.
     ///

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagram.cpp
@@ -64,9 +64,14 @@ int ttkPersistenceDiagram::dispatch(
                          inputOrder, triangulation);
 
   // something wrong in baseCode
-  if(status != 0 || CTDiagram.empty()) {
-    this->printErr("PersistenceDiagram::execute() error code : "
+  if(status != 0) {
+    this->printErr("PersistenceDiagram::execute() error code: "
                    + std::to_string(status));
+    return 0;
+  }
+
+  if(CTDiagram.empty()) {
+    this->printErr("Empty diagram!");
     return 0;
   }
 


### PR DESCRIPTION
This PR extends the (`Explicit`)`Triangulation` by adding a new precondition to detect non-manifold datasets. It checks the number of cells in the stars of (d-1)-simplices.

This new precondition is then used in `PersistenceDiagram` to select the `PersistentSimplexPairs` (Zomorodian) backend by default, instead of `DiscreteMorseSandwich`, on non-manifold datasets. As a matter of fact, the saddle-max pairs generated by `DiscreteMorseSandwich` on non-manifold datasets are invalid (`PersistentGenerators` is not affected) and the simpler `PersistentSimplexPairs` is correct and may be faster.

The `PersistentSimplexPairs` backend has been cleaned a little: the output pairs format now matches `DiscreteMorseSandwich` and the progression is displayed in the terminal.

Enjoy,
Pierre