### PR TITLE
MPIUtils: Pass global identifiers array via a Callable

### DIFF
--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -24,10 +24,10 @@ namespace ttk {
   public:
     ArrayPreconditioning();
 
-    template <typename DT, typename IT, typename GVR>
+    template <typename DT, typename GVGID, typename GVR>
     int processScalarArray(ttk::SimplexId *orderArray,
                            const DT *scalarArray,
-                           const IT *globalIds,
+                           const GVGID &getVertexGlobalId,
                            const GVR &getVertexRank,
                            const size_t nVerts,
                            const int burstSize) const { // start global timer
@@ -48,15 +48,14 @@ namespace ttk {
 #ifdef TTK_ENABLE_MPI
       if(ttk::isRunningWithMPI()) {
         std::vector<int> neighbors{};
-        ttk::produceOrdering<DT, IT>(orderArray, scalarArray, globalIds,
-                                     getVertexRank, nVerts, burstSize,
-                                     neighbors);
+        ttk::produceOrdering<DT>(orderArray, scalarArray, getVertexGlobalId,
+                                 getVertexRank, nVerts, burstSize, neighbors);
       }
 #else
       this->printMsg("MPI not enabled!");
       TTK_FORCE_USE(orderArray);
       TTK_FORCE_USE(scalarArray);
-      TTK_FORCE_USE(globalIds);
+      TTK_FORCE_USE(getVertexGlobalId);
       TTK_FORCE_USE(getVertexRank);
       TTK_FORCE_USE(burstSize);
       return 0;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -104,12 +104,11 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
     for(int i = 0; i < edgeNumber; ++i) {
       charBoundary[i] = boundaryEdges_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
-                                               ttk::SimplexId>(
+    ttk::exchangeGhostDataWithoutTriangulation(
       charBoundary.data(),
       [this](const SimplexId a) { return this->edgeRankArray_[a]; },
-      this->edgeLidToGid_.data(), this->edgeGidToLid_, edgeNumber,
-      ttk::MPIcomm_, this->getNeighborRanks());
+      [this](const SimplexId a) { return this->edgeLidToGid_[a]; },
+      this->edgeGidToLid_, edgeNumber, ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < edgeNumber; ++i) {
       boundaryEdges_[i] = (charBoundary[i] == '1');
     }
@@ -236,12 +235,12 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
     for(int i = 0; i < triangleNumber; ++i) {
       charBoundary[i] = boundaryTriangles_[i] ? '1' : '0';
     }
-    ttk::exchangeGhostDataWithoutTriangulation<unsigned char, ttk::SimplexId,
-                                               ttk::SimplexId>(
+    ttk::exchangeGhostDataWithoutTriangulation(
       charBoundary.data(),
       [this](const SimplexId a) { return this->triangleRankArray_[a]; },
-      this->triangleLidToGid_.data(), this->triangleGidToLid_, triangleNumber,
-      ttk::MPIcomm_, this->getNeighborRanks());
+      [this](const SimplexId a) { return this->triangleLidToGid_[a]; },
+      this->triangleGidToLid_, triangleNumber, ttk::MPIcomm_,
+      this->getNeighborRanks());
     for(int i = 0; i < triangleNumber; ++i) {
       boundaryTriangles_[i] = (charBoundary[i] == '1');
     }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -188,18 +188,18 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
         this->MPIPipelinePreconditioning(inputData, neighbors, nullptr);
       }
       if(ttk::isRunningWithMPI()) {
-        auto vtkGlobalPointIds = inputData->GetPointData()->GetGlobalIds();
         const auto triangulation{this->GetTriangulation(inputData)};
-        ttkTypeMacroA(
-          scalarArray->GetDataType(),
-          (ttk::produceOrdering<T0>(
-            ttkUtils::GetPointer<ttk::SimplexId>(newOrderArray),
-            ttkUtils::GetPointer<T0>(scalarArray),
-            ttkUtils::GetPointer<ttk::LongSimplexId>(vtkGlobalPointIds),
-            [triangulation](const ttk::SimplexId a) {
-              return triangulation->getVertexRank(a);
-            },
-            nVertices, 500, neighbors)));
+        ttkTypeMacroA(scalarArray->GetDataType(),
+                      (ttk::produceOrdering<T0>(
+                        ttkUtils::GetPointer<ttk::SimplexId>(newOrderArray),
+                        ttkUtils::GetPointer<T0>(scalarArray),
+                        [triangulation](const ttk::SimplexId a) {
+                          return triangulation->getVertexGlobalId(a);
+                        },
+                        [triangulation](const ttk::SimplexId a) {
+                          return triangulation->getVertexRank(a);
+                        },
+                        nVertices, 500, neighbors)));
       } else
 #endif // TTK_ENABLE_MPI
 


### PR DESCRIPTION
This PR rewrites the MPIUtils functions to pass a Callable (a lambda) instead of a pointer for the global identifiers parameter. This modification ensures that the triangulation methods can be called to provide the global identifiers instead of relying on a VTK data array.

Enjoy,
Pierre

