### PR TITLE
ExplicitTriangulation: Move preconditionEdges,TrianglesRankArray

### DIFF
--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -97,7 +97,6 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
 
 #ifdef TTK_ENABLE_MPI
 
-  this->preconditionEdgeRankArray();
   if(ttk::isRunningWithMPI()) {
     ttk::SimplexId edgeNumber = edgeList_.size();
     std::vector<unsigned char> charBoundary(edgeNumber, false);
@@ -228,7 +227,6 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
 
 #ifdef TTK_ENABLE_MPI
 
-  this->preconditionTriangleRankArray();
   if(ttk::isRunningWithMPI()) {
     ttk::SimplexId triangleNumber = triangleList_.size();
     std::vector<unsigned char> charBoundary(triangleNumber, false);
@@ -1194,6 +1192,8 @@ int ExplicitTriangulation::preconditionDistributedEdges() {
     },
     nEdgesPerCell);
 
+  this->preconditionEdgeRankArray();
+
   if(MPIrank_ == 0) {
     this->printMsg("Domain contains " + std::to_string(nEdges) + " edges", 1.0,
                    tm.getElapsedTime(), 1);
@@ -1325,6 +1325,8 @@ int ExplicitTriangulation::preconditionDistributedTriangles() {
              > 0;
     },
     nTrianglesPerCell);
+
+  this->preconditionTriangleRankArray();
 
   if(MPIrank_ == 0) {
     this->printMsg(


### PR DESCRIPTION
This PR moves the call to precondition edges & triangles rank arrays from the preconditionBoundary* methods to the preconditionDistributed* ones.

This ensures that edges & triangles rank arrays are always computed in an MPI context.

Enjoy,
Pierre
