### PR TITLE
GitHub Actions: More robust fix for windows job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -422,7 +422,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge boost glew eigen spectralib zfp \
-          scikit-learn openmp graphviz ninja websocketpp sccache python=3.9.12
+          scikit-learn openmp graphviz ninja websocketpp sccache python=3.9.13 zlib
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
         # add TTK & ParaView install folders to PATH
@@ -537,7 +537,6 @@ jobs:
         ttkExample-vtk-c++.exe -i ..\..\data\inputData.vtu
 
     - name: Test Python example
-      continue-on-error: true
       shell: cmd
       run: |
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib
@@ -566,7 +565,7 @@ jobs:
       name: Checkout ttk-data
 
     - name: Resample large datasets
-      shell: pvpython {0}
+      shell: python
       working-directory: ./ttk-data
       run: |
         from paraview import simple
@@ -576,16 +575,15 @@ jobs:
             rsi.SamplingDimensions = [128, 128, 128]
             simple.SaveData(ds, rsi)
       env:
-        PYTHONPATH: ${{ env.PV_DIR }}\bin\Lib\site-packages;${{ env.CONDA_ROOT }}\Lib
+        PYTHONPATH: ${{ env.PV_DIR }}\bin\Lib\site-packages
 
     - name: Run ttk-data Python scripts
-      continue-on-error: true
       shell: cmd
       run: |
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib
         set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
         cd ttk-data
-        pvpython -u python\run.py
+        python -u python\run.py
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]
       continue-on-error: true


### PR DESCRIPTION
This PR offers a more robust fix to the Windows job in the `test_build` CI workflow (with a first workaround in #901) by pinning a better Python version in conda (which does not seem to be the one used to build TTK-ParaView...).

This also reverts most of #901, only the pinning of the Python version persists (for now).

Enjoy,
Pierre

