### PR TITLE
[Common] Add memory usage tool

### DIFF
--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -19,6 +19,7 @@
 #elif defined(__unix__) || defined(__APPLE__)
 
 #include <dirent.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -59,6 +60,22 @@ namespace ttk {
     }
 #endif
     return 0;
+  }
+
+  float OsCall::getTotalMemoryUsage() {
+    int ru_maxrss, max_use{0};
+#ifdef __linux__
+    struct rusage use;
+    getrusage(RUSAGE_SELF, &use);
+    ru_maxrss = static_cast<int>(use.ru_maxrss);
+#ifdef TTK_ENABLE_MPI
+    MPI_Reduce(&ru_maxrss, &max_use, 1, MPI_INTEGER, MPI_MAX, 0, ttk::MPIcomm_);
+#else
+    max_use = ru_maxrss;
+#endif // TTK_ENABLE_MPI
+#endif // __linux__
+    // In Kilo Bytes
+    return (double)max_use;
   }
 
   int OsCall::getNumberOfCores() {

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -63,8 +63,9 @@ namespace ttk {
   }
 
   float OsCall::getTotalMemoryUsage() {
-    int ru_maxrss, max_use{0};
+    int max_use{0};
 #ifdef __linux__
+    int ru_maxrss;
     struct rusage use;
     getrusage(RUSAGE_SELF, &use);
     ru_maxrss = static_cast<int>(use.ru_maxrss);

--- a/core/base/common/Os.cpp
+++ b/core/base/common/Os.cpp
@@ -69,7 +69,12 @@ namespace ttk {
     getrusage(RUSAGE_SELF, &use);
     ru_maxrss = static_cast<int>(use.ru_maxrss);
 #ifdef TTK_ENABLE_MPI
-    MPI_Reduce(&ru_maxrss, &max_use, 1, MPI_INTEGER, MPI_MAX, 0, ttk::MPIcomm_);
+    if(ttk::hasInitializedMPI()) {
+      MPI_Reduce(
+        &ru_maxrss, &max_use, 1, MPI_INTEGER, MPI_MAX, 0, ttk::MPIcomm_);
+    } else {
+      max_use = ru_maxrss;
+    }
 #else
     max_use = ru_maxrss;
 #endif // TTK_ENABLE_MPI

--- a/core/base/common/Os.h
+++ b/core/base/common/Os.h
@@ -64,6 +64,8 @@ namespace ttk {
 
     static float getMemoryInstantUsage();
 
+    static float getTotalMemoryUsage();
+
     static int getNumberOfCores();
 
     static std::vector<std::string>
@@ -109,6 +111,10 @@ namespace ttk {
 
     inline float getElapsedUsage() {
       return OsCall::getMemoryInstantUsage() - initialMemory_;
+    }
+
+    inline float getTotalUsage() {
+      return OsCall::getTotalMemoryUsage();
     }
 
   protected:


### PR DESCRIPTION
Hi all,

This PR adds a memory measuring function in the common functionalities.

It uses `getrusage` to find the memory used during the execution of the process. The output quantity is in Kilo Bytes.

If TTK is compiled and executed with MPI, the maximum use of memory is computed and can be found on process 0.

Here is a snippet of example code:

    ttk::Memory m;
    float usedMemory = m.getTotalUsage();
