### PR TITLE
The switch between the legacy and the lts versions of the topological simplification are now done in the ttk layer. Also, fixing the lts module so that each function returns 0 if successful, 1 on errors.

### DIFF
--- a/core/base/legacyTopologicalSimplification/CMakeLists.txt
+++ b/core/base/legacyTopologicalSimplification/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(legacyTopologicalSimplification
+  SOURCES
+    LegacyTopologicalSimplification.cpp
+  HEADERS
+    LegacyTopologicalSimplification.h
+  DEPENDS
+    triangulation
+    )

--- a/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.cpp
+++ b/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.cpp
@@ -1,0 +1,5 @@
+#include <LegacyTopologicalSimplification.h>
+
+ttk::LegacyTopologicalSimplification::LegacyTopologicalSimplification() {
+  this->setDebugMsgPrefix("LegacyTopologicalSimplification");
+}

--- a/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.h
+++ b/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.h
@@ -178,10 +178,6 @@ namespace ttk {
       return 0;
     }
 
-    inline void setNumberOfVertices(size_t n) {
-      vertexNumber_ = n;
-    }
-
     inline void setConsiderIdentifierAsBlackList(bool onOff) {
       considerIdentifierAsBlackList_ = onOff;
     }

--- a/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.h
+++ b/core/base/legacyTopologicalSimplification/LegacyTopologicalSimplification.h
@@ -1,0 +1,503 @@
+/// \ingroup base
+/// \class ttk::LegacyTopologicalSimplification
+/// \author Julien Tierny <julien.tierny@lip6.fr>
+/// \author Guillaume Favelier <guillaume.favelier@lip6.fr>
+/// \date February 2016
+///
+/// \brief TTK processing package for the topological simplification of scalar
+/// data.
+///
+/// Given an input scalar field and a list of critical points to remove, this
+/// class minimally edits the scalar field such that the listed critical points
+/// disappear. This procedure is useful to speedup subsequent topological data
+/// analysis when outlier critical points can be easily identified. It is
+/// also useful for data simplification.
+///
+/// \b Related \b publications \n
+/// "Generalized Topological Simplification of Scalar Fields on Surfaces" \n
+/// Julien Tierny, Valerio Pascucci \n
+/// Proc. of IEEE VIS 2012.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2012.
+///
+/// "Localized Topological Simplification of Scalar Data"
+/// Jonas Lukasczyk, Christoph Garth, Ross Maciejewski, Julien Tierny
+/// Proc. of IEEE VIS 2020.
+/// IEEE Transactions on Visualization and Computer Graphics
+///
+/// \sa ttkLegacyTopologicalSimplification.cpp %for a usage example.
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/1manifoldLearning/">1-Manifold
+///   Learning example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/1manifoldLearningCircles/">1-Manifold
+///   Learning Circles example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/2manifoldLearning/">
+///   2-Manifold Learning example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/BuiltInExample1/">BuiltInExample1
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/contourTreeAlignment/">Contour
+///   Tree Alignment example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/ctBones/">CT Bones
+///   example</a> \n
+///   - <a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/harmonicSkeleton/">
+///   Harmonic Skeleton example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/imageProcessing/">Image
+///   Processing example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/interactionSites/">
+///   Interaction sites</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/karhunenLoveDigits64Dimensions/">Karhunen-Love
+///   Digits 64-Dimensions example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morsePersistence/">Morse
+///   Persistence example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleQuadrangulation/">Morse-Smale
+///   Quadrangulation example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 0 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 1 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 2 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 3 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/persistenceClustering0/">Persistence
+///   clustering 4 example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tectonicPuzzle/">Tectonic
+///   Puzzle example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/tribute/">Tribute
+///   example</a> \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/uncertainStartingVortex/">
+///   Uncertain Starting Vortex example</a> \n
+
+#pragma once
+
+// base code includes
+#include <Debug.h>
+#include <Triangulation.h>
+
+#include <cmath>
+#include <set>
+#include <tuple>
+#include <type_traits>
+
+namespace ttk {
+
+  class SweepCmp {
+    bool isIncreasingOrder_{};
+
+  public:
+    SweepCmp() = default;
+
+    SweepCmp(bool isIncreasingOrder) : isIncreasingOrder_{isIncreasingOrder} {
+    }
+
+    inline void setIsIncreasingOrder(bool isIncreasingOrder) {
+      isIncreasingOrder_ = isIncreasingOrder;
+    }
+
+    template <typename dataType>
+    bool
+      operator()(const std::tuple<dataType, SimplexId, SimplexId> &v0,
+                 const std::tuple<dataType, SimplexId, SimplexId> &v1) const {
+      if(isIncreasingOrder_) {
+        return std::get<1>(v0) < std::get<1>(v1);
+      } else {
+        return std::get<1>(v0) > std::get<1>(v1);
+      }
+    }
+  };
+
+  class LegacyTopologicalSimplification : virtual public Debug {
+  public:
+    LegacyTopologicalSimplification();
+
+    template <typename triangulationType>
+    int getCriticalType(SimplexId vertexId,
+                        const SimplexId *const offsets,
+                        const triangulationType &triangulation) const;
+
+    template <typename triangulationType>
+    int getCriticalPoints(const SimplexId *const offsets,
+                          std::vector<SimplexId> &minList,
+                          std::vector<SimplexId> &maxList,
+                          const triangulationType &triangulation) const;
+
+    template <typename triangulationType>
+    int getCriticalPoints(const SimplexId *const offsets,
+                          std::vector<SimplexId> &minList,
+                          std::vector<SimplexId> &maxList,
+                          std::vector<bool> &blackList,
+                          const triangulationType &triangulation) const;
+
+    template <typename dataType>
+    int addPerturbation(dataType *const scalars,
+                        SimplexId *const offsets) const;
+
+    /**
+     * @pre For this function to behave correctly in the absence of
+     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
+     * called to fill the @p inputOffsets buffer prior to any
+     * computation (the VTK wrapper already includes a mechanism to
+     * automatically generate such a preconditioned buffer).
+     * @see examples/c++/main.cpp for an example use.
+     */
+    template <typename dataType, typename triangulationType>
+    int execute(const dataType *const inputScalars,
+                dataType *const outputScalars,
+                const SimplexId *const identifiers,
+                const SimplexId *const inputOffsets,
+                SimplexId *const offsets,
+                const SimplexId constraintNumber,
+                const triangulationType &triangulation) const;
+
+    inline int preconditionTriangulation(AbstractTriangulation *triangulation) {
+      if(triangulation) {
+        vertexNumber_ = triangulation->getNumberOfVertices();
+        triangulation->preconditionVertexNeighbors();
+      }
+      return 0;
+    }
+
+    inline void setNumberOfVertices(size_t n) {
+      vertexNumber_ = n;
+    }
+
+    inline void setConsiderIdentifierAsBlackList(bool onOff) {
+      considerIdentifierAsBlackList_ = onOff;
+    }
+
+    inline void setAddPerturbation(bool onOff) {
+      addPerturbation_ = onOff;
+    }
+
+  protected:
+    SimplexId vertexNumber_{};
+    bool considerIdentifierAsBlackList_{false};
+    bool addPerturbation_{false};
+  };
+} // namespace ttk
+
+// if the package is a pure template typename, uncomment the following line
+// #include                  <LegacyTopologicalSimplification.cpp>
+
+template <typename triangulationType>
+int ttk::LegacyTopologicalSimplification::getCriticalType(
+  SimplexId vertex,
+  const SimplexId *const offsets,
+  const triangulationType &triangulation) const {
+
+  bool isMinima{true};
+  bool isMaxima{true};
+  SimplexId neighborNumber = triangulation.getVertexNeighborNumber(vertex);
+  for(SimplexId i = 0; i < neighborNumber; ++i) {
+    SimplexId neighbor{-1};
+    triangulation.getVertexNeighbor(vertex, i, neighbor);
+
+    if(offsets[neighbor] < offsets[vertex])
+      isMinima = false;
+    if(offsets[neighbor] > offsets[vertex])
+      isMaxima = false;
+    if(!isMinima and !isMaxima) {
+      return 0;
+    }
+  }
+
+  if(isMinima)
+    return -1;
+  if(isMaxima)
+    return 1;
+
+  return 0;
+}
+
+template <typename triangulationType>
+int ttk::LegacyTopologicalSimplification::getCriticalPoints(
+  const SimplexId *const offsets,
+  std::vector<SimplexId> &minima,
+  std::vector<SimplexId> &maxima,
+  const triangulationType &triangulation) const {
+
+  std::vector<int> type(vertexNumber_, 0);
+
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for
+#endif
+  for(SimplexId k = 0; k < vertexNumber_; ++k)
+    type[k] = getCriticalType(k, offsets, triangulation);
+
+  for(SimplexId k = 0; k < vertexNumber_; ++k) {
+    if(type[k] < 0)
+      minima.push_back(k);
+    else if(type[k] > 0)
+      maxima.push_back(k);
+  }
+  return 0;
+}
+
+template <typename triangulationType>
+int ttk::LegacyTopologicalSimplification::getCriticalPoints(
+  const SimplexId *const offsets,
+  std::vector<SimplexId> &minima,
+  std::vector<SimplexId> &maxima,
+  std::vector<bool> &extrema,
+  const triangulationType &triangulation) const {
+  std::vector<int> type(vertexNumber_);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(SimplexId k = 0; k < vertexNumber_; ++k) {
+    if(considerIdentifierAsBlackList_ xor extrema[k]) {
+      type[k] = getCriticalType(k, offsets, triangulation);
+    }
+  }
+
+  for(SimplexId k = 0; k < vertexNumber_; ++k) {
+    if(type[k] < 0)
+      minima.push_back(k);
+    else if(type[k] > 0)
+      maxima.push_back(k);
+  }
+  return 0;
+}
+
+template <typename dataType>
+int ttk::LegacyTopologicalSimplification::addPerturbation(
+  dataType *const scalars, SimplexId *const offsets) const {
+  dataType epsilon{};
+
+  if(std::is_same<dataType, double>::value)
+    epsilon = Geometry::powIntTen<dataType>(1 - DBL_DIG);
+  else if(std::is_same<dataType, float>::value)
+    epsilon = Geometry::powIntTen<dataType>(1 - FLT_DIG);
+  else
+    return -1;
+
+  std::vector<std::tuple<dataType, SimplexId, SimplexId>> perturbation(
+    vertexNumber_);
+  for(SimplexId i = 0; i < vertexNumber_; ++i) {
+    std::get<0>(perturbation[i]) = scalars[i];
+    std::get<1>(perturbation[i]) = offsets[i];
+    std::get<2>(perturbation[i]) = i;
+  }
+
+  SweepCmp cmp(true);
+  sort(perturbation.begin(), perturbation.end(), cmp);
+
+  for(SimplexId i = 0; i < vertexNumber_; ++i) {
+    if(i) {
+      if(std::get<0>(perturbation[i]) <= std::get<0>(perturbation[i - 1]))
+        std::get<0>(perturbation[i])
+          = std::get<0>(perturbation[i - 1]) + epsilon;
+    }
+    scalars[std::get<2>(perturbation[i])] = std::get<0>(perturbation[i]);
+  }
+
+  return 0;
+}
+
+template <typename dataType, typename triangulationType>
+int ttk::LegacyTopologicalSimplification::execute(
+  const dataType *const inputScalars,
+  dataType *const outputScalars,
+  const SimplexId *const identifiers,
+  const SimplexId *const inputOffsets,
+  SimplexId *const offsets,
+  const SimplexId constraintNumber,
+  const triangulationType &triangulation) const {
+
+  Timer t;
+
+  // pre-processing
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(threadNumber_)
+#endif
+  for(SimplexId k = 0; k < vertexNumber_; ++k) {
+    outputScalars[k] = inputScalars[k];
+    if(std::isnan((double)outputScalars[k]))
+      outputScalars[k] = 0;
+
+    offsets[k] = inputOffsets[k];
+  }
+
+  // get the user extremum list
+  std::vector<bool> extrema(vertexNumber_, false);
+  for(SimplexId k = 0; k < constraintNumber; ++k) {
+    const SimplexId identifierId = identifiers[k];
+
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(identifierId >= 0 and identifierId < vertexNumber_)
+#endif
+      extrema[identifierId] = true;
+  }
+
+  std::vector<SimplexId> authorizedMinima;
+  std::vector<SimplexId> authorizedMaxima;
+  std::vector<bool> authorizedExtrema(vertexNumber_, false);
+
+  getCriticalPoints(
+    offsets, authorizedMinima, authorizedMaxima, extrema, triangulation);
+
+  this->printMsg("Maintaining " + std::to_string(constraintNumber)
+                   + " constraints (" + std::to_string(authorizedMinima.size())
+                   + " minima and " + std::to_string(authorizedMaxima.size())
+                   + " maxima)",
+                 debug::Priority::DETAIL);
+
+  // declare the tuple-comparison functor
+  SweepCmp cmp;
+
+  // processing
+  for(SimplexId i = 0; i < vertexNumber_; ++i) {
+
+    this->printMsg("Starting simplifying iteration #" + std::to_string(i),
+                   debug::Priority::DETAIL);
+
+    for(int j = 0; j < 2; ++j) {
+
+      bool isIncreasingOrder = !j;
+
+      if(isIncreasingOrder && authorizedMinima.empty()) {
+        continue;
+      }
+      if(!isIncreasingOrder && authorizedMaxima.empty()) {
+        continue;
+      }
+
+      cmp.setIsIncreasingOrder(isIncreasingOrder);
+      std::set<std::tuple<dataType, SimplexId, SimplexId>, decltype(cmp)>
+        sweepFront(cmp);
+      std::vector<bool> visitedVertices(vertexNumber_, false);
+      std::vector<SimplexId> adjustmentSequence(vertexNumber_);
+
+      // add the seeds
+      if(isIncreasingOrder) {
+        for(SimplexId k : authorizedMinima) {
+          authorizedExtrema[k] = true;
+          sweepFront.emplace(outputScalars[k], offsets[k], k);
+          visitedVertices[k] = true;
+        }
+      } else {
+        for(SimplexId k : authorizedMaxima) {
+          authorizedExtrema[k] = true;
+          sweepFront.emplace(outputScalars[k], offsets[k], k);
+          visitedVertices[k] = true;
+        }
+      }
+
+      // growth by neighborhood of the seeds
+      SimplexId adjustmentPos = 0;
+      do {
+        auto front = sweepFront.begin();
+        if(front == sweepFront.end())
+          return -1;
+
+        SimplexId vertexId = std::get<2>(*front);
+        sweepFront.erase(front);
+
+        SimplexId neighborNumber
+          = triangulation.getVertexNeighborNumber(vertexId);
+        for(SimplexId k = 0; k < neighborNumber; ++k) {
+          SimplexId neighbor{-1};
+          triangulation.getVertexNeighbor(vertexId, k, neighbor);
+          if(!visitedVertices[neighbor]) {
+            sweepFront.emplace(
+              outputScalars[neighbor], offsets[neighbor], neighbor);
+            visitedVertices[neighbor] = true;
+          }
+        }
+        adjustmentSequence[adjustmentPos] = vertexId;
+        ++adjustmentPos;
+      } while(!sweepFront.empty());
+
+      // save offsets and rearrange outputScalars
+      SimplexId offset = (isIncreasingOrder ? 0 : vertexNumber_);
+
+      for(SimplexId k = 0; k < vertexNumber_; ++k) {
+
+        if(isIncreasingOrder) {
+          if(k
+             && outputScalars[adjustmentSequence[k]]
+                  <= outputScalars[adjustmentSequence[k - 1]])
+            outputScalars[adjustmentSequence[k]]
+              = outputScalars[adjustmentSequence[k - 1]];
+          ++offset;
+        } else {
+          if(k
+             && outputScalars[adjustmentSequence[k]]
+                  >= outputScalars[adjustmentSequence[k - 1]])
+            outputScalars[adjustmentSequence[k]]
+              = outputScalars[adjustmentSequence[k - 1]];
+          --offset;
+        }
+        offsets[adjustmentSequence[k]] = offset;
+      }
+    }
+
+    // test convergence
+    bool needForMoreIterations{false};
+    std::vector<SimplexId> minima;
+    std::vector<SimplexId> maxima;
+    getCriticalPoints(offsets, minima, maxima, triangulation);
+
+    if(maxima.size() > authorizedMaxima.size())
+      needForMoreIterations = true;
+    if(minima.size() > authorizedMinima.size())
+      needForMoreIterations = true;
+
+    this->printMsg(
+      std::vector<std::vector<std::string>>{
+        {"#Minima", std::to_string(minima.size())},
+        {"#Maxima", std::to_string(maxima.size())},
+      },
+      debug::Priority::DETAIL);
+
+    if(!needForMoreIterations) {
+      for(SimplexId k : minima) {
+        if(!authorizedExtrema[k]) {
+          needForMoreIterations = true;
+          break;
+        }
+      }
+    }
+    if(!needForMoreIterations) {
+      for(SimplexId k : maxima) {
+        if(!authorizedExtrema[k]) {
+          needForMoreIterations = true;
+          break;
+        }
+      }
+    }
+
+    // optional adding of perturbation
+    if(addPerturbation_)
+      addPerturbation<dataType>(outputScalars, offsets);
+
+    if(!needForMoreIterations)
+      break;
+  }
+
+  this->printMsg(
+    "Simplified scalar field", 1.0, t.getElapsedTime(), this->threadNumber_);
+
+  return 0;
+}

--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -85,7 +85,7 @@ namespace ttk {
 
         this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This method initializes all temporary memory for LTS procedures
@@ -115,7 +115,7 @@ namespace ttk {
 
         this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This method iterates over an order array and detects all maxima, for
@@ -215,7 +215,7 @@ namespace ttk {
                          + std::to_string(nVertices) + ")",
                        1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This is a simple superlevel set propagation procedure that just
@@ -302,7 +302,7 @@ namespace ttk {
             // if this thread did not register the last remaining larger
             // vertices then terminate propagation
             if(numberOfRegisteredLargerVertices != -numberOfLargerNeighbors - 1)
-              return 1;
+              return 0;
 
             // get most dominant propagation
             std::vector<Propagation<IT> *> neighborPropagations(
@@ -338,7 +338,7 @@ namespace ttk {
         this->printErr(
           "Simple propagations should never reach global minimum/maximum.");
 
-        return 0;
+        return 1;
       }
 
       /// Basically the same as the simple propagation procedure, except that a
@@ -386,7 +386,7 @@ namespace ttk {
           const DT &sd = s0 < s1 ? s1 - s0 : s0 - s1;
           if(sd > persistenceThreshold) {
             currentPropagation->aborted = true;
-            return 1;
+            return 0;
           }
 
           const IT &orderV = order[v];
@@ -436,7 +436,7 @@ namespace ttk {
             // if this thread did not register the last remaining larger
             // vertices then terminate propagation
             if(numberOfRegisteredLargerVertices != -numberOfLargerNeighbors - 1)
-              return 1;
+              return 0;
 
             // get most dominant propagation
             std::vector<Propagation<IT> *> neighborPropagations(
@@ -470,7 +470,7 @@ namespace ttk {
           currentPropagation->segmentSize++;
         }
 
-        return 0;
+        return 1;
       }
 
       /// This method computes (optionally in parallel) a list of simple
@@ -490,7 +490,7 @@ namespace ttk {
         this->printMsg(
           msg, 0, 0, this->threadNumber_, debug::LineMode::REPLACE);
 
-        int status = 1;
+        int status = 0;
 // compute propagations
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic, 1) num_threads(this->threadNumber_)
@@ -501,16 +501,16 @@ namespace ttk {
 
             triangulation, inputOrder);
 
-          if(!localStatus)
-            status = 0;
+          if(localStatus)
+            status = 1;
         }
 
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This method computes (optionally in parallel) a list of
@@ -533,7 +533,7 @@ namespace ttk {
         this->printMsg(
           msg, 0, 0, this->threadNumber_, debug::LineMode::REPLACE);
 
-        int status = 1;
+        int status = 0;
 // compute propagations
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic, 1) num_threads(this->threadNumber_)
@@ -545,16 +545,16 @@ namespace ttk {
 
               triangulation, order, scalars, persistenceThreshold);
 
-          if(!localStatus)
-            status = 0;
+          if(localStatus)
+            status = 1;
         }
 
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         this->printMsg(msg, 1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This method identifies from a set of propagations so-called parent
@@ -597,7 +597,7 @@ namespace ttk {
                          + toFixed(nSegmentVertices, nVertices) + ")",
                        1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       /// This method computes the domain segment of a given propagation. To
@@ -652,13 +652,13 @@ namespace ttk {
           this->printErr("Segment size incorrect: "
                          + std::to_string(segmentIndex) + " "
                          + std::to_string(propagation->segmentSize));
-          return 0;
+          return 1;
         }
 
         for(auto idx : propagation->segment)
           segmentation[idx] = extremumIndex;
 
-        return 1;
+        return 0;
       }
 
       /// This method computes the segments of a given list of propagations.
@@ -678,7 +678,7 @@ namespace ttk {
         this->printMsg(
           msg, 0, 0, this->threadNumber_, debug::LineMode::REPLACE);
 
-        int status = 1;
+        int status = 0;
 
 // compute segments in parallel
 #ifdef TTK_ENABLE_OPENMP
@@ -689,11 +689,11 @@ namespace ttk {
             = this->computeSegment<IT, TT>(segmentation, propagations[p],
 
                                            order, triangulation);
-          if(!localStatus)
-            status = 0;
+          if(localStatus)
+            status = 1;
         }
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // print status
         if(this->debugLevel_ < 4 || nPropagations == 0) {
@@ -722,7 +722,7 @@ namespace ttk {
                          1, timer.getElapsedTime(), this->threadNumber_);
         }
 
-        return 1;
+        return 0;
       }
 
       template <typename IT, class TT>
@@ -793,7 +793,7 @@ namespace ttk {
             localOrder[localVertexSequence[i]] = order++;
         }
 
-        return 1;
+        return 0;
       }
 
       template <typename IT, class TT>
@@ -806,7 +806,7 @@ namespace ttk {
         // quick escape for small segments
         if(propagation->segmentSize == 1) {
           localOrder[propagation->segment[0]] = -2;
-          return 1;
+          return 0;
         }
 
         // init local order by input order
@@ -825,7 +825,7 @@ namespace ttk {
         // make enough room for segment + saddle
         std::vector<IT> localVertexSequence(propagation->segmentSize + 1);
 
-        int status = 1;
+        int status = 0;
         bool containsResidualExtrema = true;
         bool performSuperlevelSetPropagation = true;
         while(containsResidualExtrema) {
@@ -840,8 +840,8 @@ namespace ttk {
 
             performSuperlevelSetPropagation, triangulation, segmentation,
             extremumIndex, boundary, propagation->segment, saddleIndex);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
 
           performSuperlevelSetPropagation = !performSuperlevelSetPropagation;
 
@@ -897,7 +897,7 @@ namespace ttk {
           }
         }
 
-        return 1;
+        return 0;
       }
 
       template <typename IT, class TT>
@@ -915,7 +915,7 @@ namespace ttk {
                          + std::to_string(nPropagations) + ")",
                        0, 0, this->threadNumber_, debug::LineMode::REPLACE);
 
-        int status = 1;
+        int status = 0;
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
@@ -924,11 +924,11 @@ namespace ttk {
             localOrder,
 
             propagations[p], triangulation, segmentation, inputOrder);
-          if(!localStatus)
-            status = 0;
+          if(localStatus)
+            status = 1;
         }
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
 // enforce that saddles have the highest local order
 #ifdef TTK_ENABLE_OPENMP
@@ -966,7 +966,7 @@ namespace ttk {
                          1, timer.getElapsedTime(), this->threadNumber_);
         }
 
-        return 1;
+        return 0;
       }
 
       template <typename IT>
@@ -995,7 +995,7 @@ namespace ttk {
         this->printMsg("Flattening Order Array", 1, timer.getElapsedTime(),
                        this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       template <typename DT, typename IT>
@@ -1035,7 +1035,7 @@ namespace ttk {
         this->printMsg("Flattening Scalar Array", 1, timer.getElapsedTime(),
                        this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       template <typename IT>
@@ -1076,7 +1076,7 @@ namespace ttk {
         this->printMsg("Computing Global Order", 1, timer.getElapsedTime(),
                        this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       template <typename DT, typename IT>
@@ -1108,7 +1108,7 @@ namespace ttk {
         this->printMsg("Applying numerical perturbation", 1,
                        timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       template <typename IT, class TT>
@@ -1133,8 +1133,8 @@ namespace ttk {
                                             propagationMask,
 
                                             nVertices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // init propagations
         status = this->initializePropagations<IT, TT>(
@@ -1146,16 +1146,16 @@ namespace ttk {
 
           authorizedExtremaIndices, nAuthorizedExtremaIndices, order,
           triangulation);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute propagations
         status = this->computeSimplePropagations<IT, TT>(
           propagations, propagationMask, segmentation, queueMask,
 
           triangulation, order);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // finalize master propagations
         std::vector<Propagation<IT> *> parentPropagations;
@@ -1163,35 +1163,35 @@ namespace ttk {
           = this->finalizePropagations<IT>(parentPropagations, propagations,
 
                                            nVertices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute segments
         status = this->computeSegments<IT, TT>(segmentation, parentPropagations,
 
                                                order, triangulation);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute local order of segments
         status = this->computeLocalOrderOfSegments<IT, TT>(
           localOrder,
 
           triangulation, segmentation, order, parentPropagations);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // flatten order
         status = this->flattenOrder<IT>(order, parentPropagations);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute global offsets
         status = this->computeGlobalOrder<IT>(order, localOrder, sortedIndices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
-        return 1;
+        return 0;
       }
 
       template <typename IT, typename DT, class TT>
@@ -1217,8 +1217,8 @@ namespace ttk {
                                             propagationMask,
 
                                             nVertices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // init propagations
         status = this->initializePropagations<IT, TT>(
@@ -1228,16 +1228,16 @@ namespace ttk {
                       // procedures)
 
           nullptr, 0, order, triangulation);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute propagations
         status = this->computePersistenceSensitivePropagations<IT, DT, TT>(
           propagations, propagationMask, segmentation, queueMask,
 
           triangulation, order, scalars, persistenceThreshold);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // finalize master propagations
         std::vector<Propagation<IT> *> parentPropagations;
@@ -1245,39 +1245,39 @@ namespace ttk {
           = this->finalizePropagations<IT>(parentPropagations, propagations,
 
                                            nVertices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute segments
         status = this->computeSegments<IT, TT>(segmentation, parentPropagations,
 
                                                order, triangulation);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute local order of segments
         status = this->computeLocalOrderOfSegments<IT, TT>(
           localOrder,
 
           triangulation, segmentation, order, parentPropagations);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // flatten order
         status = this->flattenOrder<IT>(order, parentPropagations);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // compute global offsets
         status = this->computeGlobalOrder<IT>(order, localOrder, sortedIndices);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         status = this->flattenScalars<DT, IT>(scalars, propagations);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
-        return 1;
+        return 0;
       }
 
       template <typename IT>
@@ -1297,7 +1297,7 @@ namespace ttk {
         this->printMsg(
           "Inverting Order", 1, timer.getElapsedTime(), this->threadNumber_);
 
-        return 1;
+        return 0;
       }
 
       template <typename DT, typename IT, class TT>
@@ -1358,8 +1358,8 @@ namespace ttk {
             propagationMask.data(), propagationsMax, sortedIndices,
 
             triangulation, authorizedExtremaIndices, nAuthorizedExtremaIndices);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
         }
 
         // Minima
@@ -1368,35 +1368,35 @@ namespace ttk {
                          ttk::debug::Separator::L2);
 
           // invert order
-          if(!this->invertOrder(order, nVertices))
-            return 0;
+          if(this->invertOrder(order, nVertices))
+            return 1;
 
           status = this->detectAndRemoveUnauthorizedMaxima<IT, TT>(
             order, segmentation.data(), queueMask.data(), localOrder.data(),
             propagationMask.data(), propagationsMin, sortedIndices,
 
             triangulation, authorizedExtremaIndices, nAuthorizedExtremaIndices);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
 
           // revert order
-          if(!this->invertOrder(order, nVertices))
-            return 0;
+          if(this->invertOrder(order, nVertices))
+            return 1;
         }
 
         // flatten scalars
         status = this->flattenScalars<DT, IT>(
           scalars, propagationsMax, propagationsMin);
-        if(!status)
-          return 0;
+        if(status)
+          return 1;
 
         // optionally compute perturbation
         if(computePerturbation) {
           this->printMsg(debug::Separator::L2);
           status = this->computeNumericalPerturbation<DT, IT>(
             scalars, sortedIndices);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
         }
 
         this->printMsg(debug::Separator::L2);
@@ -1405,7 +1405,7 @@ namespace ttk {
 
         this->printMsg(debug::Separator::L1);
 
-        return 1;
+        return 0;
       }
 
       template <typename DT, typename IT, class TT>
@@ -1448,8 +1448,8 @@ namespace ttk {
             sortedIndices,
 
             triangulation, persistenceThreshold);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
         }
 
         // Minima
@@ -1458,8 +1458,8 @@ namespace ttk {
           this->printMsg("----------- [Removing Non-Persistent Minima]",
                          ttk::debug::Separator::L2);
 
-          if(!this->invertOrder(order, nVertices))
-            return 0;
+          if(this->invertOrder(order, nVertices))
+            return 1;
 
           status = this->detectAndRemoveNonPersistentMaxima<IT, DT, TT>(
             scalars, order, segmentation.data(), queueMask.data(),
@@ -1467,11 +1467,11 @@ namespace ttk {
             sortedIndices,
 
             triangulation, persistenceThreshold);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
 
-          if(!this->invertOrder(order, nVertices))
-            return 0;
+          if(this->invertOrder(order, nVertices))
+            return 1;
         }
 
         // optionally compute perturbation
@@ -1479,8 +1479,8 @@ namespace ttk {
           this->printMsg(debug::Separator::L2);
           status = this->computeNumericalPerturbation<DT, IT>(
             scalars, sortedIndices, pairType == PAIR_TYPE::MAXIMUM_SADDLE);
-          if(!status)
-            return 0;
+          if(status)
+            return 1;
         }
 
         this->printMsg(debug::Separator::L2);
@@ -1489,7 +1489,7 @@ namespace ttk {
 
         this->printMsg(debug::Separator::L1);
 
-        return 1;
+        return 0;
       }
 
     }; // class

--- a/core/base/topologicalCompression/CMakeLists.txt
+++ b/core/base/topologicalCompression/CMakeLists.txt
@@ -7,7 +7,7 @@ ttk_add_base_library(topologicalCompression
     OtherCompression.h
   DEPENDS
     triangulation
-    topologicalSimplification
+    legacyTopologicalSimplification
     ftmTreePP
   )
 

--- a/core/base/topologicalCompression/TopologicalCompression.h
+++ b/core/base/topologicalCompression/TopologicalCompression.h
@@ -15,7 +15,7 @@
 
 // base code includes
 #include <FTMTreePP.h>
-#include <TopologicalSimplification.h>
+#include <LegacyTopologicalSimplification.h>
 #include <Triangulation.h>
 
 // std
@@ -359,7 +359,7 @@ namespace ttk {
 
   protected:
     // General.
-    TopologicalSimplification topologicalSimplification{};
+    LegacyTopologicalSimplification topologicalSimplification{};
     ftm::FTMTreePP ftmTreePP;
 
     // Parameters

--- a/core/base/topologicalSimplification/CMakeLists.txt
+++ b/core/base/topologicalSimplification/CMakeLists.txt
@@ -5,4 +5,6 @@ ttk_add_base_library(topologicalSimplification
     TopologicalSimplification.h
   DEPENDS
     triangulation
+    legacyTopologicalSimplification
+    localizedTopologicalSimplification
     )

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -166,7 +166,7 @@ int ttk::TopologicalSimplification::execute(
     case TOPO_LTS:
       ltsObject_.setDebugLevel(debugLevel_);
       ltsObject_.setThreadNumber(threadNumber_);
-      return !ltsObject_
+      return ltsObject_
         .removeUnauthorizedExtrema<dataType, SimplexId, triangulationType>(
           outputScalars, offsets, &triangulation, identifiers, constraintNumber,
           addPerturbation);

--- a/core/base/topologicalSimplification/TopologicalSimplification.h
+++ b/core/base/topologicalSimplification/TopologicalSimplification.h
@@ -93,6 +93,8 @@
 
 // base code includes
 #include <Debug.h>
+#include <LegacyTopologicalSimplification.h>
+#include <LocalizedTopologicalSimplification.h>
 #include <Triangulation.h>
 
 #include <cmath>
@@ -102,64 +104,14 @@
 
 namespace ttk {
 
-  class SweepCmp {
-    bool isIncreasingOrder_{};
-
-  public:
-    SweepCmp() = default;
-
-    SweepCmp(bool isIncreasingOrder) : isIncreasingOrder_{isIncreasingOrder} {
-    }
-
-    inline void setIsIncreasingOrder(bool isIncreasingOrder) {
-      isIncreasingOrder_ = isIncreasingOrder;
-    }
-
-    template <typename dataType>
-    bool
-      operator()(const std::tuple<dataType, SimplexId, SimplexId> &v0,
-                 const std::tuple<dataType, SimplexId, SimplexId> &v1) const {
-      if(isIncreasingOrder_) {
-        return std::get<1>(v0) < std::get<1>(v1);
-      } else {
-        return std::get<1>(v0) > std::get<1>(v1);
-      }
-    }
-  };
-
   class TopologicalSimplification : virtual public Debug {
   public:
     TopologicalSimplification();
 
-    template <typename triangulationType>
-    int getCriticalType(SimplexId vertexId,
-                        const SimplexId *const offsets,
-                        const triangulationType &triangulation) const;
-
-    template <typename triangulationType>
-    int getCriticalPoints(const SimplexId *const offsets,
-                          std::vector<SimplexId> &minList,
-                          std::vector<SimplexId> &maxList,
-                          const triangulationType &triangulation) const;
-
-    template <typename triangulationType>
-    int getCriticalPoints(const SimplexId *const offsets,
-                          std::vector<SimplexId> &minList,
-                          std::vector<SimplexId> &maxList,
-                          std::vector<bool> &blackList,
-                          const triangulationType &triangulation) const;
-
-    template <typename dataType>
-    int addPerturbation(dataType *const scalars,
-                        SimplexId *const offsets) const;
-
-    /**
-     * @pre For this function to behave correctly in the absence of
-     * the VTK wrapper, ttk::preconditionOrderArray() needs to be
-     * called to fill the @p inputOffsets buffer prior to any
-     * computation (the VTK wrapper already includes a mechanism to
-     * automatically generate such a preconditioned buffer).
-     * @see examples/c++/main.cpp for an example use.
+    /*
+     * Either execute this file "legacy" algorithm, or the
+     * lts algorithm. The choice depends on the value of the variable backend_.
+     * Default is lts (localized).
      */
     template <typename dataType, typename triangulationType>
     int execute(const dataType *const inputScalars,
@@ -168,148 +120,37 @@ namespace ttk {
                 const SimplexId *const inputOffsets,
                 SimplexId *const offsets,
                 const SimplexId constraintNumber,
-                const triangulationType &triangulation) const;
+                const bool addPerturbation,
+                const triangulationType &triangulation);
+
+    inline void setBackend(const std::string &arg) {
+      if(arg == "lts")
+        backend_ = TOPO_LTS;
+      else if(arg == "legacy")
+        backend_ = TOPO_LEGACY;
+      else
+        this->printMsg("Error : topological simplification should be 'lts' or "
+                       "'legacy', but got: "
+                       + arg);
+    }
 
     inline int preconditionTriangulation(AbstractTriangulation *triangulation) {
       if(triangulation) {
-        vertexNumber_ = triangulation->getNumberOfVertices();
         triangulation->preconditionVertexNeighbors();
+        if(backend_ == TOPO_LEGACY)
+          legacyObject_.setNumberOfVertices(
+            triangulation->getNumberOfVertices());
       }
       return 0;
     }
 
-    inline void setConsiderIdentifierAsBlackList(bool onOff) {
-      considerIdentifierAsBlackList_ = onOff;
-    }
-
-    inline void setAddPerturbation(bool onOff) {
-      addPerturbation_ = onOff;
-    }
-
   protected:
-    SimplexId vertexNumber_{};
-    bool considerIdentifierAsBlackList_{false};
-    bool addPerturbation_{false};
+    enum TOPO_BACKEND { TOPO_LTS, TOPO_LEGACY };
+    TOPO_BACKEND backend_{TOPO_LTS};
+    LegacyTopologicalSimplification legacyObject_;
+    lts::LocalizedTopologicalSimplification ltsObject_;
   };
 } // namespace ttk
-
-// if the package is a pure template typename, uncomment the following line
-// #include                  <TopologicalSimplification.cpp>
-
-template <typename triangulationType>
-int ttk::TopologicalSimplification::getCriticalType(
-  SimplexId vertex,
-  const SimplexId *const offsets,
-  const triangulationType &triangulation) const {
-
-  bool isMinima{true};
-  bool isMaxima{true};
-  SimplexId neighborNumber = triangulation.getVertexNeighborNumber(vertex);
-  for(SimplexId i = 0; i < neighborNumber; ++i) {
-    SimplexId neighbor{-1};
-    triangulation.getVertexNeighbor(vertex, i, neighbor);
-
-    if(offsets[neighbor] < offsets[vertex])
-      isMinima = false;
-    if(offsets[neighbor] > offsets[vertex])
-      isMaxima = false;
-    if(!isMinima and !isMaxima) {
-      return 0;
-    }
-  }
-
-  if(isMinima)
-    return -1;
-  if(isMaxima)
-    return 1;
-
-  return 0;
-}
-
-template <typename triangulationType>
-int ttk::TopologicalSimplification::getCriticalPoints(
-  const SimplexId *const offsets,
-  std::vector<SimplexId> &minima,
-  std::vector<SimplexId> &maxima,
-  const triangulationType &triangulation) const {
-
-  std::vector<int> type(vertexNumber_, 0);
-
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for
-#endif
-  for(SimplexId k = 0; k < vertexNumber_; ++k)
-    type[k] = getCriticalType(k, offsets, triangulation);
-
-  for(SimplexId k = 0; k < vertexNumber_; ++k) {
-    if(type[k] < 0)
-      minima.push_back(k);
-    else if(type[k] > 0)
-      maxima.push_back(k);
-  }
-  return 0;
-}
-
-template <typename triangulationType>
-int ttk::TopologicalSimplification::getCriticalPoints(
-  const SimplexId *const offsets,
-  std::vector<SimplexId> &minima,
-  std::vector<SimplexId> &maxima,
-  std::vector<bool> &extrema,
-  const triangulationType &triangulation) const {
-  std::vector<int> type(vertexNumber_);
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(SimplexId k = 0; k < vertexNumber_; ++k) {
-    if(considerIdentifierAsBlackList_ xor extrema[k]) {
-      type[k] = getCriticalType(k, offsets, triangulation);
-    }
-  }
-
-  for(SimplexId k = 0; k < vertexNumber_; ++k) {
-    if(type[k] < 0)
-      minima.push_back(k);
-    else if(type[k] > 0)
-      maxima.push_back(k);
-  }
-  return 0;
-}
-
-template <typename dataType>
-int ttk::TopologicalSimplification::addPerturbation(
-  dataType *const scalars, SimplexId *const offsets) const {
-  dataType epsilon{};
-
-  if(std::is_same<dataType, double>::value)
-    epsilon = Geometry::powIntTen<dataType>(1 - DBL_DIG);
-  else if(std::is_same<dataType, float>::value)
-    epsilon = Geometry::powIntTen<dataType>(1 - FLT_DIG);
-  else
-    return -1;
-
-  std::vector<std::tuple<dataType, SimplexId, SimplexId>> perturbation(
-    vertexNumber_);
-  for(SimplexId i = 0; i < vertexNumber_; ++i) {
-    std::get<0>(perturbation[i]) = scalars[i];
-    std::get<1>(perturbation[i]) = offsets[i];
-    std::get<2>(perturbation[i]) = i;
-  }
-
-  SweepCmp cmp(true);
-  sort(perturbation.begin(), perturbation.end(), cmp);
-
-  for(SimplexId i = 0; i < vertexNumber_; ++i) {
-    if(i) {
-      if(std::get<0>(perturbation[i]) <= std::get<0>(perturbation[i - 1]))
-        std::get<0>(perturbation[i])
-          = std::get<0>(perturbation[i - 1]) + epsilon;
-    }
-    scalars[std::get<2>(perturbation[i])] = std::get<0>(perturbation[i]);
-  }
-
-  return 0;
-}
 
 template <typename dataType, typename triangulationType>
 int ttk::TopologicalSimplification::execute(
@@ -319,181 +160,26 @@ int ttk::TopologicalSimplification::execute(
   const SimplexId *const inputOffsets,
   SimplexId *const offsets,
   const SimplexId constraintNumber,
-  const triangulationType &triangulation) const {
+  const bool addPerturbation,
+  const triangulationType &triangulation) {
+  switch(backend_) {
+    case TOPO_LTS:
+      ltsObject_.setDebugLevel(debugLevel_);
+      ltsObject_.setThreadNumber(threadNumber_);
+      return !ltsObject_
+        .removeUnauthorizedExtrema<dataType, SimplexId, triangulationType>(
+          outputScalars, offsets, &triangulation, identifiers, constraintNumber,
+          addPerturbation);
+    case TOPO_LEGACY:
+      legacyObject_.setDebugLevel(debugLevel_);
+      legacyObject_.setThreadNumber(threadNumber_);
+      return legacyObject_.execute(inputScalars, outputScalars, identifiers,
+                                   inputOffsets, offsets, constraintNumber,
+                                   triangulation);
 
-  Timer t;
-
-  // pre-processing
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_)
-#endif
-  for(SimplexId k = 0; k < vertexNumber_; ++k) {
-    outputScalars[k] = inputScalars[k];
-    if(std::isnan((double)outputScalars[k]))
-      outputScalars[k] = 0;
-
-    offsets[k] = inputOffsets[k];
+    default:
+      this->printErr(
+        "Error, the backend for topological simplification is invalid");
+      return -1;
   }
-
-  // get the user extremum list
-  std::vector<bool> extrema(vertexNumber_, false);
-  for(SimplexId k = 0; k < constraintNumber; ++k) {
-    const SimplexId identifierId = identifiers[k];
-
-#ifndef TTK_ENABLE_KAMIKAZE
-    if(identifierId >= 0 and identifierId < vertexNumber_)
-#endif
-      extrema[identifierId] = true;
-  }
-
-  std::vector<SimplexId> authorizedMinima;
-  std::vector<SimplexId> authorizedMaxima;
-  std::vector<bool> authorizedExtrema(vertexNumber_, false);
-
-  getCriticalPoints(
-    offsets, authorizedMinima, authorizedMaxima, extrema, triangulation);
-
-  this->printMsg("Maintaining " + std::to_string(constraintNumber)
-                   + " constraints (" + std::to_string(authorizedMinima.size())
-                   + " minima and " + std::to_string(authorizedMaxima.size())
-                   + " maxima)",
-                 debug::Priority::DETAIL);
-
-  // declare the tuple-comparison functor
-  SweepCmp cmp;
-
-  // processing
-  for(SimplexId i = 0; i < vertexNumber_; ++i) {
-
-    this->printMsg("Starting simplifying iteration #" + std::to_string(i),
-                   debug::Priority::DETAIL);
-
-    for(int j = 0; j < 2; ++j) {
-
-      bool isIncreasingOrder = !j;
-
-      if(isIncreasingOrder && authorizedMinima.empty()) {
-        continue;
-      }
-      if(!isIncreasingOrder && authorizedMaxima.empty()) {
-        continue;
-      }
-
-      cmp.setIsIncreasingOrder(isIncreasingOrder);
-      std::set<std::tuple<dataType, SimplexId, SimplexId>, decltype(cmp)>
-        sweepFront(cmp);
-      std::vector<bool> visitedVertices(vertexNumber_, false);
-      std::vector<SimplexId> adjustmentSequence(vertexNumber_);
-
-      // add the seeds
-      if(isIncreasingOrder) {
-        for(SimplexId k : authorizedMinima) {
-          authorizedExtrema[k] = true;
-          sweepFront.emplace(outputScalars[k], offsets[k], k);
-          visitedVertices[k] = true;
-        }
-      } else {
-        for(SimplexId k : authorizedMaxima) {
-          authorizedExtrema[k] = true;
-          sweepFront.emplace(outputScalars[k], offsets[k], k);
-          visitedVertices[k] = true;
-        }
-      }
-
-      // growth by neighborhood of the seeds
-      SimplexId adjustmentPos = 0;
-      do {
-        auto front = sweepFront.begin();
-        if(front == sweepFront.end())
-          return -1;
-
-        SimplexId vertexId = std::get<2>(*front);
-        sweepFront.erase(front);
-
-        SimplexId neighborNumber
-          = triangulation.getVertexNeighborNumber(vertexId);
-        for(SimplexId k = 0; k < neighborNumber; ++k) {
-          SimplexId neighbor{-1};
-          triangulation.getVertexNeighbor(vertexId, k, neighbor);
-          if(!visitedVertices[neighbor]) {
-            sweepFront.emplace(
-              outputScalars[neighbor], offsets[neighbor], neighbor);
-            visitedVertices[neighbor] = true;
-          }
-        }
-        adjustmentSequence[adjustmentPos] = vertexId;
-        ++adjustmentPos;
-      } while(!sweepFront.empty());
-
-      // save offsets and rearrange outputScalars
-      SimplexId offset = (isIncreasingOrder ? 0 : vertexNumber_);
-
-      for(SimplexId k = 0; k < vertexNumber_; ++k) {
-
-        if(isIncreasingOrder) {
-          if(k
-             && outputScalars[adjustmentSequence[k]]
-                  <= outputScalars[adjustmentSequence[k - 1]])
-            outputScalars[adjustmentSequence[k]]
-              = outputScalars[adjustmentSequence[k - 1]];
-          ++offset;
-        } else {
-          if(k
-             && outputScalars[adjustmentSequence[k]]
-                  >= outputScalars[adjustmentSequence[k - 1]])
-            outputScalars[adjustmentSequence[k]]
-              = outputScalars[adjustmentSequence[k - 1]];
-          --offset;
-        }
-        offsets[adjustmentSequence[k]] = offset;
-      }
-    }
-
-    // test convergence
-    bool needForMoreIterations{false};
-    std::vector<SimplexId> minima;
-    std::vector<SimplexId> maxima;
-    getCriticalPoints(offsets, minima, maxima, triangulation);
-
-    if(maxima.size() > authorizedMaxima.size())
-      needForMoreIterations = true;
-    if(minima.size() > authorizedMinima.size())
-      needForMoreIterations = true;
-
-    this->printMsg(
-      std::vector<std::vector<std::string>>{
-        {"#Minima", std::to_string(minima.size())},
-        {"#Maxima", std::to_string(maxima.size())},
-      },
-      debug::Priority::DETAIL);
-
-    if(!needForMoreIterations) {
-      for(SimplexId k : minima) {
-        if(!authorizedExtrema[k]) {
-          needForMoreIterations = true;
-          break;
-        }
-      }
-    }
-    if(!needForMoreIterations) {
-      for(SimplexId k : maxima) {
-        if(!authorizedExtrema[k]) {
-          needForMoreIterations = true;
-          break;
-        }
-      }
-    }
-
-    // optional adding of perturbation
-    if(addPerturbation_)
-      addPerturbation<dataType>(outputScalars, offsets);
-
-    if(!needForMoreIterations)
-      break;
-  }
-
-  this->printMsg(
-    "Simplified scalar field", 1.0, t.getElapsedTime(), this->threadNumber_);
-
-  return 0;
 }

--- a/core/vtk/ttkTopologicalSimplification/ttk.module
+++ b/core/vtk/ttkTopologicalSimplification/ttk.module
@@ -6,5 +6,4 @@ HEADERS
   ttkTopologicalSimplification.h
 DEPENDS
   topologicalSimplification
-  localizedTopologicalSimplification
   ttkAlgorithm

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -47,6 +47,11 @@ int ttkTopologicalSimplification::RequestData(
 
   using ttk::SimplexId;
 
+  // Warning: this needs to be done before the preconditioning.
+  if(!this->UseLTS) {
+    this->setBackend(BACKEND::LEGACY);
+  }
+
   const auto domain = vtkDataSet::GetData(inputVector[0]);
   const auto constraints = vtkPointSet::GetData(inputVector[1]);
   if(!domain || !constraints)
@@ -110,11 +115,6 @@ int ttkTopologicalSimplification::RequestData(
   auto identifiers = this->GetIdentifierArrayPtr(ForceInputVertexScalarField, 1,
                                                  ttk::VertexScalarFieldName,
                                                  constraints, idSpareStorage);
-
-  if(!this->UseLTS) {
-    this->setBackend("legacy");
-  }
-  // TODO nb thread et debuglevel ?
 
   int ret{};
   switch(inputScalars->GetDataType()) {

--- a/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
+++ b/core/vtk/ttkTopologicalSimplification/ttkTopologicalSimplification.cpp
@@ -12,8 +12,6 @@
 #include <ttkTopologicalSimplification.h>
 #include <ttkUtils.h>
 
-#include <LocalizedTopologicalSimplification.h>
-
 vtkStandardNewMacro(ttkTopologicalSimplification);
 
 ttkTopologicalSimplification::ttkTopologicalSimplification() {
@@ -113,37 +111,20 @@ int ttkTopologicalSimplification::RequestData(
                                                  ttk::VertexScalarFieldName,
                                                  constraints, idSpareStorage);
 
-  // NOTE it'd be better if the two backends were inheriting from the same API
-  // (the switch would then happen in the base code)
+  if(!this->UseLTS) {
+    this->setBackend("legacy");
+  }
+  // TODO nb thread et debuglevel ?
+
   int ret{};
-  if(this->UseLTS) {
-    ttk::lts::LocalizedTopologicalSimplification lts{};
-    lts.setDebugLevel(this->debugLevel_);
-    lts.setThreadNumber(this->threadNumber_);
-
-    lts.preconditionTriangulation(triangulation);
-
-    ttkVtkTemplateMacro(
-      inputScalars->GetDataType(), triangulation->getType(),
-      (ret = lts.removeUnauthorizedExtrema<VTK_TT, ttk::SimplexId, TTK_TT>(
-         ttkUtils::GetPointer<VTK_TT>(outputScalars),
-         ttkUtils::GetPointer<SimplexId>(outputOrder),
-
-         static_cast<TTK_TT *>(triangulation->getData()), identifiers,
-         numberOfConstraints, this->AddPerturbation)));
-
-    // TODO: fix convention in original ttk module
-    ret = !ret;
-  } else {
-    switch(inputScalars->GetDataType()) {
-      vtkTemplateMacro(
-        ret = this->execute(ttkUtils::GetPointer<VTK_TT>(inputScalars),
-                            ttkUtils::GetPointer<VTK_TT>(outputScalars),
-                            identifiers,
-                            ttkUtils::GetPointer<SimplexId>(inputOrder),
-                            ttkUtils::GetPointer<SimplexId>(outputOrder),
-                            numberOfConstraints, *triangulation->getData()));
-    }
+  switch(inputScalars->GetDataType()) {
+    vtkTemplateMacro(ret = this->execute(
+                       ttkUtils::GetPointer<VTK_TT>(inputScalars),
+                       ttkUtils::GetPointer<VTK_TT>(outputScalars), identifiers,
+                       ttkUtils::GetPointer<SimplexId>(inputOrder),
+                       ttkUtils::GetPointer<SimplexId>(outputOrder),
+                       numberOfConstraints, this->AddPerturbation,
+                       *triangulation->getData()));
   }
 
   // something wrong in baseCode

--- a/core/vtk/ttkTopologicalSimplificationByPersistence/ttkTopologicalSimplificationByPersistence.cpp
+++ b/core/vtk/ttkTopologicalSimplificationByPersistence/ttkTopologicalSimplificationByPersistence.cpp
@@ -101,7 +101,7 @@ int ttkTopologicalSimplificationByPersistence::RequestData(
        this->ComputePerturbation, this->PairType)));
 
   // On error cancel filter execution
-  if(status != 1)
+  if(status != 0)
     return 0;
 
   auto outputDataSet = vtkDataSet::GetData(outputVector, 0);

--- a/examples/c++/main.cpp
+++ b/examples/c++/main.cpp
@@ -212,10 +212,10 @@ int main(int argc, char **argv) {
   // 6. simplifying the input data to remove non-persistent pairs
   ttk::TopologicalSimplification simplification;
   simplification.preconditionTriangulation(&triangulation);
-  simplification.execute<float>(height.data(), simplifiedHeight.data(),
-                                authorizedCriticalPoints.data(), order.data(),
-                                simplifiedOrder.data(),
-                                authorizedCriticalPoints.size(), triangulation);
+  simplification.execute<float>(
+    height.data(), simplifiedHeight.data(), authorizedCriticalPoints.data(),
+    order.data(), simplifiedOrder.data(), authorizedCriticalPoints.size(),
+    false, triangulation);
 
   // assign the simplified values to the input mesh
   for(int i = 0; i < (int)simplifiedHeight.size(); i++) {


### PR DESCRIPTION
This PR contains two commits.

The first one modifies both the VTK and the TTK layer for the topological simplification. The TopologicalSimplificaiton class is now a container with two members : one object from the legacy implementation (formerly in the TopologicalSimplification class) and one from the lts version. We can set the backend for the new TopologicalSimplification object, which then runs the appropriate algorithm, all in the TTK Layer.

The second was prompted by a note in the code requiring to make lts use the same status return convention as the other ttk modules: return 0 in case of success and something else on errors. This commit fixes this problem for all functions and subfunctions of this module, updating the few places in the other modules which explicitely used lts.