### PR TITLE
Small CI bugfix (parallelisation of python tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,13 +198,6 @@ jobs:
             rsi.SamplingDimensions = [128, 128, 128]
             simple.SaveData(ds, rsi)
 
-    - name: Delete TTK package artifact
-      uses: geekyeggo/delete-artifact@v2
-      # delete package only once
-      if: matrix.testSet == 'screenshotTests'
-      with:
-        name: ttk-for-tests-${{ matrix.os }}.deb
-
     - name: Run ttk-data states [NOT ENFORCED]
       if: matrix.testSet == 'screenshotTests'
       id: validate
@@ -254,6 +247,13 @@ jobs:
         cd ttk-data
         cat python/res.json
         diff python/hashes/${{ matrix.os }}.json python/res.json
+
+    - name: Delete TTK package artifact
+      uses: geekyeggo/delete-artifact@v2
+      # delete package only once
+      if: matrix.testSet == 'screenshotTests'
+      with:
+        name: ttk-for-tests-${{ matrix.os }}.deb
 
 
   # -----------------#


### PR DESCRIPTION
Commit 576473427759399daf07005e5b24ce068d148b2a added the deletion of a temporary artifact (.deb package of ttk for ubuntus).
If the other python test job is run much later, the artifact was already deleted and it cannot find it.

The deletion is now at the end of one test job, hence only if the other one is not run during 30 minutes will it fail.