### PR TITLE
[MPI] Multiple bug corrections (identifiers, scalarFieldCriticalPoints, preconditioning)

### DIFF
--- a/MPI.md
+++ b/MPI.md
@@ -14,6 +14,8 @@ To specify the number of threads to use during execution, the environment variab
 
 To use Paraview in distributed mode using MPI, one has to use either `pvserver` or `pvbatch`. 
 
+Please note that TTK only supports a number of processes equal to $2^n$, with $n\in \mathbb{N}$. There are no constraints on the number of threads.
+
 #### pvserver
 The following command allows one to start `pvserver` with 4 MPI processes and 8 threads (per process) with OpenMPI:
 

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -1416,6 +1416,7 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
     return -2;
   }
 
+  this->hasPreconditionedDistributedVertices_ = true;
   this->preconditionVertexRankArray();
 
   // number of local vertices (with ghost vertices...)
@@ -1458,8 +1459,6 @@ int ExplicitTriangulation::preconditionDistributedVertices() {
                  this->remoteGhostVertices_[neigh].size(), MIT, neigh, neigh,
                  ttk::MPIcomm_, MPI_STATUS_IGNORE);
   }
-
-  this->hasPreconditionedDistributedVertices_ = true;
 
   return 0;
 }

--- a/core/base/identifiers/Identifiers.h
+++ b/core/base/identifiers/Identifiers.h
@@ -67,8 +67,8 @@ namespace ttk {
     MPI_Datatype mpiPointType_;
     int dimension_{};
     int hasSentData_{0};
-    ttk::SimplexId *vertexRankArray_{nullptr};
-    ttk::SimplexId *cellRankArray_{nullptr};
+    int *vertexRankArray_{nullptr};
+    int *cellRankArray_{nullptr};
     unsigned char *vertGhost_{nullptr};
     unsigned char *cellGhost_{nullptr};
     std::vector<std::vector<ttk::SimplexId>> pointsToCells_;
@@ -109,11 +109,11 @@ namespace ttk {
       pointsToCells_ = pointsToCells;
     }
 
-    void setVertexRankArray(ttk::SimplexId *vertexRankArray) {
+    void setVertexRankArray(int *vertexRankArray) {
       this->vertexRankArray_ = vertexRankArray;
     }
 
-    void setCellRankArray(ttk::SimplexId *cellRankArray) {
+    void setCellRankArray(int *cellRankArray) {
       this->cellRankArray_ = cellRankArray;
     }
 
@@ -156,7 +156,7 @@ namespace ttk {
 
     void buildKDTree() {
       kdt_ = ttk::KDTree<float, std::array<float, 3>>(false, 2);
-      kdt_.build(pointSet_, vertexNumber_, dimension_);
+      kdt_.build(pointSet_, vertexNumber_, 3);
     }
 
     void setOutdatedGlobalCellIds(ttk::LongSimplexId *outdatedGlobalCellIds) {
@@ -248,9 +248,9 @@ namespace ttk {
            && bounds_[5] >= receivedPoints[n].z) {
           this->findPoint(
             id, receivedPoints[n].x, receivedPoints[n].y, receivedPoints[n].z);
-          if((vertGhost_ != nullptr && vertGhost_[id] == 0)
-             || (vertexRankArray_ != nullptr
-                 && vertexRankArray_[id] == ttk::MPIrank_)) {
+          if((vertexRankArray_ != nullptr
+              && vertexRankArray_[id] == ttk::MPIrank_)
+             || (vertGhost_ != nullptr && vertGhost_[id] == 0)) {
             globalId = vertexIdentifiers_[id];
             if(globalId >= 0) {
 #ifdef TTK_ENABLE_OPENMP
@@ -351,7 +351,8 @@ namespace ttk {
       localPointIds.reserve(dimension_ + 1);
       size_t expectedSize = static_cast<size_t>(dimension_) + 1;
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) firstprivate(localPointIds)
+#pragma omp parallel for num_threads(threadNumber_) private( \
+  search, localPointIds)
 #endif
       for(int n = 0; n < recvMessageSize; n += dimension_ + 2) {
         localPointIds.clear();

--- a/core/base/identifiers/Identifiers.h
+++ b/core/base/identifiers/Identifiers.h
@@ -351,8 +351,8 @@ namespace ttk {
       localPointIds.reserve(dimension_ + 1);
       size_t expectedSize = static_cast<size_t>(dimension_) + 1;
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) private( \
-  search, localPointIds)
+#pragma omp parallel for num_threads(threadNumber_) \
+  firstprivate(search, localPointIds)
 #endif
       for(int n = 0; n < recvMessageSize; n += dimension_ + 2) {
         localPointIds.clear();

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -544,6 +544,15 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
   ttk::SimplexId lowerComponentNumber = lowerComponents->size();
   ttk::SimplexId upperComponentNumber = upperComponents->size();
 
+  if(dimension_ == 1) {
+    if(lowerComponentNumber == 0 && upperComponentNumber != 0) {
+      return (char)(CriticalType::Local_minimum);
+    } else if(lowerComponentNumber != 0 && upperComponentNumber == 0) {
+      return (char)(CriticalType::Local_maximum);
+    }
+    return (char)(CriticalType::Regular);
+  }
+
   if(lowerComponentNumber == 0 && upperComponentNumber == 1) {
     return (char)(CriticalType::Local_minimum);
   } else if(lowerComponentNumber == 1 && upperComponentNumber == 0) {

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -549,8 +549,10 @@ char ttk::ScalarFieldCriticalPoints::getCriticalType(
       return (char)(CriticalType::Local_minimum);
     } else if(lowerComponentNumber != 0 && upperComponentNumber == 0) {
       return (char)(CriticalType::Local_maximum);
+    } else if(lowerComponentNumber == 1 && upperComponentNumber == 1) {
+      return (char)(CriticalType::Regular);
     }
-    return (char)(CriticalType::Regular);
+    return (char)(CriticalType::Saddle1);
   }
 
   if(lowerComponentNumber == 0 && upperComponentNumber == 1) {

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -556,9 +556,9 @@ int ttkAlgorithm::GenerateGlobalIds(
         identifiers.setOutdatedGlobalCellIds(
           ttkUtils::GetPointer<ttk::LongSimplexId>(
             input->GetCellData()->GetGlobalIds()));
-        identifiers.setVertexRankArray(ttkUtils::GetPointer<ttk::SimplexId>(
+        identifiers.setVertexRankArray(ttkUtils::GetPointer<int>(
           input->GetPointData()->GetArray("RankArray")));
-        ttk::SimplexId *cellRankArray = ttkUtils::GetPointer<ttk::SimplexId>(
+        int *cellRankArray = ttkUtils::GetPointer<int>(
           input->GetCellData()->GetArray("RankArray"));
         identifiers.setCellRankArray(cellRankArray);
         identifiers.setVertGhost(ttkUtils::GetPointer<unsigned char>(

--- a/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
+++ b/core/vtk/ttkIdentifiers/ttkIdentifiers.cpp
@@ -43,6 +43,11 @@ int ttkIdentifiers::RequestData(vtkInformation *ttkNotUsed(request),
 
   Timer t;
 
+  int keepGoing = checkEmptyMPIInput<vtkDataSet>(input);
+  if(keepGoing < 2) {
+    return keepGoing;
+  }
+
   auto triangulation = ttkAlgorithm::GetTriangulation(input);
   if(triangulation == nullptr) {
     this->printErr("Triangulation is NULL");


### PR DESCRIPTION
Hi all,

In this Pull Request, multiple fixes are done:

- In `ExplicitTriangulation`, the function `preconditionDistributedVertices` sets its flag `hasPreconditionedDistributedVertices_` to true at the very end of the function. However, inside this function, a call to `preconditionVertexRankArray` is done and requires to use `getVertexRank`, which will print an error message if the flag `hasPreconditionedDistributedVertices_` is not equal to true. I moved the line `hasPreconditionedDistributedVertices_ = true` to the line before  `preconditionVertexRankArray` so it no longer prints out error messages.
- In Identifiers, the type of RankArray was set to ttk::SimplexId, which is false when the identifiers are 64 bits, as RankArray will always be int.
- In `Identifiers`, the dimension of the kd-tree should always be 3 as it represents the number of coordinates of the points in space, and not the dimension of the domain. VTK will always output 3 coordinates for a point.
- In `ScalarFieldCriticalPoints`, a special case was added for dimension 1, as the current code doesn't handle properly points in dimension 1 that have two upper (or lower) connected components.

Thanks for any feedback,