### PR TITLE
NoCopy arguments passing to the nmi-ari, distanceMatrixDistorsion, and LDistanceMatrix/ttktableDistanceMatrix modules

### DIFF
--- a/core/base/clusteringMetrics/CMakeLists.txt
+++ b/core/base/clusteringMetrics/CMakeLists.txt
@@ -4,5 +4,5 @@ ttk_add_base_library(clusteringMetrics
   HEADERS
     ClusteringMetrics.h
   DEPENDS
-    common
+    geometry
 )

--- a/core/base/clusteringMetrics/ClusteringMetrics.cpp
+++ b/core/base/clusteringMetrics/ClusteringMetrics.cpp
@@ -1,8 +1,8 @@
 #include <ClusteringMetrics.h>
+#include <Geometry.h> // To check wheter a double is zero.
 #include <cmath> // For the log2 function
 #include <map>
 #include <vector>
-#include <Geometry.h>  // To check wheter a double is zero.
 
 ttk::ClusteringMetrics::ClusteringMetrics() {
   // inherited from Debug: prefix will be printed at the beginning of every msg
@@ -15,7 +15,7 @@ inline int nChoose2(int x) {
 
 inline int checkContingencyMatSize(const ttk::ClusteringMetrics *object,
                                    const std::vector<std::vector<int>> &matrix,
-                                   int nPoint) {
+                                   const size_t nPoint) {
   if(nPoint == 0) {
     object->printErr("Error: clustering on zero points.");
     return 0;
@@ -47,12 +47,12 @@ inline int checkContingencyMatSize(const ttk::ClusteringMetrics *object,
 }
 
 int ttk::ClusteringMetrics::computeContingencyTables(
-  const std::vector<int> &clust1,
-  const std::vector<int> &clust2,
+  const int *clust1,
+  const int *clust2,
+  const size_t nPoint,
   std::vector<std::vector<int>> &contingencyMatrix,
   std::vector<int> &sumLin,
   std::vector<int> &sumCol) const {
-  size_t nPoint = clust1.size();
   if(nPoint == 0) {
     this->printErr("Error: clustering on zero points.");
     return 0;
@@ -60,17 +60,17 @@ int ttk::ClusteringMetrics::computeContingencyTables(
 
   std::map<int, int> values1ToId, values2ToId;
   size_t nbVal1 = 0, nbVal2 = 0;
-  for(int x : clust1) {
-    auto found = values1ToId.find(x);
-    if(found == values1ToId.end()) {
-      values1ToId[x] = nbVal1;
+  for(size_t i = 0; i < nPoint; i++) {
+    int x1 = clust1[i], x2 = clust2[i];
+    auto found1 = values1ToId.find(x1), found2 = values2ToId.find(x2);
+
+    if(found1 == values1ToId.end()) {
+      values1ToId[x1] = nbVal1;
       nbVal1++;
     }
-  }
-  for(int x : clust2) {
-    auto found = values2ToId.find(x);
-    if(found == values2ToId.end()) {
-      values2ToId[x] = nbVal2;
+
+    if(found2 == values2ToId.end()) {
+      values2ToId[x2] = nbVal2;
       nbVal2++;
     }
   }
@@ -104,7 +104,7 @@ int ttk::ClusteringMetrics::computeARI(
   const std::vector<std::vector<int>> &contingencyMatrix,
   const std::vector<int> &sumLin,
   const std::vector<int> &sumCol,
-  const int nPoint,
+  const size_t nPoint,
   double &ariValue) const {
   if(!checkContingencyMatSize(this, contingencyMatrix, nPoint))
     return 0;
@@ -141,7 +141,7 @@ int ttk::ClusteringMetrics::computeARI(
                      - (sumNChoose2_1 * sumNChoose2_2) / nChoose2(nPoint);
   double denominator = 0.5 * (sumNChoose2_1 + sumNChoose2_2)
                        - (sumNChoose2_1 * sumNChoose2_2) / nChoose2(nPoint);
-  if (denominator < ttk::Geometry::powIntTen(-DBL_DIG))
+  if(denominator < ttk::Geometry::powIntTen(-DBL_DIG))
     ariValue = 1;
   else
     ariValue = numerator / denominator;
@@ -153,7 +153,7 @@ int ttk::ClusteringMetrics::computeNMI(
   const std::vector<std::vector<int>> &contingencyMatrix,
   const std::vector<int> &sumLin,
   const std::vector<int> &sumCol,
-  const int nPoint,
+  const size_t nPoint,
   double &nmiValue) const {
   if(!checkContingencyMatSize(this, contingencyMatrix, nPoint))
     return 0;
@@ -201,27 +201,19 @@ int ttk::ClusteringMetrics::computeNMI(
   return 0;
 }
 
-int ttk::ClusteringMetrics::execute(const std::vector<int> &clustering1,
-                                    const std::vector<int> &clustering2,
+int ttk::ClusteringMetrics::execute(const int *clustering1,
+                                    const int *clustering2,
+                                    const size_t n,
                                     double &nmiValue,
                                     double &ariValue) const {
   ttk::Timer timer;
-  size_t n = clustering1.size();
 
   this->printMsg(ttk::debug::Separator::L1);
-
-  if(clustering2.size() != n) {
-    this->printMsg(" Sizes mismatch: clustering one represents "
-                   + std::to_string(n)
-                   + " points and clustering two represents "
-                   + std::to_string(clustering2.size()) + " points\n");
-    return 1;
-  }
 
   std::vector<std::vector<int>> contingencyMatrix;
   std::vector<int> sumLines, sumColumns;
   computeContingencyTables(
-    clustering1, clustering2, contingencyMatrix, sumLines, sumColumns);
+    clustering1, clustering2, n, contingencyMatrix, sumLines, sumColumns);
 
   computeARI(contingencyMatrix, sumLines, sumColumns, n, ariValue);
   computeNMI(contingencyMatrix, sumLines, sumColumns, n, nmiValue);

--- a/core/base/clusteringMetrics/ClusteringMetrics.cpp
+++ b/core/base/clusteringMetrics/ClusteringMetrics.cpp
@@ -2,6 +2,7 @@
 #include <cmath> // For the log2 function
 #include <map>
 #include <vector>
+#include <Geometry.h>  // To check wheter a double is zero.
 
 ttk::ClusteringMetrics::ClusteringMetrics() {
   // inherited from Debug: prefix will be printed at the beginning of every msg
@@ -140,7 +141,10 @@ int ttk::ClusteringMetrics::computeARI(
                      - (sumNChoose2_1 * sumNChoose2_2) / nChoose2(nPoint);
   double denominator = 0.5 * (sumNChoose2_1 + sumNChoose2_2)
                        - (sumNChoose2_1 * sumNChoose2_2) / nChoose2(nPoint);
-  ariValue = numerator / denominator;
+  if (denominator < ttk::Geometry::powIntTen(-DBL_DIG))
+    ariValue = 1;
+  else
+    ariValue = numerator / denominator;
 
   return 0;
 }

--- a/core/base/clusteringMetrics/ClusteringMetrics.h
+++ b/core/base/clusteringMetrics/ClusteringMetrics.h
@@ -32,14 +32,16 @@ namespace ttk {
   public:
     ClusteringMetrics();
 
-    int execute(const std::vector<int> &clustering1,
-                const std::vector<int> &clustering2,
+    int execute(const int *clustering1,
+                const int *clustering2,
+                const size_t n,
                 double &nmiValue,
                 double &ariValue) const;
 
     int
-      computeContingencyTables(const std::vector<int> &clust1,
-                               const std::vector<int> &clust2,
+      computeContingencyTables(const int *clust1,
+                               const int *clust2,
+                               const size_t nPoint,
                                std::vector<std::vector<int>> &contingencyMatrix,
                                std::vector<int> &sumLin,
                                std::vector<int> &sumCol) const;
@@ -49,12 +51,12 @@ namespace ttk {
     int computeARI(const std::vector<std::vector<int>> &contingencyMatrix,
                    const std::vector<int> &sumLin,
                    const std::vector<int> &sumCol,
-                   const int nPoint,
+                   const size_t nPoint,
                    double &ariValue) const;
     int computeNMI(const std::vector<std::vector<int>> &contingencyMatrix,
                    const std::vector<int> &sumLin,
                    const std::vector<int> &sumCol,
-                   const int nPoint,
+                   const size_t nPoint,
                    double &nmiValue) const;
   }; // ClusteringMetrics class
 

--- a/core/base/distanceMatrixDistorsion/DistanceMatrixDistorsion.h
+++ b/core/base/distanceMatrixDistorsion/DistanceMatrixDistorsion.h
@@ -33,10 +33,10 @@ namespace ttk {
   public:
     DistanceMatrixDistorsion();
 
-    int execute(const std::vector<std::vector<double>> &highDistMatrix,
-                const std::vector<std::vector<double>> &lowDistMatrix,
+    int execute(const std::vector<double *> &highDistMatrix,
+                const std::vector<double *> &lowDistMatrix,
                 double &distorsionValue,
-                std::vector<double> &distorsionVerticesValues) const;
+                double *distorsionVerticesValues) const;
   };
 
 } // namespace ttk

--- a/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.cpp
+++ b/core/vtk/ttkTableDistanceMatrix/ttkTableDistanceMatrix.cpp
@@ -88,8 +88,7 @@ int ttkTableDistanceMatrix::RequestData(vtkInformation * /*request*/,
     inputPtrs[i] = vec.data();
   }
 
-  std::vector<std::vector<double>> distanceMatrix{};
-  this->execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
+  std::vector<double *> distanceMatrix(inputMatrix.size());
 
   // zero-padd column name to keep Row Data columns ordered
   const auto zeroPad
@@ -108,11 +107,12 @@ int ttkTableDistanceMatrix::RequestData(vtkInformation * /*request*/,
     vtkNew<vtkDoubleArray> col{};
     col->SetNumberOfTuples(numberOfRows);
     col->SetName(name.c_str());
-    for(int j = 0; j < numberOfRows; ++j) {
-      col->SetTuple1(j, distanceMatrix[i][j]);
-    }
     output->AddColumn(col);
+    distanceMatrix[i]
+      = ttkUtils::GetPointer<double>(vtkDoubleArray::SafeDownCast(col));
   }
+
+  this->execute(distanceMatrix, inputPtrs, inputMatrix[0].size());
 
   this->printMsg("Complete (#dimensions: " + std::to_string(numberOfColumns)
                    + ", #points: " + std::to_string(numberOfRows) + ")",


### PR DESCRIPTION
Before this commits, the vtk layers of these modules would call the ttk layers passing for instance vector<int>& or vector<vector<double>>& variables arguments. Then the output arguments would be copied to the vtk structures. Now we pass vector<int*> and vector<vector<double*>> arguments, which are shallow copy from the vtk structures.
When a vector<vector>> is passed, we provide a small function allowing to use a vector<vector<>>, with a negligible time cost.

There is no big time improvement, but a quite big memory consumption reduction.