### PR TITLE
[MPI] Array preconditioning performance fix

### DIFF
--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -60,7 +60,9 @@ namespace ttk {
       TTK_FORCE_USE(scalarArray);
       TTK_FORCE_USE(getVertexGlobalId);
       TTK_FORCE_USE(getVertexRank);
+      TTK_FORCE_USE(getVertexLocalId);
       TTK_FORCE_USE(burstSize);
+      TTK_FORCE_USE(neighbors);
       return 0;
 #endif
 

--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -24,13 +24,16 @@ namespace ttk {
   public:
     ArrayPreconditioning();
 
-    template <typename DT, typename GVGID, typename GVR>
+    template <typename DT, typename GVGID, typename GVR, typename GVLID>
     int processScalarArray(ttk::SimplexId *orderArray,
                            const DT *scalarArray,
                            const GVGID &getVertexGlobalId,
                            const GVR &getVertexRank,
+                           const GVLID &getVertexLocalId,
                            const size_t nVerts,
-                           const int burstSize) const { // start global timer
+                           const int burstSize,
+                           std::vector<int> neighbors
+                           = {}) const { // start global timer
       ttk::Timer globalTimer;
 
       // print horizontal separator
@@ -47,9 +50,9 @@ namespace ttk {
 // -----------------------------------------------------------------------
 #ifdef TTK_ENABLE_MPI
       if(ttk::isRunningWithMPI()) {
-        std::vector<int> neighbors{};
         ttk::produceOrdering<DT>(orderArray, scalarArray, getVertexGlobalId,
-                                 getVertexRank, nVerts, burstSize, neighbors);
+                                 getVertexRank, getVertexLocalId, nVerts,
+                                 burstSize, neighbors);
       }
 #else
       this->printMsg("MPI not enabled!");

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -266,17 +266,20 @@ namespace ttk {
    * (most likely ttk::MPIcomm_)
    * @return 0 in case of success
    */
-  template <typename DT, typename IT, typename GVGID, typename GVR>
-  int getGhostDataScalarsWithoutTriangulation(
-    DT *scalarArray,
-    const GVR &getVertexRank,
-    const GVGID &getVertexGlobalId,
-    const std::unordered_map<IT, IT> &gidToLidMap,
-    const std::vector<int> &neighbors,
-    const int rankToSend,
-    const IT nVerts,
-    MPI_Comm communicator,
-    const int dimensionNumber) {
+  template <typename DT,
+            typename IT,
+            typename GVGID,
+            typename GVR,
+            typename GVLID>
+  int getGhostDataScalarsWithoutTriangulation(DT *scalarArray,
+                                              const GVR &getVertexRank,
+                                              const GVGID &getVertexGlobalId,
+                                              const GVLID &getVertexLocalId,
+                                              const std::vector<int> &neighbors,
+                                              const int rankToSend,
+                                              const IT nVerts,
+                                              MPI_Comm communicator,
+                                              const int dimensionNumber) {
     int neighborNumber = neighbors.size();
     if(!ttk::isRunningWithMPI()) {
       return -1;
@@ -322,7 +325,7 @@ namespace ttk {
             for(int j = 0; j < dimensionNumber; j++) {
               DT receivedVal = receivedValues[i * dimensionNumber + j];
               const auto globalId = rankVectors[neighbors[r]][i];
-              IT localId = gidToLidMap.at(globalId);
+              IT localId = getVertexLocalId(globalId);
               scalarArray[localId * dimensionNumber + j] = receivedVal;
             }
           }
@@ -349,7 +352,7 @@ namespace ttk {
           for(IT i = 0; i < nValues; i++) {
             for(int j = 0; j < dimensionNumber; j++) {
               IT globalId = receivedIds[i];
-              IT localId = gidToLidMap.at(globalId);
+              IT localId = getVertexLocalId(globalId);
               valuesToSend[i * dimensionNumber + j]
                 = scalarArray[localId * dimensionNumber + j];
             }
@@ -539,23 +542,26 @@ namespace ttk {
      * (most likely ttk::MPIcomm_)
      * @return 0 in case of success
      */
-  template <typename DT, typename IT, typename GVGID, typename GVR>
-  int exchangeGhostDataWithoutTriangulation(
-    DT *scalarArray,
-    const GVR &getVertexRank,
-    const GVGID &getVertexGlobalId,
-    const std::unordered_map<IT, IT> &gidToLidMap,
-    const IT nVerts,
-    MPI_Comm communicator,
-    const std::vector<int> &neighbors,
-    const int dimensionNumber = 1) {
+  template <typename DT,
+            typename IT,
+            typename GVGID,
+            typename GVR,
+            typename GVLID>
+  int exchangeGhostDataWithoutTriangulation(DT *scalarArray,
+                                            const GVR &getVertexRank,
+                                            const GVGID &getVertexGlobalId,
+                                            const GVLID &getVertexLocalId,
+                                            const IT nVerts,
+                                            MPI_Comm communicator,
+                                            const std::vector<int> &neighbors,
+                                            const int dimensionNumber = 1) {
     if(!ttk::isRunningWithMPI()) {
       return -1;
     }
     for(int r = 0; r < ttk::MPIsize_; r++) {
       getGhostDataScalarsWithoutTriangulation(
-        scalarArray, getVertexRank, getVertexGlobalId, gidToLidMap, neighbors,
-        r, nVerts, communicator, dimensionNumber);
+        scalarArray, getVertexRank, getVertexGlobalId, getVertexLocalId,
+        neighbors, r, nVerts, communicator, dimensionNumber);
       MPI_Barrier(communicator);
     }
     return 0;
@@ -754,7 +760,8 @@ namespace ttk {
    * counting down
    * @param[in] burstSize number of values sent in one communication step
    * @param[in] MPI_IT MPI datatype representing integers
-   * @param[out] finalValues a vector of sorted structs from each rank
+   * @param[out] processedValueCounter an counter keeping track of the number
+   * of values already processed
    * @param[in, out] unsortedReceivedValues a vector of vectors representing
    * received values for each rank
    * @param[in, out] orderResendValues a vector of vectors of integers
@@ -770,7 +777,7 @@ namespace ttk {
               IT &currentOrder,
               int burstSize,
               MPI_Datatype MPI_IT,
-              std::vector<value<DT, IT>> &finalValues,
+              IT &processedValueCounter,
               std::vector<std::vector<value<DT, IT>>> &unsortedReceivedValues,
               std::vector<std::vector<IT>> &orderResendValues,
               std::vector<IT> &orderedValuesForRank,
@@ -790,8 +797,6 @@ namespace ttk {
       }
     }
 
-    // move the struct from the unsortedReceivedValues subvector to the
-    // finalValues vector to get an ordering
     value<DT, IT> currentValue
       = unsortedReceivedValues[rankIdOfMaxScalar].back();
     // we send the globalId and the the order via one send command,
@@ -800,7 +805,7 @@ namespace ttk {
     orderResendValues[rankIdOfMaxScalar].push_back(currentValue.globalId);
     orderResendValues[rankIdOfMaxScalar].push_back(currentOrder);
     currentOrder--;
-    finalValues.push_back(currentValue);
+    processedValueCounter++;
     unsortedReceivedValues[rankIdOfMaxScalar].pop_back();
     if(unsortedReceivedValues[rankIdOfMaxScalar].size() == 0) {
       if(rankIdOfMaxScalar == 0) {
@@ -843,10 +848,10 @@ namespace ttk {
    * procedure doesn't fill it completely, ghostcells are missing
    * @param[in] nThreads number of parallel threads
    */
-  template <typename IT>
+  template <typename IT, typename GVLID>
   void buildArrayForReceivedData(const size_t nInts,
                                  const IT *const orderedValuesForRank,
-                                 std::unordered_map<IT, IT> &gidToLidMap,
+                                 const GVLID &getVertexLocalId,
                                  SimplexId *const order,
                                  const int nThreads) {
 
@@ -856,7 +861,8 @@ namespace ttk {
 #pragma omp parallel for num_threads(nThreads)
 #endif // TTK_ENABLE_OPENMP
     for(size_t i = 0; i < nInts; i += 2) {
-      order[gidToLidMap[orderedValuesForRank[i]]] = orderedValuesForRank[i + 1];
+      order[getVertexLocalId(orderedValuesForRank[i])]
+        = orderedValuesForRank[i + 1];
     }
   }
 
@@ -867,7 +873,6 @@ namespace ttk {
    *
    * @param[out] valuesToSortVector vector of value structs with global ids
    * belonging to this rank
-   * @param[out] gidsToGetVector vector of global ids not belonging to this rank
    * @param[out] gidToLidMap map mapping global ids to local rank ids
    * @param[in] nVerts number of vertices
    * @param[in] scalars the scalar data array
@@ -876,19 +881,14 @@ namespace ttk {
    */
   template <typename DT, typename IT, typename GVGID, typename GVR>
   void populateVector(std::vector<value<DT, IT>> &valuesToSortVector,
-                      std::vector<IT> &gidsToGetVector,
-                      std::unordered_map<IT, IT> &gidToLidMap,
                       const size_t nVerts,
                       const DT *const scalars,
                       const GVGID &getVertexGlobalId,
                       const GVR &getVertexRank) {
     for(size_t i = 0; i < nVerts; i++) {
       IT globalId = getVertexGlobalId(i);
-      gidToLidMap[globalId] = i;
       if(getVertexRank(i) == ttk::MPIrank_) {
         valuesToSortVector.emplace_back(scalars[i], globalId);
-      } else {
-        gidsToGetVector.push_back(globalId);
       }
     }
   }
@@ -924,11 +924,12 @@ namespace ttk {
    * @param[in] nVerts number of vertices in the arrays
    * @param[in] burstSize number of values sent in one communication step
    */
-  template <typename DT, typename GVGID, typename GVR>
+  template <typename DT, typename GVGID, typename GVR, typename GVLID>
   void produceOrdering(SimplexId *orderArray,
                        const DT *scalarArray,
                        const GVGID &getVertexGlobalId,
                        const GVR &getVertexRank,
+                       const GVLID &getVertexLocalId,
                        const size_t nVerts,
                        const int burstSize,
                        std::vector<int> &neighbors) {
@@ -945,10 +946,8 @@ namespace ttk {
 
     ttk::Timer fillAndSortTimer;
     std::vector<value<DT, IT>> sortingValues;
-    std::vector<IT> gidsToGetVector;
-    std::unordered_map<IT, IT> gidToLidMap;
-    populateVector(sortingValues, gidsToGetVector, gidToLidMap, nVerts,
-                   scalarArray, getVertexGlobalId, getVertexRank);
+    populateVector(
+      sortingValues, nVerts, scalarArray, getVertexGlobalId, getVertexRank);
 
     // sort the scalar array distributed first by the scalar value itself,
     // then by the global id
@@ -959,14 +958,13 @@ namespace ttk {
     MPI_Barrier(ttk::MPIcomm_);
 
     std::vector<IT> orderedValuesForRank;
-    std::vector<value<DT, IT>> finalValues;
+    IT processedValueCounter = 0;
     ttk::Timer mergeTimer;
     IT localSize = sortingValues.size();
     IT totalSize;
     // get the complete size  of the dataset by summing up the local sizes
     MPI_Reduce(&localSize, &totalSize, 1, MPI_IT, MPI_SUM, 0, ttk::MPIcomm_);
     if(ttk::MPIrank_ == 0) {
-      finalValues.reserve(totalSize);
       IT currentOrder = totalSize - 1;
       std::vector<std::vector<value<DT, IT>>> unsortedReceivedValues;
       unsortedReceivedValues.resize(ttk::MPIsize_);
@@ -986,10 +984,10 @@ namespace ttk {
           ReceiveAndAddToVector<DT, IT>(i, structTag, unsortedReceivedValues);
         }
       }
-      while(finalValues.size() < (size_t)totalSize) {
+      while(processedValueCounter < totalSize) {
         getMax<DT, IT>(intTag, structTag, currentOrder, burstSize, MPI_IT,
-                       finalValues, unsortedReceivedValues, orderResendValues,
-                       orderedValuesForRank, sortingValues);
+                       processedValueCounter, unsortedReceivedValues,
+                       orderResendValues, orderedValuesForRank, sortingValues);
       }
 
     } else { // other Ranks
@@ -1028,13 +1026,13 @@ namespace ttk {
 
     ttk::Timer orderTimer;
     buildArrayForReceivedData<IT>(orderedValuesForRank.size(),
-                                  orderedValuesForRank.data(), gidToLidMap,
+                                  orderedValuesForRank.data(), getVertexLocalId,
                                   orderArray, ttk::globalThreadNumber_);
 
     // we receive the values at the ghostcells through the abstract
     // exchangeGhostCells method
     ttk::exchangeGhostDataWithoutTriangulation<ttk::SimplexId, IT>(
-      orderArray, getVertexRank, getVertexGlobalId, gidToLidMap, nVerts,
+      orderArray, getVertexRank, getVertexGlobalId, getVertexLocalId, nVerts,
       ttk::MPIcomm_, neighbors);
   }
 

--- a/core/base/common/MPIUtils.h
+++ b/core/base/common/MPIUtils.h
@@ -760,7 +760,7 @@ namespace ttk {
    * counting down
    * @param[in] burstSize number of values sent in one communication step
    * @param[in] MPI_IT MPI datatype representing integers
-   * @param[out] processedValueCounter an counter keeping track of the number
+   * @param[out] processedValueCounter a counter keeping track of the number
    * of values already processed
    * @param[in, out] unsortedReceivedValues a vector of vectors representing
    * received values for each rank

--- a/core/base/explicitTriangulation/ExplicitTriangulation.cpp
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.cpp
@@ -110,7 +110,8 @@ int ExplicitTriangulation::preconditionBoundaryEdgesInternal() {
       charBoundary.data(),
       [this](const SimplexId a) { return this->edgeRankArray_[a]; },
       [this](const SimplexId a) { return this->edgeLidToGid_[a]; },
-      this->edgeGidToLid_, edgeNumber, ttk::MPIcomm_, this->getNeighborRanks());
+      [this](const SimplexId a) { return this->edgeGidToLid_[a]; }, edgeNumber,
+      ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < edgeNumber; ++i) {
       boundaryEdges_[i] = (charBoundary[i] == '1');
     }
@@ -251,8 +252,8 @@ int ExplicitTriangulation::preconditionBoundaryTrianglesInternal() {
       charBoundary.data(),
       [this](const SimplexId a) { return this->triangleRankArray_[a]; },
       [this](const SimplexId a) { return this->triangleLidToGid_[a]; },
-      this->triangleGidToLid_, triangleNumber, ttk::MPIcomm_,
-      this->getNeighborRanks());
+      [this](const SimplexId a) { return this->triangleGidToLid_[a]; },
+      triangleNumber, ttk::MPIcomm_, this->getNeighborRanks());
     for(int i = 0; i < triangleNumber; ++i) {
       boundaryTriangles_[i] = (charBoundary[i] == '1');
     }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -199,6 +199,9 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
                         [triangulation](const ttk::SimplexId a) {
                           return triangulation->getVertexRank(a);
                         },
+                        [triangulation](const ttk::SimplexId a) {
+                          return triangulation->getVertexLocalId(a);
+                        },
                         nVertices, 500, neighbors)));
       } else
 #endif // TTK_ENABLE_MPI

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -1,4 +1,3 @@
-#include "DataTypes.h"
 #include <OrderDisambiguation.h>
 #include <Triangulation.h>
 #include <ttkArrayPreconditioning.h>

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -1,3 +1,4 @@
+#include "DataTypes.h"
 #include <OrderDisambiguation.h>
 #include <Triangulation.h>
 #include <ttkArrayPreconditioning.h>
@@ -55,7 +56,9 @@ int ttkArrayPreconditioning::RequestData(vtkInformation *ttkNotUsed(request),
   if(keepGoing < 2) {
     return keepGoing;
   }
-
+#ifdef TTK_ENABLE_MPI
+  const auto triangulation{this->GetTriangulation(input)};
+#endif
   output->ShallowCopy(input);
 
   auto pointData = input->GetPointData();
@@ -88,8 +91,6 @@ int ttkArrayPreconditioning::RequestData(vtkInformation *ttkNotUsed(request),
   if(ttk::isRunningWithMPI()) {
     // add the order array for every scalar array, except the ghostcells, the
     // rankarray and the global ids
-    const auto triangulation{this->GetTriangulation(input)};
-
     for(auto scalarArray : scalarArrays) {
       int status = 0;
       std::string arrayName = std::string(scalarArray->GetName());
@@ -103,17 +104,21 @@ int ttkArrayPreconditioning::RequestData(vtkInformation *ttkNotUsed(request),
         orderArray->SetNumberOfTuples(nVertices);
 
         this->printMsg(std::to_string(scalarArray->GetDataType()));
-        ttkTypeMacroA(scalarArray->GetDataType(),
-                      (status = processScalarArray(
-                         ttkUtils::GetPointer<ttk::SimplexId>(orderArray),
-                         ttkUtils::GetPointer<T0>(scalarArray),
-                         [triangulation](const ttk::SimplexId a) {
-                           return triangulation->getVertexGlobalId(a);
-                         },
-                         [triangulation](const ttk::SimplexId a) {
-                           return triangulation->getVertexRank(a);
-                         },
-                         nVertices, BurstSize)));
+        ttkTypeMacroA(
+          scalarArray->GetDataType(),
+          (status = processScalarArray(
+             ttkUtils::GetPointer<ttk::SimplexId>(orderArray),
+             ttkUtils::GetPointer<T0>(scalarArray),
+             [triangulation](const ttk::SimplexId a) {
+               return triangulation->getVertexGlobalId(a);
+             },
+             [triangulation](const ttk::SimplexId a) {
+               return triangulation->getVertexRank(a);
+             },
+             [triangulation](const ttk::SimplexId a) {
+               return triangulation->getVertexLocalId(a);
+             },
+             nVertices, BurstSize, triangulation->getNeighborRanks())));
 
         // On error cancel filter execution
         if(status != 1)


### PR DESCRIPTION
Hi all,

While working on a pipeline using a quite substantial dataset, I noticed an unreasonable growth in the memory footprint of the `ArrayPreconditioning` filter.
I looked into the code and made three changes, two small and one that has a big impact:

- I prevented the recomputation of the `gidToLidMap` variable using lambdas as it had been done for RankArrays and GlobalIds
- I prevented the recomputation of neighbors by passing it as an optionnal argument in `ProcessScalarArray`
- Here is the big one: in `produceOrdering`, the vector `finalValues` was reserved a size of `totalSize`, the size of all the points on all the processes, which defeated the purpose of the `burstSize` variable, as it would make the memory footprint on the root process grow enormously. `finalValues` was only used for its size, the elements inserted in it were never actually accessed. I therefore replaced it with a simple counter. This doesn't really change how the whole function works, but it greatly improves the size of the memory footprint, as well as the execution time. 

For a dataset of $512^3$, on 16 nodes, the memory footprint is reduced by 38% compared to before these changes.

Thanks for any feedback,