### PR TITLE
[MPI] Fix preconditionDistributedCells

### DIFF
--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3154,6 +3154,16 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
                  MPI_STATUS_IGNORE);
   }
 
+  int cellRank = 0;
+  for(LongSimplexId lcid = 0; lcid < nLocCells; ++lcid) {
+    cellRank = this->getCellRankInternal(lcid);
+    if(cellRank != ttk::MPIrank_) {
+      // store ghost cell global ids (per rank)
+      this->ghostCellsPerOwner_[cellRank].emplace_back(
+        this->getCellGlobalIdInternal(lcid));
+    }
+  }
+
   // for each rank, store the global id of local cells that are ghost cells of
   // other ranks.
   const auto MIT{ttk::getMPIType(ttk::SimplexId{})};


### PR DESCRIPTION
Hi all,

While going through the code, I noticed the attribute `ghostCellsPerOwner_` was created and later exchanged between processes to create `remoteGhostCells_`, but never actually populated, though I knew that it was at some point in the history of the code.

I traced the disappearance back to PR #888 (line 3097 in ImplicitTriangulation.cpp). The line was probably forgotten as the PR was quite substantial.

The goal of `ghostCellsPerOwner_` is to store TTK ghost cells. There is no longer need to translate from VTK to TTK cell identifiers (as it was done in #888) since the method `getCellRankInternal` does it for us.

This wasn't noticed earlier as right now, no filter uses functions that use  `ghostCellsPerOwner_`.

Thanks for any feedback,
