### PR TITLE
GitHub Actions: Use curl on Windows 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -332,9 +332,7 @@ jobs:
 
     - name: Fetch TTK-ParaView installer
       run: |
-        Invoke-WebRequest `
-        -OutFile ttk-paraview.exe `
-        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
+        curl.exe -OL https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
 
     - name: Install ParaView
       shell: cmd
@@ -343,9 +341,7 @@ jobs:
 
     - name: Fetch Visual C++ redistribuable run-time
       run: |
-        Invoke-WebRequest `
-          -OutFile vc_redist.x64.exe `
-          -Uri https://aka.ms/vs/16/release/vc_redist.x64.exe
+        curl.exe -OL https://aka.ms/vs/16/release/vc_redist.x64.exe
 
     - name: Create & configure TTK build directory
       shell: cmd
@@ -422,9 +418,7 @@ jobs:
 
     - name: Fetch TTK-ParaView installer
       run: |
-        Invoke-WebRequest `
-        -OutFile ttk-paraview.exe `
-        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
+        curl.exe -OL https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}.exe
 
     - name: Fetch TTK .exe artifact
       uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,23 +437,19 @@ jobs:
     - name: Fetch archived ccache
       continue-on-error: true
       run: |
-        Invoke-WebRequest `
-        -OutFile ttk-sccache.tar.gz `
-        -Uri https://github.com/topology-tool-kit/ttk/releases/download/ccache/ttk-sccache-windows.tar.gz
+        curl.exe -OL https://github.com/topology-tool-kit/ttk/releases/download/ccache/ttk-sccache-windows.tar.gz
 
     - name: Decompress ccache archive
       continue-on-error: true
       shell: bash
       run: |
-        tar xzf ttk-sccache.tar.gz
+        tar xzf ttk-sccache-windows.tar.gz
         mkdir -p /c/Users/runneradmin/AppData/Local/Mozilla/sccache
         mv cache /c/Users/runneradmin/AppData/Local/Mozilla/sccache
 
     - name: Fetch TTK-ParaView headless Windows installer
       run: |
-        Invoke-WebRequest `
-        -OutFile ttk-paraview-headless.exe `
-        -Uri https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.exe
+        curl.exe -OL https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless.exe
 
     - name: Install ParaView
       shell: cmd


### PR DESCRIPTION
This PR replaces the PowerShell command `Invoke-WebRequest` in Windows virtual machines with the `curl` program, which is easier to use and lead to more readable commands. Sadly, `wget` is not available on Windows VMs.

Enjoy,
Pierre