### PR TITLE
[integralLines] Fix integralLine Mask with MPI OFF

### DIFF
--- a/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
+++ b/core/vtk/ttkIntegralLines/ttkIntegralLines.cpp
@@ -176,10 +176,8 @@ int ttkIntegralLines::getTrajectories(
             // iteration
             ids[0] = ids[1];
           }
-#ifdef TTK_ENABLE_MPI
           outputMaskField->SetTuple1(
             outputMaskField->GetNumberOfTuples() - 1, 0);
-#endif
         } else {
           break;
         }


### PR DESCRIPTION
Hi all,

This PR aims at fixing the following bug: the Mask value is not correct for the critical point of the end of an integral line.
This is only true when `TTK_ENABLE_MPI` is OFF. This was due to the two deleted lines of this Pull Request. Smoothing will no longer shorten the integral line.

Thanks for any feedback,
Eve

