### PR TITLE
[MPI] Simplify order array computation

### DIFF
--- a/core/base/arrayPreconditioning/ArrayPreconditioning.h
+++ b/core/base/arrayPreconditioning/ArrayPreconditioning.h
@@ -80,6 +80,8 @@ namespace ttk {
       return 1; // return success
     }
 
+  protected:
+    bool GlobalOrder{false};
   }; // ArrayPreconditioning class
 
 } // namespace ttk

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1,4 +1,3 @@
-#include "BaseClass.h"
 #include <ImplicitTriangulation.h>
 
 #include <numeric>

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -1,3 +1,4 @@
+#include "BaseClass.h"
 #include <ImplicitTriangulation.h>
 
 #include <numeric>
@@ -3736,7 +3737,7 @@ int ttk::ImplicitTriangulation::getVertexRankInternal(
   const SimplexId lvid) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(this->neighborRanks_.empty()) {
+  if(this->neighborRanks_.empty() && ttk::MPIsize_ > 1) {
     this->printErr("Empty neighborsRanks_!");
     return -1;
   }
@@ -3762,7 +3763,7 @@ int ttk::ImplicitTriangulation::getCellRankInternal(
   const SimplexId lcid) const {
 
 #ifndef TTK_ENABLE_KAMIKAZE
-  if(this->neighborRanks_.empty()) {
+  if(this->neighborRanks_.empty() && ttk::MPIsize_ > 1) {
     this->printErr("Empty neighborsRanks_!");
     return -1;
   }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -182,10 +182,12 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       newOrderArray->SetNumberOfComponents(1);
       newOrderArray->SetNumberOfTuples(nVertices);
       std::vector<int> neighbors;
+#ifdef TTK_ENABLE_MPI
       if(ttk::hasInitializedMPI()) {
         this->MPIGhostPipelinePreconditioning(inputData);
         this->MPIPipelinePreconditioning(inputData, neighbors, nullptr);
       }
+#endif
       switch(scalarArray->GetDataType()) {
         vtkTemplateMacro(ttk::preconditionOrderArray(
           nVertices,

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -181,40 +181,18 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       newOrderArray->SetName(this->GetOrderArrayName(scalarArray).data());
       newOrderArray->SetNumberOfComponents(1);
       newOrderArray->SetNumberOfTuples(nVertices);
-#ifdef TTK_ENABLE_MPI
       std::vector<int> neighbors;
       if(ttk::hasInitializedMPI()) {
         this->MPIGhostPipelinePreconditioning(inputData);
         this->MPIPipelinePreconditioning(inputData, neighbors, nullptr);
       }
-      if(ttk::isRunningWithMPI()) {
-        const auto triangulation{this->GetTriangulation(inputData)};
-        ttkTypeMacroA(scalarArray->GetDataType(),
-                      (ttk::produceOrdering<T0>(
-                        ttkUtils::GetPointer<ttk::SimplexId>(newOrderArray),
-                        ttkUtils::GetPointer<T0>(scalarArray),
-                        [triangulation](const ttk::SimplexId a) {
-                          return triangulation->getVertexGlobalId(a);
-                        },
-                        [triangulation](const ttk::SimplexId a) {
-                          return triangulation->getVertexRank(a);
-                        },
-                        [triangulation](const ttk::SimplexId a) {
-                          return triangulation->getVertexLocalId(a);
-                        },
-                        nVertices, 500, neighbors)));
-      } else
-#endif // TTK_ENABLE_MPI
-
-      {
-        switch(scalarArray->GetDataType()) {
-          vtkTemplateMacro(ttk::preconditionOrderArray(
-            nVertices,
-            static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(scalarArray)),
-            static_cast<ttk::SimplexId *>(
-              ttkUtils::GetVoidPointer(newOrderArray)),
-            this->threadNumber_));
-        }
+      switch(scalarArray->GetDataType()) {
+        vtkTemplateMacro(ttk::preconditionOrderArray(
+          nVertices,
+          static_cast<VTK_TT *>(ttkUtils::GetVoidPointer(scalarArray)),
+          static_cast<ttk::SimplexId *>(
+            ttkUtils::GetVoidPointer(newOrderArray)),
+          this->threadNumber_));
       }
 
       // append order array temporarily to input

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.cpp
@@ -87,54 +87,53 @@ int ttkArrayPreconditioning::RequestData(vtkInformation *ttkNotUsed(request),
   }
 
 #ifdef TTK_ENABLE_MPI
-  if(ttk::isRunningWithMPI()) {
-    // add the order array for every scalar array, except the ghostcells, the
-    // rankarray and the global ids
-    for(auto scalarArray : scalarArrays) {
-      int status = 0;
-      std::string arrayName = std::string(scalarArray->GetName());
-      if(arrayName != "GlobalPointIds" && arrayName != "vtkGhostType"
-         && arrayName != "RankArray") {
-        this->printMsg("Arrayname: " + arrayName);
-        vtkNew<ttkSimplexIdTypeArray> orderArray{};
-        orderArray->SetName(
-          ttkArrayPreconditioning::GetOrderArrayName(scalarArray).data());
-        orderArray->SetNumberOfComponents(1);
-        orderArray->SetNumberOfTuples(nVertices);
+  if(GlobalOrder) {
+    if(ttk::isRunningWithMPI()) {
+      // add the order array for every scalar array, except the ghostcells, the
+      // rankarray and the global ids
+      for(auto scalarArray : scalarArrays) {
+        int status = 0;
+        std::string arrayName = std::string(scalarArray->GetName());
+        if(arrayName != "GlobalPointIds" && arrayName != "vtkGhostType"
+           && arrayName != "RankArray") {
+          this->printMsg("Arrayname: " + arrayName);
+          vtkNew<ttkSimplexIdTypeArray> orderArray{};
+          orderArray->SetName(
+            ttkArrayPreconditioning::GetOrderArrayName(scalarArray).data());
+          orderArray->SetNumberOfComponents(1);
+          orderArray->SetNumberOfTuples(nVertices);
 
-        this->printMsg(std::to_string(scalarArray->GetDataType()));
-        ttkTypeMacroA(
-          scalarArray->GetDataType(),
-          (status = processScalarArray(
-             ttkUtils::GetPointer<ttk::SimplexId>(orderArray),
-             ttkUtils::GetPointer<T0>(scalarArray),
-             [triangulation](const ttk::SimplexId a) {
-               return triangulation->getVertexGlobalId(a);
-             },
-             [triangulation](const ttk::SimplexId a) {
-               return triangulation->getVertexRank(a);
-             },
-             [triangulation](const ttk::SimplexId a) {
-               return triangulation->getVertexLocalId(a);
-             },
-             nVertices, BurstSize, triangulation->getNeighborRanks())));
+          this->printMsg(std::to_string(scalarArray->GetDataType()));
+          ttkTypeMacroA(
+            scalarArray->GetDataType(),
+            (status = processScalarArray(
+               ttkUtils::GetPointer<ttk::SimplexId>(orderArray),
+               ttkUtils::GetPointer<T0>(scalarArray),
+               [triangulation](const ttk::SimplexId a) {
+                 return triangulation->getVertexGlobalId(a);
+               },
+               [triangulation](const ttk::SimplexId a) {
+                 return triangulation->getVertexRank(a);
+               },
+               [triangulation](const ttk::SimplexId a) {
+                 return triangulation->getVertexLocalId(a);
+               },
+               nVertices, BurstSize, triangulation->getNeighborRanks())));
 
-        // On error cancel filter execution
-        if(status != 1)
-          return 0;
-        output->GetPointData()->AddArray(orderArray);
+          // On error cancel filter execution
+          if(status != 1)
+            return 0;
+          output->GetPointData()->AddArray(orderArray);
+        }
       }
+      this->printMsg("Preconditioned selected scalar arrays", 1.0,
+                     tm.getElapsedTime(), this->threadNumber_);
+      return 1;
+    } else {
+      this->printMsg("Necessary arrays are present,  TTK is built with MPI "
+                     "support, but not run with mpirun. Running sequentially.");
     }
-    this->printMsg("Preconditioned selected scalar arrays", 1.0,
-                   tm.getElapsedTime(), this->threadNumber_);
-    return 1;
-  } else {
-    this->printMsg("Necessary arrays are present,  TTK is built with MPI "
-                   "support, but not run with mpirun. Running sequentially.");
   }
-#else
-  this->printMsg("Necessary arrays are present, but TTK is not built with "
-                 "MPI support, running sequentially.");
 #endif
 
   for(auto scalarArray : scalarArrays) {

--- a/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
+++ b/core/vtk/ttkArrayPreconditioning/ttkArrayPreconditioning.h
@@ -50,6 +50,9 @@ public:
   vtkSetMacro(RegexpString, const std::string &);
   vtkGetMacro(RegexpString, std::string);
 
+  vtkSetMacro(GlobalOrder, bool);
+  vtkGetMacro(GlobalOrder, bool);
+
   // copy the vtkPassSelectedArray ("PassArrays" filter) API
   vtkDataArraySelection *GetPointDataArraySelection() {
     return this->ArraySelection;

--- a/paraview/xmls/ArrayPreconditioning.xml
+++ b/paraview/xmls/ArrayPreconditioning.xml
@@ -86,6 +86,20 @@
                 <Documentation>Controls how many elements are sent from the ranks at once.</Documentation>
       </IntVectorProperty>
 
+      <IntVectorProperty name="GlobalOrder"
+        label="Global Order Array"
+        command="SetGlobalOrder"
+        number_of_elements="1"
+        default_values="0"
+        panel_visibility="advanced">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+        Request a global order array. By default, order arrays are computed locally on each process.
+        This forces the filter to compute an order for all processes. 
+        It is a costly and sometimes unnecessary computation. Requires MPI to have an effect. 
+        </Documentation>
+      </IntVectorProperty>      
+
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input Options">


### PR DESCRIPTION
Hi all,

The current `ArrayPreconditioning` filter computes an order array for all process. This means that if vertex `v` has an order value of $n$, then this vertex is the $n^{th}$ vertex for all processes. This computation requires to do a parallel sort, which is quite costly and often unnecessary in our use cases. 

The choice is made in this PR to switch to local sorting: each process will compute a local order array. By default, `ttkAlgorithm` will trigger the computation of local order arrays.

Similarly, the filter `ArrayPreconditioning` will now by default compute order arrays locally. However, the code for global order array computation is kept in TTK and can be called in this filter by checking the option `Global Order`.

A small fix for a bug in the `ImplicitTriangulation` on one process is also made here.

Thanks for any feedback,
Eve