### PR TITLE
[MergeTree*] Clean and optimize code

### DIFF
--- a/core/base/mergeTreeClustering/MergeTreeClustering.h
+++ b/core/base/mergeTreeClustering/MergeTreeClustering.h
@@ -399,12 +399,8 @@ namespace ttk {
                           std::vector<ftm::FTMTree_MT *> &trees2,
                           std::vector<ftm::MergeTree<dataType>> &centroids2) {
       oldBestCentroid_ = bestCentroid_;
-      if(normalizedWasserstein_ and rescaledWasserstein_)
-        assignmentCentroidsNaive<dataType>(
-          trees, centroids, assignmentC, bestDistanceT, trees2, centroids2);
-      else
-        assignmentCentroidsAccelerated<dataType>(
-          trees, centroids, assignmentC, bestDistanceT, trees2, centroids2);
+      assignmentCentroidsAccelerated<dataType>(
+        trees, centroids, assignmentC, bestDistanceT, trees2, centroids2);
     }
 
     template <class dataType>
@@ -617,11 +613,8 @@ namespace ttk {
         &finalMatchings) {
       MergeTreeBarycenter mergeTreeBary;
       mergeTreeBary.setDebugLevel(std::min(debugLevel_, 2));
-      mergeTreeBary.setProgressiveComputation(false);
       mergeTreeBary.setBranchDecomposition(true);
       mergeTreeBary.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeBary.setNormalizedWassersteinReg(normalizedWassersteinReg_);
-      mergeTreeBary.setRescaledWasserstein(rescaledWasserstein_);
       mergeTreeBary.setKeepSubtree(keepSubtree_);
       mergeTreeBary.setAssignmentSolver(assignmentSolverID_);
       mergeTreeBary.setIsCalled(true);

--- a/core/base/mergeTreeClustering/MergeTreeUtils.h
+++ b/core/base/mergeTreeClustering/MergeTreeUtils.h
@@ -26,7 +26,6 @@ namespace ttk {
   // --------------------
   // Normalized Wasserstein
   // --------------------
-
   template <class dataType>
   dataType getMinMaxLocal(ftm::FTMTree_MT *tree,
                           ftm::idNode nodeId,
@@ -72,6 +71,8 @@ namespace ttk {
     double death = std::get<1>(birthDeath);
     dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
     dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
+    if((shiftMax - shiftMin) == 0)
+      return std::make_tuple(0, 0);
     birth = (newMax - newMin) * (birth - shiftMin)
             / (shiftMax - shiftMin); // + newMin;
     death = (newMax - newMin) * (death - shiftMin)
@@ -90,6 +91,8 @@ namespace ttk {
     dataType death = std::get<1>(birthDeath);
     dataType shiftMin = getMinMaxLocal<dataType>(tree, nodeId);
     dataType shiftMax = getMinMaxLocal<dataType>(tree, nodeId, false);
+    if((shiftMax - shiftMin) == 0)
+      return std::make_tuple(0, 0);
     birth = (newMax - newMin) * (birth - shiftMin)
             / (shiftMax - shiftMin); // + newMin;
     death = (newMax - newMin) * (death - shiftMin)
@@ -97,31 +100,11 @@ namespace ttk {
     return std::make_tuple(birth, death);
   }
 
-  // --------------------
-  // Rescaled Wasserstein (old)
-  // --------------------
-
   template <class dataType>
-  std::tuple<dataType, dataType> getNewMinMax(ftm::FTMTree_MT *tree1,
-                                              ftm::idNode nodeId1,
-                                              ftm::FTMTree_MT *tree2,
-                                              ftm::idNode nodeId2) {
-    dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
-    dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
-    dataType shiftMin2 = getMinMaxLocal<dataType>(tree2, nodeId2);
-    dataType shiftMax2 = getMinMaxLocal<dataType>(tree2, nodeId2, false);
-    return std::make_tuple(
-      (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
-  }
-
-  template <class dataType>
-  std::tuple<dataType, dataType> getRescaledBirthDeath(ftm::FTMTree_MT *tree1,
-                                                       ftm::idNode nodeId1,
-                                                       ftm::FTMTree_MT *tree2,
-                                                       ftm::idNode nodeId2) {
-    auto newMinMax = getNewMinMax<dataType>(tree1, nodeId1, tree2, nodeId2);
-    return getNormalizedBirthDeath<dataType>(
-      tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
+  std::tuple<dataType, dataType> getParametrizedBirthDeath(
+    ftm::FTMTree_MT *tree, ftm::idNode node, bool normalize) {
+    return normalize ? getNormalizedBirthDeath<dataType>(tree, node)
+                     : tree->getBirthDeath<dataType>(node);
   }
 
   template <class dataType>
@@ -144,48 +127,6 @@ namespace ttk {
     }
 
     return getMin ? birth : death;
-  }
-
-  template <class dataType>
-  std::tuple<dataType, dataType>
-    getMinMaxLocalFromVectorT(ftm::FTMTree_MT *tree,
-                              ftm::idNode nodeId,
-                              std::vector<dataType> &scalarsVector) {
-    dataType min
-      = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector);
-    dataType max
-      = getMinMaxLocalFromVector<dataType>(tree, nodeId, scalarsVector, false);
-    return std::make_tuple(min, max);
-  }
-
-  template <class dataType>
-  std::tuple<dataType, dataType>
-    getNewMinMaxFromVector(ftm::FTMTree_MT *tree1,
-                           ftm::idNode nodeId1,
-                           ftm::FTMTree_MT *tree2,
-                           ftm::idNode nodeId2,
-                           std::vector<dataType> &scalarsVector) {
-    dataType shiftMin1 = getMinMaxLocal<dataType>(tree1, nodeId1);
-    dataType shiftMax1 = getMinMaxLocal<dataType>(tree1, nodeId1, false);
-    dataType shiftMin2
-      = getMinMaxLocalFromVector<dataType>(tree2, nodeId2, scalarsVector);
-    dataType shiftMax2 = getMinMaxLocalFromVector<dataType>(
-      tree2, nodeId2, scalarsVector, false);
-    return std::make_tuple(
-      (shiftMin1 + shiftMin2) / 2.0, (shiftMax1 + shiftMax2) / 2.0);
-  }
-
-  template <class dataType>
-  std::tuple<dataType, dataType>
-    getRescaledBirthDeathFromVector(ftm::FTMTree_MT *tree1,
-                                    ftm::idNode nodeId1,
-                                    ftm::FTMTree_MT *tree2,
-                                    ftm::idNode nodeId2,
-                                    std::vector<dataType> &scalarsVector) {
-    auto newMinMax = getNewMinMaxFromVector<dataType>(
-      tree1, nodeId1, tree2, nodeId2, scalarsVector);
-    return getNormalizedBirthDeath<dataType>(
-      tree1, nodeId1, std::get<0>(newMinMax), std::get<1>(newMinMax));
   }
 
   // --------------------

--- a/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
+++ b/core/base/mergeTreeDistanceMatrix/MergeTreeDistanceMatrix.h
@@ -145,7 +145,6 @@ namespace ttk {
             stream << i << " / " << distanceMatrix.size();
             printMsg(stream.str());
           }
-
           distanceMatrix[i][i] = 0.0;
           for(unsigned int j = i + 1; j < distanceMatrix[0].size(); ++j) {
             // Execute
@@ -158,8 +157,6 @@ namespace ttk {
               mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
               mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
               mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
-              mergeTreeDistance.setProgressiveComputation(
-                progressiveComputation_);
               mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
               mergeTreeDistance.setParallelize(parallelize_);
               mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
@@ -167,9 +164,6 @@ namespace ttk {
               mergeTreeDistance.setThreadNumber(this->threadNumber_);
               mergeTreeDistance.setNormalizedWasserstein(
                 normalizedWasserstein_);
-              mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
-              mergeTreeDistance.setNormalizedWassersteinReg(
-                normalizedWassersteinReg_);
               mergeTreeDistance.setKeepSubtree(keepSubtree_);
               mergeTreeDistance.setDistanceSquaredRoot(distanceSquaredRoot_);
               mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);

--- a/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
+++ b/core/base/mergeTreeTemporalReductionDecoding/MergeTreeTemporalReductionDecoding.h
@@ -53,13 +53,10 @@ namespace ttk {
       mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
       mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
       mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
-      mergeTreeDistance.setProgressiveComputation(progressiveComputation_);
       mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
       mergeTreeDistance.setParallelize(parallelize_);
       mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
       mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeDistance.setNormalizedWassersteinReg(normalizedWassersteinReg_);
-      mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
       mergeTreeDistance.setKeepSubtree(keepSubtree_);
       mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
@@ -94,14 +91,10 @@ namespace ttk {
       mergeTreeBarycenter.setEpsilon2Tree2(epsilon2Tree2_);
       mergeTreeBarycenter.setEpsilon3Tree1(epsilon3Tree1_);
       mergeTreeBarycenter.setEpsilon3Tree2(epsilon3Tree2_);
-      mergeTreeBarycenter.setProgressiveComputation(progressiveComputation_);
       mergeTreeBarycenter.setBranchDecomposition(branchDecomposition_);
       mergeTreeBarycenter.setParallelize(parallelize_);
       mergeTreeBarycenter.setPersistenceThreshold(persistenceThreshold_);
       mergeTreeBarycenter.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeBarycenter.setNormalizedWassersteinReg(
-        normalizedWassersteinReg_);
-      mergeTreeBarycenter.setRescaledWasserstein(rescaledWasserstein_);
       mergeTreeBarycenter.setKeepSubtree(keepSubtree_);
       mergeTreeBarycenter.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeBarycenter.setThreadNumber(this->threadNumber_);

--- a/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
+++ b/core/base/mergeTreeTemporalReductionEncoding/MergeTreeTemporalReductionEncoding.h
@@ -99,13 +99,10 @@ namespace ttk {
       mergeTreeDistance.setEpsilon2Tree2(epsilon2Tree2_);
       mergeTreeDistance.setEpsilon3Tree1(epsilon3Tree1_);
       mergeTreeDistance.setEpsilon3Tree2(epsilon3Tree2_);
-      mergeTreeDistance.setProgressiveComputation(progressiveComputation_);
       mergeTreeDistance.setBranchDecomposition(branchDecomposition_);
       mergeTreeDistance.setParallelize(parallelize_);
       mergeTreeDistance.setPersistenceThreshold(persistenceThreshold_);
       mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeDistance.setNormalizedWassersteinReg(normalizedWassersteinReg_);
-      mergeTreeDistance.setRescaledWasserstein(rescaledWasserstein_);
       mergeTreeDistance.setKeepSubtree(keepSubtree_);
       mergeTreeDistance.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeDistance.setThreadNumber(this->threadNumber_);
@@ -135,14 +132,10 @@ namespace ttk {
       mergeTreeBarycenter.setEpsilon2Tree2(epsilon2Tree2_);
       mergeTreeBarycenter.setEpsilon3Tree1(epsilon3Tree1_);
       mergeTreeBarycenter.setEpsilon3Tree2(epsilon3Tree2_);
-      mergeTreeBarycenter.setProgressiveComputation(progressiveComputation_);
       mergeTreeBarycenter.setBranchDecomposition(branchDecomposition_);
       mergeTreeBarycenter.setParallelize(parallelize_);
       mergeTreeBarycenter.setPersistenceThreshold(persistenceThreshold_);
       mergeTreeBarycenter.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeBarycenter.setNormalizedWassersteinReg(
-        normalizedWassersteinReg_);
-      mergeTreeBarycenter.setRescaledWasserstein(rescaledWasserstein_);
       mergeTreeBarycenter.setKeepSubtree(keepSubtree_);
       mergeTreeBarycenter.setUseMinMaxPair(useMinMaxPair_);
       mergeTreeBarycenter.setThreadNumber(this->threadNumber_);


### PR DESCRIPTION
This PR cleans and optimizes the code related to merge tree classes like distance, barycenter and clustering.

- Regarding cleaning:
  - It removes the "rescaled Wasserstein" option, it was an attempt to alleviate the normalization by rescaling using the values of the other tree (when computing a distance). Unfortunately this is not a metric, the option is not here anymore on the ParaView GUI and it was never really used so I think it makes sense to remove it.
  - It removes the "Normalized Wasserstein regularizer", another attempt to alleviate normalization. With the same arguments than before I think it should be removed.
  - It removes the attempt to progressively compute the distance between merge trees, the corresponding code related to progressivity is not even in TTK but some variables and condition still remains in the code that I think should be removed.

- Regarding optimization:
  - Fix an implicit conversion between float and double that could cause a round-off error hence a non determinism depending on the machine executing the code.
  - Merge tree distance now call the exhaustive solver when the assignment problem is small and have few combinations to test.
  - Some mathematical terms were removed in the Wasserstein distance compared to the classical edit distance (that uses the minimum of three terms for computing distance between trees and between forests). Even if the Wasserstein distance does not use these terms, they were still computed, this PR avoid the computation of these terms when the Wasserstein distance backend is choosen.

- Regarding new features:
  - Prepare the code for the "Convert to diagram" option, that convert the merge trees given in input of the filter to diagrams. It allows the user to give merge trees and ask to consider them as diagrams hence having diagrams visualization instead of merge trees visualisation. It is particularly useful to have the same pipeline and just change an option to switch between diagrams and merge trees computation and visualization (before this PR we could only give merge trees or persistence diagrams, and not convert merge trees to persistence diagrams).
  - It fixes the persistence thresholding of merge trees. From a pure practical point of view, a BDT should contains at least two nodes (to have at least one edge), so we need to keep at least two persistence pairs. If there is only one non-zero persistence pair we need to add a "dummy" persistence pair with zero persistence (that will be matched to the diagonal with zero cost when computing a distance). It is a very special case.