### PR TITLE
[PersistenceDiagramClustering] Auction lower bound trick

### DIFF
--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
@@ -117,7 +117,6 @@ double ttk::PersistenceDiagramAuction::initLowerBoundCost(const int kdt_index) {
     bool use_kdt = use_kdt_;
 
     // Get closest good
-    int bestIndex = std::numeric_limits<int>::max();
     double bestCost = std::numeric_limits<double>::max();
     std::vector<KDT *> neighbours;
     std::vector<double> costs;
@@ -125,17 +124,15 @@ double ttk::PersistenceDiagramAuction::initLowerBoundCost(const int kdt_index) {
       std::array<double, 5> coordinates;
       bidders_[i].GetKDTCoordinates(geometricalFactor_, coordinates);
       kdt_.getKClosest(1, coordinates, neighbours, costs, kdt_index);
-      bestIndex = neighbours[0]->id_;
+      int bestIndex = neighbours[0]->id_;
       bestCost
         = bidders_[i].cost(goods_[bestIndex], wasserstein_, geometricalFactor_);
     } else {
       for(unsigned int j = 0; j < goods_.size(); ++j) {
         double cost
           = bidders_[i].cost(goods_[j], wasserstein_, geometricalFactor_);
-        if(cost < bestCost) {
+        if(cost < bestCost)
           bestCost = cost;
-          bestIndex = j;
-        }
       }
     }
 
@@ -143,10 +140,8 @@ double ttk::PersistenceDiagramAuction::initLowerBoundCost(const int kdt_index) {
     Good g{bidders_[i].x_, bidders_[i].y_, true, -bidders_[i].id_ - 1};
     g.projectOnDiagonal();
     double cost = bidders_[i].cost(g, wasserstein_, geometricalFactor_);
-    if(cost < bestCost) {
+    if(cost < bestCost)
       bestCost = cost;
-      bestIndex = -1;
-    }
 
     // Update lower bound
     lowerBoundCost_ += bestCost;

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
@@ -108,8 +108,56 @@ double ttk::PersistenceDiagramAuction::getMatchingsAndDistance(
   return wassersteinDistance;
 }
 
-double
-  ttk::PersistenceDiagramAuction::run(std::vector<MatchingType> &matchings) {
+double ttk::PersistenceDiagramAuction::initLowerBoundCost(const int kdt_index) {
+  lowerBoundCost_ = 0;
+  for(unsigned int i = 0; i < bidders_.size(); ++i) {
+    if(bidders_[i].isDiagonal())
+      continue;
+
+    bool use_kdt = use_kdt_;
+
+    // Get closest good
+    int bestIndex = std::numeric_limits<int>::max();
+    double bestCost = std::numeric_limits<double>::max();
+    std::vector<KDT *> neighbours;
+    std::vector<double> costs;
+    if(use_kdt) {
+      std::array<double, 5> coordinates;
+      bidders_[i].GetKDTCoordinates(geometricalFactor_, coordinates);
+      kdt_.getKClosest(1, coordinates, neighbours, costs, kdt_index);
+      bestIndex = neighbours[0]->id_;
+      bestCost
+        = bidders_[i].cost(goods_[bestIndex], wasserstein_, geometricalFactor_);
+    } else {
+      for(unsigned int j = 0; j < goods_.size(); ++j) {
+        double cost
+          = bidders_[i].cost(goods_[j], wasserstein_, geometricalFactor_);
+        if(cost < bestCost) {
+          bestCost = cost;
+          bestIndex = j;
+        }
+      }
+    }
+
+    // Compare with diagonal good
+    Good g{bidders_[i].x_, bidders_[i].y_, true, -bidders_[i].id_ - 1};
+    g.projectOnDiagonal();
+    double cost = bidders_[i].cost(g, wasserstein_, geometricalFactor_);
+    if(cost < bestCost) {
+      bestCost = cost;
+      bestIndex = -1;
+    }
+
+    // Update lower bound
+    lowerBoundCost_ += bestCost;
+  }
+  return lowerBoundCost_;
+}
+
+double ttk::PersistenceDiagramAuction::run(std::vector<MatchingType> &matchings,
+                                           const int kdt_index) {
+  initLowerBoundCostWeight(delta_lim_);
+  initLowerBoundCost(kdt_index);
   initializeEpsilon();
   int n_biddings = 0;
   double delta = 5;
@@ -117,7 +165,7 @@ double
     epsilon_ /= 5;
     this->buildUnassignedBidders();
     this->reinitializeGoods();
-    this->runAuctionRound(n_biddings);
+    this->runAuctionRound(n_biddings, kdt_index);
     delta = this->getRelativePrecision();
   }
   double wassersteinDistance = this->getMatchingsAndDistance(matchings, true);
@@ -454,14 +502,8 @@ int ttk::Bidder::runKDTBidding(GoodDiagram *goods,
   std::vector<KDT *> neighbours;
   std::vector<double> costs;
 
-  std::array<double, 5> coordinates{
-    geometricalFactor * this->x_, geometricalFactor * this->y_, 0.0, 0.0, 0.0,
-  };
-  if(geometricalFactor < 1) {
-    coordinates[2] = (1 - geometricalFactor) * this->coords_[0];
-    coordinates[3] = (1 - geometricalFactor) * this->coords_[1];
-    coordinates[4] = (1 - geometricalFactor) * this->coords_[2];
-  }
+  std::array<double, 5> coordinates;
+  GetKDTCoordinates(geometricalFactor, coordinates);
 
   kdt->getKClosest(2, coordinates, neighbours, costs, kdt_index);
   double best_val, second_val;

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
@@ -20,6 +20,12 @@ namespace ttk {
     std::vector<KDT *> &correspondence_kdt_map_{
       default_correspondence_kdt_map_};
 
+    inline void initLowerBoundCostWeight(double delta_lim) {
+      lowerBoundCostWeight_ = 1 + delta_lim;
+    }
+
+    double initLowerBoundCost(const int kdt_index = 0);
+
     PersistenceDiagramAuction(int wasserstein,
                               double geometricalFactor,
                               double lambda,
@@ -81,7 +87,7 @@ namespace ttk {
     void runAuctionRound(int &n_biddings, const int kdt_index = 0);
     double getMatchingsAndDistance(std::vector<MatchingType> &matchings,
                                    bool get_diagonal_matches = false);
-    double run(std::vector<MatchingType> &matchings);
+    double run(std::vector<MatchingType> &matchings, const int kdt_index = 0);
     double run() {
       std::vector<MatchingType> matchings{};
       return this->run(matchings);
@@ -241,7 +247,7 @@ namespace ttk {
 
     double getRelativePrecision() {
       double d = this->getMatchingDistance();
-      if(d < 1e-12) {
+      if(d < 1e-6 or d <= (lowerBoundCost_ * lowerBoundCostWeight_)) {
         return 0;
       }
       double denominator = d - bidders_.size() * epsilon_;
@@ -298,6 +304,7 @@ namespace ttk {
     // pair sad-max) lambda = 0 : saddle (bad stability) lambda = 1/2 : middle
     // of the 2 critical points of the pair
     double delta_lim_{};
+    double lowerBoundCost_, lowerBoundCostWeight_;
     bool use_kdt_{true};
 
   }; // namespace ttk

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuctionActor.h
@@ -44,6 +44,21 @@ namespace ttk {
       return this->coords_;
     }
 
+    void GetKDTCoordinates(double geometricalFactor,
+                           std::array<double, 5> &coordinates) const {
+      coordinates[0] = geometricalFactor * this->x_;
+      coordinates[1] = geometricalFactor * this->y_;
+      if(geometricalFactor < 1) {
+        coordinates[2] = (1 - geometricalFactor) * this->coords_[0];
+        coordinates[3] = (1 - geometricalFactor) * this->coords_[1];
+        coordinates[4] = (1 - geometricalFactor) * this->coords_[2];
+      } else {
+        coordinates[2] = 0;
+        coordinates[3] = 0;
+        coordinates[4] = 0;
+      }
+    }
+
     void projectOnDiagonal() {
       x_ = (x_ + y_) / 2;
       y_ = x_;

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -83,10 +83,10 @@ void ttk::PDBarycenter::runMatchingAuction(
   for(int i = 0; i < numberOfInputs_; i++) {
     PersistenceDiagramAuction auction(
       current_bidder_diagrams_[i], barycenter_goods_[i], wasserstein_,
-      geometrical_factor_, lambda_, 0.01, kdt, correspondence_kdt_map,
+      geometrical_factor_, lambda_, 0.01, kdt, correspondence_kdt_map, 0,
       (*min_diag_price)[i], use_kdt);
     std::vector<MatchingType> matchings;
-    double cost = auction.run(matchings);
+    double cost = auction.run(matchings, i);
     all_matchings->at(i) = matchings;
 
     (*total_cost) += cost * cost;

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
@@ -73,7 +73,7 @@ void ttk::PersistenceDiagramBarycenter::execute(
   std::vector<std::vector<MatchingType>> matching_min, matching_sad,
     matching_max;
 
-  double total_cost = 0;
+  double total_cost = 0, min_cost = 0, sad_cost = 0, max_cost = 0;
   /*omp_set_num_threads(1);
   #ifdef TTK_ENABLE_OPENMP
   #pragma omp parallel sections
@@ -101,7 +101,8 @@ void ttk::PersistenceDiagramBarycenter::execute(
     bary_min.setReinitPrices(reinit_prices_);
     bary_min.setDiagrams(&data_min);
     matching_min = bary_min.execute(barycenter_min);
-    total_cost += bary_min.getCost();
+    min_cost = bary_min.getCost();
+    total_cost += min_cost;
   }
   /*}
 
@@ -127,7 +128,8 @@ void ttk::PersistenceDiagramBarycenter::execute(
     bary_sad.setReinitPrices(reinit_prices_);
     bary_sad.setDiagrams(&data_sad);
     matching_sad = bary_sad.execute(barycenter_sad);
-    total_cost += bary_sad.getCost();
+    sad_cost = bary_sad.getCost();
+    total_cost += sad_cost;
   }
   /*}
 
@@ -153,7 +155,8 @@ void ttk::PersistenceDiagramBarycenter::execute(
     bary_max.setReinitPrices(reinit_prices_);
     bary_max.setDiagrams(&data_max);
     matching_max = bary_max.execute(barycenter_max);
-    total_cost += bary_max.getCost();
+    max_cost = bary_max.getCost();
+    total_cost += max_cost;
   }
   //}
   //}
@@ -271,6 +274,9 @@ void ttk::PersistenceDiagramBarycenter::execute(
     }
   }
 
-  printMsg("Total cost : " + std::to_string(total_cost));
+  printMsg("Min-saddle cost    : " + std::to_string(min_cost));
+  printMsg("Saddle-saddle cost : " + std::to_string(sad_cost));
+  printMsg("Saddle-max cost    : " + std::to_string(max_cost));
+  printMsg("Total cost         : " + std::to_string(total_cost));
   printMsg("Complete", 1, tm.getElapsedTime(), threadNumber_);
 }


### PR DESCRIPTION
This PR adds the auction lower bound trick (previously added in the cost-matrix-based Auction in #918 ) to the `PersistenceDiagramAuction` class. It also modifies classes related to persistence diagram distance, barycenter and clustering to use this feature. For now it is only added in the "Classical Auction Approach" backend and not in the progressive one.