### PR TITLE
[PersistenceDiagramClustering] lower bound trick for progressive algo

### DIFF
--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
@@ -114,13 +114,11 @@ double ttk::PersistenceDiagramAuction::initLowerBoundCost(const int kdt_index) {
     if(bidders_[i].isDiagonal())
       continue;
 
-    bool use_kdt = use_kdt_;
-
     // Get closest good
     double bestCost = std::numeric_limits<double>::max();
     std::vector<KDT *> neighbours;
     std::vector<double> costs;
-    if(use_kdt) {
+    if(use_kdt_) {
       std::array<double, 5> coordinates;
       bidders_[i].GetKDTCoordinates(geometricalFactor_, coordinates);
       kdt_.getKClosest(1, coordinates, neighbours, costs, kdt_index);

--- a/core/base/persistenceDiagramClustering/PDClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PDClustering.cpp
@@ -344,7 +344,9 @@ std::vector<int> ttk::PDClustering::execute(
         }
         converged = converged
                     || (all_diagrams_complete && !do_min_ && !do_sad_
-                        && !do_max_ && (precision_criterion_reached));
+                        && !do_max_ && (precision_criterion_reached))
+                    || (precision_criterion_reached && UseDeltaLim_
+                        && numberOfInputs_ == 2);
       }
 
       total_time


### PR DESCRIPTION
This PR adds the lower bound trick for the Auction algorithm of persistence diagrams for the progressive algorithm of the `PersistenceDiagramClustering` module.

For now it is only for 2 inputs (without progressivity) and when the option to force the precision is enabled.