### PR TITLE
[PersistenceDiagramClustering] homogenize distance accumulation between classic and progressive

### DIFF
--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -33,11 +33,12 @@ void ttk::PDBarycenter::runMatching(
   std::vector<double> *min_price,
   std::vector<std::vector<MatchingType>> *all_matchings,
   bool use_kdt,
-  int actual_distance) {
+  bool actual_distance) {
   Timer time_matchings;
 
+  double local_cost = *total_cost;
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1)
+#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1) reduction(+:local_cost)
 #endif
   for(int i = 0; i < numberOfInputs_; i++) {
     double delta_lim = 0.01;
@@ -58,9 +59,9 @@ void ttk::PDBarycenter::runMatching(
     double cost = auction.getMatchingsAndDistance(matchings, true);
     all_matchings->at(i) = matchings;
     if(actual_distance) {
-      (*total_cost) += cost;
+      local_cost += sqrt(cost);
     } else {
-      (*total_cost) += cost * cost;
+      local_cost += cost;
     }
 
     double quotient = epsilon * auction.getAugmentedNumberOfBidders() / cost;
@@ -72,6 +73,7 @@ void ttk::PDBarycenter::runMatching(
     // TODO do this inside the auction !
     current_bidder_diagrams_[i].resize(sizes[i]);
   }
+  *total_cost = local_cost;
 }
 
 void ttk::PDBarycenter::runMatchingAuction(
@@ -81,9 +83,11 @@ void ttk::PDBarycenter::runMatchingAuction(
   std::vector<KDT *> &correspondence_kdt_map,
   std::vector<double> *min_diag_price,
   std::vector<std::vector<MatchingType>> *all_matchings,
-  bool use_kdt) {
+  bool use_kdt,
+  bool actual_distance) {
+  double local_cost = *total_cost;
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1)
+#pragma omp parallel for num_threads(threadNumber_) schedule(dynamic, 1) reduction(+:local_cost)
 #endif
   for(int i = 0; i < numberOfInputs_; i++) {
     PersistenceDiagramAuction auction(
@@ -93,13 +97,18 @@ void ttk::PDBarycenter::runMatchingAuction(
     std::vector<MatchingType> matchings;
     double cost = auction.run(matchings, i);
     all_matchings->at(i) = matchings;
+    if(actual_distance) {
+      local_cost += sqrt(cost);
+    } else {
+      local_cost += cost;
+    }
 
-    (*total_cost) += cost * cost;
     // Resizes the diagram which was enrich with diagonal bidders
     // during the auction
     // TODO do this inside the auction !
     current_bidder_diagrams_[i].resize(sizes[i]);
   }
+  *total_cost = local_cost;
 }
 
 bool ttk::PDBarycenter::hasBarycenterConverged(
@@ -634,8 +643,10 @@ std::vector<std::vector<ttk::MatchingType>>
                                               diagramType_, true});
     }
 
+    bool actual_distance = (numberOfInputs_ == 2);
     runMatchingAuction(&total_cost, sizes, *pair.first, pair.second,
-                       &min_diag_price, &all_matchings, use_kdt);
+                       &min_diag_price, &all_matchings, use_kdt,
+                       actual_distance);
 
     this->printMsg("Barycenter cost : " + std::to_string(total_cost),
                    debug::Priority::DETAIL);
@@ -683,7 +694,7 @@ std::vector<std::vector<ttk::MatchingType>>
                                             diagramType_, true});
   }
 
-  cost_ = sqrt(total_cost);
+  cost_ = total_cost;
   std::vector<std::vector<MatchingType>> corrected_matchings
     = correctMatchings(previous_matchings);
   return corrected_matchings;

--- a/core/base/persistenceDiagramClustering/PDBarycenter.h
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.h
@@ -67,7 +67,7 @@ namespace ttk {
                      std::vector<double> *min_price,
                      std::vector<std::vector<MatchingType>> *all_matchings,
                      bool use_kdt,
-                     int actual_distance);
+                     bool actual_distance);
 
     void
       runMatchingAuction(double *total_cost,
@@ -76,7 +76,8 @@ namespace ttk {
                          std::vector<KDT *> &correspondence_kdt_map,
                          std::vector<double> *min_diag_price,
                          std::vector<std::vector<MatchingType>> *all_matchings,
-                         bool use_kdt);
+                         bool use_kdt,
+                         bool actual_distance);
 
     double updateBarycenter(std::vector<std::vector<MatchingType>> &matchings);
 

--- a/core/base/persistenceDiagramClustering/PDClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PDClustering.cpp
@@ -1687,7 +1687,7 @@ std::vector<double> ttk::PDClustering::updateCentroidsPosition(
 
         precision_min
           = barycenter_computer_min_[c].isPrecisionObjectiveMet(deltaLim_, 0);
-        cost_min_ += sqrt(total_cost);
+        cost_min_ += total_cost;
         Timer time_update;
         if(!only_matchings) {
           max_shift_c_min
@@ -1784,7 +1784,7 @@ std::vector<double> ttk::PDClustering::updateCentroidsPosition(
             = barycenter_computer_sad_[c].updateBarycenter(all_matchings);
         }
 
-        cost_sad_ += sqrt(total_cost);
+        cost_sad_ += total_cost;
 
         if(max_shift_c_sad > max_shift_vector[1]) {
           max_shift_vector[1] = max_shift_c_sad;
@@ -1869,7 +1869,7 @@ std::vector<double> ttk::PDClustering::updateCentroidsPosition(
         precision_max
           = barycenter_computer_max_[c].isPrecisionObjectiveMet(deltaLim_, 0);
 
-        cost_max_ += sqrt(total_cost);
+        cost_max_ += total_cost;
         Timer time_update;
         if(!only_matchings) {
           max_shift_c_max


### PR DESCRIPTION
This PR modifies how the classical approach of `PersistenceDiagramClustering` accumulates distances to be like the progressive one. Without this, both backend could display different distance values whereas having same matchings.

The problem was that the classical approach in the case of 2 inputs returned the square root of the sum of the squared distances instead of just the sum of distances.

Some minor modifications in this PR also include:
- Use of OpenMP reduction to accumulate distances, before this PR the different threads computing distances were adding to the `total_cost` variable without any safety. It seems to me that the reduction is necessary here to make these functions thread-safe.
- Change of the *meaning* of the return value of `runMatching` and `runMatchingAuction`. Before this PR, these functions returned the squared distance or the distance to the power of 4 (depending on an input parameter), then the code calling these functions square root the result (to have the distance or the squared distance). From my point of view it is better to have these functions returning directly the distance or the squared distance without having to square root the result outside these functions.