### PR TITLE
Fix GCC13 warnings

### DIFF
--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -429,6 +429,9 @@ namespace ttk {
     void alloc(const triangulationType &triangulation) {
       Timer tm{};
       const auto dim{this->dg_.getDimensionality()};
+      if(dim > 3 || dim < 1) {
+        return;
+      }
       this->firstRepMin_.resize(triangulation.getNumberOfVertices());
       if(dim > 1) {
         this->firstRepMax_.resize(triangulation.getNumberOfCells());

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -185,6 +185,10 @@ int ttkTriangulationManager::processExplicit(
   // insert cells in the output mesh
   output->Allocate(cells.size());
   const size_t dimension = triangulation.getCellVertexNumber(0);
+  if(dimension > 4 || dimension < 2) {
+    this->printErr("Dimension not supported");
+    return 0;
+  }
 
   for(unsigned int i = 0; i < cells.size(); i++) {
     std::array<vtkIdType, 4> cell{};


### PR DESCRIPTION
GCC 13 has arrived this week in ArchLinux repositories and when rebuilding TTK with it, two new warnings popped up. These warnings are linked to the use of `std::array` that are only valid up to 3D datasets (and not more).

This PR fixes these warnings by adding checks to please GCC 13.

Enjoy,
Pierre
