### PR TITLE
ImplicitTriangulation: Fix MPI 2D segfault

### DIFF
--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3115,6 +3115,9 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
       this->tetrahedronToPosition(lcid, p.data());
     } else if(this->dimensionality_ == 2) {
       this->triangleToPosition2d(lcid, p.data());
+      // compatibility with tetrahedronToPosition; fix a bounding box
+      // error in the first axis
+      p[0] /= 2;
     }
 
     // global vertex coordinates

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -415,6 +415,9 @@ int ttkAlgorithm::RequestDataObject(vtkInformation *ttkNotUsed(request),
 #ifdef TTK_ENABLE_MPI
 
 int ttkAlgorithm::updateMPICommunicator(vtkDataSet *input) {
+  if(input == nullptr) {
+    return 0;
+  }
   int isEmpty
     = input->GetNumberOfCells() == 0 || input->GetNumberOfPoints() == 0;
   int oldSize = ttk::MPIsize_;
@@ -860,7 +863,7 @@ int ttkAlgorithm::ProcessRequest(vtkInformation *request,
     this->printMsg("Processing REQUEST_DATA", ttk::debug::Priority::VERBOSE);
     this->printMsg(ttk::debug::Separator::L0);
 #ifdef TTK_ENABLE_MPI
-    if(ttk::hasInitializedMPI()) {
+    if(ttk::hasInitializedMPI() && inputVector != nullptr) {
       if(this->updateMPICommunicator(vtkDataSet::GetData(inputVector[0], 0))) {
         return 1;
       };


### PR DESCRIPTION
This PR adds a workaround when computing the 2D bounding box of an implicit triangulation. It fixes #929.

Also added are two `nullptr` checks inside `ttkAlgorithm.cpp` . Without them, I cannot open the Python state files inside `ttk-data/states` (e.g. `states/cinemaDarkroom.py`) without a segfault.

Enjoy,
Pierre
