### PR TITLE
Remove Windows-specific OpenMP directives

### DIFF
--- a/core/base/continuousScatterPlot/ContinuousScatterPlot.h
+++ b/core/base/continuousScatterPlot/ContinuousScatterPlot.h
@@ -500,25 +500,14 @@ int ttk::ContinuousScatterPlot::execute(
 
               // triangle/ray intersection below
 #ifdef TTK_ENABLE_OPENMP
-#ifdef _WIN32
-#pragma omp atomic
-#else
 #pragma omp atomic update
-#endif
 #endif
             (*density_)[i][j] += (1.0 - u - v) * density;
 
 #ifdef TTK_ENABLE_OPENMP
-#ifdef _WIN32
-#pragma omp atomic
-            (*validPointMask_)[i][j] += 1;
-#else
 #pragma omp atomic write
-            (*validPointMask_)[i][j] = 1;
 #endif
-#else
             (*validPointMask_)[i][j] = 1;
-#endif
             break;
           }
         }

--- a/core/base/uncertainDataEstimator/UncertainDataEstimator.cpp
+++ b/core/base/uncertainDataEstimator/UncertainDataEstimator.cpp
@@ -10,12 +10,8 @@ void ttk::PDFHistograms::getVertexHistogram(
   histogram.resize(numberOfBins_);
   if(vertexId < numberOfVertices_) {
 #ifdef TTK_ENABLE_OPENMP
-#ifdef _WIN32
-#pragma omp parallel for num_threads(threadNumber_)
-#else
 #pragma omp parallel for num_threads(threadNumber_) \
   schedule(static, numberOfBins_ / threadNumber_)
-#endif
 #endif
     for(int i = 0; i < (int)numberOfBins_; i++) {
       if((SimplexId)probability_[i].size() == numberOfVertices_) {
@@ -32,12 +28,8 @@ void ttk::PDFHistograms::getVertexHistogram(
 void ttk::PDFHistograms::normalize() {
   const double normalization = 1.0 / static_cast<double>(numberOfInputs_);
 #ifdef TTK_ENABLE_OPENMP
-#ifdef _WIN32
-#pragma omp parallel for num_threads(threadNumber_)
-#else
 #pragma omp parallel for num_threads(threadNumber_) collapse(2) \
   schedule(static, (numberOfBins_ * numberOfVertices_) / threadNumber_)
-#endif
 #endif
   for(int i = 0; i < numberOfBins_; i++) {
     for(SimplexId j = 0; j < numberOfVertices_; j++) {


### PR DESCRIPTION
This PR removes old Windows-specific OpenMP directives in the `ContinuousScatterPlot` and `UncertainDataEstimator` modules. These directives should be useless now since with the `clang-cl` frontend, OpenMP is fully supported on Windows. Removing these directives unifies the OpenMP usage in these modules and reduces the Windows-specific code.

In the `ttk-data` repository, the `python/builtInExample2.py` Python script should be the only one affected by this change. The ValidPointMask array values should now be identical between Windows and Linux/macOS. I will do a PR on ttk-data that updates the hashes later.

Enjoy,
Pierre

