### PR TITLE
[MPI] ImplicitTriangulation: Fixes for Cell IDs in 2D

### DIFF
--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3115,9 +3115,6 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
       this->tetrahedronToPosition(lcid, p.data());
     } else if(this->dimensionality_ == 2) {
       this->triangleToPosition2d(lcid, p.data());
-      // compatibility with tetrahedronToPosition; fix a bounding box
-      // error in the first axis
-      p[0] /= 2;
     }
 
     // global vertex coordinates

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3115,6 +3115,7 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
       this->tetrahedronToPosition(lcid, p.data());
     } else if(this->dimensionality_ == 2) {
       this->triangleToPosition2d(lcid, p.data());
+      p[0] /= 2;
     }
 
     // global vertex coordinates
@@ -3480,6 +3481,7 @@ SimplexId ttk::ImplicitTriangulation::getCellGlobalIdInternal(
     this->tetrahedronToPosition(lcid, p.data());
   } else if(this->dimensionality_ == 2) {
     this->triangleToPosition2d(lcid, p.data());
+    p[0] /= 2;
   }
 
   // global cube coordinates
@@ -3520,6 +3522,7 @@ SimplexId ttk::ImplicitTriangulation::getCellLocalIdInternal(
     this->metaGrid_->tetrahedronToPosition(gcid, p.data());
   } else if(this->dimensionality_ == 2) {
     this->metaGrid_->triangleToPosition2d(gcid, p.data());
+    p[0] /= 2;
   }
 
   // local cube coordinates

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -3115,6 +3115,8 @@ int ttk::ImplicitTriangulation::preconditionDistributedCells() {
       this->tetrahedronToPosition(lcid, p.data());
     } else if(this->dimensionality_ == 2) {
       this->triangleToPosition2d(lcid, p.data());
+      // compatibility with tetrahedronToPosition; fix a bounding box
+      // error in the first axis
       p[0] /= 2;
     }
 
@@ -3481,6 +3483,8 @@ SimplexId ttk::ImplicitTriangulation::getCellGlobalIdInternal(
     this->tetrahedronToPosition(lcid, p.data());
   } else if(this->dimensionality_ == 2) {
     this->triangleToPosition2d(lcid, p.data());
+    // compatibility with tetrahedronToPosition; fix a bounding box
+    // error in the first axis
     p[0] /= 2;
   }
 
@@ -3522,6 +3526,8 @@ SimplexId ttk::ImplicitTriangulation::getCellLocalIdInternal(
     this->metaGrid_->tetrahedronToPosition(gcid, p.data());
   } else if(this->dimensionality_ == 2) {
     this->metaGrid_->triangleToPosition2d(gcid, p.data());
+    // compatibility with tetrahedronToPosition; fix a bounding box
+    // error in the first axis
     p[0] /= 2;
   }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -1082,7 +1082,7 @@ inline void
                                                    SimplexId p[2]) const {
   // compatibility with tetrahedronToPosition; fix a bounding box
   // error in the first axis
-  p[0] = (triangle % tshift_[0]) / 2;
+  p[0] = triangle % tshift_[0];
   p[1] = triangle / tshift_[0];
 }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -1080,7 +1080,9 @@ inline void ttk::ImplicitTriangulation::edgeToPosition2d(const SimplexId edge,
 inline void
   ttk::ImplicitTriangulation::triangleToPosition2d(const SimplexId triangle,
                                                    SimplexId p[2]) const {
-  p[0] = triangle % tshift_[0];
+  // compatibility with tetrahedronToPosition; fix a bounding box
+  // error in the first axis
+  p[0] = (triangle % tshift_[0]) / 2;
   p[1] = triangle / tshift_[0];
 }
 

--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -1080,8 +1080,6 @@ inline void ttk::ImplicitTriangulation::edgeToPosition2d(const SimplexId edge,
 inline void
   ttk::ImplicitTriangulation::triangleToPosition2d(const SimplexId triangle,
                                                    SimplexId p[2]) const {
-  // compatibility with tetrahedronToPosition; fix a bounding box
-  // error in the first axis
   p[0] = triangle % tshift_[0];
   p[1] = triangle / tshift_[0];
 }


### PR DESCRIPTION
As an extension of #933 , this PR moves the division to `triangleToPosition2d` itself, to fix some lingering issues with global / local cell id computation.