### PR TITLE
[ProjectionFromTable] fix array size

### DIFF
--- a/core/base/projectionFromTable/ProjectionFromTable.h
+++ b/core/base/projectionFromTable/ProjectionFromTable.h
@@ -68,8 +68,9 @@ namespace ttk {
         }
 
         // Find barycentric coordinates
-        std::array<double, 2> tableValues{static_cast<double>(tableXValues[i]),
-                                          static_cast<double>(tableYValues[i])};
+        std::array<double, 3> tableValues{static_cast<double>(tableXValues[i]),
+                                          static_cast<double>(tableYValues[i]),
+                                          0};
         std::array<std::array<double, 3>, 3> trianglePoints;
         std::array<int, 3> indexes;
         std::array<double, 2> mid{(points[3][0] - points[1][0]) / 2.0,
@@ -90,9 +91,11 @@ namespace ttk {
             indexes[2] = 3;
         }
 
-        for(unsigned int j = 0; j < 3; ++j)
+        for(unsigned int j = 0; j < 3; ++j) {
           for(unsigned int k = 0; k < 2; ++k)
             trianglePoints[j][k] = points[indexes[j]][k];
+          trianglePoints[j][2] = 0;
+        }
 
         Geometry::computeTriangleArea(
           tableValues.data(), trianglePoints[0].data(),


### PR DESCRIPTION
This PR fixes an _out of bound_ access in `ProjectionFromTable` that can lead to non-determinism (due to accessing non-initialized values in the memory).

The problem was that the array `tableValues` had a size of 2 and then the pointer to its data was given to `computeTriangleArea` from `Geometry` that assume size 3, hence accessing something out of the array for the last index.