### PR TITLE
Restrict input domain to point data for persistence diagram filters

### DIFF
--- a/paraview/xmls/PersistenceDiagram.xml
+++ b/paraview/xmls/PersistenceDiagram.xml
@@ -154,7 +154,7 @@
         <DataTypeDomain name="input_type">
           <DataType value="vtkDataSet"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
+        <InputArrayDomain name="input_scalars" attribute_type="point" number_of_components="1">
           <Property name="Input" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>

--- a/paraview/xmls/PersistenceDiagramApproximation.xml
+++ b/paraview/xmls/PersistenceDiagramApproximation.xml
@@ -45,7 +45,7 @@
         <DataTypeDomain name="input_type">
           <DataType value="vtkImageData"/>
         </DataTypeDomain>
-        <InputArrayDomain name="input_scalars" number_of_components="1">
+        <InputArrayDomain name="input_scalars" attribute_type="point" number_of_components="1">
           <Property name="Input" function="FieldDataSelection" />
         </InputArrayDomain>
         <Documentation>


### PR DESCRIPTION
Dear Julien,

This PR restrict the input domain of persistence diagram filters to point data.
Without this change, we can call these filters with unsupported cell data input, leading to undefined behavior.

Best,  
Charles
