### PR TITLE
Path compression

### DIFF
--- a/core/base/pathCompression/CMakeLists.txt
+++ b/core/base/pathCompression/CMakeLists.txt
@@ -1,0 +1,8 @@
+ttk_add_base_library(pathCompression
+  SOURCES
+    PathCompression.cpp
+  HEADERS
+    PathCompression.h
+  DEPENDS
+    triangulation
+)

--- a/core/base/pathCompression/PathCompression.cpp
+++ b/core/base/pathCompression/PathCompression.cpp
@@ -1,0 +1,6 @@
+#include <PathCompression.h>
+
+ttk::PathCompression::PathCompression() {
+  // inherited from Debug: prefix will be printed at the beginning of every msg
+  this->setDebugMsgPrefix("PathCompression");
+}

--- a/core/base/pathCompression/PathCompression.h
+++ b/core/base/pathCompression/PathCompression.h
@@ -164,7 +164,7 @@ namespace ttk {
     bool ComputeDescendingSegmentation{true};
 
     // Compute Morse-Smale segmentation hash?
-    bool computeMSSegmentationHash{true};
+    bool ComputeMSSegmentationHash{true};
   };
 } // namespace ttk
 
@@ -181,7 +181,7 @@ int ttk::PathCompression::execute(OutputSegmentation &outSegmentation,
                  this->threadNumber_);
 
   if((ComputeAscendingSegmentation && ComputeDescendingSegmentation)
-     || computeMSSegmentationHash) {
+     || ComputeMSSegmentationHash) {
     computePathCompression(outSegmentation.ascending_,
                            outSegmentation.descending_, orderArray,
                            triangulation);
@@ -193,7 +193,7 @@ int ttk::PathCompression::execute(OutputSegmentation &outSegmentation,
       outSegmentation.descending_, false, orderArray, triangulation);
   }
 
-  if(computeMSSegmentationHash) {
+  if(ComputeMSSegmentationHash) {
     computeMSHash(outSegmentation.morseSmale_, outSegmentation.ascending_,
                   outSegmentation.descending_, triangulation);
   }

--- a/core/base/pathCompression/PathCompression.h
+++ b/core/base/pathCompression/PathCompression.h
@@ -159,7 +159,7 @@ namespace ttk {
     template <typename triangulationType>
     int computeMSHash(SimplexId *const morseSmaleSegmentation,
                       const SimplexId *const ascSegmentation,
-                      const SimplexId *const desSegmentation,
+                      const SimplexId *const dscSegmentation,
                       const triangulationType &triangulation) const;
 
     // Compute ascending segmentation?

--- a/core/base/pathCompression/PathCompression.h
+++ b/core/base/pathCompression/PathCompression.h
@@ -233,7 +233,7 @@ int ttk::PathCompression::computePathCompression(
 
     // find maxima/minima and intialize vector of vertices to compress
     for(SimplexId i = 0; i < nVertices; i++) {
-      SimplexId neighborId;
+      SimplexId neighborId{0};
       const SimplexId numNeighbors = triangulation.getVertexNeighborNumber(i);
 
       bool hasLargerNeighbor = false;
@@ -297,7 +297,7 @@ int ttk::PathCompression::computePathCompression(
 // find the biggest neighbor for each vertex
 #pragma omp for schedule(static)
       for(SimplexId i = 0; i < nVertices; i++) {
-        SimplexId neighborId;
+        SimplexId neighborId{0};
         SimplexId numNeighbors = triangulation.getVertexNeighborNumber(i);
 
         bool hasLargerNeighbor = false;
@@ -383,7 +383,7 @@ int ttk::PathCompression::computePathCompressionSingle(
     activeVertices.reserve(nVertices);
     // find maxima and intialize vector of not fully compressed vertices
     for(SimplexId i = 0; i < nVertices; i++) {
-      SimplexId neighborId;
+      SimplexId neighborId{0};
       const SimplexId numNeighbors = triangulation.getVertexNeighborNumber(i);
 
       bool hasLargerNeighbor = false;
@@ -445,7 +445,7 @@ int ttk::PathCompression::computePathCompressionSingle(
 // find the biggest neighbor for each vertex
 #pragma omp for schedule(static)
       for(SimplexId i = 0; i < nVertices; i++) {
-        SimplexId neighborId;
+        SimplexId neighborId{0};
         SimplexId numNeighbors = triangulation.getVertexNeighborNumber(i);
 
         bool hasLargerNeighbor = false;

--- a/core/base/pathCompression/PathCompression.h
+++ b/core/base/pathCompression/PathCompression.h
@@ -18,7 +18,12 @@
 /// Ross Maciejewski, Christoph Garth \n
 /// IEEE Transactions on Visualization and Computer Graphics \n
 ///
-/// \sa ttk::Triangulation
+/// \sa ttkPathCompression.cpp %for a usage example
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleSegmentation_at/">Morse-Smale
+///   segmentation example</a> \n
 
 #pragma once
 

--- a/core/base/pathCompression/PathCompression.h
+++ b/core/base/pathCompression/PathCompression.h
@@ -1,0 +1,514 @@
+/// \ingroup base
+/// \class ttk::PathCompression
+/// \author Robin G. C. Maack <maack@rptu.de>
+/// \date January 2023.
+///
+/// \brief TTK processing package for the computation of Morse-Smale
+/// segmentations using Path Compression.
+///
+/// \b Related \b publication \n
+/// "Parallel Computation of Piecewise Linear Morse-Smale Segmentations" \n
+/// Robin G. C. Maack, Jonas Lukasczyk, Julien Tierny, Hans Hagen,
+/// Ross Maciejewski, Christoph Garth \n
+/// IEEE Transactions on Visualization and Computer Graphics \n
+///
+/// \sa ttk::Triangulation
+
+#pragma once
+
+// base code includes
+#include <Triangulation.h>
+
+
+using ttk::SimplexId;
+
+#ifdef TTK_ENABLE_64BIT_IDS
+constexpr unsigned long long int hash_max = ULONG_LONG_MAX;
+
+constexpr unsigned long long int getHash(
+  const unsigned long long int a, const unsigned long long int b)  {
+  return (a*b + (a*a) + (b*b) + (a*a*a)*(b*b*b)) % hash_max;
+	//return std::rotl(a,1) ^ b;
+}
+#else
+constexpr unsigned int hash_max = UINT_MAX;
+
+/**
+ * @brief Get a hash
+ * 
+ * @param a 
+ * @param b 
+ * @return constexpr unsigned int 
+ */
+constexpr unsigned int getHash(
+  const unsigned int a, const unsigned int b) {
+  return (a*b + (a*a) + (b*b) + (a*a*a)*(b*b*b)) % hash_max;
+  //return std::rotl(a,1) ^ b;
+}
+#endif
+
+namespace ttk {
+  class PathCompression : public virtual Debug {
+  public:
+    PathCompression();
+
+    /** @brief Pointers to pre-allocated segmentation point data arrays */
+    struct OutputManifold {
+      SimplexId *ascending_;
+      SimplexId *descending_;
+      SimplexId *morseSmale_;
+    };
+
+    /**
+     * Main function for computing the Morse-Smale complex.
+     *
+     * @pre PathCompression::preconditionTriangulation must be
+     * called prior to this.
+     */
+    template <typename dataType, typename triangulationType>
+    inline int execute(OutputManifold &outManifold,
+                       const dataType *const scalars,
+                       const SimplexId *const offsets,
+                       const triangulationType &triangulation);
+
+    /**
+     * Enable/Disable computation of the geometrical embedding of the
+     * manifolds of the critical points.
+     */
+    inline void setComputeSegmentation(const bool doAscending,
+                                       const bool doDescending,
+                                       const bool doMorseSmale) {
+      this->ComputeAscendingSegmentation = doAscending;
+      this->ComputeDescendingSegmentation = doDescending;
+      this->ComputeFinalSegmentation = doMorseSmale;
+    }
+
+    /**
+     * Set the input triangulation and preprocess the needed
+     * mesh traversal queries.
+     */
+    inline void preconditionTriangulation(AbstractTriangulation *const data) {
+      data->preconditionVertexNeighbors();
+    }
+
+    template <typename triangulationType>
+    int computePathCompression(
+      SimplexId *const ascManifold,
+      SimplexId *const dscManifold,
+      const SimplexId *const orderArr,
+      const triangulationType &triangulation) const;
+
+    template <typename triangulationType>
+    int computePathCompressionSingle(
+      SimplexId *const manifold,
+      const bool computeAscending,
+      const SimplexId *const orderArr,
+      const triangulationType &triangulation) const;
+
+    template <typename triangulationType>
+    int computeFinalSegmentation(
+      SimplexId *const morseSmaleManifold,
+      const SimplexId *const ascManifold,
+      const SimplexId *const desManifold,
+      const triangulationType &triangulation) const;
+
+    bool ComputeDescendingSeparatrices2{false};
+    bool ComputeAscendingSegmentation{true};
+    bool ComputeDescendingSegmentation{true};
+    bool ComputeFinalSegmentation{true};
+
+  };
+} // namespace ttk
+
+// ---------------- //
+//  Execute method  //
+// ---------------- //
+
+template <typename dataType, typename triangulationType>
+int ttk::PathCompression::execute(OutputManifold &outManifold,
+                                  const dataType *const scalars,
+                                  const SimplexId *const orderArray,
+                                  const triangulationType &triangulation) {
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(scalars == nullptr) {
+    this->printErr("Input scalar field pointer is null.");
+    return -1;
+  }
+
+  if(orderArray == nullptr) {
+    this->printErr("Input offset field pointer is null.");
+    return -1;
+  }
+#endif
+
+  Timer t;
+
+  if((ComputeAscendingSegmentation && ComputeDescendingSegmentation) ||
+    ComputeFinalSegmentation) {
+    computePathCompression(outManifold.ascending_,
+      outManifold.descending_, orderArray, triangulation);
+  } else if(ComputeAscendingSegmentation) {
+    computePathCompressionSingle(
+      outManifold.ascending_, true, orderArray, triangulation);
+  } else if(ComputeDescendingSegmentation) {
+    computePathCompressionSingle(
+      outManifold.descending_, false, orderArray, triangulation);
+  }
+
+  if(ComputeFinalSegmentation) {
+    computeFinalSegmentation(outManifold.morseSmale_, outManifold.ascending_,
+      outManifold.descending_, triangulation);
+  }
+
+  this->printMsg("Data-set ("
+                   + std::to_string(triangulation.getNumberOfVertices())
+                   + " points) processed",
+                 1.0, t.getElapsedTime(), this->threadNumber_);
+
+  return 0;
+}
+
+template <typename triangulationType>
+int ttk::PathCompression::computePathCompression(
+  SimplexId *const ascManifold,
+  SimplexId *const dscManifold,
+  const SimplexId *const orderArr,
+  const triangulationType &triangulation) const {
+
+  ttk::Timer localTimer;
+
+  //this->printWrn(ttk::debug::Separator::L1);
+  // print the progress of the current subprocedure (currently 0%)
+  this->printWrn("Computing Manifolds");
+
+  /* compute the Descending Maifold iterating over each vertex, searching
+   * the biggest neighbor and compressing its path to its maximum */
+  const SimplexId nVertices = triangulation.getNumberOfVertices();
+
+#ifdef TTK_ENABLE_OPENMP
+if(threadNumber_ == 1) {
+#endif // TTK_ENABLE_OPENMP
+
+  SimplexId nActiveVertices;
+  std::vector<SimplexId> activeVertices;
+  activeVertices.reserve(nVertices);
+  // find maxima and intialize vector of not fully compressed vertices
+  for(SimplexId i = 0; i < nVertices; i++) {
+    SimplexId neighborId;
+    const SimplexId numNeighbors =
+      triangulation.getVertexNeighborNumber(i);      
+
+    bool hasLargerNeighbor = false;
+    SimplexId &dmi = dscManifold[i];
+    dmi = i;
+
+    bool hasSmallerNeighbor = false;
+    SimplexId &ami = ascManifold[i];
+    ami = i;
+
+    // check all neighbors
+    for(SimplexId n = 0; n < numNeighbors; n++) {
+      triangulation.getVertexNeighbor(i, n, neighborId);
+
+      if(orderArr[neighborId] < orderArr[ami]) {
+        ami = neighborId;
+        hasSmallerNeighbor = true;
+      } else if(orderArr[neighborId] > orderArr[dmi]) {
+        dmi = neighborId;
+        hasLargerNeighbor = true;
+      }
+    }
+
+    if(hasLargerNeighbor || hasSmallerNeighbor) {
+      activeVertices.push_back(i);
+    }
+  }
+
+  nActiveVertices = activeVertices.size();
+  size_t currentIndex = 0;
+
+  // compress paths until no changes occur
+  while(nActiveVertices > 0) {      
+    for(SimplexId i = 0; i < nActiveVertices; i++) {
+      SimplexId &v = activeVertices[i];
+      SimplexId &vDsc = dscManifold[v];
+      SimplexId &vAsc = ascManifold[v];
+
+      // compress paths
+      vDsc = dscManifold[vDsc];
+      vAsc = ascManifold[vAsc];
+
+      // check if not fully compressed
+      if(vDsc != dscManifold[vDsc] || vAsc != ascManifold[vAsc]) {
+        activeVertices[currentIndex++] = v;
+      }
+    }
+
+    nActiveVertices = currentIndex;
+    currentIndex = 0;
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+} else {
+
+  #pragma omp parallel num_threads(threadNumber_)
+  {
+    std::vector<SimplexId> lActiveVertices;
+    lActiveVertices.reserve(std::ceil(nVertices / threadNumber_));
+
+    // find the biggest neighbor for each vertex
+    #pragma omp for schedule(static)
+    for(SimplexId i = 0; i < nVertices; i++) {
+      SimplexId neighborId;
+      SimplexId numNeighbors =
+        triangulation.getVertexNeighborNumber(i);
+
+      bool hasLargerNeighbor = false;
+      SimplexId &dmi = dscManifold[i];
+      dmi = i;
+
+      bool hasSmallerNeighbor = false;
+      SimplexId &ami = ascManifold[i];
+      ami = i;
+
+      // check all neighbors
+      for(SimplexId n = 0; n < numNeighbors; n++) {
+        triangulation.getVertexNeighbor(i, n, neighborId);
+
+        if(orderArr[neighborId] < orderArr[ami]) {
+          ami = neighborId;
+          hasSmallerNeighbor = true;
+        } else if(orderArr[neighborId] > orderArr[dmi]) {
+          dmi = neighborId;
+          hasLargerNeighbor = true;
+        }
+      }
+
+      if(hasLargerNeighbor || hasSmallerNeighbor) {
+        lActiveVertices.push_back(i);
+      } 
+    }
+
+    size_t lnActiveVertices = lActiveVertices.size();
+    size_t currentIndex = 0;
+
+    // compress paths until no changes occur
+    while(lnActiveVertices > 0) {
+      for(size_t i = 0; i < lnActiveVertices; i++) {
+        SimplexId &v = lActiveVertices[i];
+        SimplexId &vDsc = dscManifold[v];
+        SimplexId &vAsc = ascManifold[v];
+
+        // compress paths
+        #pragma omp atomic read
+        vDsc = dscManifold[vDsc];
+
+        #pragma omp atomic read
+        vAsc = ascManifold[vAsc];
+
+        // check if fully compressed
+        if(vDsc != dscManifold[vDsc] || vAsc != ascManifold[vAsc]) {
+          lActiveVertices[currentIndex++] = v;
+        }
+      }
+
+      lnActiveVertices = currentIndex;
+      currentIndex = 0;
+    }
+  }
+}
+#endif // TTK_ENABLE_OPENMP
+
+  this->printWrn("Computed Manifolds");
+
+  return 1; // return success
+}
+
+template <typename triangulationType>
+int ttk::PathCompression::computePathCompressionSingle(
+  SimplexId *const manifold,
+  const bool computeAscending,
+  const SimplexId *const orderArr,
+  const triangulationType &triangulation) const {
+
+  ttk::Timer localTimer;
+
+  //this->printWrn(ttk::debug::Separator::L1);
+  // print the progress of the current subprocedure (currently 0%)
+  this->printWrn("Computing Manifolds");
+
+  /* compute the Descending Maifold iterating over each vertex, searching
+   * the biggest neighbor and compressing its path to its maximum */
+  const SimplexId nVertices = triangulation.getNumberOfVertices();
+
+#ifdef TTK_ENABLE_OPENMP
+if(threadNumber_ == 1) {
+#endif // TTK_ENABLE_OPENMP
+
+  SimplexId nActiveVertices;
+  std::vector<SimplexId> activeVertices;
+  activeVertices.reserve(nVertices);
+  // find maxima and intialize vector of not fully compressed vertices
+  for(SimplexId i = 0; i < nVertices; i++) {
+    SimplexId neighborId;
+    const SimplexId numNeighbors =
+      triangulation.getVertexNeighborNumber(i);      
+
+    bool hasLargerNeighbor = false;
+    SimplexId &mi = manifold[i];
+    mi = i;
+
+    // check all neighbors
+    for(SimplexId n = 0; n < numNeighbors; n++) {
+      triangulation.getVertexNeighbor(i, n, neighborId);
+
+      if(computeAscending) {
+        if(orderArr[neighborId] < orderArr[mi]) {
+          mi = neighborId;
+          hasLargerNeighbor = true;
+        }
+      } else {
+        if(orderArr[neighborId] > orderArr[mi]) {
+          mi = neighborId;
+          hasLargerNeighbor = true;
+        }
+      }
+    }
+
+    if(hasLargerNeighbor) {
+      activeVertices.push_back(i);
+    }
+  }
+
+  nActiveVertices = activeVertices.size();
+  size_t currentIndex = 0;
+
+  // compress paths until no changes occur
+  while(nActiveVertices > 0) {      
+    for(SimplexId i = 0; i < nActiveVertices; i++) {
+      SimplexId &v = activeVertices[i];
+      SimplexId &vMan = manifold[v];
+
+      // compress paths
+      vMan = manifold[vMan];
+
+      // check if not fully compressed
+      if(vMan != manifold[vMan]) {
+        activeVertices[currentIndex++] = v;
+      }
+    }
+
+    nActiveVertices = currentIndex;
+    currentIndex = 0;
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+} else {
+
+  #pragma omp parallel num_threads(threadNumber_)
+  {
+    std::vector<SimplexId> lActiveVertices;
+    lActiveVertices.reserve(std::ceil(nVertices / threadNumber_));
+
+    // find the biggest neighbor for each vertex
+    #pragma omp for schedule(static)
+    for(SimplexId i = 0; i < nVertices; i++) {
+      SimplexId neighborId;
+      SimplexId numNeighbors =
+        triangulation.getVertexNeighborNumber(i);
+
+      bool hasLargerNeighbor = false;
+      SimplexId &mi = manifold[i];
+      mi = i;
+
+      // check all neighbors
+      for(SimplexId n = 0; n < numNeighbors; n++) {
+        triangulation.getVertexNeighbor(i, n, neighborId);
+
+        if(computeAscending) {
+          if(orderArr[neighborId] < orderArr[mi]) {
+            mi = neighborId;
+            hasLargerNeighbor = true;
+          }
+        } else {
+          if(orderArr[neighborId] > orderArr[mi]) {
+            mi = neighborId;
+            hasLargerNeighbor = true;
+          }
+        }
+      }
+
+      if(hasLargerNeighbor) {
+        lActiveVertices.push_back(i);
+      } 
+    }
+
+    size_t lnActiveVertices = lActiveVertices.size();
+    size_t currentIndex = 0;
+
+    // compress paths until no changes occur
+    while(lnActiveVertices > 0) {
+      for(size_t i = 0; i < lnActiveVertices; i++) {
+        SimplexId &v = lActiveVertices[i];
+        SimplexId &vMan = manifold[v];
+
+        // compress paths
+        #pragma omp atomic read
+        vMan = manifold[vMan];
+
+        // check if fully compressed
+        if(vMan != manifold[vMan]) {
+          lActiveVertices[currentIndex++] = v;
+        }
+      }
+
+      lnActiveVertices = currentIndex;
+      currentIndex = 0;
+    }
+  }
+}
+#endif // TTK_ENABLE_OPENMP
+
+  this->printWrn("Computed Manifolds");
+
+  return 1; // return success
+}
+
+template <typename triangulationType>
+int ttk::PathCompression::computeFinalSegmentation(
+  SimplexId *const morseSmaleManifold,
+  const SimplexId *const ascManifold,
+  const SimplexId *const dscManifold,
+  const triangulationType &triangulation) const {
+    ttk::Timer localTimer;
+
+  this->printMsg("Computing MSC Manifold",
+                 0, localTimer.getElapsedTime(), this->threadNumber_,
+                 ttk::debug::LineMode::REPLACE);
+  
+  const size_t nVerts = triangulation.getNumberOfVertices();
+  
+
+#ifdef TTK_ENABLE_OPENMP
+if(threadNumber_ == 1) {
+#endif // TTK_ENABLE_OPENMP
+
+  for(size_t i = 0; i < nVerts; ++i) {
+    morseSmaleManifold[i] = getHash(ascManifold[i], dscManifold[i]);
+  }
+
+#ifdef TTK_ENABLE_OPENMP
+} else {
+
+  #pragma omp parallel for schedule(static) num_threads(threadNumber_)
+  for(size_t i = 0; i < nVerts; ++i) {
+    morseSmaleManifold[i] = getHash(ascManifold[i], dscManifold[i]);
+  }
+}
+#endif // TTK_ENABLE_OPENMP
+
+  this->printMsg("Computed MSC Manifold",
+                 1, localTimer.getElapsedTime(), this->threadNumber_);
+
+  return 0;
+}

--- a/core/vtk/ttkPathCompression/CMakeLists.txt
+++ b/core/vtk/ttkPathCompression/CMakeLists.txt
@@ -1,0 +1,1 @@
+ttk_add_vtk_module()

--- a/core/vtk/ttkPathCompression/ttk.module
+++ b/core/vtk/ttkPathCompression/ttk.module
@@ -1,0 +1,9 @@
+NAME
+  ttkPathCompression
+SOURCES
+  ttkPathCompression.cpp
+HEADERS
+  ttkPathCompression.h
+DEPENDS
+  pathCompression
+  ttkAlgorithm

--- a/core/vtk/ttkPathCompression/ttkPathCompression.cpp
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.cpp
@@ -1,0 +1,192 @@
+#include <ttkMacros.h>
+#include <ttkPathCompression.h>
+#include <ttkUtils.h>
+
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDataObject.h>
+#include <vtkDataSet.h>
+#include <vtkDoubleArray.h>
+#include <vtkFloatArray.h>
+#include <vtkIdTypeArray.h>
+#include <vtkInformation.h>
+#include <vtkNew.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkSignedCharArray.h>
+#include <vtkUnsignedCharArray.h>
+
+vtkStandardNewMacro(ttkPathCompression);
+
+ttkPathCompression::ttkPathCompression() {
+  this->setDebugMsgPrefix("PathCompression");
+  SetNumberOfInputPorts(1);
+  SetNumberOfOutputPorts(1);
+}
+
+int ttkPathCompression::FillInputPortInformation(int port,
+                                                   vtkInformation *info) {
+  if(port == 0) {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
+    return 1;
+  }
+  return 0;
+}
+
+int ttkPathCompression::FillOutputPortInformation(int port,
+                                                    vtkInformation *info) {
+  if(port == 0) {
+    info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
+    return 1;
+  }
+  return 0;
+}
+
+template <typename vtkArrayType, typename vectorType>
+void setArray(vtkArrayType &vtkArray, vectorType &vector) {
+  ttkUtils::SetVoidArray(vtkArray, vector.data(), vector.size(), 1);
+}
+
+template <typename scalarType, typename triangulationType>
+int ttkPathCompression::dispatch(vtkDataArray *const inputScalars,
+                                  const SimplexId *const inputOffsets,
+                                  const triangulationType &triangulation) {
+
+  const auto scalars = ttkUtils::GetPointer<scalarType>(inputScalars);
+
+  const int ret = this->execute(
+    segmentations_, scalars, inputOffsets, triangulation);
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(ret != 0) {
+    this->printErr("PathCompression.execute() error");
+    return -1;
+  }
+#endif
+
+  return ret;
+}
+
+int ttkPathCompression::RequestData(vtkInformation *ttkNotUsed(request),
+                                      vtkInformationVector **inputVector,
+                                      vtkInformationVector *outputVector) {
+
+  const auto input = vtkDataSet::GetData(inputVector[0]);
+  auto outputMorseComplexes = vtkDataSet::GetData(outputVector, 0);
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(!input) {
+    this->printErr("Input pointer is NULL.");
+    return -1;
+  }
+  if(input->GetNumberOfPoints() == 0) {
+    this->printErr("Input has no point.");
+    return -1;
+  }
+  if(!outputMorseComplexes) {
+    this->printErr("Output pointers are NULL.");
+    return -1;
+  }
+#endif
+
+  const auto triangulation = ttkAlgorithm::GetTriangulation(input);
+  if(triangulation == nullptr) {
+    this->printErr("Triangulation is null");
+    return 0;
+  }
+  this->preconditionTriangulation(triangulation);
+
+  const auto inputScalars = this->GetInputArrayToProcess(0, inputVector);
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(inputScalars == nullptr) {
+    this->printErr("wrong scalars.");
+    return -1;
+  }
+#endif
+
+  auto inputOffsets = ttkAlgorithm::GetOrderArray(
+    input, 0, 1, this->ForceInputOffsetScalarField);
+
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(inputOffsets == nullptr) {
+    this->printErr("wrong offsets.");
+    return -1;
+  }
+  if(inputOffsets->GetDataType() != VTK_INT
+     and inputOffsets->GetDataType() != VTK_ID_TYPE) {
+    this->printErr("input offset field type not supported.");
+    return -1;
+  }
+#endif
+
+  this->printMsg("Launching computation on field `"
+                 + std::string(inputScalars->GetName()) + "'...");
+
+  // morse complexes
+  const SimplexId numberOfVertices = triangulation->getNumberOfVertices();
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(!numberOfVertices) {
+    this->printErr("Input has no vertices.");
+    return -1;
+  }
+#endif
+
+  vtkNew<ttkSimplexIdTypeArray> ascendingManifold{};
+  vtkNew<ttkSimplexIdTypeArray> descendingManifold{};
+  vtkNew<ttkSimplexIdTypeArray> morseSmaleManifold{};
+#ifndef TTK_ENABLE_KAMIKAZE
+  if(!ascendingManifold || !descendingManifold || !morseSmaleManifold) {
+    this->printErr("Manifold vtkDataArray allocation problem.");
+    return -1;
+  }
+#endif
+  ascendingManifold->SetNumberOfComponents(1);
+  ascendingManifold->SetNumberOfTuples(numberOfVertices);
+  ascendingManifold->SetName(ttk::MorseSmaleAscendingName);
+
+  descendingManifold->SetNumberOfComponents(1);
+  descendingManifold->SetNumberOfTuples(numberOfVertices);
+  descendingManifold->SetName(ttk::MorseSmaleDescendingName);
+
+  morseSmaleManifold->SetNumberOfComponents(1);
+  morseSmaleManifold->SetNumberOfTuples(numberOfVertices);
+  morseSmaleManifold->SetName(ttk::MorseSmaleManifoldName);
+
+  this->segmentations_ = {ttkUtils::GetPointer<SimplexId>(ascendingManifold),
+                          ttkUtils::GetPointer<SimplexId>(descendingManifold),
+                          ttkUtils::GetPointer<SimplexId>(morseSmaleManifold)};
+
+  int ret{};
+
+  ttkVtkTemplateMacro(
+    inputScalars->GetDataType(), triangulation->getType(),
+    (ret = dispatch<VTK_TT, TTK_TT>(
+       inputScalars, ttkUtils::GetPointer<SimplexId>(inputOffsets),
+       *static_cast<TTK_TT *>(triangulation->getData()))));
+
+  if(ret != 0) {
+    return -1;
+  }
+
+  outputMorseComplexes->ShallowCopy(input);
+  // morse complexes
+  if(ComputeAscendingSegmentation || ComputeDescendingSegmentation) {
+    vtkPointData *pointData = outputMorseComplexes->GetPointData();
+#ifndef TTK_ENABLE_KAMIKAZE
+    if(!pointData) {
+      this->printErr("outputMorseComplexes has no point data.");
+      return -1;
+    }
+#endif
+
+    if(ComputeDescendingSegmentation || ComputeFinalSegmentation)
+      pointData->AddArray(descendingManifold);
+    if(ComputeAscendingSegmentation || ComputeFinalSegmentation)
+      pointData->AddArray(ascendingManifold);
+    if(ComputeFinalSegmentation)
+      pointData->AddArray(morseSmaleManifold);
+  }
+
+  return !ret;
+}

--- a/core/vtk/ttkPathCompression/ttkPathCompression.cpp
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.cpp
@@ -25,7 +25,7 @@ ttkPathCompression::ttkPathCompression() {
 }
 
 int ttkPathCompression::FillInputPortInformation(int port,
-                                                   vtkInformation *info) {
+                                                 vtkInformation *info) {
   if(port == 0) {
     info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkDataSet");
     return 1;
@@ -34,7 +34,7 @@ int ttkPathCompression::FillInputPortInformation(int port,
 }
 
 int ttkPathCompression::FillOutputPortInformation(int port,
-                                                    vtkInformation *info) {
+                                                  vtkInformation *info) {
   if(port == 0) {
     info->Set(ttkAlgorithm::SAME_DATA_TYPE_AS_INPUT_PORT(), 0);
     return 1;
@@ -42,151 +42,116 @@ int ttkPathCompression::FillOutputPortInformation(int port,
   return 0;
 }
 
-template <typename vtkArrayType, typename vectorType>
-void setArray(vtkArrayType &vtkArray, vectorType &vector) {
-  ttkUtils::SetVoidArray(vtkArray, vector.data(), vector.size(), 1);
-}
+template <typename triangulationType>
+int ttkPathCompression::dispatch(const SimplexId *const inputOrderArray,
+                                 const triangulationType &triangulation) {
 
-template <typename scalarType, typename triangulationType>
-int ttkPathCompression::dispatch(vtkDataArray *const inputScalars,
-                                  const SimplexId *const inputOffsets,
-                                  const triangulationType &triangulation) {
+  const int ret = this->execute<triangulationType>(
+    segmentations_, inputOrderArray, triangulation);
 
-  const auto scalars = ttkUtils::GetPointer<scalarType>(inputScalars);
-
-  const int ret = this->execute(
-    segmentations_, scalars, inputOffsets, triangulation);
-
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(ret != 0) {
-    this->printErr("PathCompression.execute() error");
-    return -1;
-  }
-#endif
+  if(ret != 0)
+    return !this->printErr("PathCompression.execute() error");
 
   return ret;
 }
 
 int ttkPathCompression::RequestData(vtkInformation *ttkNotUsed(request),
-                                      vtkInformationVector **inputVector,
-                                      vtkInformationVector *outputVector) {
+                                    vtkInformationVector **inputVector,
+                                    vtkInformationVector *outputVector) {
 
   const auto input = vtkDataSet::GetData(inputVector[0]);
   auto outputMorseComplexes = vtkDataSet::GetData(outputVector, 0);
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!input) {
-    this->printErr("Input pointer is NULL.");
-    return -1;
-  }
-  if(input->GetNumberOfPoints() == 0) {
-    this->printErr("Input has no point.");
-    return -1;
-  }
-  if(!outputMorseComplexes) {
-    this->printErr("Output pointers are NULL.");
-    return -1;
-  }
-#endif
+  if(!input)
+    return !this->printErr("Input pointer is NULL.");
+
+  if(input->GetNumberOfPoints() == 0)
+    return !this->printErr("Input has no point.");
+
+  if(!outputMorseComplexes)
+    return !this->printErr("Output pointers are NULL.");
 
   const auto triangulation = ttkAlgorithm::GetTriangulation(input);
-  if(triangulation == nullptr) {
-    this->printErr("Triangulation is null");
-    return 0;
-  }
+
+  if(triangulation == nullptr)
+    return !this->printErr("Triangulation is null");
+
   this->preconditionTriangulation(triangulation);
 
   const auto inputScalars = this->GetInputArrayToProcess(0, inputVector);
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(inputScalars == nullptr) {
-    this->printErr("wrong scalars.");
-    return -1;
-  }
-#endif
+  if(inputScalars == nullptr)
+    return !this->printErr("No input scalars");
 
-  auto inputOffsets = ttkAlgorithm::GetOrderArray(
+  auto inputOrderArray = ttkAlgorithm::GetOrderArray(
     input, 0, 1, this->ForceInputOffsetScalarField);
 
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(inputOffsets == nullptr) {
-    this->printErr("wrong offsets.");
-    return -1;
-  }
-  if(inputOffsets->GetDataType() != VTK_INT
-     and inputOffsets->GetDataType() != VTK_ID_TYPE) {
-    this->printErr("input offset field type not supported.");
-    return -1;
-  }
-#endif
+  if(inputOrderArray == nullptr)
+    return !this->printErr("No order array");
+
+  if(inputOrderArray->GetDataType() != VTK_INT
+     && inputOrderArray->GetDataType() != VTK_ID_TYPE)
+    return !this->printErr("input offset field type not supported.");
 
   this->printMsg("Launching computation on field `"
                  + std::string(inputScalars->GetName()) + "'...");
 
-  // morse complexes
   const SimplexId numberOfVertices = triangulation->getNumberOfVertices();
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!numberOfVertices) {
-    this->printErr("Input has no vertices.");
-    return -1;
-  }
-#endif
 
-  vtkNew<ttkSimplexIdTypeArray> ascendingManifold{};
-  vtkNew<ttkSimplexIdTypeArray> descendingManifold{};
-  vtkNew<ttkSimplexIdTypeArray> morseSmaleManifold{};
-#ifndef TTK_ENABLE_KAMIKAZE
-  if(!ascendingManifold || !descendingManifold || !morseSmaleManifold) {
-    this->printErr("Manifold vtkDataArray allocation problem.");
-    return -1;
-  }
-#endif
-  ascendingManifold->SetNumberOfComponents(1);
-  ascendingManifold->SetNumberOfTuples(numberOfVertices);
-  ascendingManifold->SetName(ttk::MorseSmaleAscendingName);
+  if(!numberOfVertices)
+    return !this->printErr("Input has no vertices.");
 
-  descendingManifold->SetNumberOfComponents(1);
-  descendingManifold->SetNumberOfTuples(numberOfVertices);
-  descendingManifold->SetName(ttk::MorseSmaleDescendingName);
+  vtkNew<ttkSimplexIdTypeArray> ascendingSegmentation{};
+  vtkNew<ttkSimplexIdTypeArray> descendingSegmentation{};
+  vtkNew<ttkSimplexIdTypeArray> morseSmaleSegmentation{};
 
-  morseSmaleManifold->SetNumberOfComponents(1);
-  morseSmaleManifold->SetNumberOfTuples(numberOfVertices);
-  morseSmaleManifold->SetName(ttk::MorseSmaleManifoldName);
+  if(!ascendingSegmentation || !descendingSegmentation
+     || !morseSmaleSegmentation)
+    return !this->printErr("Segmentation vtkDataArray allocation problem.");
 
-  this->segmentations_ = {ttkUtils::GetPointer<SimplexId>(ascendingManifold),
-                          ttkUtils::GetPointer<SimplexId>(descendingManifold),
-                          ttkUtils::GetPointer<SimplexId>(morseSmaleManifold)};
+  ascendingSegmentation->SetNumberOfComponents(1);
+  ascendingSegmentation->SetNumberOfTuples(numberOfVertices);
+  ascendingSegmentation->SetName("AscendingSegmentation");
+
+  descendingSegmentation->SetNumberOfComponents(1);
+  descendingSegmentation->SetNumberOfTuples(numberOfVertices);
+  descendingSegmentation->SetName("DescendingSegmentation");
+
+  morseSmaleSegmentation->SetNumberOfComponents(1);
+  morseSmaleSegmentation->SetNumberOfTuples(numberOfVertices);
+  morseSmaleSegmentation->SetName("MorseSmaleSegmentation");
+
+  this->segmentations_
+    = {ttkUtils::GetPointer<SimplexId>(ascendingSegmentation),
+       ttkUtils::GetPointer<SimplexId>(descendingSegmentation),
+       ttkUtils::GetPointer<SimplexId>(morseSmaleSegmentation)};
 
   int ret{};
 
-  ttkVtkTemplateMacro(
-    inputScalars->GetDataType(), triangulation->getType(),
-    (ret = dispatch<VTK_TT, TTK_TT>(
-       inputScalars, ttkUtils::GetPointer<SimplexId>(inputOffsets),
-       *static_cast<TTK_TT *>(triangulation->getData()))));
+  ttkTemplateMacro(
+    triangulation->getType(),
+    (ret = dispatch<TTK_TT>(ttkUtils::GetPointer<SimplexId>(inputOrderArray),
+                            *static_cast<TTK_TT *>(triangulation->getData()))));
 
-  if(ret != 0) {
+  if(ret != 0)
     return -1;
-  }
 
   outputMorseComplexes->ShallowCopy(input);
-  // morse complexes
-  if(ComputeAscendingSegmentation || ComputeDescendingSegmentation) {
-    vtkPointData *pointData = outputMorseComplexes->GetPointData();
-#ifndef TTK_ENABLE_KAMIKAZE
-    if(!pointData) {
-      this->printErr("outputMorseComplexes has no point data.");
-      return -1;
-    }
-#endif
 
-    if(ComputeDescendingSegmentation || ComputeFinalSegmentation)
-      pointData->AddArray(descendingManifold);
-    if(ComputeAscendingSegmentation || ComputeFinalSegmentation)
-      pointData->AddArray(ascendingManifold);
-    if(ComputeFinalSegmentation)
-      pointData->AddArray(morseSmaleManifold);
+  if(ComputeAscendingSegmentation || ComputeDescendingSegmentation
+     || computeMSSegmentationHash) {
+    vtkPointData *pointData = outputMorseComplexes->GetPointData();
+
+    if(!pointData)
+      return !this->printErr("outputMorseComplexes has no point data.");
+
+    if(ComputeDescendingSegmentation || computeMSSegmentationHash)
+      pointData->AddArray(descendingSegmentation);
+    if(ComputeAscendingSegmentation || computeMSSegmentationHash)
+      pointData->AddArray(ascendingSegmentation);
+    if(computeMSSegmentationHash)
+      pointData->AddArray(morseSmaleSegmentation);
   }
 
-  return !ret;
+  return 1;
 }

--- a/core/vtk/ttkPathCompression/ttkPathCompression.cpp
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.cpp
@@ -139,17 +139,17 @@ int ttkPathCompression::RequestData(vtkInformation *ttkNotUsed(request),
   outputMorseComplexes->ShallowCopy(input);
 
   if(ComputeAscendingSegmentation || ComputeDescendingSegmentation
-     || computeMSSegmentationHash) {
+     || ComputeMSSegmentationHash) {
     vtkPointData *pointData = outputMorseComplexes->GetPointData();
 
     if(!pointData)
       return !this->printErr("outputMorseComplexes has no point data.");
 
-    if(ComputeDescendingSegmentation || computeMSSegmentationHash)
+    if(ComputeDescendingSegmentation || ComputeMSSegmentationHash)
       pointData->AddArray(descendingSegmentation);
-    if(ComputeAscendingSegmentation || computeMSSegmentationHash)
+    if(ComputeAscendingSegmentation || ComputeMSSegmentationHash)
       pointData->AddArray(ascendingSegmentation);
-    if(computeMSSegmentationHash)
+    if(ComputeMSSegmentationHash)
       pointData->AddArray(morseSmaleSegmentation);
   }
 

--- a/core/vtk/ttkPathCompression/ttkPathCompression.h
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.h
@@ -76,8 +76,8 @@ public:
   vtkSetMacro(ComputeDescendingSegmentation, bool);
   vtkGetMacro(ComputeDescendingSegmentation, bool);
 
-  vtkSetMacro(computeMSSegmentationHash, bool);
-  vtkGetMacro(computeMSSegmentationHash, bool);
+  vtkSetMacro(ComputeMSSegmentationHash, bool);
+  vtkGetMacro(ComputeMSSegmentationHash, bool);
 
   vtkSetMacro(ForceInputOffsetScalarField, bool);
   vtkGetMacro(ForceInputOffsetScalarField, bool);

--- a/core/vtk/ttkPathCompression/ttkPathCompression.h
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.h
@@ -1,0 +1,84 @@
+/// \ingroup vtk
+/// \class ttkPathCompression
+/// \author Robin Maack <maack@rptu.de>
+/// \date January 2023.
+///
+/// \brief TTK VTK-filter that wraps the ttk::PathCompression module.
+///
+/// This VTK filter uses the ttk::PathCompression module to compute a
+/// Morse-Smale segmentation using path compression
+///
+/// \param Input vtkDataSet.
+/// \param Output vtkDataSet.
+///
+/// This filter can be used as any other VTK filter (for instance, by using the
+/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
+/// The input data array needs to be specified via the standard VTK call
+/// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
+/// \param idx 0 (FIXED: the first array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the input array)
+///
+/// See the corresponding standalone program for a usage example:
+///   - standalone/PathCompression/main.cpp
+///
+/// See the related ParaView example state files for usage examples within a
+/// VTK pipeline.
+///
+/// \sa ttk::PathCompression
+/// \sa ttkAlgorithm
+
+#pragma once
+
+// VTK Module
+#include <ttkPathCompressionModule.h>
+
+// ttk code includes
+#include <PathCompression.h>
+#include <ttkAlgorithm.h>
+#include <ttkMacros.h>
+
+class vtkPolyData;
+
+class TTKPATHCOMPRESSION_EXPORT ttkPathCompression
+  : public ttkAlgorithm,
+    protected ttk::PathCompression {
+
+public:
+  static ttkPathCompression *New();
+
+  vtkTypeMacro(ttkPathCompression, ttkAlgorithm);
+
+  vtkSetMacro(ComputeAscendingSegmentation, bool);
+  vtkGetMacro(ComputeAscendingSegmentation, bool);
+
+  vtkSetMacro(ComputeDescendingSegmentation, bool);
+  vtkGetMacro(ComputeDescendingSegmentation, bool);
+
+  vtkSetMacro(ComputeFinalSegmentation, bool);
+  vtkGetMacro(ComputeFinalSegmentation, bool);
+
+  vtkSetMacro(ForceInputOffsetScalarField, bool);
+  vtkGetMacro(ForceInputOffsetScalarField, bool);
+
+protected:
+  template <typename scalarType, typename triangulationType>
+  int dispatch(vtkDataArray *const inputScalars,
+               const SimplexId *const inputOffsets,
+               const triangulationType &triangulation);
+
+  ttkPathCompression();
+
+  int FillInputPortInformation(int port, vtkInformation *info) override;
+  int FillOutputPortInformation(int port, vtkInformation *info) override;
+  int RequestData(vtkInformation *request,
+                  vtkInformationVector **inputVector,
+                  vtkInformationVector *outputVector) override;
+
+private:
+  bool ForceInputOffsetScalarField{};
+  OutputManifold segmentations_{};
+};

--- a/core/vtk/ttkPathCompression/ttkPathCompression.h
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.h
@@ -5,18 +5,16 @@
 ///
 /// \brief TTK VTK-filter that wraps the ttk::PathCompression module.
 ///
-/// Given an input order field, this class computes its ascending and descending
-/// segmentation by assigning every vertex to its minimum or maximum in gradient
-/// or inverse gradient direction. For convienience a hash (no hash collision
-/// detection) of both segmentations can be created to represent the Morse-Smale
-/// segmentation.
+/// Given an input order field, this filter computes its ascending and
+/// descending segmentation by assigning every vertex to its minimum or maximum
+/// in gradient or inverse gradient direction. For convienience a hash (no hash
+/// collision detection) of both segmentations can be created to represent the
+/// Morse-Smale segmentation.
 ///
-/// \param Input vtkDataSet containing the input scalar field as point data
-/// \param Output vtkDataSet containing the output segmentations as point data
-/// arrays
-///
-/// This filter can be used like any other VTK filter (for instance, by using
-/// the sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+/// \param Input scalar field, either 2D or 3D, regular grid or
+/// triangulation (vtkDataSet)
+/// \param Output scalar field, either 2D or 3D, regular grid or
+/// triangulation (vtkDataSet) with resulting arrays attached to point data
 ///
 /// The input data array needs to be specified via the standard VTK call
 /// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
@@ -36,18 +34,27 @@
 /// \note: To use this optional array, `ForceInputOffsetScalarField` needs to be
 /// enabled with the setter `setForceInputOffsetScalarField()'.
 ///
+/// This filter can be used like any other VTK filter (for instance, by using
+/// the sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+///
 /// See the corresponding standalone program for a usage example:
 ///   - standalone/PathCompression/main.cpp
 ///
 /// See the related ParaView example state files for usage examples within a
 /// VTK pipeline.
 ///
-/// \b Online \b examples: \n
-///   - <a href="https://topology-tool-kit.github.io/examples/TODO/">TODO
-///   example</a> \n
+/// \b Related \b publication \n
+/// "Parallel Computation of Piecewise Linear Morse-Smale Segmentations" \n
+/// Robin G. C. Maack, Jonas Lukasczyk, Julien Tierny, Hans Hagen,
+/// Ross Maciejewski, Christoph Garth \n
+/// IEEE Transactions on Visualization and Computer Graphics \n
 ///
 /// \sa ttk::PathCompression
-/// \sa ttkAlgorithm
+///
+/// \b Online \b examples: \n
+///   - <a
+///   href="https://topology-tool-kit.github.io/examples/morseSmaleSegmentation_at/">Morse-Smale
+///   segmentation example</a> \n
 
 #pragma once
 

--- a/core/vtk/ttkPathCompression/ttkPathCompression.h
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.h
@@ -11,9 +11,11 @@
 /// collision detection) of both segmentations can be created to represent the
 /// Morse-Smale segmentation.
 ///
-/// \param Input scalar field, either 2D or 3D, regular grid or
+/// \param Input Input scalar field, defined as a point data scalar field
+/// attached to a geometry, either 2D or 3D, either regular grid or
 /// triangulation (vtkDataSet)
-/// \param Output scalar field, either 2D or 3D, regular grid or
+/// \param Output output scalar field, defined as a point data scalar field
+/// attached to a geometry, either 2D or 3D, either regular grid or
 /// triangulation (vtkDataSet) with resulting arrays attached to point data
 ///
 /// The input data array needs to be specified via the standard VTK call

--- a/core/vtk/ttkPathCompression/ttkPathCompression.h
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.h
@@ -1,18 +1,22 @@
 /// \ingroup vtk
 /// \class ttkPathCompression
 /// \author Robin Maack <maack@rptu.de>
-/// \date January 2023.
+/// \date May 2023.
 ///
 /// \brief TTK VTK-filter that wraps the ttk::PathCompression module.
 ///
-/// This VTK filter uses the ttk::PathCompression module to compute a
-/// Morse-Smale segmentation using path compression
+/// Given an input order field, this class computes its ascending and descending
+/// segmentation by assigning every vertex to its minimum or maximum in gradient
+/// or inverse gradient direction. For convienience a hash (no hash collision
+/// detection) of both segmentations can be created to represent the Morse-Smale
+/// segmentation.
 ///
-/// \param Input vtkDataSet.
-/// \param Output vtkDataSet.
+/// \param Input vtkDataSet containing the input scalar field as point data
+/// \param Output vtkDataSet containing the output segmentations as point data
+/// arrays
 ///
-/// This filter can be used as any other VTK filter (for instance, by using the
-/// sequence of calls SetInputData(), Update(), GetOutputDataObject()).
+/// This filter can be used like any other VTK filter (for instance, by using
+/// the sequence of calls SetInputData(), Update(), GetOutputDataObject()).
 ///
 /// The input data array needs to be specified via the standard VTK call
 /// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
@@ -22,11 +26,25 @@
 /// \param fieldAssociation 0 (FIXED: point data)
 /// \param arrayName (DYNAMIC: string identifier of the input array)
 ///
+/// The optional offset array can be specified via the standard VTK call
+/// vtkAlgorithm::SetInputArrayToProcess() with the following parameters:
+/// \param idx 1 (FIXED: the second array the algorithm requires)
+/// \param port 0 (FIXED: first port)
+/// \param connection 0 (FIXED: first connection)
+/// \param fieldAssociation 0 (FIXED: point data)
+/// \param arrayName (DYNAMIC: string identifier of the offset array)
+/// \note: To use this optional array, `ForceInputOffsetScalarField` needs to be
+/// enabled with the setter `setForceInputOffsetScalarField()'.
+///
 /// See the corresponding standalone program for a usage example:
 ///   - standalone/PathCompression/main.cpp
 ///
 /// See the related ParaView example state files for usage examples within a
 /// VTK pipeline.
+///
+/// \b Online \b examples: \n
+///   - <a href="https://topology-tool-kit.github.io/examples/TODO/">TODO
+///   example</a> \n
 ///
 /// \sa ttk::PathCompression
 /// \sa ttkAlgorithm
@@ -58,16 +76,15 @@ public:
   vtkSetMacro(ComputeDescendingSegmentation, bool);
   vtkGetMacro(ComputeDescendingSegmentation, bool);
 
-  vtkSetMacro(ComputeFinalSegmentation, bool);
-  vtkGetMacro(ComputeFinalSegmentation, bool);
+  vtkSetMacro(computeMSSegmentationHash, bool);
+  vtkGetMacro(computeMSSegmentationHash, bool);
 
   vtkSetMacro(ForceInputOffsetScalarField, bool);
   vtkGetMacro(ForceInputOffsetScalarField, bool);
 
 protected:
-  template <typename scalarType, typename triangulationType>
-  int dispatch(vtkDataArray *const inputScalars,
-               const SimplexId *const inputOffsets,
+  template <typename triangulationType>
+  int dispatch(const SimplexId *const inputOffsets,
                const triangulationType &triangulation);
 
   ttkPathCompression();
@@ -80,5 +97,5 @@ protected:
 
 private:
   bool ForceInputOffsetScalarField{};
-  OutputManifold segmentations_{};
+  OutputSegmentation segmentations_{};
 };

--- a/core/vtk/ttkPathCompression/vtk.module
+++ b/core/vtk/ttkPathCompression/vtk.module
@@ -1,0 +1,4 @@
+NAME
+  ttkPathCompression
+DEPENDS
+  ttkAlgorithm

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -128,7 +128,7 @@
 
        <IntVectorProperty name="ComputeFinalSegmentation"
          label="Morse-Smale Complex Hash"
-         command="SetComputeFinalSegmentation"
+         command="computeMSSegmentationHash"
          number_of_elements="1"
          default_values="1"
          panel_visibility="default">

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -7,10 +7,8 @@
       <Documentation
         long_help="TTK pathCompression plugin."
         short_help="TTK pathCompression plugin.">
-        TTK plugin for the computation of Morse-Smale segmentation.
-
-        Morse-Smale complexes are useful topological abstractions of scalar
-        fields for data segmentation, feature extraction, etc.
+        TTK plugin for the computation of Morse-Smale segmentation. It allows to extract the ascending, descending, and Morse-Smale segmentation hash as point data arrays.
+        Each array represents the minimum/maximum/minimum-maximum combination a vertex is reaching when following the gradient direction. By using path compression, the computational complexity was minimized.
 
         Related publication:
         "Parallel Computation of Piecewise Linear Morse-Smale Segmentations"
@@ -112,7 +110,7 @@
          panel_visibility="default">
          <BooleanDomain name="bool"/>
          <Documentation>
-           Toggles the creation of the Ascending segmentation, where each vertex points towards its minimum.
+           Toggles the creation of the ascending segmentation, where each vertex points towards its minimum.
          </Documentation>
        </IntVectorProperty>
 
@@ -124,7 +122,7 @@
          panel_visibility="default">
          <BooleanDomain name="bool"/>
          <Documentation>
-           Toggles the creation of the Descending segmentation, where each vertex points towards its maximum.
+           Toggles the creation of the descending segmentation, where each vertex points towards its maximum.
          </Documentation>
        </IntVectorProperty>
 

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -128,7 +128,7 @@
 
        <IntVectorProperty name="ComputeFinalSegmentation"
          label="Morse-Smale Complex Hash"
-         command="computeMSSegmentationHash"
+         command="SetComputeMSSegmentationHash"
          number_of_elements="1"
          default_values="1"
          panel_visibility="default">

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -5,8 +5,8 @@
       class="ttkPathCompression"
       label="TTK PathCompression">
       <Documentation
-        long_help="TTK pathCompression plugin."
-        short_help="TTK pathCompression plugin.">
+        long_help="TTK plugin for the computation of Morse-Smale segmentation."
+        short_help="TTK plugin for the computation of Morse-Smale segmentation.">
         TTK plugin for the computation of Morse-Smale segmentation. It allows to extract the ascending, descending, and Morse-Smale segmentation hash as point data arrays.
         Each array represents the minimum/maximum/minimum-maximum combination a vertex is reaching when following the gradient direction. By using path compression, the computational complexity was minimized.
 
@@ -17,7 +17,7 @@
 
         Online examples:
 
-        - https://topology-tool-kit.github.io/examples/?/
+        - https://topology-tool-kit.github.io/examples/morseSmaleSegmentation_at/
 
       </Documentation>
       <InputProperty

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -8,7 +8,7 @@
         long_help="TTK plugin for the computation of Morse-Smale segmentation."
         short_help="TTK plugin for the computation of Morse-Smale segmentation.">
         TTK plugin for the computation of Morse-Smale segmentation. It allows to extract the ascending, descending, and Morse-Smale segmentation hash as point data arrays.
-        Each array represents the minimum/maximum/minimum-maximum combination a vertex is reaching when following the gradient direction. By using path compression, the computational complexity was minimized.
+        Each array represents the minimum/maximum/minimum-maximum combination a vertex is reaching when following the gradient direction. By using path compression, the computational cost was minimized.
 
         Related publication:
         "Parallel Computation of Piecewise Linear Morse-Smale Segmentations"

--- a/paraview/xmls/PathCompression.xml
+++ b/paraview/xmls/PathCompression.xml
@@ -1,0 +1,164 @@
+<ServerManagerConfiguration>
+  <ProxyGroup name="filters">
+    <SourceProxy
+      name="ttkPathCompression"
+      class="ttkPathCompression"
+      label="TTK PathCompression">
+      <Documentation
+        long_help="TTK pathCompression plugin."
+        short_help="TTK pathCompression plugin.">
+        TTK plugin for the computation of Morse-Smale segmentation.
+
+        Morse-Smale complexes are useful topological abstractions of scalar
+        fields for data segmentation, feature extraction, etc.
+
+        Related publication:
+        "Parallel Computation of Piecewise Linear Morse-Smale Segmentations"
+        Robin G. C. Maack, Jonas Lukasczyk, Julien Tierny, Hans Hagen, Ross Maciejewski, Christoph Garth
+        IEEE Transactions on Visualization and Computer Graphics, 2023
+
+        Online examples:
+
+        - https://topology-tool-kit.github.io/examples/?/
+
+      </Documentation>
+      <InputProperty
+        name="Input"
+        command="SetInputConnection">
+        <ProxyGroupDomain name="groups">
+          <Group name="sources"/>
+          <Group name="filters"/>
+        </ProxyGroupDomain>
+        <DataTypeDomain name="input_type">
+          <DataType value="vtkDataSet"/>
+        </DataTypeDomain>
+        <InputArrayDomain name="input_scalars" number_of_components="1">
+          <Property name="Input" function="FieldDataSelection" />
+        </InputArrayDomain>
+        <Documentation>
+          Data-set to process.
+          TTK assumes that the input dataset is made of only one connected component.
+          If it's not the case, you can use the filter "Connectivity" (and select "Extract Largest Region").
+        </Documentation>
+      </InputProperty>
+
+      <StringVectorProperty
+        name="Scalar Field"
+        command="SetInputArrayToProcess"
+        element_types="0 0 0 0 2"
+        default_values="0"
+        number_of_elements="5"
+        animateable="0"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0">
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Documentation>
+          Select the scalar field to process.
+        </Documentation>
+      </StringVectorProperty>
+
+      <IntVectorProperty
+        name="ForceInputOffsetScalarField"
+        command="SetForceInputOffsetScalarField"
+        label="Force Input Offset Field"
+        number_of_elements="1"
+        panel_visibility="advanced"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+          Check this box to force the usage of a specific input scalar field
+           as vertex offset (used to disambiguate flat plateaus).
+        </Documentation>
+      </IntVectorProperty>
+
+      <StringVectorProperty
+        name="Offset Field"
+        command="SetInputArrayToProcess"
+        element_types="0 0 0 0 2"
+        default_values="1"
+        number_of_elements="5"
+        animateable="0"
+        panel_visibility="advanced"
+        >
+        <ArrayListDomain
+          name="array_list"
+          default_values="0"
+          >
+          <RequiredProperties>
+            <Property name="Input" function="Input" />
+          </RequiredProperties>
+        </ArrayListDomain>
+        <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+            mode="visibility"
+            property="ForceInputOffsetScalarField"
+            value="1" />
+        </Hints>
+        <Documentation>
+          Select the input offset field (to disambiguate flat plateaus).
+        </Documentation>
+      </StringVectorProperty>
+
+       <IntVectorProperty name="ComputeAscendingSegmentation"
+         label="Ascending Segmentation"
+         command="SetComputeAscendingSegmentation"
+         number_of_elements="1"
+         default_values="1"
+         panel_visibility="default">
+         <BooleanDomain name="bool"/>
+         <Documentation>
+           Toggles the creation of the Ascending segmentation, where each vertex points towards its minimum.
+         </Documentation>
+       </IntVectorProperty>
+
+       <IntVectorProperty name="ComputeDescendingSegmentation"
+         label="Descending Segmentation"
+         command="SetComputeDescendingSegmentation"
+         number_of_elements="1"
+         default_values="1"
+         panel_visibility="default">
+         <BooleanDomain name="bool"/>
+         <Documentation>
+           Toggles the creation of the Descending segmentation, where each vertex points towards its maximum.
+         </Documentation>
+       </IntVectorProperty>
+
+       <IntVectorProperty name="ComputeFinalSegmentation"
+         label="Morse-Smale Complex Hash"
+         command="SetComputeFinalSegmentation"
+         number_of_elements="1"
+         default_values="1"
+         panel_visibility="default">
+         <BooleanDomain name="bool"/>
+         <Documentation>
+           Toggles the creation of a hash from the Ascending and Descending labels that can still exhibit hash collisions. 
+         </Documentation>
+       </IntVectorProperty>
+
+      <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="Scalar Field" />
+        <Property name="ForceInputOffsetScalarField"/>
+        <Property name="Offset Field"/>
+      </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="ComputeAscendingSegmentation"/>
+        <Property name="ComputeDescendingSegmentation"/>
+        <Property name="ComputeFinalSegmentation"/>
+      </PropertyGroup>
+
+      <OutputPort name="Segmentation" index="0" id="port0"/>
+
+      ${DEBUG_WIDGETS}
+
+      <Hints>
+        <ShowInMenu category="TTK - Scalar Data" />
+      </Hints>
+    </SourceProxy>
+  </ProxyGroup>
+</ServerManagerConfiguration>

--- a/standalone/PathCompression/CMakeLists.txt
+++ b/standalone/PathCompression/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(ttkPathCompressionCmd)
+
+if(TARGET ttkPathCompression)
+  add_executable(${PROJECT_NAME} main.cpp)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ttkPathCompression
+      VTK::IOXML
+    )
+  set_target_properties(${PROJECT_NAME}
+    PROPERTIES
+      INSTALL_RPATH
+        "${CMAKE_INSTALL_RPATH}"
+    )
+  install(
+    TARGETS
+      ${PROJECT_NAME}
+    RUNTIME DESTINATION
+      ${TTK_INSTALL_BINARY_DIR}
+    )
+endif()

--- a/standalone/PathCompression/main.cpp
+++ b/standalone/PathCompression/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
 
   pathCompression->SetComputeAscendingSegmentation(true);
   pathCompression->SetComputeDescendingSegmentation(true);
-  pathCompression->SetcomputeMSSegmentationHash(true);
+  pathCompression->SetComputeMSSegmentationHash(true);
   pathCompression->SetInputArrayToProcess(
     0, 0, 0, 0, inputArrayNames[0].data());
   pathCompression->Update();

--- a/standalone/PathCompression/main.cpp
+++ b/standalone/PathCompression/main.cpp
@@ -1,0 +1,163 @@
+/// TODO 12: Add your information
+/// \author Your Name Here <Your Email Address Here>.
+/// \date The Date Here.
+///
+/// \brief dummy program example.
+
+// TTK Includes
+#include <CommandLineParser.h>
+#include <ttkPathCompression.h>
+
+// VTK Includes
+#include <vtkCellData.h>
+#include <vtkDataArray.h>
+#include <vtkDataSet.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkXMLDataObjectWriter.h>
+#include <vtkXMLGenericDataObjectReader.h>
+
+int main(int argc, char **argv) {
+
+  // ---------------------------------------------------------------------------
+  // Program variables
+  // ---------------------------------------------------------------------------
+  std::vector<std::string> inputFilePaths;
+  std::vector<std::string> inputArrayNames;
+  std::string outputArrayName{"AveragedArray"};
+  std::string outputPathPrefix{"output"};
+  bool listArrays{false};
+
+  // ---------------------------------------------------------------------------
+  // Set program variables based on command line arguments
+  // ---------------------------------------------------------------------------
+  {
+    ttk::CommandLineParser parser;
+
+    // -------------------------------------------------------------------------
+    // Standard options and arguments
+    // -------------------------------------------------------------------------
+    parser.setArgument(
+      "i", &inputFilePaths, "Input data-sets (*.vti, *vtu, *vtp)", false);
+    parser.setArgument("a", &inputArrayNames, "Input array names", true);
+    parser.setArgument(
+      "o", &outputPathPrefix, "Output file prefix (no extension)", true);
+    parser.setOption("l", &listArrays, "List available arrays");
+
+    // -------------------------------------------------------------------------
+    // TODO 13: Declare custom arguments and options
+    // -------------------------------------------------------------------------
+    parser.setArgument("O", &outputArrayName, "Output array name", true);
+
+    parser.parse(argc, argv);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Command line output messages.
+  // ---------------------------------------------------------------------------
+  ttk::Debug msg;
+  msg.setDebugMsgPrefix("PathCompression");
+
+  // ---------------------------------------------------------------------------
+  // Initialize ttkPathCompression module (adjust parameters)
+  // ---------------------------------------------------------------------------
+  auto pathCompression = vtkSmartPointer<ttkPathCompression>::New();
+
+  // ---------------------------------------------------------------------------
+  // TODO 14: Pass custom arguments and options to the module
+  // ---------------------------------------------------------------------------
+  // pathCompression->SetOutputArrayName(outputArrayName);
+
+  // ---------------------------------------------------------------------------
+  // Read input vtkDataObjects (optionally: print available arrays)
+  // ---------------------------------------------------------------------------
+  vtkDataArray *defaultArray = nullptr;
+  for(size_t i = 0; i < inputFilePaths.size(); i++) {
+    // init a reader that can parse any vtkDataObject stored in xml format
+    auto reader = vtkSmartPointer<vtkXMLGenericDataObjectReader>::New();
+    reader->SetFileName(inputFilePaths[i].data());
+    reader->Update();
+
+    // check if input vtkDataObject was successfully read
+    auto inputDataObject = reader->GetOutput();
+    if(!inputDataObject) {
+      msg.printErr("Unable to read input file `" + inputFilePaths[i] + "' :(");
+      return 1;
+    }
+
+    auto inputAsVtkDataSet = vtkDataSet::SafeDownCast(inputDataObject);
+
+    // if requested print list of arrays, otherwise proceed with execution
+    if(listArrays) {
+      msg.printMsg(inputFilePaths[i] + ":");
+      if(inputAsVtkDataSet) {
+        // Point Data
+        msg.printMsg("  PointData:");
+        auto pointData = inputAsVtkDataSet->GetPointData();
+        for(int j = 0; j < pointData->GetNumberOfArrays(); j++)
+          msg.printMsg("    - " + std::string(pointData->GetArrayName(j)));
+
+        // Cell Data
+        msg.printMsg("  CellData:");
+        auto cellData = inputAsVtkDataSet->GetCellData();
+        for(int j = 0; j < cellData->GetNumberOfArrays(); j++)
+          msg.printMsg("    - " + std::string(cellData->GetArrayName(j)));
+      } else {
+        msg.printErr("Unable to list arrays on file `" + inputFilePaths[i]
+                     + "'");
+        return 1;
+      }
+    } else {
+      // feed input object to ttkPathCompression filter
+      pathCompression->SetInputDataObject(i, reader->GetOutput());
+
+      // default arrays
+      if(!defaultArray) {
+        defaultArray = inputAsVtkDataSet->GetPointData()->GetArray(0);
+        if(!defaultArray)
+          defaultArray = inputAsVtkDataSet->GetCellData()->GetArray(0);
+      }
+    }
+  }
+
+  // terminate program if it was just asked to list arrays
+  if(listArrays) {
+    return 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Specify which arrays of the input vtkDataObjects will be processed
+  // ---------------------------------------------------------------------------
+  if(!inputArrayNames.size()) {
+    if(defaultArray)
+      inputArrayNames.emplace_back(defaultArray->GetName());
+  }
+  for(size_t i = 0; i < inputArrayNames.size(); i++)
+    pathCompression->SetInputArrayToProcess(i, 0, 0, 0, inputArrayNames[i].data());
+
+  // ---------------------------------------------------------------------------
+  // Execute ttkPathCompression filter
+  // ---------------------------------------------------------------------------
+  pathCompression->Update();
+
+  // ---------------------------------------------------------------------------
+  // If output prefix is specified then write all output objects to disk
+  // ---------------------------------------------------------------------------
+  if(!outputPathPrefix.empty()) {
+    for(int i = 0; i < pathCompression->GetNumberOfOutputPorts(); i++) {
+      auto output = pathCompression->GetOutputDataObject(i);
+      auto writer = vtkSmartPointer<vtkXMLWriter>::Take(
+        vtkXMLDataObjectWriter::NewWriter(output->GetDataObjectType()));
+
+      std::string outputFileName = outputPathPrefix + "_port_"
+                                   + std::to_string(i) + "."
+                                   + writer->GetDefaultFileExtension();
+      msg.printMsg("Writing output file `" + outputFileName + "'...");
+      writer->SetInputDataObject(output);
+      writer->SetFileName(outputFileName.data());
+      writer->Update();
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The path compression filter allows to take an input scalar field (vtkDataSet) and compute the ascending and descending Morse segmentations, as well as a Morse-Smale segmentation hash.
