### PR TITLE
Enable & fix compiler flags

### DIFF
--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -9,6 +9,7 @@ if (NOT MSVC) # GCC and Clang
     -Wtype-limits
     -Wshadow
     -Wvla
+    -Wcast-qual
     )
 
   # performance and debug flags

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -10,6 +10,7 @@ if (NOT MSVC) # GCC and Clang
     -Wshadow
     -Wvla
     -Wcast-qual
+    -Wmissing-declarations
     )
 
   # performance and debug flags

--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -11,6 +11,7 @@ if (NOT MSVC) # GCC and Clang
     -Wvla
     -Wcast-qual
     -Wmissing-declarations
+    -Wundef
     )
 
   # performance and debug flags

--- a/core/base/bottleneckDistance/BottleneckDistance.cpp
+++ b/core/base/bottleneckDistance/BottleneckDistance.cpp
@@ -370,20 +370,20 @@ void ttk::BottleneckDistance::computeMinMaxSaddleNumberAndMapping(
   }
 }
 
-void solvePWasserstein(std::vector<std::vector<double>> &matrix,
-                       std::vector<ttk::MatchingType> &matchings,
-                       ttk::AssignmentMunkres<double> &solver) {
+static void solvePWasserstein(std::vector<std::vector<double>> &matrix,
+                              std::vector<ttk::MatchingType> &matchings,
+                              ttk::AssignmentMunkres<double> &solver) {
 
   solver.setInput(matrix);
   solver.run(matchings);
   solver.clearMatrix();
 }
 
-void solveInfinityWasserstein(const int nbRow,
-                              const int nbCol,
-                              std::vector<std::vector<double>> &matrix,
-                              std::vector<ttk::MatchingType> &matchings,
-                              ttk::GabowTarjan &solver) {
+static void solveInfinityWasserstein(const int nbRow,
+                                     const int nbCol,
+                                     std::vector<std::vector<double>> &matrix,
+                                     std::vector<ttk::MatchingType> &matchings,
+                                     ttk::GabowTarjan &solver) {
 
   // Copy input matrix.
   auto bottleneckMatrix = matrix;

--- a/core/base/cinemaImaging/CinemaImagingEmbree.cpp
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.cpp
@@ -5,7 +5,7 @@ ttk::CinemaImagingEmbree::CinemaImagingEmbree() {
 }
 ttk::CinemaImagingEmbree::~CinemaImagingEmbree() = default;
 
-#if TTK_ENABLE_EMBREE
+#ifdef TTK_ENABLE_EMBREE
 
 int ttk::CinemaImagingEmbree::deallocateScene(RTCDevice &device,
                                               RTCScene &scene) const {
@@ -221,4 +221,4 @@ int ttk::CinemaImagingEmbree::renderImage(
   return 1;
 };
 
-#endif
+#endif // TTK_ENABLE_EMBREE

--- a/core/base/cinemaImaging/CinemaImagingEmbree.h
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.h
@@ -11,11 +11,11 @@
 
 #include <CinemaImaging.h>
 
-#if TTK_ENABLE_EMBREE
+#ifdef TTK_ENABLE_EMBREE
 #include <embree3/rtcore.h>
 #include <limits>
 #include <string>
-#endif
+#endif // TTK_ENABLE_EMBREE
 
 namespace ttk {
 
@@ -24,7 +24,7 @@ namespace ttk {
     CinemaImagingEmbree();
     ~CinemaImagingEmbree() override;
 
-#if TTK_ENABLE_EMBREE
+#ifdef TTK_ENABLE_EMBREE
 
     int initializeDevice(RTCDevice &device) const;
 
@@ -51,11 +51,11 @@ namespace ttk {
 
     int deallocateScene(RTCDevice &device, RTCScene &scene) const;
 
-#endif
+#endif // TTK_ENABLE_EMBREE
   };
 } // namespace ttk
 
-#if TTK_ENABLE_EMBREE
+#ifdef TTK_ENABLE_EMBREE
 
 template <typename IT>
 int ttk::CinemaImagingEmbree::initializeScene(
@@ -116,4 +116,4 @@ int ttk::CinemaImagingEmbree::initializeScene(
   return 1;
 };
 
-#endif
+#endif // TTK_ENABLE_EMBREE

--- a/core/base/common/BaseClass.h
+++ b/core/base/common/BaseClass.h
@@ -14,10 +14,10 @@
 
 #include <DataTypes.h>
 #include <OpenMP.h>
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
 #define OMPI_SKIP_MPICXX 1
 #include <mpi.h>
-#endif
+#endif // TTK_ENABLE_MPI
 
 #if defined(_MSC_VER) && defined(TTK_ENABLE_SHARED_BASE_LIBRARIES)
 #if defined(common_EXPORTS)

--- a/core/base/common/Debug.cpp
+++ b/core/base/common/Debug.cpp
@@ -33,11 +33,11 @@ Debug::~Debug() {
 
 int Debug::welcomeMsg(ostream &stream) {
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
   if(MPIrank_ != 0) {
     ttk::welcomeMsg_ = false;
   }
-#endif
+#endif // TTK_ENABLE_MPI
 
   int priorityAsInt = (int)debug::Priority::PERFORMANCE;
 

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -363,7 +363,7 @@ namespace ttk {
      */
     inline void setDebugMsgPrefix(const std::string &prefix) {
       this->debugMsgNamePrefix_ = prefix;
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
       this->debugMsgPrefix_
         = debugMsgNamePrefix_.length() > 0
             ? "[" + debugMsgNamePrefix_ + "-" + std::to_string(MPIrank_) + "] "
@@ -372,7 +372,7 @@ namespace ttk {
       this->debugMsgPrefix_ = debugMsgNamePrefix_.length() > 0
                                 ? "[" + debugMsgNamePrefix_ + "] "
                                 : "";
-#endif
+#endif // TTK_ENABLE_MPI
     }
 
   protected:

--- a/core/base/common/Debug.h
+++ b/core/base/common/Debug.h
@@ -325,8 +325,9 @@ namespace ttk {
          && (globalDebugLevel_ < (int)priority))
         return 0;
 
-      return this->printMsgInternal(
-        "", "", std::string(1, (char &)separator), priority, lineMode, stream);
+      return this->printMsgInternal("", "",
+                                    std::string(1, (const char &)separator),
+                                    priority, lineMode, stream);
     }
 
     /**
@@ -351,8 +352,9 @@ namespace ttk {
          && (globalDebugLevel_ < (int)priority))
         return 0;
 
-      return this->printMsgInternal(
-        msg, "", std::string(1, (char &)separator), priority, lineMode, stream);
+      return this->printMsgInternal(msg, "",
+                                    std::string(1, (const char &)separator),
+                                    priority, lineMode, stream);
     }
 
     /**

--- a/core/base/compactTriangulation/CompactTriangulation.cpp
+++ b/core/base/compactTriangulation/CompactTriangulation.cpp
@@ -74,24 +74,27 @@ int CompactTriangulation::reorderVertices(std::vector<SimplexId> &vertexMap) {
     for(SimplexId vid = 0; vid < vertexNumber_; vid++) {
       for(int j = 0; j < 3; j++) {
         newPointSet[3 * vertexMap[vid] + j]
-          = ((double *)pointSet_)[3 * vid + j];
+          = ((const double *)pointSet_)[3 * vid + j];
       }
     }
     for(SimplexId vid = 0; vid < vertexNumber_; vid++) {
       for(int j = 0; j < 3; j++) {
-        ((double *)pointSet_)[3 * vid + j] = newPointSet[3 * vid + j];
+        const_cast<double *>((const double *)pointSet_)[3 * vid + j]
+          = newPointSet[3 * vid + j];
       }
     }
   } else {
     std::vector<float> newPointSet(3 * vertexNumber_);
     for(SimplexId vid = 0; vid < vertexNumber_; vid++) {
       for(int j = 0; j < 3; j++) {
-        newPointSet[3 * vertexMap[vid] + j] = ((float *)pointSet_)[3 * vid + j];
+        newPointSet[3 * vertexMap[vid] + j]
+          = ((const float *)pointSet_)[3 * vid + j];
       }
     }
     for(SimplexId vid = 0; vid < vertexNumber_; vid++) {
       for(int j = 0; j < 3; j++) {
-        ((float *)pointSet_)[3 * vid + j] = newPointSet[3 * vid + j];
+        const_cast<float *>((const float *)pointSet_)[3 * vid + j]
+          = newPointSet[3 * vid + j];
       }
     }
   }
@@ -100,7 +103,7 @@ int CompactTriangulation::reorderVertices(std::vector<SimplexId> &vertexMap) {
   for(SimplexId nid = 1; nid <= nodeNumber_; nid++) {
     for(SimplexId vid = vertexIntervals_[nid - 1] + 1;
         vid <= vertexIntervals_[nid]; vid++) {
-      ((int *)vertexIndices_)[vid] = nid;
+      const_cast<int *>(vertexIndices_)[vid] = nid;
     }
   }
 
@@ -114,7 +117,7 @@ int CompactTriangulation::reorderCells(const std::vector<SimplexId> &vertexMap,
   // change the indices in cell array
   SimplexId cellCount = 0, verticesPerCell = offset[1] - offset[0];
   std::vector<std::vector<SimplexId>> nodeCells(nodeNumber_ + 1);
-  LongSimplexId *cellArr = ((LongSimplexId *)connectivity);
+  LongSimplexId *cellArr = const_cast<LongSimplexId *>(connectivity);
 
   for(SimplexId cid = 0; cid < cellNumber; cid++) {
     SimplexId cellId = offset[cid];
@@ -151,7 +154,7 @@ int CompactTriangulation::reorderCells(const std::vector<SimplexId> &vertexMap,
 
   // copy the new cell array back to original one
   for(SimplexId i = 0; i < verticesPerCell * cellNumber; i++) {
-    ((LongSimplexId *)connectivity)[i] = newCellArray[i];
+    const_cast<LongSimplexId *>(connectivity)[i] = newCellArray[i];
   }
 
   return 0;
@@ -162,7 +165,7 @@ int CompactTriangulation::reorderCells(const std::vector<SimplexId> &vertexMap,
   // change the indices in cell array
   SimplexId cellCount = 0, verticesPerCell = cellArray[0];
   std::vector<std::vector<SimplexId>> nodeCells(nodeNumber_ + 1);
-  LongSimplexId *cellArr = ((LongSimplexId *)cellArray);
+  LongSimplexId *cellArr = const_cast<LongSimplexId *>(cellArray);
 
   for(SimplexId cid = 0; cid < cellNumber_; cid++) {
     SimplexId cellId = (verticesPerCell + 1) * cid;
@@ -200,7 +203,7 @@ int CompactTriangulation::reorderCells(const std::vector<SimplexId> &vertexMap,
 
   // copy the new cell array back to original one
   for(SimplexId i = 0; i < (verticesPerCell + 1) * cellNumber_; i++) {
-    ((LongSimplexId *)cellArray)[i] = newCellArray[i];
+    const_cast<LongSimplexId *>(cellArray)[i] = newCellArray[i];
   }
 
   return 0;

--- a/core/base/compactTriangulation/CompactTriangulation.h
+++ b/core/base/compactTriangulation/CompactTriangulation.h
@@ -1147,13 +1147,13 @@ namespace ttk {
 #endif
 
       if(doublePrecision_) {
-        x = ((double *)pointSet_)[3 * vertexId];
-        y = ((double *)pointSet_)[3 * vertexId + 1];
-        z = ((double *)pointSet_)[3 * vertexId + 2];
+        x = ((const double *)pointSet_)[3 * vertexId];
+        y = ((const double *)pointSet_)[3 * vertexId + 1];
+        z = ((const double *)pointSet_)[3 * vertexId + 2];
       } else {
-        x = ((float *)pointSet_)[3 * vertexId];
-        y = ((float *)pointSet_)[3 * vertexId + 1];
-        z = ((float *)pointSet_)[3 * vertexId + 2];
+        x = ((const float *)pointSet_)[3 * vertexId];
+        y = ((const float *)pointSet_)[3 * vertexId + 1];
+        z = ((const float *)pointSet_)[3 * vertexId + 2];
       }
 
       return 0;

--- a/core/base/explicitTriangulation/ExplicitTriangulation.h
+++ b/core/base/explicitTriangulation/ExplicitTriangulation.h
@@ -410,13 +410,13 @@ namespace ttk {
 #endif
 
       if(doublePrecision_) {
-        x = ((double *)pointSet_)[3 * vertexId];
-        y = ((double *)pointSet_)[3 * vertexId + 1];
-        z = ((double *)pointSet_)[3 * vertexId + 2];
+        x = ((const double *)pointSet_)[3 * vertexId];
+        y = ((const double *)pointSet_)[3 * vertexId + 1];
+        z = ((const double *)pointSet_)[3 * vertexId + 2];
       } else {
-        x = ((float *)pointSet_)[3 * vertexId];
-        y = ((float *)pointSet_)[3 * vertexId + 1];
-        z = ((float *)pointSet_)[3 * vertexId + 2];
+        x = ((const float *)pointSet_)[3 * vertexId];
+        y = ((const float *)pointSet_)[3 * vertexId + 1];
+        z = ((const float *)pointSet_)[3 * vertexId + 2];
       }
 
       return 0;

--- a/core/base/fiberSurface/FiberSurface.h
+++ b/core/base/fiberSurface/FiberSurface.h
@@ -613,10 +613,10 @@ inline int ttk::FiberSurface::computeBaseTriangle(
 
     std::array<double, 2> baryCentrics{};
     std::array<double, 2> p0{}, p1{}, p{};
-    p0[0] = ((dataTypeU *)uField_)[vertexId0];
-    p0[1] = ((dataTypeV *)vField_)[vertexId0];
-    p1[0] = ((dataTypeU *)uField_)[vertexId1];
-    p1[1] = ((dataTypeV *)vField_)[vertexId1];
+    p0[0] = ((const dataTypeU *)uField_)[vertexId0];
+    p0[1] = ((const dataTypeV *)vField_)[vertexId0];
+    p1[0] = ((const dataTypeU *)uField_)[vertexId1];
+    p1[1] = ((const dataTypeV *)vField_)[vertexId1];
     p[0] = basePointProjections[i].first;
     p[1] = basePointProjections[i].second;
     Geometry::computeBarycentricCoordinates(
@@ -755,10 +755,10 @@ inline int ttk::FiberSurface::computeCase0(
 
     std::array<double, 2> baryCentrics{};
     std::array<double, 2> p0{}, p1{}, p{};
-    p0[0] = ((dataTypeU *)uField_)[vertexId0];
-    p0[1] = ((dataTypeV *)vField_)[vertexId0];
-    p1[0] = ((dataTypeU *)uField_)[vertexId1];
-    p1[1] = ((dataTypeV *)vField_)[vertexId1];
+    p0[0] = ((const dataTypeU *)uField_)[vertexId0];
+    p0[1] = ((const dataTypeV *)vField_)[vertexId0];
+    p1[0] = ((const dataTypeU *)uField_)[vertexId1];
+    p1[1] = ((const dataTypeV *)vField_)[vertexId1];
     p[0] = (*polygonEdgeVertexLists_[polygonEdgeId])[vertexId + i].uv_.first;
     p[1] = (*polygonEdgeVertexLists_[polygonEdgeId])[vertexId + i].uv_.second;
     Geometry::computeBarycentricCoordinates(
@@ -1861,8 +1861,8 @@ inline int ttk::FiberSurface::processTetrahedron(
     }
 
     double projectedVertex[2];
-    projectedVertex[0] = ((dataTypeU *)uField_)[vertexId];
-    projectedVertex[1] = ((dataTypeV *)vField_)[vertexId];
+    projectedVertex[0] = ((const dataTypeU *)uField_)[vertexId];
+    projectedVertex[1] = ((const dataTypeV *)vField_)[vertexId];
 
     double vertexRangeEdge[2];
     vertexRangeEdge[0] = projectedVertex[0] - rangePoint0.first;
@@ -2053,11 +2053,11 @@ inline int ttk::FiberSurface::processTetrahedron(
              && (triangleEdges[i][j] == triangleEdges[i][j + 1])) {
 
             // special case of a jacobi edge
-            uv[j].first = ((dataTypeU *)uField_)[vertexId0];
-            uv[j].second = ((dataTypeV *)vField_)[vertexId0];
+            uv[j].first = ((const dataTypeU *)uField_)[vertexId0];
+            uv[j].second = ((const dataTypeV *)vField_)[vertexId0];
 
-            uv[j + 1].first = ((dataTypeU *)uField_)[vertexId1];
-            uv[j + 1].second = ((dataTypeV *)vField_)[vertexId1];
+            uv[j + 1].first = ((const dataTypeU *)uField_)[vertexId1];
+            uv[j + 1].second = ((const dataTypeV *)vField_)[vertexId1];
 
           } else if((!j)
                     || ((j)
@@ -2065,12 +2065,12 @@ inline int ttk::FiberSurface::processTetrahedron(
 
             // regular intersection case
             d0 = d[edgeImplicitEncoding_[2 * triangleEdges[i][j]]];
-            uv0.first = ((dataTypeU *)uField_)[vertexId0];
-            uv0.second = ((dataTypeV *)vField_)[vertexId0];
+            uv0.first = ((const dataTypeU *)uField_)[vertexId0];
+            uv0.second = ((const dataTypeV *)vField_)[vertexId0];
 
             d1 = d[edgeImplicitEncoding_[2 * triangleEdges[i][j] + 1]];
-            uv1.first = ((dataTypeU *)uField_)[vertexId1];
-            uv1.second = ((dataTypeV *)vField_)[vertexId1];
+            uv1.first = ((const dataTypeU *)uField_)[vertexId1];
+            uv1.second = ((const dataTypeV *)vField_)[vertexId1];
 
             uv[j].first
               = uv0.first + (d0 / (d0 - d1)) * (uv1.first - uv0.first);

--- a/core/base/ftmTree/FTMTree_MT.h
+++ b/core/base/ftmTree/FTMTree_MT.h
@@ -341,8 +341,8 @@ namespace ttk {
       }
 
       template <typename scalarType>
-      inline void setVertexScalars(scalarType *vals) {
-        scalars_->values = (void *)vals;
+      inline void setVertexScalars(const scalarType *vals) {
+        scalars_->values = static_cast<void *>(const_cast<scalarType *>(vals));
       }
 
       // offset

--- a/core/base/ftrGraph/FTRGraph.h
+++ b/core/base/ftrGraph/FTRGraph.h
@@ -186,7 +186,8 @@ namespace ttk {
 
       /// Scalar field used to compute the Reeb Graph
       void setScalars(const void *scalars) {
-        scalars_.setScalars((ScalarType *)scalars);
+        scalars_.setScalars(
+          const_cast<ScalarType *>((const ScalarType *)scalars));
       }
 
       /// When several points have the same scalar value,

--- a/core/base/implicitTriangulation/ImplicitTriangulation.cpp
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.cpp
@@ -283,11 +283,11 @@ template <typename Derived>
 bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
   isVertexOnBoundary)(const SimplexId &vertexId) const {
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
   if(this->metaGrid_ != nullptr) {
     return this->isVertexOnGlobalBoundaryInternal(vertexId);
   }
-#endif
+#endif // TTK_ENABLE_MPI
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(vertexId < 0 or vertexId >= vertexNumber_)
@@ -308,11 +308,11 @@ template <typename Derived>
 bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
   isEdgeOnBoundary)(const SimplexId &edgeId) const {
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
   if(this->metaGrid_ != nullptr) {
     return this->isEdgeOnGlobalBoundaryInternal(edgeId);
   }
-#endif
+#endif // TTK_ENABLE_MPI
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(edgeId < 0 or edgeId >= edgeNumber_)
@@ -340,11 +340,11 @@ bool ImplicitTriangulationCRTP<Derived>::TTK_TRIANGULATION_INTERNAL(
 bool ImplicitTriangulation::TTK_TRIANGULATION_INTERNAL(isTriangleOnBoundary)(
   const SimplexId &triangleId) const {
 
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
   if(this->metaGrid_ != nullptr) {
     return this->isTriangleOnGlobalBoundaryInternal(triangleId);
   }
-#endif
+#endif // TTK_ENABLE_MPI
 
 #ifndef TTK_ENABLE_KAMIKAZE
   if(triangleId < 0 or triangleId >= triangleNumber_)

--- a/core/base/integralLines/IntegralLines.h
+++ b/core/base/integralLines/IntegralLines.h
@@ -403,9 +403,9 @@ void ttk::IntegralLines::receiveElement(
 
   // Create integral line object on this process
   int threadNum{0};
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
   threadNum = omp_get_thread_num();
-#endif
+#endif // TTK_ENABLE_OPENMP
 
   ttk::intgl::IntegralLine *integralLine
     = outputIntegralLines_->at(threadNum).addArrayElement(
@@ -463,14 +463,14 @@ void ttk::IntegralLines::storeToSendIfNecessary(
           = integralLine->localVertexIdentifier.back();
         element.LocalVertexIdentifier1
           = integralLine->localVertexIdentifier.at(size - 2);
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
         toSend_
           ->at(neighborsToId_.find(rankArray)->second)[omp_get_thread_num()]
           .push_back(element);
 #else
         toSend_->at(neighborsToId_.find(rankArray)->second)[0].push_back(
           element);
-#endif
+#endif // TTK_ENABLE_OPENMP
         isMax = true;
       }
     }
@@ -528,9 +528,9 @@ void ttk::IntegralLines::computeIntegralLine(
 #ifdef TTK_ENABLE_MPI
       if(ttk::isRunningWithMPI()
          && triangulation->getVertexRank(v) == ttk::MPIrank_) {
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic update seq_cst
-#endif
+#endif // TTK_ENABLE_OPENMP
         ttk::intgl::finishedElement_++;
       } else {
         this->storeToSendIfNecessary<triangulationType>(
@@ -552,13 +552,13 @@ void ttk::IntegralLines::computeIntegralLine(
         // and a task is created to further the computation of the integral line
         ttk::SimplexId numberOfComponents = components->size();
 #ifdef TTK_ENABLE_MPI
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic update seq_cst
-#endif
+#endif // TTK_ENABLE_OPENMP
         ttk::intgl::finishedElement_++;
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp atomic update seq_cst
-#endif
+#endif // TTK_ENABLE_OPENMP
         ttk::intgl::addedElement_ += numberOfComponents;
 #endif
         isMax = true;
@@ -576,9 +576,9 @@ void ttk::IntegralLines::computeIntegralLine(
           triangulation->getVertexPoint(vnext, p1[0], p1[1], p1[2]);
           double distanceFork = Geometry::distance(p0, p1, 3);
           int threadNum{0};
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
           threadNum = omp_get_thread_num();
-#endif
+#endif // TTK_ENABLE_OPENMP
           ttk::intgl::IntegralLine *integralLineFork
             = outputIntegralLines_->at(threadNum).addArrayElement(
               ttk::intgl::IntegralLine{
@@ -589,10 +589,10 @@ void ttk::IntegralLines::computeIntegralLine(
                    integralLine->localVertexIdentifier.back() + 1}),
                 integralLine->seedIdentifier, forkIdentifier});
 
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(integralLineFork)
           {
-#endif
+#endif // TTK_ENABLE_OPENMP
 #ifdef TTK_ENABLE_MPI
             bool hasBeenSent = false;
             this->storeToSendIfNecessary<triangulationType>(
@@ -604,9 +604,9 @@ void ttk::IntegralLines::computeIntegralLine(
 #ifdef TTK_ENABLE_MPI
             }
 #endif
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
           }
-#endif
+#endif // TTK_ENABLE_OPENMP
         }
       } else {
         // In case the vertex is not a saddle point, all neighbor vertices
@@ -663,9 +663,9 @@ void ttk::IntegralLines::prepareForTask(
     seedIdentifier = v;
 #endif
     int threadNum{0};
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
     threadNum = omp_get_thread_num();
-#endif
+#endif // TTK_ENABLE_OPENMP
     chunkIntegralLine[j] = outputIntegralLines_->at(threadNum).addArrayElement(
       ttk::intgl::IntegralLine{
         std::vector<ttk::SimplexId>(1, v), std::vector<double>(1, 0),
@@ -679,17 +679,17 @@ void ttk::IntegralLines::createTask(
   std::vector<ttk::intgl::IntegralLine *> &chunkIntegralLine,
   const ttk::SimplexId *offsets,
   int nbElement) const {
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp task firstprivate(chunkIntegralLine)
   {
-#endif
+#endif // TTK_ENABLE_OPENMP
     for(int j = 0; j < nbElement; j++) {
       this->computeIntegralLine<triangulationType>(
         triangulation, chunkIntegralLine[j], offsets);
     }
-#if TTK_ENABLE_OPENMP
+#ifdef TTK_ENABLE_OPENMP
   }
-#endif
+#endif // TTK_ENABLE_OPENMP
 }
 
 template <class triangulationType>

--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -573,7 +573,8 @@ int ttk::PersistenceDiagram::executeApproximateTopology(
 
   approxT_.setDebugLevel(debugLevel_);
   approxT_.setThreadNumber(threadNumber_);
-  approxT_.setupTriangulation((ttk::ImplicitTriangulation *)triangulation);
+  approxT_.setupTriangulation(const_cast<ttk::ImplicitTriangulation *>(
+    (const ImplicitTriangulation *)triangulation));
   approxT_.setStartingResolutionLevel(StartingResolutionLevel);
   approxT_.setStoppingResolutionLevel(StoppingResolutionLevel);
   approxT_.setPreallocateMemory(true);
@@ -616,7 +617,8 @@ int ttk::PersistenceDiagram::executeProgressiveTopology(
 
   progT_.setDebugLevel(debugLevel_);
   progT_.setThreadNumber(threadNumber_);
-  progT_.setupTriangulation((ttk::ImplicitTriangulation *)triangulation);
+  progT_.setupTriangulation(const_cast<ttk::ImplicitTriangulation *>(
+    (const ImplicitTriangulation *)triangulation));
   progT_.setStartingResolutionLevel(StartingResolutionLevel);
   progT_.setStoppingResolutionLevel(StoppingResolutionLevel);
   progT_.setTimeLimit(TimeLimit);

--- a/core/base/rangeDrivenOctree/RangeDrivenOctree.h
+++ b/core/base/rangeDrivenOctree/RangeDrivenOctree.h
@@ -132,8 +132,8 @@ int ttk::RangeDrivenOctree::build(
 
   Timer t;
 
-  dataTypeU *u = (dataTypeU *)u_;
-  dataTypeV *v = (dataTypeV *)v_;
+  const dataTypeU *u = (const dataTypeU *)u_;
+  const dataTypeV *v = (const dataTypeV *)v_;
 
   if(triangulation) {
     cellNumber_ = triangulation->getNumberOfCells();

--- a/core/base/ripsComplex/RipsComplex.cpp
+++ b/core/base/ripsComplex/RipsComplex.cpp
@@ -12,11 +12,11 @@ struct LocCell {
   std::array<ttk::SimplexId, n> verts;
 };
 
-void computeEdges(std::vector<ttk::SimplexId> &connectivity,
-                  std::vector<double> &diameters,
-                  const double epsilon,
-                  const std::vector<std::vector<double>> &distanceMatrix,
-                  const int nThreads) {
+static void computeEdges(std::vector<ttk::SimplexId> &connectivity,
+                         std::vector<double> &diameters,
+                         const double epsilon,
+                         const std::vector<std::vector<double>> &distanceMatrix,
+                         const int nThreads) {
 
   TTK_FORCE_USE(nThreads);
 
@@ -62,11 +62,12 @@ static inline void maxAssign(double &a, const double b) {
   }
 }
 
-void computeTriangles(std::vector<ttk::SimplexId> &connectivity,
-                      std::vector<double> &diameters,
-                      const double epsilon,
-                      const std::vector<std::vector<double>> &distanceMatrix,
-                      const int nThreads) {
+static void
+  computeTriangles(std::vector<ttk::SimplexId> &connectivity,
+                   std::vector<double> &diameters,
+                   const double epsilon,
+                   const std::vector<std::vector<double>> &distanceMatrix,
+                   const int nThreads) {
 
   TTK_FORCE_USE(nThreads);
 
@@ -118,11 +119,12 @@ void computeTriangles(std::vector<ttk::SimplexId> &connectivity,
   }
 }
 
-void computeTetras(std::vector<ttk::SimplexId> &connectivity,
-                   std::vector<double> &diameters,
-                   const double epsilon,
-                   const std::vector<std::vector<double>> &distanceMatrix,
-                   const int nThreads) {
+static void
+  computeTetras(std::vector<ttk::SimplexId> &connectivity,
+                std::vector<double> &diameters,
+                const double epsilon,
+                const std::vector<std::vector<double>> &distanceMatrix,
+                const int nThreads) {
 
   TTK_FORCE_USE(nThreads);
 

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -204,7 +204,8 @@ int ttk::ScalarFieldCriticalPoints::executeProgressive(
 
   progT_.setDebugLevel(debugLevel_);
   progT_.setThreadNumber(threadNumber_);
-  progT_.setupTriangulation((ttk::ImplicitTriangulation *)triangulation);
+  progT_.setupTriangulation(const_cast<ttk::ImplicitTriangulation *>(
+    (const ImplicitTriangulation *)triangulation));
   progT_.setStartingResolutionLevel(StartingResolutionLevel);
   progT_.setStoppingResolutionLevel(StoppingResolutionLevel);
   progT_.setTimeLimit(TimeLimit);

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -255,15 +255,14 @@ int ttk::ScalarFieldCriticalPoints::executeLegacy(
 #pragma omp parallel for schedule(dynamic, chunkSize) num_threads(threadNumber_)
 #endif
     for(SimplexId i = 0; i < (SimplexId)vertexNumber_; i++) {
-#if TTK_ENABLE_MPI
+#ifdef TTK_ENABLE_MPI
       if(!isRunningWithMPI()
          || (isRunningWithMPI()
-             && (triangulation->getVertexRank(i) == ttk::MPIrank_))) {
-#endif
+             && (triangulation->getVertexRank(i) == ttk::MPIrank_)))
+#endif // TTK_ENABLE_MPI
+      {
         vertexTypes[i] = getCriticalType(i, offsets, triangulation);
-#if TTK_ENABLE_MPI
       }
-#endif
     }
   } else if(vertexLinkEdgeLists_) {
     // legacy implementation

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -13,7 +13,7 @@
 #include <vtkUnstructuredGrid.h>
 #include <vtkVersion.h>
 
-vtkCellArray *GetCells(vtkDataSet *dataSet) {
+static vtkCellArray *GetCells(vtkDataSet *dataSet) {
   switch(dataSet->GetDataObjectType()) {
     case VTK_UNSTRUCTURED_GRID: {
       auto dataSetAsUG = static_cast<vtkUnstructuredGrid *>(dataSet);
@@ -29,7 +29,7 @@ vtkCellArray *GetCells(vtkDataSet *dataSet) {
   return nullptr;
 }
 
-int checkCellTypes(vtkPointSet *object) {
+static int checkCellTypes(vtkPointSet *object) {
 
   size_t nTypes = 0;
 

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -38,14 +38,13 @@ static int checkCellTypes(vtkPointSet *object) {
     auto objectAsUG = vtkUnstructuredGrid::SafeDownCast(object);
     auto distinctCellTypes = objectAsUG->GetDistinctCellTypesArray();
     nTypes = distinctCellTypes->GetNumberOfTuples();
-  } else {
+  } else
 #endif
+  {
     auto cellTypes = vtkSmartPointer<vtkCellTypes>::New();
     object->GetCellTypes(cellTypes);
     nTypes = cellTypes->GetNumberOfTypes();
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 2, 0)
   }
-#endif
 
   // if cells are empty
   if(nTypes == 0)

--- a/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
+++ b/core/vtk/ttkBlockAggregator/ttkBlockAggregator.cpp
@@ -46,7 +46,7 @@ int ttkBlockAggregator::Reset() {
   return 1;
 }
 
-int copyObjects(vtkDataObject *source, vtkDataObject *copy) {
+static int copyObjects(vtkDataObject *source, vtkDataObject *copy) {
   if(source->IsA("vtkMultiBlockDataSet")) {
     auto sourceAsMB = vtkMultiBlockDataSet::SafeDownCast(source);
     auto copyAsMB = vtkMultiBlockDataSet::SafeDownCast(copy);

--- a/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.cpp
+++ b/core/vtk/ttkBottleneckDistance/ttkBottleneckDistance.cpp
@@ -38,16 +38,16 @@ int ttkBottleneckDistance::FillOutputPortInformation(int port,
   return 0;
 }
 
-int generateMatchings(vtkUnstructuredGrid *const outputCT3,
-                      const ttk::DiagramType &diagram1,
-                      const ttk::DiagramType &diagram2,
-                      const std::vector<ttk::MatchingType> &matchings,
-                      const std::array<double, 3> &distances,
-                      const double globalDist,
-                      const double spacing,
-                      const bool isBottleneck,
-                      const bool is2D0,
-                      const bool is2D1) {
+static int generateMatchings(vtkUnstructuredGrid *const outputCT3,
+                             const ttk::DiagramType &diagram1,
+                             const ttk::DiagramType &diagram2,
+                             const std::vector<ttk::MatchingType> &matchings,
+                             const std::array<double, 3> &distances,
+                             const double globalDist,
+                             const double spacing,
+                             const bool isBottleneck,
+                             const bool is2D0,
+                             const bool is2D1) {
 
   vtkNew<vtkUnstructuredGrid> vtu{};
 

--- a/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.cpp
+++ b/core/vtk/ttkCinemaImaging/ttkCinemaImagingEmbree.cpp
@@ -25,7 +25,7 @@ int ttk::ttkCinemaImagingEmbree::RenderVTKObject(
   vtkPointSet *inputGrid) const {
   int status = 0;
 
-#if TTK_ENABLE_EMBREE
+#ifdef TTK_ENABLE_EMBREE
 
   auto inputObjectCells = ttkCinemaImaging::GetCells(inputObject);
 

--- a/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
+++ b/core/vtk/ttkCinemaWriter/ttkCinemaWriter.cpp
@@ -58,7 +58,7 @@ int ttkCinemaWriter::FillOutputPortInformation(int port, vtkInformation *info) {
   return 1;
 }
 
-int ensureFolder(const std::string &path) {
+static int ensureFolder(const std::string &path) {
   auto directory = vtkSmartPointer<vtkDirectory>::New();
   if(directory->Open(path.data()) == 1
      || vtkDirectory::MakeDirectory(path.data()) == 1)

--- a/core/vtk/ttkEndFor/ttkEndFor.cpp
+++ b/core/vtk/ttkEndFor/ttkEndFor.cpp
@@ -19,7 +19,6 @@ ttkEndFor::ttkEndFor() {
 }
 
 ttkEndFor::~ttkEndFor() = default;
-;
 
 int ttkEndFor::FillInputPortInformation(int port, vtkInformation *info) {
   if(port == 0 || port == 1) {
@@ -37,7 +36,7 @@ int ttkEndFor::FillOutputPortInformation(int port, vtkInformation *info) {
   return 0;
 }
 
-int removeFieldDataRecursively(vtkDataObject *object) {
+static int removeFieldDataRecursively(vtkDataObject *object) {
   object->GetFieldData()->RemoveArray("_ttk_IterationInfo");
   if(object->IsA("vtkMultiBlockDataSet")) {
     auto objectAsMB = static_cast<vtkMultiBlockDataSet *>(object);

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -32,7 +32,6 @@ ttkExtract::ttkExtract() {
   this->SetNumberOfOutputPorts(1);
 }
 ttkExtract::~ttkExtract() = default;
-;
 
 std::string ttkExtract::GetVtkDataTypeName(const int outputType) const {
   switch(outputType) {
@@ -99,7 +98,8 @@ int ttkExtract::RequestInformation(
   return 1;
 }
 
-int doubleVectorToString(std::string &str, const std::vector<double> &vec) {
+static int doubleVectorToString(std::string &str,
+                                const std::vector<double> &vec) {
   std::stringstream ss;
   for(auto &v : vec)
     ss << v << ",";

--- a/core/vtk/ttkForEach/ttkForEach.cpp
+++ b/core/vtk/ttkForEach/ttkForEach.cpp
@@ -22,10 +22,10 @@ ttkForEach::ttkForEach() {
 }
 
 ttkForEach::~ttkForEach() = default;
-;
 
-int addRecursivelyToFieldData(vtkDataObject *object,
-                              const vtkSmartPointer<vtkDataArray> &array) {
+static int
+  addRecursivelyToFieldData(vtkDataObject *object,
+                            const vtkSmartPointer<vtkDataArray> &array) {
   object->GetFieldData()->AddArray(array);
   if(object->IsA("vtkMultiBlockDataSet")) {
     auto objectAsMB = (vtkMultiBlockDataSet *)object;

--- a/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.cpp
+++ b/core/vtk/ttkMandatoryCriticalPoints/ttkMandatoryCriticalPoints.cpp
@@ -41,7 +41,7 @@ int ttkMandatoryCriticalPoints::FillOutputPortInformation(
   return 0;
 }
 
-void buildVtkTree(
+static void buildVtkTree(
   vtkUnstructuredGrid *outputTree,
   const ttk::Graph &graph,
   const std::vector<double> &xCoord,

--- a/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
+++ b/core/vtk/ttkMergeTreeClustering/ttkMergeTreeClustering.cpp
@@ -355,7 +355,7 @@ int ttkMergeTreeClustering::runCompute(
   return 1;
 }
 
-void addFieldData(vtkDataSet *in, vtkDataSet *out) {
+static void addFieldData(vtkDataSet *in, vtkDataSet *out) {
   auto inFieldData = in->GetFieldData();
   auto outFieldData = out->GetFieldData();
   for(int i = 0; i < inFieldData->GetNumberOfArrays(); ++i) {

--- a/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
+++ b/core/vtk/ttkMergeTreeTemporalReductionEncoding/ttkMergeTreeTemporalReductionEncoding.cpp
@@ -125,7 +125,7 @@ int ttkMergeTreeTemporalReductionEncoding::run(
   return 1;
 }
 
-std::vector<vtkSmartPointer<vtkDataSet>>
+static std::vector<vtkSmartPointer<vtkDataSet>>
   preprocessSegmentation(std::vector<vtkDataSet *> &treesSegmentation,
                          bool doResampleToImage = false) {
   std::vector<vtkSmartPointer<vtkDataSet>> images;

--- a/core/vtk/ttkOFFReader/ttkOFFReader.cpp
+++ b/core/vtk/ttkOFFReader/ttkOFFReader.cpp
@@ -39,7 +39,7 @@ ttkOFFReader::ttkOFFReader() {
   this->SetNumberOfOutputPorts(1);
 }
 
-int countVertsData(const std::string &line) {
+static int countVertsData(const std::string &line) {
   std::istringstream ss(line);
   double buffer;
   int nbFields = -1;
@@ -51,7 +51,7 @@ int countVertsData(const std::string &line) {
   return nbFields - 3;
 }
 
-int countCellsData(const std::string &line) {
+static int countCellsData(const std::string &line) {
   std::istringstream ss(line);
   double buffer;
   int nbFields = -1;
@@ -67,11 +67,11 @@ int countCellsData(const std::string &line) {
   return nbFields - sizeCell;
 }
 
-int processLineVert(vtkIdType curLine,
-                    std::string &line,
-                    vtkPoints *points,
-                    std::vector<vtkNew<vtkDoubleArray>> &vertScalars,
-                    const vtkIdType nbVertsData) {
+static int processLineVert(vtkIdType curLine,
+                           std::string &line,
+                           vtkPoints *points,
+                           std::vector<vtkNew<vtkDoubleArray>> &vertScalars,
+                           const vtkIdType nbVertsData) {
 
   double x, y, z;
   std::istringstream ss(line);
@@ -91,13 +91,13 @@ int processLineVert(vtkIdType curLine,
   return ++curLine;
 }
 
-int processLineCell(vtkIdType curLine,
-                    std::string &line,
-                    vtkUnstructuredGrid *mesh,
-                    std::vector<vtkNew<vtkDoubleArray>> &cellScalars,
-                    const vtkIdType nbVerts,
-                    const vtkIdType nbCellsData,
-                    const ttk::Debug &dbg) {
+static int processLineCell(vtkIdType curLine,
+                           std::string &line,
+                           vtkUnstructuredGrid *mesh,
+                           std::vector<vtkNew<vtkDoubleArray>> &cellScalars,
+                           const vtkIdType nbVerts,
+                           const vtkIdType nbCellsData,
+                           const ttk::Debug &dbg) {
   int nbCellVerts;
   vtkNew<vtkIdList> cellVerts{};
   std::istringstream ss(line);

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -169,10 +169,10 @@ int ttkPersistenceDiagramClustering::RequestData(
   return 1;
 }
 
-void addCostsAsFieldData(vtkUnstructuredGrid *vtu,
-                         const double minSadCost,
-                         const double sadSadCost,
-                         const double sadMaxCost) {
+static void addCostsAsFieldData(vtkUnstructuredGrid *vtu,
+                                const double minSadCost,
+                                const double sadSadCost,
+                                const double sadMaxCost) {
 
   // add global matchings cost as FieldData (only 1 tuple per array)
   vtkNew<vtkDoubleArray> minSad{};

--- a/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
+++ b/core/vtk/ttkTrackingFromOverlap/ttkTrackingFromOverlap.cpp
@@ -20,15 +20,15 @@
 using namespace std;
 using namespace ttk;
 
-vtkStandardNewMacro(ttkTrackingFromOverlap)
+vtkStandardNewMacro(ttkTrackingFromOverlap);
 
-  // Function to fetch data of a specificd block
-  void getData(vtkMultiBlockDataSet *mb,
-               size_t time,
-               size_t level,
-               const string &labelFieldName,
-               vtkPointSet *&pointSet,
-               vtkDataArray *&labels) {
+// Function to fetch data of a specificd block
+static void getData(vtkMultiBlockDataSet *mb,
+                    size_t time,
+                    size_t level,
+                    const string &labelFieldName,
+                    vtkPointSet *&pointSet,
+                    vtkDataArray *&labels) {
   auto timesteps = vtkMultiBlockDataSet::SafeDownCast(mb->GetBlock(level));
   pointSet = vtkPointSet::SafeDownCast(timesteps->GetBlock(time));
   if(pointSet == nullptr) {
@@ -40,9 +40,9 @@ vtkStandardNewMacro(ttkTrackingFromOverlap)
 
 // Function to compute number of levels and timesteps contained in a
 // vtkMultiBlockDataSet
-void getNumberOfLevelsAndTimesteps(vtkMultiBlockDataSet *mb,
-                                   size_t &nL,
-                                   size_t &nT) {
+static void getNumberOfLevelsAndTimesteps(vtkMultiBlockDataSet *mb,
+                                          size_t &nL,
+                                          size_t &nT) {
   nL = mb->GetNumberOfBlocks();
   auto timesteps = vtkMultiBlockDataSet::SafeDownCast(mb->GetBlock(0));
   nT = timesteps->GetNumberOfBlocks();

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -49,9 +49,9 @@ int ttkTriangulationManager::FillOutputPortInformation(int port,
   return 0;
 }
 
-void switchPeriodicity(ttk::Triangulation &triangulation,
-                       const bool periodic,
-                       const ttk::Debug &dbg) {
+static void switchPeriodicity(ttk::Triangulation &triangulation,
+                              const bool periodic,
+                              const ttk::Debug &dbg) {
   const bool prevPeriodic = triangulation.hasPeriodicBoundaries();
 
   if(prevPeriodic != periodic) {
@@ -73,9 +73,9 @@ void switchPeriodicity(ttk::Triangulation &triangulation,
   }
 }
 
-void switchPreconditions(ttk::Triangulation &triangulation,
-                         const ttk::Triangulation::STRATEGY precStrategy,
-                         const ttk::Debug &dbg) {
+static void switchPreconditions(ttk::Triangulation &triangulation,
+                                const ttk::Triangulation::STRATEGY precStrategy,
+                                const ttk::Debug &dbg) {
   const bool prevPreconditions = triangulation.hasImplicitPreconditions();
   if((precStrategy == ttk::Triangulation::STRATEGY::NO_PRECONDITIONS
       && !prevPreconditions)

--- a/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
+++ b/core/vtk/ttkWebSocketIO/ttkWebSocketIO.cpp
@@ -124,8 +124,8 @@ void jsonArrayToArray(const boost::property_tree::ptree &pt,
   }
 }
 
-bool jsonHasChild(const boost::property_tree::ptree &pt,
-                  const boost::property_tree::ptree::key_type &key) {
+static bool jsonHasChild(const boost::property_tree::ptree &pt,
+                         const boost::property_tree::ptree::key_type &key) {
   return pt.find(key) != pt.not_found();
 }
 


### PR DESCRIPTION
This PR enables 3 new compiler flags:

* `-Wcast-qual` enforces the use of `const_cast` when modifying the constness of a variable (this makes these workarounds easier to detect);
* `-Wmissing-declarations` ensures that all (non-`static`) free functions have been declared in a header file;
* `-Wundef` makes sure that `#ifdef` is used instead of `#if` when checking if a macro-definition has been defined (`#if` only checks if the value of the macro is `!= 0`).

Enjoy,
Pierre

