### PR TITLE
[MT-PGA] refactor and convert to diagram feature

### DIFF
--- a/core/base/mergeTreePrincipalGeodesics/CMakeLists.txt
+++ b/core/base/mergeTreePrincipalGeodesics/CMakeLists.txt
@@ -1,8 +1,10 @@
 ttk_add_base_library(mergeTreePrincipalGeodesics
   SOURCES
+    MergeTreeAxesAlgorithmBase.cpp
     MergeTreePrincipalGeodesicsBase.cpp
     MergeTreePrincipalGeodesics.cpp
   HEADERS
+    MergeTreeAxesAlgorithmBase.h
     MergeTreePrincipalGeodesicsBase.h
     MergeTreePrincipalGeodesics.h
     MergeTreePrincipalGeodesicsUtils.h

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.cpp
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.cpp
@@ -1,0 +1,1 @@
+#include <MergeTreeAxesAlgorithmBase.h>

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
@@ -69,36 +69,8 @@ namespace ttk {
         double weight = mixDistancesMinMaxPairWeight(isFirstInput);
         mergeTreeDistance.setMinMaxPairWeight(weight);
       }
-
-      Timer t;
-
       distance = mergeTreeDistance.computeDistance<dataType>(
         &(tree1.tree), &(tree2.tree), matching);
-
-      auto time = t.getElapsedTime();
-      double mult = (tree1.tree.getRealNumberOfNodes()
-                     + tree2.tree.getRealNumberOfNodes())
-                    / 2.0 / 10;
-      mult = 1;
-      if(false and time > 1 * mult) {
-        if((tree1.tree.getRealNumberOfNodes()
-            + tree2.tree.getRealNumberOfNodes())
-             / 2.0
-           <= 100) {
-          std::cout
-            << tree1.tree.template printPairsFromTree<dataType>(true).str()
-            << std::endl;
-          std::cout
-            << tree2.tree.template printPairsFromTree<dataType>(true).str()
-            << std::endl;
-        }
-        std::cout << "time = " << time << std::endl;
-        std::cout << "distance = " << distance << std::endl;
-        // std::cout << std::endl << std::endl;
-        /*std::cout << "pause" << std::endl;
-        int temp;
-        std::cin >> temp;*/
-      }
     }
 
     template <class dataType>

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
@@ -640,30 +640,6 @@ namespace ttk {
       zeroPadding(name, noTrees, treeNum);
       return name;
     }
-
-    //----------------------------------------------------------------------------
-    // Testing
-    //----------------------------------------------------------------------------
-    void printVector(std::vector<double> &v, bool printHead = true) {
-      if(printHead)
-        std::cout << "======= printVector" << std::endl;
-      for(auto vv : v)
-        std::cout << vv << " ";
-      std::cout << std::endl;
-    }
-
-    void printVectorOfVector(std::vector<std::vector<double>> &v) {
-      std::cout << "======= printVectorOfVector" << std::endl;
-      for(auto vv : v)
-        printVector(vv, false);
-    }
-
-    void printVectorOfVectorOfVector(
-      std::vector<std::vector<std::vector<double>>> &v) {
-      std::cout << "======= printVectorOfVectorOfVector" << std::endl;
-      for(auto vv : v)
-        printVectorOfVector(vv);
-    }
   }; // MergeTreeAxesAlgorithmBase class
 
 } // namespace ttk

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreeAxesAlgorithmBase.h
@@ -1,0 +1,669 @@
+/// \ingroup base
+/// \class ttk::MergeTreeAxesAlgorithmBase
+/// \author Mathieu Pont <mathieu.pont@lip6.fr>
+/// \date 2023
+///
+/// \b Related \b publication: \n
+/// "Principal Geodesic Analysis of Merge Trees (and Persistence Diagrams)" \n
+/// Mathieu Pont, Jules Vidal, Julien Tierny.\n
+/// IEEE Transactions on Visualization and Computer Graphics, 2022
+
+#pragma once
+
+#include <Geometry.h>
+#include <MergeTreeBarycenter.h>
+#include <MergeTreeBase.h>
+#include <MergeTreeDistance.h>
+#include <MergeTreeUtils.h>
+#include <Statistics.h>
+
+#define ENERGY_COMPARISON_TOLERANCE 1e-6
+
+namespace ttk {
+
+  class MergeTreeAxesAlgorithmBase : virtual public Debug,
+                                     public MergeTreeBase {
+
+  protected:
+    bool deterministic_ = true;
+    unsigned int numberOfGeodesics_ = 1;
+    unsigned int k_ = 10;
+    double barycenterSizeLimitPercent_ = 0.0;
+
+    // Clean correspondence
+    std::vector<std::vector<int>> trees2NodeCorr_;
+
+  public:
+    MergeTreeAxesAlgorithmBase() {
+      this->setDebugMsgPrefix(
+        "MergeTreeAxesAlgorithmBase"); // inherited from Debug: prefix will
+                                       // be printed at the beginning of
+                                       // every msg
+    }
+
+    //----------------------------------------------------------------------------
+    // Matching / Distance
+    //----------------------------------------------------------------------------
+    template <class dataType>
+    void computeOneDistance(
+      ftm::MergeTree<dataType> &tree1,
+      ftm::MergeTree<dataType> &tree2,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching,
+      dataType &distance,
+      bool isCalled = false,
+      bool useDoubleInput = false,
+      bool isFirstInput = true) {
+      MergeTreeDistance mergeTreeDistance;
+      mergeTreeDistance.setDebugLevel(std::min(debugLevel_, 2));
+      mergeTreeDistance.setPreprocess(false);
+      mergeTreeDistance.setPostprocess(false);
+      mergeTreeDistance.setBranchDecomposition(true);
+      mergeTreeDistance.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeDistance.setKeepSubtree(false);
+      mergeTreeDistance.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeDistance.setIsCalled(isCalled);
+      mergeTreeDistance.setThreadNumber(this->threadNumber_);
+      mergeTreeDistance.setDistanceSquaredRoot(true); // squared root
+      mergeTreeDistance.setNodePerTask(nodePerTask_);
+      if(useDoubleInput) {
+        double weight = mixDistancesMinMaxPairWeight(isFirstInput);
+        mergeTreeDistance.setMinMaxPairWeight(weight);
+      }
+
+      Timer t;
+
+      distance = mergeTreeDistance.computeDistance<dataType>(
+        &(tree1.tree), &(tree2.tree), matching);
+
+      auto time = t.getElapsedTime();
+      double mult = (tree1.tree.getRealNumberOfNodes()
+                     + tree2.tree.getRealNumberOfNodes())
+                    / 2.0 / 10;
+      mult = 1;
+      if(false and time > 1 * mult) {
+        if((tree1.tree.getRealNumberOfNodes()
+            + tree2.tree.getRealNumberOfNodes())
+             / 2.0
+           <= 100) {
+          std::cout
+            << tree1.tree.template printPairsFromTree<dataType>(true).str()
+            << std::endl;
+          std::cout
+            << tree2.tree.template printPairsFromTree<dataType>(true).str()
+            << std::endl;
+        }
+        std::cout << "time = " << time << std::endl;
+        std::cout << "distance = " << distance << std::endl;
+        // std::cout << std::endl << std::endl;
+        /*std::cout << "pause" << std::endl;
+        int temp;
+        std::cin >> temp;*/
+      }
+    }
+
+    template <class dataType>
+    void computeOneDistance(ftm::MergeTree<dataType> &tree1,
+                            ftm::MergeTree<dataType> &tree2,
+                            dataType &distance,
+                            bool isCalled = false,
+                            bool useDoubleInput = false,
+                            bool isFirstInput = true) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching;
+      computeOneDistance<dataType>(tree1, tree2, matching, distance, isCalled,
+                                   useDoubleInput, isFirstInput);
+    }
+
+    //----------------------------------------------------------------------------
+    // Init
+    //----------------------------------------------------------------------------
+    template <class dataType>
+    void initVectorFromMatching(
+      ftm::MergeTree<dataType> &barycenter,
+      ftm::MergeTree<dataType> &tree,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching,
+      std::vector<std::vector<double>> &v) {
+      ftm::FTMTree_MT *barycenterTree = &(barycenter.tree);
+      ftm::FTMTree_MT *treeTree = &(tree.tree);
+
+      std::vector<ftm::idNode> matchingVector;
+      getMatchingVector<dataType>(barycenter, tree, matching, matchingVector);
+
+      v.resize(barycenter.tree.getNumberOfNodes(), std::vector<double>(2, 0));
+      for(unsigned int j = 0; j < barycenter.tree.getNumberOfNodes(); ++j) {
+        if(barycenter.tree.isNodeAlone(j))
+          continue;
+        auto birthDeathBary
+          = getParametrizedBirthDeath<dataType>(barycenterTree, j);
+        std::tuple<dataType, dataType> birthDeath;
+        if(matchingVector[j] != std::numeric_limits<ftm::idNode>::max()) {
+          birthDeath
+            = getParametrizedBirthDeath<dataType>(treeTree, matchingVector[j]);
+        } else {
+          dataType projec
+            = (std::get<0>(birthDeathBary) + std::get<1>(birthDeathBary)) / 2.0;
+          birthDeath = std::make_tuple(projec, projec);
+        }
+        v[j][0] = std::get<0>(birthDeath) - std::get<0>(birthDeathBary);
+        v[j][1] = std::get<1>(birthDeath) - std::get<1>(birthDeathBary);
+      }
+    }
+
+    template <class dataType>
+    void initRandomVector(ftm::MergeTree<dataType> &barycenter,
+                          std::vector<std::vector<double>> &v,
+                          std::vector<std::vector<std::vector<double>>> &vS,
+                          std::vector<std::vector<std::vector<double>>> &v2s) {
+      // Get average norm of the previous vectors
+      std::vector<std::vector<double>> sumVs;
+      ttk::Geometry::multiAddVectorsFlatten(vS, v2s, sumVs);
+      double newNorm = 0;
+      for(auto &sumVi : sumVs)
+        newNorm += ttk::Geometry::magnitude(sumVi) / sumVs.size();
+
+      // Generate random vector
+      v.resize(barycenter.tree.getNumberOfNodes(), std::vector<double>(2, 0));
+      for(unsigned int i = 0; i < barycenter.tree.getNumberOfNodes(); ++i) {
+        if(barycenter.tree.isNodeAlone(i))
+          continue;
+        v[i][0] = (double)rand() / RAND_MAX * newNorm * 2 - newNorm;
+        v[i][1] = (double)rand() / RAND_MAX * newNorm * 2 - newNorm;
+      }
+
+      // Change the norm of the random vector to be the average norm
+      double normV = ttk::Geometry::magnitudeFlatten(v);
+      for(unsigned int i = 0; i < barycenter.tree.getNumberOfNodes(); ++i) {
+        if(barycenter.tree.isNodeAlone(i))
+          continue;
+        v[i][0] = v[i][0] / normV * newNorm;
+        v[i][1] = v[i][1] / normV * newNorm;
+      }
+    }
+
+    template <class dataType, typename F>
+    int initVectors(
+      int geodesicNumber,
+      ftm::MergeTree<dataType> &barycenter,
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      ftm::MergeTree<dataType> &barycenter2,
+      std::vector<ftm::MergeTree<dataType>> &trees2,
+      std::vector<std::vector<double>> &v1,
+      std::vector<std::vector<double>> &v2,
+      std::vector<std::vector<double>> &trees2V1,
+      std::vector<std::vector<double>> &trees2V2,
+      int newVectorOffset,
+      std::vector<double> &inputToOriginDistances,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &baryMatchings,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &baryMatchings2,
+      std::vector<std::vector<double>> &inputToGeodesicsDistances,
+      std::vector<std::vector<std::vector<double>>> &vS,
+      std::vector<std::vector<std::vector<double>>> &v2s,
+      std::vector<std::vector<std::vector<double>>> &trees2Vs,
+      std::vector<std::vector<std::vector<double>>> &trees2V2s,
+      bool projectInitializedVectors,
+      F initializedVectorsProjection) {
+
+      bool doOffset = (newVectorOffset != 0);
+      // Get best distance, best matching and best index
+      dataType bestDistance = std::numeric_limits<dataType>::lowest();
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> bestMatching,
+        bestMatching2;
+      std::vector<std::tuple<double, unsigned int>> distancesAndIndexes(
+        trees.size());
+      int bestIndex = -1;
+      for(unsigned int i = 0; i < trees.size(); ++i) {
+        dataType distance = 0.0, distance2 = 0.0;
+        std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching,
+          matching2;
+        if(geodesicNumber == 0) {
+          if(inputToOriginDistances.size() == 0) {
+            computeOneDistance<dataType>(
+              barycenter, trees[i], matching, distance, false, useDoubleInput_);
+            if(trees2.size() != 0) {
+              computeOneDistance<dataType>(barycenter2, trees2[i], matching2,
+                                           distance2, false, useDoubleInput_,
+                                           false);
+              distance = mixDistances(distance, distance2);
+            }
+          } else {
+            distance = inputToOriginDistances[i];
+            matching = baryMatchings[i];
+            if(trees2.size() != 0)
+              matching2 = baryMatchings2[i];
+          }
+        } else {
+          for(unsigned j = 0; j < inputToGeodesicsDistances.size(); ++j)
+            distance += inputToGeodesicsDistances[j][i];
+          distancesAndIndexes[i] = std::make_tuple(distance, i);
+        }
+        if(distance > bestDistance) {
+          bestDistance = distance;
+          bestMatching = matching;
+          bestMatching2 = matching2;
+          bestIndex = i;
+        }
+      }
+
+      // Sort all distances and their respective indexes
+      if(geodesicNumber != 0)
+        std::sort(distancesAndIndexes.begin(), distancesAndIndexes.end(),
+                  [](const std::tuple<double, unsigned int> &a,
+                     const std::tuple<double, unsigned int> &b) -> bool {
+                    return (std::get<0>(a) > std::get<0>(b));
+                  });
+
+      // Init vectors according farthest input
+      // (repeat with the ith farthest until projection gives non null vector)
+      unsigned int i = 0;
+      bool foundGoodIndex = false;
+      while(not foundGoodIndex) {
+        // Get matching of the ith farthest input
+        if(bestIndex >= 0 and bestIndex < (int)trees.size()) {
+          if(geodesicNumber != 0) {
+            if(baryMatchings.size() == 0
+               and (baryMatchings.size() == 0 or trees2.size() == 0)) {
+              dataType distance;
+              computeOneDistance<dataType>(barycenter, trees[bestIndex],
+                                           bestMatching, distance, false,
+                                           useDoubleInput_);
+              if(trees2.size() != 0)
+                computeOneDistance<dataType>(barycenter2, trees2[bestIndex],
+                                             bestMatching2, distance, false,
+                                             useDoubleInput_, false);
+            } else {
+              bestMatching = baryMatchings[bestIndex];
+              if(trees2.size() != 0)
+                bestMatching2 = baryMatchings2[bestIndex];
+            }
+          }
+
+          // Init vectors from matching
+          initVectorFromMatching<dataType>(
+            barycenter, trees[bestIndex], bestMatching, v1);
+          v2 = v1;
+          if(trees2.size() != 0) {
+            initVectorFromMatching<dataType>(
+              barycenter2, trees2[bestIndex], bestMatching2, trees2V1);
+            trees2V2 = trees2V1;
+          }
+        } else {
+          initRandomVector(barycenter, v1, vS, v2s);
+          v2 = v1;
+          if(trees2.size() != 0) {
+            initRandomVector(barycenter2, trees2V1, trees2Vs, trees2V2s);
+            trees2V2 = trees2V1;
+          }
+        }
+
+        // Project initialized vectors to satisfy constraints
+        if(projectInitializedVectors) {
+          initializedVectorsProjection(
+            geodesicNumber, barycenter, v1, v2, vS, v2s, barycenter2, trees2V1,
+            trees2V2, trees2Vs, trees2V2s, (trees2.size() != 0), 1);
+        }
+
+        // Check if the initialized vectors are good
+        foundGoodIndex
+          = (geodesicNumber == 0 or not ttk::Geometry::isVectorNullFlatten(v1));
+
+        // Init next bestIndex
+        if(not foundGoodIndex) {
+          i += 1;
+          if(i < distancesAndIndexes.size())
+            bestIndex = std::get<1>(distancesAndIndexes[i]);
+          else
+            bestIndex = -1;
+        }
+
+        // If newVector jump to the next valid bestIndex
+        if(foundGoodIndex and doOffset and bestIndex >= 0) {
+          bestIndex += newVectorOffset;
+          if(bestIndex >= (int)trees.size())
+            bestIndex = -1;
+          foundGoodIndex = false;
+          doOffset = false;
+        }
+      }
+      return bestIndex;
+    }
+
+    //----------------------------------------------------------------------------
+    // Barycenter
+    //----------------------------------------------------------------------------
+    template <class dataType>
+    void computeOneBarycenter(
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      ftm::MergeTree<dataType> &baryMergeTree,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &matchings,
+      std::vector<double> &finalDistances,
+      double barycenterSizeLimitPercent,
+      unsigned int barycenterMaximumNumberOfPairs,
+      bool useDoubleInput = false,
+      bool isFirstInput = true) {
+      MergeTreeBarycenter mergeTreeBary;
+      mergeTreeBary.setDebugLevel(std::min(debugLevel_, 2));
+      mergeTreeBary.setPreprocess(false);
+      mergeTreeBary.setPostprocess(false);
+      mergeTreeBary.setBranchDecomposition(true);
+      mergeTreeBary.setNormalizedWasserstein(normalizedWasserstein_);
+      mergeTreeBary.setKeepSubtree(false);
+      mergeTreeBary.setAssignmentSolver(assignmentSolverID_);
+      mergeTreeBary.setThreadNumber(this->threadNumber_);
+      mergeTreeBary.setDeterministic(deterministic_);
+      mergeTreeBary.setBarycenterSizeLimitPercent(barycenterSizeLimitPercent);
+      mergeTreeBary.setBarycenterMaximumNumberOfPairs(
+        barycenterMaximumNumberOfPairs);
+
+      matchings.resize(trees.size());
+      mergeTreeBary.execute<dataType>(
+        trees, matchings, baryMergeTree, useDoubleInput, isFirstInput);
+      finalDistances = mergeTreeBary.getFinalDistances();
+    }
+
+    template <class dataType>
+    void computeOneBarycenter(
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      ftm::MergeTree<dataType> &baryMergeTree,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &matchings,
+      std::vector<double> &finalDistances,
+      double barycenterSizeLimitPercent,
+      bool useDoubleInput = false,
+      bool isFirstInput = true) {
+      unsigned int barycenterMaximumNumberOfPairs = 0;
+      computeOneBarycenter(trees, baryMergeTree, matchings, finalDistances,
+                           barycenterSizeLimitPercent,
+                           barycenterMaximumNumberOfPairs, useDoubleInput,
+                           isFirstInput);
+    }
+
+    template <class dataType>
+    void computeOneBarycenter(
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      ftm::MergeTree<dataType> &baryMergeTree,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &matchings,
+      std::vector<double> &finalDistances,
+      bool useDoubleInput = false,
+      bool isFirstInput = true) {
+      computeOneBarycenter(trees, baryMergeTree, matchings, finalDistances,
+                           barycenterSizeLimitPercent_, useDoubleInput,
+                           isFirstInput);
+    }
+
+    template <class dataType>
+    void computeOneBarycenter(
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      ftm::MergeTree<dataType> &baryMergeTree,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &matchings) {
+      std::vector<double> finalDistances;
+      computeOneBarycenter<dataType>(
+        trees, baryMergeTree, matchings, finalDistances);
+    }
+
+    template <class dataType>
+    void computeOneBarycenter(std::vector<ftm::MergeTree<dataType>> &trees,
+                              ftm::MergeTree<dataType> &baryMergeTree) {
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        matchings;
+      computeOneBarycenter<dataType>(trees, baryMergeTree, matchings);
+    }
+
+    //----------------------------------------------------------------------------
+    // Preprocessing
+    //----------------------------------------------------------------------------
+    template <class dataType>
+    void preprocessingTrees(std::vector<ftm::MergeTree<dataType>> &trees,
+                            std::vector<std::vector<int>> &nodeCorr,
+                            bool useMinMaxPairT = true) {
+      nodeCorr.resize(trees.size());
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for schedule(dynamic) num_threads(this->threadNumber_)
+#endif
+      for(unsigned int i = 0; i < trees.size(); ++i) {
+        preprocessingPipeline<dataType>(
+          trees[i], epsilonTree1_, epsilon2Tree1_, epsilon3Tree1_,
+          branchDecomposition_, useMinMaxPairT, cleanTree_, nodeCorr[i]);
+        if(trees.size() < 40)
+          printTreeStats(trees[i]);
+      }
+      if(trees.size() != 0)
+        printTreesStats(trees);
+    }
+
+    template <class dataType>
+    void preprocessingTrees(std::vector<ftm::MergeTree<dataType>> &trees,
+                            bool useMinMaxPairT = true) {
+      std::vector<std::vector<int>> nodeCorr(trees.size());
+      preprocessingTrees(trees, nodeCorr, useMinMaxPairT);
+    }
+
+    //----------------------------------------------------------------------------
+    // Utils
+    //----------------------------------------------------------------------------
+    // v[i] contains the node in tree matched to the node i in barycenter
+    template <class dataType>
+    void getMatchingVector(
+      ftm::MergeTree<dataType> &barycenter,
+      ftm::MergeTree<dataType> &tree,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings,
+      std::vector<ftm::idNode> &matchingVector) {
+      matchingVector.clear();
+      matchingVector.resize(barycenter.tree.getNumberOfNodes(),
+                            std::numeric_limits<ftm::idNode>::max());
+      for(unsigned int j = 0; j < matchings.size(); ++j) {
+        auto match0 = std::get<0>(matchings[j]);
+        auto match1 = std::get<1>(matchings[j]);
+        if(match0 < barycenter.tree.getNumberOfNodes()
+           and match1 < tree.tree.getNumberOfNodes())
+          matchingVector[match0] = match1;
+      }
+    }
+
+    // v[i] contains the node in barycenter matched to the node i in tree
+    template <class dataType>
+    void getInverseMatchingVector(
+      ftm::MergeTree<dataType> &barycenter,
+      ftm::MergeTree<dataType> &tree,
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matchings,
+      std::vector<ftm::idNode> &matchingVector) {
+      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> invMatchings(
+        matchings.size());
+      for(unsigned int i = 0; i < matchings.size(); ++i)
+        invMatchings[i] = std::make_tuple(std::get<1>(matchings[i]),
+                                          std::get<0>(matchings[i]),
+                                          std::get<2>(matchings[i]));
+      getMatchingVector(tree, barycenter, invMatchings, matchingVector);
+    }
+
+    // m[i][j] contains the node in trees[j] matched to the node i in the
+    // barycenter
+    template <class dataType>
+    void getMatchingMatrix(
+      ftm::MergeTree<dataType> &barycenter,
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &matchings,
+      std::vector<std::vector<ftm::idNode>> &matchingMatrix) {
+      matchingMatrix.clear();
+      matchingMatrix.resize(
+        barycenter.tree.getNumberOfNodes(),
+        std::vector<ftm::idNode>(
+          trees.size(), std::numeric_limits<ftm::idNode>::max()));
+      for(unsigned int i = 0; i < trees.size(); ++i) {
+        std::vector<ftm::idNode> matchingVector;
+        getMatchingVector<dataType>(
+          barycenter, trees[i], matchings[i], matchingVector);
+        for(unsigned int j = 0; j < matchingVector.size(); ++j)
+          matchingMatrix[j][i] = matchingVector[j];
+      }
+    }
+
+    template <class dataType>
+    std::tuple<dataType, dataType>
+      getParametrizedBirthDeath(ftm::FTMTree_MT *tree, ftm::idNode node) {
+      return ttk::getParametrizedBirthDeath<dataType>(
+        tree, node, normalizedWasserstein_);
+    }
+
+    //----------------------------------------------------------------------------
+    // Utils
+    //----------------------------------------------------------------------------
+    template <class dataType>
+    void computeBranchesCorrelationMatrix(
+      ftm::MergeTree<dataType> &barycenter,
+      std::vector<ftm::MergeTree<dataType>> &trees,
+      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
+        &baryMatchings,
+      std::vector<std::vector<double>> &allTs,
+      std::vector<std::vector<double>> &branchesCorrelationMatrix,
+      std::vector<std::vector<double>> &persCorrelationMatrix) {
+      branchesCorrelationMatrix.resize(barycenter.tree.getNumberOfNodes(),
+                                       std::vector<double>(allTs.size(), 0.0));
+      persCorrelationMatrix = branchesCorrelationMatrix;
+
+      // m[i][j] contains the node in trees[j] matched to the node i in the
+      // barycenter
+      std::vector<std::vector<ftm::idNode>> matchingMatrix;
+      getMatchingMatrix(barycenter, trees, baryMatchings, matchingMatrix);
+
+      std::queue<ftm::idNode> queue;
+      queue.emplace(barycenter.tree.getRoot());
+      while(!queue.empty()) {
+        ftm::idNode node = queue.front();
+        queue.pop();
+
+        // Get births and deaths array
+        std::vector<double> births(trees.size(), 0.0),
+          deaths(trees.size(), 0.0), pers(trees.size(), 0.0);
+        for(unsigned int i = 0; i < trees.size(); ++i) {
+          auto matched = matchingMatrix[node][i];
+          std::tuple<dataType, dataType> birthDeath;
+          if(matched == std::numeric_limits<ftm::idNode>::max()) {
+            birthDeath = barycenter.tree.template getBirthDeath<dataType>(node);
+            auto projec
+              = (std::get<0>(birthDeath) + std::get<1>(birthDeath)) / 2.0;
+            birthDeath = std::make_tuple(projec, projec);
+          } else
+            birthDeath
+              = trees[i].tree.template getBirthDeath<dataType>(matched);
+          births[i] = std::get<0>(birthDeath);
+          deaths[i] = std::get<1>(birthDeath);
+          pers[i] = deaths[i] - births[i];
+        }
+
+        // Compute correlations
+        for(unsigned int g = 0; g < allTs.size(); ++g) {
+          double birthCorr = ttk::Statistics::corr(births, allTs[g]);
+          double deathCorr = ttk::Statistics::corr(deaths, allTs[g]);
+          double persCorr = ttk::Statistics::corr(pers, allTs[g]);
+
+          if(std::isnan(birthCorr))
+            birthCorr = 0.0;
+          if(std::isnan(deathCorr))
+            deathCorr = 0.0;
+          if(std::isnan(persCorr))
+            persCorr = 0.0;
+
+          auto birthDeathNode
+            = barycenter.tree.template getBirthDeathNode<dataType>(node);
+          auto birthNode = std::get<0>(birthDeathNode);
+          auto deathNode = std::get<1>(birthDeathNode);
+          branchesCorrelationMatrix[birthNode][g] = birthCorr;
+          branchesCorrelationMatrix[deathNode][g] = deathCorr;
+          persCorrelationMatrix[birthNode][g] = persCorr;
+          persCorrelationMatrix[deathNode][g] = persCorr;
+        }
+
+        // Push children to the queue
+        std::vector<ftm::idNode> children;
+        barycenter.tree.getChildren(node, children);
+        for(auto child : children)
+          queue.emplace(child);
+      }
+    }
+
+    //----------------------------------------------------------------------------
+    // Output Utils
+    //----------------------------------------------------------------------------
+    void zeroPadding(std::string &colName,
+                     const size_t numberCols,
+                     const size_t colIdx) {
+      std::string max{std::to_string(numberCols - 1)};
+      std::string cur{std::to_string(colIdx)};
+      std::string zer(max.size() - cur.size(), '0');
+      colName.append(zer).append(cur);
+    }
+
+    std::string getTableCoefficientName(int noGeodesics, int geodesicNum) {
+      std::string name{"T"};
+      zeroPadding(name, noGeodesics, geodesicNum);
+      return name;
+    }
+
+    std::string getTableCoefficientNormName(int noGeodesics, int geodesicNum) {
+      std::string name{"TNorm"};
+      zeroPadding(name, noGeodesics, geodesicNum);
+      return name;
+    }
+
+    std::string getTableVectorName(int noGeodesics,
+                                   int geodesicNum,
+                                   int vId,
+                                   int vComp,
+                                   bool isSecondInput = false) {
+      std::string indexString{};
+      zeroPadding(indexString, noGeodesics, geodesicNum);
+      std::string prefix{(isSecondInput ? "T2_" : "")};
+      std::string name{prefix + "V" + indexString + "_" + std::to_string(vId)
+                       + "_" + std::to_string(vComp)};
+      return name;
+    }
+
+    std::string getTableCorrelationName(int noGeodesics, int geodesicNum) {
+      std::string name{"Corr"};
+      zeroPadding(name, noGeodesics, geodesicNum);
+      return name;
+    }
+
+    std::string getTableCorrelationPersName(int noGeodesics, int geodesicNum) {
+      std::string name{"CorrPers"};
+      zeroPadding(name, noGeodesics, geodesicNum);
+      return name;
+    }
+
+    std::string getTableCorrelationTreeName(int noTrees, int treeNum) {
+      std::string name{"Tree"};
+      zeroPadding(name, noTrees, treeNum);
+      return name;
+    }
+
+    //----------------------------------------------------------------------------
+    // Testing
+    //----------------------------------------------------------------------------
+    void printVector(std::vector<double> &v, bool printHead = true) {
+      if(printHead)
+        std::cout << "======= printVector" << std::endl;
+      for(auto vv : v)
+        std::cout << vv << " ";
+      std::cout << std::endl;
+    }
+
+    void printVectorOfVector(std::vector<std::vector<double>> &v) {
+      std::cout << "======= printVectorOfVector" << std::endl;
+      for(auto vv : v)
+        printVector(vv, false);
+    }
+
+    void printVectorOfVectorOfVector(
+      std::vector<std::vector<std::vector<double>>> &v) {
+      std::cout << "======= printVectorOfVectorOfVector" << std::endl;
+      for(auto vv : v)
+        printVectorOfVector(vv);
+    }
+  }; // MergeTreeAxesAlgorithmBase class
+
+} // namespace ttk

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
@@ -22,11 +22,7 @@
 
 // ttk common includes
 #include <Debug.h>
-#include <MergeTreeBarycenter.h>
 #include <MergeTreePrincipalGeodesicsBase.h>
-#include <Statistics.h>
-
-#define ENERGY_COMPARISON_TOLERANCE 1e-6
 
 namespace ttk {
 
@@ -40,13 +36,10 @@ namespace ttk {
                                       public MergeTreePrincipalGeodesicsBase {
 
   protected:
-    bool deterministic_ = true;
-    unsigned int numberOfGeodesics_ = 1;
-    unsigned int noProjectionStep_ = 2;
     bool doComputeReconstructionError_ = false;
-    double barycenterSizeLimitPercent_ = 0.0;
     // TODO keepState works only when enabled before first computation
     bool keepState_ = false;
+    unsigned int noProjectionStep_ = 2;
 
     // Advanced parameters
     bool projectInitializedVectors_ = true;
@@ -63,9 +56,6 @@ namespace ttk {
 
     int newVectorOffset_ = 0;
     double cumulVariance_ = 0.0, cumulTVariance_ = 0.0;
-
-    // Clean correspondence
-    std::vector<std::vector<int>> trees2NodeCorr_;
 
   public:
     MergeTreePrincipalGeodesics() {
@@ -95,69 +85,6 @@ namespace ttk {
     // Init
     //----------------------------------------------------------------------------
     template <class dataType>
-    void initVectorFromMatching(
-      ftm::MergeTree<dataType> &barycenter,
-      ftm::MergeTree<dataType> &tree,
-      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> &matching,
-      std::vector<std::vector<double>> &v) {
-      ftm::FTMTree_MT *barycenterTree = &(barycenter.tree);
-      ftm::FTMTree_MT *treeTree = &(tree.tree);
-
-      std::vector<ftm::idNode> matchingVector;
-      getMatchingVector<dataType>(barycenter, tree, matching, matchingVector);
-
-      v.resize(barycenter.tree.getNumberOfNodes(), std::vector<double>(2, 0));
-      for(unsigned int j = 0; j < barycenter.tree.getNumberOfNodes(); ++j) {
-        if(barycenter.tree.isNodeAlone(j))
-          continue;
-        auto birthDeathBary
-          = getParametrizedBirthDeath<dataType>(barycenterTree, j);
-        std::tuple<dataType, dataType> birthDeath;
-        if(matchingVector[j] != std::numeric_limits<ftm::idNode>::max()) {
-          birthDeath
-            = getParametrizedBirthDeath<dataType>(treeTree, matchingVector[j]);
-        } else {
-          dataType projec
-            = (std::get<0>(birthDeathBary) + std::get<1>(birthDeathBary)) / 2.0;
-          birthDeath = std::make_tuple(projec, projec);
-        }
-        v[j][0] = std::get<0>(birthDeath) - std::get<0>(birthDeathBary);
-        v[j][1] = std::get<1>(birthDeath) - std::get<1>(birthDeathBary);
-      }
-    }
-
-    template <class dataType>
-    void initRandomVector(ftm::MergeTree<dataType> &barycenter,
-                          std::vector<std::vector<double>> &v,
-                          std::vector<std::vector<std::vector<double>>> &vS,
-                          std::vector<std::vector<std::vector<double>>> &v2s) {
-      // Get average norm of the previous vectors
-      std::vector<std::vector<double>> sumVs;
-      ttk::Geometry::multiAddVectorsFlatten(vS, v2s, sumVs);
-      double newNorm = 0;
-      for(auto &sumVi : sumVs)
-        newNorm += ttk::Geometry::magnitude(sumVi) / sumVs.size();
-
-      // Generate random vector
-      v.resize(barycenter.tree.getNumberOfNodes(), std::vector<double>(2, 0));
-      for(unsigned int i = 0; i < barycenter.tree.getNumberOfNodes(); ++i) {
-        if(barycenter.tree.isNodeAlone(i))
-          continue;
-        v[i][0] = (double)rand() / RAND_MAX * newNorm * 2 - newNorm;
-        v[i][1] = (double)rand() / RAND_MAX * newNorm * 2 - newNorm;
-      }
-
-      // Change the norm of the random vector to be the average norm
-      double normV = ttk::Geometry::magnitudeFlatten(v);
-      for(unsigned int i = 0; i < barycenter.tree.getNumberOfNodes(); ++i) {
-        if(barycenter.tree.isNodeAlone(i))
-          continue;
-        v[i][0] = v[i][0] / normV * newNorm;
-        v[i][1] = v[i][1] / normV * newNorm;
-      }
-    }
-
-    template <class dataType>
     void initVectors(int geodesicNumber,
                      ftm::MergeTree<dataType> &barycenter,
                      std::vector<ftm::MergeTree<dataType>> &trees,
@@ -167,169 +94,30 @@ namespace ttk {
                      std::vector<std::vector<double>> &v2,
                      std::vector<std::vector<double>> &trees2V1,
                      std::vector<std::vector<double>> &trees2V2) {
-      bool doOffset = (newVectorOffset_ != 0);
-      // Get best distance, best matching and best index
-      dataType bestDistance = std::numeric_limits<dataType>::lowest();
-      std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> bestMatching,
-        bestMatching2;
-      std::vector<std::tuple<double, unsigned int>> distancesAndIndexes(
-        trees.size());
-      int bestIndex = -1;
-      for(unsigned int i = 0; i < trees.size(); ++i) {
-        dataType distance = 0.0, distance2 = 0.0;
-        std::vector<std::tuple<ftm::idNode, ftm::idNode, double>> matching,
-          matching2;
-        if(geodesicNumber == 0) {
-          if(inputToBaryDistances_.size() == 0) {
-            computeOneDistance<dataType>(
-              barycenter, trees[i], matching, distance, false, useDoubleInput_);
-            if(trees2.size() != 0) {
-              computeOneDistance<dataType>(barycenter2, trees2[i], matching2,
-                                           distance2, false, useDoubleInput_,
-                                           false);
-              distance = mixDistances(distance, distance2);
-            }
-          } else {
-            distance = inputToBaryDistances_[i];
-            matching = baryMatchings_[i];
-            if(trees2.size() != 0)
-              matching2 = baryMatchings2_[i];
-          }
-        } else {
-          for(unsigned j = 0; j < inputToGeodesicsDistances_.size(); ++j)
-            distance += inputToGeodesicsDistances_[j][i];
-          distancesAndIndexes[i] = std::make_tuple(distance, i);
-        }
-        if(distance > bestDistance) {
-          bestDistance = distance;
-          bestMatching = matching;
-          bestMatching2 = matching2;
-          bestIndex = i;
-        }
-      }
+      auto initializedVectorsProjection
+        = [=](int _geodesicNumber, ftm::MergeTree<dataType> &_barycenter,
+              std::vector<std::vector<double>> &_v,
+              std::vector<std::vector<double>> &_v2,
+              std::vector<std::vector<std::vector<double>>> &_vS,
+              std::vector<std::vector<std::vector<double>>> &_v2s,
+              ftm::MergeTree<dataType> &_barycenter2,
+              std::vector<std::vector<double>> &_trees2V,
+              std::vector<std::vector<double>> &_trees2V2,
+              std::vector<std::vector<std::vector<double>>> &_trees2Vs,
+              std::vector<std::vector<std::vector<double>>> &_trees2V2s,
+              bool _useSecondInput, unsigned int _noProjectionStep) {
+            return this->projectionStep(_geodesicNumber, _barycenter, _v, _v2,
+                                        _vS, _v2s, _barycenter2, _trees2V,
+                                        _trees2V2, _trees2Vs, _trees2V2s,
+                                        _useSecondInput, _noProjectionStep);
+          };
 
-      // Sort all distances and their respective indexes
-      if(geodesicNumber != 0)
-        std::sort(distancesAndIndexes.begin(), distancesAndIndexes.end(),
-                  [](const std::tuple<double, unsigned int> &a,
-                     const std::tuple<double, unsigned int> &b) -> bool {
-                    return (std::get<0>(a) > std::get<0>(b));
-                  });
-
-      // Init vectors according fairest input
-      // (repeat with the ith fairest until projection gives non null vector)
-      unsigned int i = 0;
-      bool foundGoodIndex = false;
-      while(not foundGoodIndex) {
-        // Get matching of the ith fairest input
-        if(bestIndex >= 0 and bestIndex < (int)trees.size()) {
-          if(geodesicNumber != 0) {
-            dataType distance;
-            computeOneDistance<dataType>(barycenter, trees[bestIndex],
-                                         bestMatching, distance, false,
-                                         useDoubleInput_);
-            if(trees2.size() != 0)
-              computeOneDistance<dataType>(barycenter2, trees2[bestIndex],
-                                           bestMatching2, distance, false,
-                                           useDoubleInput_, false);
-          }
-
-          // Init vectors from matching
-          initVectorFromMatching<dataType>(
-            barycenter, trees[bestIndex], bestMatching, v1);
-          v2 = v1;
-          if(trees2.size() != 0) {
-            initVectorFromMatching<dataType>(
-              barycenter2, trees2[bestIndex], bestMatching2, trees2V1);
-            trees2V2 = trees2V1;
-          }
-        } else {
-          initRandomVector(barycenter, v1, vS_, v2s_);
-          v2 = v1;
-          if(trees2.size() != 0) {
-            initRandomVector(barycenter2, trees2V1, trees2Vs_, trees2V2s_);
-            trees2V2 = trees2V1;
-          }
-        }
-
-        // Project initialized vectors to satisfy constraints
-        if(projectInitializedVectors_) {
-          projectionStep<dataType>(
-            geodesicNumber, barycenter, v1, v2, vS_, v2s_, barycenter2,
-            trees2V1, trees2V2, trees2Vs_, trees2V2s_, (trees2.size() != 0), 1);
-        }
-
-        // Check if the initialized vectors are good
-        foundGoodIndex
-          = (geodesicNumber == 0 or not ttk::Geometry::isVectorNullFlatten(v1));
-
-        // Init next bestIndex
-        if(not foundGoodIndex) {
-          i += 1;
-          if(i < distancesAndIndexes.size())
-            bestIndex = std::get<1>(distancesAndIndexes[i]);
-          else
-            bestIndex = -1;
-        }
-
-        // If newVector jump to the next valid bestIndex
-        if(foundGoodIndex and doOffset and bestIndex >= 0) {
-          bestIndex += newVectorOffset_;
-          if(bestIndex >= (int)trees.size())
-            bestIndex = -1;
-          foundGoodIndex = false;
-          doOffset = false;
-        }
-      }
-    }
-
-    //----------------------------------------------------------------------------
-    // Barycenter / Interpolation
-    //----------------------------------------------------------------------------
-    template <class dataType>
-    void computeOneBarycenter(
-      std::vector<ftm::MergeTree<dataType>> &trees,
-      ftm::MergeTree<dataType> &baryMergeTree,
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
-        &matchings,
-      std::vector<double> &finalDistances,
-      bool useDoubleInput = false,
-      bool isFirstInput = true) {
-      MergeTreeBarycenter mergeTreeBary;
-      mergeTreeBary.setDebugLevel(std::min(debugLevel_, 2));
-      mergeTreeBary.setPreprocess(false);
-      mergeTreeBary.setPostprocess(false);
-      mergeTreeBary.setBranchDecomposition(true);
-      mergeTreeBary.setNormalizedWasserstein(normalizedWasserstein_);
-      mergeTreeBary.setKeepSubtree(false);
-      mergeTreeBary.setAssignmentSolver(assignmentSolverID_);
-      mergeTreeBary.setThreadNumber(this->threadNumber_);
-      mergeTreeBary.setDeterministic(deterministic_);
-      mergeTreeBary.setBarycenterSizeLimitPercent(barycenterSizeLimitPercent_);
-
-      matchings.resize(trees.size());
-      mergeTreeBary.execute<dataType>(
-        trees, matchings, baryMergeTree, useDoubleInput, isFirstInput);
-      finalDistances = mergeTreeBary.getFinalDistances();
-    }
-
-    template <class dataType>
-    void computeOneBarycenter(
-      std::vector<ftm::MergeTree<dataType>> &trees,
-      ftm::MergeTree<dataType> &baryMergeTree,
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
-        &matchings) {
-      std::vector<double> finalDistances;
-      computeOneBarycenter<dataType>(
-        trees, baryMergeTree, matchings, finalDistances);
-    }
-
-    template <class dataType>
-    void computeOneBarycenter(std::vector<ftm::MergeTree<dataType>> &trees,
-                              ftm::MergeTree<dataType> &baryMergeTree) {
-      std::vector<std::vector<std::tuple<ftm::idNode, ftm::idNode, double>>>
-        matchings;
-      computeOneBarycenter<dataType>(trees, baryMergeTree, matchings);
+      MergeTreeAxesAlgorithmBase::initVectors<dataType>(
+        geodesicNumber, barycenter, trees, barycenter2, trees2, v1, v2,
+        trees2V1, trees2V2, newVectorOffset_, inputToBaryDistances_,
+        baryMatchings_, baryMatchings2_, inputToGeodesicsDistances_, vS_, v2s_,
+        trees2Vs_, trees2V2s_, projectInitializedVectors_,
+        initializedVectorsProjection);
     }
 
     //----------------------------------------------------------------------------
@@ -714,7 +502,6 @@ namespace ttk {
       std::vector<double> &ts,
       std::vector<double> &distances) {
 
-      // Init output
       matchings.resize(trees.size());
       matchings2.resize(trees2.size());
       ts.resize(trees.size());
@@ -1393,70 +1180,9 @@ namespace ttk {
     void computeBranchesCorrelationMatrix(
       ftm::MergeTree<dataType> &barycenter,
       std::vector<ftm::MergeTree<dataType>> &trees) {
-      branchesCorrelationMatrix_.resize(
-        barycenter.tree.getNumberOfNodes(),
-        std::vector<double>(numberOfGeodesics_, 0.0));
-      persCorrelationMatrix_ = branchesCorrelationMatrix_;
-
-      // m[i][j] contains the node in trees[j] matched to the node i in the
-      // barycenter
-      std::vector<std::vector<ftm::idNode>> matchingMatrix;
-      getMatchingMatrix(barycenter, trees, baryMatchings_, matchingMatrix);
-
-      std::queue<ftm::idNode> queue;
-      queue.emplace(barycenter.tree.getRoot());
-      while(!queue.empty()) {
-        ftm::idNode node = queue.front();
-        queue.pop();
-
-        // Get births and deaths array
-        std::vector<double> births(trees.size(), 0.0),
-          deaths(trees.size(), 0.0), pers(trees.size(), 0.0);
-        for(unsigned int i = 0; i < trees.size(); ++i) {
-          auto matched = matchingMatrix[node][i];
-          std::tuple<dataType, dataType> birthDeath;
-          if(matched == std::numeric_limits<ftm::idNode>::max()) {
-            birthDeath = barycenter.tree.template getBirthDeath<dataType>(node);
-            auto projec
-              = (std::get<0>(birthDeath) + std::get<1>(birthDeath)) / 2.0;
-            birthDeath = std::make_tuple(projec, projec);
-          } else
-            birthDeath
-              = trees[i].tree.template getBirthDeath<dataType>(matched);
-          births[i] = std::get<0>(birthDeath);
-          deaths[i] = std::get<1>(birthDeath);
-          pers[i] = deaths[i] - births[i];
-        }
-
-        // Compute correlations
-        for(unsigned int g = 0; g < numberOfGeodesics_; ++g) {
-          double birthCorr = ttk::Statistics::corr(births, allTs_[g]);
-          double deathCorr = ttk::Statistics::corr(deaths, allTs_[g]);
-          double persCorr = ttk::Statistics::corr(pers, allTs_[g]);
-
-          if(std::isnan(birthCorr))
-            birthCorr = 0.0;
-          if(std::isnan(deathCorr))
-            deathCorr = 0.0;
-          if(std::isnan(persCorr))
-            persCorr = 0.0;
-
-          auto birthDeathNode
-            = barycenter.tree.template getBirthDeathNode<dataType>(node);
-          auto birthNode = std::get<0>(birthDeathNode);
-          auto deathNode = std::get<1>(birthDeathNode);
-          branchesCorrelationMatrix_[birthNode][g] = birthCorr;
-          branchesCorrelationMatrix_[deathNode][g] = deathCorr;
-          persCorrelationMatrix_[birthNode][g] = persCorr;
-          persCorrelationMatrix_[deathNode][g] = persCorr;
-        }
-
-        // Push children to the queue
-        std::vector<ftm::idNode> children;
-        barycenter.tree.getChildren(node, children);
-        for(auto child : children)
-          queue.emplace(child);
-      }
+      ttk::MergeTreeAxesAlgorithmBase::computeBranchesCorrelationMatrix(
+        barycenter, trees, baryMatchings_, allTs_, branchesCorrelationMatrix_,
+        persCorrelationMatrix_);
     }
 
     // ----------------------------------------
@@ -1593,10 +1319,6 @@ namespace ttk {
                                      std::vector<std::vector<double>> &trees2V2,
                                      std::vector<double> &ts);
 
-    template <class dataType>
-    std::tuple<dataType, dataType>
-      getParametrizedBirthDeath(ftm::FTMTree_MT *tree, ftm::idNode node);
-
     // ----------------------------------------
     // Testing
     // ----------------------------------------
@@ -1636,7 +1358,6 @@ namespace ttk {
         printErr("[computePrincipalGeodesics] tree root is not min max.");
       }
     }
-
   }; // MergeTreePrincipalGeodesics class
 } // namespace ttk
 

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsUtils.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesicsUtils.h
@@ -139,13 +139,4 @@ namespace ttk {
       distances[i] = mixDistances(distances[i], distances2[i]);
     return computeVarianceFromDistances(distances);
   }
-
-  template <class dataType>
-  std::tuple<dataType, dataType>
-    MergeTreePrincipalGeodesics::getParametrizedBirthDeath(
-      ftm::FTMTree_MT *tree, ftm::idNode node) {
-    return normalizedWasserstein_
-             ? getNormalizedBirthDeath<dataType>(tree, node)
-             : tree->getBirthDeath<dataType>(node);
-  }
 } // namespace ttk

--- a/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
+++ b/core/vtk/ttkMergeTreePrincipalGeodesics/ttkMergeTreePrincipalGeodesics.h
@@ -81,14 +81,8 @@ private:
   // Output
   // -> base class
 
-  void setDataVisualization(int numInputs, int numInputs2) {
-    // Trees
-    treesNodes.resize(numInputs);
-    treesNodes2.resize(numInputs2);
-    treesArcs.resize(numInputs);
-    treesArcs2.resize(numInputs2);
-    treesSegmentation.resize(numInputs);
-    treesSegmentation2.resize(numInputs2);
+  void setDataVisualization(int ttkNotUsed(numInputs),
+                            int ttkNotUsed(numInputs2)) {
   }
 
   void resetDataVisualization() {

--- a/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
+++ b/core/vtk/ttkMergeTreePrincipalGeodesicsDecoding/ttkMergeTreePrincipalGeodesicsDecoding.cpp
@@ -612,6 +612,8 @@ int ttkMergeTreePrincipalGeodesicsDecoding::runOutput(
       }
     } else
       visuMaker.setShiftMode(2); // Line
+    if(isPersistenceDiagram_)
+      visuMaker.setPlanarLayout(true);
 
     // TODO transfer other information?
     if(isReconstructedTree) {

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -1331,7 +1331,6 @@ public:
               if(embeddedDiagram) {
                 bool nodeSup = trees[i]->getValue<dataType>(node)
                                > trees[i]->getValue<dataType>(nodeOrigin);
-                // TODO is this correct?
                 criticalTypeT
                   = ((nodeSup and toAddT == 1) or (not nodeSup and toAddT == 0)
                        ? (isPDSadMax or nodeIsRoot ? locMax : saddle1)

--- a/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
+++ b/core/vtk/ttkPlanarGraphLayout/ttkMergeTreeVisualization.h
@@ -40,6 +40,7 @@ private:
   int MinimumImportantPairs = 0;
   bool outputTreeNodeIndex = false;
   bool isPersistenceDiagram = false;
+  bool convertedToDiagram = false;
   bool isPDSadMax = true;
 
   // Shift mode
@@ -137,6 +138,9 @@ public:
 
   void setIsPersistenceDiagram(bool isPD) {
     isPersistenceDiagram = isPD;
+  }
+  void setConvertedToDiagram(bool converted) {
+    convertedToDiagram = converted;
   }
   void setIsPDSadMax(bool isSadMax) {
     isPDSadMax = isSadMax;
@@ -576,7 +580,7 @@ public:
     bool clusteringOutput = (NumberOfBarycenters != 0);
     NumberOfBarycenters
       = std::max(NumberOfBarycenters, 1); // to always enter the outer loop
-    PlanarLayout |= isPersistenceDiagram;
+    bool embeddedDiagram = not PlanarLayout and isPersistenceDiagram;
 
     // TreeNodeIdRev
     for(int i = 0; i < numInputs; ++i) {
@@ -684,6 +688,11 @@ public:
     persistenceBaryNode->SetName("PersistenceBarycenter");
     vtkNew<vtkIntArray> persistenceBaryOrderNode{};
     persistenceBaryOrderNode->SetName("PersistenceBarycenterOrder");
+
+    vtkNew<vtkDoubleArray> pairPersistenceNode{};
+    pairPersistenceNode->SetName(ttk::PersistenceName);
+    vtkNew<vtkDoubleArray> pairBirthNode{};
+    pairBirthNode->SetName(ttk::PersistenceBirthName);
 
     vtkNew<vtkFloatArray> treeNodeId{};
     treeNodeId->SetName("TreeNodeId");
@@ -986,15 +995,19 @@ public:
           // --------------
           auto getPoint
             = [&](vtkUnstructuredGrid *vtu, int pointID, double(&point)[3]) {
-                if(not isPersistenceDiagram) {
+                if(not vtu)
+                  return;
+                if(not isPersistenceDiagram or convertedToDiagram) {
                   double *pointTemp = vtu->GetPoints()->GetPoint(pointID);
                   for(int k = 0; k < 3; ++k)
                     point[k] += pointTemp[k];
                 } else {
-                  for(int k = 0; k < 3; ++k)
-                    point[k] = vtu->GetPointData()
-                                 ->GetArray(ttk::PersistenceCoordinatesName)
-                                 ->GetComponent(pointID, k);
+                  for(int k = 0; k < 3; ++k) {
+                    auto array = vtu->GetPointData()->GetArray(
+                      ttk::PersistenceCoordinatesName);
+                    if(array)
+                      point[k] += array->GetComponent(pointID, k);
+                  }
                 }
               };
 
@@ -1007,7 +1020,8 @@ public:
             for(int j = 0; j < numInputsOri; ++j) {
               if(baryMatching[node][j] != std::numeric_limits<idNode>::max()) {
                 nodeMesh = treesNodeCorrMesh[j][baryMatching[node][j]];
-                getPoint(treesNodes[j], nodeMesh, point);
+                if(not PlanarLayout)
+                  getPoint(treesNodes[j], nodeMesh, point);
                 noMatched += 1;
                 nodeMeshTreeIndex = j;
               }
@@ -1017,7 +1031,8 @@ public:
           } else if(not isInterpolatedTree and treesNodes.size() != 0
                     and treesNodes[i] != nullptr) {
             nodeMesh = treesNodeCorrMesh[i][node];
-            getPoint(treesNodes[i], nodeMesh, point);
+            if(not PlanarLayout)
+              getPoint(treesNodes[i], nodeMesh, point);
           }
           if(PlanarLayout) {
             layoutCorr[node] = cptNode;
@@ -1049,30 +1064,41 @@ public:
           bool dummyNode
             = PlanarLayout and not branchDecompositionPlanarLayout_
               and (!trees[i]->isRoot(node) or isPersistenceDiagram);
+          dummyNode = dummyNode or embeddedDiagram;
           if(dummyNode) {
-            double pointToAdd[3];
-            if(not isPersistenceDiagram)
-              // will be modified when processing son
-              std::copy(
-                std::begin(point), std::end(point), std::begin(pointToAdd));
-            else {
-              double pdPoint[3] = {
-                point[0],
-                point[1]
-                  - (layout[layoutCorr[node] + 1] - layout[layoutCorr[node]]),
-                0};
-              std::copy(
-                std::begin(pdPoint), std::end(pdPoint), std::begin(pointToAdd));
+            double pointToAdd[3] = {0, 0, 0};
+            if(embeddedDiagram) {
+              if(i < (int)treesNodes.size()
+                 and i < (int)treesNodeCorrMesh.size()
+                 and nodeOrigin < treesNodeCorrMesh[i].size())
+                getPoint(
+                  treesNodes[i], treesNodeCorrMesh[i][nodeOrigin], pointToAdd);
+            } else {
+              if(not isPersistenceDiagram) {
+                // will be modified when processing son
+                std::copy(
+                  std::begin(point), std::end(point), std::begin(pointToAdd));
+              } else {
+                double pdPoint[3] = {
+                  point[0],
+                  point[1]
+                    - (layout[layoutCorr[node] + 1] - layout[layoutCorr[node]]),
+                  0};
+                std::copy(std::begin(pdPoint), std::end(pdPoint),
+                          std::begin(pointToAdd));
+              }
             }
             treeDummySimplexId[node] = points->InsertNextPoint(pointToAdd);
-            if(isPersistenceDiagram) {
-              if(layout[layoutCorr[node]] < minBirth) {
-                minBirth = layout[layoutCorr[node]];
-                minBirthNode = treeDummySimplexId[node];
-              }
-              if(layout[layoutCorr[node]] > maxBirth) {
-                maxBirth = layout[layoutCorr[node]];
-                maxBirthNode = treeDummySimplexId[node];
+            if(not embeddedDiagram) {
+              if(isPersistenceDiagram) {
+                if(layout[layoutCorr[node]] < minBirth) {
+                  minBirth = layout[layoutCorr[node]];
+                  minBirthNode = treeDummySimplexId[node];
+                }
+                if(layout[layoutCorr[node]] > maxBirth) {
+                  maxBirth = layout[layoutCorr[node]];
+                  maxBirthNode = treeDummySimplexId[node];
+                }
               }
             }
           }
@@ -1186,7 +1212,7 @@ public:
               clusterIDArc->InsertNextTuple1(clusteringAssignment[i]);
 
               // Add arc tree ID
-              treeIDArc->InsertNextTuple1(i);
+              treeIDArc->InsertNextTuple1(i + iSampleOffset);
 
               // Add isImportantPair
               bool isImportant = false;
@@ -1280,12 +1306,14 @@ public:
                     auto array
                       = treesNodes[nodeMeshTreeIndex]->GetPointData()->GetArray(
                         "CriticalType");
-                    criticalTypeT = array->GetTuple1(nodeMesh);
+                    if(array)
+                      criticalTypeT = array->GetTuple1(nodeMesh);
                   }
                 } else if(treesNodes.size() != 0 and treesNodes[i] != nullptr) {
                   auto array
                     = treesNodes[i]->GetPointData()->GetArray("CriticalType");
-                  criticalTypeT = array->GetTuple1(nodeMesh);
+                  if(array)
+                    criticalTypeT = array->GetTuple1(nodeMesh);
                 }
               } else {
                 // TODO critical type for interpolated trees
@@ -1300,6 +1328,15 @@ public:
                 = (toAddT == 1
                      ? (isPDSadMax or nodeIsRoot ? locMax : saddle1)
                      : (not isPDSadMax or nodeIsRoot ? locMin : saddle2));
+              if(embeddedDiagram) {
+                bool nodeSup = trees[i]->getValue<dataType>(node)
+                               > trees[i]->getValue<dataType>(nodeOrigin);
+                // TODO is this correct?
+                criticalTypeT
+                  = ((nodeSup and toAddT == 1) or (not nodeSup and toAddT == 0)
+                       ? (isPDSadMax or nodeIsRoot ? locMax : saddle1)
+                       : (not isPDSadMax or nodeIsRoot ? locMin : saddle2));
+              }
             }
             criticalType->InsertNextTuple1(criticalTypeT);
 
@@ -1350,7 +1387,7 @@ public:
             clusterIDNode->InsertNextTuple1(clusteringAssignment[i]);
 
             // Add node tree ID
-            treeIDNode->InsertNextTuple1(i);
+            treeIDNode->InsertNextTuple1(i + iSampleOffset);
 
             // Add isDummyNode
             bool isDummy
@@ -1359,6 +1396,12 @@ public:
 
             // Add isInterpolatedTree
             isInterpolatedTreeNode->InsertNextTuple1(isInterpolatedTree);
+
+            // Add birth and death
+            auto birthDeath = trees[i]->getBirthDeath<dataType>(node);
+            pairBirthNode->InsertNextTuple1(std::get<0>(birthDeath));
+            pairPersistenceNode->InsertNextTuple1(std::get<1>(birthDeath)
+                                                  - std::get<0>(birthDeath));
 
             // Add isImportantPair
             bool isImportant = false;
@@ -1374,6 +1417,7 @@ public:
             treeNodeIdOrigin->InsertNextTuple1(nodeOrigin);
 
             // Add coordinates
+            printMsg("// Add coordinates", ttk::debug::Priority::VERBOSE);
             if(isPersistenceDiagram and !treesNodes.empty()
                and ShiftMode != 1) {
               double coord[3] = {0.0, 0.0, 0.0};
@@ -1382,6 +1426,7 @@ public:
             }
 
             // Add isMultiPersPairArc
+            printMsg("// isMultiPersPairArc", ttk::debug::Priority::VERBOSE);
             bool isMultiPersPair = (trees[i]->isMultiPersPair(node)
                                     or trees[i]->isMultiPersPair(
                                       trees[i]->getNode(node)->getOrigin()));
@@ -1405,7 +1450,7 @@ public:
         } // end tree traversal
 
         // Add diagonal if isPersistenceDiagram
-        if(isPersistenceDiagram) {
+        if(isPersistenceDiagram and not embeddedDiagram) {
           vtkIdType pointIds[2];
           pointIds[0] = minBirthNode;
           pointIds[1] = maxBirthNode;
@@ -1427,7 +1472,7 @@ public:
 
           isMultiPersPairArc->InsertNextTuple1(0);
           clusterIDArc->InsertNextTuple1(clusteringAssignment[i]);
-          treeIDArc->InsertNextTuple1(i);
+          treeIDArc->InsertNextTuple1(i + iSampleOffset);
           isImportantPairsArc->InsertNextTuple1(0);
           branchBaryID->InsertNextTuple1(-1);
           percentMatchArc->InsertNextTuple1(100);
@@ -1527,6 +1572,8 @@ public:
       if(!treesNodes.empty() and ShiftMode != 1)
         vtkOutputNode->GetPointData()->AddArray(coordinates);
     }
+    vtkOutputNode->GetPointData()->AddArray(pairPersistenceNode);
+    vtkOutputNode->GetPointData()->AddArray(pairBirthNode);
 
     // - Manage arc output
     // Custom arrays
@@ -1562,12 +1609,12 @@ public:
       vtkArcs->GetCellData()->AddArray(pairIdentifier);
       vtkArcs->GetCellData()->AddArray(pairType);
       vtkArcs->GetCellData()->AddArray(pairIsFinite);
-      vtkArcs->GetCellData()->AddArray(pairPersistence);
-      vtkArcs->GetCellData()->AddArray(pairBirth);
     }
+    vtkArcs->GetCellData()->AddArray(pairPersistence);
+    vtkArcs->GetCellData()->AddArray(pairBirth);
     if(vtkOutputArc == vtkOutputNode)
       vtkArcs->GetPointData()->ShallowCopy(vtkOutputNode->GetPointData());
-    if(not branchDecompositionPlanarLayout_)
+    if(not branchDecompositionPlanarLayout_ and not isPersistenceDiagram)
       vtkArcs->GetPointData()->AddArray(scalar);
     vtkOutputArc->ShallowCopy(vtkArcs);
 


### PR DESCRIPTION
The main addition of this PR is to refactor the code of MT-PGA to create a super class `MergeTreeAxesAlgorithmBase` having the aim to be a super class for algorithms involving optimization of some axes in the Wasserstein space of merge trees or persistence diagrams.

This PR also finishes the feature introduced by #923 regarding the "convert to diagram" option, that convert the merge trees given in input of the filter to diagrams. It allows the user to give merge trees and ask to consider them as diagrams hence having diagrams visualization instead of merge trees visualisation. It is particularly useful to have the same pipeline and just change an option to switch between diagrams and merge trees computation and visualization (before this PR we could only give merge trees or persistence diagrams, and not convert merge trees to persistence diagrams).

It also adds the feature to embed diagrams and matchings in the domain (like it is done for merge trees in the feature tracking example).