### PR TITLE
fixed namespace hierarchy for periodicGhosts

### DIFF
--- a/core/vtk/ttkPeriodicGhostsGeneration/ttkPeriodicGhostsGeneration.cpp
+++ b/core/vtk/ttkPeriodicGhostsGeneration/ttkPeriodicGhostsGeneration.cpp
@@ -604,16 +604,16 @@ int ttkPeriodicGhostsGeneration::MPIPeriodicGhostPipelinePreconditioning(
 
   // Preparation of the MPI type for the matches
   MPI_Datatype partialGlobalBoundMPI;
-  std::vector<periodicGhosts::partialGlobalBound> allLocalGlobalBounds(
-    ttk::MPIsize_ * 6, periodicGhosts::partialGlobalBound{});
+  std::vector<ttk::periodicGhosts::partialGlobalBound> allLocalGlobalBounds(
+    ttk::MPIsize_ * 6, ttk::periodicGhosts::partialGlobalBound{});
   MPI_Datatype types[]
     = {MPI_UNSIGNED_CHAR, MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
   int lengths[] = {1, 1, 1, 1};
   const long int mpi_offsets[]
-    = {offsetof(periodicGhosts::partialGlobalBound, isBound),
-       offsetof(periodicGhosts::partialGlobalBound, x),
-       offsetof(periodicGhosts::partialGlobalBound, y),
-       offsetof(periodicGhosts::partialGlobalBound, z)};
+    = {offsetof(ttk::periodicGhosts::partialGlobalBound, isBound),
+       offsetof(ttk::periodicGhosts::partialGlobalBound, x),
+       offsetof(ttk::periodicGhosts::partialGlobalBound, y),
+       offsetof(ttk::periodicGhosts::partialGlobalBound, z)};
   MPI_Type_create_struct(
     4, lengths, mpi_offsets, types, &partialGlobalBoundMPI);
   MPI_Type_commit(&partialGlobalBoundMPI);

--- a/core/vtk/ttkPeriodicGhostsGeneration/ttkPeriodicGhostsGeneration.h
+++ b/core/vtk/ttkPeriodicGhostsGeneration/ttkPeriodicGhostsGeneration.h
@@ -53,14 +53,18 @@
 #include <vtkExtentTranslator.h>
 #include <vtkExtractVOI.h>
 #endif
-namespace periodicGhosts {
-  struct partialGlobalBound {
-    unsigned char isBound{0};
-    double x{0};
-    double y{0};
-    double z{0};
-  };
-} // namespace periodicGhosts
+
+namespace ttk {
+
+  namespace periodicGhosts {
+    struct partialGlobalBound {
+      unsigned char isBound{0};
+      double x{0};
+      double y{0};
+      double z{0};
+    };
+  } // namespace periodicGhosts
+} // namespace ttk
 
 class TTKPERIODICGHOSTSGENERATION_EXPORT ttkPeriodicGhostsGeneration
   : public ttkAlgorithm {
@@ -74,7 +78,7 @@ private:
   std::array<double, 3> origin_;
   std::array<double, 3> spacing_;
   bool isOutputExtentComputed_{false};
-  std::array<periodicGhosts::partialGlobalBound, 6> localGlobalBounds_;
+  std::array<ttk::periodicGhosts::partialGlobalBound, 6> localGlobalBounds_;
   std::vector<int> neighbors_;
   std::vector<std::array<ttk::SimplexId, 6>> neighborVertexBBoxes_;
   std::array<unsigned char, 6> isBoundaryPeriodic_{};


### PR DESCRIPTION
This fixes the namespace hierarchy for periodicGhosts (it matters for the doxygen doc)

