### PR TITLE
VTK FiberSurface : detect ill-formed range polygons to avoid out-of-bounds array access

### DIFF
--- a/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
+++ b/core/vtk/ttkFiberSurface/ttkFiberSurface.cpp
@@ -114,15 +114,21 @@ int ttkFiberSurface::RequestData(vtkInformation *ttkNotUsed(request),
 
   inputPolygon_.clear();
 
+  SimplexId cellNumber = polygon->GetNumberOfCells();
+  vtkCellArray *connectivity = polygon->GetCells();
+
+  if(connectivity->GetData()->GetNumberOfTuples() < 3 * cellNumber) {
+    this->printErr("Error: ill-defined range polygon.");
+    return 0;
+  }
+
 #if !defined(_WIN32) || defined(_WIN32) && defined(VTK_USE_64BIT_IDS)
-  const long long int *cellArray
-    = polygon->GetCells()->GetData()->GetPointer(0);
+  const long long int *cellArray = connectivity->GetData()->GetPointer(0);
 #else
-  int *pt = polygon->GetCells()->GetPointer();
+  int *pt = connectivity->GetPointer();
   long long extra_pt = *pt;
   const long long int *cellArray = &extra_pt;
 #endif
-  SimplexId cellNumber = polygon->GetNumberOfCells();
 
   SimplexId vertexId0, vertexId1;
   std::pair<std::pair<double, double>, std::pair<double, double>> rangeEdge;


### PR DESCRIPTION
A crash could happen when using the FiberSurface filter in Paraview, when the selected range is a point cloud and not a set of 2D cells, for example when using the tool "Select Points With Polygon" instead of "Select Cells With Polygon" (it definitely did not happen to me).

`cellArray[3 * i + 1]`  can then be out-of-bounds because we did not check the size of the connectivity array `cellArray` points to.

With this fix, the filter returns an error in this case and does not trigger a segfault anymore.