### PR TITLE
[CI] Fix for docker build timeout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        arch: [linux/amd64, linux/arm64]
     timeout-minutes: 3600
     steps:
       -
@@ -34,7 +37,7 @@ jobs:
         name: Build and push ttk
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.arch }}
           context: "{{defaultContext}}:scripts/docker"
           target: ttk
           push: true
@@ -46,7 +49,7 @@ jobs:
         name: Build and push ttk-dev
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.arch }}
           context: "{{defaultContext}}:scripts/docker"
           target: ttk-dev
           push: true


### PR DESCRIPTION
The docker script builds ttk containers for two architectures (linux/amd64 and linux/arm64). The two were done sequentially, causing a fail because of Github timeout.
Now the two containers are built in parallel,, hence dividing by two the total time, now under the time limit.