### PR TITLE
[CI] [Bugfix] Upgraded deprecated docker/ actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,20 +22,20 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2 
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push ttk
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: ${{ matrix.arch }}
           context: "{{defaultContext}}:scripts/docker"
@@ -47,7 +47,7 @@ jobs:
           cache-to:   type=gha,ref=ghcr.io/topology-tool-kit/ttk:buildcache,mode=max
       -
         name: Build and push ttk-dev
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           platforms: ${{ matrix.arch }}
           context: "{{defaultContext}}:scripts/docker"


### PR DESCRIPTION
The previous PR should have fixed the timelimit problem but there was another issue: the version of Nodejs used by the docker/ actions was no longer supported. This PR uses the last version of these actions.