### PR TITLE
Misc MPI fixes

### DIFF
--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -618,4 +618,13 @@ void ttk::ScalarFieldCriticalPoints::checkProgressivityRequirement(
 
     BackEnd = BACKEND::GENERIC;
   }
+
+#ifdef TTK_ENABLE_MPI
+  if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
+    printWrn("MPI run detected.");
+    printWrn("Defaulting to the generic backend.");
+
+    BackEnd = BACKEND::GENERIC;
+  }
+#endif // TTK_ENABLE_MPI
 }

--- a/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
+++ b/core/base/scalarFieldCriticalPoints/ScalarFieldCriticalPoints.h
@@ -613,16 +613,21 @@ void ttk::ScalarFieldCriticalPoints::checkProgressivityRequirement(
      && !std::is_same<ttk::ImplicitWithPreconditions, triangulationType>::value
      && !std::is_same<ttk::ImplicitNoPreconditions, triangulationType>::value) {
 
-    printWrn("Explicit, Compact or Periodic triangulation detected.");
+    printMsg(ttk::debug::Separator::L2);
+    printWrn("Explicit, Compact or Periodic");
+    printWrn("triangulation detected.");
     printWrn("Defaulting to the generic backend.");
+    printMsg(ttk::debug::Separator::L2);
 
     BackEnd = BACKEND::GENERIC;
   }
 
 #ifdef TTK_ENABLE_MPI
   if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
+    printMsg(ttk::debug::Separator::L2);
     printWrn("MPI run detected.");
     printWrn("Defaulting to the generic backend.");
+    printMsg(ttk::debug::Separator::L2);
 
     BackEnd = BACKEND::GENERIC;
   }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -170,11 +170,13 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
   switch(isValidOrderArray(orderArray)) {
     case -4: {
       ttk::Timer timer;
+      printMsg(ttk::debug::Separator::L2);
       this->printWrn("No pre-existing order for array:");
       this->printWrn("  `" + std::string(scalarArray->GetName()) + "`.");
 
       this->printMsg("Initializing order array.", 0, 0, this->threadNumber_,
                      ttk::debug::LineMode::REPLACE);
+      printMsg(ttk::debug::Separator::L2);
 
       auto nVertices = scalarArray->GetNumberOfTuples();
       auto newOrderArray = vtkSmartPointer<ttkSimplexIdTypeArray>::New();
@@ -205,8 +207,10 @@ vtkDataArray *ttkAlgorithm::GetOrderArray(vtkDataSet *const inputData,
       this->printMsg("Initializing order array.", 1, timer.getElapsedTime(),
                      this->threadNumber_);
 
+      printMsg(ttk::debug::Separator::L2);
       this->printWrn("TIP: run `ttkArrayPreconditioning` first");
       this->printWrn("for improved performances :)");
+      printMsg(ttk::debug::Separator::L2);
 
       return newOrderArray;
     }
@@ -684,6 +688,29 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
 
   ttk::SimplexId vertexNumber = input->GetNumberOfPoints();
   ttk::SimplexId cellNumber = input->GetNumberOfCells();
+
+  if((input->GetDataObjectType() == VTK_POLY_DATA
+      || input->GetDataObjectType() == VTK_UNSTRUCTURED_GRID)) {
+
+    if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
+      printMsg(ttk::debug::Separator::L2);
+      printWrn("The distribution by VTK of Unstructured");
+      printWrn("Grids and Poly Data has been reported");
+      printWrn("to be affected by bugs (at least up");
+      printWrn("to ParaView 5.10.1).");
+
+      if((input->GetCellData()->GetGlobalIds() == nullptr)
+         || (input->GetPointData()->GetGlobalIds() == nullptr)) {
+
+        printWrn("=> Global identifiers may be incorrect.");
+      }
+      if((input->GetPointData()->GetArray("RankArray") == nullptr)
+         || (input->GetCellData()->GetArray("RankArray") == nullptr)) {
+        printWrn("=> Rank arrays may be incorrect.");
+      }
+      printMsg(ttk::debug::Separator::L2);
+    }
+  }
 
   // Get the neighbor ranks
   std::vector<int> &neighborRanks{

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -43,10 +43,10 @@ ttk::Triangulation *ttkAlgorithm::GetTriangulation(vtkDataSet *dataSet) {
                    + std::string(dataSet->GetClassName()) + "'",
                  ttk::debug::Priority::DETAIL);
 #ifdef TTK_ENABLE_MPI
-  if(ttk::hasInitializedMPI()) {
+  if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
     if(!hasMPISupport_) {
-      printErr(
-        "MPI is not supported for this filter, the results will be incorrect");
+      printErr("MPI is not formally supported for this filter :(");
+      printErr("The results are likely to be incorrect.");
     }
     this->MPIGhostPipelinePreconditioning(dataSet);
   }

--- a/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
+++ b/core/vtk/ttkAlgorithm/ttkAlgorithm.cpp
@@ -684,29 +684,6 @@ void ttkAlgorithm::MPIPipelinePreconditioning(
 
   ttk::SimplexId vertexNumber = input->GetNumberOfPoints();
   ttk::SimplexId cellNumber = input->GetNumberOfCells();
-  if((input->GetDataObjectType() == VTK_POLY_DATA
-      || input->GetDataObjectType() == VTK_UNSTRUCTURED_GRID)) {
-    if((input->GetCellData()->GetGlobalIds() == nullptr)
-       || (input->GetPointData()->GetGlobalIds() == nullptr)) {
-      printWrn("Up to Paraview 5.10.1, bugs have been found in VTK for the "
-               "distribution of Unstructured Grids and Poly Data");
-      printWrn("As a consequence, the generation of Global ids is "
-               "incorrect for those simplices");
-      printWrn(
-        "Beware when using TTK for such data set types, some results may "
-        "be false");
-    }
-    if((input->GetPointData()->GetArray("RankArray") == nullptr)
-       || (input->GetCellData()->GetArray("RankArray") == nullptr)) {
-      printWrn("Up to Paraview 5.10.1, bugs have been found in VTK for the "
-               "distribution of Unstructured Grids and Poly Data");
-      printWrn("As a consequence, the generation of RankArray is "
-               "incorrect for those simplices");
-      printWrn(
-        "Beware when using TTK for such data set types, some results may "
-        "be false");
-    }
-  }
 
   // Get the neighbor ranks
   std::vector<int> &neighborRanks{

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -166,12 +166,12 @@ int ttkTriangulationManager::processExplicit(
   ttk::Timer tm{};
 
 #ifdef TTK_ENABLE_MPI
-  if(ttk::hasInitializedMPI()) {
-    this->printErr(
-      "Compact triangulation not (yet) supported in an MPI context!");
-    this->printErr("Keeping the Explicit triangulation.");
+  if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
+    this->printWrn("Compact triangulation not supported with MPI!");
+    this->printWrn("Keeping the Explicit triangulation.");
+    printf("\n\n\ngoing for the explicit\n\n\n");
     output->ShallowCopy(input);
-    return 0;
+    return 1;
   }
 #endif // TTK_ENABLE_MPI
 

--- a/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
+++ b/core/vtk/ttkTriangulationManager/ttkTriangulationManager.cpp
@@ -169,7 +169,6 @@ int ttkTriangulationManager::processExplicit(
   if((ttk::hasInitializedMPI()) && (ttk::isRunningWithMPI())) {
     this->printWrn("Compact triangulation not supported with MPI!");
     this->printWrn("Keeping the Explicit triangulation.");
-    printf("\n\n\ngoing for the explicit\n\n\n");
     output->ShallowCopy(input);
     return 1;
   }


### PR DESCRIPTION
This PR fixes various little details in the MPI support:
- filters now run without warnings when used with only 1 rank
- the critical points use the legacy backend by default if used with more than 1 rank
- the compact triangulation runs without warnings when used with only 1 rank
- adjusted warnings

@eve-le-guillou thanks for double-checking everything's ok.