### PR TITLE
Fix TTK_ENABLE_MPI_TIME creation

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -44,6 +44,7 @@ option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 if (TTK_ENABLE_MPI)
   find_package(MPI REQUIRED)
   option(TTK_ENABLE_MPI_TIME "Enable time measuring for MPI computation" TRUE)
+  mark_as_advanced(TTK_ENABLE_MPI_TIME)
 endif()
 
 if(TTK_BUILD_PARAVIEW_PLUGINS OR TTK_BUILD_VTK_WRAPPERS)

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -43,7 +43,7 @@ mark_as_advanced(TTK_CELL_ARRAY_LAYOUT)
 option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 if (TTK_ENABLE_MPI)
   find_package(MPI REQUIRED)
-  option(TTK_ENABLE_MPI_TIME "Enable time measuring for MPI computation" TRUE)
+  option(TTK_ENABLE_MPI_TIME "Enable time measuring for MPI computation" FALSE)
   mark_as_advanced(TTK_ENABLE_MPI_TIME)
 endif()
 

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -43,6 +43,7 @@ mark_as_advanced(TTK_CELL_ARRAY_LAYOUT)
 option(TTK_ENABLE_MPI "Enable MPI support" FALSE)
 if (TTK_ENABLE_MPI)
   find_package(MPI REQUIRED)
+  option(TTK_ENABLE_MPI_TIME "Enable time measuring for MPI computation" TRUE)
 endif()
 
 if(TTK_BUILD_PARAVIEW_PLUGINS OR TTK_BUILD_VTK_WRAPPERS)


### PR DESCRIPTION
Hi all,

This PR fixes the creation of `TTK_ENABLE_MPI_TIME` and ensures it is automatically visible in `ccmake` or `cmake-gui`.

Now the variable will be automatically created when `TTK_ENABLE_MPI` is set to ON and will be set to ON by default.

Thanks for any feedback,