### PR TITLE
New option for distanceMatrixDistortion: do not normalize the result

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@
 - Wasserstein distance performance improvements
 - Support for Persistence Diagrams in Merge Tree Clustering
 - Clustering scores (NMI/ARI)
-- Dimensionality reduction metric preservation score (DistanceMatrixDistorsion)
+- Dimensionality reduction metric preservation score (DistanceMatrixDistortion)
 - On-surface smoothing
 - API improvements
 - Bug fixes

--- a/core/base/distanceMatrixDistortion/DistanceMatrixDistortion.cpp
+++ b/core/base/distanceMatrixDistortion/DistanceMatrixDistortion.cpp
@@ -11,8 +11,8 @@ ttk::DistanceMatrixDistortion::DistanceMatrixDistortion() {
 int ttk::DistanceMatrixDistortion::execute(
   const std::vector<double *> &highDistMatrix,
   const std::vector<double *> &lowDistMatrix,
-  double &distorsionValue,
-  double *distorsionVerticesValues) const {
+  double &distortionValue,
+  double *distortionVerticesValues) const {
   ttk::Timer timer;
   auto n = highDistMatrix.size();
 
@@ -28,14 +28,14 @@ int ttk::DistanceMatrixDistortion::execute(
    * as follows: compute for each (x,y) delta(x,y) =
    * (dist_low(x,y)-dist_high(x,y))^2. Compute maxi = maximum (delta(x,y)) over
    * all (x,y). Compute delta2(x,y) = 1-delta(x,y) for each (x,y). The sim value
-   * is the mean of the n^2 values of delta2(x,y). The distorsion for a vertex
+   * is the mean of the n^2 values of delta2(x,y). The distortion for a vertex
    * x0 is the mean of delta2(x0,y) over all y's.
    */
 
   double maxi = 0;
-  if(distorsionVerticesValues == nullptr) {
+  if(distortionVerticesValues == nullptr) {
     this->printErr(
-      " The output pointer to the distorsionValues must be non NULL. "
+      " The output pointer to the distortionValues must be non NULL. "
       "It must point to an allocated array of the right size.");
     return 1;
   }
@@ -71,17 +71,17 @@ int ttk::DistanceMatrixDistortion::execute(
       const double diff2 = diff * diff;
       sum += diff2;
     }
-    const double sumHarmonized = sum / maxi;
-    distorsionVerticesValues[i] = 1 - sumHarmonized / n;
-    totalSum += 1 - sumHarmonized / n;
+    const double sumNormalized = (this->DoNotNormalize ? sum : sum / maxi);
+    distortionVerticesValues[i] = 1 - sumNormalized / n;
+    totalSum += 1 - sumNormalized / n;
   }
 
-  distorsionValue = totalSum / n;
+  distortionValue = totalSum / n;
 
   this->printMsg("Size of output in ttk/base = " + std::to_string(n));
 
-  this->printMsg("Computed distorsion value: "
-                 + std::to_string(distorsionValue));
+  this->printMsg("Computed distortion value: "
+                 + std::to_string(distortionValue));
   this->printMsg(ttk::debug::Separator::L2); // horizontal '-' separator
   this->printMsg("Complete", 1, timer.getElapsedTime());
   this->printMsg(ttk::debug::Separator::L1); // horizontal '=' separator

--- a/core/base/distanceMatrixDistortion/DistanceMatrixDistortion.h
+++ b/core/base/distanceMatrixDistortion/DistanceMatrixDistortion.h
@@ -25,7 +25,7 @@ namespace ttk {
 
   /**
    * The DistanceMatrixDistortion class provides a method to compute the
-   * distorsion score between two distance matrices representing the same
+   * distortion score between two distance matrices representing the same
    * points.
    */
   class DistanceMatrixDistortion : virtual public Debug {
@@ -35,8 +35,13 @@ namespace ttk {
 
     int execute(const std::vector<double *> &highDistMatrix,
                 const std::vector<double *> &lowDistMatrix,
-                double &distorsionValue,
-                double *distorsionVerticesValues) const;
+                double &distortionValue,
+                double *distortionVerticesValues) const;
+
+  protected:
+    // Warning: If this is set to true, then the similarity values we return
+    // will lie between -inf and 1 (best similarity).
+    bool DoNotNormalize{false};
   };
 
 } // namespace ttk

--- a/core/vtk/ttkDistanceMatrixDistortion/ttkDistanceMatrixDistortion.cpp
+++ b/core/vtk/ttkDistanceMatrixDistortion/ttkDistanceMatrixDistortion.cpp
@@ -126,20 +126,20 @@ int ttkDistanceMatrixDistortion::RequestData(
     vectMatLow[i] = ttkUtils::GetPointer<double>(arraysLow[i]);
   }
 
-  double distorsionValue = 0;
-  vtkNew<vtkDoubleArray> tmpCol{}, distorsionValArray{};
+  double distortionValue = 0;
+  vtkNew<vtkDoubleArray> tmpCol{}, distortionValArray{};
   tmpCol->SetNumberOfTuples(n);
-  this->printMsg("Starting computation of sim distorsion value...");
-  this->execute(vectMatHigh, vectMatLow, distorsionValue,
+  this->printMsg("Starting computation of sim distortion value...");
+  this->execute(vectMatHigh, vectMatLow, distortionValue,
                 ttkUtils::GetPointer<double>(tmpCol));
 
   tmpCol->SetName("SimValue");
   // No deep copy, makes output->RowData points to the data of tmpCol.
   output->AddColumn(tmpCol);
-  distorsionValArray->SetName("DistortionValue");
-  distorsionValArray->SetNumberOfTuples(1);
-  distorsionValArray->SetTuple1(0, distorsionValue);
-  output->GetFieldData()->AddArray(distorsionValArray);
+  distortionValArray->SetName("DistortionValue");
+  distortionValArray->SetNumberOfTuples(1);
+  distortionValArray->SetTuple1(0, distortionValue);
+  output->GetFieldData()->AddArray(distortionValArray);
 
   return 1;
 }

--- a/core/vtk/ttkDistanceMatrixDistortion/ttkDistanceMatrixDistortion.h
+++ b/core/vtk/ttkDistanceMatrixDistortion/ttkDistanceMatrixDistortion.h
@@ -6,7 +6,7 @@
 /// \brief TTK VTK-filter that wraps the ttk::DistanceMatrixDistortion module.
 ///
 /// This VTK filter uses the ttk::DistanceMatrixDistortion module to compute the
-/// distorsion between two distance matrices representing the same points (for
+/// distortion between two distance matrices representing the same points (for
 /// instance in low and high dimensions), according to the SIM formula.
 ///
 /// \param Input0 vtkTable.
@@ -61,6 +61,8 @@ public:
   vtkGetMacro(SelectFieldsWithRegexpHigh, bool);
   vtkSetMacro(SelectFieldsWithRegexpLow, bool);
   vtkGetMacro(SelectFieldsWithRegexpLow, bool);
+  vtkSetMacro(DoNotNormalize, bool);
+  vtkGetMacro(DoNotNormalize, bool);
 
   vtkSetMacro(RegexpStringHigh, const std::string &);
   vtkGetMacro(RegexpStringHigh, std::string);

--- a/paraview/xmls/DistanceMatrixDistortion.xml
+++ b/paraview/xmls/DistanceMatrixDistortion.xml
@@ -2,7 +2,7 @@
 <ServerManagerConfiguration>
   <ProxyGroup name="filters">
     <SourceProxy name="ttkDistanceMatrixDistortion" class="ttkDistanceMatrixDistortion" label="TTK DistanceMatrixDistortion">
-      <Documentation long_help="DistanceMatrixDistortion plugin" short_help="DistanceMatrixDistortion plugin">This plugin, given two distance matrices representing the same points, computes the distortion between the two, according the SIM formula. It also provides, for each point, the distorsion for its own distances to the other points.</Documentation>
+      <Documentation long_help="DistanceMatrixDistortion plugin" short_help="DistanceMatrixDistortion plugin">This plugin, given two distance matrices representing the same points, computes the distortion between the two, according the SIM formula. It also provides, for each point, the distortion for its own distances to the other points.</Documentation>
 
       <!-- INPUT DATA OBJECTS -->
       <InputProperty
@@ -24,7 +24,18 @@
           High dimension distance matrix.
         </Documentation>
       </InputProperty>
-      
+
+      <IntVectorProperty
+        name="DoNotNormalize"
+        label="Do not normalize computations"
+        command="SetDoNotNormalize"
+        number_of_elements="1"
+        default_values="0">
+        <BooleanDomain name="bool"/>
+        <Documentation>
+        If the box is not checked, we normalize the results by dividing the sums by the maximum element of the line. Warning: if the box is checked, the values will lie between -inf and 1 (best similarity).
+        </Documentation>
+      </IntVectorProperty>
 
       <IntVectorProperty
         name="SelectFieldsWithRegexpHigh"
@@ -161,6 +172,7 @@
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
+        <Property name="DoNotNormalize" />
         <Property name="SelectFieldsWithRegexpHigh" />
         <Property name="ScalarFieldsHigh" />
         <Property name="RegexpHigh" />

--- a/paraview/xmls/DistanceMatrixDistortion.xml
+++ b/paraview/xmls/DistanceMatrixDistortion.xml
@@ -29,6 +29,7 @@
         name="DoNotNormalize"
         label="Do not normalize computations"
         command="SetDoNotNormalize"
+        panel_visibility="advanced"
         number_of_elements="1"
         default_values="0">
         <BooleanDomain name="bool"/>
@@ -172,7 +173,6 @@
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
-        <Property name="DoNotNormalize" />
         <Property name="SelectFieldsWithRegexpHigh" />
         <Property name="ScalarFieldsHigh" />
         <Property name="RegexpHigh" />
@@ -180,6 +180,11 @@
         <Property name="ScalarFieldsLow" />
         <Property name="RegexpLow" />
       </PropertyGroup>
+
+      <PropertyGroup panel_widget="Line" label="Output options">
+        <Property name="DoNotNormalize" />
+      </PropertyGroup>
+
 
       <!-- MENU CATEGORY -->
       <Hints>


### PR DESCRIPTION
We propose here two modifications to the distanceMatrixDistortion class. First at a few locations we correct a spelling mistake: distorTion insted of distorsion.

Secondly, we provide the possibility to compute a non-normalized similarity score. Before, we divided everything by the maximum values for each row such that the final result would lie in [0,1]. With the new options enabled, it lies in [-inf, 1].