### PR TITLE
Export declaration fixes

### DIFF
--- a/CMake/BaseCode.cmake
+++ b/CMake/BaseCode.cmake
@@ -22,6 +22,15 @@ function(ttk_add_base_library library)
     PROPERTIES
       POSITION_INDEPENDENT_CODE TRUE
     )
+
+  if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)
+    set_target_properties(${library}
+      PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
+  endif()
+
+
   target_include_directories(${library}
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -129,9 +129,6 @@ mark_as_advanced(TTK_SCRIPTS_PATH)
 
 option(TTK_ENABLE_SHARED_BASE_LIBRARIES "Generate shared base libraries instead of static ones" ON)
 mark_as_advanced(TTK_ENABLE_SHARED_BASE_LIBRARIES)
-if(TTK_ENABLE_SHARED_BASE_LIBRARIES AND MSVC)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
 
 option(TTK_BUILD_DOCUMENTATION "Build doxygen developer documentation" OFF)
 if(TTK_BUILD_DOCUMENTATION)

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.h
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.h
@@ -1,6 +1,9 @@
 #include <Debug.h>
 #include <PersistenceDiagramUtils.h>
 
+// VTK Module
+#include <ttkPersistenceDiagramModule.h>
+
 class vtkUnstructuredGrid;
 class vtkDataArray;
 
@@ -15,9 +18,9 @@ class vtkDataArray;
  *
  * @return 0 in case of success, negative number otherwise
  */
-int VTUToDiagram(ttk::DiagramType &diagram,
-                 vtkUnstructuredGrid *vtu,
-                 const ttk::Debug &dbg);
+TTKPERSISTENCEDIAGRAM_EXPORT int VTUToDiagram(ttk::DiagramType &diagram,
+                                              vtkUnstructuredGrid *vtu,
+                                              const ttk::Debug &dbg);
 
 /**
  * @brief Converts a Persistence Diagram in the
@@ -35,12 +38,12 @@ int VTUToDiagram(ttk::DiagramType &diagram,
  *
  * @return 0 in case of success, negative number otherwise
  */
-int DiagramToVTU(vtkUnstructuredGrid *vtu,
-                 const ttk::DiagramType &diagram,
-                 vtkDataArray *const inputScalars,
-                 const ttk::Debug &dbg,
-                 const int dim,
-                 const bool embedInDomain);
+TTKPERSISTENCEDIAGRAM_EXPORT int DiagramToVTU(vtkUnstructuredGrid *vtu,
+                                              const ttk::DiagramType &diagram,
+                                              vtkDataArray *const inputScalars,
+                                              const ttk::Debug &dbg,
+                                              const int dim,
+                                              const bool embedInDomain);
 
 /**
  * @brief Generate the spatial embedding of a given Persistence Diagram
@@ -53,9 +56,10 @@ int DiagramToVTU(vtkUnstructuredGrid *vtu,
  *
  * @return 0 in case of success
  */
-int ProjectDiagramInsideDomain(vtkUnstructuredGrid *const inputDiagram,
-                               vtkUnstructuredGrid *const outputDiagram,
-                               const ttk::Debug &dbg);
+TTKPERSISTENCEDIAGRAM_EXPORT int
+  ProjectDiagramInsideDomain(vtkUnstructuredGrid *const inputDiagram,
+                             vtkUnstructuredGrid *const outputDiagram,
+                             const ttk::Debug &dbg);
 
 /**
  * @brief Generate the 2D embedding of a given Persistence Diagram
@@ -68,9 +72,10 @@ int ProjectDiagramInsideDomain(vtkUnstructuredGrid *const inputDiagram,
  *
  * @return 0 in case of success
  */
-int ProjectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
-                       vtkUnstructuredGrid *const outputDiagram,
-                       const ttk::Debug &dbg);
+TTKPERSISTENCEDIAGRAM_EXPORT int
+  ProjectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
+                     vtkUnstructuredGrid *const outputDiagram,
+                     const ttk::Debug &dbg);
 
 /**
  * @brief Translate a diagram to a new position.
@@ -80,8 +85,9 @@ int ProjectDiagramIn2D(vtkUnstructuredGrid *const inputDiagram,
  *
  * @return 0 in case of success
  */
-int TranslateDiagram(vtkUnstructuredGrid *const diagram,
-                     const std::array<double, 3> &trans);
+TTKPERSISTENCEDIAGRAM_EXPORT int
+  TranslateDiagram(vtkUnstructuredGrid *const diagram,
+                   const std::array<double, 3> &trans);
 
 /**
  * @brief Translate back a canonical diagram into its original position.
@@ -93,5 +99,6 @@ int TranslateDiagram(vtkUnstructuredGrid *const diagram,
  *
  * @return 0 in case of success
  */
-int ResetDiagramPosition(vtkUnstructuredGrid *const diagram,
-                         const ttk::Debug &dbg);
+TTKPERSISTENCEDIAGRAM_EXPORT int
+  ResetDiagramPosition(vtkUnstructuredGrid *const diagram,
+                       const ttk::Debug &dbg);


### PR DESCRIPTION
Added missing exports in ttkPersistenceDiagramUtils. Disabled the global use of CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS since it will lead to duplicated exports in the vtk layer that has explicit exports. Enabled WINDOWS_EXPORT_ALL_SYMBOLS only for the base modules since they are missing export declaration.



