### PR TITLE
[CMAKE] Standalone apps and examples now require cmake version 3.21 i…

### DIFF
--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 
 # name of the project
 project(ttkExample-c++)

--- a/examples/vtk-c++/CMakeLists.txt
+++ b/examples/vtk-c++/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.21)
 
 # name of the project
 project(ttkExample-vtk-c++ LANGUAGES CXX C)

--- a/standalone/ContinuousScatterPlot/CMakeLists.txt
+++ b/standalone/ContinuousScatterPlot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkContinuousScatterPlotCmd)
 

--- a/standalone/ContourAroundPoint/CMakeLists.txt
+++ b/standalone/ContourAroundPoint/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkContourAroundPointCmd)
 

--- a/standalone/ContourForests/CMakeLists.txt
+++ b/standalone/ContourForests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkContourForestsCmd)
 

--- a/standalone/ContourTree/CMakeLists.txt
+++ b/standalone/ContourTree/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkContourTreeCmd)
 

--- a/standalone/GeometrySmoother/cmd/CMakeLists.txt
+++ b/standalone/GeometrySmoother/cmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkGeometrySmootherCmd)
 

--- a/standalone/GeometrySmoother/gui/CMakeLists.txt
+++ b/standalone/GeometrySmoother/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkGeometrySmootherGui)
 

--- a/standalone/HelloWorld/CMakeLists.txt
+++ b/standalone/HelloWorld/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkHelloWorldCmd)
 

--- a/standalone/JacobiSet/CMakeLists.txt
+++ b/standalone/JacobiSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkJacobiSetCmd)
 

--- a/standalone/LDistance/CMakeLists.txt
+++ b/standalone/LDistance/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkLDistanceCmd)
 

--- a/standalone/MandatoryCriticalPoints/CMakeLists.txt
+++ b/standalone/MandatoryCriticalPoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMandatoryCriticalPointsCmd)
 

--- a/standalone/ManifoldCheck/CMakeLists.txt
+++ b/standalone/ManifoldCheck/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkManifoldCheckCmd)
 

--- a/standalone/MarchingTetrahedra/CMakeLists.txt
+++ b/standalone/MarchingTetrahedra/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMarchingTetrahedraCmd)
 

--- a/standalone/MergeTree/CMakeLists.txt
+++ b/standalone/MergeTree/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMergeTreeCmd)
 

--- a/standalone/MeshSubdivision/CMakeLists.txt
+++ b/standalone/MeshSubdivision/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMeshSubdivisionCmd)
 

--- a/standalone/MetricDistortion/CMakeLists.txt
+++ b/standalone/MetricDistortion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMetricDistortionCmd)
 

--- a/standalone/MorseSmaleComplex/CMakeLists.txt
+++ b/standalone/MorseSmaleComplex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkMorseSmaleComplexCmd)
 

--- a/standalone/PathCompression/CMakeLists.txt
+++ b/standalone/PathCompression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkPathCompressionCmd)
 

--- a/standalone/PersistenceDiagram/CMakeLists.txt
+++ b/standalone/PersistenceDiagram/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkPersistenceDiagramCmd)
 

--- a/standalone/PointMerger/CMakeLists.txt
+++ b/standalone/PointMerger/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkPointMergerCmd)
 

--- a/standalone/ReebGraph/CMakeLists.txt
+++ b/standalone/ReebGraph/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkReebGraphCmd)
 

--- a/standalone/ReebSpace/CMakeLists.txt
+++ b/standalone/ReebSpace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkReebSpaceCmd)
 

--- a/standalone/ScalarFieldCriticalPoints/CMakeLists.txt
+++ b/standalone/ScalarFieldCriticalPoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkScalarFieldCriticalPointsCmd)
 

--- a/standalone/ScalarFieldSmoother/CMakeLists.txt
+++ b/standalone/ScalarFieldSmoother/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkScalarFieldSmootherCmd)
 

--- a/standalone/UncertainDataEstimator/CMakeLists.txt
+++ b/standalone/UncertainDataEstimator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.21)
 
 project(ttkUncertainDataEstimatorCmd)
 


### PR DESCRIPTION
Updating the minimum required CMake version to 3.21 for the files which required an older version.

