### PR TITLE
Added fix for joinTree not inverting the data order back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Set PYTHONPATH for macOS pvpython
       run: |
         # pvpython does not embed the correct PYTHONPATH
-        echo "PYTHONPATH=/usr/local/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=/usr/local/lib/python3.11/site-packages:$PYTHONPATH" >> $GITHUB_ENV
 
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -360,7 +360,7 @@ jobs:
       run: |
         cd ttk-data/tests
         mkdir output_screenshots
-        python3 -u validate.py || (tar zcf screenshots.tar.gz output_screenshots && false)
+        pvpython -u validate.py || (tar zcf screenshots.tar.gz output_screenshots && false)
       env:
         PV_PLUGIN_PATH: /usr/local/bin/plugins/TopologyToolKit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,7 +341,7 @@ jobs:
     - name: Set PYTHONPATH for macOS pvpython
       run: |
         # pvpython does not embed the correct PYTHONPATH
-        echo "PYTHONPATH=/usr/local/lib/python3.11/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=/usr/local/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
 
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix

--- a/core/vtk/ttkMergeTree/ttkMergeTree.cpp
+++ b/core/vtk/ttkMergeTree/ttkMergeTree.cpp
@@ -286,6 +286,13 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
         triangulation->getType(),
         getMergeTreePoints<T0>(outputPoints, persistencePairsJoin, scalarArray,
                                (T0 *)triangulation->getData()));
+      //swap the data back
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif
+      for(size_t i = 0; i < nVertices; i++) {
+        orderArrayData[i] = nVertices - orderArrayData[i] - 1;
+      }
 
     } else {
       std::vector<std::pair<ttk::SimplexId, ttk::SimplexId>>

--- a/core/vtk/ttkMergeTree/ttkMergeTree.cpp
+++ b/core/vtk/ttkMergeTree/ttkMergeTree.cpp
@@ -286,7 +286,7 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
         triangulation->getType(),
         getMergeTreePoints<T0>(outputPoints, persistencePairsJoin, scalarArray,
                                (T0 *)triangulation->getData()));
-      //swap the data back
+      // swap the data back
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
 #endif

--- a/core/vtk/ttkMergeTree/ttkMergeTree.cpp
+++ b/core/vtk/ttkMergeTree/ttkMergeTree.cpp
@@ -186,28 +186,32 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
     auto segmentationPD = segmentation->GetPointData();
 
     // enforce that ascending and descending manifolds exist
-    if(!segmentationPD->HasArray(ttk::MorseSmaleAscendingName)
-       || !segmentationPD->HasArray(ttk::MorseSmaleDescendingName)) {
+    std::string ascendingName = std::string(scalarArray->GetName()) + "_"
+                                + std::string(ttk::MorseSmaleAscendingName);
+    std::string descendingName = std::string(scalarArray->GetName()) + "_"
+                                 + std::string(ttk::MorseSmaleDescendingName);
+    if(!segmentationPD->HasArray(ascendingName.data())
+       || !segmentationPD->HasArray(descendingName.data())) {
       printMsg(ttk::debug::Separator::L2);
       this->printWrn("TIP: run `ttkPathCompression` first");
       this->printWrn("for improved performances :)");
       printMsg(ttk::debug::Separator::L2);
       bool doAscend = false;
       bool doDescend = false;
-      if(!segmentationPD->HasArray(ttk::MorseSmaleAscendingName)) {
+      if(!segmentationPD->HasArray(ascendingName.data())) {
         doAscend = true;
         auto ascendingManifold = vtkSmartPointer<vtkIdTypeArray>::New();
         ascendingManifold->SetNumberOfComponents(1);
         ascendingManifold->SetNumberOfTuples(nVertices);
-        ascendingManifold->SetName(ttk::MorseSmaleAscendingName);
+        ascendingManifold->SetName(ascendingName.data());
         segmentationPD->AddArray(ascendingManifold);
       }
-      if(!segmentationPD->HasArray(ttk::MorseSmaleDescendingName)) {
+      if(!segmentationPD->HasArray(descendingName.data())) {
         doDescend = true;
         auto descendingManifold = vtkSmartPointer<vtkIdTypeArray>::New();
         descendingManifold->SetNumberOfComponents(1);
         descendingManifold->SetNumberOfTuples(nVertices);
-        descendingManifold->SetName(ttk::MorseSmaleDescendingName);
+        descendingManifold->SetName(descendingName.data());
         segmentationPD->AddArray(descendingManifold);
       }
       ttk::PathCompression subModule;
@@ -218,9 +222,9 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
 
       ttk::PathCompression::OutputSegmentation om{
         ttkUtils::GetPointer<ttk::SimplexId>(
-          segmentationPD->GetArray(ttk::MorseSmaleAscendingName)),
+          segmentationPD->GetArray(ascendingName.data())),
         ttkUtils::GetPointer<ttk::SimplexId>(
-          segmentationPD->GetArray(ttk::MorseSmaleDescendingName)),
+          segmentationPD->GetArray(descendingName.data())),
         nullptr};
 
       int status = 0;
@@ -233,10 +237,8 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
         return 0;
     }
 
-    auto ascendingManifold
-      = segmentationPD->GetArray(ttk::MorseSmaleAscendingName);
-    auto descendingManifold
-      = segmentationPD->GetArray(ttk::MorseSmaleDescendingName);
+    auto ascendingManifold = segmentationPD->GetArray(ascendingName.data());
+    auto descendingManifold = segmentationPD->GetArray(descendingName.data());
 
     vtkNew<ttkSimplexIdTypeArray> segmentationId{};
     segmentationId->SetNumberOfComponents(1);
@@ -272,7 +274,13 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
                        ttkUtils::GetPointer<ttk::SimplexId>(ascendingManifold),
                        ttkUtils::GetPointer<ttk::SimplexId>(descendingManifold),
                        orderArrayData, (T0 *)triangulation->getData())));
-
+      // swap the data back (even if the execution failed)
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel for num_threads(this->threadNumber_)
+#endif
+      for(size_t i = 0; i < nVertices; i++) {
+        orderArrayData[i] = nVertices - orderArrayData[i] - 1;
+      }
       if(status != 1)
         return 0;
 
@@ -286,13 +294,6 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
         triangulation->getType(),
         getMergeTreePoints<T0>(outputPoints, persistencePairsJoin, scalarArray,
                                (T0 *)triangulation->getData()));
-      // swap the data back
-#ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads(this->threadNumber_)
-#endif
-      for(size_t i = 0; i < nVertices; i++) {
-        orderArrayData[i] = nVertices - orderArrayData[i] - 1;
-      }
 
     } else {
       std::vector<std::pair<ttk::SimplexId, ttk::SimplexId>>

--- a/core/vtk/ttkPathCompression/ttkPathCompression.cpp
+++ b/core/vtk/ttkPathCompression/ttkPathCompression.cpp
@@ -111,15 +111,21 @@ int ttkPathCompression::RequestData(vtkInformation *ttkNotUsed(request),
 
   ascendingSegmentation->SetNumberOfComponents(1);
   ascendingSegmentation->SetNumberOfTuples(numberOfVertices);
-  ascendingSegmentation->SetName("AscendingSegmentation");
+  ascendingSegmentation->SetName((std::string(inputScalars->GetName()) + "_"
+                                  + std::string(ttk::MorseSmaleAscendingName))
+                                   .data());
 
   descendingSegmentation->SetNumberOfComponents(1);
   descendingSegmentation->SetNumberOfTuples(numberOfVertices);
-  descendingSegmentation->SetName("DescendingSegmentation");
+  descendingSegmentation->SetName((std::string(inputScalars->GetName()) + "_"
+                                   + std::string(ttk::MorseSmaleDescendingName))
+                                    .data());
 
   morseSmaleSegmentation->SetNumberOfComponents(1);
   morseSmaleSegmentation->SetNumberOfTuples(numberOfVertices);
-  morseSmaleSegmentation->SetName("MorseSmaleSegmentation");
+  morseSmaleSegmentation->SetName((std::string(inputScalars->GetName()) + "_"
+                                   + std::string(ttk::MorseSmaleManifoldName))
+                                    .data());
 
   this->segmentations_
     = {ttkUtils::GetPointer<SimplexId>(ascendingSegmentation),


### PR DESCRIPTION
There was a bug when computing the join tree with ExTreeM. By default it computes the split tree and it can be adapted into computing the join tree by inverting the order values of the data. However, the values weren't inverted back, leading to wrong values in further steps. This PR fixes this.