### PR TITLE
[CI/MacOS] Bugfix Pythons 3.12 + 3.11

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -170,14 +170,15 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout TTK source code
 
-#    - name: Remove hosted Python
-#      run: |
-#        sudo rm -rf /Library/Frameworks/Python.framework
-#        sudo rm -rf /usr/local/Frameworks/Python.framework
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        sudo rm -rf /usr/local/Frameworks/Python.framework/
 
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
+        brew reinstall python
         brew install --cask xquartz
         brew install wget llvm libomp mesa glew qt@5 ninja 
         # TTK dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,11 +270,16 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout TTK source code
 
+    - name: Remove hosted Python
+      run: |
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        sudo rm -rf /usr/local/Frameworks/Python.framework/
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
+        brew reinstall python
         brew install --cask xquartz
-        brew install wget llvm libomp ninja python open-mpi
+        brew install wget llvm libomp ninja open-mpi
         # TTK dependencies
         brew install boost eigen graphviz numpy websocketpp ccache
         # prepend ccache to system path


### PR DESCRIPTION
The Github MacOS runner seems to ship Python 3.12 binaries/libraries along with Python 3.11.6 being installed. This cause some problems which we solve here by removing th 3.12 files.
