### PR TITLE
Added CritType and RegionType for ExTreeM

### DIFF
--- a/core/base/exTreeM/ExTreeM.h
+++ b/core/base/exTreeM/ExTreeM.h
@@ -1212,6 +1212,7 @@ namespace ttk {
      * of the branch for each vertex
      * @param[out] regionType type of the segmentation region, see FTMTree for
      * more detail
+     * @param[in] cpMap a point id -> critical type map
      * @param[in] branches mergetree as vector of branch structs
      * @param[in] order order array
      * @param[in] descendingManifold descending manifold

--- a/core/base/exTreeM/ExTreeM.h
+++ b/core/base/exTreeM/ExTreeM.h
@@ -1210,7 +1210,8 @@ namespace ttk {
      *
      * @param[out] segmentation segmentation array, representing the upper end
      * of the branch for each vertex
-     * @param[out] isLeaf vector of bools, 1 if vertex is a leaf, 0 otherwise
+     * @param[out] regionType type of the segmentation region, see FTMTree for
+     * more detail
      * @param[in] branches mergetree as vector of branch structs
      * @param[in] order order array
      * @param[in] descendingManifold descending manifold
@@ -1220,7 +1221,8 @@ namespace ttk {
      */
     template <typename triangulationType>
     int constructSegmentation(ttk::SimplexId *segmentation,
-                              unsigned char *isLeaf,
+                              char *regionType,
+                              const std::map<ttk::SimplexId, int> &cpMap,
                               const std::vector<Branch> &branches,
                               const ttk::SimplexId *order,
                               ttk::SimplexId *descendingManifold,
@@ -1239,7 +1241,7 @@ namespace ttk {
         auto orderForVertex = order[i];
         if(orderForVertex <= trunkSaddle.first) {
           segmentation[i] = trunkSaddle.second;
-          isLeaf[i] = 0;
+          regionType[i] = 1;
           continue;
         }
         auto maximum
@@ -1249,16 +1251,28 @@ namespace ttk {
         auto lowestOrder = (*(cBranch->vertices.rbegin())).first;
         while(lowestOrder
               >= orderForVertex) { // finding the branch on which we are
+          // save previous maximum as downNode
           cBranch = cBranch->parentBranch;
           lowestOrder = (*(cBranch->vertices.rbegin())).first;
         }
         auto vect = &cBranch->vertices;
         auto lower = std::lower_bound(
           vect->rbegin(), vect->rend(), std::make_pair(orderForVertex, i));
-        if(lower == vect->rend() - 1) {
-          isLeaf[i] = 1;
+        auto upNode = (*lower).second;
+        auto downNode = (*(lower - 1)).second;
+        int upNodeType = cpMap.at(upNode);
+        int downNodeType = cpMap.at(downNode);
+        if((upNodeType == 0 && downNodeType == 3)
+           || (upNodeType == 0 || downNodeType == 0)) {
+          regionType[i] = 0;
+        } else if(upNodeType == 3 || downNodeType == 3) {
+          regionType[i] = 1;
+        } else if(upNodeType == 1 && downNodeType == 1) {
+          regionType[i] = 2;
+        } else if(upNodeType == 2 && downNodeType == 2) {
+          regionType[i] = 3;
         } else {
-          isLeaf[i] = 0;
+          regionType[i] = 4;
         }
 
         segmentation[i] = (*lower).second;
@@ -1378,9 +1392,10 @@ namespace ttk {
     template <class triangulationType>
     int computePairs(
       std::vector<std::pair<ttk::SimplexId, ttk::SimplexId>> &persistencePairs,
+      std::map<ttk::SimplexId, int> &cpMap,
       std::vector<Branch> &branches,
       ttk::SimplexId *segmentation,
-      unsigned char *isLeaf,
+      char *regionType,
       ttk::SimplexId *descendingManifold,
       ttk::SimplexId *tempArray,
       const ttk::SimplexId *order,
@@ -1399,11 +1414,18 @@ namespace ttk {
 
       // -----------------------------------------------------------------------
       {
-        std::array<std::vector<ttk::SimplexId>, 4> criticalPoints;
         std::array<std::vector<std::vector<ttk::SimplexId>>, 4> criticalPoints_;
+        std::array<std::vector<ttk::SimplexId>, 4> criticalPoints;
         this->computeCriticalPoints(criticalPoints_, order, descendingManifold,
                                     descendingManifold, triangulation);
         this->mergeCriticalPointVectors(criticalPoints, criticalPoints_);
+        // flatten the criticalpoints for the segmentation
+        for(int i = 0; i < 4; i++) {
+          for(ttk::SimplexId point : criticalPoints[i]) {
+            cpMap[point] = 3 - i;
+          }
+        }
+
         ttk::SimplexId *minimaIds = criticalPoints[0].data();
         ttk::SimplexId *saddle2Ids = criticalPoints[2].data();
         ttk::SimplexId *maximaIds = criticalPoints[3].data();
@@ -1472,9 +1494,9 @@ namespace ttk {
         ttk::Timer segmentationTimer;
         this->printMsg("Starting with mergetree segmentation", 0,
                        ttk::debug::LineMode::REPLACE);
-        constructSegmentation<triangulationType>(segmentation, isLeaf, branches,
-                                                 order, descendingManifold,
-                                                 tempArray, triangulation);
+        constructSegmentation<triangulationType>(
+          segmentation, regionType, cpMap, branches, order, descendingManifold,
+          tempArray, triangulation);
         this->printMsg("Finished mergetree segmentation", 1,
                        segmentationTimer.getElapsedTime(), this->threadNumber_);
 //  print the progress of the current subprocedure with elapsed time

--- a/core/vtk/ttkMergeTree/ttkMergeTreeBase.h
+++ b/core/vtk/ttkMergeTree/ttkMergeTreeBase.h
@@ -205,6 +205,7 @@ protected:
   template <class triangulationType>
   int getMergeTreePoints(
     vtkUnstructuredGrid *outputSkeletonNodes,
+    std::map<ttk::SimplexId, int> cpMap,
     std::vector<std::pair<ttk::SimplexId, ttk::SimplexId>> &persistencePairs,
     vtkDataArray *inputScalars,
     const triangulationType *triangulation) {
@@ -218,6 +219,10 @@ protected:
       = vtkSmartPointer<vtkDataArray>::Take(inputScalars->NewInstance());
     scalarArray->SetNumberOfComponents(1);
     scalarArray->SetName("Scalar");
+    vtkNew<vtkIntArray> cpArray{};
+    cpArray->SetNumberOfComponents(1);
+    cpArray->SetName("CriticalType");
+
     float point[3];
     long long pointId = 0;
 
@@ -226,10 +231,12 @@ protected:
       points->InsertNextPoint(point);
       gIdArray->InsertNextTuple1(pair.first);
       scalarArray->InsertNextTuple1(inputScalars->GetTuple1(pair.first));
+      cpArray->InsertNextTuple1(cpMap[pair.first]);
       triangulation->getVertexPoint(pair.second, point[0], point[1], point[2]);
       points->InsertNextPoint(point);
       gIdArray->InsertNextTuple1(pair.second);
       scalarArray->InsertNextTuple1(inputScalars->GetTuple1(pair.second));
+      cpArray->InsertNextTuple1(cpMap[pair.second]);
       skeletonNodes->InsertNextCell(VTK_VERTEX, 1, &pointId);
       pointId++;
       skeletonNodes->InsertNextCell(VTK_VERTEX, 1, &pointId);
@@ -239,6 +246,7 @@ protected:
     outputSkeletonNodes->ShallowCopy(skeletonNodes);
     outputSkeletonNodes->GetPointData()->AddArray(gIdArray);
     outputSkeletonNodes->GetPointData()->AddArray(scalarArray);
+    outputSkeletonNodes->GetPointData()->AddArray(cpArray);
 
     return 1;
   }


### PR DESCRIPTION
Hello,

this PR adds the CriticalType array to the nodes and the RegionType array to the segmentation of the merge tree. The types follow the implementation of FTMTree for compatibility, see https://github.com/topology-tool-kit/ttk-data/pull/152

