### PR TITLE
[ttkMergeTree] Changed criticalType computation for ExTreeM based on treetype

### DIFF
--- a/core/base/exTreeM/ExTreeM.h
+++ b/core/base/exTreeM/ExTreeM.h
@@ -1400,7 +1400,8 @@ namespace ttk {
       ttk::SimplexId *descendingManifold,
       ttk::SimplexId *tempArray,
       const ttk::SimplexId *order,
-      const triangulationType *triangulation) {
+      const triangulationType *triangulation,
+      const char type) {
 
       // start global timer
       ttk::Timer globalTimer;
@@ -1423,7 +1424,11 @@ namespace ttk {
         // flatten the criticalpoints for the segmentation
         for(int i = 0; i < 4; i++) {
           for(ttk::SimplexId point : criticalPoints[i]) {
-            cpMap[point] = 3 - i;
+            if(type == 0) {
+              cpMap[point] = 3 - i;
+            } else {
+              cpMap[point] = i;
+            }
           }
         }
 

--- a/core/vtk/ttkMergeTree/ttkMergeTree.cpp
+++ b/core/vtk/ttkMergeTree/ttkMergeTree.cpp
@@ -161,7 +161,6 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
      && (!(params_.treeType == ttk::ftm::TreeType::Contour))
      && (input->IsA("vtkImageData"))) {
     printMsg("Triggering ExTreeM Backend.");
-    // TODO: add CriticalType PointData Array and change isLeaf to RegionType
     const size_t nVertices = input->GetNumberOfPoints();
 
     // Get triangulation of the input object
@@ -269,14 +268,15 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
       for(size_t i = 0; i < nVertices; i++) {
         orderArrayData[i] = nVertices - orderArrayData[i] - 1;
       }
-      ttkTypeMacroT(triangulation->getType(),
-                    (status = exTreeMTree.computePairs<T0>(
-                       persistencePairsJoin, cpMap, mergeTreeJoin,
-                       ttkUtils::GetPointer<ttk::SimplexId>(segmentationId),
-                       ttkUtils::GetPointer<char>(regionType),
-                       ttkUtils::GetPointer<ttk::SimplexId>(ascendingManifold),
-                       ttkUtils::GetPointer<ttk::SimplexId>(descendingManifold),
-                       orderArrayData, (T0 *)triangulation->getData())));
+      ttkTypeMacroT(
+        triangulation->getType(),
+        (status = exTreeMTree.computePairs<T0>(
+           persistencePairsJoin, cpMap, mergeTreeJoin,
+           ttkUtils::GetPointer<ttk::SimplexId>(segmentationId),
+           ttkUtils::GetPointer<char>(regionType),
+           ttkUtils::GetPointer<ttk::SimplexId>(ascendingManifold),
+           ttkUtils::GetPointer<ttk::SimplexId>(descendingManifold),
+           orderArrayData, (T0 *)triangulation->getData(), params_.treeType)));
       // swap the data back (even if the execution failed)
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel for num_threads(this->threadNumber_)
@@ -306,18 +306,18 @@ int ttkMergeTree::RequestData(vtkInformation *ttkNotUsed(request),
 
       int status = 0;
 
-      ttkTypeMacroT(triangulation->getType(),
-                    (status = exTreeMTree.computePairs<T0>(
-                       persistencePairsSplit, cpMap, mergeTreeSplit,
-                       ttkUtils::GetPointer<ttk::SimplexId>(segmentationId),
-                       ttkUtils::GetPointer<char>(regionType),
-                       ttkUtils::GetPointer<ttk::SimplexId>(descendingManifold),
-                       ttkUtils::GetPointer<ttk::SimplexId>(ascendingManifold),
-                       orderArrayData, (T0 *)triangulation->getData())));
+      ttkTypeMacroT(
+        triangulation->getType(),
+        (status = exTreeMTree.computePairs<T0>(
+           persistencePairsSplit, cpMap, mergeTreeSplit,
+           ttkUtils::GetPointer<ttk::SimplexId>(segmentationId),
+           ttkUtils::GetPointer<char>(regionType),
+           ttkUtils::GetPointer<ttk::SimplexId>(descendingManifold),
+           ttkUtils::GetPointer<ttk::SimplexId>(ascendingManifold),
+           orderArrayData, (T0 *)triangulation->getData(), params_.treeType)));
 
       if(status != 1)
         return 0;
-
       auto outputPoints = vtkUnstructuredGrid::GetData(outputVector, 0);
       auto outputMergeTreeSplit = vtkUnstructuredGrid::GetData(outputVector, 1);
 


### PR DESCRIPTION
This PR fixes an oversight in the criticalType computation for splitTrees. Changes between join- and splitTrees were done by inverting the order of the data, the rest of the computation was treeType agnostic, which led to the wrong criticalType (the right one for the inverted data). This fixes it based on the treeType supplied in parameters.