### PR TITLE
From c++14 to c++17 standard

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -1,6 +1,6 @@
 # --- Prerequisites
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # --- Global Options
 


### PR DESCRIPTION
This changes is prompted by the use of if constexpr expressions in the near future, unsuported with std=c++14.