### PR TITLE
[DimensionReduction] Fixing wrong default value for se

### DIFF
--- a/core/base/dimensionReduction/DimensionReduction.h
+++ b/core/base/dimensionReduction/DimensionReduction.h
@@ -215,7 +215,7 @@ namespace ttk {
     // se
     std::string se_Affinity{"nearest_neighbors"};
     float se_Gamma{1};
-    std::string se_EigenSolver{"auto"};
+    std::string se_EigenSolver{"None"};
 
     // lle
     float lle_Regularization{1e-3};


### PR DESCRIPTION
Unlike the other sklearn modules, Spectral Embedding does not accept "auto" as a value for the eigen solver, but None instead.
