### PR TITLE
[OpenMP] Parallelize memory allocation in DiscreteMorseSandwich

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -26,8 +26,8 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
   // clear & init gradient memory
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel master num_threads(threadNumber_)
-  {
 #endif
+  {
     for(int i = 0; i < dimensionality_; ++i) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task
@@ -44,9 +44,7 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
         (*gradient_)[2 * i + 1].resize(numberOfCells[i + 1], -1);
       }
     }
-#ifdef TTK_ENABLE_OPENMP
   }
-#endif
 
   std::vector<std::vector<std::string>> rows{
     {"#Vertices", std::to_string(numberOfCells[0])},

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -24,12 +24,31 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
   }
 
   // clear & init gradient memory
-  for(int i = 0; i < dimensionality_; ++i) {
-    (*gradient_)[2 * i].clear();
-    (*gradient_)[2 * i].resize(numberOfCells[i], -1);
-    (*gradient_)[2 * i + 1].clear();
-    (*gradient_)[2 * i + 1].resize(numberOfCells[i + 1], -1);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel master num_threads(threadNumber_)
+  {
+#endif
+    for(int i = 0; i < dimensionality_; ++i) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+      {
+#endif
+        (*gradient_)[2 * i].clear();
+        (*gradient_)[2 * i].resize(numberOfCells[i], -1);
+#ifdef TTK_ENABLE_OPENMP
+      }
+#pragma omp task
+      {
+#endif
+        (*gradient_)[2 * i + 1].clear();
+        (*gradient_)[2 * i + 1].resize(numberOfCells[i + 1], -1);
+#ifdef TTK_ENABLE_OPENMP
+      }
+#endif
+    }
+#ifdef TTK_ENABLE_OPENMP
   }
+#endif
 
   std::vector<std::vector<std::string>> rows{
     {"#Vertices", std::to_string(numberOfCells[0])},

--- a/core/base/discreteGradient/DiscreteGradient.cpp
+++ b/core/base/discreteGradient/DiscreteGradient.cpp
@@ -31,20 +31,18 @@ void DiscreteGradient::initMemory(const AbstractTriangulation &triangulation) {
     for(int i = 0; i < dimensionality_; ++i) {
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp task
-      {
 #endif
+      {
         (*gradient_)[2 * i].clear();
         (*gradient_)[2 * i].resize(numberOfCells[i], -1);
-#ifdef TTK_ENABLE_OPENMP
       }
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp task
-      {
 #endif
+      {
         (*gradient_)[2 * i + 1].clear();
         (*gradient_)[2 * i + 1].resize(numberOfCells[i + 1], -1);
-#ifdef TTK_ENABLE_OPENMP
       }
-#endif
     }
 #ifdef TTK_ENABLE_OPENMP
   }

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -433,25 +433,58 @@ namespace ttk {
       if(dim > 3 || dim < 1) {
         return;
       }
-      this->firstRepMin_.resize(triangulation.getNumberOfVertices());
-      if(dim > 1) {
-        this->firstRepMax_.resize(triangulation.getNumberOfCells());
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp parallel master num_threads(threadNumber_)
+      {
+#pragma omp task
+#endif // TTK_ENABLE_OPENMP
+        this->firstRepMin_.resize(triangulation.getNumberOfVertices());
+        if(dim > 1) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->firstRepMax_.resize(triangulation.getNumberOfCells());
+        }
+        if(dim > 2) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->critEdges_.resize(triangulation.getNumberOfEdges());
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->edgeTrianglePartner_.resize(
+            triangulation.getNumberOfEdges(), -1);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->onBoundary_.resize(triangulation.getNumberOfEdges(), false);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->s2Mapping_.resize(triangulation.getNumberOfTriangles(), -1);
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->s1Mapping_.resize(triangulation.getNumberOfEdges(), -1);
+        }
+        for(int i = 0; i < dim + 1; ++i) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->pairedCritCells_[i].resize(
+            this->dg_.getNumberOfCells(i, triangulation), false);
+        }
+        for(int i = 1; i < dim + 1; ++i) {
+#ifdef TTK_ENABLE_OPENMP
+#pragma omp task
+#endif
+          this->critCellsOrder_[i].resize(
+            this->dg_.getNumberOfCells(i, triangulation), -1);
+        }
+#ifdef TTK_ENABLE_OPENMP
       }
-      if(dim > 2) {
-        this->critEdges_.resize(triangulation.getNumberOfEdges());
-        this->edgeTrianglePartner_.resize(triangulation.getNumberOfEdges(), -1);
-        this->onBoundary_.resize(triangulation.getNumberOfEdges(), false);
-        this->s2Mapping_.resize(triangulation.getNumberOfTriangles(), -1);
-        this->s1Mapping_.resize(triangulation.getNumberOfEdges(), -1);
-      }
-      for(int i = 0; i < dim + 1; ++i) {
-        this->pairedCritCells_[i].resize(
-          this->dg_.getNumberOfCells(i, triangulation), false);
-      }
-      for(int i = 1; i < dim + 1; ++i) {
-        this->critCellsOrder_[i].resize(
-          this->dg_.getNumberOfCells(i, triangulation), -1);
-      }
+#endif
       this->printMsg("Memory allocations", 1.0, tm.getElapsedTime(), 1,
                      debug::LineMode::NEW, debug::Priority::DETAIL);
     }

--- a/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
+++ b/core/base/discreteMorseSandwich/DiscreteMorseSandwich.h
@@ -435,7 +435,9 @@ namespace ttk {
       }
 #ifdef TTK_ENABLE_OPENMP
 #pragma omp parallel master num_threads(threadNumber_)
+#endif
       {
+#ifdef TTK_ENABLE_OPENMP
 #pragma omp task
 #endif // TTK_ENABLE_OPENMP
         this->firstRepMin_.resize(triangulation.getNumberOfVertices());
@@ -482,9 +484,7 @@ namespace ttk {
           this->critCellsOrder_[i].resize(
             this->dg_.getNumberOfCells(i, triangulation), -1);
         }
-#ifdef TTK_ENABLE_OPENMP
       }
-#endif
       this->printMsg("Memory allocations", 1.0, tm.getElapsedTime(), 1,
                      debug::LineMode::NEW, debug::Priority::DETAIL);
     }


### PR DESCRIPTION
Hi all,

In this PR, the allocation of memory in DiscreteMorseSandwich has been parallelized using OpenMP tasks.

This results in a speed-up of x3.65 on 24 cores (the computation step goes from 2.45s to 0.67s on average).
The results were verified using Pierre Guillou's pdiags_bench benchmark.

The same type of parallelization was performed on the Discrete Gradient's memory allocation step.

Thanks for any feedback.

