### PR TITLE
Missing includes for PV master

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -11,7 +11,7 @@
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkUnstructuredGrid.h>
-#include <vtkVersion.h>
+#include <vtkVersionMacros.h>
 
 static vtkCellArray *GetCells(vtkDataSet *dataSet) {
   switch(dataSet->GetDataObjectType()) {

--- a/core/vtk/ttkContourTree/ttkContourTree.cpp
+++ b/core/vtk/ttkContourTree/ttkContourTree.cpp
@@ -9,6 +9,7 @@
 #include <vtkInformationVector.h>
 #include <vtkPolyData.h>
 #include <vtkThreshold.h>
+#include <vtkVersionMacros.h>
 
 vtkStandardNewMacro(ttkContourTree);
 

--- a/core/vtk/ttkExtract/ttkExtract.cpp
+++ b/core/vtk/ttkExtract/ttkExtract.cpp
@@ -18,6 +18,7 @@
 #include <vtkPointData.h>
 #include <vtkSignedCharArray.h>
 #include <vtkThreshold.h>
+#include <vtkVersionMacros.h>
 
 #include <ttkUtils.h>
 

--- a/core/vtk/ttkMergeTree/ttkMergeTree.cpp
+++ b/core/vtk/ttkMergeTree/ttkMergeTree.cpp
@@ -12,6 +12,7 @@
 #include <vtkSignedCharArray.h>
 #include <vtkThreshold.h>
 #include <vtkUnsignedCharArray.h>
+#include <vtkVersionMacros.h>
 
 vtkStandardNewMacro(ttkMergeTree);
 

--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -11,7 +11,7 @@
 #include <vtkTransformFilter.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
-#include <vtkVersion.h> // for VTK_VERSION_CHECK via ParaView 5.8.1
+#include <vtkVersionMacros.h> // for VTK_VERSION_CHECK
 
 int VTUToDiagram(ttk::DiagramType &diagram,
                  vtkUnstructuredGrid *vtu,


### PR DESCRIPTION
Dear Julien,

On PV Master, the `VTK_VERSION_NUMBER` now needs an explicit include of `vtkVersionMacro.h`. This MR allows TTK to compile on PV master once again :)

Best,  
Charles