### PR TITLE
disabling cinemaquery tests under windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,7 +467,7 @@ jobs:
     - name: Create & configure TTK build directory
       shell: cmd
       run: |
-        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake
+        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake;%CONDA_ROOT%\Library\share\zlib\cmake;%CONDA_ROOT%\Library\share\sqlite\cmake
         set CC=clang-cl.exe
         set CXX=clang-cl.exe
         call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -586,11 +586,11 @@ jobs:
         # under Windows. it is installed indeed, but cmake can't seem to find 
         # it anymore.
         # let's remove the related state files
-        rm python\cinemaIO.py
-        rm python\clusteringKelvinHelmholtzInstabilities.py
-        rm python\contourTreeAlignment.py
-        rm python\mergeTreeFeatureTracking.py
-        rm python\nestedTrackingFromOverlap.py
+        del python\cinemaIO.py
+        del python\clusteringKelvinHelmholtzInstabilities.py
+        del python\contourTreeAlignment.py
+        del python\mergeTreeFeatureTracking.py
+        del python\nestedTrackingFromOverlap.py
         pvpython.exe -u python\run.py
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -582,6 +582,15 @@ jobs:
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib;%CONDA_ROOT%\DLLs
         set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
         cd ttk-data
+        # as of February 2024, the sqlite installation by conda seems broken
+        # under Windows. it is installed indeed, but cmake can't seem to find 
+        # it anymore.
+        # let's remove the related state files
+        rm python\cinemaIO.py
+        rm python\clusteringKelvinHelmholtzInstabilities.py
+        rm python\contourTreeAlignment.py
+        rm python\mergeTreeFeatureTracking.py
+        rm python\nestedTrackingFromOverlap.py
         pvpython.exe -u python\run.py
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,7 +428,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge boost glew eigen spectralib zfp sqlite \
+        conda install -c conda-forge boost glew eigen spectralib zfp libsqlite \
           scikit-learn openmp graphviz ninja websocketpp sccache=0.4.2 python=3.10 zlib qhull
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -582,10 +582,6 @@ jobs:
         set PYTHONPATH=%PV_DIR%\bin\Lib\site-packages;%TTK_DIR%\bin\Lib\site-packages;%CONDA_ROOT%\Lib;%CONDA_ROOT%\DLLs
         set PV_PLUGIN_PATH=%TTK_DIR%\bin\plugins
         cd ttk-data
-        # as of February 2024, the sqlite installation by conda seems broken
-        # under Windows. it is installed indeed, but cmake can't seem to find 
-        # it anymore.
-        # let's remove the related state files
         del python\cinemaIO.py
         del python\clusteringKelvinHelmholtzInstabilities.py
         del python\contourTreeAlignment.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,7 +467,7 @@ jobs:
     - name: Create & configure TTK build directory
       shell: cmd
       run: |
-        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake;%CONDA_ROOT%\Library\bin;%CONDA_ROOT%\Library\lib
+        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake
         set CC=clang-cl.exe
         set CXX=clang-cl.exe
         call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,7 +428,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge boost glew eigen spectralib zfp \
+        conda install -c conda-forge boost glew eigen spectralib zfp sqlite \
           scikit-learn openmp graphviz ninja websocketpp sccache=0.4.2 python=3.10 zlib qhull
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -588,6 +588,7 @@ jobs:
         del python\contourTreeAlignment.py
         del python\mergeTreeFeatureTracking.py
         del python\nestedTrackingFromOverlap.py
+        del python\persistenceDrivenCompression.py
         pvpython.exe -u python\run.py
 
     - name: Test ttk-data Python scripts results [NOT ENFORCED]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -435,6 +435,7 @@ jobs:
         # add TTK & ParaView install folders to PATH
         echo "$PV_DIR/bin" >> $GITHUB_PATH
         echo "$TTK_DIR/bin" >> $GITHUB_PATH
+        conda info --all
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,7 +428,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge boost glew eigen spectralib zfp libsqlite \
+        conda install -c conda-forge boost glew eigen spectralib zfp libsqlite sqlite \
           scikit-learn openmp graphviz ninja websocketpp sccache=0.4.2 python=3.10 zlib qhull
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,7 +467,7 @@ jobs:
     - name: Create & configure TTK build directory
       shell: cmd
       run: |
-        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake;%CONDA_ROOT%\Library\share\zlib\cmake;%CONDA_ROOT%\Library\share\sqlite\cmake
+        set CMAKE_PREFIX_PATH=%CONDA_ROOT%\Library\lib\cmake;%CONDA_ROOT%\Library\share\eigen3\cmake;%CONDA_ROOT%\Library\share\Qull\cmake;%CONDA_ROOT%\Library\cmake;%ProgramFiles%\TTK-ParaView\lib\cmake;%CONDA_ROOT%\Library\bin;%CONDA_ROOT%\Library\lib
         set CC=clang-cl.exe
         set CXX=clang-cl.exe
         call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
as of February 2024, the sqlite installation by conda seems broken under Windows. 
it is installed indeed, but cmake can't seem to find it anymore.

the corresponding tests are disabled for the time being.