### PR TITLE
[PersistenceDiagram] fix vtuToDiagram for 64 bit ids

### DIFF
--- a/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
+++ b/core/vtk/ttkPersistenceDiagram/ttkPersistenceDiagramUtils.cpp
@@ -35,7 +35,7 @@ int VTUToDiagram(ttk::DiagramType &diagram,
   }
 
   // cell data
-  const auto pairId = vtkIntArray::SafeDownCast(
+  const auto pairId = ttkSimplexIdTypeArray::SafeDownCast(
     cd->GetArray(ttk::PersistencePairIdentifierName));
   const auto pairType
     = vtkIntArray::SafeDownCast(cd->GetArray(ttk::PersistencePairTypeName));
@@ -44,8 +44,8 @@ int VTUToDiagram(ttk::DiagramType &diagram,
   const auto isFinite = cd->GetArray(ttk::PersistenceIsFinite);
 
   // point data
-  const auto vertexId
-    = vtkIntArray::SafeDownCast(pd->GetArray(ttk::VertexScalarFieldName));
+  const auto vertexId = ttkSimplexIdTypeArray::SafeDownCast(
+    pd->GetArray(ttk::VertexScalarFieldName));
   const auto critType
     = vtkIntArray::SafeDownCast(pd->GetArray(ttk::PersistenceCriticalTypeName));
   const auto coords = vtkFloatArray::SafeDownCast(


### PR DESCRIPTION
This PR fixes the `vtuToDiagram` function when TTK is compiled with 64 bit ids.

In the `diagramToVTU` function, the arrays `ttk::PersistencePairIdentifierName` and `ttk::VertexScalarFieldName` are of types `ttkSimplexIdTypeArray` (that is either `vtkIntArray` or `vtkIdTypeArray` if 64 bit ids is respectively disabled or not).
However, currently, the corresponding arrays in the `vtuToDiagram` function are only read with a `SafeDownCast` to `vtkIntArray` returning therefore a `nullptr` when TTK is compiled with 64 bit ids.

It can leads to problems in other methods using persistence diagrams, for instance executing `states/persistenceDiagramClustering.pvsm` does not work with 64 bit ids and the current TTK (except if I have missed something).