### PR TITLE
[MorseSmaleComplex] Return saddle connectors and detecting cycles 

### DIFF
--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -255,8 +255,8 @@ in the gradient.
                                        std::vector<Cell> *const vpath,
                                        const triangulationType &triangulation,
                                        const bool stopIfMultiConnected = false,
-                                       const bool enableCycleDetector
-                                       = false) const;
+                                       const bool enableCycleDetector = false,
+                                       bool *const cycleFound = nullptr) const;
 
       /**
        * Detect the presence of a cycle on a edge-triangle path starting from an

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -259,6 +259,14 @@ in the gradient.
                                        = false) const;
 
       /**
+       * Detect the presence of a cycle on a edge-triangle path starting from an
+       * edge.
+       */
+      template <typename triangulationType>
+      bool detectGradientCycle(const Cell &cell,
+                               const triangulationType &triangulation) const;
+
+      /**
        * Return the 2-separatrice terminating at the given 2-saddle.
        */
       template <typename triangulationType>

--- a/core/base/discreteGradient/DiscreteGradient.h
+++ b/core/base/discreteGradient/DiscreteGradient.h
@@ -485,9 +485,9 @@ gradient, false otherwise.
        * Reverse the given ascending VPath restricted on a 2-separatrice.
        */
       template <typename triangulationType>
-      int reverseAscendingPathOnWall(
-        const std::vector<Cell> &vpath,
-        const triangulationType &triangulation) const;
+      int reverseAscendingPathOnWall(const std::vector<Cell> &vpath,
+                                     const triangulationType &triangulation,
+                                     bool cancelReversal = false) const;
 
       /**
        * Reverse the given descending VPath restricted on a 2-separatrice.

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1360,8 +1360,13 @@ int DiscreteGradient::reverseAscendingPathOnWall(
   if(dimensionality_ == 3) {
     // assume that the first cell is an edge
     if(cancelReversal) {
-      (*gradient_)[2][vpath[0].id_] = -1;
-      (*gradient_)[3][vpath[vpath.size() - 1].id_] = -1;
+      if(vpath.empty())
+        return 0;
+      (*gradient_)[2][vpath[0].id_] = NULL_GRADIENT;
+      // assume that the last cell is a triangle
+      if(vpath.size() <= 1)
+        return 0;
+      (*gradient_)[3][vpath[vpath.size() - 1].id_] = NULL_GRADIENT;
     }
     const SimplexId numberOfCellsInPath = vpath.size();
     const SimplexId startIndex = (cancelReversal ? 2 : 0);

--- a/core/base/discreteGradient/DiscreteGradient_Template.h
+++ b/core/base/discreteGradient/DiscreteGradient_Template.h
@@ -1354,14 +1354,22 @@ int DiscreteGradient::reverseDescendingPath(
 template <typename triangulationType>
 int DiscreteGradient::reverseAscendingPathOnWall(
   const std::vector<Cell> &vpath,
-  const triangulationType &triangulation) const {
+  const triangulationType &triangulation,
+  bool cancelReversal) const {
 
   if(dimensionality_ == 3) {
     // assume that the first cell is an edge
+    if(cancelReversal) {
+      (*gradient_)[2][vpath[0].id_] = -1;
+      (*gradient_)[3][vpath[vpath.size() - 1].id_] = -1;
+    }
     const SimplexId numberOfCellsInPath = vpath.size();
-    for(SimplexId i = 0; i < numberOfCellsInPath; i += 2) {
-      const SimplexId edgeId = vpath[i].id_;
-      const SimplexId triangleId = vpath[i + 1].id_;
+    const SimplexId startIndex = (cancelReversal ? 2 : 0);
+    for(SimplexId i = startIndex; i < numberOfCellsInPath; i += 2) {
+      const SimplexId vpathEdgeIndex = i;
+      const SimplexId vpathTriangleIndex = (cancelReversal ? i - 1 : i + 1);
+      const SimplexId edgeId = vpath[vpathEdgeIndex].id_;
+      const SimplexId triangleId = vpath[vpathTriangleIndex].id_;
 
 #ifdef TTK_ENABLE_DCG_OPTIMIZE_MEMORY
       for(int k = 0; k < 3; ++k) {

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1761,11 +1761,13 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
     const auto &pair{dms_pairs[i]};
     pairs.emplace_back(std::make_tuple(i, getPersistence(pair)));
   }
-  const auto comparePersistence = [](std::tuple<size_t, dataType> &pair1,
-                                     std::tuple<size_t, dataType> &pair2) {
-    return std::get<1>(pair1) < std::get<1>(pair2);
-  };
-  std::sort(pairs.begin(), pairs.end(), comparePersistence);
+  const auto comparePersistence
+    = [](const std::tuple<size_t, dataType> &pair1,
+         const std::tuple<size_t, dataType> &pair2) {
+        return std::get<1>(pair1) < std::get<1>(pair2);
+      };
+  TTK_PSORT(
+    this->threadNumber_, pairs.begin(), pairs.end(), comparePersistence);
 
   // Process pairs
   for(const auto &pairTup : pairs) {

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -413,6 +413,7 @@ namespace ttk {
     bool ReturnSaddleConnectors{false};
     double SaddleConnectorsPersistenceThreshold{};
     bool ThresholdIsAbsolute{false};
+    bool ForceLoopFreeGradient{false};
   };
 } // namespace ttk
 
@@ -1818,46 +1819,21 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
     if(vpath.back() == death) {
       this->discreteGradient_.reverseAscendingPathOnWall(vpath, triangulation);
 
+      // 3.1 Detect cycle
       bool cycle = false;
-      // cycle = this->discreteGradient_.detectGradientCycle(birth,
-      // triangulation);
-
-      std::vector<SimplexId> saddles2{};
-      /*std::vector<bool> isVisitedT2(
-        triangulation.getNumberOfTriangles(), false);
-      std::vector<SimplexId> visitedTrianglesT2{};
-      VisitedMask maskT2{isVisitedT2, visitedTrianglesT2};
-      this->discreteGradient_.getAscendingWall(
-        birth, maskT2, triangulation, nullptr, &saddles2);*/
-      saddles2.emplace_back(death.id_);
-
-      // #ifdef TTK_ENABLE_OPENMP
-      // #pragma omp parallel for num_threads(threadNumber_) schedule(dynamic)
-      //   firstprivate(isVisitedT, visitedTrianglesT, saddles1)
-      // #endif
-      for(const auto &saddle2Id : saddles2) {
-        const Cell s2{2, saddle2Id};
-        //         for(const auto &pairTupT : pairs) {
-        //           const auto &pairT = std::get<0>(pairTupT);
-        //           const Cell s2{2, pairT.death};
-
+      if(ForceLoopFreeGradient)
+        cycle
+          = this->discreteGradient_.detectGradientCycle(birth, triangulation);
+      else {
         std::vector<bool> isVisitedT(
           triangulation.getNumberOfTriangles(), false);
         std::vector<SimplexId> visitedTrianglesT{};
-        std::vector<SimplexId> saddles1{};
-
         VisitedMask maskT{isVisitedT, visitedTrianglesT};
-        discreteGradient_.getDescendingWall(
-          s2, maskT, triangulation, nullptr, &saddles1);
-
-        for(const auto saddle1Id : saddles1) {
-          const Cell s1{1, saddle1Id};
-          std::vector<Cell> vpathT;
-          discreteGradient_.getAscendingPathThroughWall(
-            s1, s2, isVisitedT, &vpathT, triangulation, false, true, &cycle);
-        }
+        discreteGradient_.getDescendingWall(death, maskT, triangulation);
+        discreteGradient_.getAscendingPathThroughWall(birth, death, isVisitedT,
+                                                      nullptr, triangulation,
+                                                      false, true, &cycle);
       }
-
       if(cycle) {
         this->printMsg("Could not return saddle connector " + birth.to_string()
                          + " -> " + death.to_string()
@@ -1867,6 +1843,7 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
           vpath, triangulation, true);
       } else
         nReturned++;
+
     } else {
       this->printMsg("Could not return saddle connector " + birth.to_string()
                        + " -> " + death.to_string(),

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -413,7 +413,7 @@ namespace ttk {
     bool ReturnSaddleConnectors{false};
     double SaddleConnectorsPersistenceThreshold{};
     bool ThresholdIsAbsolute{false};
-    bool ForceLoopFreeGradient{false};
+    bool ForceLoopFreeGradient{true};
   };
 } // namespace ttk
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1764,10 +1764,6 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
 
   size_t nReturned{};
 
-  // offset from firstSadSadPair should index s2Children and simplifyS2
-  const auto &s2Children{dms.get2SaddlesChildren()};
-  std::vector<bool> simplifyS2(s2Children.size(), true);
-
   // Sort pairs to process by persistence
   std::vector<std::tuple<PersPairType, size_t, dataType>> pairs;
   for(size_t i = firstSadSadPair; i < dms_pairs.size(); ++i) {
@@ -1791,23 +1787,9 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
       continue;
     }
 
-    const auto o{pairIndex - firstSadSadPair};
     const Cell birth{1, pair.birth};
     const Cell death{2, pair.death};
-    bool skip{false};
-    for(const auto child : s2Children[o]) {
-      if(!simplifyS2[child]) {
-        skip = true;
-        break;
-      }
-    }
-    if(skip) {
-      this->printMsg("Skipping saddle connector " + birth.to_string() + " -> "
-                       + death.to_string(),
-                     debug::Priority::VERBOSE);
-      simplifyS2[o] = false;
-      continue;
-    }
+
     // 1. get the 2-saddle wall
     VisitedMask mask{isVisited, visitedTriangles};
     this->discreteGradient_.getDescendingWall(death, mask, triangulation);
@@ -1849,7 +1831,6 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
       this->printMsg("Could not return saddle connector " + birth.to_string()
                        + " -> " + death.to_string(),
                      debug::Priority::VERBOSE);
-      simplifyS2[o] = false;
     }
   }
 

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1813,8 +1813,9 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
     this->discreteGradient_.getDescendingWall(death, mask, triangulation);
     // 2. get the saddle connector
     std::vector<Cell> vpath{};
+    bool noForkReversal = not ForceLoopFreeGradient;
     this->discreteGradient_.getAscendingPathThroughWall(
-      birth, death, isVisited, &vpath, triangulation, true);
+      birth, death, isVisited, &vpath, triangulation, noForkReversal);
     // 3. reverse the gradient on the saddle connector path
     if(vpath.back() == death) {
       this->discreteGradient_.reverseAscendingPathOnWall(vpath, triangulation);

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -1758,14 +1758,30 @@ int ttk::MorseSmaleComplex::returnSaddleConnectors(
   const auto &s2Children{dms.get2SaddlesChildren()};
   std::vector<bool> simplifyS2(s2Children.size(), true);
 
+  // Sort pairs to process by persistence
+  std::vector<std::tuple<PersPairType, size_t, dataType>> pairs;
   for(size_t i = firstSadSadPair; i < dms_pairs.size(); ++i) {
     const auto &pair{dms_pairs[i]};
+    pairs.emplace_back(std::make_tuple(pair, i, getPersistence(pair)));
+  }
+  const auto comparePersistence
+    = [](std::tuple<PersPairType, size_t, dataType> &pair1,
+         std::tuple<PersPairType, size_t, dataType> &pair2) {
+        return std::get<2>(pair1) < std::get<2>(pair2);
+      };
+  std::sort(pairs.begin(), pairs.end(), comparePersistence);
 
-    if(pair.type != 1 || getPersistence(pair) > persistenceThreshold) {
+  // Process pairs
+  for(const auto &pairTup : pairs) {
+    const auto &pair = std::get<0>(pairTup);
+    const auto &pairIndex = std::get<1>(pairTup);
+    const auto &pairPersistence = std::get<2>(pairTup);
+
+    if(pair.type != 1 || pairPersistence > persistenceThreshold) {
       continue;
     }
 
-    const auto o{i - firstSadSadPair};
+    const auto o{pairIndex - firstSadSadPair};
     const Cell birth{1, pair.birth};
     const Cell death{2, pair.death};
     bool skip{false};

--- a/core/base/morseSmaleComplex/MorseSmaleComplex.h
+++ b/core/base/morseSmaleComplex/MorseSmaleComplex.h
@@ -471,12 +471,6 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
                      debug::Priority::DETAIL);
     }
 
-    std::array<std::vector<SimplexId>, 4> criticalPoints{};
-    discreteGradient_.getCriticalPoints(criticalPoints, triangulation);
-    std::cout << "==============================" << std::endl;
-    for(auto &critPoints : criticalPoints)
-      std::cout << critPoints.size() << std::endl;
-
     this->returnSaddleConnectors(
       persistenceThreshold, scalars, offsets, triangulation);
   }
@@ -488,9 +482,6 @@ int ttk::MorseSmaleComplex::execute(OutputCriticalPoints &outCP,
     this->printMsg("  Critical points extracted", 1.0, tm.getElapsedTime(),
                    this->threadNumber_, debug::LineMode::NEW,
                    debug::Priority::DETAIL);
-    std::cout << "==============================" << std::endl;
-    for(auto &critPoints : criticalPoints)
-      std::cout << critPoints.size() << std::endl;
   }
 
   std::vector<std::vector<Separatrix>> separatrices1{};

--- a/core/vtk/ttkMorseSmaleComplex/CMakeLists.txt
+++ b/core/vtk/ttkMorseSmaleComplex/CMakeLists.txt
@@ -1,3 +1,1 @@
 ttk_add_vtk_module()
-#target_compile_options(ttkMorseSmaleComplex PRIVATE -ggdb -O0 -fsanitize=address)
-#target_link_options(ttkMorseSmaleComplex PRIVATE -fsanitize=address)

--- a/core/vtk/ttkMorseSmaleComplex/CMakeLists.txt
+++ b/core/vtk/ttkMorseSmaleComplex/CMakeLists.txt
@@ -1,1 +1,3 @@
 ttk_add_vtk_module()
+#target_compile_options(ttkMorseSmaleComplex PRIVATE -ggdb -O0 -fsanitize=address)
+#target_link_options(ttkMorseSmaleComplex PRIVATE -fsanitize=address)

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -165,7 +165,7 @@ public:
 
   vtkSetMacro(ThresholdIsAbsolute, bool);
   vtkGetMacro(ThresholdIsAbsolute, bool);
-  
+
   vtkSetMacro(ForceLoopFreeGradient, bool);
   vtkGetMacro(ForceLoopFreeGradient, bool);
 

--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -165,6 +165,9 @@ public:
 
   vtkSetMacro(ThresholdIsAbsolute, bool);
   vtkGetMacro(ThresholdIsAbsolute, bool);
+  
+  vtkSetMacro(ForceLoopFreeGradient, bool);
+  vtkGetMacro(ForceLoopFreeGradient, bool);
 
 protected:
   template <typename scalarType, typename triangulationType>

--- a/paraview/xmls/MorseSmaleComplex.xml
+++ b/paraview/xmls/MorseSmaleComplex.xml
@@ -297,6 +297,25 @@
         </Documentation>
       </IntVectorProperty>
 
+       <IntVectorProperty name="ForceLoopFreeGradient"
+         label="Force loop-free gradient"
+         command="SetForceLoopFreeGradient"
+         number_of_elements="1"
+         default_values="0"
+         panel_visibility="advanced">
+         <BooleanDomain name="bool"/>
+         <Hints>
+          <PropertyWidgetDecorator type="GenericDecorator"
+            mode="visibility"
+            property="ReturnSaddleConnectors"
+            value="1" />
+        </Hints>
+         <Documentation>
+           If set to true, the saddle connectors that will create a loop in the whole gradient after returning them will not be processed.
+           Otherwise, only the saddle connectors that will create a loop in their wall will not be processed.
+         </Documentation>
+       </IntVectorProperty>
+      
       ${DEBUG_WIDGETS}
 
       <PropertyGroup panel_widget="Line" label="Input options">
@@ -318,6 +337,7 @@
         <Property name="ReturnSaddleConnectors"/>
         <Property name="SaddleConnectorsPersistenceThreshold"/>
         <Property name="ThresholdIsAbsolute" />
+        <Property name="ForceLoopFreeGradient"/>
       </PropertyGroup>
 
       <OutputPort name="Critical Points" index="0" id="port0"/>

--- a/paraview/xmls/MorseSmaleComplex.xml
+++ b/paraview/xmls/MorseSmaleComplex.xml
@@ -282,7 +282,8 @@
        <IntVectorProperty name="ThresholdIsAbsolute"
                           command="SetThresholdIsAbsolute"
                           number_of_elements="1"
-                          default_values="0">
+                          default_values="0"
+                          panel_visibility="advanced">
         <BooleanDomain name="bool" />
          <Hints>
           <PropertyWidgetDecorator type="GenericDecorator"
@@ -301,7 +302,7 @@
          label="Force loop-free gradient"
          command="SetForceLoopFreeGradient"
          number_of_elements="1"
-         default_values="0"
+         default_values="1"
          panel_visibility="advanced">
          <BooleanDomain name="bool"/>
          <Hints>
@@ -311,8 +312,8 @@
             value="1" />
         </Hints>
          <Documentation>
-           If set to true, the saddle connectors that will create a loop in the whole gradient after returning them will not be processed.
-           Otherwise, only the saddle connectors that will create a loop in their wall will not be processed.
+           If set to true, the saddle connectors that would create a loop in the whole gradient after returning them will not be processed.
+           Otherwise, only the saddle connectors that will create a loop in the wall of the corresponding 2-saddle will not be processed.
          </Documentation>
        </IntVectorProperty>
       


### PR DESCRIPTION
This PR adds methods to detect a cycle in the gradient after reversing the path between a 1-saddle and a 2-saddle paired together.
If the reversal of such a path creates a cycle then the reversal is cancelled.
The cycle is detected either in the whole gradient ("Force loop-free gradient" option in the ParaView GUI) or only in the wall of the 2-saddle.
If the search of cycles is not restricted to the wall of a 2-saddle then the saddle connectors involved in a "gradient fork" are now processed.
The pairs are now processed by order of persistence when reversing saddle connectors, from the lowest to the highest.
A pair is not skipped anymore if one of its children was not reversed.