### PR TITLE
128-bits indices in Ripser

### DIFF
--- a/core/base/ripsPersistenceDiagram/ripserpy.cpp
+++ b/core/base/ripsPersistenceDiagram/ripserpy.cpp
@@ -93,7 +93,13 @@ static const size_t num_coefficient_bits = 8;
 
 // 1L on windows is ALWAYS 32 bits, when on unix systems is pointer size
 static const index_t max_simplex_index
-  = (uintptr_t(1) << (8 * sizeof(index_t) - 1 - num_coefficient_bits)) - 1;
+  = (__int128(1) << (8 * sizeof(index_t) - 1 - num_coefficient_bits)) - 1;
+
+namespace std {
+  inline std::string to_string(__int128) {
+    return "";
+  }
+}
 
 void check_overflow(index_t i) {
   if

--- a/core/base/ripsPersistenceDiagram/ripserpy.cpp
+++ b/core/base/ripsPersistenceDiagram/ripserpy.cpp
@@ -99,7 +99,7 @@ namespace std {
   inline std::string to_string(__int128) {
     return "";
   }
-}
+} // namespace std
 
 void check_overflow(index_t i) {
   if


### PR DESCRIPTION
This PR allows 128-bit indices to be used in Ripser.