### PR TITLE
[PointSetToSurface] fix allocate

### DIFF
--- a/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
+++ b/core/vtk/ttkPointSetToSurface/ttkPointSetToSurface.cpp
@@ -142,6 +142,10 @@ int ttkPointSetToSurface::RequestData(vtkInformation *ttkNotUsed(request),
   // Create new grid
   vtkNew<vtkPolyData> vtkOutput{};
   vtkOutput->DeepCopy(input);
+  auto numberOfCells = (nUniqueXValues - 1) * nUniqueYValues
+                       + nUniqueXValues * (nUniqueYValues - 1)
+                       + (nUniqueXValues - 1) * (nUniqueYValues - 1);
+  vtkOutput->Allocate(numberOfCells);
 
   for(unsigned int i = 0; i < nUniqueXValues; ++i) {
     for(unsigned int j = 0; j < nUniqueYValues; ++j) {


### PR DESCRIPTION
With the migration to ParaView 5.12 the state file `mergeTreePGA.pvsm` results in a segmentation fault.

The problem seems to be related to the `pointSetToSurface` filter due to a missing `Allocate`.
With this PR the state file should work correctly.