### PR TITLE
[PersistenceDiagramClustering] fix incorrect matchings when 2 diagrams

### DIFF
--- a/core/base/persistenceDiagramAuction/CMakeLists.txt
+++ b/core/base/persistenceDiagramAuction/CMakeLists.txt
@@ -7,5 +7,4 @@ ttk_add_base_library(persistenceDiagramAuction
   DEPENDS
     kdTree
     persistenceDiagram
-    triangulation
 )

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.cpp
@@ -278,7 +278,7 @@ int ttk::Bidder::runDiagonalBidding(
   // First, find the lowest and second lowest weights for diagonal goods
   // Take this time to update the weights in the priority queue of the goods
   // tested. It is not necessary to update weights for all diagonal bidders in
-  // the pririty queue since weights can only increase and we are interested
+  // the priority queue since weights can only increase and we are interested
   // only in the lowest ones
   bool updated_top_pair
     = false; // Boolean which equals true iff the top pair in the priority
@@ -396,7 +396,7 @@ int ttk::Bidder::runDiagonalKDTBidding(
   // First, find the lowest and second lowest weights for diagonal goods
   // Take this time to update the weights in the priority queue of the goods
   // tested. It is not necessary to update weights for all diagonal bidders in
-  // the pririty queue since weights can only increase and we are interested
+  // the priority queue since weights can only increase and we are interested
   // only in the lowest ones
   bool updated_top_pair
     = false; // Boolean which equals true iff the top pair in the priority

--- a/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
+++ b/core/base/persistenceDiagramAuction/PersistenceDiagramAuction.h
@@ -173,7 +173,7 @@ namespace ttk {
 
     void setGoods(const DiagramType &diagram2) {
       for(size_t i = 0; i < diagram2.size(); i++) {
-        // Add bidder to bidders
+        // Add good to goods
         Good const g{diagram2[i], static_cast<int>(i), lambda_};
         goods_.emplace_back(g);
       }
@@ -285,7 +285,7 @@ namespace ttk {
     }
 
   protected:
-    int wasserstein_{2}; // Power in Wassertsein distance (by default set to 2)
+    int wasserstein_{2}; // Power in Wasserstein distance (by default set to 2)
     BidderDiagram default_bidders_{};
     BidderDiagram &bidders_{default_bidders_};
     GoodDiagram default_goods_{};
@@ -302,12 +302,12 @@ namespace ttk {
 
     double epsilon_{1};
     double geometricalFactor_{};
-    double lambda_{};
     // lambda : 0<=lambda<=1
     // parametrizes the point used for the physical (critical) coordinates of
     // the persistence paired lambda = 1 : extremum (min if pair min-sad, max if
     // pair sad-max) lambda = 0 : saddle (bad stability) lambda = 1/2 : middle
     // of the 2 critical points of the pair
+    double lambda_{};
     double delta_lim_{};
     double lowerBoundCost_, lowerBoundCostWeight_;
     bool use_kdt_{true};

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -171,20 +171,24 @@ double ttk::PDBarycenter::updateBarycenter(
   points_deleted_ = 0;
   double max_shift = 0;
 
-  std::vector<size_t> count_diag_matchings(n_goods, 0); // Number of diagonal matchings for each point of the barycenter
+  std::vector<size_t> count_diag_matchings(
+    n_goods,
+    0); // Number of diagonal matchings for each point of the barycenter
   std::vector<double> x(n_goods, 0);
   std::vector<double> y(n_goods, 0);
   std::vector<double> crit_coords_x(n_goods, 0);
   std::vector<double> crit_coords_y(n_goods, 0);
   std::vector<double> crit_coords_z(n_goods, 0);
 
-  std::vector<double> min_prices(n_diagrams, std::numeric_limits<double>::max());
+  std::vector<double> min_prices(
+    n_diagrams, std::numeric_limits<double>::max());
 
   std::vector<Bidder *>
     points_to_append; // Will collect bidders linked to diagonal
   std::vector<int> diagonalToNewGood;
-  if (numberOfInputs_ == 2)
-    diagonalToNewGood.resize((*inputDiagrams_)[0].size() + (*inputDiagrams_)[1].size());
+  if(numberOfInputs_ == 2)
+    diagonalToNewGood.resize((*inputDiagrams_)[0].size()
+                             + (*inputDiagrams_)[1].size());
   // 2. Preprocess the matchings
   for(size_t j = 0; j < matchings.size(); j++) {
     for(size_t i = 0; i < matchings[j].size(); i++) {
@@ -194,7 +198,8 @@ double ttk::PDBarycenter::updateBarycenter(
         // Future new barycenter point
         points_to_append.push_back(&current_bidder_diagrams_[j].at(bidder_id));
         if(numberOfInputs_ == 2)
-          diagonalToNewGood[-good_id-1] = n_goods + points_to_append.size()-1;
+          diagonalToNewGood[-good_id - 1]
+            = n_goods + points_to_append.size() - 1;
       }
 
       else if(good_id >= 0 && bidder_id >= 0) {
@@ -335,16 +340,16 @@ double ttk::PDBarycenter::updateBarycenter(
   }
 
   // final update of matchings here if there are only 2 input diagrams
-  if (numberOfInputs_ == 2) {
+  if(numberOfInputs_ == 2) {
     std::vector<double> costs(n_goods + points_to_append.size());
-    for (int i=0; i<2; ++i) {
-      for (auto& [b_id,g_id,c] : matchings[i]) {
-        if (g_id < 0 && diagonalToNewGood[-g_id-1] > 0)
-          g_id = diagonalToNewGood[-g_id-1];
+    for(int i = 0; i < 2; ++i) {
+      for(auto &[b_id, g_id, c] : matchings[i]) {
+        if(g_id < 0 && diagonalToNewGood[-g_id - 1] > 0)
+          g_id = diagonalToNewGood[-g_id - 1];
         costs[g_id] += c;
       }
     }
-    for (int i=0; i<2; ++i) {
+    for(int i = 0; i < 2; ++i) {
       for(auto &[b_id, g_id, c] : matchings[i])
         c = costs[g_id] / Geometry::pow(2, wasserstein_);
     }

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -194,6 +194,9 @@ double ttk::PDBarycenter::updateBarycenter(
 
   std::vector<Bidder *>
     points_to_append; // Will collect bidders linked to diagonal
+  std::vector<int> diagonalToNewGood;
+  if (numberOfInputs_ == 2)
+    diagonalToNewGood.resize((*inputDiagrams_)[0].size() + (*inputDiagrams_)[1].size());
   // 2. Preprocess the matchings
   for(size_t j = 0; j < matchings.size(); j++) {
     for(size_t i = 0; i < matchings[j].size(); i++) {
@@ -202,6 +205,8 @@ double ttk::PDBarycenter::updateBarycenter(
       if(good_id < 0 && bidder_id >= 0) {
         // Future new barycenter point
         points_to_append.push_back(&current_bidder_diagrams_[j].at(bidder_id));
+        if(numberOfInputs_ == 2)
+          diagonalToNewGood[-good_id-1] = n_goods + points_to_append.size()-1;
       }
 
       else if(good_id >= 0 && bidder_id >= 0) {
@@ -339,6 +344,22 @@ double ttk::PDBarycenter::updateBarycenter(
       }
     }
     barycenter_goods_[j] = new_barycenter;
+  }
+
+  // final update of matchings here if there are only 2 input diagrams
+  if (numberOfInputs_ == 2) {
+    std::vector<double> costs(n_goods + points_to_append.size());
+    for (int i=0; i<2; ++i) {
+      for (auto& [b_id,g_id,c] : matchings[i]) {
+        if (g_id < 0 && diagonalToNewGood[-g_id-1] > 0)
+          g_id = diagonalToNewGood[-g_id-1];
+        costs[g_id] += c;
+      }
+    }
+    for (int i=0; i<2; ++i) {
+      for(auto &[b_id, g_id, c] : matchings[i])
+        c = costs[g_id] / Geometry::pow(2, wasserstein_);
+    }
   }
 
   return max_shift;

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -341,7 +341,7 @@ double ttk::PDBarycenter::updateBarycenter(
 
   // final update of matchings here if there are only 2 input diagrams
   if(numberOfInputs_ == 2) {
-    std::vector<double> costs(n_goods + points_to_append.size());
+    std::vector<double> costs(n_goods + points_to_append.size(), 0.);
     for(int i = 0; i < 2; ++i) {
       for(auto &[b_id, g_id, c] : matchings[i]) {
         if(g_id < 0 && diagonalToNewGood[-g_id - 1] > 0)
@@ -350,8 +350,10 @@ double ttk::PDBarycenter::updateBarycenter(
       }
     }
     for(int i = 0; i < 2; ++i) {
-      for(auto &[b_id, g_id, c] : matchings[i])
-        c = costs[g_id] / Geometry::pow(2, wasserstein_);
+      for(auto &[b_id, g_id, c] : matchings[i]) {
+        if (g_id >= 0)
+          c = costs[g_id] / Geometry::pow(2, wasserstein_);
+      }
     }
   }
 

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -351,7 +351,7 @@ double ttk::PDBarycenter::updateBarycenter(
     }
     for(int i = 0; i < 2; ++i) {
       for(auto &[b_id, g_id, c] : matchings[i]) {
-        if (g_id >= 0)
+        if(g_id >= 0)
           c = costs[g_id] / Geometry::pow(2, wasserstein_);
       }
     }

--- a/core/base/persistenceDiagramClustering/PDBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PDBarycenter.cpp
@@ -187,8 +187,8 @@ double ttk::PDBarycenter::updateBarycenter(
     points_to_append; // Will collect bidders linked to diagonal
   std::vector<int> diagonalToNewGood;
   if(numberOfInputs_ == 2)
-    diagonalToNewGood.resize((*inputDiagrams_)[0].size()
-                             + (*inputDiagrams_)[1].size());
+    diagonalToNewGood.resize(current_bidder_diagrams_[0].size()
+                             + current_bidder_diagrams_[1].size());
   // 2. Preprocess the matchings
   for(size_t j = 0; j < matchings.size(); j++) {
     for(size_t i = 0; i < matchings[j].size(); i++) {

--- a/core/base/persistenceDiagramClustering/PDClustering.cpp
+++ b/core/base/persistenceDiagramClustering/PDClustering.cpp
@@ -1248,10 +1248,7 @@ void ttk::PDClustering::invertClusters() {
   /// diagram.
 
   // Initializes clusters with -1
-  inv_clustering_ = std::vector<int>(numberOfInputs_);
-  for(int i = 0; i < numberOfInputs_; ++i) {
-    inv_clustering_[i] = -1;
-  }
+  inv_clustering_ = std::vector<int>(numberOfInputs_, -1);
 
   // Fill in the clusters
   for(int c = 0; c < k_; ++c) {
@@ -1959,10 +1956,7 @@ void ttk::PDClustering::setBidderDiagrams() {
       bidder_diagrams_min_.emplace_back(bidders);
       current_bidder_diagrams_min_.emplace_back();
       centroids_with_price_min_.emplace_back();
-      std::vector<int> ids(bidders.size());
-      for(size_t j = 0; j < ids.size(); j++) {
-        ids[j] = -1;
-      }
+      std::vector<int> ids(bidders.size(), -1);
       current_bidder_ids_min_.emplace_back(ids);
     }
 
@@ -1983,10 +1977,7 @@ void ttk::PDClustering::setBidderDiagrams() {
       bidder_diagrams_saddle_.emplace_back(bidders);
       current_bidder_diagrams_saddle_.emplace_back();
       centroids_with_price_saddle_.emplace_back();
-      std::vector<int> ids(bidders.size());
-      for(size_t j = 0; j < ids.size(); j++) {
-        ids[j] = -1;
-      }
+      std::vector<int> ids(bidders.size(), -1);
       current_bidder_ids_sad_.emplace_back(ids);
     }
 
@@ -2007,10 +1998,7 @@ void ttk::PDClustering::setBidderDiagrams() {
       bidder_diagrams_max_.emplace_back(bidders);
       current_bidder_diagrams_max_.emplace_back();
       centroids_with_price_max_.emplace_back();
-      std::vector<int> ids(bidders.size());
-      for(size_t j = 0; j < ids.size(); j++) {
-        ids[j] = -1;
-      }
+      std::vector<int> ids(bidders.size(), -1);
       current_bidder_ids_max_.emplace_back(ids);
     }
   }
@@ -2199,7 +2187,7 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
 
   // 3. Add the points to the current diagrams
   if(do_min_) {
-    int compteur_for_adding_points = 0;
+    int counter_for_adding_points = 0;
     for(int i = 0; i < numberOfInputs_; i++) {
       int const size = candidates_to_be_added_min[i].size();
       for(int j = 0; j < std::min(max_points_to_add_min, size); j++) {
@@ -2235,7 +2223,7 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             r_[i] = true;
           }
           int const to_be_added_to_barycenter
-            = deterministic_ ? compteur_for_adding_points % numberOfInputs_
+            = deterministic_ ? counter_for_adding_points % numberOfInputs_
                              : rand() % numberOfInputs_;
           if(to_be_added_to_barycenter == 0 && add_points_to_barycenter) {
             for(int k = 0; k < numberOfInputs_; k++) {
@@ -2254,12 +2242,12 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             centroids_min_[inv_clustering_[i]].emplace_back(g);
           }
         }
-        compteur_for_adding_points++;
+        counter_for_adding_points++;
       }
     }
   }
   if(do_sad_) {
-    int compteur_for_adding_points = 0;
+    int counter_for_adding_points = 0;
     for(int i = 0; i < numberOfInputs_; i++) {
       int const size = candidates_to_be_added_sad[i].size();
       for(int j = 0; j < std::min(max_points_to_add_sad, size); j++) {
@@ -2295,7 +2283,7 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             r_[i] = true;
           }
           int const to_be_added_to_barycenter
-            = deterministic_ ? compteur_for_adding_points % numberOfInputs_
+            = deterministic_ ? counter_for_adding_points % numberOfInputs_
                              : rand() % numberOfInputs_;
           if(to_be_added_to_barycenter == 0 && add_points_to_barycenter) {
             for(int k = 0; k < numberOfInputs_; k++) {
@@ -2310,12 +2298,12 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             }
           }
         }
-        compteur_for_adding_points++;
+        counter_for_adding_points++;
       }
     }
   }
   if(do_max_) {
-    int compteur_for_adding_points = 0;
+    int counter_for_adding_points = 0;
     for(int i = 0; i < numberOfInputs_; i++) {
       int const size = candidates_to_be_added_max[i].size();
       for(int j = 0; j < std::min(max_points_to_add_max, size); j++) {
@@ -2351,7 +2339,7 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             r_[i] = true;
           }
           int const to_be_added_to_barycenter
-            = deterministic_ ? compteur_for_adding_points % numberOfInputs_
+            = deterministic_ ? counter_for_adding_points % numberOfInputs_
                              : rand() % numberOfInputs_;
           if(to_be_added_to_barycenter == 0 && add_points_to_barycenter) {
             for(int k = 0; k < numberOfInputs_; k++) {
@@ -2370,7 +2358,7 @@ std::vector<double> ttk::PDClustering::enrichCurrentBidderDiagrams(
             centroids_max_[inv_clustering_[i]].emplace_back(g);
           }
         }
-        compteur_for_adding_points++;
+        counter_for_adding_points++;
       }
     }
   }

--- a/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
+++ b/core/base/persistenceDiagramClustering/PersistenceDiagramBarycenter.cpp
@@ -213,7 +213,7 @@ void ttk::PersistenceDiagramBarycenter::execute(
       }
     }
   }
-  // Reconstruct barcenter
+  // Reconstruct barycenter
   for(size_t j = 0; j < barycenter_min.size(); j++) {
     const auto &dt = barycenter_min[j];
     barycenter.push_back(dt);


### PR DESCRIPTION
This PR changes the code of `PersistenceDiagramBarycenter` (classical Auction) in order to fix incorrect matchings when 2 diagrams are provided in input.
It also simplifies some code snippets and corrects a few typos in `PersistenceDiagramClustering` and `PersistenceDiagramAuction` folders.