### PR TITLE
[PersistenceDiagramClustering] fix uninitialized value

### DIFF
--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -274,7 +274,10 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
       pointPers->SetTuple1(2 * j + 0, pers);
       pointPers->SetTuple1(2 * j + 1, pers);
     }
-    pointPers->SetTuple1(vtu->GetNumberOfPoints() - 1, vtu->GetCellData()->GetArray("Persistence")->GetTuple1(vtu->GetNumberOfCells() - 1));
+    pointPers->SetTuple1(
+      vtu->GetNumberOfPoints() - 1, vtu->GetCellData()
+                                      ->GetArray("Persistence")
+                                      ->GetTuple1(vtu->GetNumberOfCells() - 1));
 
     const auto cid = inv_clustering[i];
     const auto &matchings{matchingsPerCluster[cid][i]};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -274,6 +274,7 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
       pointPers->SetTuple1(2 * j + 0, pers);
       pointPers->SetTuple1(2 * j + 1, pers);
     }
+    pointPers->SetTuple1(vtu->GetNumberOfPoints() - 1, vtu->GetCellData()->GetArray("Persistence")->GetTuple1(vtu->GetNumberOfCells() - 1));
 
     const auto cid = inv_clustering[i];
     const auto &matchings{matchingsPerCluster[cid][i]};

--- a/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
+++ b/core/vtk/ttkPersistenceDiagramClustering/ttkPersistenceDiagramClustering.cpp
@@ -268,16 +268,14 @@ void ttkPersistenceDiagramClustering::outputClusteredDiagrams(
     vtu->GetPointData()->AddArray(pointPers);
 
     // diagonal uses two existing points
+    const auto persArray = vtu->GetCellData()->GetArray("Persistence");
     for(int j = 0; j < vtu->GetNumberOfCells() - 1; ++j) {
-      const auto persArray = vtu->GetCellData()->GetArray("Persistence");
       const auto pers = persArray->GetTuple1(j);
       pointPers->SetTuple1(2 * j + 0, pers);
       pointPers->SetTuple1(2 * j + 1, pers);
     }
-    pointPers->SetTuple1(
-      vtu->GetNumberOfPoints() - 1, vtu->GetCellData()
-                                      ->GetArray("Persistence")
-                                      ->GetTuple1(vtu->GetNumberOfCells() - 1));
+    pointPers->SetTuple1(vtu->GetNumberOfPoints() - 1,
+                         persArray->GetTuple1(vtu->GetNumberOfCells() - 1));
 
     const auto cid = inv_clustering[i];
     const auto &matchings{matchingsPerCluster[cid][i]};


### PR DESCRIPTION
This PR aims to fix the uninitialized persistence value of the (0,0) point (used by the diagonal cell) in the PersistenceDiagramClustering TTK filter.