### PR TITLE
[Torch] fix external project linkage

### DIFF
--- a/core/base/TTKBaseConfig.cmake.in
+++ b/core/base/TTKBaseConfig.cmake.in
@@ -17,8 +17,9 @@ if (@TTK_ENABLE_QHULL@ AND @Qhull_FOUND@)
   find_dependency(Qhull REQUIRED)
 endif()
 
-if (@TTK_ENABLE_TORCH@ AND TORCH_FOUND)
-  find_dependency(Torch REQUIRED)
+if (@TTK_ENABLE_TORCH@ AND @TORCH_FOUND@)
+  set(Torch_DIR "@Torch_DIR@" CACHE PATH "Use TTK Torch dir" FORCE)
+  find_dependency(Torch REQUIRED @Torch_DIR@)
 endif()
 
 if (@TTK_ENABLE_ZFP@ AND NOT @TTK_ENABLE_SHARED_BASE_LIBRARIES@)

--- a/core/base/TTKBaseConfig.cmake.in
+++ b/core/base/TTKBaseConfig.cmake.in
@@ -17,7 +17,7 @@ if (@TTK_ENABLE_QHULL@ AND @Qhull_FOUND@)
   find_dependency(Qhull REQUIRED)
 endif()
 
-if (@TTK_ENABLE_TORCH@ AND @TORCH_FOUND@)
+if (@TTK_ENABLE_TORCH@)
   set(Torch_DIR "@Torch_DIR@" CACHE PATH "Use TTK Torch dir" FORCE)
   find_dependency(Torch REQUIRED @Torch_DIR@)
 endif()

--- a/examples/c++/CMakeLists.txt
+++ b/examples/c++/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 # name of the project
 project(ttkExample-c++)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_BUILD_TYPE "Release")
 

--- a/examples/vtk-c++/CMakeLists.txt
+++ b/examples/vtk-c++/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.21)
 # name of the project
 project(ttkExample-vtk-c++ LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_BUILD_TYPE "Release")
 


### PR DESCRIPTION
This PR fixes the link with Torch when TTK is used as a library for another project such that the c++ example in TTK.

It fixes a typo `TORCH_FOUND` to `@TORCH_FOUND@`.
Inspired by the ZFP dependency, it sets the `Torch_DIR` variable for external projects as the value used to make TTK, in order to avoid to set this variable in external projects.
It also changes the c++ version of the c++ example from 14 to 17 because 17 is needed for Torch.