### PR TITLE
[SignedDistanceField] not expanded box precision

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -326,7 +326,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" libboost-devel eigen spectralib zfp \
-          scikit-learn llvm-openmp graphviz websocketpp clangxx
+          scikit-learn llvm-openmp graphviz clangxx
 
     - name: Remove hosted Python
       shell: bash
@@ -412,7 +412,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge "qt>=5.12" libboost-devel eigen spectralib zfp \
-          scikit-learn openmp graphviz websocketpp
+          scikit-learn openmp graphviz 
 
     - name: Remove hosted Python
       shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -325,7 +325,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
+        conda install -c conda-forge "qt>=5.12" libboost-devel eigen spectralib zfp \
           scikit-learn llvm-openmp graphviz websocketpp clangxx
 
     - name: Remove hosted Python
@@ -411,7 +411,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge "qt>=5.12" boost eigen spectralib zfp \
+        conda install -c conda-forge "qt>=5.12" libboost-devel eigen spectralib zfp \
           scikit-learn openmp graphviz websocketpp
 
     - name: Remove hosted Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -444,7 +444,7 @@ jobs:
       shell: bash
       run: |
         conda install -c conda-forge libboost-devel glew eigen spectralib zfp  \
-          scikit-learn graphviz ninja websocketpp sccache=0.4.2 python=3.10 zlib qhull llvm-openmp clangxx
+          scikit-learn graphviz ninja sccache=0.4.2 python=3.10 zlib qhull llvm-openmp clangxx
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH
         # add TTK & ParaView install folders to PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -443,7 +443,7 @@ jobs:
     - name: Install dependencies with conda
       shell: bash
       run: |
-        conda install -c conda-forge boost glew eigen spectralib zfp  \
+        conda install -c conda-forge libboost-devel glew eigen spectralib zfp  \
           scikit-learn graphviz ninja websocketpp sccache=0.4.2 python=3.10 zlib qhull llvm-openmp clangxx
         # add sccache to PATH
         echo "$CONDA_ROOT/bin" >> $GITHUB_PATH

--- a/core/vtk/ttkSignedDistanceField/ttkSignedDistanceField.cpp
+++ b/core/vtk/ttkSignedDistanceField/ttkSignedDistanceField.cpp
@@ -230,6 +230,7 @@ int ttkSignedDistanceField::RequestData(vtkInformation *ttkNotUsed(request),
 
   int ret{};
 
+  expandBox_ = ExpandBox;
   backend_ = Backend;
   fastMarchingOrder_ = FastMarchingOrder;
   ttkVtkTemplate2Macro(


### PR DESCRIPTION
When disabling the `expandBox` parameter of the signed distance field module it is possible for a triangle to lie on the boundary of the box.
However in practice it can results in the triangle not being detected by a ray due to precision problems.
In the end, this can result in the algorithm being unable to detect the interior and exterior of the surface.

To fix this, this PR shift a little bit the rays that are cast on the boundary by 0.1% of the size of the spacing in the corresponding dimensions (i.e the extent of a dimension divided by its resolution).