### PR TITLE
[WIP] Updating CI for newer OS'es

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
       name: Checkout TTK source code
@@ -99,7 +99,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
       name: Checkout TTK source code
@@ -122,6 +122,12 @@ jobs:
 
     - name: Set PYTHONPATH for Ubuntu 22.04 pvpython
       if: matrix.os == 'ubuntu-22.04'
+      run: |
+        # pvpython does not embed the correct PYTHONPATH
+        echo "PYTHONPATH=/usr/lib/python3/dist-packages:$PYTHONPATH" >> $GITHUB_ENV
+
+    - name: Set PYTHONPATH for Ubuntu 24.04 pvpython
+      if: matrix.os == 'ubuntu-24.04'
       run: |
         # pvpython does not embed the correct PYTHONPATH
         echo "PYTHONPATH=/usr/lib/python3/dist-packages:$PYTHONPATH" >> $GITHUB_ENV
@@ -569,6 +575,14 @@ jobs:
         tag: ${{ github.ref }}
         file: ttk-ubuntu-22.04.deb/ttk.deb
         asset_name: ttk-$tag-ubuntu-22.04.deb
+
+    - name: Upload Ubuntu Noble Numbat .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-ubuntu-24.04.deb/ttk.deb
+        asset_name: ttk-$tag-ubuntu-24.04.deb
 
     - name: Upload macOS binary archives as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.repository_owner == 'topology-tool-kit' || !contains(github.ref, 'heads') }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
     env:
       CCACHE_DIR: /home/runner/.ccache
       CCACHE_MAXSIZE: 500M
@@ -163,7 +163,7 @@ jobs:
     needs: test-build-ubuntu
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
         testSet: [pyTests, screenshotTests]
     steps:
     - name: Install Ubuntu dependencies
@@ -684,6 +684,14 @@ jobs:
         tag: ccache
         file: ttk-ccache-ubuntu-22.04/ttk-ccache.tar.gz
         asset_name: ttk-ccache-ubuntu-22.04.tar.gz
+
+    - name: Upload Ubuntu Nobel Numbat .deb as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ccache
+        file: ttk-ccache-ubuntu-24.04/ttk-ccache.tar.gz
+        asset_name: ttk-ccache-ubuntu-24.04.tar.gz
 
     - name: Upload .pkg as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,14 @@
 =
 ### dev
 - Wasserstein Auto-Encoders of Merge Trees / Pers. Diagrams (IEEE TVCG 2024)
+- Topological simplification optimization (IEEE VIS 2024)
 - TopoMap dimensionality reduction (IEEE TVCG 2020)
 - TTK is Getting MPI-ready! (IEEE TVCG 2024)
 - ExTreeM merge tree computation backend (IEEE TVCG 2024)
 - Ripser integration
 - DMS performance improvements (allocation)
 - Saddle connector reversal performance improvements
+- Signed distance fields
 - Migration to ParaView 5.12
 - Switch to C++17
 - Bug fixes


### PR DESCRIPTION
This PI is a work in progress to upgrade the OS'es in the CI.
This PI is dependent on the upgrade of ttk-paraview's CI (https://github.com/topology-tool-kit/ttk-paraview). Once the latter is successful (at least for the headless packages), this PR can start to move on.