### PR TITLE
[MPI] Fix int to SimplexId

### DIFF
--- a/core/base/implicitTriangulation/ImplicitTriangulation.h
+++ b/core/base/implicitTriangulation/ImplicitTriangulation.h
@@ -1720,7 +1720,7 @@ inline void ttk::ImplicitTriangulation::vertexToPosition(const SimplexId vertex,
 inline void ttk::ImplicitTriangulation::edgeToPosition(const SimplexId edge,
                                                        const int k,
                                                        SimplexId p[3]) const {
-  const int e = (k) ? edge - esetshift_[k - 1] : edge;
+  const ttk::SimplexId e = (k) ? edge - esetshift_[k - 1] : edge;
   p[0] = e % eshift_[2 * k];
   p[1] = (e % eshift_[2 * k + 1]) / eshift_[2 * k];
   p[2] = e / eshift_[2 * k + 1];

--- a/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
+++ b/core/base/periodicImplicitTriangulation/PeriodicImplicitTriangulation.h
@@ -1106,7 +1106,7 @@ inline void
 
 inline void ttk::PeriodicImplicitTriangulation::edgeToPosition(
   const SimplexId edge, const int k, SimplexId p[3]) const {
-  const int e = (k) ? edge - esetshift_[k - 1] : edge;
+  const ttk::SimplexId e = (k) ? edge - esetshift_[k - 1] : edge;
   p[0] = e % eshift_[2 * k];
   p[1] = (e % eshift_[2 * k + 1]) / eshift_[2 * k];
   p[2] = e / eshift_[2 * k + 1];


### PR DESCRIPTION
Hi all,

In `edgeToPosition` of both Implicit and Periodic Triangulations, an intermediary variable (`e`) was set and was an integer. This worked only up until a certain number of edges. 
For a grid of $2048$ x $2048$ x $1024$, a problem would arise, as the computed number needed a `long int` type to be expressed and was expressed as an `int`. The result was negative integer positions (impossible in our grids).

Setting the`int` as a `ttk::SimplexId` solves the problem.

For `triangleToPosition`, the variable (here `t`) is already a `ttk::SimplexId`.

Thanks for any feedback.