### PR TITLE
[MPI] fix image spacing implicit triangulation in 1d and 2d cases

### DIFF
--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -185,10 +185,10 @@ RegistryTriangulation
   double spacing[3];
   image->GetSpacing(spacing);
 
-  // 1D
-  if(!spacing[1])
+  // 1D (not tested)
+  if(!spacing[1] && !spacing[2])
     spacing[1] = 1;
-  if(!spacing[2]) // 2D
+  if(!spacing[2]) // 2D (tested)
     spacing[2] = 1;
 
   int dimensions[3];

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -189,7 +189,7 @@ RegistryTriangulation
   if(!spacing[1])
     spacing[1] = 1;
   if(!spacing[2]) // 2D
-    spacing[2] = 1;  
+    spacing[2] = 1;
 
   int dimensions[3];
   image->GetDimensions(dimensions);

--- a/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
+++ b/core/vtk/ttkAlgorithm/ttkTriangulationFactory.cpp
@@ -185,6 +185,12 @@ RegistryTriangulation
   double spacing[3];
   image->GetSpacing(spacing);
 
+  // 1D
+  if(!spacing[1])
+    spacing[1] = 1;
+  if(!spacing[2]) // 2D
+    spacing[2] = 1;  
+
   int dimensions[3];
   image->GetDimensions(dimensions);
 


### PR DESCRIPTION
In case of 1D or 2D vtkImageData, the function getSpacing might return 0 as spacing[1] and/or spacing[2].

Here is a liittle fix to ensure that spacing is at least 1 (it's an integer).