### PR TITLE
fix for persistence diagram multi-threading with DMS

### DIFF
--- a/core/base/persistenceDiagram/PersistenceDiagram.h
+++ b/core/base/persistenceDiagram/PersistenceDiagram.h
@@ -521,6 +521,7 @@ int ttk::PersistenceDiagram::executeDiscreteMorseSandwich(
 
   Timer const tm{};
   const auto dim = triangulation->getDimensionality();
+  dms_.setThreadNumber(this->threadNumber_);
 
   dms_.buildGradient(
     inputScalars, scalarsMTime, inputOffsets, *triangulation, updateMask);


### PR DESCRIPTION
Thanks for contributing to TTK!

Before submitting your pull request, please:

- [x] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/dev/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.

- [x] Please provide a quick description of your contributions below:

When computing persistence diagrams with the Discrete Morse Sandwich backend, the number of threads of the DiscreteMorseSandwich object should be set to the number of threads of the PersistenceDiagram object.

