### PR TITLE
fix morse smale complex for multiblock input

### DIFF
--- a/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
+++ b/core/vtk/ttkMorseSmaleComplex/ttkMorseSmaleComplex.h
@@ -192,8 +192,5 @@ protected:
 private:
   bool ForceInputOffsetScalarField{};
   int IterationThreshold{-1};
-  OutputCriticalPoints criticalPoints_{};
-  Output1Separatrices separatrices1_{};
-  Output2Separatrices separatrices2_{};
   OutputManifold segmentations_{};
 };


### PR DESCRIPTION
Thanks for contributing to TTK!

Before submitting your pull request, please:

- [x] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/dev/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.

- [x] Please provide a quick description of your contributions below:

The function setArray is changed so that the output of the ttk layer is correctly copied in the vtkArrays (especially when the input is a vtkMutliBlockDataSet). The points coordinates of the 1-separatrices and 2-separatrices are copied manually. The output of the ttk layerare no longer attributes of the class but local variables in the function dispatch.

