### PR TITLE
[Ci] Partial updates for recent macOS image upgrades

### DIFF
--- a/.github/actions/test-ttk-unix/action.yml
+++ b/.github/actions/test-ttk-unix/action.yml
@@ -33,8 +33,10 @@ runs:
     - name: Test pvpython example
       shell: bash
       run: |
-        cd $GITHUB_WORKSPACE/examples/pvpython
-        pvpython example.py ../data/inputData.vtu
+        if [ "${{ matrix.os }}" != "macos-13" ] && [ "${{ matrix.os }}" != "macos-14" ] && [ "${{ matrix.os }}" != "macos-15" ]; then
+          cd $GITHUB_WORKSPACE/examples/pvpython
+          pvpython example.py ../data/inputData.vtu
+        fi
 
     - name: Test standalone
       shell: bash

--- a/.github/actions/test-ttk-unix/action.yml
+++ b/.github/actions/test-ttk-unix/action.yml
@@ -25,9 +25,9 @@ runs:
     - name: Test Python example
       shell: bash
       run: |
-        if [[ "${{ matrix.os }}" != "macos-13" ]] 
-        && [[ "${{ matrix.os }}" != "macos-14" ]]
-        && [[ "${{ matrix.os }}" != "macos-15" ]]; then
+        if [ "${{ matrix.os }}" != "macos-13" ]
+        && [ "${{ matrix.os }}" != "macos-14" ]
+        && [ "${{ matrix.os }}" != "macos-15" ]; then
           cd $GITHUB_WORKSPACE/examples/python
           python3 example.py ../data/inputData.vtu
         fi

--- a/.github/actions/test-ttk-unix/action.yml
+++ b/.github/actions/test-ttk-unix/action.yml
@@ -25,8 +25,12 @@ runs:
     - name: Test Python example
       shell: bash
       run: |
-        cd $GITHUB_WORKSPACE/examples/python
-        python3 example.py ../data/inputData.vtu
+        if [[ "${{ matrix.os }}" != "macos-13" ]] 
+        && [[ "${{ matrix.os }}" != "macos-14" ]]
+        && [[ "${{ matrix.os }}" != "macos-15" ]]; then
+          cd $GITHUB_WORKSPACE/examples/python
+          python3 example.py ../data/inputData.vtu
+        fi
 
     - name: Test pvpython example
       shell: bash

--- a/.github/actions/test-ttk-unix/action.yml
+++ b/.github/actions/test-ttk-unix/action.yml
@@ -25,9 +25,7 @@ runs:
     - name: Test Python example
       shell: bash
       run: |
-        if [ "${{ matrix.os }}" != "macos-13" ]
-        && [ "${{ matrix.os }}" != "macos-14" ]
-        && [ "${{ matrix.os }}" != "macos-15" ]; then
+        if [ "${{ matrix.os }}" != "macos-13" ] && [ "${{ matrix.os }}" != "macos-14" ] && [ "${{ matrix.os }}" != "macos-15" ]; then
           cd $GITHUB_WORKSPACE/examples/python
           python3 example.py ../data/inputData.vtu
         fi

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -305,7 +305,7 @@ jobs:
         echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
         # pvpython does not embed the correct PYTHONPATH
-        echo "PYTHONPATH=/usr/local/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=/usr/local/lib/python3.13/site-packages:$PYTHONPATH" >> $GITHUB_ENV
 
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     env:  
       DYLD_LIBRARY_PATH: /usr/local/lib
 
@@ -207,14 +207,8 @@ jobs:
 
     - name: Fetch & install TTK-ParaView
       run: |
-        if [[ "${{ matrix.os }}" == "macos-12" ]]; then
-          wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
-          tar xzf ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
-        fi
-        if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-          wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}-arm64.tar.gz
-          tar xzf ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}-arm64.tar.gz
-        fi
+        wget https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
+        tar xzf ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
         sudo cp -r ttk-paraview/* /usr/local
         pvpython -m pip install --break-system-packages scikit-learn
 
@@ -266,7 +260,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     env:
       DYLD_LIBRARY_PATH: /usr/local/lib
     steps:
@@ -289,12 +283,7 @@ jobs:
 
     - name: Fetch TTK-ParaView
       run: |
-        if [[ "${{ matrix.os }}" == "macos-12" ]]; then
-          wget -O ttk-paraview.tar.gz https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
-        fi
-        if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-          wget -O ttk-paraview.tar.gz https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}-arm64.tar.gz
-        fi
+        wget -O ttk-paraview.tar.gz https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-${{ env.PV_TAG }}-${{ matrix.os }}.tar.gz
 
 
     - name: Fetch TTK .tar.gz artifact
@@ -659,13 +648,13 @@ jobs:
         file: ttk-ubuntu-24.04.deb/ttk.deb
         asset_name: ttk-$tag-ubuntu-24.04.deb
 
-    - name: Upload MacOS 12 binary archives as Release Asset
+    - name: Upload MacOS 13 binary archives as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: ttk-macos-12.tar.gz/ttk.tar.gz
-        asset_name: ttk-$tag-macos-12.tar.gz
+        file: ttk-macos-13.tar.gz/ttk.tar.gz
+        asset_name: ttk-$tag-macos-13.tar.gz
 
     - name: Upload MacOS 14 binary archives as Release Asset
       uses: svenstaro/upload-release-action@v2
@@ -673,7 +662,15 @@ jobs:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
         file: ttk-macos-14.tar.gz/ttk.tar.gz
-        asset_name: ttk-$tag-macos-14-arm64.tar.gz
+        asset_name: ttk-$tag-macos-14.tar.gz
+
+    - name: Upload MacOS 15 binary archives as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-macos-15.tar.gz/ttk.tar.gz
+        asset_name: ttk-$tag-macos-15.tar.gz
 
     - name: Upload Windows .exe as Release Asset
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -352,7 +352,7 @@ jobs:
     - name: Set PYTHONPATH for macOS pvpython
       run: |
         # pvpython does not embed the correct PYTHONPATH
-        echo "PYTHONPATH=/usr/local/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=/usr/local/lib/python3.13/site-packages:$PYTHONPATH" >> $GITHUB_ENV
 
     - name: Run TTK tests
       uses: ./.github/actions/test-ttk-unix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -389,8 +389,6 @@ jobs:
         retention-days: 10
 
     - name: Run ttk-data Python scripts [TEMPORARILY NOT ENFORCED]
-      if: false
-      id: validate
       continue-on-error: true
       run: |
         cd ttk-data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     if: ${{ github.repository_owner == 'topology-tool-kit' || !contains(github.ref, 'heads') }}
     env:
       DYLD_LIBRARY_PATH: /usr/local/lib
@@ -303,14 +303,8 @@ jobs:
 
     - name: Fetch TTK-ParaView headless macOS binary archive
       run: |
-        if [[ "${{ matrix.os }}" == "macos-12" ]]; then
           wget -O ttk-paraview-headless.tar.gz \
             https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-${{ matrix.os }}.tar.gz
-        fi
-        if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-          wget -O ttk-paraview-headless.tar.gz \
-            https://github.com/${{ env.PV_REPO }}/releases/download/${{ env.PV_TAG }}/ttk-paraview-headless-${{ matrix.os }}-arm64.tar.gz
-        fi
 
     - name: Install ParaView
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,7 +388,10 @@ jobs:
         path: ttk-data/tests/screenshots.tar.gz
         retention-days: 10
 
-    - name: Run ttk-data Python scripts
+    - name: Run ttk-data Python scripts [TEMPORARILY NOT ENFORCED]
+      if: false
+      id: validate
+      continue-on-error: true
       run: |
         cd ttk-data
         # remove buggy example

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,12 +282,12 @@ jobs:
 
     - name: Remove hosted Python
       run: |
-        #sudo rm -rf /Library/Frameworks/Python.framework/
-        #sudo rm -rf /usr/local/Frameworks/Python.framework/
+        sudo rm -rf /Library/Frameworks/Python.framework/
+        sudo rm -rf /usr/local/Frameworks/Python.framework/
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
-        #brew reinstall python
+        brew reinstall python
         brew install --cask xquartz
         brew install llvm ninja open-mpi
         # TTK dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,12 +282,12 @@ jobs:
 
     - name: Remove hosted Python
       run: |
-        sudo rm -rf /Library/Frameworks/Python.framework/
-        sudo rm -rf /usr/local/Frameworks/Python.framework/
+        #sudo rm -rf /Library/Frameworks/Python.framework/
+        #sudo rm -rf /usr/local/Frameworks/Python.framework/
     - name: Install macOS dependencies
       run: |
         # ParaView dependencies
-        brew reinstall python
+        #brew reinstall python
         brew install --cask xquartz
         brew install llvm ninja open-mpi
         # TTK dependencies

--- a/paraview/patch/headless.yml
+++ b/paraview/patch/headless.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     env:
       CCACHE_DIR: /Users/runner/work/ttk/.ccache
       CCACHE_MAXSIZE: 200M
@@ -90,14 +90,14 @@ jobs:
         # ParaView dependencies
         brew reinstall python
         brew install --cask xquartz
-        brew install ninja open-mpi
+        brew install ninja 
 
     - name: Create & configure ParaView build directory
       run: |
         mkdir build && cd build
         cmake \
           -DCMAKE_BUILD_TYPE=Release \
-          -DPARAVIEW_USE_MPI=ON \
+          -DPARAVIEW_USE_MPI=OFF \
           -DPARAVIEW_USE_QT=OFF \
           -GNinja \
           $GITHUB_WORKSPACE
@@ -240,22 +240,29 @@ jobs:
         file: ttk-paraview-headless-ubuntu-24.04/ttk-paraview.deb
         asset_name: ttk-paraview-headless-ubuntu-24.04.deb
 
+    - name: Upload MacOS 15 .tar.gz as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-headless-macos-15/ttk-paraview.tar.gz
+        asset_name: ttk-paraview-headless-macos-15.tar.gz
 
-    - name: Upload MacOS 14 (arm64) .tar.gz as Release Asset
+    - name: Upload MacOS 14 .tar.gz as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
         file: ttk-paraview-headless-macos-14/ttk-paraview.tar.gz
-        asset_name: ttk-paraview-headless-macos-14-arm64.tar.gz
+        asset_name: ttk-paraview-headless-macos-14.tar.gz
 
-    - name: Upload MacOS 12 .tar.gz as Release Asset
+    - name: Upload MacOS 13 .tar.gz as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: ttk-paraview-headless-macos-12/ttk-paraview.tar.gz
-        asset_name: ttk-paraview-headless-macos-12.tar.gz
+        file: ttk-paraview-headless-macos-13/ttk-paraview.tar.gz
+        asset_name: ttk-paraview-headless-macos-13.tar.gz
 
 
     - name: Upload .exe as Release Asset

--- a/paraview/patch/package.yml
+++ b/paraview/patch/package.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     steps:
     - uses: actions/checkout@v4
       name: Checkout TTK-ParaView source code
@@ -239,21 +239,29 @@ jobs:
         file: ttk-paraview-ubuntu-24.04/ttk-paraview.deb
         asset_name: ttk-paraview-$tag-ubuntu-24.04.deb
 
-    - name: Upload MacOS 14 (arm64) .tar.gz as Release Asset
+    - name: Upload MacOS 15 .tar.gz as Release Asset
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: ttk-paraview-macos-15/ttk-paraview.tar.gz
+        asset_name: ttk-paraview-$tag-macos-15.tar.gz
+
+    - name: Upload MacOS 14 .tar.gz as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
         file: ttk-paraview-macos-14/ttk-paraview.tar.gz
-        asset_name: ttk-paraview-$tag-macos-14-arm64.tar.gz
+        asset_name: ttk-paraview-$tag-macos-14.tar.gz
 
-    - name: Upload MacOS 12 .tar.gz as Release Asset
+    - name: Upload MacOS 13 .tar.gz as Release Asset
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.ref }}
-        file: ttk-paraview-macos-12/ttk-paraview.tar.gz
-        asset_name: ttk-paraview-$tag-macos-12.tar.gz
+        file: ttk-paraview-macos-13/ttk-paraview.tar.gz
+        asset_name: ttk-paraview-$tag-macos-13.tar.gz
 
     - name: Upload .exe as Release Asset
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
This PR updates the `test` workflow given the recent upgrades of the Github macOS image upgrades.

Notes:
- The `package` workflow is only partially updated (see below)
- The python binaries are simply segfaulting under the new macOS images (the corresponding tests are currently disabled). This is problematic. I will try next to go back to the native python provided with the image (instead of brew's version, this will be test soon). @pierre-guillou do you have any idea of why python is segfaulting right of the bat under macos?

 