### PR TITLE
LTS special case fix

### DIFF
--- a/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
+++ b/core/base/localizedTopologicalSimplification/LocalizedTopologicalSimplification.h
@@ -142,8 +142,7 @@ namespace ttk {
 
         const IT nVertices = triangulation->getNumberOfVertices();
 #ifdef TTK_ENABLE_OPENMP
-#pragma omp parallel for num_threads( \
-  this->threadNumber_) if(nAuthorizedExtremaIndices > 1000)
+#pragma omp parallel for num_threads(this->threadNumber_)
 #endif // TTK_ENABLE_OPENMP
         for(IT i = 0; i < nAuthorizedExtremaIndices; i++)
           authorizationMask[authorizedExtremaIndices[i]] = -2;
@@ -887,7 +886,13 @@ namespace ttk {
             }
           }
 
-          containsResidualExtrema = nResidualMinima > 0 || nResidualMaxima > 0;
+          // perform another iteration iff
+          // (i) there are residual maxima, OR
+          // (ii) there are residual minima and there exists a boundary on which
+          //      they can be placed
+          containsResidualExtrema
+            = nResidualMaxima > 0
+              || (nResidualMinima > 0 && boundaryWriteIdx > 0);
 
           if(containsResidualExtrema && boundary.size() == 0) {
             boundary.resize(boundaryWriteIdx);


### PR DESCRIPTION
Hi Julien,
this is a fix for issue #1081. The technical details are documented there. In short, this PR just adds an additional check to the LTS subprocedure that computes the local order of a segment. Before this subprocedure could run into an infinite loop if the segment that needs to be simplified does not have a boundary on which minima can be placed. Now the subprocedure checks if a boundary exists in the first place.

I did not test this yet!

Thanks
Jonas