### PR TITLE
CMake: Add delayed load support

### DIFF
--- a/paraview/CMakeLists.txt
+++ b/paraview/CMakeLists.txt
@@ -46,6 +46,10 @@ paraview_plugin_build(
     "${CMAKE_INSTALL_BINDIR}/plugins"
   LIBRARY_DESTINATION
     "${CMAKE_INSTALL_BINDIR}/plugins"
+  PLUGINS_FILE_NAME
+    "ttk.plugins.xml"
+  DELAYED_LOAD
+    TopologyToolKit
   )
 
 install(


### PR DESCRIPTION
Thanks for contributing to TTK!

Before submitting your pull request, please:

- [x] Review our [Contributor Guidelines](https://github.com/topology-tool-kit/ttk/blob/dev/CONTRIBUTING.md), in particular regarding code formatting (with clang-format) and continuous integration.

- [x] Please provide a quick description of your contributions below:

Add delayed load support to the TTK ParaView plugin, which can be used in ParaView 5.13 and 6.0 to load the TTK plugin only when needed. More information here: https://www.kitware.com/reducing-the-temporal-impact-of-loading-plugins-in-paraview/

