### PR TITLE
[ci] replacing deprecated omp_set_nested

### DIFF
--- a/core/base/contourForests/ContourForestsTemplate.h
+++ b/core/base/contourForests/ContourForestsTemplate.h
@@ -287,7 +287,7 @@ namespace ttk {
 #endif
 
 #ifdef TTK_ENABLE_OPENMP
-      omp_set_nested(1);
+      omp_set_max_active_levels(100);
 #endif
 
 // std::cout << "NO PARALLEL DEBUG MODE" << std::endl;

--- a/core/base/discreteMorseSandwichMPI/DiscreteMorseSandwichMPI.h
+++ b/core/base/discreteMorseSandwichMPI/DiscreteMorseSandwichMPI.h
@@ -6334,7 +6334,7 @@ int ttk::DiscreteMorseSandwichMPI::computePersistencePairs(
     int minSadThreadNumber = std::max(1, static_cast<int>(threadNumber_ / 2));
     int maxSadThreadNumber = std::max(1, threadNumber_ - minSadThreadNumber);
     int taskNumber = std::min(2, threadNumber_);
-    omp_set_nested(1);
+    omp_set_max_active_levels(100);
     std::vector<PersistencePair> sadMaxPairs;
     MPI_Comm minSadComm;
     MPI_Comm_dup(ttk::MPIcomm_, &minSadComm);
@@ -6358,7 +6358,7 @@ int ttk::DiscreteMorseSandwichMPI::computePersistencePairs(
           ignoreBoundary, offsets, sadMaxComm, maxSadThreadNumber);
       }
     }
-    omp_set_nested(0);
+    omp_set_max_active_levels(1);
     MPI_Comm_free(&minSadComm);
     MPI_Comm_free(&sadMaxComm);
     pairs.insert(pairs.end(), sadMaxPairs.begin(), sadMaxPairs.end());

--- a/core/base/ftmTree/FTMTree_Template.h
+++ b/core/base/ftmTree/FTMTree_Template.h
@@ -36,7 +36,7 @@ void ttk::ftm::FTMTree::build(const triangulationType *mesh) {
 
 #ifdef TTK_ENABLE_OPENMP
   ParallelGuard const pg{threadNumber_};
-  omp_set_nested(1);
+  omp_set_max_active_levels(100);
 #ifdef TTK_ENABLE_OMP_PRIORITY
   if(omp_get_max_task_priority() < 5) {
     this->printWrn("OpenMP max priority is lower than 5");

--- a/core/base/ftrGraph/FTRGraph_Template.h
+++ b/core/base/ftrGraph/FTRGraph_Template.h
@@ -42,7 +42,7 @@ namespace ttk {
 
 #ifdef TTK_ENABLE_OPENMP
       ParallelGuard const pg{params_.threadNumber};
-      omp_set_nested(1);
+      omp_set_max_active_levels(100);
 #ifdef TTK_ENABLE_OMP_PRIORITY
       if(omp_get_max_task_priority() < PriorityLevel::Max) {
         this->printWrn("OpenMP max priority is lower than 5");

--- a/core/base/mergeTreeAutoencoder/MergeTreeAutoencoder.cpp
+++ b/core/base/mergeTreeAutoencoder/MergeTreeAutoencoder.cpp
@@ -2609,8 +2609,8 @@ void ttk::MergeTreeAutoencoder::execute(
   printErr("This module requires Torch.");
 #else
 #ifdef TTK_ENABLE_OPENMP
-  int ompNested = omp_get_nested();
-  omp_set_nested(1);
+  int ompNested = omp_get_max_active_levels();
+  omp_set_max_active_levels(100);
 #endif
   // --- Preprocessing
   Timer t_preprocess;
@@ -2697,7 +2697,7 @@ void ttk::MergeTreeAutoencoder::execute(
     }
   }
 #ifdef TTK_ENABLE_OPENMP
-  omp_set_nested(ompNested);
+  omp_set_max_active_levels(ompNested);
 #endif
 #endif
 }

--- a/core/base/mergeTreeClustering/MergeTreeBarycenter.h
+++ b/core/base/mergeTreeClustering/MergeTreeBarycenter.h
@@ -58,7 +58,7 @@ namespace ttk {
         "MergeTreeBarycenter"); // inherited from Debug: prefix will be printed
                                 // at the beginning of every msg
 #ifdef TTK_ENABLE_OPENMP4
-      omp_set_nested(1);
+      omp_set_max_active_levels(100);
 #endif
     }
     ~MergeTreeBarycenter() override = default;

--- a/core/base/mergeTreeClustering/MergeTreeDistance.h
+++ b/core/base/mergeTreeClustering/MergeTreeDistance.h
@@ -65,7 +65,7 @@ namespace ttk {
         "MergeTreeDistance"); // inherited from Debug: prefix will be printed at
                               // the beginning of every msg
 #ifdef TTK_ENABLE_OPENMP4
-      omp_set_nested(1);
+      omp_set_max_active_levels(100);
 #endif
     }
     ~MergeTreeDistance() override = default;

--- a/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
+++ b/core/base/mergeTreePrincipalGeodesics/MergeTreePrincipalGeodesics.h
@@ -66,7 +66,7 @@ namespace ttk {
       // msg
       this->setDebugMsgPrefix("MergeTreePrincipalGeodesics");
 #ifdef TTK_ENABLE_OPENMP
-      omp_set_nested(1);
+      omp_set_max_active_levels(100);
 #endif
     }
 


### PR DESCRIPTION
Needed to speedup the CI under macos (which currently takes hours due to tons of warnings).

@CharlesGueunet 
@MatPont 
Could you double-check my edits are OK?

@MatPont 
To double-check but it looks like the state file mergeTreeWAEDecoding.pvsm is broken (the top right view is missing the data points here).

Thanks for your feedback!