### PR TITLE
Support embree 4

### DIFF
--- a/CMake/config.cmake
+++ b/CMake/config.cmake
@@ -180,7 +180,11 @@ else()
   message(STATUS "Zlib not found, disabling Zlib support in TTK.")
 endif()
 
-find_package(EMBREE 3.4 QUIET)
+# TTK supports embree 3 (>= 3.4) and embree 4, prefer embree 4 if available
+find_package(EMBREE 4 QUIET)
+if(NOT EMBREE_FOUND)
+  find_package(EMBREE 3.4 QUIET)
+endif()
 if(EMBREE_FOUND)
   option(TTK_ENABLE_EMBREE "Enable embree raytracing for ttkCinemaImaging" ON)
   message(STATUS "Found Embree ${EMBREE_VERSION} (${EMBREE_LIBRARY})")

--- a/core/base/cinemaImaging/CMakeLists.txt
+++ b/core/base/cinemaImaging/CMakeLists.txt
@@ -12,6 +12,9 @@ ttk_add_base_library(cinemaImaging
 
 if (TTK_ENABLE_EMBREE AND EMBREE_FOUND)
   target_compile_definitions(cinemaImaging PUBLIC TTK_ENABLE_EMBREE)
+  if(EMBREE_VERSION_MAJOR EQUAL 4)
+    target_compile_definitions(cinemaImaging PUBLIC TTK_EMBREE4)
+  endif()
   target_include_directories(cinemaImaging PUBLIC ${EMBREE_INCLUDE_DIRS})
   target_link_libraries(cinemaImaging PUBLIC ${EMBREE_LIBRARY})
 endif()

--- a/core/base/cinemaImaging/CMakeLists.txt
+++ b/core/base/cinemaImaging/CMakeLists.txt
@@ -12,6 +12,6 @@ ttk_add_base_library(cinemaImaging
 
 if (TTK_ENABLE_EMBREE AND EMBREE_FOUND)
   target_compile_definitions(cinemaImaging PUBLIC TTK_ENABLE_EMBREE)
-  target_include_directories(cinemaImaging PUBLIC ${EMBREE_INCLUDE_DIR})
+  target_include_directories(cinemaImaging PUBLIC ${EMBREE_INCLUDE_DIRS})
   target_link_libraries(cinemaImaging PUBLIC ${EMBREE_LIBRARY})
 endif()

--- a/core/base/cinemaImaging/CinemaImagingEmbree.cpp
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.cpp
@@ -66,8 +66,13 @@ int ttk::CinemaImagingEmbree::renderImage(
                    + std::to_string(resX) + "x" + std::to_string(resY) + ")",
                  0, 0, this->threadNumber_, ttk::debug::LineMode::REPLACE);
 
+#ifdef TTK_EMBREE4
+  struct RTCIntersectArguments args;
+  rtcInitIntersectArguments(&args);
+#else
   struct RTCIntersectContext context;
   rtcInitIntersectContext(&context);
+#endif
 
   const auto normalize = [](double out[3], const double in[3]) {
     const double temp = sqrt(in[0] * in[0] + in[1] * in[1] + in[2] * in[2]);
@@ -148,7 +153,11 @@ int ttk::CinemaImagingEmbree::renderImage(
         rayhit.ray.flags = 0;
         rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
         rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
+#ifdef TTK_EMBREE4
+        rtcIntersect1(scene, &rayhit, &args);
+#else
         rtcIntersect1(scene, &context, &rayhit);
+#endif
 
         // write depth
         const bool hitPrimitive = rayhit.hit.geomID != RTC_INVALID_GEOMETRY_ID;
@@ -194,7 +203,11 @@ int ttk::CinemaImagingEmbree::renderImage(
         rayhit.ray.flags = 0;
         rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID;
         rayhit.hit.instID[0] = RTC_INVALID_GEOMETRY_ID;
+#ifdef TTK_EMBREE4
+        rtcIntersect1(scene, &rayhit, &args);
+#else
         rtcIntersect1(scene, &context, &rayhit);
+#endif
 
         // write depth
         const bool hitPrimitive = rayhit.hit.geomID != RTC_INVALID_GEOMETRY_ID;

--- a/core/base/cinemaImaging/CinemaImagingEmbree.h
+++ b/core/base/cinemaImaging/CinemaImagingEmbree.h
@@ -12,7 +12,11 @@
 #include <CinemaImaging.h>
 
 #ifdef TTK_ENABLE_EMBREE
+#ifdef TTK_EMBREE4
+#include <embree4/rtcore.h>
+#else
 #include <embree3/rtcore.h>
+#endif
 #include <limits>
 #include <string>
 #endif // TTK_ENABLE_EMBREE


### PR DESCRIPTION
This adds support for embree 4 - fixes https://github.com/topology-tool-kit/ttk/issues/1122

I've kept support for embree 3 which is pinned in [scripts/docker/pkg/embree.sh](https://github.com/topology-tool-kit/ttk/blob/dev/scripts/docker/pkg/embree.sh). The Docker image uses outdated versions across the entire stack (embree, ospray, openvkl, ispc, paraview, ...) and should be updated, but I will leave this to somebody else.